### PR TITLE
GUI: redesigned connection lost widget

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/Confirm.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/Confirm.java
@@ -13,433 +13,464 @@ import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
 
 /**
  * Custom confirm widget class
- * 
+ *
  * @author Vaclav Mach <374430@mail.muni.cz>
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
 public class Confirm {
-	
-	/**
-	 * Whether the dialog blocks the browser shortcut keys
-	 */
-	static private boolean BLOCK_KEYS = false; 
-	
-	/**
-	 * Whether show black page overlay
-	 */
-	static private boolean OVERLAY_ENABLED = true; 
-	
-	
-	/**
-	 * The inner content
-	 */
-	private Widget content;
-	
-	/**
-	 * The widget itself
-	 */
-	private DialogBox dialogBox;
 
-	/**
-	 * OK button text
-	 */
-	private String okButtonText = ButtonTranslation.INSTANCE.okButton();
+    /**
+     * Whether the dialog blocks the browser shortcut keys
+     */
+    static private boolean BLOCK_KEYS = false;
 
-	/**
-	 * OK click event
-	 */
-	private ClickHandler okClickHandler = new ClickHandler() {
-		public void onClick(ClickEvent event) {
-			// do nothing
-		}
-	};
-	
-	/**
-	 * Cancel button text
-	 */
-	private String cancelButtonText = ButtonTranslation.INSTANCE.cancelButton();
+    /**
+     * Whether show black page overlay
+     */
+    static private boolean OVERLAY_ENABLED = true;
 
-	/**
-	 * Cancel click event
-	 */
-	private ClickHandler cancelClickHandler = new ClickHandler() {
-		public void onClick(ClickEvent event) {
-			// do nothing
-		}
-	};
-	
-	/**
-	 * Build widget with Icons ??
-	 */
-	private boolean useIcons = false;
-	
-	/**
-	 * Icons for OK / Cancle buttons
-	 */
-	private static final ImageResource OK_ICON = SmallIcons.INSTANCE.acceptIcon();
-	private static final ImageResource CANCEL_ICON = SmallIcons.INSTANCE.stopIcon();
-	private ImageResource okIcon;
-	private ImageResource cancelIcon;
-	
-	/**
-	 * Confirm box caption
-	 */
-	private String caption = "Confirmation";
 
-	/**
-	 * Value
-	 */
-	private boolean value = false;
-	
-	/**
-	 * Event called
-	 */
-	private boolean eventCalled = false;
-	
-	/**
-	 * Whether should the content be non scrollable
-	 */
-	private boolean nonScrollable = false;
-	
-	/**
-	 * Confirm, which does nothing - alert
-	 * 
-	 * @param caption
-	 * @param content
-	 */
-	public Confirm(String caption, Widget content, boolean useIcons) {
-		this.content = content;
-		this.caption = caption;
-		this.cancelButtonText = "";
-		this.useIcons = useIcons;
-	}
-	
-	/**
-	 * Creates the new instance of the Confirm widget just with OK.
-	 * Cancel does nothing.
-	 * 
-	 * @param caption
-	 * @param content
- 	 * @param okClickHandler
- 	 * @param useIcons (uses icons in widget) - if no icon set, use default
-	 */
-	public Confirm(String caption, Widget content, ClickHandler okClickHandler, boolean useIcons) {
-		this.content = content;
-		this.okClickHandler = okClickHandler;
-		this.caption = caption;
-		this.useIcons = useIcons;
-	}
-	
-	/**
-	 * Creates the new instance of the Confirm widget just with OK button and custom OK text.
-	 * Cancel does nothing.
-	 * 
-	 * @param caption
-	 * @param content
- 	 * @param okClickHandler
- 	 * @param useIcons (uses icons in widget) - if no icon set, use default
-	 */
-	public Confirm(String caption, Widget content, ClickHandler okClickHandler, String okButtonText, boolean useIcons) {
-		this.content = content;
-		this.okClickHandler = okClickHandler;
-		this.caption = caption;
-		this.okButtonText = okButtonText;
-		this.useIcons = useIcons;
-	}
-	
-	/**
-	 * Creates the new instance of the Confirm widget
-	 * @param caption
-	 * @param content
- 	 * @param okClickHandler
- 	 * @param cancelClickHandler
- 	 * @param useIcons (uses icons in widget) - if no icon set, use default
-	 */
-	public Confirm(String caption, Widget content, ClickHandler okClickHandler, ClickHandler cancelClickHandler, boolean useIcons) {
-		this.content = content;
-		this.okClickHandler = okClickHandler;
-		this.cancelClickHandler = cancelClickHandler;
-		this.caption = caption;
-		this.useIcons = useIcons;
-	}
+    /**
+     * The inner content
+     */
+    private Widget content;
 
-	/**
-	 * Creates the new instance of the Confirm widget with custom button labels
-	 * @param caption
-	 * @param content
-	 * @param okClickHandler
-	 * @param cancelClickHandler
-	 * @param okButtonText
-	 * @param cancelButtonText
- 	 * @param useIcons (uses icons in widget) - if no icon set, use default
-	 */
-	public Confirm(String caption, Widget content, ClickHandler okClickHandler, ClickHandler cancelClickHandler, String okButtonText, String cancelButtonText, boolean useIcons) {
-		this.content = content;
-		this.okButtonText = okButtonText;
-		this.cancelButtonText = cancelButtonText;
-		this.okClickHandler = okClickHandler;
-		this.cancelClickHandler = cancelClickHandler;
-		this.caption = caption;
-		this.useIcons = useIcons;
-	}
+    /**
+     * The widget itself
+     */
+    private DialogBox dialogBox;
 
-	/**
-	 * @return the content
-	 */
-	public Widget getContent() {
-		return content;
-	}
+    /**
+     * OK button text
+     */
+    private String okButtonText = ButtonTranslation.INSTANCE.okButton();
 
-	/**
-	 * @return the okButtonText
-	 */
-	public String getOkButtonText() {
-		return okButtonText;
-	}
+    /**
+     * OK click event
+     */
+    private ClickHandler okClickHandler = new ClickHandler() {
+        public void onClick(ClickEvent event) {
+            // do nothing
+        }
+    };
 
-	/**
-	 * @return the cancelButtonText
-	 */
-	public String getCancelButtonText() {
-		return cancelButtonText;
-	}
+    /**
+     * Cancel button text
+     */
+    private String cancelButtonText = ButtonTranslation.INSTANCE.cancelButton();
 
-	/**
-	 * @param content
-	 *            the content to set
-	 */
-	public void setContent(Widget content) {
-		this.content = content;
-	}
+    /**
+     * Cancel click event
+     */
+    private ClickHandler cancelClickHandler = new ClickHandler() {
+        public void onClick(ClickEvent event) {
+            // do nothing
+        }
+    };
 
-	/**
-	 * @param okButtonText
-	 *            the okButtonText to set
-	 */
-	public void setOkButtonText(String okButtonText) {
-		this.okButtonText = okButtonText;
-	}
+    /**
+     * Build widget with Icons ??
+     */
+    private boolean useIcons = false;
+    private boolean autoHide = true;
+    private boolean hideOnClick = true;
 
-	/**
-	 * @return the okClickHandler
-	 */
-	public ClickHandler getOkClickHandler() {
-		return okClickHandler;
-	}
 
-	/**
-	 * @return the cancelClickHandler
-	 */
-	public ClickHandler getCancelClickHandler() {
-		return cancelClickHandler;
-	}
+    /**
+     * Icons for OK / Cancel buttons
+     */
+    private CustomButton okButton;
+    private CustomButton cancelButton;
+    private static final ImageResource OK_ICON = SmallIcons.INSTANCE.acceptIcon();
+    private static final ImageResource CANCEL_ICON = SmallIcons.INSTANCE.stopIcon();
+    private ImageResource okIcon;
+    private ImageResource cancelIcon;
 
-	/**
-	 * @param okClickHandler the okClickHandler to set
-	 */
-	public void setOkClickHandler(ClickHandler okClickHandler) {
-		this.okClickHandler = okClickHandler;
-	}
+    /**
+     * Confirm box caption
+     */
+    private String caption = "Confirmation";
 
-	/**
-	 * @param cancelClickHandler the cancelClickHandler to set
-	 */
-	public void setCancelClickHandler(ClickHandler cancelClickHandler) {
-		this.cancelClickHandler = cancelClickHandler;
-	}
+    /**
+     * Value
+     */
+    private boolean value = false;
 
-	/**
-	 * @param cancelButtonText
-	 *            the cancelButtonText to set
-	 */
-	public void setCancelButtonText(String cancelButtonText) {
-		this.cancelButtonText = cancelButtonText;
-	}
-	
-	/**
-	 * @param okIcon
-	 */
-	public void setOkIcon(ImageResource okIcon) {
-		this.okIcon = okIcon;
-	}
-	
-	/**
-	 * @param cancelIcon
-	 */
-	public void setCancelIcon(ImageResource cancelIcon) {
-		this.cancelIcon = cancelIcon;
-	}
-	
-	/**
-	 * @return the value
-	 */
-	public boolean getValue(){
-		return this.value;
-	}
-	
-	/**
-	 * Shows the confirm window
-	 */
-	public void show()
-	{
-		this.eventCalled = false;
-		this.buildWidget();
-	}
-	
-	
-	/**
-	 * Whether should be the content non-scrollable 
-	 * @param nonScrollable
-	 */
-	public void setNonScrollable(boolean nonScrollable)
-	{
-		this.nonScrollable = nonScrollable;
-	}
-	
-	
-	/**
-	 * Creates and displays the widget
-	 */
-	private void buildWidget()
-	{
-		// menu panel
-		TabMenu menu = new TabMenu();
+    /**
+     * Event called
+     */
+    private boolean eventCalled = false;
 
-		// OK BUTTON
-		if(this.okButtonText.length() > 0)
-		{
-			// build with icons
-			if (useIcons == true) {
-				// if no icon set - use default
-				if (okIcon == null) { okIcon = OK_ICON; }
-				
-				final Button btn = new CustomButton(this.okButtonText, okIcon, new ClickHandler() {
-					public void onClick(ClickEvent event) {
-						value = true;
-						okClickHandler.onClick(event);
-						eventCalled = true;
-						dialogBox.hide();
-					}
-				});
-				// disable on click
-				btn.addClickHandler(new ClickHandler() {
-					public void onClick(ClickEvent event) {
-						btn.setEnabled(false);
-					}
-				});
+    /**
+     * Whether should the content be non scrollable
+     */
+    private boolean nonScrollable = false;
 
-                menu.addWidget(btn);
-			// build without icons
-			} else {
-				
-				final Button btn = new Button(this.okButtonText, new ClickHandler() {
-					public void onClick(ClickEvent event) {
-						value = true;
-						okClickHandler.onClick(event);
-						eventCalled = true;
-						dialogBox.hide();
-					}
-				});
+    /**
+     * Confirm, which does nothing - alert
+     *
+     * @param caption
+     * @param content
+     */
+    public Confirm(String caption, Widget content, boolean useIcons) {
+        this.content = content;
+        this.caption = caption;
+        this.cancelButtonText = "";
+        this.useIcons = useIcons;
+    }
 
-                menu.addWidget(btn);
-				
-				// disable on click
-				btn.addClickHandler(new ClickHandler() {
-					public void onClick(ClickEvent event) {
-						btn.setEnabled(false);
-					}
-				});
+    /**
+     * Creates the new instance of the Confirm widget just with OK.
+     * Cancel does nothing.
+     *
+     * @param caption
+     * @param content
+     * @param okClickHandler
+     * @param useIcons (uses icons in widget) - if no icon set, use default
+     */
+    public Confirm(String caption, Widget content, ClickHandler okClickHandler, boolean useIcons) {
+        this.content = content;
+        this.okClickHandler = okClickHandler;
+        this.caption = caption;
+        this.useIcons = useIcons;
+    }
 
-			}
-		}
-		
-		// CANCEL BUTTON
-		if(this.cancelButtonText.length() > 0)
-		{
-			// build with icons
-			if (useIcons == true ) {
-				// if no icon set - use default
-				if (cancelIcon == null) { cancelIcon = CANCEL_ICON; }
-                menu.addWidget(new CustomButton(this.cancelButtonText, cancelIcon, new ClickHandler() {
-					public void onClick(ClickEvent event) {
-						value = false;
-						cancelClickHandler.onClick(event);
-						eventCalled = true;
-						dialogBox.hide();
-					}
-				}));
-			// build without icons	
-			} else {
-                menu.addWidget(new Button(this.cancelButtonText, new ClickHandler() {
-					public void onClick(ClickEvent event) {
-						value = false;
-						cancelClickHandler.onClick(event);
-						eventCalled = true;
-						dialogBox.hide();
-					}
-				}));
-			}
-		}	
-		
-		// widget panel
-		VerticalPanel dialogBoxInside = new VerticalPanel();
-		
-		final Widget contentWrapper;
-		if (nonScrollable) {
-			contentWrapper = new SimplePanel(this.content);
-		} else {
-			contentWrapper = new ScrollPanel(this.content);
-		}
-		
-		dialogBoxInside.add(contentWrapper);
-		dialogBoxInside.add(menu);
-		dialogBoxInside.setCellHorizontalAlignment(menu, HasHorizontalAlignment.ALIGN_RIGHT);
+    /**
+     * Creates the new instance of the Confirm widget just with OK button and custom OK text.
+     * Cancel does nothing.
+     *
+     * @param caption
+     * @param content
+     * @param okClickHandler
+     * @param useIcons (uses icons in widget) - if no icon set, use default
+     */
+    public Confirm(String caption, Widget content, ClickHandler okClickHandler, String okButtonText, boolean useIcons) {
+        this.content = content;
+        this.okClickHandler = okClickHandler;
+        this.caption = caption;
+        this.okButtonText = okButtonText;
+        this.useIcons = useIcons;
+    }
 
-		dialogBox = new DialogBox(true);
-		dialogBox.setModal(BLOCK_KEYS);
-		dialogBox.setGlassEnabled(OVERLAY_ENABLED);
-		
-		// on close call cancel
-		dialogBox.addCloseHandler(new CloseHandler<PopupPanel>() {
-			
-			public void onClose(CloseEvent<PopupPanel> event) {
-				// if event not called already
-				if(!eventCalled){
-					cancelClickHandler.onClick(null);
-				}
-			}
-		});
-		
-		dialogBox.ensureDebugId("cwDialogBox");
-		dialogBox.setWidget(dialogBoxInside);
-		dialogBox.setText(caption);
-		dialogBox.center();
-		dialogBox.show();
-		
-		// generates the resize command
-		Command c = new Command() { 
-			public void execute() {
-				if(content.getParent() == null) return; 
-				
-				if(!nonScrollable){
-					if (content.getOffsetHeight() > 250) {
-						contentWrapper.setHeight("250px");
-					} else {
-						contentWrapper.setHeight(content.getOffsetHeight()+"px");
-					}
-				}
-				dialogBox.center();
-			}
-		};
-		Scheduler.get().scheduleDeferred(c);
-		
-	}
+    /**
+     * Creates the new instance of the Confirm widget
+     * @param caption
+     * @param content
+     * @param okClickHandler
+     * @param cancelClickHandler
+     * @param useIcons (uses icons in widget) - if no icon set, use default
+     */
+    public Confirm(String caption, Widget content, ClickHandler okClickHandler, ClickHandler cancelClickHandler, boolean useIcons) {
+        this.content = content;
+        this.okClickHandler = okClickHandler;
+        this.cancelClickHandler = cancelClickHandler;
+        this.caption = caption;
+        this.useIcons = useIcons;
+    }
 
-	/**
-	 * Hide the box
-	 */
-	public void hide() {
-		dialogBox.hide();
-	}
+    /**
+     * Creates the new instance of the Confirm widget with custom button labels
+     * @param caption
+     * @param content
+     * @param okClickHandler
+     * @param cancelClickHandler
+     * @param okButtonText
+     * @param cancelButtonText
+     * @param useIcons (uses icons in widget) - if no icon set, use default
+     */
+    public Confirm(String caption, Widget content, ClickHandler okClickHandler, ClickHandler cancelClickHandler, String okButtonText, String cancelButtonText, boolean useIcons) {
+        this.content = content;
+        this.okButtonText = okButtonText;
+        this.cancelButtonText = cancelButtonText;
+        this.okClickHandler = okClickHandler;
+        this.cancelClickHandler = cancelClickHandler;
+        this.caption = caption;
+        this.useIcons = useIcons;
+    }
+
+    /**
+     * @return the content
+     */
+    public Widget getContent() {
+        return content;
+    }
+
+    /**
+     * @return the okButtonText
+     */
+    public String getOkButtonText() {
+        return okButtonText;
+    }
+
+    /**
+     * @return the cancelButtonText
+     */
+    public String getCancelButtonText() {
+        return cancelButtonText;
+    }
+
+    /**
+     * @param content
+     *            the content to set
+     */
+    public void setContent(Widget content) {
+        this.content = content;
+    }
+
+    /**
+     * @param okButtonText
+     *            the okButtonText to set
+     */
+    public void setOkButtonText(String okButtonText) {
+        this.okButtonText = okButtonText;
+    }
+
+    /**
+     * @return the okClickHandler
+     */
+    public ClickHandler getOkClickHandler() {
+        return okClickHandler;
+    }
+
+    /**
+     * @return the cancelClickHandler
+     */
+    public ClickHandler getCancelClickHandler() {
+        return cancelClickHandler;
+    }
+
+    /**
+     * @param okClickHandler the okClickHandler to set
+     */
+    public void setOkClickHandler(ClickHandler okClickHandler) {
+        this.okClickHandler = okClickHandler;
+    }
+
+    /**
+     * @param cancelClickHandler the cancelClickHandler to set
+     */
+    public void setCancelClickHandler(ClickHandler cancelClickHandler) {
+        this.cancelClickHandler = cancelClickHandler;
+    }
+
+    /**
+     * @param cancelButtonText
+     *            the cancelButtonText to set
+     */
+    public void setCancelButtonText(String cancelButtonText) {
+        this.cancelButtonText = cancelButtonText;
+    }
+
+    /**
+     * @param okIcon
+     */
+    public void setOkIcon(ImageResource okIcon) {
+        this.okIcon = okIcon;
+    }
+
+    /**
+     * @param cancelIcon
+     */
+    public void setCancelIcon(ImageResource cancelIcon) {
+        this.cancelIcon = cancelIcon;
+    }
+
+    /**
+     * @return the value
+     */
+    public boolean getValue() {
+        return this.value;
+    }
+
+    /**
+     * Shows the confirm window
+     */
+    public void show() {
+        this.eventCalled = false;
+        this.buildWidget();
+        dialogBox.show();
+    }
+
+
+    /**
+     * Whether should be the content non-scrollable
+     * @param nonScrollable
+     */
+    public void setNonScrollable(boolean nonScrollable) {
+        this.nonScrollable = nonScrollable;
+    }
+
+
+    /**
+     * Creates and displays the widget
+     */
+    public void buildWidget() {
+        // menu panel
+        TabMenu menu = new TabMenu();
+
+        // OK BUTTON
+        if(this.okButtonText.length() > 0) {
+
+            // build with icons
+            if (useIcons == true) {
+                // if no icon set - use default
+                if (okIcon == null) { okIcon = OK_ICON; }
+
+                okButton = new CustomButton(this.okButtonText, okIcon, new ClickHandler() {
+                    public void onClick(ClickEvent event) {
+                        value = true;
+                        okClickHandler.onClick(event);
+                        eventCalled = true;
+                        if (hideOnClick) dialogBox.hide();
+                    }
+                });
+
+                // build without icons
+            } else {
+
+                okButton = new CustomButton(this.okButtonText, "", null, new ClickHandler() {
+                    public void onClick(ClickEvent event) {
+                        value = true;
+                        okClickHandler.onClick(event);
+                        eventCalled = true;
+                        if (hideOnClick) dialogBox.hide();
+                    }
+                });
+
+            }
+
+            menu.addWidget(okButton);
+
+        }
+
+        // CANCEL BUTTON
+        if(this.cancelButtonText.length() > 0) {
+
+            // build with icons
+            if (useIcons == true ) {
+                // if no icon set - use default
+                if (cancelIcon == null) { cancelIcon = CANCEL_ICON; }
+                cancelButton = new CustomButton(this.cancelButtonText, cancelIcon, new ClickHandler() {
+                    public void onClick(ClickEvent event) {
+                        value = false;
+                        cancelClickHandler.onClick(event);
+                        eventCalled = true;
+                        if (hideOnClick) dialogBox.hide();
+                    }
+                });
+                // build without icons
+            } else {
+                cancelButton = new CustomButton(this.cancelButtonText, "", null, new ClickHandler() {
+                    public void onClick(ClickEvent event) {
+                        value = false;
+                        cancelClickHandler.onClick(event);
+                        eventCalled = true;
+                        if (hideOnClick) dialogBox.hide();
+                    }
+                });
+            }
+            menu.addWidget(cancelButton);
+        }
+
+        // widget panel
+        VerticalPanel dialogBoxInside = new VerticalPanel();
+
+        final Widget contentWrapper;
+        if (nonScrollable) {
+            contentWrapper = new SimplePanel(this.content);
+        } else {
+            contentWrapper = new ScrollPanel(this.content);
+        }
+
+        dialogBoxInside.add(contentWrapper);
+        dialogBoxInside.add(menu);
+        dialogBoxInside.setCellHorizontalAlignment(menu, HasHorizontalAlignment.ALIGN_RIGHT);
+
+        dialogBox = new DialogBox(true);
+        dialogBox.setModal(BLOCK_KEYS);
+        dialogBox.setGlassEnabled(OVERLAY_ENABLED);
+        dialogBox.setAutoHideEnabled(autoHide);
+
+        // on close call cancel
+        dialogBox.addCloseHandler(new CloseHandler<PopupPanel>() {
+
+            public void onClose(CloseEvent<PopupPanel> event) {
+                // if event not called already
+                if(!eventCalled){
+                    cancelClickHandler.onClick(null);
+                }
+            }
+        });
+
+        dialogBox.ensureDebugId("cwDialogBox");
+        dialogBox.setWidget(dialogBoxInside);
+        dialogBox.setText(caption);
+        dialogBox.center();
+
+        // generates the resize command
+        Command c = new Command() {
+            public void execute() {
+                if(content.getParent() == null) return;
+
+                if(!nonScrollable){
+                    if (content.getOffsetHeight() > 250) {
+                        contentWrapper.setHeight("250px");
+                    } else {
+                        contentWrapper.setHeight(content.getOffsetHeight()+"px");
+                    }
+                }
+                dialogBox.center();
+            }
+        };
+        Scheduler.get().scheduleDeferred(c);
+
+    }
+
+    /**
+     * Hide the box
+     */
+    public void hide() {
+        dialogBox.hide();
+    }
+
+    /**
+     * Set TRUE if confirm should autohide (perform cancel action)
+     * if user click outside of the box.
+     *
+     * @param autoHide TRUE to autohide / FALSE otherwise
+     */
+    public void setAutoHide(boolean autoHide) {
+        this.autoHide = autoHide;
+    }
+
+    public CustomButton getOkButton() {
+        return okButton;
+    }
+
+    public CustomButton getCancelButton() {
+        return cancelButton;
+    }
+
+    /**
+     * TRUE if dialog box is currently displayed,
+     * FALSE otherwise.
+     *
+     * @return
+     */
+    public boolean isShowing() {
+
+        if (dialogBox == null) return false;
+        return this.dialogBox.isShowing();
+    }
+
+    /**
+     * TRUE if dialog box should hide on
+     * clicking any button, FALSE otherwise.
+     *
+     * @param hide TRUE to hide confirm widget on button click
+     */
+    public void setHideOnButtonClick(boolean hide) {
+        this.hideOnClick = hide;
+    }
 
 }


### PR DESCRIPTION
- Display "re-connect" button for manual checking.
- Still checks automatically if connection is back online.
- If manual check fails, display message about browser refresh.
- Updated implementation of Confirm widget
  (added more native DialogBox settings).
