### PR TITLE
Core: fixed copy attributes on facility

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -829,6 +829,14 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
         List<Attribute> sourceAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, sourceFacility);
         List<Attribute> destinationAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, destinationFacility);
 
+        // do not get virtual attributes from source facility, they can't be set to destination
+        Iterator<Attribute> it = sourceAttributes.iterator();
+        while (it.hasNext()) {
+            if (it.next().getNamespace().startsWith(AttributesManager.NS_FACILITY_ATTR_VIRT)) {
+                it.remove();
+            }
+        }
+
         // create intersection of destination and source attributes
         List<Attribute> intersection = new ArrayList<>();
         intersection.addAll(destinationAttributes);


### PR DESCRIPTION
Remove all virtual attributes from list, taken from source facility,
since they can't be set to destination facility.
