### PR TITLE
Core: Facility has voluntary attribute type.

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Facility.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Facility.java
@@ -13,7 +13,7 @@ import cz.metacentrum.perun.core.api.BeansUtils;
 public class Facility extends Auditable implements Comparable<Facility> {
 
   private String name;
-  private String type;
+  private String type = "general";
   // TODO kontakty na spravce facility
 
   public Facility() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -76,8 +76,24 @@ public interface FacilitiesManager {
   * @throws FacilityNotExistsException
   * @throws InternalErrorException
   * @throws PrivilegeException
+  * @deprecated use {@link #getFacilityByName(PerunSession, String)} instead
   */
+ @Deprecated
  Facility getFacilityByName(PerunSession perunSession, String name, String type) throws InternalErrorException, FacilityNotExistsException, PrivilegeException;
+
+ /**
+  * Searches the Facility by its name.
+  *
+  * @param perunSession
+  * @param name
+  *  
+  * @return Facility with specified name
+  * 
+  * @throws FacilityNotExistsException
+  * @throws InternalErrorException
+  * @throws PrivilegeException
+  */
+ Facility getFacilityByName(PerunSession perunSession, String name) throws InternalErrorException, FacilityNotExistsException, PrivilegeException;
 
  /**
   * Get all possible rich Facilities with all their owners.
@@ -115,7 +131,9 @@ public interface FacilitiesManager {
   * 
   * @throws InternalErrorException
   * @throws PrivilegeException
+  * @deprecated the type attribute of the bean Facility will not be supported
   */
+ @Deprecated
  List<Facility> getFacilitiesByType(PerunSession perunSession, String type) throws InternalErrorException, PrivilegeException;
 
  /**
@@ -128,7 +146,9 @@ public interface FacilitiesManager {
   * 
   * @throws InternalErrorException
   * @throws PrivilegeException
+  * @deprecated the type attribute of the bean Facility will not be supported
   */
+ @Deprecated
  int getFacilitiesCountByType(PerunSession perunSession, String type) throws InternalErrorException, PrivilegeException;
 
  /**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -80,9 +80,24 @@ public interface FacilitiesManagerBl {
    * @return Facility with specified name
    * 
    * @throws InternalErrorException
+   * @deprecated use {@link #getFacilityByName(PerunSession, String)} instead
    */
+  @Deprecated
   Facility getFacilityByName(PerunSession perunSession, String name, String type) throws InternalErrorException, FacilityNotExistsException;
 
+  /**
+   * Searches for the Facility by its name.
+   *
+   * @param perunSession
+   * @param name
+   * @param type
+   *  
+   * @return Facility with specified name
+   * 
+   * @throws InternalErrorException
+   */
+  Facility getFacilityByName(PerunSession perunSession, String name) throws InternalErrorException, FacilityNotExistsException;
+  
    /**
   * Get all rich Facilities with all their owners.
   * 
@@ -135,7 +150,9 @@ public interface FacilitiesManagerBl {
    * @return Facilities with specified types
    * 
    * @throws InternalErrorException
+   * @deprecated the type attribute of the bean Facility will not be supported
    */
+  @Deprecated
   List<Facility> getFacilitiesByType(PerunSession perunSession, String type) throws InternalErrorException;
 
   /**
@@ -147,7 +164,9 @@ public interface FacilitiesManagerBl {
    * @return count of facilities of specified types
    * 
    * @throws InternalErrorException
+   * @deprecated the type attribute of the bean Facility will not be supported
    */
+  @Deprecated
   int getFacilitiesCountByType(PerunSession perunSession, String type) throws InternalErrorException;
 
   /**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -92,8 +92,13 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
     return getFacilitiesManagerImpl().getFacilityById(sess, id);
   }
 
+  @Deprecated
   public Facility getFacilityByName(PerunSession sess, String name, String type) throws InternalErrorException, FacilityNotExistsException {
     return getFacilitiesManagerImpl().getFacilityByName(sess, name, type);
+  }
+  
+  public Facility getFacilityByName(PerunSession sess, String name) throws InternalErrorException, FacilityNotExistsException {
+    return getFacilitiesManagerImpl().getFacilityByName(sess, name);
   }
   
   public List<RichFacility> getRichFacilities(PerunSession perunSession) throws InternalErrorException {
@@ -127,12 +132,14 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
     return facilities;
   }
 
+  @Deprecated
   public List<Facility> getFacilitiesByType(PerunSession sess, String type) throws InternalErrorException {
     List<Facility> facilities = getFacilitiesManagerImpl().getFacilitiesByType(sess, type);
     Collections.sort(facilities);
     return facilities;
   }
 
+  @Deprecated
   public int getFacilitiesCountByType(PerunSession sess, String type) throws InternalErrorException {
     return getFacilitiesManagerImpl().getFacilitiesCountByType(sess, type);
   }
@@ -266,9 +273,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
   }
 
   public Facility createFacility(PerunSession sess, Facility facility) throws InternalErrorException, FacilityExistsException {
-    //
-    //TODO check if facility type is correct
-
+    
     //check facility name, it can contain only a-zA-Z.0-9_-
     if (!facility.getName().matches("^[ a-zA-Z.0-9_-]+$")) {
       throw new InternalErrorException(new IllegalArgumentException("Wrong facility name, facility name can contain only a-Z0-9.-_ and space characters"));
@@ -276,7 +281,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 
     //check if facility have uniq name
     try {
-      this.getFacilityByName(sess, facility.getName(), facility.getType());
+      this.getFacilityByName(sess, facility.getName());
       throw new FacilityExistsException(facility);
     } catch(FacilityNotExistsException ex) { /* OK */ }
     

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -95,11 +95,28 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
     return facility;
   }
 
+  @Deprecated
   public Facility getFacilityByName(PerunSession sess, String name, String type) throws InternalErrorException, FacilityNotExistsException, PrivilegeException {
     Utils.checkPerunSession(sess);
     Utils.notNull(name, "name");
 
     Facility facility = getFacilitiesManagerBl().getFacilityByName(sess, name, type);
+
+    // Authorization
+    if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility) &&
+        !AuthzResolver.isAuthorized(sess, Role.SERVICE) &&
+        !AuthzResolver.isAuthorized(sess, Role.RPC)) {
+      throw new PrivilegeException(sess, "getFacilityByName");
+    }
+
+    return facility;
+  }
+  
+   public Facility getFacilityByName(PerunSession sess, String name) throws InternalErrorException, FacilityNotExistsException, PrivilegeException {
+    Utils.checkPerunSession(sess);
+    Utils.notNull(name, "name");
+
+    Facility facility = getFacilitiesManagerBl().getFacilityByName(sess, name);
 
     // Authorization
     if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility) &&
@@ -144,7 +161,8 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 
     return facilities;
   }
-
+  
+  @Deprecated
   public List<Facility> getFacilitiesByType(PerunSession sess, String type) throws InternalErrorException, PrivilegeException {
     Utils.checkPerunSession(sess);
     Utils.notNull(type, "type");
@@ -157,6 +175,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
     return getFacilitiesManagerBl().getFacilitiesByType(sess, type);
   }
 
+  @Deprecated
   public int getFacilitiesCountByType(PerunSession sess, String type) throws InternalErrorException, PrivilegeException {
     Utils.checkPerunSession(sess);
     Utils.notNull(type, "type");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -196,6 +196,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
     }
   }
 
+  @Deprecated
   public Facility getFacilityByName(PerunSession sess, String name, String type) throws InternalErrorException, FacilityNotExistsException {
     try {
       return jdbc.queryForObject("select " + facilityMappingSelectQuery + " from facilities where name=? and type=?", FACILITY_MAPPER, name, type);
@@ -209,6 +210,19 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
     }
   }
 
+  public Facility getFacilityByName(PerunSession sess, String name) throws InternalErrorException, FacilityNotExistsException {
+    try {
+      return jdbc.queryForObject("select " + facilityMappingSelectQuery + " from facilities where name=?", FACILITY_MAPPER, name);
+    } catch (EmptyResultDataAccessException ex) {
+      Facility fac = new Facility();
+      fac.setName(name);
+      throw new FacilityNotExistsException(fac);
+    } catch (RuntimeException ex) {
+      throw new InternalErrorException(ex);
+    }
+  }
+
+  
   public List<Facility> getFacilitiesByDestination(PerunSession sess, String destination) throws InternalErrorException, FacilityNotExistsException {
     try {
       return jdbc.query("select distinct " + facilityMappingSelectQuery + " from facilities, destinations, facility_service_destinations " +
@@ -230,6 +244,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
     }
   }
 
+  @Deprecated
   public List<Facility> getFacilitiesByType(PerunSession sess, String type) throws InternalErrorException {
     try {
       return jdbc.query("select " + facilityMappingSelectQuery + " from facilities where facilities.type=?", FACILITY_MAPPER, type);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -63,9 +63,26 @@ public interface FacilitiesManagerImplApi {
    * 
    * @throws FacilityNotExistsException
    * @throws InternalErrorException
+   * @deprecated use {@link #getFacilityByName(PerunSession, String)} instead 
    */
+  @Deprecated
   Facility getFacilityByName(PerunSession perunSession, String name, String type) throws InternalErrorException, FacilityNotExistsException;
+ 
+  /**
+   * Searches for the Facility by its name.
+   *
+   * @param perunSession
+   * @param name
+   * @param type
+   * 
+   * @return Facility with specified name
+   * 
+   * @throws FacilityNotExistsException
+   * @throws InternalErrorException
+   */
+  Facility getFacilityByName(PerunSession perunSession, String name) throws InternalErrorException, FacilityNotExistsException;
 
+  
   /**
    * Searches for the Facilities by theirs destination.
    *
@@ -99,7 +116,9 @@ public interface FacilitiesManagerImplApi {
    * @return Facilities with specified types
    * 
    * @throws InternalErrorException
+   * @deprecated the type attribute of the bean Facility will not be supported
    */
+  @Deprecated
   List<Facility> getFacilitiesByType(PerunSession perunSession, String type) throws InternalErrorException;
 
   /**
@@ -111,7 +130,9 @@ public interface FacilitiesManagerImplApi {
    * @return count of facilities of specified types
    * 
    * @throws InternalErrorException
+   * @deprecated the type attribute of the bean Facility will not be supported
    */
+  @Deprecated
   int getFacilitiesCountByType(PerunSession perunSession, String type) throws InternalErrorException;
 
   /**

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -431,7 +431,6 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		Facility facility = new Facility();
 		facility.setName("FacilitiesManagerTestFacility");
-		facility.setType("Testing");
 
 		perun.getFacilitiesManager().createFacility(sess, facility);
 		// shouldn't create same facility twice


### PR DESCRIPTION
- Methods using type attribute in FacilitiesManager altered as deprecated:
  - getFacilityByName - created new one without type attribute as parameter
  - getFacilitiesByType - deprecated
  - getFacilitiesCountByType - deprecated
- Method createFacility prohibits duplicates in the name, type is ignored.
