### PR TITLE
New methods for addDestination and addDestinationsDefinedByHostsOnFacility

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -474,6 +474,22 @@ public interface ServicesManager {
   Destination addDestination(PerunSession perunSession, Service service, Facility facility, Destination destination) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, FacilityNotExistsException, DestinationAlreadyAssignedException;
 
   /**
+   * Adds an destination for the facility and all services. Destination id doesn't need to be filled. If destination doesn't exist it will be created.
+   * 
+   * @param perunSession
+   * @param services
+   * @param facility
+   * @param destination (id of this destination doesn't need to be filled.)
+   * @return destination with it's id set
+   * @throws PrivilegeException
+   * @throws InternalErrorException
+   * @throws ServiceNotExistsException
+   * @throws FacilityNotExistsException
+   * @throws DestinationAlreadyAssignedException 
+   */
+  Destination addDestination(PerunSession perunSession, List<Service> services, Facility facility, Destination destination) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, FacilityNotExistsException, DestinationAlreadyAssignedException;
+  
+  /**
    * Adds destination for all services defined on the facility.
    * 
    * @param perunSession
@@ -517,6 +533,38 @@ public interface ServicesManager {
    * @throws DestinationAlreadyAssignedException 
    */
   List<Destination> addDestinationsDefinedByHostsOnFacility(PerunSession perunSession, Service service, Facility facility) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, FacilityNotExistsException, DestinationAlreadyAssignedException;
+  
+  /**
+   * Defines services destination for all hosts using their hostnames.
+   * Do it for all services in List.
+   * 
+   * If some destination for service and facility already exist, do not create it but still return back in the list.
+   * 
+   * @param perunSession
+   * @param services
+   * @param facility
+   * @return list of added destiniations (even if they alredy was adedded before)
+   * @throws PrivilegeException
+   * @throws InternalErrorException
+   * @throws ServiceNotExistsException
+   * @throws FacilityNotExistsException 
+   */
+  List<Destination> addDestinationsDefinedByHostsOnFacility(PerunSession perunSession, List<Service> services, Facility facility) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, FacilityNotExistsException;
+  
+  /**
+   * Defines services destiniation for all hosts using their hostnames.
+   * Use all assigned services to resources for the facility.
+   * 
+   * If some destination for service and facility already exist, do not create it but still return back in the list.
+   * 
+   * @param perunSession
+   * @param facility
+   * @return list of added destiniations (even if they alredy was adedded before)
+   * @throws PrivilegeException
+   * @throws InternalErrorException
+   * @throws FacilityNotExistsException 
+   */
+  List<Destination> addDestinationsDefinedByHostsOnFacility(PerunSession perunSession, Facility facility) throws PrivilegeException, InternalErrorException, FacilityNotExistsException;
   
   /**
    * Removes an destination from the facility and service.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -333,6 +333,19 @@ public interface ServicesManagerBl {
   Destination addDestination(PerunSession perunSession, Service service, Facility facility, Destination destination) throws InternalErrorException, DestinationAlreadyAssignedException;
 
   /**
+   * Adds an destination for the facility and all services. Destination id doesn't need to be filled. If destination doesn't exist it will be created.
+   * 
+   * @param perunSession
+   * @param services
+   * @param facility
+   * @param destination (id of this destination doesn't need to be filled.)
+   * @return destination with it's id set
+   * @throws InternalErrorException
+   * @throws DestinationAlreadyAssignedException 
+   */
+  Destination addDestination(PerunSession perunSession, List<Service> services, Facility facility, Destination destination) throws InternalErrorException, DestinationAlreadyAssignedException;
+    
+  /**
    * Adds destination for all services defined on the facility.
    * 
    * @param perunSession
@@ -367,6 +380,35 @@ public interface ServicesManagerBl {
    * @throws DestinationAlreadyAssignedException 
    */
   List<Destination> addDestinationsDefinedByHostsOnFacility(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException, DestinationAlreadyAssignedException;
+  
+  /**
+   * Defines services destination for all hosts using their hostnames.
+   * Do it for all services in List.
+   * 
+   * If some destination for service and facility already exist, do not create it but still return back in the list.
+   * 
+   * @param perunSession
+   * @param service
+   * @param facility
+   * @return list of added destiniations (even if they alredy was adedded before)
+   * @throws InternalErrorException 
+   */
+  List<Destination> addDestinationsDefinedByHostsOnFacility(PerunSession perunSession, List<Service> services, Facility facility) throws InternalErrorException;
+  
+  /**
+   * Defines services destiniation for all hosts using their hostnames.
+   * Use all assigned services to resources for the facility.
+   * 
+   * If some destination for service and facility already exist, do not create it but still return back in the list.
+   * 
+   * @param perunSession
+   * @param service
+   * @param facility
+   * @return list of added destiniations (even if they alredy was adedded before)
+   * @throws InternalErrorException 
+   */
+  List<Destination> addDestinationsDefinedByHostsOnFacility(PerunSession perunSession, Facility facility) throws InternalErrorException;
+  
   
   /**
    * Removes an destination from the facility and service.

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -628,11 +628,20 @@ public enum ServicesManagerMethod implements ManagerMethod {
       @Override
       public Destination call(ApiCaller ac, Deserializer parms) throws PerunException {
         ac.stateChangingCheck();
+        
+        if(parms.contains("services")) {
+            return ac.getServicesManager().addDestination(ac.getSession(),
+                parms.readList("services", Service.class),
+                ac.getFacilityById(parms.readInt("facility")),
+                ac.getDestination(parms.readString("destination"), parms.readString("type")));
+        } else {
+            return ac.getServicesManager().addDestination(ac.getSession(),
+                ac.getServiceById(parms.readInt("service")),
+                ac.getFacilityById(parms.readInt("facility")),
+                ac.getDestination(parms.readString("destination"), parms.readString("type")));
+        }
 
-        return ac.getServicesManager().addDestination(ac.getSession(),
-            ac.getServiceById(parms.readInt("service")),
-            ac.getFacilityById(parms.readInt("facility")),
-            ac.getDestination(parms.readString("destination"), parms.readString("type")));
+        
       }
     },
     
@@ -688,9 +697,19 @@ public enum ServicesManagerMethod implements ManagerMethod {
       public List<Destination> call(ApiCaller ac, Deserializer parms) throws PerunException {
         ac.stateChangingCheck();
 
-        return ac.getServicesManager().addDestinationsDefinedByHostsOnFacility(ac.getSession(),
+        if(parms.contains("service")) {
+            return ac.getServicesManager().addDestinationsDefinedByHostsOnFacility(ac.getSession(),
             ac.getServiceById(parms.readInt("service")),
             ac.getFacilityById(parms.readInt("facility")));
+        } else if (parms.contains("services")) {
+            return ac.getServicesManager().addDestinationsDefinedByHostsOnFacility(ac.getSession(),
+            parms.readList("services", Service.class),
+            ac.getFacilityById(parms.readInt("facility")));
+        } else {
+            return ac.getServicesManager().addDestinationsDefinedByHostsOnFacility(ac.getSession(),
+            ac.getFacilityById(parms.readInt("facility")));
+        }
+        
       }
     },
 


### PR DESCRIPTION
- method addDestination for list of Services
- method addDestinationsDefinedByHostsOnFacility for listOfServices
- method addDestinationsDefinedByHostsOnFacility for only already assigned services on facility
- helping private method addDestinationEvenIfAlreadyExists which do not throw exception if destination already exists, only return this destination.
- basic tests for all three methods
