### PR TITLE
Added possibility to change perun's configuration files location on build or runtime

### DIFF
--- a/perun-cabinet/src/main/resources/perun-cabinet-applicationContext.xml
+++ b/perun-cabinet/src/main/resources/perun-cabinet-applicationContext.xml
@@ -59,7 +59,11 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
         <property name="locations">
             <list>
                 <value>file:${perun.conf}/perun-cabinet.properties</value>
+                <value>file:${perun.conf.custom}/perun-cabinet.properties</value>
             </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
         </property>
     </bean>
 

--- a/perun-controller/src/main/resources/perun-controller-applicationcontext.xml
+++ b/perun-controller/src/main/resources/perun-controller-applicationcontext.xml
@@ -12,18 +12,18 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 ">
     <!-- Perun Tasks Lib -->
     <import resource="classpath:perun-tasks-lib-applicationcontext.xml"/>
-    
+
     <import resource="classpath:perun-datasources.xml"/>
-    
+
     <import resource="classpath:perun-transaction-manager.xml"/>
-    
+
     <!-- Enable @Transactional support -->
-     <tx:annotation-driven transaction-manager="springTransactionManager"/>
-     
+    <tx:annotation-driven transaction-manager="springTransactionManager"/>
+
     <!-- Enable @AspectJ support -->
     <aop:aspectj-autoproxy/>
-    
+
     <!-- Scans for @Repository, @Service and @Component -->
     <context:component-scan base-package="cz.metacentrum.perun.controller"/>
-      
+
 </beans>

--- a/perun-core/src/main/resources/perun-beans.xml
+++ b/perun-core/src/main/resources/perun-beans.xml
@@ -259,6 +259,19 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
         <constructor-arg ref="dataSource" />
     </bean>
 
+    <!-- Properties Bean for perun-core -->
+    <bean id="coreProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <property name="locations">
+            <list>
+                <value>file:${perun.conf}/perun.properties</value>
+                <value>file:${perun.conf.custom}/perun.properties</value>
+            </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
+        </property>
+    </bean>
+
     <import resource="classpath:perun-core-trace-log.xml"/>
     
 </beans>

--- a/perun-core/src/main/resources/perun-datasources.xml
+++ b/perun-core/src/main/resources/perun-datasources.xml
@@ -8,7 +8,8 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 ">
-    <context:property-placeholder location="${perun.jdbc}"/>
+    <!-- later location overwrite previous -->
+    <context:property-placeholder ignore-resource-not-found="true" ignore-unresolvable="true" location="${perun.jdbc}, file:${perun.conf.custom}/jdbc.properties"/>
 
     <!-- DataSource implementation -->    
     <bean id="dataSource" class="org.apache.tomcat.dbcp.dbcp.BasicDataSource" destroy-method="close">

--- a/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
@@ -12,7 +12,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
 ">
-    <context:property-placeholder location="${perun.jdbc}"/>
+    <context:property-placeholder ignore-resource-not-found="true" ignore-unresolvable="true" location="${perun.jdbc}, file:${perun.conf.custom}/jdbc.properties"/>
 
     <!-- Enable @Transactional support -->
     <tx:annotation-driven/>
@@ -51,7 +51,11 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
         <property name="locations">
         	<list>
 	            <value>file:${perun.conf}/perun-dispatcher.properties</value>
+                <value>file:${perun.conf.custom}/perun-dispatcher.properties</value>
             </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
         </property>
     </bean>
     

--- a/perun-engine/src/main/resources/devel/perun-engine-applicationcontext.xml
+++ b/perun-engine/src/main/resources/devel/perun-engine-applicationcontext.xml
@@ -108,7 +108,11 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
         <property name="locations">
             <list>
                 <value>file:${perun.conf}/perun-engine.properties</value>
+                <value>file:${perun.conf.custom}/perun-engine.properties</value>
             </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
         </property>
     </bean>
 </beans>

--- a/perun-engine/src/main/resources/production/perun-engine-applicationcontext.xml
+++ b/perun-engine/src/main/resources/production/perun-engine-applicationcontext.xml
@@ -108,7 +108,11 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
         <property name="locations">
             <list>
                 <value>file:${perun.conf}/perun-engine.properties</value>
+                <value>file:${perun.conf.custom}/perun-engine.properties</value>
             </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
         </property>
     </bean>
     

--- a/perun-engine/src/main/resources/production/perun-engine-datasources.xml
+++ b/perun-engine/src/main/resources/production/perun-engine-datasources.xml
@@ -8,7 +8,7 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 ">
-    <context:property-placeholder location="${perun.jdbc}"/>
+    <context:property-placeholder ignore-resource-not-found="true" ignore-unresolvable="true" location="${perun.jdbc}, file:${perun.conf.custom}/jdbc.properties"/>
 
     <!-- DataSource implementation -->    
     <bean id="dataSource" class="org.apache.tomcat.dbcp.dbcp.BasicDataSource" destroy-method="close">

--- a/perun-ldapc/src/main/resources/perun-ldapc-applicationcontext.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc-applicationcontext.xml
@@ -8,35 +8,37 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
 http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
     <!-- Use in initialize script -->
-    <!-- -DldapPropertyFile=/etc/perunv3/filename -->  
-    <context:property-placeholder 
-        ignore-resource-not-found="true" ignore-unresolvable="true" 
-        location="${perun.jdbc}, file:${perun.conf.custom}/jdbc.properties, ${perun.ldapc}, file:${perun.conf.custom}/perun-ldapc.properties"/>
-    
+    <!-- -Dperun.conf.custom=/etc/perunv3/filename -->
+    <context:property-placeholder
+            ignore-resource-not-found="true" ignore-unresolvable="true"
+            location="${perun.jdbc}, file:${perun.conf.custom}/jdbc.properties,
+            ${perun.ldapc}, file:${perun.conf.custom}/perun-ldapc.properties"/>
+
     <!-- Enable @AspectJ support -->
     <aop:aspectj-autoproxy/>
 
     <!-- Scans for @Repository, @Service and @Component -->
     <context:component-scan base-package="cz.metacentrum.perun.ldapc"/>
     <context:annotation-config/>
-    
+
     <!-- Properties Bean -->
-   <bean id="ldapcProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-       <property name="locations">
-           <list>
-               <value>file:${perun.conf}/perun-ldapc.properties</value>
-               <value>file:${perun.conf.custom}/perun-ldapc.properties</value>
-           </list>
-       </property>
-       <property name="ignoreResourceNotFound">
-           <value>true</value>
-       </property>
-   </bean>
-   <bean id="ldapProperties" class="cz.metacentrum.perun.ldapc.beans.LdapProperties">
+    <bean id="ldapcProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <property name="locations">
+            <list>
+                <value>file:${perun.conf}/perun-ldapc.properties</value>
+                <value>file:${perun.conf.custom}/perun-ldapc.properties</value>
+            </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
+        </property>
+    </bean>
+    <bean id="ldapProperties" class="cz.metacentrum.perun.ldapc.beans.LdapProperties">
         <constructor-arg ref="ldapcProperties" />
     </bean>
-    
+
     <!-- These beans are for define ldapTemplate -->
     <bean id="contextSource" class="org.springframework.ldap.core.support.LdapContextSource">
         <property name="url" value="${ldap.url}" />
@@ -47,5 +49,5 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
     <bean id="ldapTemplate" class="org.springframework.ldap.core.LdapTemplate">
         <constructor-arg ref="contextSource" />
     </bean>
-    
+
 </beans>

--- a/perun-notification/src/main/resources/perun-notification-applicationcontext.xml
+++ b/perun-notification/src/main/resources/perun-notification-applicationcontext.xml
@@ -17,7 +17,11 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
         <property name="locations">
             <list>
                 <value>file:${perun.conf}/perun-notification.properties</value>
+                <value>file:${perun.conf.custom}/perun-notification.properties</value>
             </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
         </property>
     </bean>
 

--- a/perun-notification/src/test/resources/perun-notification-applicationcontext-test.xml
+++ b/perun-notification/src/test/resources/perun-notification-applicationcontext-test.xml
@@ -19,7 +19,11 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
         <property name="locations">
             <list>
                 <value>file:${perun.conf}/perun-notification-test.properties</value>
+                <value>file:${perun.conf.custom}/perun-notification-test.properties</value>
             </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
         </property>
     </bean>
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -9,7 +9,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Resource;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.sql.DataSource;
@@ -63,8 +62,7 @@ public class MailManagerImpl implements MailManager {
 
 	@Autowired PerunBl perun;
 	@Autowired RegistrarManager registrarManager;
-    @Resource( name = "registrarProperties" )
-    private Properties registrarProperties;
+    @Autowired private Properties registrarProperties;
 	private PerunSession registrarSession;
 	private SimpleJdbcTemplate jdbc;
 	private MailSender mailSender;
@@ -113,8 +111,8 @@ public class MailManagerImpl implements MailManager {
 				throw new PrivilegeException(sess, "addMail");				
 			}
 		}
-		
-	    int id = Utils.getNewId(jdbc, "APPLICATION_MAILS_ID_SEQ");
+
+        int id = Utils.getNewId(jdbc, "APPLICATION_MAILS_ID_SEQ");
 		mail.setId(id);
 		
 		jdbc.update("insert into application_mails(id, form_id, app_type, mail_type, send) values (?,?,?,?,?)",

--- a/perun-registrar-lib/src/main/resources/perun-registrar-lib-applicationcontext.xml
+++ b/perun-registrar-lib/src/main/resources/perun-registrar-lib-applicationcontext.xml
@@ -40,6 +40,16 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
     </bean>
 
     <!-- Properties Bean -->
-    <util:properties id="registrarProperties" location="file:${perun.conf}/perun-registrar-lib.properties" />
+    <bean id="registrarProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <property name="locations">
+            <list>
+                <value>file:${perun.conf}/perun-registrar-lib.properties</value>
+                <value>file:${perun.conf.custom}/perun-registrar-lib.properties</value>
+            </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
+        </property>
+    </bean>
 
 </beans>


### PR DESCRIPTION
- added variable ${perun.conf.custom} which is not used by maven (but can be)
- running jar/war with -Dperun.conf.custom=/home/user_name/.perunv3 will override default config location from /etc/perunv3
- changed way of wiring property file in perun-registrar
- added definition of coreProperties to perun-core (not yet used to loading properties)
