### PR TITLE
GUI: send shortName as new name in group object

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/UpdateGroup.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/UpdateGroup.java
@@ -56,7 +56,8 @@ public class UpdateGroup {
 		// RECONSTRUCT OBJECT
 		JSONObject newGroup = new JSONObject();
 		newGroup.put("id", oldGroup.get("id"));
-		newGroup.put("name", oldGroup.get("name"));
+		// fake new group short name as name in order to update
+        newGroup.put("name", oldGroup.get("shortName"));
 		newGroup.put("description", oldGroup.get("description"));
 		newGroup.put("voId", oldGroup.get("voId"));
 		newGroup.put("beanName", oldGroup.get("beanName"));


### PR DESCRIPTION
- When updating group (name+description) set new shortName
  as name of group in order to update without mistakes in ":".
