### PR TITLE
ServiceUser ownership status instead of removing

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -67,6 +67,7 @@ public interface UsersManager {
   
   /**
    * Remove serviceUser owner (the user)
+   * Only disable ownership of user and serviceUser
    * 
    * @param sess
    * @param user the user
@@ -84,6 +85,8 @@ public interface UsersManager {
   
   /**
    * Add serviceUser owner (the user)
+   * If not exists, create new ownership.
+   * If exists, only enable ownership for user and serviceUser
    * 
    * @param sess
    * @param user the user

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -68,7 +68,7 @@ public interface UsersManagerBl {
   User getUserByMember(PerunSession perunSession, Member member) throws InternalErrorException;
 
   /**
-   * Return all serviceUsers who are owned by the user
+   * Return all serviceUsers who are owned by the user and their ownership is not in status disabled
    * 
    * @param sess
    * @param user the user
@@ -78,7 +78,7 @@ public interface UsersManagerBl {
   List<User> getServiceUsersByUser(PerunSession sess, User user) throws InternalErrorException;
 
   /**
-   * Return all users who owns the serviceUser
+   * Return all users who owns the serviceUser and their ownership is not in status disabled
    * 
    * @param sess
    * @param serviceUser the service User
@@ -89,6 +89,7 @@ public interface UsersManagerBl {
 
   /**
    * Remove serviceUser owner (the user)
+   * Only disable ownership of user and serviceUser
    * 
    * @param sess
    * @param user the user
@@ -102,6 +103,8 @@ public interface UsersManagerBl {
 
   /**
    * Add serviceUser owner (the user)
+   * If not exists, create new ownership.
+   * If exists, only enable ownership for user and serviceUser
    * 
    * @param sess
    * @param user the user
@@ -111,6 +114,20 @@ public interface UsersManagerBl {
    */
   void addServiceUserOwner(PerunSession sess, User user, User serviceUser) throws InternalErrorException, RelationExistsException;
 
+  /**
+   * Return true if ownership of user and serviceUser already exists.
+   * Return false if not.
+   * 
+   * Looking for enabled and also for disabled ownership.
+   * 
+   * @param sess
+   * @param user
+   * @param serviceUser
+   * @return
+   * @throws InternalErrorException 
+   */
+  boolean serviceUserOwnershipExists(PerunSession sess, User user, User serviceUser) throws InternalErrorException;
+  
   /**
    * Return all service Users (only service users)
    * 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -111,7 +111,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		  
 		  // Get service users for user
 		  List<Integer> authzServiceUsers = jdbc.query("select service_user_users.service_user_id as id from users, " +
-		  		"service_user_users where users.id=service_user_users.user_id and users.id=?", Utils.ID_MAPPER ,user.getId());
+		  		"service_user_users where users.id=service_user_users.user_id and service_user_users='0' and users.id=?", Utils.ID_MAPPER ,user.getId());
 		  for (Integer serviceUserId : authzServiceUsers) {
 		    authzRoles.putAuthzRole(Role.SELF, User.class, serviceUserId);
 		  }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -68,7 +68,7 @@ public interface UsersManagerImplApi {
     User getUserById(PerunSession perunSession, int id) throws InternalErrorException, UserNotExistsException;
 
     /**
-     * Return all serviceUsers who are owned by the user
+     * Return all serviceUsers who are owned by the user and their ownership is not in status disabled
      * 
      * @param sess
      * @param user the user
@@ -78,7 +78,7 @@ public interface UsersManagerImplApi {
     List<User> getServiceUsersByUser(PerunSession sess, User user) throws InternalErrorException;
     
     /**
-     * Return all users who owns the serviceUser
+     * Return all users who owns the serviceUser and their ownership is not in status disabled
      * 
      * @param sess
      * @param serviceUser the service User
@@ -89,6 +89,7 @@ public interface UsersManagerImplApi {
     
     /**
      * Remove serviceUser owner (the user)
+     * Only disable ownership of user and serviceUser
      * 
      * @param sess
      * @param user the user
@@ -99,8 +100,10 @@ public interface UsersManagerImplApi {
     void removeServiceUserOwner(PerunSession sess, User user, User serviceUser) throws InternalErrorException, ServiceUserOwnerAlredyRemovedException;
     
     /**
-     * Add serviceUser owner (the user)
-     * 
+     * Add serviceUser owner (the user).
+     * If not exists, create new ownership.
+     * If exists, only enable ownership for user and serviceUser
+     *
      * @param sess
      * @param user the user
      * @param serviceUser the serviceUser
@@ -109,7 +112,40 @@ public interface UsersManagerImplApi {
     void addServiceUserOwner(PerunSession sess, User user, User serviceUser) throws InternalErrorException;
     
     /**
+     * Set ownership for user and serviceUser to ENABLE (0).
+     * 
+     * @param sess
+     * @param user
+     * @param serviceUser
+     * @throws InternalErrorException 
+     */
+    void enableOwnership(PerunSession sess, User user, User serviceUser) throws InternalErrorException;
+    
+    /**
+     * Set ownership for user and serviceUser to DISABLE (1).
+     * 
+     * @param sess
+     * @param user
+     * @param serviceUser
+     * @throws InternalErrorException 
+     */
+    void disableOwnership(PerunSession sess, User user, User serviceUser) throws InternalErrorException;
+    
+    /**
+     * Return true if ownership between user and serviceUser already exists.
+     * Return false if not.
+     * 
+     * @param sess
+     * @param user
+     * @param serviceUser
+     * @return true if ownership exists, false if not
+     * @throws InternalErrorException 
+     */
+    boolean serviceUserOwnershipExists(PerunSession sess, User user, User serviceUser) throws InternalErrorException;
+    
+    /**
      * Return all service Users (only service users)
+     * Return also users who has no owners.
      * 
      * @param sess
      * @return list of all service users in perun


### PR DESCRIPTION
- add new method ableOwnership to impl which set status=0 for ownership
- add new method disableOwnership to impl which set status=1 for ownership
- add new method serviceUserOwnershipExists which get true if some relation in DB exists, false if not
- add status condition (status=0 | 1) to all get methods (working with ServiceUsers and Users)
- modify method addServiceUserOwner to choose if want to add new ownership or modify existing
- modify method removeServiceUserOwner in BlImpl to only disable ownership (set status=1)
- add a lots of tests for serviceUser actions
- modify method deleteUser in BlImpl to allow removing ownership even if deleted user is the last owner of serviceUser
- modify AuthzResolverImpl query to get only enable ownerships
- fix method getServiceUsers (for PostgreSQL)
