### PR TITLE
Attr. modules: unixGroupName can work without GID

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -402,8 +402,6 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
                     //If facilityGIDNamespace exists and is not null, save to the hashSet of gidNamespaces
                     if(facilityGIDNamespace.getValue() != null) {
                         gidNamespaces.add((String) facilityGIDNamespace.getValue());
-                    } else {
-                      throw new WrongReferenceAttributeValueException(unixGroupNameNamespace, facilityGIDNamespace, "Facility has groupNameNamespace set, but gidNamespace not set.");
                     }
                 }
             }


### PR DESCRIPTION
Addition to commit 678b82f74ff0b7124da622243fea48bd226ef762 (Now you can
set unixGroupName without unixGID if unixGIDNamespace isn't set on
facility.) which works only for resource's attributes. This one work for
group's attributes too.
