### PR TITLE
Remove creating facadminVo from initialize method

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -53,11 +53,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 public interface FacilitiesManagerBl {
 
   /**
-   * Initialize manager.
-   */
-  void initialize(PerunSession sess);
-  
-  /**
    * Searches for the Facility with specified id.
    *
    * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -710,30 +710,6 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
   public List<Facility> getFacilitiesWhereUserIsAdmin(PerunSession sess, User user) throws InternalErrorException {
 	  return  facilitiesManagerImpl.getFacilitiesWhereUserIsAdmin(sess, user);
   }
-  
-  public void initialize(PerunSession sess) {
-    if (!this.initialized.compareAndSet(false, true)) return;
-
-    // Check if the facility administrators VO exists
-    try  {
-      perunBl.getVosManagerBl().getVoByShortName(sess, FacilitiesManager.FACADMINVO);
-    } catch (VoNotExistsException e) {
-      // Create the VO
-      Vo vo = new Vo();
-      vo.setName(FacilitiesManager.FACADMINVONAME);
-      vo.setShortName(FacilitiesManager.FACADMINVO);
-      try {
-        vo = perunBl.getVosManagerBl().createVo(sess, vo);
-
-      } catch (VoExistsException e1) {
-        throw new ConsistencyErrorRuntimeException("Newly created VO already exists", e1);
-      } catch (InternalErrorException e1) {
-        throw new InternalErrorRuntimeException(e1);
-      }
-    } catch (InternalErrorException e) {
-      throw new InternalErrorRuntimeException(e);
-    }
-  }
 
   public Host addHost(PerunSession sess, Host host, Facility facility) throws InternalErrorException {
     getPerunBl().getAuditer().log(sess, "{} added to {}.", host, facility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -371,7 +371,6 @@ public class PerunBlImpl implements PerunBl {
      */
     public void initialize() throws InternalErrorException {
         this.extSourcesManagerBl.initialize(this.getPerunSession());
-        this.facilitiesManagerBl.initialize(this.getPerunSession());
     }
 
     /**


### PR DESCRIPTION
- remove code with creating facadminVo from initialize method in FacilitiesManagerBlmpl
- remove initialize method from FacilitiesManagerBl/BlImpl
- remove calling initialize method of FacilitiesManagerBl from initialize method of PerunBlImpl

Comment: Spring did not call initialize method of FacilitiesManagerBlImpl, he called initialize method of PerunBlImpl which after that called initialize method of FacilitiesManagerBlImpl.
