### PR TITLE
Add new methods for assigning and removing group to/from resources

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -216,6 +216,23 @@ public interface ResourcesManager {
   void assignGroupsToResource(PerunSession perunSession, List<Group> groups, Resource resource) throws InternalErrorException, PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException;
   
   /**
+   * Assign group to the resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values.
+   * 
+   * @param perunSession
+   * @param group the group
+   * @param resources list of resources
+   * 
+   * @throws InternalErrorException
+   * @throws PrivilegeException
+   * @throws GroupNotExistsException
+   * @throws ResourceNotExistsException
+   * @throws WrongAttributeValueException
+   * @throws WrongReferenceAttributeValueException
+   * @throws GroupAlreadyAssignedException 
+   */
+  void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources) throws InternalErrorException, PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException;
+  
+  /**
    * Remove group from a resource.
    * After removing, check attributes and fix them if it is needed.
    * 
@@ -233,7 +250,7 @@ public interface ResourcesManager {
 
   /**
    * Remove groups from a resource.
-   * After removing, check attributes and ifx them if it is needed.
+   * After removing, check attributes and fix them if it is needed.
    * 
    * @param perunSession
    * @param groups list of groups
@@ -248,6 +265,23 @@ public interface ResourcesManager {
    */
   void removeGroupsFromResource(PerunSession perunSession, List<Group> groups, Resource resource) throws InternalErrorException, PrivilegeException, GroupNotExistsException, ResourceNotExistsException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException; 
  
+  /**
+   * Remove group from the resources.
+   * After removing, check attributes and fix them if it is needed.
+   * 
+   * @param perunSession
+   * @param groups list of groups
+   * @param resources list of resources
+   * 
+   * @throws InternalErrorException
+   * @throws PrivilegeException
+   * @throws GroupNotExistsException
+   * @throws ResourceNotExistsException
+   * @throws GroupNotDefinedOnResourceException
+   * @throws GroupAlreadyRemovedFromResourceException 
+   */
+  void removeGroupFromResources(PerunSession perunSession, Group groups, List<Resource> resources) throws InternalErrorException, PrivilegeException, GroupNotExistsException, ResourceNotExistsException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException;   
+  
   /**
    * List all groups associated with the resource.
    * 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -236,6 +236,20 @@ public interface ResourcesManagerBl {
   void assignGroupsToResource(PerunSession perunSession, List<Group> groups, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException;   
   
   /**
+   * Assign group to the resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values.
+   * 
+   * @param perunSession
+   * @param group the group
+   * @param resources list of resources
+   * 
+   * @throws InternalErrorException
+   * @throws WrongAttributeValueException
+   * @throws WrongReferenceAttributeValueException 
+   * @throws GroupAlreadyAssignedException
+   */
+  void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException;   
+  
+  /**
    * Remove group from a resource.
    * After removing, check attributes and fix them if it is needed.
    *
@@ -252,7 +266,7 @@ public interface ResourcesManagerBl {
 
   /**
    * Remove groups from a resource.
-   * After removing, check attributes and ifx them if it is needed.
+   * After removing, check attributes and fix them if it is needed.
    * 
    * @param perunSession
    * @param groups list of groups
@@ -263,7 +277,21 @@ public interface ResourcesManagerBl {
    * @throws GroupAlreadyRemovedFromResourceException 
    */
   void removeGroupsFromResource(PerunSession perunSession, List<Group> groups, Resource resource) throws InternalErrorException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException;   
-  
+
+  /**
+   * Remove group from resources.
+   * After removing, check attributes and fix them if it is needed.
+   * 
+   * @param perunSession
+   * @param group the group
+   * @param resources list of resources
+   * 
+   * @throws InternalErrorException
+   * @throws GroupNotDefinedOnResourceException
+   * @throws GroupAlreadyRemovedFromResourceException 
+   */
+  void removeGroupFromResources(PerunSession perunSession, Group group, List<Resource> resources) throws InternalErrorException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException;   
+    
   /**
    * List all groups associated with the resource.
    * 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -273,6 +273,12 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
     }
   }
 
+  public void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException {
+    for(Resource r: resources) {
+        this.assignGroupToResource(perunSession, group, r);
+    }
+  }
+  
   public void removeGroupFromResource(PerunSession sess, Group group, Resource resource) throws InternalErrorException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException {
     Vo groupVo = getPerunBl().getGroupsManagerBl().getVo(sess, group);
 
@@ -357,6 +363,12 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
     }
   }
 
+  public void removeGroupFromResources(PerunSession perunSession, Group group, List<Resource> resources) throws InternalErrorException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException {
+    for(Resource r: resources) {
+        this.removeGroupFromResource(perunSession, group, r);
+    }
+  }
+  
   public List<Group> getAssignedGroups(PerunSession sess, Resource resource) throws InternalErrorException {
     return getPerunBl().getGroupsManagerBl().getAssignedGroupsToResource(sess, resource);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -249,7 +249,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
     getResourcesManagerBl().checkResourceExists(sess, resource);
 
     // Authorization
-    if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) && !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, resource)) {
+    if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource)) {
       throw new PrivilegeException(sess, "assignGroupToResource");
     }
     
@@ -264,7 +264,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
     getResourcesManagerBl().checkResourceExists(perunSession, resource);
     
     // Authorization
-    if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, resource) && !AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER, resource)) {
+    if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, resource)) {
       throw new PrivilegeException(perunSession, "assignGroupsToResource");
     }
     
@@ -275,6 +275,23 @@ public class ResourcesManagerEntry implements ResourcesManager {
     getResourcesManagerBl().assignGroupsToResource(perunSession, groups, resource);
   }
 
+  public void assignGroupToResources(PerunSession perunSession, Group group, List<Resource> resources) throws InternalErrorException, PrivilegeException, GroupNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupAlreadyAssignedException {
+    Utils.checkPerunSession(perunSession);
+    Utils.notNull(resources, "resources");
+    getPerunBl().getGroupsManagerBl().checkGroupExists(perunSession, group);
+
+    // Authorization
+    if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, group)) {
+      throw new PrivilegeException(perunSession, "assignGroupToResources");
+    }
+    
+    for(Resource r: resources) {
+        getResourcesManagerBl().checkResourceExists(perunSession, r);
+    }
+    
+    getResourcesManagerBl().assignGroupToResources(perunSession, group, resources);
+  }
+  
   public void removeGroupFromResource(PerunSession sess, Group group, Resource resource) throws InternalErrorException, PrivilegeException, GroupNotExistsException, ResourceNotExistsException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException {
     Utils.checkPerunSession(sess);
     getResourcesManagerBl().checkResourceExists(sess, resource);
@@ -295,7 +312,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
     getResourcesManagerBl().checkResourceExists(perunSession, resource);
     
     // Authorization
-    if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, resource) && !AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER, resource)) {
+    if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, resource)) {
       throw new PrivilegeException(perunSession, "removeGroupsFromResource");
     }
     
@@ -304,6 +321,23 @@ public class ResourcesManagerEntry implements ResourcesManager {
     }
     
     getResourcesManagerBl().removeGroupsFromResource(perunSession, groups, resource);  
+  }
+  
+  public void removeGroupFromResources(PerunSession perunSession, Group group, List<Resource> resources) throws InternalErrorException, PrivilegeException, GroupNotExistsException, ResourceNotExistsException, GroupNotDefinedOnResourceException, GroupAlreadyRemovedFromResourceException {
+    Utils.checkPerunSession(perunSession);
+    Utils.notNull(resources, "resources");
+    getPerunBl().getGroupsManagerBl().checkGroupExists(perunSession, group);
+    
+    // Authorization
+    if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, group)) {
+      throw new PrivilegeException(perunSession, "removeGroupFromResources");
+    }
+    
+    for(Resource r: resources) {
+        getResourcesManagerBl().checkResourceExists(perunSession, r);
+    }
+    
+    getResourcesManagerBl().removeGroupFromResources(perunSession, group, resources);  
   }
 
   public List<Group> getAssignedGroups(PerunSession sess, Resource resource) throws InternalErrorException, PrivilegeException, ResourceNotExistsException {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -181,7 +181,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
     },
 
     /*#
-     * Assign group to a resource. Check if attributes for each member form group are valid. Fill members' attributes with missing value.
+     * Assign group to a resource. Check if attributes for each member from group are valid. Fill members' attributes with missing value.
      *
      * @param group int Group ID
      * @param resource int Resource ID
@@ -200,7 +200,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
     },
     
     /*#
-     * Assign groups to a resource. Check if attributes for each member form groups are valid. Fill members' attributes with missing values.
+     * Assign groups to a resource. Check if attributes for each member from groups are valid. Fill members' attributes with missing values.
      *
      * @param groups List<Integer> list of groups IDs
      * @param resource int Resource ID
@@ -219,6 +219,30 @@ public enum ResourcesManagerMethod implements ManagerMethod {
             ac.getResourcesManager().assignGroupsToResource(ac.getSession(),
                     groups,
                     ac.getResourceById(parms.readInt("resource")));
+            return null;
+        }
+    },
+    
+    /*#
+     * Assign group to resources. Check if attributes for each member from group are valid. Fill members' attributes with missing values.
+     *
+     * @param group int Group ID
+     * @param resources List<Integer> list of resources IDs
+     */
+    assignGroupToResources {
+
+        @Override
+        public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+            ac.stateChangingCheck();
+
+            List<Integer> ids = parms.readList("resources", Integer.class);
+            List<Resource> resources = new ArrayList<Resource>();
+            for (Integer i : ids) {
+                resources.add(ac.getResourceById(i));
+            }
+            ac.getResourcesManager().assignGroupToResources(ac.getSession(),
+                    ac.getGroupById(parms.readInt("group")),
+                    resources);
             return null;
         }
     },
@@ -256,9 +280,39 @@ public enum ResourcesManagerMethod implements ManagerMethod {
         public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
             ac.stateChangingCheck();
 
+            List<Integer> ids = parms.readList("groups", Integer.class);
+            List<Group> groups = new ArrayList<Group>();
+            for (Integer i : ids) {
+                groups.add(ac.getGroupById(i));
+            }
             ac.getResourcesManager().removeGroupsFromResource(ac.getSession(),
-                    parms.readList("groups", Group.class),
+                    groups,
                     ac.getResourceById(parms.readInt("resource")));
+            return null;
+        }
+    },
+    
+    /*#
+     * Remove group from resources.
+     * After removing, check attributes and fix them if it is needed.
+     *
+     * @param group int Group ID
+     * @param resources List<Integer> list of resources IDs
+     */
+    removeGroupFromResources {
+
+        @Override
+        public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+            ac.stateChangingCheck();
+
+            List<Integer> ids = parms.readList("resources", Integer.class);
+            List<Resource> resources = new ArrayList<Resource>();
+            for (Integer i : ids) {
+                resources.add(ac.getResourceById(i));
+            }
+            ac.getResourcesManager().removeGroupFromResources(ac.getSession(),
+                    ac.getGroupById(parms.readInt("group")),
+                    resources);
             return null;
         }
     },


### PR DESCRIPTION
- hint: (one group, more resources)
- add method removeGroupFromResources
- add method assignGroupToResources
- add these method also to RPC
- methods are only cycles through existing methods removeGroupFromResource and assignGroupToResource in BlImpl
- fix rpc calling of method removeGroupsFromResource to use IDs instead of whole objects
- fix some javadoc
