### PR TITLE
Core: FacilityManager.bl.addHosts generates hosts by pattern.

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/WrongPatternException.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/WrongPatternException.java
@@ -1,0 +1,24 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * Pattern is not well-formed.
+ * 
+ * Is to be thrown when the generative pattern of hostname e.g. local[00-12]domain has a wrong syntax.
+ * 
+ * @author Jirka Mauritz <jirmauritz@gmail.com>
+ */
+public class WrongPatternException extends PerunException {
+    static final long serialVersionUID = 0;
+    
+    public WrongPatternException(String message) {
+        super(message);
+    }
+    
+    public WrongPatternException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    public WrongPatternException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -27,6 +27,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 
 /**
@@ -483,6 +484,27 @@ public interface FacilitiesManager {
    * @throws HostExistsException
    */
   List<Host> addHosts(PerunSession sess, List<Host> hosts, Facility facility) throws FacilityNotExistsException, InternalErrorException, PrivilegeException, HostExistsException;
+
+   /**
+   * Create hosts in Perun and add them to the Facility.
+   * Names of the hosts can be generative.
+   * The pattern is string with square brackets, e.g. "local[1-3]domain". Then the content of the brackets
+   * is distributed, so the list is [local1domain, local2domain, local3domain].
+   * Multibrackets are aslo allowed. For example "a[00-01]b[90-91]c" generates [a00b90c, a00b91c, a01b90c, a01b91c].
+   *
+   * @param sess
+   * @param hosts list of strings with names of hosts, the name can by generative
+   * @param facility
+   *
+   * @return Hosts with ID's set.
+   *
+   * @throws FacilityNotExistsException
+   * @throws PrivilegeException
+   * @throws InternalErrorException
+   * @throws HostExistsException
+   * @throws WrongPatternException when syntax of any of the hostnames is wrong
+   */
+  List<Host> addHosts(PerunSession sess, Facility facility, List<String> hosts) throws FacilityNotExistsException, InternalErrorException, PrivilegeException, HostExistsException, WrongPatternException;
 
   /**
    * Remove hosts from the Facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -41,6 +41,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 
 /**
  * Facility manager can create a new facility or find an existing facility.
@@ -464,6 +465,25 @@ public interface FacilitiesManagerBl {
    * @throws HostExistsException
    */
   List<Host> addHosts(PerunSession sess, List<Host> hosts, Facility facility) throws InternalErrorException, HostExistsException; 
+
+  /**
+   * Create hosts in Perun and add them to the Facility.
+   * Names of the hosts can be generative.
+   * The pattern is string with square brackets, e.g. "local[1-3]domain". Then the content of the brackets
+   * is distributed, so the list is [local1domain, local2domain, local3domain].
+   * Multibrackets are aslo allowed. For example "a[00-01]b[90-91]c" generates [a00b90c, a00b91c, a01b90c, a01b91c].
+   * 
+   * @param sess
+   * @param hosts list of strings with names of hosts, the name can by generative
+   * @param facility
+   *
+   * @return Hosts with ID's set.
+   * 
+   * @throws InternalErrorException
+   * @throws HostExistsException
+   * @throws WrongPatternException when syntax of any of the hostnames is wrong
+   */
+  List<Host> addHosts(PerunSession sess, Facility facility, List<String> hosts) throws InternalErrorException, HostExistsException, WrongPatternException; 
 
   /**
    * Adds host to the Facility. 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -61,6 +61,7 @@ import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.rt.ConsistencyErrorRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
@@ -569,6 +570,23 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
     getPerunBl().getAuditer().log(sess, "Hosts {} added to cluster {}", hosts, facility);
     
     return hosts;
+  }
+
+  public List<Host> addHosts(PerunSession sess, Facility facility, List<String> hosts) throws InternalErrorException, HostExistsException, WrongPatternException {
+    // generate hosts by pattern
+    List<Host> generatedHosts = new ArrayList<Host>();
+    for (String host : hosts) {
+        List<String> listOfStrings = Utils.generateStringsByPattern(host);
+        List<Host> listOfHosts = new ArrayList<Host>();
+        for (String hostName : listOfStrings) {
+            Host newHost = new Host();
+            newHost.setHostname(hostName);
+            listOfHosts.add(newHost);
+        }
+        generatedHosts.addAll(listOfHosts);
+    }
+    // add generated hosts
+    return addHosts(sess, generatedHosts, facility);
   }
 
   public void removeHosts(PerunSession sess, List<Host> hosts, Facility facility) throws InternalErrorException, HostAlreadyRemovedException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -48,6 +48,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
 import cz.metacentrum.perun.core.bl.FacilitiesManagerBl;
@@ -512,6 +513,20 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
     Utils.notNull(hosts, "hosts");
 
     return getFacilitiesManagerBl().addHosts(sess, hosts, facility);
+  }
+  
+  public List<Host> addHosts(PerunSession sess, Facility facility, List<String> hosts) throws FacilityNotExistsException, InternalErrorException, PrivilegeException, HostExistsException, WrongPatternException {
+    Utils.checkPerunSession(sess);
+
+    getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+    // Authorization
+    if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+      throw new PrivilegeException(sess, "addHosts");
+    }
+
+    Utils.notNull(hosts, "hosts");
+
+    return getFacilitiesManagerBl().addHosts(sess, facility, hosts);
   }
 
   public void removeHosts(PerunSession sess, List<Host> hosts, Facility facility) throws FacilityNotExistsException, InternalErrorException, PrivilegeException, HostAlreadyRemovedException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -43,6 +43,7 @@ import cz.metacentrum.perun.core.api.exceptions.NumberNotInRangeException;
 import cz.metacentrum.perun.core.api.exceptions.NumbersNotAllowedException;
 import cz.metacentrum.perun.core.api.exceptions.SpaceNotAllowedException;
 import cz.metacentrum.perun.core.api.exceptions.SpecialCharsNotAllowedException;
+import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import java.util.LinkedHashSet;
 /**
  * Utilities.
@@ -498,5 +499,155 @@ public class Utils {
         copyTo.setValueModifiedAt(copyFrom.getValueModifiedAt());
         copyTo.setValueModifiedBy(copyFrom.getValueModifiedBy());
         return copyTo;
+    }
+    
+    /**
+     * Method generates strings by pattern.
+     * The pattern is string with square brackets, e.g. "a[1-3]b". Then the content of the brackets
+     * is distributed, so the list is [a1b, a2b, a3c].
+     * Multibrackets are aslo allowed. For example "a[00-01]b[90-91]c" generates [a00b90c, a00b91c, a01b90c, a01b91c].
+     * 
+     * @param pattern
+     * @return list of all generated strings
+     */
+    public static List<String> generateStringsByPattern(String pattern) throws WrongPatternException {
+        List<String> result = new ArrayList<String>();
+        
+        // get chars between the brackets
+        List<String> values = new ArrayList<String>(Arrays.asList(pattern.split("\\[[^\\]]*\\]")));
+        // get content of the brackets
+        List<String> generators = new ArrayList<String>();
+        Pattern generatorPattern = Pattern.compile("\\[([^\\]]*)\\]");
+        Matcher m = generatorPattern.matcher(pattern);
+        while (m.find()) {
+            generators.add(m.group(1));
+        }
+        
+        // if values strings contain square brackets, wrong syntax, abort
+        for (String value: values) {
+            if (value.contains("]") || (value.contains("["))) {
+                throw new WrongPatternException("The pattern \"" + pattern + "\" has a wrong syntax. Too much closing brackets.");
+            }
+        }
+        
+        // if generators strings contain square brackets, wrong syntax, abort
+        for (String generator: generators) {
+            if (generator.contains("]") || (generator.contains("["))) {
+                throw new WrongPatternException("The pattern \"" + pattern + "\" has a wrong syntax. Too much opening brackets.");
+            } 
+        }
+        
+        // list, that contains list for each generator, with already generated numbers
+        List<List<String>> listOfGenerated = new ArrayList<List<String>>();
+        
+        Pattern rangePattern = Pattern.compile("^(\\d+)-(\\d+)$");
+        for (String range: generators) {
+            m = rangePattern.matcher(range);
+            if (m.find()) {
+                String start = m.group(1);
+                String end = m.group(2);
+                int startNumber;
+                int endNumber;
+                try {
+                    startNumber = Integer.parseInt(start);
+                    endNumber = Integer.parseInt(end);
+                } catch (NumberFormatException ex) {
+                    throw new WrongPatternException("The pattern \"" + pattern + "\" has a wrong syntax. Wrong format of the range.");
+                }
+                
+                // if end is before start -> abort
+                if (startNumber > endNumber) {
+                    throw new WrongPatternException("The pattern \"" + pattern + "\" has a wrong syntax. Start number has to be lower than end number.");
+
+                }
+                
+                // find out, how many zeros are before start number
+                int zerosInStart = 0;
+                int counter = 0;
+                while ( (start.charAt(counter) == '0') && (counter < start.length()-1) ) {
+                    zerosInStart++;
+                    counter++;
+                }
+                
+                String zeros = start.substring(0, zerosInStart);
+                int oldNumberOfDigits = String.valueOf(startNumber).length();
+                
+                // list of already generated numbers
+                List<String> generated = new ArrayList<String>();
+                while (endNumber >= startNumber) {
+                    // keep right number of zeros before number
+                    if (String.valueOf(startNumber).length() == oldNumberOfDigits +1) {
+                        if (!zeros.isEmpty()) zeros = zeros.substring(1);
+                    }
+                    generated.add(zeros + startNumber);
+                    oldNumberOfDigits = String.valueOf(startNumber).length();
+                    startNumber++;
+                }
+                
+                listOfGenerated.add(generated);
+                
+            } else {
+                // range is not in the format number-number -> abort
+                throw new WrongPatternException("The pattern \"" + pattern + "\" has a wrong syntax. The format numer-number not found.");
+            }
+        }
+        
+        // add values among the generated numbers as one item lists
+        List<List<String>> listOfGeneratorsAndValues = new ArrayList<List<String>>();
+        int index = 0;
+        
+        for (List<String> list : listOfGenerated) {
+            if (index < values.size()) {
+                List<String> listWithValue = new ArrayList<>();
+                listWithValue.add(values.get(index));
+                listOfGeneratorsAndValues.add(listWithValue);
+                index++;
+            }
+            listOfGeneratorsAndValues.add(list);
+        }
+        
+        // complete list with remaining values
+        for (int i = index; i < values.size(); i++) {
+             List<String> listWithValue = new ArrayList<>();
+             listWithValue.add(values.get(i));
+             listOfGeneratorsAndValues.add(listWithValue);
+        }
+        
+        // generate all posibilities
+        return getCombinationsOfLists(listOfGeneratorsAndValues);
+    }
+    
+    /**
+     * Method generates all combinations of joining of strings.
+     * It respects given order of lists.
+     * Example: input: [[a,b],[c,d]], output: [ac,ad,bc,bd] 
+     * @param lists list of lists, which will be joined
+     * @return all joined strings
+     */
+    private static List<String> getCombinationsOfLists(List<List<String>> lists) {
+        if (lists.isEmpty()) {
+            // this should not happen
+            return new ArrayList<>();
+        }
+        if (lists.size() == 1) {
+            return lists.get(0);
+        }
+        List<String> result = new ArrayList<String>();
+        
+        List<String> list = lists.remove(0);
+        // get recursively all posibilities without first list
+        List<String> posibilities = getCombinationsOfLists(lists);
+        
+        // join all strings from first list with the others
+        for (String item: list) {
+            if (posibilities.isEmpty()) {
+                result.add(item);
+            } else {
+                for (String itemToConcat : posibilities) {
+                    result.add(item + itemToConcat);
+                }
+            }
+        }
+        return result;
     }
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -48,6 +48,9 @@ import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author Pavel Zlamal <256627@mail.muni.cz>
@@ -514,6 +517,67 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		facilitiesManagerEntry.addHosts(sess, hosts, emptyFac);
 		// shouldn't find facility
 
+	}
+        
+        @Test
+	public void addHostsWithPattern()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWithPattern()");
+
+                String hostname = "name[00-01]surname[99-100]cz";
+                List<String> listOfHosts = new ArrayList<String>();
+                listOfHosts.add(hostname);
+                hostname = "local";
+                listOfHosts.add(hostname);
+		hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
+		// test
+		assertNotNull("Unable to add hosts", hosts);
+		assertEquals("There should be 5 hosts in list", 5, hosts.size());
+		
+                Set<String> hostNames = new HashSet<String>();
+                for (Host h: hosts) {
+                    hostNames.add(h.getHostname());
+                }
+                assertTrue("List doesn't contain host with name 'name00surname99cz'.", hostNames.contains("name00surname99cz"));
+                assertTrue("List doesn't contain host with name 'name00surname100cz'.", hostNames.contains("name00surname100cz"));
+                assertTrue("List doesn't contain host with name 'name01surname99cz'.", hostNames.contains("name01surname99cz"));
+                assertTrue("List doesn't contain host with name 'name01surname100cz'.", hostNames.contains("name01surname100cz"));
+                assertTrue("List doesn't contain host with name 'local'.", hostNames.contains("local"));
+	}
+        
+        @Test(expected = WrongPatternException.class)
+	public void addHostsWithWrongPattern()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern()");
+
+                String hostname = "name[00]-01]surname[99-100]cz";
+                List<String> listOfHosts = new ArrayList<String>();
+                listOfHosts.add(hostname);
+                hostname = "local";
+                listOfHosts.add(hostname);
+		hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
+	}
+        
+        @Test(expected = WrongPatternException.class)
+	public void addHostsWithWrongPattern2()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern2()");
+
+                String hostname = "name[00-a01]surname[99-100]cz";
+                List<String> listOfHosts = new ArrayList<String>();
+                listOfHosts.add(hostname);
+                hostname = "local";
+                listOfHosts.add(hostname);
+		hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
+	}
+        
+        @Test(expected = WrongPatternException.class)
+	public void addHostsWithWrongPattern3()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern3()");
+
+                String hostname = "name[01-00]surname[99-100]cz";
+                List<String> listOfHosts = new ArrayList<String>();
+                listOfHosts.add(hostname);
+                hostname = "local";
+                listOfHosts.add(hostname);
+		hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
 	}
 
 	@Test

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -397,14 +397,8 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
       Facility facility = ac.getFacilityById(parms.readInt("facility"));
 
       List<String> hostnames = parms.readList("hostnames", String.class);
-      List<Host> hosts = new ArrayList<Host>();
-      for(String hostname : hostnames) {
-        Host host = new Host();
-        host.setHostname(hostname);
-        hosts.add(host);
-      }
-
-      return ac.getFacilitiesManager().addHosts(ac.getSession(), hosts, facility);
+     
+      return ac.getFacilitiesManager().addHosts(ac.getSession(), facility, hostnames);
     }
   },
   


### PR DESCRIPTION
- addHosts
  - Core: New method addHost take host names as list of string and if there is a pattern made of square
    brackets (e.g. "name[00-12]domain") it generates new host names and
    then call old method addHosts, so all hosts are created. The logic is written in the class impl.Utils.
  - Beans: New created exception WrongPatternException thrown when generative
    hostname has a wrong syntax.
  - RPC: Now when addHosts is called from RPC, the generation of host names
    is enabled.
- The method getFacilityByHostName added to the RPC.
