### PR TITLE
CORE: fixed javadoc in API for getMembers() like methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -224,7 +224,7 @@ public interface GroupsManager {
    * 
    * @param perunSession
    * @param group
-   * @return list of users or empty list if the group is empty
+   * @return list of members or empty list if the group is empty
    *
    * @throws InternalErrorException
    * @throws PrivilegeException
@@ -234,12 +234,12 @@ public interface GroupsManager {
   List<Member> getGroupMembers(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
 
   /** 
-   * Return group members for displaying on pages.
+   * Return group members with specified vo membership status.
    * 
    * @param perunSession
    * @param group
    * @param status
-   * @return list users on specified page or empty list if there are no users on specified page
+   * @return list of members with specified membership status or empty list if no such member is found in group
    * 
    * @throws InternalErrorException
    * @throws PrivilegeException
@@ -262,7 +262,7 @@ public interface GroupsManager {
   List<RichMember> getGroupRichMembers(PerunSession sess, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
   
   /**
-   * Returns group members in the RichMember object, which contains Member+User data.
+   * Returns group members with specified membership status in the RichMember object, which contains Member+User data.
    * 
    * @param sess
    * @param group
@@ -287,7 +287,7 @@ public interface GroupsManager {
   List<RichMember> getGroupRichMembersWithAttributes(PerunSession sess, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
   
   /**
-   * Returns group members in the RichMember object, which contains Member+User data. Also contains user and member attributes.
+   * Returns group members with specified membership status in the RichMember object, which contains Member+User data. Also contains user and member attributes.
    * 
    * @param sess
    * @param group

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -483,11 +483,11 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
     List<RichMember> getRichMembersWithAttributes(PerunSession sess, Group group, List<AttributeDefinition> attrsDef) throws InternalErrorException, PrivilegeException, GroupNotExistsException;    
     
     /**
-     * Get rich members for displaying on pages. Rich member object contains user, member, userExtSources.
+     * Get all rich members of VO. Rich member object contains user, member, userExtSources.
      *
      * @param sess
      * @param vo
-     * @return list of rich members on specified page, empty list if there are no user in this VO or in this page
+     * @return list of rich members, empty list if there are no members in VO
      * @throws InternalErrorException
      * @throws PrivilegeException
      * @throws VoNotExistsException
@@ -495,11 +495,11 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
     List<RichMember> getRichMembers(PerunSession sess, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException;
 
     /**
-     * Get rich members for displaying on pages. Rich member object contains user, member, userExtSources.
+     * Get all rich members of Group. Rich member object contains user, member, userExtSources.
      * 
      * @param sess
      * @param group
-     * @return list of rich members on specified page, empty list if there are no user in this Group or in this page
+     * @return list of rich members, empty list if there are no members in Group
      * @throws InternalErrorException
      * @throws PrivilegeException
      * @throws GroupNotExistsException 
@@ -507,12 +507,12 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
     List<RichMember> getRichMembers(PerunSession sess, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
     
     /**
-     * Get rich members who have the status, for displaying on pages. Rich member object contains user, member, userExtSources.
+     * Get all rich members of VO with specified status. Rich member object contains user, member, userExtSources.
      *
      * @param sess
      * @param vo
      * @param status get only members who have this status
-     * @return list of rich members on specified page, empty list if there are no user in this VO or in this page
+     * @return list of rich members, empty list if there are no members in VO with specified status
      * @throws InternalErrorException
      * @throws PrivilegeException
      * @throws VoNotExistsException
@@ -520,11 +520,11 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
     List<RichMember> getRichMembers(PerunSession sess, Vo vo, Status status) throws InternalErrorException, PrivilegeException, VoNotExistsException;
     
     /**
-     * Get rich members for displaying on pages. Rich member object contains user, member, userExtSources, userAttributes, memberAttributes.
+     * Get all rich members of VO. Rich member object contains user, member, userExtSources and member/user attributes.
      *
      * @param sess
      * @param vo
-     * @return list of rich members on specified page, empty list if there are no user in this VO or in this page
+     * @return list of rich members with all member/user attributes, empty list if there are no members in VO
      * @throws InternalErrorException
      * @throws PrivilegeException
      * @throws VoNotExistsException
@@ -532,12 +532,12 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
     List<RichMember> getRichMembersWithAttributes(PerunSession sess, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException;
 
     /**
-     * Get rich members who have the status, for displaying on pages. Rich member object contains user, member, userExtSources, userAttributes, memberAttributes.
+     * Get all rich members of VO with specified status. Rich member object contains user, member, userExtSources and member/user attributes.
      *
      * @param sess
      * @param vo
      * @param status
-     * @return list of rich members on specified page, empty list if there are no user in this VO or in this page
+     * @return list of rich members with all member/user attributes, empty list if there are no members in VO with specified status
      * @throws InternalErrorException
      * @throws PrivilegeException
      * @throws VoNotExistsException


### PR DESCRIPTION
- fixed javadoc in API for getMembers(), getRichMembers() and
  getRichMembersWithAttributes() methods in Members/GroupsManager.
  Javadoc described methods using pageNum/pageSize, which are
  long gone.
