### PR TITLE
We must use getColumnLabel instead getColumnName.

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -178,7 +178,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceApi {
         }
 
         for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
-          String columnName = rs.getMetaData().getColumnName(i);
+          String columnName = rs.getMetaData().getColumnLabel(i);
           log.trace("Iterating through attribute {}", columnName);
           // Now go through all other attributes. If the column name(=attribute name) contains ":", then it represents an attribute
           if (columnName.contains(":")) {


### PR DESCRIPTION
MySQL doesn't return alias in getColumnName. It shouldn't brake Oracle because getColumnLabel returns name of the column if the alias hasn't been specified.
