### PR TITLE
GUI: do not allow ":" in group name

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -17,6 +17,7 @@ public class Utils {
     private static final int DEFAULT_LENGTH = 25;
 
     public static final String GROUP_NAME_MATCHER = "^[- a-zA-Z.0-9_:]+$";
+    public static final String GROUP_SHORT_NAME_MATCHER = "^[- a-zA-Z.0-9_]+$";
     public static final String VO_SHORT_NAME_MATCHER = "^[-a-zA-Z0-9_]+$";
     public static final String ATTRIBUTE_FRIENDLY_NAME_MATCHER = "^[-a-zA-Z:]+$";
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
@@ -179,7 +179,7 @@ public class CreateGroupTabItem implements TabItem {
             public boolean validateTextBox() {
                 if (groupNameTextBox.getTextBox().getText().trim().isEmpty()) {
                     groupNameTextBox.setError("Name can't be empty.");
-                } else if (!groupNameTextBox.getTextBox().getText().trim().matches(Utils.GROUP_NAME_MATCHER)) {
+                } else if (!groupNameTextBox.getTextBox().getText().trim().matches(Utils.GROUP_SHORT_NAME_MATCHER)) {
                     groupNameTextBox.setError("Name can contain only letters, numbers, spaces, dots, '_' and '-'.");
                 } else {
                     groupNameTextBox.setOk();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/EditGroupDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/EditGroupDetailsTabItem.java
@@ -98,7 +98,7 @@ public class EditGroupDetailsTabItem implements TabItem {
             public boolean validateTextBox() {
                 if (nameTextBox.getTextBox().getText().trim().isEmpty()) {
                     nameTextBox.setError("Name can't be empty.");
-                } else if (!nameTextBox.getTextBox().getText().trim().matches(Utils.GROUP_NAME_MATCHER)) {
+                } else if (!nameTextBox.getTextBox().getText().trim().matches(Utils.GROUP_SHORT_NAME_MATCHER)) {
                     nameTextBox.setError("Name can contain only letters, numbers, spaces, dots, '_' and '-'.");
                 } else {
                     nameTextBox.setOk();


### PR DESCRIPTION
- Do not allow ":" to be part of group.shortName
  (still can be part of group.name as names separator).
