### PR TITLE
RPC: Deserializer now can provide its HttpServletRequest

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -43,7 +43,6 @@ import cz.metacentrum.perun.rpc.serializer.JsonSerializer;
 import cz.metacentrum.perun.rpc.serializer.JsonSerializerJSONP;
 import cz.metacentrum.perun.rpc.serializer.Serializer;
 
-
 @SuppressWarnings("serial")
 /**
  * HTTP servlet wrapping Perun's method calls. Returned values are serialized and sent as an HTTP response.
@@ -442,7 +441,7 @@ public class Api extends HttpServlet {
     switch (Formats.match(format)) {
     case json:
     case jsonp:
-      return new JsonDeserializer(req.getInputStream());
+      return new JsonDeserializer(req);
     case urlinjsonout:
       return new UrlDeserializer(req);
     default:

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -1,6 +1,8 @@
 package cz.metacentrum.perun.rpc.deserializer;
 
 import cz.metacentrum.perun.rpc.RpcException;
+
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 /**
@@ -9,7 +11,7 @@ import java.util.List;
  * are undefined if multiple values with the same name are supplied. Implementing any of the read* methods is optional.
  *
  * @author Jan Klos <ddd@mail.muni.cz>
- * @since 0.1
+ * @author Pavel Zlamal <256627@mail.muni.cz>
  */
 public abstract class Deserializer {
 
@@ -72,12 +74,27 @@ public abstract class Deserializer {
     public <T> List<T> readList(String name, Class<T> valueType) throws RpcException {
         throw new UnsupportedOperationException("readList(String name, Class<T> valueType)");
     }
-    
+
     /**
      * Returns string representation of the variables stored in the deserializer.
-     * 
+     *
      * @return string containing all variables
      * @throws RpcException
      */
     public abstract String readAll() throws RpcException;
+
+    /**
+     * Return HttpServletRequest related to concrete call this deserializer is used to process.
+     *
+     * Note that this "request" is not necessarily used as source to read parameters by
+     * other methods of deserializer. It IS typically for GET requests, but NOT for POST with
+     * JSON/JSONP data format.
+     *
+     * @return HttpServletRequest related to concrete call
+     * @throws UnsupportedOperationException if this deserializer does not implement this method
+     */
+    public HttpServletRequest getServletRequest() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("readList(String name, Class<T> valueType)");
+    }
+
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
@@ -4,77 +4,88 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 import cz.metacentrum.perun.rpc.RpcException;
 
 /**
- * Deserializer that reads values as parameters from {@code ServletRequest}. Only the basic read methods (for
- * {@code int} and {@code String}) are implemented.
+ * Deserializer for URL data format.
+ *
+ * Reads parameters only from URL of request, which is typically GET.
+ * Doesn't read any parameters from request body (InputStream)!
  *
  * @author Jan Klos <ddd@mail.muni.cz>
- * @since 0.1
+ * @author Pavel Zlamal <256627@mail.muni.cz>
  */
 public class UrlDeserializer extends Deserializer {
-  private ServletRequest req;
 
-  /**
-   * @param req {@code ServletRequest} to read values from
-   */
-  public UrlDeserializer(ServletRequest req) {
-    this.req = req;
-  }
+    private HttpServletRequest req;
 
-  @Override
-  public boolean contains(String name) {
-    return (req.getParameter(name) != null);
-  }
-
-  @Override
-  public String readString(String name) throws RpcException {
-    if (!contains(name)) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
-
-    return req.getParameter(name);
-  }
-
-  @Override
-  public int readInt(String name) throws RpcException {
-    if (!contains(name)) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
-
-    try {
-      return Integer.parseInt(req.getParameter(name));
-    } catch (NumberFormatException ex) {
-      throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, name + " as int", ex);
+    /**
+     * Create deserializer for URL data format.
+     *
+     * @param req HttpServletRequest this deserializer is about to process
+     */
+    public UrlDeserializer(HttpServletRequest req) {
+        this.req = req;
     }
-  }
-  
-  @Override 
-  public <T> List<T> readList(String name, Class<T> valueType) throws RpcException {
-    if (!contains(name + "[]")) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
-    
-    List<T> list = new ArrayList<T>();
-    
-    String[] stringParams = req.getParameterValues(name + "[]");
 
-    for (String param: stringParams) {
-      if (valueType.isAssignableFrom(String.class)) {
-        list.add(valueType.cast(param));
-      } else if (valueType.isAssignableFrom(Integer.class)) {
-        list.add(valueType.cast(Integer.valueOf(param)));
-      } else if (valueType.isAssignableFrom(Float.class)) {
-        list.add(valueType.cast(Float.valueOf(param)));
-      }
+    @Override
+    public boolean contains(String name) {
+        return (req.getParameter(name) != null);
     }
-    
-    return list;
-  }
 
-  public String readAll() throws RpcException {
-    StringBuffer stringParams = new StringBuffer();
-    for (Enumeration<String> parameters = req.getParameterNames(); parameters.hasMoreElements() ;) {
-      String paramName = (String) parameters.nextElement();
-      stringParams.append(paramName + "=" + req.getParameter(paramName) + " ");
+    @Override
+    public String readString(String name) throws RpcException {
+        if (!contains(name)) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
+
+        return req.getParameter(name);
     }
-    return stringParams.toString();
-  }
+
+    @Override
+    public int readInt(String name) throws RpcException {
+        if (!contains(name)) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
+
+        try {
+            return Integer.parseInt(req.getParameter(name));
+        } catch (NumberFormatException ex) {
+            throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, name + " as int", ex);
+        }
+    }
+
+    @Override
+    public <T> List<T> readList(String name, Class<T> valueType) throws RpcException {
+        if (!contains(name + "[]")) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
+
+        List<T> list = new ArrayList<T>();
+
+        String[] stringParams = req.getParameterValues(name + "[]");
+
+        for (String param: stringParams) {
+            if (valueType.isAssignableFrom(String.class)) {
+                list.add(valueType.cast(param));
+            } else if (valueType.isAssignableFrom(Integer.class)) {
+                list.add(valueType.cast(Integer.valueOf(param)));
+            } else if (valueType.isAssignableFrom(Float.class)) {
+                list.add(valueType.cast(Float.valueOf(param)));
+            }
+        }
+
+        return list;
+    }
+
+    public String readAll() throws RpcException {
+        StringBuffer stringParams = new StringBuffer();
+        for (Enumeration<String> parameters = req.getParameterNames(); parameters.hasMoreElements() ;) {
+            String paramName = (String) parameters.nextElement();
+            stringParams.append(paramName + "=" + req.getParameter(paramName) + " ");
+        }
+        return stringParams.toString();
+    }
+
+    @Override
+    public HttpServletRequest getServletRequest() {
+        return this.req;
+    }
+
 }


### PR DESCRIPTION
- All RPC's deserializers now takes HttpServletRequest in constructor
- Implemented method getServletRequest() which returns request for
  which is deserializer used.
- Such request and its parameters (like URL) can be then passed to
  Perun's API methods like "parms.getServletRequest()".
- Can be used to determine "where is Perun running" on runtime
  without static configuration in perun.properties.
- Updated javadoc for all related classes.
- Fixed source formatting.
