### PR TITLE
GUI: fixed IE compatibility

### DIFF
--- a/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
+++ b/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
@@ -36,8 +36,9 @@
 	<!--  Support only these browsers for devel -->
 	
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
-	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
-	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
+    <extend-property name="user.agent" values="safari" /> <!-- CHROME -->
+    <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
+    <extend-property name="user.agent" values="ie9" />
     <!-- Other possibilities are 'ie6', 'ie8', 'opera', 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 	

--- a/perun-web-gui/src/main/webapp/ApplicationForm.html
+++ b/perun-web-gui/src/main/webapp/ApplicationForm.html
@@ -11,9 +11,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/ApplicationFormCert.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormCert.html
@@ -11,9 +11,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/ApplicationFormFed.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormFed.html
@@ -11,9 +11,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/ApplicationFormKrb.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormKrb.html
@@ -11,9 +11,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PasswordReset.html
+++ b/perun-web-gui/src/main/webapp/PasswordReset.html
@@ -11,9 +11,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PasswordResetCert.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetCert.html
@@ -11,9 +11,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PasswordResetFed.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetFed.html
@@ -11,9 +11,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PasswordResetKrb.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetKrb.html
@@ -11,9 +11,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PerunWeb.html
+++ b/perun-web-gui/src/main/webapp/PerunWeb.html
@@ -6,9 +6,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PerunWebCert.html
+++ b/perun-web-gui/src/main/webapp/PerunWebCert.html
@@ -6,9 +6,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PerunWebFed.html
+++ b/perun-web-gui/src/main/webapp/PerunWebFed.html
@@ -6,9 +6,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PerunWebKrb.html
+++ b/perun-web-gui/src/main/webapp/PerunWebKrb.html
@@ -6,9 +6,6 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Backward compatibility for IE 10+ -->
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
-
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 


### PR DESCRIPTION
- removed forcing IE9 compatibility mode from HTML
- webapp runs correctly in IE11 (even thou there isn't
  any separate compilation permutation for it) with rendering mode
  set to IE11 or IE10 but not IE9, so it seems, that only IE9
  permutation is broken
- from IE8/9 there is an auto-update enabled by default,
  so we should expect majority of users with latest IE version
- IE10 is not directly tested, just via IE11 with IE10 rendering mode
