### PR TITLE
Core: ResourcesManager: copy methods added.

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -22,6 +22,7 @@ import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServicesPackageNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SubGroupCannotBeRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 
@@ -547,5 +548,49 @@ public interface ResourcesManager {
    * @throws PrivilegeException 
    */
   List<ResourceTag> getAllResourcesTagsForResource(PerunSession perunSession, Resource resource) throws InternalErrorException, ResourceNotExistsException, PrivilegeException;  
+
+   
+ /**
+  * Copy all attributes of the source resource to the destionation resource.
+  * The attributes, that are in the destination resource and aren't in the source resource, are retained.
+  * The common attributes are replaced with the attributes from the source resource.
+  * 
+  * @param sess
+  * @param sourceResource
+  * @param destinationResource
+  * @throws InternalErrorException
+  * @throws PrivilegeException
+  * @throws ResourceNotExistsException
+  * @throws WrongAttributeAssignmentException if there is no resource attribute
+  * @throws WrongAttributeValueException if the attribute value is illegal
+  * @throws WrongReferenceAttributeValueException if the attribute value is illegal
+  */
+  public void copyAttributes(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, PrivilegeException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+  /**
+   * Copy all services of the source resource to the destionation resource.
+   * The services, that are in the destination resource and aren't in the source resource, are retained.
+   * The common services are replaced with the services from source resource.
+   * 
+   * @param sourceResource 
+   * @param destinationResource 
+   * @throws InternalErrorException
+   * @throws ResourceNotExistsException
+   * @throws PrivilegeException
+   */
+  public void copyServices(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, ResourceNotExistsException, PrivilegeException;
+
+  /**
+   * Copy all groups of the source resource to the destionation resource.
+   * The groups, that are in the destination resource and aren't in the source resource, are retained.
+   * The common groups are replaced with the groups from source resource.
+   * 
+   * @param sourceResource 
+   * @param destinationResource 
+   * @throws InternalErrorException
+   * @throws ResourceNotExistsException
+   * @throws PrivilegeException
+   */
+  public void copyGroups(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, ResourceNotExistsException, PrivilegeException;
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -219,7 +219,7 @@ public interface ResourcesManagerBl {
    * @throws GroupAlreadyAssignedException
    * @throws WrongReferenceAttributeValueException
    */
-  void assignGroupToResource(PerunSession perunSession, Group group, Resource resource) throws InternalErrorException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException;
+  void assignGroupToResource(PerunSession perunSession, Group group, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException;
 
   /**
    * Remove group from a resource.
@@ -545,6 +545,44 @@ public interface ResourcesManagerBl {
    * @throws InternalErrorException
    */
   List<ResourceTag> getAllResourcesTagsForResource(PerunSession perunSession, Resource resource) throws InternalErrorException;
+  
+  /**
+  * Copy all attributes of the source resource to the destionation resource.
+  * The attributes, that are in the destination resource and aren't in the source resource, are retained.
+  * The common attributes are replaced with attributes from the source resource.
+  * 
+  * @param sess
+  * @param sourceResource
+  * @param destinationResource
+  * @throws InternalErrorException
+  * @throws WrongAttributeAssignmentException if there is no resource attribute
+  * @throws WrongAttributeValueException if the attribute value is illegal
+  * @throws WrongReferenceAttributeValueException if the attribute value is illegal
+  */
+  public void copyAttributes(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+  /**
+   * Copy all services of the source resource to the destionation resource.
+   * The services, that are in the destination resource and aren't in the source resource, are retained.
+   * The common services are replaced with services from source resource.
+   * 
+   * @param sourceResource 
+   * @param destinationResource 
+   * @throws InternalErrorException
+   */
+  public void copyServices(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException;
+
+  /**
+   * Copy all groups of the source resource to the destionation resource.
+   * The groups, that are in the destination resource and aren't in the source resource, are retained.
+   * The common groups are replaced with the groups from source resource.
+   * 
+   * @param sourceResource 
+   * @param destinationResource 
+   * @throws InternalErrorException
+   */
+  public void copyGroups(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException;
+
   
   void checkResourceExists(PerunSession sess, Resource resource) throws InternalErrorException, ResourceNotExistsException;
   

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -172,7 +172,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
         try {
             addOwner(sess, destinationFacility, owner);
         } catch (OwnerAlreadyAssignedException ex) {
-            // we can ignore the exception in this particular case, user can be owner in both of the facilities
+            // we can ignore the exception in this particular case, owner can exists in both of the facilities
         }
     }
   }
@@ -323,8 +323,6 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
     // Assign newly created group to resource
     try {
       perunBl.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
-    } catch (ResourceNotExistsException e) {
-      throw new ConsistencyErrorException("Assigning group to non existent resource", e);
     } catch (WrongAttributeValueException e) {
       throw new InternalErrorException("Group " + group + " shouldn't have any members");
     } catch (WrongReferenceAttributeValueException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -203,7 +203,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
   }
 
 
-  public void assignGroupToResource(PerunSession sess, Group group, Resource resource) throws InternalErrorException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException {
+  public void assignGroupToResource(PerunSession sess, Group group, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException {
     Vo groupVo = getPerunBl().getGroupsManagerBl().getVo(sess, group);
 
     // Check if the group and resource belongs to the same VO
@@ -532,6 +532,60 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
    public Resource updateResource(PerunSession sess, Resource resource) throws InternalErrorException {
     getPerunBl().getAuditer().log(sess, "{} updated.", resource);
     return getResourcesManagerImpl().updateResource(sess, resource);
+  }
+   
+  public void copyAttributes(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+        List<Attribute> sourceAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, sourceResource);
+        List<Attribute> destinationAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, destinationResource);
+
+        // do not get virtual attributes from source resource, they can't be set to destination
+        Iterator<Attribute> it = sourceAttributes.iterator();
+        while (it.hasNext()) {
+            if (it.next().getNamespace().startsWith(AttributesManager.NS_RESOURCE_ATTR_VIRT)) {
+                it.remove();
+            }
+        }
+
+        // create intersection of destination and source attributes
+        List<Attribute> intersection = new ArrayList<>();
+        intersection.addAll(destinationAttributes);
+        intersection.retainAll(sourceAttributes);
+
+        // delete all common attributes from destination resource
+        getPerunBl().getAttributesManagerBl().removeAttributes(sess, destinationResource, intersection);
+        // add all attributes from the source resource to the destination resource
+        getPerunBl().getAttributesManagerBl().setAttributes(sess, destinationResource, sourceAttributes);
+    }
+
+  public void copyServices(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException {
+        for (Service owner : getAssignedServices(sess, sourceResource)) {
+          try {
+              assignService(sess, destinationResource, owner);
+          } catch (ServiceAlreadyAssignedException ex) {
+              // we can ignore the exception in this particular case, service can exists in both of the resources
+          } catch (ServiceNotExistsException ex) {
+              throw new InternalErrorException("Service from source Resource does not exists when copying services.", ex);
+          } catch (WrongAttributeValueException ex) {
+              throw new InternalErrorException("Copying of services failed.", ex);
+          } catch (WrongReferenceAttributeValueException ex) {
+              throw new InternalErrorException("Copying of services failed.", ex);
+          }
+      }
+  }
+
+    @Override
+  public void copyGroups(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException {
+        for (Group group: getAssignedGroups(sess, sourceResource)) {
+            try {
+                assignGroupToResource(sess, group, destinationResource);
+            } catch (GroupAlreadyAssignedException ex) {
+                // we can ignore the exception in this particular case, group can exists in both of the resources
+            } catch (WrongAttributeValueException ex) {
+              throw new InternalErrorException("Copying of groups failed.", ex);
+            } catch (WrongReferenceAttributeValueException ex) {
+              throw new InternalErrorException("Copying of groups failed.", ex);
+            }
+        }
   }
 
   /**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -698,10 +698,10 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
         
         // Authorization - facility admin of the both facilities required
         if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, sourceFacility)) {
-            throw new PrivilegeException(sess, "copyManager");
+            throw new PrivilegeException(sess, "copyAttributes");
         }
         if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, destinationFacility)) {
-            throw new PrivilegeException(sess, "copyManager");
+            throw new PrivilegeException(sess, "copyAttributes");
         }
         
         getFacilitiesManagerBl().copyAttributes(sess, sourceFacility, destinationFacility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -39,6 +39,7 @@ import cz.metacentrum.perun.core.api.exceptions.ServiceNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServicesPackageNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
@@ -577,6 +578,57 @@ public class ResourcesManagerEntry implements ResourcesManager {
     }
     
     return resourcesManagerBl.getAllResourcesTagsForResource(perunSession, resource);
+  }
+  
+  public void copyAttributes(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, PrivilegeException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+        Utils.checkPerunSession(sess);
+
+        getResourcesManagerBl().checkResourceExists(sess, sourceResource);
+        getResourcesManagerBl().checkResourceExists(sess, destinationResource);
+        
+        // Authorization - facility admin of the both resources required
+        if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, sourceResource)) {
+            throw new PrivilegeException(sess, "copyAttributes");
+        }
+        if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, destinationResource)) {
+            throw new PrivilegeException(sess, "copyAttributes");
+        }
+        
+        getResourcesManagerBl().copyAttributes(sess, sourceResource, destinationResource);
+    }
+
+  public void copyServices(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, ResourceNotExistsException, PrivilegeException {
+        Utils.checkPerunSession(sess);
+
+        getResourcesManagerBl().checkResourceExists(sess, sourceResource);
+        getResourcesManagerBl().checkResourceExists(sess, destinationResource);
+        
+        // Authorization - facility admin of the both resources required
+        if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, sourceResource)) {
+            throw new PrivilegeException(sess, "copyServices");
+        }
+        if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, destinationResource)) {
+            throw new PrivilegeException(sess, "copyServices");
+        }
+        
+        getResourcesManagerBl().copyServices(sess, sourceResource, destinationResource);
+  }
+  
+  public void copyGroups(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, ResourceNotExistsException, PrivilegeException {
+        Utils.checkPerunSession(sess);
+
+        getResourcesManagerBl().checkResourceExists(sess, sourceResource);
+        getResourcesManagerBl().checkResourceExists(sess, destinationResource);
+        
+        // Authorization - vo admin of the both resources required
+        if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, sourceResource)) {
+            throw new PrivilegeException(sess, "copyGroups");
+        }
+        if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, destinationResource)) {
+            throw new PrivilegeException(sess, "copyGroups");
+        }
+        
+        getResourcesManagerBl().copyGroups(sess, sourceResource, destinationResource);
   }
   
   /**

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -790,7 +790,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
             
             // add second attribute to both
             Attribute secondAttribute = setUpAttribute2();
-            perun.getAttributesManager(). setAttribute(sess, facility, secondAttribute);
+            perun.getAttributesManager().setAttribute(sess, facility, secondAttribute);
             perun.getAttributesManager().setAttribute(sess, secondFacility, secondAttribute);
             
             // add third attribute to destination

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -869,6 +869,90 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
         assertTrue("Resource with tag is not returned by same tag", resources.contains(resource));
 
     }
+    
+    @Test
+    public void copyAttributes() throws Exception {
+        System.out.println("ResourcesManager.copyAttributes");
+
+        vo = setUpVo();
+        facility = setUpFacility();
+        resource = setUpResource();
+
+        // set up second resource
+        Resource newResource = new Resource();
+        newResource.setName("SecondResource");
+        newResource.setDescription("pro kopirovani");
+        Resource secondResource = resourcesManager.createResource(sess, newResource, vo, facility);
+
+        // add first attribute to source
+        Attribute firstAttribute = setUpAttribute1();
+        perun.getAttributesManager().setAttribute(sess, resource, firstAttribute);
+
+        // add second attribute to both
+        Attribute secondAttribute = setUpAttribute2();
+        perun.getAttributesManager().setAttribute(sess, resource, secondAttribute);
+        perun.getAttributesManager().setAttribute(sess, secondResource, secondAttribute);
+
+        // add third attribute to destination
+        Attribute thirdAttribute = setUpAttribute3();
+        perun.getAttributesManager().setAttribute(sess, secondResource, thirdAttribute);
+
+        // copy
+        resourcesManager.copyAttributes(sess, resource, secondResource);
+
+        // tests
+        List<Attribute> destinationAttributes = perun.getAttributesManager().getAttributes(sess, secondResource);
+        assertNotNull(destinationAttributes);
+        assertTrue((destinationAttributes.size() - perun.getAttributesManager().getAttributes(sess, resource).size()) == 1);
+        assertTrue(destinationAttributes.contains(firstAttribute));
+        assertTrue(destinationAttributes.contains(secondAttribute));
+        assertTrue(destinationAttributes.contains(thirdAttribute));
+    }
+    
+    @Test
+    public void copyServices() throws Exception {
+        System.out.println("ResourcesManager.copyServices");
+        
+        vo = setUpVo();
+        facility = setUpFacility();
+        resource = setUpResource();
+        service = setUpService();
+        resourcesManager.assignService(sess, resource, service);
+        
+        // set up second resource
+        Resource newResource = new Resource();
+        newResource.setName("SecondResource");
+        newResource.setDescription("pro kopirovani");
+        Resource secondResource = resourcesManager.createResource(sess, newResource, vo, facility);
+        
+        resourcesManager.copyServices(sess, resource, secondResource);
+        
+        //test
+        assertTrue(resourcesManager.getAssignedServices(sess, secondResource).contains(service));
+    }
+    
+    @Test
+    public void copyGroups() throws Exception {
+        System.out.println("ResourcesManager.copyGroups");
+        
+        vo = setUpVo();
+        facility = setUpFacility();
+        resource = setUpResource();
+        member = setUpMember(vo);
+        group = setUpGroup(vo, member);
+        resourcesManager.assignGroupToResource(sess, group, resource);
+        
+        // set up second resource
+        Resource newResource = new Resource();
+        newResource.setName("SecondResource");
+        newResource.setDescription("pro kopirovani");
+        Resource secondResource = resourcesManager.createResource(sess, newResource, vo, facility);
+        
+        resourcesManager.copyGroups(sess, resource, secondResource);
+        
+        //test
+        assertTrue(resourcesManager.getAssignedGroups(sess, secondResource).contains(group));
+    }
 
 	// PRIVATE METHODS -----------------------------------------------------------
 
@@ -996,4 +1080,39 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	}
 
+        private Attribute setUpAttribute1() throws Exception {
+                AttributeDefinition attrDef = new AttributeDefinition();
+                attrDef.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+                attrDef.setDescription("Test attribute description");
+                attrDef.setFriendlyName("testingAttribute");
+                attrDef.setType(String.class.getName());
+                attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+                Attribute attribute = new Attribute(attrDef);
+                attribute.setValue("Testing value");
+                return attribute;
+        }
+        
+        private Attribute setUpAttribute2() throws Exception {
+                AttributeDefinition attrDef = new AttributeDefinition();
+                attrDef.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+                attrDef.setDescription("Test attribute2 description");
+                attrDef.setFriendlyName("testingAttribute2");
+                attrDef.setType(String.class.getName());
+                attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+                Attribute attribute = new Attribute(attrDef);
+                attribute.setValue("Testing value for second attribute");
+                return attribute;
+        }
+        
+        private Attribute setUpAttribute3() throws Exception {
+                AttributeDefinition attrDef = new AttributeDefinition();
+                attrDef.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+                attrDef.setDescription("Test attribute3 description");
+                attrDef.setFriendlyName("testingAttribute3");
+                attrDef.setType(String.class.getName());
+                attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+                Attribute attribute = new Attribute(attrDef);
+                attribute.setValue("Testing value for third attribute");
+                return attribute;
+        }
 }


### PR DESCRIPTION
- added methods for copying from one resource to another
  - copyAttributes
  - copyServices
  - copyGroups
- tests created one for each method
- removed unused exception ResourceNotExistsException from
  bl.assignGroupToResource
