### PR TITLE
CORE, RPC, REGISTRAR: allow updating titles in name for users

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -289,7 +289,22 @@ public interface UsersManager {
    */
   User updateUser(PerunSession perunSession, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException;
 
-  /**
+    /**
+     *  Updates titles before/after name of user.
+     *
+     *  New titles must be set inside User object.
+     *  Setting any title to null will remove title from name.
+     *
+     * @param perunSession
+     * @param user
+     * @return updated user with new titles before/after name
+     * @throws InternalErrorException
+     * @throws UserNotExistsException
+     * @throws PrivilegeException
+     */
+    User updateNameTitles(PerunSession perunSession, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException;
+
+    /**
    *  Updates user's userExtSource in DB.
    *
    * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -287,8 +287,18 @@ public interface UsersManagerBl {
    * @throws InternalErrorException
    */
   User updateUser(PerunSession perunSession, User user) throws InternalErrorException;
-  
-  /**
+
+    /**
+     *  Updates titles before/after users name
+     *
+     * @param perunSession
+     * @param user
+     * @return updated user with new titles before/after name
+     * @throws InternalErrorException
+     */
+    User updateNameTitles(PerunSession perunSession, User user) throws InternalErrorException;
+
+    /**
    *  Updates user's userExtSource in DB.
    *
    * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -392,6 +392,12 @@ public class UsersManagerBlImpl implements UsersManagerBl {
     getPerunBl().getAuditer().log(sess, "{} updated.", user);
     return getUsersManagerImpl().updateUser(sess, user);
   }
+
+    public User updateNameTitles(PerunSession sess, User user) throws InternalErrorException {
+        // must audit like update user since it changes same object
+        getPerunBl().getAuditer().log(sess, "{} updated.", user);
+        return getUsersManagerImpl().updateNameTitles(sess, user);
+    }
   
   public UserExtSource updateUserExtSource(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException {
 	    getPerunBl().getAuditer().log(sess, "{} updated.", userExtSource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -319,6 +319,19 @@ public class UsersManagerEntry implements UsersManager {
     return getUsersManagerBl().updateUser(sess, user);
   }
 
+    public User updateNameTitles(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException {
+        Utils.checkPerunSession(sess);
+
+        // Authorization
+        if(!AuthzResolver.isAuthorized(sess, Role.SELF, user)) {
+            throw new PrivilegeException(sess, "updateNameTitles");
+        }
+
+        getUsersManagerBl().checkUserExists(sess, user);
+
+        return getUsersManagerBl().updateNameTitles(sess, user);
+    }
+
   public UserExtSource updateUserExtSource(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException, PrivilegeException {
             Utils.checkPerunSession(sess);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -220,7 +220,17 @@ public interface UsersManagerImplApi {
      * @throws InternalErrorException
      */
     User updateUser(PerunSession perunSession, User user) throws InternalErrorException;
-    
+
+      /**
+       *  Updates titles before/after users name
+       *
+       * @param perunSession
+       * @param user
+       * @return updated user with new titles before/after name
+       * @throws InternalErrorException
+       */
+      User updateNameTitles(PerunSession perunSession, User user) throws InternalErrorException;
+
     /**
      *  Updates user;s userExtSource in DB.
      *

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -326,6 +326,26 @@ public enum UsersManagerMethod implements ManagerMethod {
     },
 
     /*#
+     * Updates titles before/after users name
+     *
+     * Titles must be set in User object.
+     * Setting any title to null will remove title from name.
+     *
+     * @param user User JSON object with titles to set
+     * @return User Updated user
+     */
+    updateNameTitles {
+
+        @Override
+        public User call(ApiCaller ac, Deserializer parms) throws PerunException {
+            ac.stateChangingCheck();
+
+            return ac.getUsersManager().updateUser(ac.getSession(),
+                    parms.read("user", User.class));
+        }
+    },
+
+    /*#
      * Updates user's userExtSource in DB.
      *
      * @param userExtSource UserExtSource JSON object


### PR DESCRIPTION
CORE, RPC:
- Added updateNameTitles(PerunSession sess, User user) method which updates titles
  in users name. Implementation is almost same as updateUser() method, but updates
  only titles and also allow to remove title by setting parameter to null.
  Auditer message same as in updateUser() is logged, since it's change of User object.

REGISTRAR:
- If titles before/after name are part of application form, they are stored to user
  during application approval. Values are taken from items linked to "displayName" attribute
  and "titleBefore/titleAfter" attributes, which takes precedence over "displayName".
- Only non-empty titles are stored by application in order to prevent deletion while
  user is logged-in by IDP without his/hers titles included.
- If any of form items can't be stored to DB, exception and wrong value is logged and stored
  for notification to vo manager/user purpose. Password items are not logged.
- Prevent logging unnecessary exceptions when instantiating registrar module.
- Updated logging messages.
