### PR TITLE
Core: New method FacilityManager.bl.addHosts.

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -484,6 +484,26 @@ public interface FacilitiesManager {
    */
   List<Host> addHosts(PerunSession sess, List<Host> hosts, Facility facility) throws FacilityNotExistsException, InternalErrorException, PrivilegeException, HostExistsException;
 
+   /**
+   * Create hosts in Perun and add them to the Facility.
+   * Names of the hosts can be generative.
+   * The pattern is string with square brackets, e.g. "local[1-3]domain". Then the content of the brackets
+   * is distributed, so the list is [local1domain, local2domain, local3domain].
+   * Multibrackets are aslo allowed. For example "a[00-01]b[90-91]c" generates [a00b90c, a00b91c, a01b90c, a01b91c].
+   *
+   * @param sess
+   * @param hosts list of strings with names of hosts, the name can by generative
+   * @param facility
+   *
+   * @return Hosts with ID's set.
+   *
+   * @throws FacilityNotExistsException
+   * @throws PrivilegeException
+   * @throws InternalErrorException
+   * @throws HostExistsException
+   */
+  List<Host> addHosts(PerunSession sess, Facility facility, List<String> hosts) throws FacilityNotExistsException, InternalErrorException, PrivilegeException, HostExistsException;
+
   /**
    * Remove hosts from the Facility.
    *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -466,6 +466,24 @@ public interface FacilitiesManagerBl {
   List<Host> addHosts(PerunSession sess, List<Host> hosts, Facility facility) throws InternalErrorException, HostExistsException; 
 
   /**
+   * Create hosts in Perun and add them to the Facility.
+   * Names of the hosts can be generative.
+   * The pattern is string with square brackets, e.g. "local[1-3]domain". Then the content of the brackets
+   * is distributed, so the list is [local1domain, local2domain, local3domain].
+   * Multibrackets are aslo allowed. For example "a[00-01]b[90-91]c" generates [a00b90c, a00b91c, a01b90c, a01b91c].
+   * 
+   * @param sess
+   * @param hosts list of strings with names of hosts, the name can by generative
+   * @param facility
+   *
+   * @return Hosts with ID's set.
+   * 
+   * @throws InternalErrorException
+   * @throws HostExistsException
+   */
+  List<Host> addHosts(PerunSession sess, Facility facility, List<String> hosts) throws InternalErrorException, HostExistsException; 
+
+  /**
    * Adds host to the Facility. 
    * 
    * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -571,6 +571,23 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
     return hosts;
   }
 
+  public List<Host> addHosts(PerunSession sess, Facility facility, List<String> hosts) throws InternalErrorException, HostExistsException {
+    // generate hosts by pattern
+    List<Host> generatedHosts = new ArrayList<Host>();
+    for (String host : hosts) {
+        List<String> listOfStrings = Utils.generateStringsByPattern(host);
+        List<Host> listOfHosts = new ArrayList<Host>();
+        for (String hostName : listOfStrings) {
+            Host newHost = new Host();
+            newHost.setHostname(hostName);
+            listOfHosts.add(newHost);
+        }
+        generatedHosts.addAll(listOfHosts);
+    }
+    // add generated hosts
+    return addHosts(sess, generatedHosts, facility);
+  }
+
   public void removeHosts(PerunSession sess, List<Host> hosts, Facility facility) throws InternalErrorException, HostAlreadyRemovedException {
     for(Host host : hosts) {  
       // Remove hosts attributes

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -513,6 +513,20 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 
     return getFacilitiesManagerBl().addHosts(sess, hosts, facility);
   }
+  
+  public List<Host> addHosts(PerunSession sess, Facility facility, List<String> hosts) throws FacilityNotExistsException, InternalErrorException, PrivilegeException, HostExistsException {
+    Utils.checkPerunSession(sess);
+
+    getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+    // Authorization
+    if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+      throw new PrivilegeException(sess, "addHosts");
+    }
+
+    Utils.notNull(hosts, "hosts");
+
+    return getFacilitiesManagerBl().addHosts(sess, facility, hosts);
+  }
 
   public void removeHosts(PerunSession sess, List<Host> hosts, Facility facility) throws FacilityNotExistsException, InternalErrorException, PrivilegeException, HostAlreadyRemovedException {
     Utils.checkPerunSession(sess);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -48,6 +48,8 @@ import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author Pavel Zlamal <256627@mail.muni.cz>
@@ -514,6 +516,31 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		facilitiesManagerEntry.addHosts(sess, hosts, emptyFac);
 		// shouldn't find facility
 
+	}
+        
+        @Test
+	public void addHostsWithPattern()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWithPattern()");
+
+                String hostname = "name[00-01]surname[99-100]cz";
+                List<String> listOfHosts = new ArrayList<String>();
+                listOfHosts.add(hostname);
+                hostname = "local";
+                listOfHosts.add(hostname);
+		hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
+		// test
+		assertNotNull("Unable to add hosts", hosts);
+		assertEquals("There should be 5 hosts in list", 5, hosts.size());
+		
+                Set<String> hostNames = new HashSet<String>();
+                for (Host h: hosts) {
+                    hostNames.add(h.getHostname());
+                }
+                assertTrue("List doesn't contain host with name 'name00surname99cz'.", hostNames.contains("name00surname99cz"));
+                assertTrue("List doesn't contain host with name 'name00surname100cz'.", hostNames.contains("name00surname100cz"));
+                assertTrue("List doesn't contain host with name 'name01surname99cz'.", hostNames.contains("name01surname99cz"));
+                assertTrue("List doesn't contain host with name 'name01surname100cz'.", hostNames.contains("name01surname100cz"));
+                assertTrue("List doesn't contain host with name 'local'.", hostNames.contains("local"));
 	}
 
 	@Test

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -397,14 +397,8 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
       Facility facility = ac.getFacilityById(parms.readInt("facility"));
 
       List<String> hostnames = parms.readList("hostnames", String.class);
-      List<Host> hosts = new ArrayList<Host>();
-      for(String hostname : hostnames) {
-        Host host = new Host();
-        host.setHostname(hostname);
-        hosts.add(host);
-      }
-
-      return ac.getFacilitiesManager().addHosts(ac.getSession(), hosts, facility);
+     
+      return ac.getFacilitiesManager().addHosts(ac.getSession(), facility, hostnames);
     }
   },
   


### PR DESCRIPTION
New method addHost take host names as list of string and if there is a pattern made of square
brackets (e.g. "name[00-12]domain") it generates new host names and
then call old method addHosts, so all hosts are created. The logic is written in the class impl.Utils.
RPC: Now when addHosts is called from RPC, the generation of host names
is enabled.
