### PR TITLE
GUI: display error ID in report box header

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -70,7 +70,7 @@ public class JsonErrorHandler {
         }
 
         // build confirm
-        Confirm conf = new Confirm(getCaption(type), layout, okClickHandler, reportClickHandler, okLabel, reportLabel, true);
+        Confirm conf = new Confirm(getCaption(type) + ((!error.getErrorId().equals("")) ? " ("+error.getErrorId()+")" : ""), layout, okClickHandler, reportClickHandler, okLabel, reportLabel, true);
         conf.setNonScrollable(true);
         conf.setCancelIcon(SmallIcons.INSTANCE.emailIcon());
 


### PR DESCRIPTION
- Display error ID in heading of report box sice
  some users sends screenshot of an error
  instead of using report widget itself.
