### PR TITLE
Add Resoure to LDAP schema

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/LdapConnector.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/LdapConnector.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.ldapc.processor;
 
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -13,6 +14,32 @@ import javax.naming.directory.ModificationItem;
 
 public interface LdapConnector {
   
+  //--------------------RESOURCE METHODS----------------------------------------
+  /**
+   * Remove resource from LDAP
+   * 
+   * @param resource resource from Perun
+   * @throws InternalErrorException if NameNotFoundException is thrown
+   */
+  public void deleteResource(Resource resource) throws InternalErrorException;
+  
+  /**
+   * Update resource in LDAP
+   * 
+   * @param resource resource from Perun
+   * @param modificationItems attributes of resources which need to be modified
+   * @throws InternalErrorException if NameNotFoundException is thrown
+   */
+  public void updateResource(Resource resource, ModificationItem[] modificationItems) throws InternalErrorException;
+  
+  /**
+   * Add resource to LDAP.
+   * 
+   * @param resource resource from Perun
+   * @throws InternalErrorException if NameNotFoundException is thrown
+   */
+  public void createResource(Resource resource) throws InternalErrorException;
+    
   //---------------------GROUP METHODS------------------------------------------  
   /**
    * Add group to LDAP.


### PR DESCRIPTION
- main.java will be generate also resources
- LdapConnector/Impl has new methods for work with resources
- EventProcessorImpl has new strategy to work with resources messages (from log)

Other changes which need to be done before starting LDAP:
- add resource and his attributes to perun.schema file
## This must be add to perun.schema:

attributetype ( 1.3.6.1.4.1.8057.2.80.16
    NAME 'perunResourceId'
    DESC 'Unique resource identifier managed by Perun'
    EQUALITY caseIgnoreMatch
    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
    SINGLE-VALUE
    )

attributetype ( 1.3.6.1.4.1.8057.2.80.17
    NAME 'perunFacilityId'
    DESC 'Unique facilityId identifier managed by Perun'
    EQUALITY caseIgnoreMatch
    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
    SINGLE-VALUE
    )

attributetype ( 1.3.6.1.4.1.8057.2.80.18
    NAME 'assignedGroupId'
    DESC 'Identifier of group which is assigned to this resource'
    EQUALITY caseIgnoreMatch
    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
    )

objectclass ( 1.3.6.1.4.1.8057.2.80.15
    NAME 'perunResource'
    DESC 'Resource managed by Perun'
    SUP groupOfUniqueNames
    STRUCTURAL
    MUST (
         perunResourceId $
         perunVoId $
         perunFacilityId
         )
    MAY (
        assignedGroupId
        )
    )

---
