### PR TITLE
GUI: added support for groups as entities managers

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ButtonTranslation.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ButtonTranslation.java
@@ -295,14 +295,32 @@ public interface ButtonTranslation extends Messages {
     @DefaultMessage("Remove selected VO managers")
     String removeManagerFromVo();
 
-   @DefaultMessage("Add new group manager")
+    @DefaultMessage("Add group as new VO manager")
+    String addManagerGroupToVo();
+
+    @DefaultMessage("Add selected groups as VO`s managers")
+    String addSelectedManagersGroupToVo();
+
+    @DefaultMessage("Remove selected groups from VO managers")
+    String removeManagerGroupFromVo();
+
+    @DefaultMessage("Add new group manager")
     String addManagerToGroup();
 
-    @DefaultMessage("Add selected users as VO`s managers")
+    @DefaultMessage("Add selected users as groups managers")
     String addSelectedManagersToGroup();
 
     @DefaultMessage("Remove selected group managers")
     String removeManagerFromGroup();
+
+    @DefaultMessage("Add group as new group manager")
+    String addManagerGroupToGroup();
+
+    @DefaultMessage("Add selected groups as groups managers")
+    String addSelectedManagersGroupToGroup();
+
+    @DefaultMessage("Remove selected groups from group managers")
+    String removeManagerGroupFromGroup();
 
     @DefaultMessage("Add new facility manager")
     String addManagerToFacility();
@@ -312,6 +330,15 @@ public interface ButtonTranslation extends Messages {
 
     @DefaultMessage("Remove selected facility managers")
     String removeManagerFromFacility();
+
+    @DefaultMessage("Add new group as facility manager")
+    String addManagerGroupToFacility();
+
+    @DefaultMessage("Add selected groups as facility managers")
+    String addSelectedManagersGroupToFacility();
+
+    @DefaultMessage("Remove selected groups from facility managers")
+    String removeManagerGroupFromFacility();
 
     /* USERS */
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/authzResolver/GetAdminGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/authzResolver/GetAdminGroups.java
@@ -1,0 +1,293 @@
+package cz.metacentrum.perun.webgui.json.authzResolver;
+
+import com.google.gwt.cell.client.FieldUpdater;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.cellview.client.Column;
+import com.google.gwt.user.cellview.client.ColumnSortEvent.ListHandler;
+import com.google.gwt.view.client.DefaultSelectionEventManager;
+import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.MultiSelectionModel;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
+import cz.metacentrum.perun.webgui.client.resources.TableSorter;
+import cz.metacentrum.perun.webgui.json.*;
+import cz.metacentrum.perun.webgui.json.comparators.GeneralComparator;
+import cz.metacentrum.perun.webgui.json.keyproviders.GeneralKeyProvider;
+import cz.metacentrum.perun.webgui.model.Group;
+import cz.metacentrum.perun.webgui.model.PerunError;
+import cz.metacentrum.perun.webgui.widgets.AjaxLoaderImage;
+import cz.metacentrum.perun.webgui.widgets.PerunTable;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+
+/**
+ * Ajax query to get VO/GROUP/FACILITY admins
+ *
+ * @author Pavel Zlamal <256627@mail.muni.cz>
+ * @version $Id: $
+ */
+public class GetAdminGroups implements JsonCallback, JsonCallbackTable<Group> {
+
+	// Session
+	private PerunWebSession session = PerunWebSession.getInstance();
+	// JSON URL
+	private static final String GROUP_JSON_URL = "groupsManager/getAdminGroups";
+    private static final String VO_JSON_URL = "vosManager/getAdminGroups";
+    private static final String FACILITY_JSON_URL = "facilitiesManager/getAdminGroups";
+
+    // entity ID
+	private int entityId;
+	// Selection model for the table
+	final MultiSelectionModel<Group> selectionModel = new MultiSelectionModel<Group>(new GeneralKeyProvider<Group>());
+	// Table data provider.
+	private ListDataProvider<Group> dataProvider = new ListDataProvider<Group>();
+	// Cell table
+	private PerunTable<Group> table;
+	// List of members
+	private ArrayList<Group> list = new ArrayList<Group>();
+	// Table field updater
+	private FieldUpdater<Group, String> tableFieldUpdater;
+	// External events
+	private JsonCallbackEvents events = new JsonCallbackEvents();
+	// loader image
+	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
+    private PerunEntity entity;
+
+	/**
+	 * Creates a new instance of callback
+	 *
+     * @param entity entity
+	 * @param id entity ID
+     */
+	public GetAdminGroups(PerunEntity entity, int id) {
+        this.entity = entity;
+		this.entityId = id;
+	}
+
+	/**
+	 * Creates a new instance of callback
+	 *
+     * @param entity entity
+     * @param id entity ID
+     * @param events
+     */
+	public GetAdminGroups(PerunEntity entity, int id, JsonCallbackEvents events) {
+        this.entity = entity;
+		this.entityId = id;
+		this.events = events;
+	}
+
+	/**
+	 * Retrieves members from RPC
+	 */
+	public void retrieveData() {
+
+        JsonClient js = new JsonClient(60000);
+        String param;
+
+        if (entity.equals(PerunEntity.VIRTUAL_ORGANIZATION)) {
+            param = "vo="+entityId;
+            js.retrieveData(VO_JSON_URL, param, this);
+        } else if (entity.equals(PerunEntity.GROUP)) {
+            param = "group="+entityId;
+            js.retrieveData(GROUP_JSON_URL, param, this);
+        } else if (entity.equals(PerunEntity.FACILITY)) {
+            param = "facility="+entityId;
+            js.retrieveData(FACILITY_JSON_URL, param, this);
+        }
+
+	}
+
+	/**
+	 * Returns the table with member-Groups
+	 * 
+	 * @param fu Custom field updater
+	 * @return CellTable widget
+	 */
+	public CellTable<Group> getTable(FieldUpdater<Group, String> fu) {
+		this.tableFieldUpdater = fu;
+		return this.getTable();
+	}
+
+	/**
+	 * Returns the table with member-Groups
+	 * 
+	 * @return CellTable widget
+	 */
+	public CellTable<Group> getTable() {
+
+		// Retrieves data
+		this.retrieveData();
+
+		// Table data provider.
+		dataProvider = new ListDataProvider<Group>(list);
+		
+		// Cell table
+		table = new PerunTable<Group>(list);
+		
+		// Connect the table to the data provider.
+		dataProvider.addDataDisplay(table);
+
+		// Sorting
+		ListHandler<Group> columnSortHandler = new ListHandler<Group>(dataProvider.getList());
+		table.addColumnSortHandler(columnSortHandler);
+		
+		// Table selection
+		table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Group> createCheckboxManager());
+
+		// Set empty content & loader
+		table.setEmptyTableWidget(loaderImage);
+		
+		// Checkbox column column
+		table.addCheckBoxColumn();
+
+		// Create Group ID column.
+		Column<Group, String> groupIdColumn = JsonUtils.addColumn(
+				new JsonUtils.GetValue<Group, String>() {
+					public String getValue(Group object) {
+						return String.valueOf(object.getId());
+					}
+				}, this.tableFieldUpdater);
+		
+
+		groupIdColumn.setSortable(true);
+		columnSortHandler.setComparator(groupIdColumn, new GeneralComparator<Group>(GeneralComparator.Column.ID));
+		
+		table.setColumnWidth(groupIdColumn, 110.0, Unit.PX);
+		
+		if(JsonUtils.isExtendedInfoVisible()){
+			table.addColumn(groupIdColumn,  "Group ID");
+		}
+
+        table.addNameColumn(tableFieldUpdater);
+        table.addDescriptionColumn(tableFieldUpdater);
+
+		return table;
+		
+	}
+
+    /**
+     * Sorts table by objects Name
+     */
+    public void sortTable() {
+        list = new TableSorter<Group>().sortByName(getList());
+        dataProvider.flush();
+        dataProvider.refresh();
+    }
+
+    /**
+     * Add object as new row to table
+     *
+     * @param object Group to be added as new row
+     */
+    public void addToTable(Group object) {
+        list.add(object);
+        dataProvider.flush();
+        dataProvider.refresh();
+    }
+
+    /**
+     * Removes object as row from table
+     *
+     * @param object Group to be removed as row
+     */
+    public void removeFromTable(Group object) {
+        list.remove(object);
+        selectionModel.getSelectedSet().remove(object);
+        dataProvider.flush();
+        dataProvider.refresh();
+    }
+
+    /**
+     * Clear all table content
+     */
+    public void clearTable(){
+        loaderImage.loadingStart();
+        list.clear();
+        selectionModel.clear();
+        dataProvider.flush();
+        dataProvider.refresh();
+    }
+
+    /**
+     * Clears list of selected items
+     */
+    public void clearTableSelectedSet(){
+        selectionModel.clear();
+    }
+
+    /**
+     * Return selected items from list
+     *
+     * @return return list of checked items
+     */
+    public ArrayList<Group> getTableSelectedList(){
+        return JsonUtils.setToList(selectionModel.getSelectedSet());
+    }
+
+    /**
+     * Called, when an error occurs
+     */
+    public void onError(PerunError error) {
+        session.getUiElements().setLogErrorText("Error while loading admin groups.");
+        loaderImage.loadingError(error);
+        events.onError(error);
+    }
+
+    /**
+     * Called, when loading starts
+     */
+    public void onLoadingStart() {
+        session.getUiElements().setLogText("Loading admin groups started.");
+        events.onLoadingStart();
+    }
+
+    /**
+     * Called, when operation finishes successfully.
+     */
+    public void onFinished(JavaScriptObject jso) {
+        setList(JsonUtils.<Group>jsoAsList(jso));
+        sortTable();
+        loaderImage.loadingFinished();
+        session.getUiElements().setLogText("Admin groups loaded: " + list.size());
+        events.onFinished(jso);
+    }
+
+    public void insertToTable(int index, Group object) {
+        list.add(index, object);
+        dataProvider.flush();
+        dataProvider.refresh();
+    }
+
+    public void setEditable(boolean editable) {
+        // TODO Auto-generated method stub
+    }
+
+    public void setCheckable(boolean checkable) {
+        // TODO Auto-generated method stub
+    }
+
+    public void setList(ArrayList<Group> list) {
+        clearTable();
+        this.list.addAll(list);
+        dataProvider.flush();
+        dataProvider.refresh();
+    }
+
+    public ArrayList<Group> getList() {
+        return this.list;
+    }
+
+	/**
+	 * Sets external events after callback creation
+	 * 
+	 * @param externalEvents external events
+	 */
+	public void setEvents(JsonCallbackEvents externalEvents) {
+		events = externalEvents;
+	}
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/authzResolver/RemoveAdmin.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/authzResolver/RemoveAdmin.java
@@ -3,21 +3,19 @@ package cz.metacentrum.perun.webgui.json.authzResolver;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
-import com.google.gwt.user.client.ui.HTML;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.UiElements;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonPostClient;
 import cz.metacentrum.perun.webgui.model.PerunError;
-import cz.metacentrum.perun.webgui.widgets.Confirm;
 
 /**
  * Ajax query which removes admin from VO / Group
  * 
  * @author Pavel Zlamal <256627@mail.muni.cz>
- * @version $Id$
+ * @version $Id: 61d3044b749b99e22722b4696d2c1abfd221b7fc $
  */
-
 public class RemoveAdmin {
 
 	// web session
@@ -26,6 +24,7 @@ public class RemoveAdmin {
 	final String VO_JSON_URL = "vosManager/removeAdmin";
     final String GROUP_JSON_URL = "groupsManager/removeAdmin";
     final String FACILITY_JSON_URL = "facilitiesManager/removeAdmin";
+
 	// external events
 	private JsonCallbackEvents events = new JsonCallbackEvents();
 	// ids
@@ -97,31 +96,75 @@ public class RemoveAdmin {
             jspc.sendData(FACILITY_JSON_URL, prepareJSONObject());
         }
 
-	}	
+	}
 
-	/**
+    /**
+     * Attempts to remove admin from VO
+     *
+     * @param id ID of entity, where should be change done
+     * @param groupId ID of group which should be removed from admins
+     */
+    public void removeAdminGroup(final int id,final int groupId)	{
+
+        this.userId = groupId;
+        this.entityId = id;
+
+        // test arguments
+        if(!this.testRemoving()){
+            return;
+        }
+
+        // new events
+        JsonCallbackEvents newEvents = new JsonCallbackEvents(){
+            public void onError(PerunError error) {
+                session.getUiElements().setLogErrorText("Removing admin (Group ID: " + userId + ") from "+entity+": "+entityId+" failed.");
+                events.onError(error);
+            };
+
+            public void onFinished(JavaScriptObject jso) {
+                session.getUiElements().setLogSuccessText("Admin (Group ID: " + userId + ") successfully removed from "+entity+": "+ entityId);
+                events.onFinished(jso);
+            };
+
+            public void onLoadingStart() {
+                events.onLoadingStart();
+            };
+        };
+
+        // sending data
+        JsonPostClient jspc = new JsonPostClient(newEvents);
+
+        if (entity.equals(PerunEntity.VIRTUAL_ORGANIZATION)) {
+            jspc.sendData(VO_JSON_URL, prepareJSONObjectForGroup());
+        } else if (entity.equals(PerunEntity.GROUP)) {
+            jspc.sendData(GROUP_JSON_URL, prepareJSONObjectForGroup());
+        } else if (entity.equals(PerunEntity.FACILITY)) {
+            jspc.sendData(FACILITY_JSON_URL, prepareJSONObjectForGroup());
+        }
+
+    }
+
+    /**
 	 * Tests the values, if the process can continue
 	 * 
 	 * @return true/false for continue/stop
 	 */
-	private boolean testRemoving()
-	{
+	private boolean testRemoving() {
 		boolean result = true;
 		String errorMsg = "";
 
 		if(entityId == 0){
-			errorMsg += "Wrong parameter <strong>Entity ID</strong>. ";
+			errorMsg += "Wrong parameter <strong>Entity ID</strong>.<br/>";
 			result = false;
 		}
 
 		if(userId == 0){
-			errorMsg += "Wrong parameter <strong>User ID</strong>. ";
+			errorMsg += "Wrong parameter <strong>User ID</strong>.";
 			result = false;
 		}
 
 		if(errorMsg.length()>0){
-			Confirm c = new Confirm("Error while removing admin", new HTML(errorMsg), true);
-			c.show();
+            UiElements.generateAlert("Parameter error", errorMsg);
 		}
 
 		return result;
@@ -132,8 +175,7 @@ public class RemoveAdmin {
 	 * 
 	 * @return JSONObject the whole query
 	 */
-	private JSONObject prepareJSONObject()
-	{
+	private JSONObject prepareJSONObject() {
 		// whole JSON query
 		JSONObject jsonQuery = new JSONObject();
         if (entity.equals(PerunEntity.VIRTUAL_ORGANIZATION)) {
@@ -146,5 +188,24 @@ public class RemoveAdmin {
         jsonQuery.put("user", new JSONNumber(userId));
 		return jsonQuery;
 	}
+
+    /**
+     * Prepares a JSON object
+     *
+     * @return JSONObject the whole query
+     */
+    private JSONObject prepareJSONObjectForGroup() {
+        // whole JSON query
+        JSONObject jsonQuery = new JSONObject();
+        if (entity.equals(PerunEntity.VIRTUAL_ORGANIZATION)) {
+            jsonQuery.put("vo", new JSONNumber(entityId));
+        } else if (entity.equals(PerunEntity.GROUP)) {
+            jsonQuery.put("group", new JSONNumber(entityId));
+        } else if (entity.equals(PerunEntity.FACILITY)) {
+            jsonQuery.put("facility", new JSONNumber(entityId));
+        }
+        jsonQuery.put("authorizedGroup", new JSONNumber(userId));
+        return jsonQuery;
+    }
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllGroups.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
  * 
  * @author Vaclav Mach <374430@mail.muni.cz>
  * @author Pavel Zlamal <256627@mail.muni.cz>
- * @version $Id$
+ * @version $Id: 0414f62c24d92793accb99a4c248bcdbac7e0d8d $
  */
 public class GetAllGroups implements JsonCallback, JsonCallbackTable<Group>, JsonCallbackOracle<Group> {
 
@@ -369,6 +369,10 @@ public class GetAllGroups implements JsonCallback, JsonCallbackTable<Group>, Jso
 
     public void setVoId(int voId) {
         this.voId = voId;
+    }
+
+    public MultiSelectionModel<Group> getSelectionModel() {
+        return this.selectionModel;
     }
 	
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/GroupsTabs.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/GroupsTabs.java
@@ -9,7 +9,7 @@ import java.util.Map;
  * Groups
  * 
  * @author Vaclav Mach <374430@mail.muni.cz>
- * @version $Id$
+ * @version $Id: ec60c9c53ef0fc8492a859893e10daef9914f272 $
  */
 public class GroupsTabs {
 
@@ -34,12 +34,6 @@ public class GroupsTabs {
 		}
 		// if active
 		boolean open = ("1".equals(parameters.get("active")));
-					
-				
-		if (tab.equals(AddGroupManagerTabItem.URL)) {
-			session.getTabManager().addTab(AddGroupManagerTabItem.load(parameters), open);
-			return true;
-		}
 		
 		if (tab.equals(GroupSettingsTabItem.URL)) {
 			session.getTabManager().addTab(GroupSettingsTabItem.load(parameters), open);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/VosTabs.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/VosTabs.java
@@ -81,12 +81,6 @@ public class VosTabs {
 			session.getTabManager().addTab(VoSettingsTabItem.load(parameters), open);
 			return true;
 		}
-		
-		if (tab.equals(AddVoManagerTabItem.URL))
-		{
-			session.getTabManager().addTab(AddVoManagerTabItem.load(parameters), open);
-			return true;
-		}
 
 		if (tab.equals(VoExtSourcesTabItem.URL))
 		{

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerGroupTabItem.java
@@ -1,0 +1,295 @@
+package cz.metacentrum.perun.webgui.tabs.facilitiestabs;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.client.ui.*;
+import com.google.gwt.view.client.SelectionChangeEvent;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.UiElements;
+import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
+import cz.metacentrum.perun.webgui.client.resources.*;
+import cz.metacentrum.perun.webgui.json.GetEntityById;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.JsonUtils;
+import cz.metacentrum.perun.webgui.json.authzResolver.AddAdmin;
+import cz.metacentrum.perun.webgui.json.groupsManager.GetAllGroups;
+import cz.metacentrum.perun.webgui.json.vosManager.GetVos;
+import cz.metacentrum.perun.webgui.model.Facility;
+import cz.metacentrum.perun.webgui.model.Group;
+import cz.metacentrum.perun.webgui.model.PerunError;
+import cz.metacentrum.perun.webgui.model.VirtualOrganization;
+import cz.metacentrum.perun.webgui.tabs.TabItem;
+import cz.metacentrum.perun.webgui.widgets.CustomButton;
+import cz.metacentrum.perun.webgui.widgets.ListBoxWithObjects;
+import cz.metacentrum.perun.webgui.widgets.TabMenu;
+
+import java.util.ArrayList;
+
+/**
+ * !! USE AS INNER TAB ONLY !!
+ *
+ * Provides page with add admin facility to Facility form
+ *
+ * @author Pavel Zlamal <256627@mail.muni.cz>
+ * @version $Id: $
+ */
+public class AddFacilityManagerGroupTabItem implements TabItem {
+
+    /**
+     * Perun web session
+     */
+    private PerunWebSession session = PerunWebSession.getInstance();
+
+    /**
+     * Content widget - should be simple panel
+     */
+    private SimplePanel contentWidget = new SimplePanel();
+
+    /**
+     * Title widget
+     */
+    private Label titleWidget = new Label("Add facility manager");
+
+    /**
+     * Entity ID to set
+     */
+    private int facilityId = 0;
+    private Facility facility;
+    private GetAllGroups getAllGroups;
+    private JsonCallbackEvents refreshEvents;
+
+    /**
+     * Creates a tab instance
+     *
+     * @param facilityId ID of Facility to add admin into
+     * @param refreshEvents events to trigger on finish
+     */
+    public AddFacilityManagerGroupTabItem(int facilityId, JsonCallbackEvents refreshEvents){
+        this.facilityId = facilityId;
+        JsonCallbackEvents events = new JsonCallbackEvents(){
+            public void onFinished(JavaScriptObject jso) {
+                facility = jso.cast();
+            }
+        };
+        new GetEntityById(PerunEntity.GROUP, facilityId, events).retrieveData();
+        this.refreshEvents = refreshEvents;
+    }
+
+    /**
+     * Creates a tab instance
+     *
+     * @param facility Facility to add admin into
+     * @param refreshEvents events to trigger on finish
+     */
+    public AddFacilityManagerGroupTabItem(Facility facility, JsonCallbackEvents refreshEvents){
+        this.facilityId = facility.getId();
+        this.facility = facility;
+        this.refreshEvents = refreshEvents;
+    }
+
+
+    public boolean isPrepared(){
+        return facility != null;
+    }
+
+    public Widget draw() {
+
+        titleWidget.setText(Utils.getStrippedStringWithEllipsis(facility.getName())+" ("+facility.getType()+"): add manager group");
+
+        // MAIN TAB PANEL
+        VerticalPanel firstTabPanel = new VerticalPanel();
+        firstTabPanel.setSize("100%", "100%");
+
+        // HORIZONTAL MENU
+        final TabMenu tabMenu = new TabMenu();
+        final ListBoxWithObjects<VirtualOrganization> box = new ListBoxWithObjects<VirtualOrganization>();
+
+        // pass empty items to menu to ensure drawing of rest
+        tabMenu.addWidget(new HTML(""));
+        tabMenu.addWidget(new HTML(""));
+        tabMenu.addWidget(2, new HTML("<strong>Select VO:</strong>"));
+        tabMenu.addWidget(3, box);
+
+        // get the table
+        final ScrollPanel sp = new ScrollPanel();
+        sp.addStyleName("perun-tableScrollPanel");
+
+        box.addChangeHandler(new ChangeHandler() {
+            @Override
+            public void onChange(ChangeEvent event) {
+                sp.setWidget(fillGroupsContent(new GetAllGroups(box.getSelectedObject().getId()), tabMenu, box));
+            }
+        });
+
+        if (box.getAllObjects().isEmpty()) {
+            GetVos vos = new GetVos(new JsonCallbackEvents(){
+                @Override
+                public void onFinished(JavaScriptObject jso) {
+                    box.clear();
+                    ArrayList<VirtualOrganization> list = new TableSorter<VirtualOrganization>().sortByName(JsonUtils.<VirtualOrganization>jsoAsList(jso));
+                    if (list != null && !list.isEmpty()) {
+                        box.addAllItems(list);
+                        sp.setWidget(fillGroupsContent(new GetAllGroups(box.getSelectedObject().getId()), tabMenu, box));
+                    } else {
+                        box.addItem("No VOs found");
+                    }
+                }
+                @Override
+                public void onError(PerunError error) {
+                    box.clear();
+                    box.addItem("Error while loading");
+                }
+                @Override
+                public void onLoadingStart() {
+                    box.clear();
+                    box.addItem("Loading...");
+                }
+            });
+            vos.retrieveData();
+        }
+
+        final TabItem tab = this;
+        tabMenu.addWidget(1, TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent clickEvent) {
+                if (refreshEvents != null) refreshEvents.onFinished(null);
+                session.getTabManager().closeTab(tab, false);
+            }
+        }));
+
+        // add menu and the table to the main panel
+        firstTabPanel.add(tabMenu);
+        firstTabPanel.setCellHeight(tabMenu, "30px");
+        firstTabPanel.add(sp);
+
+        session.getUiElements().resizePerunTable(sp, 350, this);
+
+        this.contentWidget.setWidget(firstTabPanel);
+
+        return getWidget();
+
+    }
+
+    private Widget fillGroupsContent(GetAllGroups groups, TabMenu tabMenu, final ListBoxWithObjects<VirtualOrganization> box) {
+
+        getAllGroups = groups;
+        getAllGroups.setCoreGroupsCheckable(true);
+        final CellTable<Group> table = getAllGroups.getTable();
+
+        getAllGroups.getSelectionModel().addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
+            private boolean found = false;
+            @Override
+            public void onSelectionChange(SelectionChangeEvent event) {
+                for (Group g : getAllGroups.getTableSelectedList()) {
+                    if (g.isCoreGroup()) {
+                        if (!found) {
+                            // display only once
+                            UiElements.generateInfo("You have selected 'all vo members' group", "If this group will be added as 'manager group', all new members of VO "+box.getSelectedObject().getName()+" will be automatically managers of your Facility and all removed members will lose management rights.");
+                        }
+                        found = true;
+                        return;
+                    }
+                }
+                found = false;
+            }
+        });
+
+        final CustomButton addButton = TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addSelectedManagersGroupToGroup());
+        tabMenu.addWidget(0, addButton);
+        final TabItem tab = this;
+        addButton.addClickHandler(new ClickHandler(){
+            public void onClick(ClickEvent event) {
+                ArrayList<Group> list = getAllGroups.getTableSelectedList();
+                if (UiElements.cantSaveEmptyListDialogBox(list)){
+                    for (int i=0; i<list.size(); i++) {
+                        if (i == list.size() - 1) {
+                            AddAdmin request = new AddAdmin(PerunEntity.FACILITY, JsonCallbackEvents.disableButtonEvents(addButton, new JsonCallbackEvents(){
+                                public void onFinished(JavaScriptObject jso) {
+                                    // close tab and refresh table
+                                    if (refreshEvents != null) refreshEvents.onFinished(null);
+                                    session.getTabManager().closeTab(tab, false);
+                                }
+                            }));
+                            request.addAdminGroup(facilityId, list.get(i).getId());
+                        } else {
+                            AddAdmin request = new AddAdmin(PerunEntity.FACILITY, JsonCallbackEvents.disableButtonEvents(addButton));
+                            request.addAdminGroup(facilityId, list.get(i).getId());
+                        }
+                    }
+                }
+            }
+        });
+
+        addButton.setEnabled(false);
+        JsonUtils.addTableManagedButton(getAllGroups, table, addButton);
+
+        // add a class to the table and wrap it into scroll panel
+        table.addStyleName("perun-table");
+
+        return table;
+
+    }
+
+    public Widget getWidget() {
+        return this.contentWidget;
+    }
+
+    public Widget getTitle() {
+        return this.titleWidget;
+    }
+
+    public ImageResource getIcon() {
+        return SmallIcons.INSTANCE.addIcon();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + 6786786;
+        return result;
+    }
+
+    /**
+     * @param obj
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+
+        AddFacilityManagerGroupTabItem create = (AddFacilityManagerGroupTabItem) obj;
+        if (facilityId != create.facilityId){
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean multipleInstancesEnabled() {
+        return false;
+    }
+
+    public void open() {
+    }
+
+    public boolean isAuthorized() {
+
+        if (session.isFacilityAdmin(facilityId)) {
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityManagersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityManagersTabItem.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.webgui.tabs.facilitiestabs;
 
 import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
@@ -18,11 +20,14 @@ import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
+import cz.metacentrum.perun.webgui.json.authzResolver.GetAdminGroups;
 import cz.metacentrum.perun.webgui.json.authzResolver.GetRichAdminsWithAttributes;
 import cz.metacentrum.perun.webgui.json.authzResolver.RemoveAdmin;
 import cz.metacentrum.perun.webgui.model.Facility;
+import cz.metacentrum.perun.webgui.model.Group;
 import cz.metacentrum.perun.webgui.model.User;
 import cz.metacentrum.perun.webgui.tabs.*;
+import cz.metacentrum.perun.webgui.tabs.groupstabs.GroupDetailTabItem;
 import cz.metacentrum.perun.webgui.tabs.userstabs.UserDetailTabItem;
 import cz.metacentrum.perun.webgui.widgets.CustomButton;
 import cz.metacentrum.perun.webgui.widgets.TabMenu;
@@ -32,74 +37,129 @@ import java.util.Map;
 
 /**
  * Tab with list of administrators on facility
- * 
+ *
  * @author Pavel Zlamal <256627@mail.muni.cz>
- * @version $Id$
+ * @version $Id: b2c3f64a0a8205817fe0bdfd122b33f45f4b2635 $
  */
 public class FacilityManagersTabItem implements TabItem, TabItemWithUrl{
 
-	/**
-	 * Perun web session
-	 */
-	private PerunWebSession session = PerunWebSession.getInstance();
-	
-	/**
-	 * Content widget - should be simple panel
-	 */
-	private SimplePanel contentWidget = new SimplePanel();
-	
-	/**
-	 * Title widget
-	 */
-	private Label titleWidget = new Label("Loading facility");
-	
-	// data
-	private int facilityId;
-	private Facility facility;
-	
-	/**
-	 * Creates a tab instance
-	 *
+    /**
+     * Perun web session
+     */
+    private PerunWebSession session = PerunWebSession.getInstance();
+
+    /**
+     * Content widget - should be simple panel
+     */
+    private SimplePanel contentWidget = new SimplePanel();
+
+    /**
+     * Title widget
+     */
+    private Label titleWidget = new Label("Loading facility");
+
+    // data
+    private int facilityId;
+    private Facility facility;
+    private int selectedDropDownIndex = 0;
+
+    /**
+     * Creates a tab instance
+     *
      * @param facility Facility
      */
-	public FacilityManagersTabItem(Facility facility){
-		this.facility = facility;
-		this.facilityId = facility.getId();
-	}
-	
-	/**
-	 * Creates a tab instance
-	 *
+    public FacilityManagersTabItem(Facility facility){
+        this.facility = facility;
+        this.facilityId = facility.getId();
+    }
+
+    /**
+     * Creates a tab instance
+     *
      * @param facilityId ID of facility
      */
-	public FacilityManagersTabItem(int facilityId){
-		this.facilityId = facilityId;
+    public FacilityManagersTabItem(int facilityId){
+        this.facilityId = facilityId;
         new GetEntityById(PerunEntity.FACILITY, facilityId, new JsonCallbackEvents(){
             public void onFinished(JavaScriptObject jso){
                 facility = jso.cast();
             }
         }).retrieveData();
-	}
-	
-	public boolean isPrepared(){
-		return !(facility == null);
-	}
-	
-	public Widget draw() {
-		
-		// set title
-		titleWidget.setText(Utils.getStrippedStringWithEllipsis(facility.getName())+" ("+facility.getType()+"): Managers");
+    }
 
-		// content
-		VerticalPanel vp = new VerticalPanel();
-		vp.setSize("100%", "100%");
+    public boolean isPrepared(){
+        return !(facility == null);
+    }
 
-		// Menu
-		TabMenu menu = new TabMenu();
-		
-		// get the table
-		final GetRichAdminsWithAttributes jsonCallback = new GetRichAdminsWithAttributes(PerunEntity.FACILITY, facilityId, null);
-		CellTable<User> table;
+    public Widget draw() {
+
+        // set title
+        titleWidget.setText(Utils.getStrippedStringWithEllipsis(facility.getName())+" ("+facility.getType()+"): Managers");
+
+        // content
+        VerticalPanel vp = new VerticalPanel();
+        vp.setSize("100%", "100%");
+
+        // HORIZONTAL MENU
+        final TabMenu menu = new TabMenu();
+
+        final ListBox box = new ListBox();
+        box.addItem("Users");
+        box.addItem("Groups");
+        box.setSelectedIndex(selectedDropDownIndex);
+
+        final ScrollPanel sp = new ScrollPanel();
+        sp.addStyleName("perun-tableScrollPanel");
+
+        // request
+        final GetRichAdminsWithAttributes admins = new GetRichAdminsWithAttributes(PerunEntity.FACILITY, facilityId, null);
+        final GetAdminGroups adminGroups = new GetAdminGroups(PerunEntity.FACILITY, facilityId);
+
+        box.addChangeHandler(new ChangeHandler() {
+            @Override
+            public void onChange(ChangeEvent event) {
+
+                if (box.getSelectedIndex() == 0) {
+                    selectedDropDownIndex = 0;
+                    sp.setWidget(fillContentUsers(admins, menu));
+                } else {
+                    selectedDropDownIndex = 1;
+                    sp.setWidget(fillContentGroups(adminGroups, menu));
+                }
+
+            }
+        });
+
+        if (selectedDropDownIndex == 0) {
+            sp.setWidget(fillContentUsers(admins, menu));
+        } else {
+            sp.setWidget(fillContentGroups(adminGroups, menu));
+        }
+
+        menu.addWidget(2, new HTML("<strong>Select mode: </strong>"));
+        menu.addWidget(3, box);
+        menu.addWidget(4, new Image(SmallIcons.INSTANCE.helpIcon()));
+        menu.addWidget(5, new HTML("<strong>People with privilege to manage this facility in Perun. They aren't automatically \"roots\" on machine.</strong>"));
+
+        session.getUiElements().resizePerunTable(sp, 350, this);
+
+        // add menu and the table to the main panel
+        vp.add(menu);
+        vp.setCellHeight(menu, "30px");
+        vp.add(sp);
+
+        this.contentWidget.setWidget(vp);
+
+        return getWidget();
+
+    }
+
+    private Widget fillContentUsers(final GetRichAdminsWithAttributes jsonCallback, TabMenu menu) {
+
+        jsonCallback.clearTableSelectedSet();
+
+        // get the table
+        CellTable<User> table;
         if (session.isPerunAdmin()) {
             table = jsonCallback.getTable(new FieldUpdater<User, String>() {
                 @Override
@@ -111,17 +171,17 @@ public class FacilityManagersTabItem implements TabItem, TabItemWithUrl{
             table = jsonCallback.getTable();
         }
 
-		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addManagerToFacility(), new ClickHandler() {
+        menu.addWidget(0, TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addManagerToFacility(), new ClickHandler() {
             public void onClick(ClickEvent event) {
                 session.getTabManager().addTabToCurrentTab(new AddFacilityManagerTabItem(facility), true);
             }
         }));
-		
-		final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, ButtonTranslation.INSTANCE.removeManagerFromFacility());
-		menu.addWidget(removeButton);
-		removeButton.addClickHandler(new ClickHandler(){
-			public void onClick(ClickEvent event) {
-				final ArrayList<User> list = jsonCallback.getTableSelectedList();
+
+        final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, ButtonTranslation.INSTANCE.removeManagerFromFacility());
+        menu.addWidget(1, removeButton);
+        removeButton.addClickHandler(new ClickHandler(){
+            public void onClick(ClickEvent event) {
+                final ArrayList<User> list = jsonCallback.getTableSelectedList();
                 String text = "Following users won't be facility managers anymore and won't be able to manage this facility in Perun.";
                 UiElements.showDeleteConfirm(list, text, new ClickHandler() {
                     @Override
@@ -138,111 +198,149 @@ public class FacilityManagersTabItem implements TabItem, TabItemWithUrl{
                         }
                     }
                 });
-			}
-		});
-
-        menu.addWidget(new Image(SmallIcons.INSTANCE.helpIcon()));
-        menu.addWidget(new HTML("<strong>People with privilege to manage this facility in Perun. They aren't automatically \"roots\" on machine.</strong>"));
-
-		vp.add(menu);
-		vp.setCellHeight(menu, "30px");
+            }
+        });
 
         removeButton.setEnabled(false);
         JsonUtils.addTableManagedButton(jsonCallback, table, removeButton);
 
-		table.addStyleName("perun-table");
-		ScrollPanel sp = new ScrollPanel(table);
-		sp.addStyleName("perun-tableScrollPanel");		
+        table.addStyleName("perun-table");
 
-		vp.add(sp);
+        return table;
 
-		session.getUiElements().resizePerunTable(sp, 350, this);
+    }
 
-		this.contentWidget.setWidget(vp);
-		return getWidget();
-		
-	}
+    private Widget fillContentGroups(final GetAdminGroups jsonCallback, TabMenu menu) {
 
-	public Widget getWidget() {
-		return this.contentWidget;
-	}
+        jsonCallback.clearTableSelectedSet();
 
-	public Widget getTitle() {
-		return this.titleWidget;
-	}
+        // get the table
+        CellTable<Group> table = jsonCallback.getTable(new FieldUpdater<Group, String>() {
+            @Override
+            public void update(int i, Group grp, String s) {
+                session.getTabManager().addTab(new GroupDetailTabItem(grp));
+            }
+        });
 
-	public ImageResource getIcon() {
-		return SmallIcons.INSTANCE.administratorIcon(); 
-	}
+        menu.addWidget(0, TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addManagerGroupToFacility(), new ClickHandler() {
+            public void onClick(ClickEvent event) {
+                session.getTabManager().addTabToCurrentTab(new AddFacilityManagerGroupTabItem(facility, JsonCallbackEvents.refreshTableEvents(jsonCallback)), true);
+            }
+        }));
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + facilityId;
-		return result;
-	}
+        final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, ButtonTranslation.INSTANCE.removeManagerGroupFromFacility());
+        menu.addWidget(1, removeButton);
+        removeButton.addClickHandler(new ClickHandler(){
+            public void onClick(ClickEvent event) {
+                final ArrayList<Group> list = jsonCallback.getTableSelectedList();
+                String text = "Members of following groups won't be facility managers anymore and won't be able to manage this facility in Perun.";
+                UiElements.showDeleteConfirm(list, text, new ClickHandler() {
+                    @Override
+                    public void onClick(ClickEvent clickEvent) {
+                        // TODO - SHOULD HAVE ONLY ONE CALLBACK TO CORE !!
+                        for (int i=0; i<list.size(); i++) {
+                            if (i == list.size()-1) {
+                                RemoveAdmin request = new RemoveAdmin(PerunEntity.FACILITY, JsonCallbackEvents.disableButtonEvents(removeButton, JsonCallbackEvents.refreshTableEvents(jsonCallback)));
+                                request.removeAdminGroup(facilityId, list.get(i).getId());
+                            } else {
+                                RemoveAdmin request = new RemoveAdmin(PerunEntity.FACILITY, JsonCallbackEvents.disableButtonEvents(removeButton));
+                                request.removeAdminGroup(facilityId, list.get(i).getId());
+                            }
+                        }
+                    }
+                });
+            }
+        });
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
+        removeButton.setEnabled(false);
+        JsonUtils.addTableManagedButton(jsonCallback, table, removeButton);
+
+        table.addStyleName("perun-table");
+
+        return table;
+
+    }
+
+    public Widget getWidget() {
+        return this.contentWidget;
+    }
+
+    public Widget getTitle() {
+        return this.titleWidget;
+    }
+
+    public ImageResource getIcon() {
+        return SmallIcons.INSTANCE.administratorIcon();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + facilityId;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
         FacilityManagersTabItem other = (FacilityManagersTabItem) obj;
-		if (facilityId != other.facilityId)
-			return false;
-		return true;
-	}
+        if (facilityId != other.facilityId)
+            return false;
+        return true;
+    }
 
-	public boolean multipleInstancesEnabled() {
-		return false;
-	}
-	
-	public void open()
-	{
-		session.getUiElements().getMenu().openMenu(MainMenu.FACILITY_ADMIN);
+    public boolean multipleInstancesEnabled() {
+        return false;
+    }
+
+    public void open()
+    {
+        session.getUiElements().getMenu().openMenu(MainMenu.FACILITY_ADMIN);
         session.getUiElements().getBreadcrumbs().setLocation(facility, "Managers", getUrlWithParameters());
-		if(facility != null) {
-			session.setActiveFacility(facility);
-		} else {
-			session.setActiveFacilityId(facilityId);
-		}
-	}
+        if(facility != null) {
+            session.setActiveFacility(facility);
+        } else {
+            session.setActiveFacilityId(facilityId);
+        }
+    }
 
-	public boolean isAuthorized() {
+    public boolean isAuthorized() {
 
-		if (session.isFacilityAdmin(facility.getId())) {
-			return true; 
-		} else {
-			return false;
-		}
+        if (session.isFacilityAdmin(facility.getId())) {
+            return true;
+        } else {
+            return false;
+        }
 
-	}
-	
-	public final static String URL = "managers";
-	
-	public String getUrl()
-	{
-		return URL;
-	}
-	
-	public String getUrlWithParameters()
-	{
-		return FacilitiesTabs.URL + UrlMapper.TAB_NAME_SEPARATOR + getUrl() + "?id=" + facilityId;
-	}
-	
-	static public FacilityManagersTabItem load(Facility facility)
-	{
-		return new FacilityManagersTabItem(facility);
-	}
-	
-	static public FacilityManagersTabItem load(Map<String, String> parameters)
-	{
-		int fid = Integer.parseInt(parameters.get("id"));
-		return new FacilityManagersTabItem(fid);
-	}
-	
+    }
+
+    public final static String URL = "managers";
+
+    public String getUrl()
+    {
+        return URL;
+    }
+
+    public String getUrlWithParameters()
+    {
+        return FacilitiesTabs.URL + UrlMapper.TAB_NAME_SEPARATOR + getUrl() + "?id=" + facilityId;
+    }
+
+    static public FacilityManagersTabItem load(Facility facility)
+    {
+        return new FacilityManagersTabItem(facility);
+    }
+
+    static public FacilityManagersTabItem load(Map<String, String> parameters)
+    {
+        int fid = Integer.parseInt(parameters.get("id"));
+        return new FacilityManagersTabItem(fid);
+    }
+
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerGroupTabItem.java
@@ -1,0 +1,294 @@
+package cz.metacentrum.perun.webgui.tabs.groupstabs;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.client.ui.*;
+import com.google.gwt.view.client.SelectionChangeEvent;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.UiElements;
+import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
+import cz.metacentrum.perun.webgui.client.resources.*;
+import cz.metacentrum.perun.webgui.json.GetEntityById;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.JsonUtils;
+import cz.metacentrum.perun.webgui.json.authzResolver.AddAdmin;
+import cz.metacentrum.perun.webgui.json.groupsManager.GetAllGroups;
+import cz.metacentrum.perun.webgui.json.vosManager.GetVos;
+import cz.metacentrum.perun.webgui.model.Group;
+import cz.metacentrum.perun.webgui.model.PerunError;
+import cz.metacentrum.perun.webgui.model.VirtualOrganization;
+import cz.metacentrum.perun.webgui.tabs.TabItem;
+import cz.metacentrum.perun.webgui.widgets.CustomButton;
+import cz.metacentrum.perun.webgui.widgets.ListBoxWithObjects;
+import cz.metacentrum.perun.webgui.widgets.TabMenu;
+
+import java.util.ArrayList;
+
+/**
+ * !! USE AS INNER TAB ONLY !!
+ *
+ * Provides page with add admin group to Group form
+ *
+ * @author Pavel Zlamal <256627@mail.muni.cz>
+ * @version $Id: $
+ */
+public class AddGroupManagerGroupTabItem implements TabItem {
+
+    /**
+     * Perun web session
+     */
+    private PerunWebSession session = PerunWebSession.getInstance();
+
+    /**
+     * Content widget - should be simple panel
+     */
+    private SimplePanel contentWidget = new SimplePanel();
+
+    /**
+     * Title widget
+     */
+    private Label titleWidget = new Label("Add group manager");
+
+    /**
+     * Entity ID to set
+     */
+    private int groupId = 0;
+    private Group group;
+    private GetAllGroups getAllGroups;
+    private JsonCallbackEvents refreshEvents;
+
+    /**
+     * Creates a tab instance
+     *
+     * @param groupId ID of Group to add admin into
+     * @param refreshEvents events to trigger on finish
+     */
+    public AddGroupManagerGroupTabItem(int groupId, JsonCallbackEvents refreshEvents){
+        this.groupId = groupId;
+        JsonCallbackEvents events = new JsonCallbackEvents(){
+            public void onFinished(JavaScriptObject jso) {
+                group = jso.cast();
+            }
+        };
+        new GetEntityById(PerunEntity.GROUP, groupId, events).retrieveData();
+        this.refreshEvents = refreshEvents;
+    }
+
+    /**
+     * Creates a tab instance
+     *
+     * @param group Group to add admin into
+     * @param refreshEvents events to trigger on finish
+     */
+    public AddGroupManagerGroupTabItem(Group group, JsonCallbackEvents refreshEvents){
+        this.groupId = group.getId();
+        this.group = group;
+        this.refreshEvents = refreshEvents;
+    }
+
+
+    public boolean isPrepared(){
+        return group != null;
+    }
+
+    public Widget draw() {
+
+        titleWidget.setText(Utils.getStrippedStringWithEllipsis(group.getShortName())+": add manager group");
+
+        // MAIN TAB PANEL
+        VerticalPanel firstTabPanel = new VerticalPanel();
+        firstTabPanel.setSize("100%", "100%");
+
+        // HORIZONTAL MENU
+        final TabMenu tabMenu = new TabMenu();
+        final ListBoxWithObjects<VirtualOrganization> box = new ListBoxWithObjects<VirtualOrganization>();
+
+        // pass empty items to menu to ensure drawing of rest
+        tabMenu.addWidget(new HTML(""));
+        tabMenu.addWidget(new HTML(""));
+        tabMenu.addWidget(2, new HTML("<strong>Select VO:</strong>"));
+        tabMenu.addWidget(3, box);
+
+        // get the table
+        final ScrollPanel sp = new ScrollPanel();
+        sp.addStyleName("perun-tableScrollPanel");
+
+        box.addChangeHandler(new ChangeHandler() {
+            @Override
+            public void onChange(ChangeEvent event) {
+                sp.setWidget(fillGroupsContent(new GetAllGroups(box.getSelectedObject().getId()), tabMenu, box));
+            }
+        });
+
+        if (box.getAllObjects().isEmpty()) {
+            GetVos vos = new GetVos(new JsonCallbackEvents(){
+                @Override
+                public void onFinished(JavaScriptObject jso) {
+                    box.clear();
+                    ArrayList<VirtualOrganization> list = new TableSorter<VirtualOrganization>().sortByName(JsonUtils.<VirtualOrganization>jsoAsList(jso));
+                    if (list != null && !list.isEmpty()) {
+                        box.addAllItems(list);
+                        sp.setWidget(fillGroupsContent(new GetAllGroups(box.getSelectedObject().getId()), tabMenu, box));
+                    } else {
+                        box.addItem("No VOs found");
+                    }
+                }
+                @Override
+                public void onError(PerunError error) {
+                    box.clear();
+                    box.addItem("Error while loading");
+                }
+                @Override
+                public void onLoadingStart() {
+                    box.clear();
+                    box.addItem("Loading...");
+                }
+            });
+            vos.retrieveData();
+        }
+
+        final TabItem tab = this;
+        tabMenu.addWidget(1, TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent clickEvent) {
+                if (refreshEvents != null) refreshEvents.onFinished(null);
+                session.getTabManager().closeTab(tab, false);
+            }
+        }));
+
+        // add menu and the table to the main panel
+        firstTabPanel.add(tabMenu);
+        firstTabPanel.setCellHeight(tabMenu, "30px");
+        firstTabPanel.add(sp);
+
+        session.getUiElements().resizePerunTable(sp, 350, this);
+
+        this.contentWidget.setWidget(firstTabPanel);
+
+        return getWidget();
+
+    }
+
+    private Widget fillGroupsContent(GetAllGroups groups, TabMenu tabMenu, final ListBoxWithObjects<VirtualOrganization> box) {
+
+        getAllGroups = groups;
+        getAllGroups.setCoreGroupsCheckable(true);
+        final CellTable<Group> table = getAllGroups.getTable();
+
+        getAllGroups.getSelectionModel().addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
+            private boolean found = false;
+            @Override
+            public void onSelectionChange(SelectionChangeEvent event) {
+                for (Group g : getAllGroups.getTableSelectedList()) {
+                    if (g.isCoreGroup()) {
+                        if (!found) {
+                            // display only once
+                            UiElements.generateInfo("You have selected 'all vo members' group", "If this group will be added as 'manager group', all new members of VO "+box.getSelectedObject().getName()+" will be automatically managers of your Group and all removed members will lose management rights.");
+                        }
+                        found = true;
+                        return;
+                    }
+                }
+                found = false;
+            }
+        });
+
+        final CustomButton addButton = TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addSelectedManagersGroupToGroup());
+        tabMenu.addWidget(0, addButton);
+        final TabItem tab = this;
+        addButton.addClickHandler(new ClickHandler(){
+            public void onClick(ClickEvent event) {
+                ArrayList<Group> list = getAllGroups.getTableSelectedList();
+                if (UiElements.cantSaveEmptyListDialogBox(list)){
+                    for (int i=0; i<list.size(); i++) {
+                        if (i == list.size() - 1) {
+                            AddAdmin request = new AddAdmin(PerunEntity.GROUP, JsonCallbackEvents.disableButtonEvents(addButton, new JsonCallbackEvents(){
+                                public void onFinished(JavaScriptObject jso) {
+                                    // close tab and refresh table
+                                    if (refreshEvents != null) refreshEvents.onFinished(null);
+                                    session.getTabManager().closeTab(tab, false);
+                                }
+                            }));
+                            request.addAdminGroup(groupId, list.get(i).getId());
+                        } else {
+                            AddAdmin request = new AddAdmin(PerunEntity.GROUP, JsonCallbackEvents.disableButtonEvents(addButton));
+                            request.addAdminGroup(groupId, list.get(i).getId());
+                        }
+                    }
+                }
+            }
+        });
+
+        addButton.setEnabled(false);
+        JsonUtils.addTableManagedButton(getAllGroups, table, addButton);
+
+        // add a class to the table and wrap it into scroll panel
+        table.addStyleName("perun-table");
+
+        return table;
+
+    }
+
+    public Widget getWidget() {
+        return this.contentWidget;
+    }
+
+    public Widget getTitle() {
+        return this.titleWidget;
+    }
+
+    public ImageResource getIcon() {
+        return SmallIcons.INSTANCE.addIcon();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + 6786786;
+        return result;
+    }
+
+    /**
+     * @param obj
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+
+        AddGroupManagerGroupTabItem create = (AddGroupManagerGroupTabItem) obj;
+        if (groupId != create.groupId){
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean multipleInstancesEnabled() {
+        return false;
+    }
+
+    public void open() {
+    }
+
+    public boolean isAuthorized() {
+
+        if (session.isVoAdmin(group.getVoId()) || session.isGroupAdmin(groupId)) {
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerTabItem.java
@@ -10,7 +10,6 @@ import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
-import cz.metacentrum.perun.webgui.client.mainmenu.MainMenu;
 import cz.metacentrum.perun.webgui.client.resources.*;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
@@ -26,16 +25,17 @@ import cz.metacentrum.perun.webgui.widgets.CustomButton;
 import cz.metacentrum.perun.webgui.widgets.TabMenu;
 
 import java.util.ArrayList;
-import java.util.Map;
 
 /**
- * Provides page with add admin to VO form
+ * Provides page with add admin to Group form
+ *
+ * !! USE AS INNER TAB ONLY !!
  * 
  * @author Pavel Zlamal <256627@mail.muni.cz>
  * @author Vaclav Mach <374430@mail.muni.cz>
- * @version $Id$
+ * @version $Id: $
  */
-public class AddGroupManagerTabItem implements TabItem, TabItemWithUrl{
+public class AddGroupManagerTabItem implements TabItem {
 
 	/**
 	 * Perun web session
@@ -275,7 +275,7 @@ public class AddGroupManagerTabItem implements TabItem, TabItemWithUrl{
 	}
 
 	public ImageResource getIcon() {
-		return SmallIcons.INSTANCE.administratorIcon(); 
+		return SmallIcons.INSTANCE.addIcon();
 	}
 
 	@Override
@@ -310,15 +310,7 @@ public class AddGroupManagerTabItem implements TabItem, TabItemWithUrl{
 		return false;
 	}
 	
-	public void open()
-	{
-		session.getUiElements().getMenu().openMenu(MainMenu.GROUP_ADMIN);
-		if(group != null){
-			session.setActiveGroup(group);
-			return;
-		}
-		session.setActiveGroupId(groupId);
-		
+	public void open() {
 	}
 	
 	public boolean isAuthorized() {
@@ -329,24 +321,6 @@ public class AddGroupManagerTabItem implements TabItem, TabItemWithUrl{
 			return false;
 		}
 
-	}
-	
-	public final static String URL = "add-manager";
-	
-	public String getUrl()
-	{
-		return URL;
-	}
-	
-	public String getUrlWithParameters()
-	{
-		return GroupsTabs.URL + UrlMapper.TAB_NAME_SEPARATOR + getUrl() + "?id=" + groupId;
-	}
-	
-	static public AddGroupManagerTabItem load(Map<String, String> parameters)
-	{
-		int id = Integer.parseInt(parameters.get("id"));
-		return new AddGroupManagerTabItem(id);
 	}
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerGroupTabItem.java
@@ -1,0 +1,296 @@
+package cz.metacentrum.perun.webgui.tabs.vostabs;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.client.ui.*;
+import com.google.gwt.view.client.SelectionChangeEvent;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.UiElements;
+import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
+import cz.metacentrum.perun.webgui.client.resources.*;
+import cz.metacentrum.perun.webgui.json.GetEntityById;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.JsonUtils;
+import cz.metacentrum.perun.webgui.json.authzResolver.AddAdmin;
+import cz.metacentrum.perun.webgui.json.groupsManager.GetAllGroups;
+import cz.metacentrum.perun.webgui.json.vosManager.GetVos;
+import cz.metacentrum.perun.webgui.model.Group;
+import cz.metacentrum.perun.webgui.model.PerunError;
+import cz.metacentrum.perun.webgui.model.VirtualOrganization;
+import cz.metacentrum.perun.webgui.tabs.TabItem;
+import cz.metacentrum.perun.webgui.widgets.CustomButton;
+import cz.metacentrum.perun.webgui.widgets.ListBoxWithObjects;
+import cz.metacentrum.perun.webgui.widgets.TabMenu;
+
+import java.util.ArrayList;
+
+/**
+ * !! USE AS INNER TAB ONLY !!
+ *
+ * Provides page with add admin group to VO form
+ *
+ * @author Pavel Zlamal <256627@mail.muni.cz>
+ * @version $Id: $
+ */
+public class AddVoManagerGroupTabItem implements TabItem {
+
+    /**
+     * Perun web session
+     */
+    private PerunWebSession session = PerunWebSession.getInstance();
+
+    /**
+     * Content widget - should be simple panel
+     */
+    private SimplePanel contentWidget = new SimplePanel();
+
+    /**
+     * Title widget
+     */
+    private Label titleWidget = new Label("Add VO manager");
+
+    /**
+     * Entity ID to set
+     */
+    private int voId = 0;
+    private VirtualOrganization vo;
+    private GetAllGroups getAllGroups;
+    private JsonCallbackEvents refreshEvents;
+
+    /**
+     * Creates a tab instance
+     *
+     * @param voId ID of VO to add admin into
+     * @param refreshEvents events to trigger on finish
+     */
+    public AddVoManagerGroupTabItem(int voId, JsonCallbackEvents refreshEvents){
+        this.voId = voId;
+        JsonCallbackEvents events = new JsonCallbackEvents(){
+            public void onFinished(JavaScriptObject jso) {
+                vo = jso.cast();
+            }
+        };
+        new GetEntityById(PerunEntity.VIRTUAL_ORGANIZATION, voId, events).retrieveData();
+        this.refreshEvents = refreshEvents;
+    }
+
+    /**
+     * Creates a tab instance
+     *
+     * @param vo VO to add admin into
+     * @param refreshEvents events to trigger on finish
+     */
+    public AddVoManagerGroupTabItem(VirtualOrganization vo, JsonCallbackEvents refreshEvents){
+        this.voId = vo.getId();
+        this.vo = vo;
+        this.refreshEvents = refreshEvents;
+    }
+
+
+    public boolean isPrepared(){
+        return vo != null;
+    }
+
+    public Widget draw() {
+
+        titleWidget.setText(Utils.getStrippedStringWithEllipsis(vo.getName())+": add manager group");
+
+        // MAIN TAB PANEL
+        VerticalPanel firstTabPanel = new VerticalPanel();
+        firstTabPanel.setSize("100%", "100%");
+
+        // HORIZONTAL MENU
+        final TabMenu tabMenu = new TabMenu();
+        final ListBoxWithObjects<VirtualOrganization> box = new ListBoxWithObjects<VirtualOrganization>();
+
+        // get the table
+        final ScrollPanel sp = new ScrollPanel();
+        sp.addStyleName("perun-tableScrollPanel");
+
+        box.addChangeHandler(new ChangeHandler() {
+            @Override
+            public void onChange(ChangeEvent event) {
+                sp.setWidget(fillGroupsContent(new GetAllGroups(box.getSelectedObject().getId()), tabMenu, box));
+            }
+        });
+
+        if (box.getAllObjects().isEmpty()) {
+            GetVos vos = new GetVos(new JsonCallbackEvents(){
+                @Override
+                public void onFinished(JavaScriptObject jso) {
+                    box.clear();
+                    ArrayList<VirtualOrganization> list = new TableSorter<VirtualOrganization>().sortByName(JsonUtils.<VirtualOrganization>jsoAsList(jso));
+                    if (list != null && !list.isEmpty()) {
+                        box.addAllItems(list);
+                        sp.setWidget(fillGroupsContent(new GetAllGroups(box.getSelectedObject().getId()), tabMenu, box));
+                    } else {
+                        box.addItem("No VOs found");
+                    }
+                }
+                @Override
+                public void onError(PerunError error) {
+                    box.clear();
+                    box.addItem("Error while loading");
+                }
+                @Override
+                public void onLoadingStart() {
+                    box.clear();
+                    box.addItem("Loading...");
+                }
+            });
+            vos.retrieveData();
+        }
+
+        // add menu and the table to the main panel
+        firstTabPanel.add(tabMenu);
+        firstTabPanel.setCellHeight(tabMenu, "30px");
+        firstTabPanel.add(sp);
+
+        // pass empty first item to tab menu to ensure rest is added
+        tabMenu.addWidget(new HTML(""));
+
+        final TabItem tab = this;
+        tabMenu.addWidget(1, TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent clickEvent) {
+                if (refreshEvents != null) refreshEvents.onFinished(null);
+                session.getTabManager().closeTab(tab, false);
+            }
+        }));
+
+        tabMenu.addWidget(2, new HTML("<strong>Select VO:</strong>"));
+        tabMenu.addWidget(3, box);
+
+        session.getUiElements().resizePerunTable(sp, 350, this);
+
+        this.contentWidget.setWidget(firstTabPanel);
+
+        return getWidget();
+
+    }
+
+    private Widget fillGroupsContent(GetAllGroups groups, TabMenu tabMenu, final ListBoxWithObjects<VirtualOrganization> box) {
+
+        getAllGroups = groups;
+        getAllGroups.setCoreGroupsCheckable(true);
+        final CellTable<Group> table = getAllGroups.getTable();
+
+        getAllGroups.getSelectionModel().addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
+            private boolean found = false;
+            @Override
+            public void onSelectionChange(SelectionChangeEvent event) {
+                for (Group g : getAllGroups.getTableSelectedList()) {
+                    if (g.isCoreGroup()) {
+                        if (!found) {
+                            // display only once
+                            UiElements.generateInfo("You have selected 'all vo members' group", "If this group will be added as 'manager group', all new members of VO "+box.getSelectedObject().getName()+" will be automatically managers of your VO and all removed members will lose management rights.");
+                        }
+                        found = true;
+                        return;
+                    }
+                }
+                found = false;
+            }
+        });
+
+        final CustomButton addButton = TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addSelectedManagersGroupToVo());
+        tabMenu.addWidget(0, addButton);
+        final TabItem tab = this;
+        addButton.addClickHandler(new ClickHandler(){
+            public void onClick(ClickEvent event) {
+                ArrayList<Group> list = getAllGroups.getTableSelectedList();
+                if (UiElements.cantSaveEmptyListDialogBox(list)){
+                    for (int i=0; i<list.size(); i++) {
+                        if (i == list.size() - 1) {
+                            AddAdmin request = new AddAdmin(PerunEntity.VIRTUAL_ORGANIZATION, JsonCallbackEvents.disableButtonEvents(addButton, new JsonCallbackEvents(){
+                                public void onFinished(JavaScriptObject jso) {
+                                    // close tab and refresh table
+                                    if (refreshEvents != null) refreshEvents.onFinished(null);
+                                    session.getTabManager().closeTab(tab, false);
+                                }
+                            }));
+                            request.addAdminGroup(voId, list.get(i).getId());
+                        } else {
+                            AddAdmin request = new AddAdmin(PerunEntity.VIRTUAL_ORGANIZATION, JsonCallbackEvents.disableButtonEvents(addButton));
+                            request.addAdminGroup(voId, list.get(i).getId());
+                        }
+                    }
+                }
+            }
+        });
+
+        addButton.setEnabled(false);
+        JsonUtils.addTableManagedButton(getAllGroups, table, addButton);
+
+        // add a class to the table and wrap it into scroll panel
+        table.addStyleName("perun-table");
+
+        return table;
+
+    }
+
+    public Widget getWidget() {
+        return this.contentWidget;
+    }
+
+    public Widget getTitle() {
+        return this.titleWidget;
+    }
+
+    public ImageResource getIcon() {
+        return SmallIcons.INSTANCE.addIcon();
+    }
+
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + 6786786;
+        return result;
+    }
+
+    /**
+     * @param obj
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+
+        AddVoManagerGroupTabItem create = (AddVoManagerGroupTabItem) obj;
+        if (voId != create.voId){
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean multipleInstancesEnabled() {
+        return false;
+    }
+
+    public void open() {
+    }
+
+
+    public boolean isAuthorized() {
+
+        if (session.isVoAdmin(voId)) {
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerTabItem.java
@@ -10,7 +10,6 @@ import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
-import cz.metacentrum.perun.webgui.client.mainmenu.MainMenu;
 import cz.metacentrum.perun.webgui.client.resources.*;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
@@ -35,9 +34,9 @@ import java.util.Map;
  * 
  * @author Pavel Zlamal <256627@mail.muni.cz>
  * @author Vaclav Mach <374430@mail.muni.cz>
- * @version $Id$
+ * @version $Id: c9103388cea74cc079e1a408a09442ac2cdbb81a $
  */
-public class AddVoManagerTabItem implements TabItem, TabItemWithUrl{
+public class AddVoManagerTabItem implements TabItem {
 
 	/**
 	 * Perun web session
@@ -260,7 +259,7 @@ public class AddVoManagerTabItem implements TabItem, TabItemWithUrl{
 	}
 
 	public ImageResource getIcon() {
-		return SmallIcons.INSTANCE.administratorIcon(); 
+		return SmallIcons.INSTANCE.addIcon();
 	}
 
 
@@ -296,17 +295,9 @@ public class AddVoManagerTabItem implements TabItem, TabItemWithUrl{
 		return false;
 	}
 	
-	public void open()
-	{
-		session.getUiElements().getMenu().openMenu(MainMenu.VO_ADMIN);
-		if(vo != null){
-			session.setActiveVo(vo);
-			return;
-		}
-		session.setActiveVoId(voId);
+	public void open() {
 	}
 
-	
 	public boolean isAuthorized() {
 
 		if (session.isVoAdmin(voId)) {
@@ -316,23 +307,5 @@ public class AddVoManagerTabItem implements TabItem, TabItemWithUrl{
 		}
 
 	}
-	
-	
-	public final static String URL = "add-manager";
-	
-	public String getUrl()
-	{
-		return URL;
-	}
-	
-	public String getUrlWithParameters()
-	{
-		return VosTabs.URL + UrlMapper.TAB_NAME_SEPARATOR + getUrl() + "?id=" + voId;
-	}
-	
-	static public AddVoManagerTabItem load(Map<String, String> parameters)
-	{
-		int voId = Integer.parseInt(parameters.get("id"));
-		return new AddVoManagerTabItem(voId);
-	}
+
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoManagersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoManagersTabItem.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.webgui.tabs.vostabs;
 
 import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
@@ -15,11 +17,14 @@ import cz.metacentrum.perun.webgui.client.resources.*;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
+import cz.metacentrum.perun.webgui.json.authzResolver.GetAdminGroups;
 import cz.metacentrum.perun.webgui.json.authzResolver.GetRichAdminsWithAttributes;
 import cz.metacentrum.perun.webgui.json.authzResolver.RemoveAdmin;
+import cz.metacentrum.perun.webgui.model.Group;
 import cz.metacentrum.perun.webgui.model.User;
 import cz.metacentrum.perun.webgui.model.VirtualOrganization;
 import cz.metacentrum.perun.webgui.tabs.*;
+import cz.metacentrum.perun.webgui.tabs.groupstabs.GroupDetailTabItem;
 import cz.metacentrum.perun.webgui.tabs.userstabs.UserDetailTabItem;
 import cz.metacentrum.perun.webgui.widgets.CustomButton;
 import cz.metacentrum.perun.webgui.widgets.TabMenu;
@@ -32,9 +37,9 @@ import java.util.Map;
  * 
  * @author Vaclav Mach <374430@mail.muni.cz>
  * @author Pavel Zlamal <256627@mail.muni.cz>
- * @version $Id$
+ * @version $Id: 0c2d0786c3c7f2b51bcb8f9ee9a114e1a220fcfe $
  */
-public class VoManagersTabItem implements TabItem, TabItemWithUrl{
+public class VoManagersTabItem implements TabItem, TabItemWithUrl {
 
 	/**
 	 * Perun web session
@@ -53,8 +58,8 @@ public class VoManagersTabItem implements TabItem, TabItemWithUrl{
 	
 	// data
 	private VirtualOrganization vo;
-	//
 	private int voId;
+    private int selectedDropDownIndex = 0;
 
 	/**
 	 * Creates a tab instance
@@ -95,29 +100,78 @@ public class VoManagersTabItem implements TabItem, TabItemWithUrl{
 		firstTabPanel.setSize("100%", "100%");
 
 		// HORIZONTAL MENU
-		TabMenu menu = new TabMenu();
+		final TabMenu menu = new TabMenu();
 
-		// members request
-		final GetRichAdminsWithAttributes admins = new GetRichAdminsWithAttributes(PerunEntity.VIRTUAL_ORGANIZATION, voId, null);
+        final ListBox box = new ListBox();
+        box.addItem("Users");
+        box.addItem("Groups");
+        box.setSelectedIndex(selectedDropDownIndex);
 
-		// Events for reloading when finished
-		final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(admins);
+        final ScrollPanel sp = new ScrollPanel();
+        sp.addStyleName("perun-tableScrollPanel");
 
-		CustomButton addButton = TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addManagerToVo(), new ClickHandler() {
-            public void onClick(ClickEvent event) {
-                session.getTabManager().addTabToCurrentTab(new AddVoManagerTabItem(voId), true);
+        // request
+        final GetRichAdminsWithAttributes admins = new GetRichAdminsWithAttributes(PerunEntity.VIRTUAL_ORGANIZATION, voId, null);
+        final GetAdminGroups adminGroups = new GetAdminGroups(PerunEntity.VIRTUAL_ORGANIZATION, voId);
+
+        box.addChangeHandler(new ChangeHandler() {
+            @Override
+            public void onChange(ChangeEvent event) {
+
+                if (box.getSelectedIndex() == 0) {
+                    selectedDropDownIndex = 0;
+                    sp.setWidget(fillContentUsers(admins, menu));
+                } else {
+                    selectedDropDownIndex = 1;
+                    sp.setWidget(fillContentGroups(adminGroups, menu));
+                }
+
             }
         });
-		menu.addWidget(addButton);
+
+        if (selectedDropDownIndex == 0) {
+            sp.setWidget(fillContentUsers(admins, menu));
+        } else {
+            sp.setWidget(fillContentGroups(adminGroups, menu));
+        }
+
+        menu.addWidget(2, new HTML("<strong>Select mode: </strong>"));
+        menu.addWidget(3, box);
+
+        session.getUiElements().resizePerunTable(sp, 350, this);
+
+		// add menu and the table to the main panel
+		firstTabPanel.add(menu);
+		firstTabPanel.setCellHeight(menu, "30px");
+		firstTabPanel.add(sp);
+
+		this.contentWidget.setWidget(firstTabPanel);
+		
+		return getWidget();
+	}
+
+    private Widget fillContentUsers(final GetRichAdminsWithAttributes admins, TabMenu menu) {
+
+        admins.clearTableSelectedSet();
+
+        // Events for reloading when finished
+        final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(admins);
+
+        CustomButton addButton = TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addManagerToVo(), new ClickHandler() {
+            public void onClick(ClickEvent event) {
+                session.getTabManager().addTabToCurrentTab(new AddVoManagerTabItem(vo), true);
+            }
+        });
+        menu.addWidget(0, addButton);
 
 
-		final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, ButtonTranslation.INSTANCE.removeManagerFromVo());
-		menu.addWidget(removeButton);
+        final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, ButtonTranslation.INSTANCE.removeManagerFromVo());
+        menu.addWidget(1, removeButton);
         removeButton.addClickHandler(new ClickHandler() {
-			public void onClick(ClickEvent event) {
-				final ArrayList<User> adminsForRemoving = admins.getTableSelectedList();
+            public void onClick(ClickEvent event) {
+                final ArrayList<User> adminsForRemoving = admins.getTableSelectedList();
                 String text = "Following users won't be VO managers anymore.";
-				UiElements.showDeleteConfirm(adminsForRemoving, text, new ClickHandler() {
+                UiElements.showDeleteConfirm(adminsForRemoving, text, new ClickHandler() {
                     @Override
                     public void onClick(ClickEvent clickEvent) {
                         // TODO - SHOULD HAVE ONLY ONE CALLBACK TO CORE !!
@@ -132,8 +186,8 @@ public class VoManagersTabItem implements TabItem, TabItemWithUrl{
                         }
                     }
                 });
-			}
-		});
+            }
+        });
 
         // get the table
         CellTable<User> table;
@@ -147,25 +201,70 @@ public class VoManagersTabItem implements TabItem, TabItemWithUrl{
             table = admins.getTable();
         }
 
-		// add a class to the table and wrap it into scroll panel
-		table.addStyleName("perun-table");
-		ScrollPanel sp = new ScrollPanel(table);
-		sp.addStyleName("perun-tableScrollPanel");		
-
-		// add menu and the table to the main panel
-		firstTabPanel.add(menu);
-		firstTabPanel.setCellHeight(menu, "30px");
-		firstTabPanel.add(sp);
+        // add a class to the table and wrap it into scroll panel
+        table.addStyleName("perun-table");
 
         removeButton.setEnabled(false);
         JsonUtils.addTableManagedButton(admins, table, removeButton);
 
-		session.getUiElements().resizePerunTable(sp, 350, this);
+        return table;
 
-		this.contentWidget.setWidget(firstTabPanel);
-		
-		return getWidget();
-	}
+    }
+
+    private Widget fillContentGroups(final GetAdminGroups adminGroups, TabMenu menu) {
+
+        adminGroups.clearTableSelectedSet();
+
+        // Events for reloading when finished
+        final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(adminGroups);
+
+        CustomButton addButton = TabMenu.getPredefinedButton(ButtonType.ADD, ButtonTranslation.INSTANCE.addManagerGroupToVo(), new ClickHandler() {
+            public void onClick(ClickEvent event) {
+                session.getTabManager().addTabToCurrentTab(new AddVoManagerGroupTabItem(vo, events), true);
+            }
+        });
+        menu.addWidget(0, addButton);
+
+
+        final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, ButtonTranslation.INSTANCE.removeManagerGroupFromVo());
+        menu.addWidget(1, removeButton);
+        removeButton.addClickHandler(new ClickHandler() {
+            public void onClick(ClickEvent event) {
+                final ArrayList<Group> adminsForRemoving = adminGroups.getTableSelectedList();
+                String text = "Members of following groups won't be VO managers anymore.";
+                UiElements.showDeleteConfirm(adminsForRemoving, text, new ClickHandler() {
+                    @Override
+                    public void onClick(ClickEvent clickEvent) {
+                        // TODO - SHOULD HAVE ONLY ONE CALLBACK TO CORE !!
+                        for (int i=0; i<adminsForRemoving.size(); i++ ) {
+                            RemoveAdmin request;
+                            if(i == adminsForRemoving.size() - 1) {
+                                request = new RemoveAdmin(PerunEntity.VIRTUAL_ORGANIZATION, JsonCallbackEvents.disableButtonEvents(removeButton, events));
+                            } else {
+                                request = new RemoveAdmin(PerunEntity.VIRTUAL_ORGANIZATION, JsonCallbackEvents.disableButtonEvents(removeButton));
+                            }
+                            request.removeAdminGroup(voId, adminsForRemoving.get(i).getId());
+                        }
+                    }
+                });
+            }
+        });
+
+        // get the table
+        CellTable<Group> table = adminGroups.getTable(new FieldUpdater<Group, String>() {
+                public void update(int i, Group grp, String s) {
+                    session.getTabManager().addTab(new GroupDetailTabItem(grp));
+                }
+            });
+
+        // add a class to the table and wrap it into scroll panel
+        table.addStyleName("perun-table");
+
+        removeButton.setEnabled(false);
+        JsonUtils.addTableManagedButton(adminGroups, table, removeButton);
+
+        return table;
+    }
 
 	public Widget getWidget() {
 		return this.contentWidget;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/TabMenu.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/TabMenu.java
@@ -8,6 +8,7 @@ import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.UiElements;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
@@ -26,9 +27,9 @@ public class TabMenu extends Composite {
 
     // menu content
     private FlexTable menu = new FlexTable();
-    private int cellsCount = 0;
     private static ButtonTranslation translation = ButtonTranslation.INSTANCE;
     private static SmallIcons icons = SmallIcons.INSTANCE;
+    private int cellCount = 0;
 
     /**
      * Constructor for tab menu
@@ -43,36 +44,45 @@ public class TabMenu extends Composite {
      * @param widget
      */
     public void addWidget(Widget widget){
-
-        // set style
-        menu.getFlexCellFormatter().addStyleName(0, cellsCount, "tabMenu");
-        if (cellsCount == 0) {
-            // set first and last
-            menu.getFlexCellFormatter().addStyleName(0, cellsCount, "tabMenu-first");
-            menu.getFlexCellFormatter().addStyleName(0, cellsCount, "tabMenu-last");
-        } else if (cellsCount > 0) {
-            // move last from previous to this
-            menu.getFlexCellFormatter().removeStyleName(0, cellsCount-1, "tabMenu-last");
-            menu.getFlexCellFormatter().addStyleName(0, cellsCount, "tabMenu-last");
-        }
-
-        menu.setWidget(0, cellsCount, widget);
-
-        cellsCount++;
-
+        addWidget(cellCount, widget);
     }
 
     /**
      * Method which adds any kind of widget into TabMenu on specific position
      * (replace any content on this position)
      *
-     * @param widget
+     * @param position position in menu starting from 0
+     * @param widget widget to put in menu
      */
     public void addWidget(int position, Widget widget){
 
-        menu.setWidget(0, position, widget);
-        // TODO - better handling
+        if (position <= cellCount) {
+            menu.setWidget(0, position, widget);
+            if (position == cellCount) {
+                cellCount++; // if new
+                setStyles();
+            }
+        } else {
+            // TODO not allowed
+        }
 
+    }
+
+    /**
+     * Method to set proper CSS styles to menu widget.
+     * Should be called after any widget content change
+     */
+    private void setStyles() {
+
+        // set proper last item tag
+        for (int i=0; i < cellCount; i++) {
+            if (i == 0) menu.getFlexCellFormatter().addStyleName(0, i, "tabMenu-first");
+            menu.getFlexCellFormatter().addStyleName(0, i, "tabMenu");
+            menu.getFlexCellFormatter().removeStyleName(0, i, "tabMenu-last");
+            if (i == cellCount-1) {
+                menu.getFlexCellFormatter().addStyleName(0, i, "tabMenu-last");
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
- TabMenu - proper way of styling and widget putting
- added calls to get/add/remove managers groups
- added new buttons translation
- groups can be VO/Group/Facility managers
- removed unnecessary code
- groups to be added as managers are offered based on VO/Group admin rights
- if 'members' group is about to be added, warning is show to inform user about consequences
