### PR TITLE
CABINET: Use same method when checking and getting Authorship

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/service/impl/AuthorshipServiceImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/service/impl/AuthorshipServiceImpl.java
@@ -112,7 +112,7 @@ public class AuthorshipServiceImpl implements IAuthorshipService {
 			Authorship filter = new Authorship();
 			filter.setPublicationId(authorship.getPublicationId());
 			filter.setUserId(authorship.getUserId());
-			return authorshipDao.findByFilter(filter, null).size() > 0;
+			return authorshipDao.findByFilter(filter).size() > 0;
 		}
 		return false;
 	}


### PR DESCRIPTION
- When we check for authorship existence we must use same method
  to get authorships by filter (if ID not provided) so it matches
  results of listing authorships.
