### PR TITLE
Attr. modules: unixGroupName can work without GID

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespace.java
@@ -129,8 +129,6 @@ public class urn_perun_resource_attribute_def_def_unixGroupName_namespace extend
                   Attribute facilityGIDNamespace = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facilityOfResource, A_F_unixGID_namespace);
                   if(facilityGIDNamespace.getValue() != null) {
                       gidNamespace = (String) facilityGIDNamespace.getValue();
-                  } else {
-                      throw new WrongReferenceAttributeValueException(attribute, facilityGIDNamespace, "Facility has groupNameNamespace set, but gidNamespace not set.");
                   }
               }
           }


### PR DESCRIPTION
Now you can set unixGroupName without unixGID if unixGIDNamespace isn't
set on facility.
