### PR TITLE
Core: FacilityManager.addAdmin edited, so as it throws right exception.

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -353,7 +353,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
   public void addAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, AlreadyAdminException {
     try {
       jdbc.update("insert into authz (user_id, role_id, facility_id) values (?, (select id from roles where name=?), ?)", user.getId(), Role.FACILITYADMIN.getRoleName(), facility.getId());
-    } catch (DataIntegrityViolationException e) {
+    } catch (org.springframework.jdbc.UncategorizedSQLException e) {
       throw new AlreadyAdminException("User id=" + user.getId() + " is already admin of the facility " + facility, e, user, facility);
     } catch (RuntimeException e) {
       throw new InternalErrorException(e);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -35,6 +35,7 @@ import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.HostExistsException;
@@ -590,6 +591,21 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
                 assertNotNull(admins);
                 assertTrue(admins.size() > 0);
         }
+        
+        @Test(expected = AlreadyAdminException.class)
+         public void addAdminWithTwoSameUsers() throws Exception {
+                 System.out.println(FACILITIES_MANAGER + ".addAdminWithTwoSameUsers()");
+                 
+                 final Member member = setUpMember(facAdminsVo);
+                 User u = perun.getUsersManagerBl().getUserByMember(sess, member);
+  
+                 facilitiesManagerEntry.addAdmin(sess, facility, u);
+                 final List<User> admins = facilitiesManagerEntry.getAdmins(sess, facility);
+                 assertNotNull(admins);
+                 assertTrue(admins.size() > 0);
+                  
+                 facilitiesManagerEntry.addAdmin(sess, facility, u);
+         }
         
         @Test
         public void addAdminWithGroup() throws Exception {


### PR DESCRIPTION
Core: FacilityManager.addAdmin edited, so as it throws right exception (AlreadyAdminException) instead of InternalErrorException, when one user is added more than once as admin.

The functionality is tested with the new written test addAdminWithTwoSameUsers in the FacilityManagerEntryIntegrationTest.
