### PR TITLE
GUI: bumped to GWT 2.6 release

### DIFF
--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <!-- Convenience property to set the GWT version -->
-        <gwtVersion>2.5.1</gwtVersion>
+        <gwtVersion>2.6.0</gwtVersion>
         <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
         <gui.url.modifier></gui.url.modifier>
     </properties>
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>2.6.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -223,7 +223,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>gwt-maven-plugin</artifactId>
-                        <version>2.5.1</version>
+                        <version>2.6.0</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/ApplicationForm.gwt.xml
+++ b/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/ApplicationForm.gwt.xml
@@ -41,7 +41,7 @@
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
 	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
-	<!-- Other possibilities are 'ie6', 'ie8', 'opera', 'gecko' - for FF2 -->
+	<!-- Other possibilities are 'ie8', 'ie9', 'ie10', 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 	
 	<!-- Specify the paths for translatable code -->

--- a/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
+++ b/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
@@ -38,7 +38,7 @@
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
 	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
-	<!-- Other possibilities are 'ie6', 'ie8', 'opera', 'gecko' - for FF2 -->
+    <!-- Other possibilities are 'ie8', 'ie9', 'ie10', 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 	
 	<!-- Specify the paths for translatable code -->

--- a/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
+++ b/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
@@ -38,8 +38,7 @@
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
     <extend-property name="user.agent" values="safari" /> <!-- CHROME -->
     <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
-    <extend-property name="user.agent" values="ie9" />
-    <!-- Other possibilities are 'ie6', 'ie8', 'opera', 'gecko' - for FF2 -->
+    <!-- Other possibilities are 'ie8', 'ie9', 'ie10', 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 	
 	<!-- Specify the paths for translatable code -->

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/ApplicationForm.gwt.xml
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/ApplicationForm.gwt.xml
@@ -42,8 +42,9 @@
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
+    <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
 	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
-	<!-- Other possibilities are 'ie6', 'ie8', 'opera', 'gecko' - for FF2 -->
+	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 	
 	<!-- Specify the paths for translatable code -->

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
@@ -39,8 +39,9 @@
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
-	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
-	<!-- Other possibilities are 'ie6', 'ie8', 'opera', 'gecko' - for FF2 -->
+    <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
+    <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
+	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 	
 	<!-- Specify the paths for translatable code -->

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
@@ -38,8 +38,9 @@
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
-	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
-	<!-- Other possibilities are 'ie6', 'gecko' - for FF2 -->
+    <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
+    <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
+	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 
 	<!-- Specify the paths for translatable code -->


### PR DESCRIPTION
- Updated GUI modules definitions and pom.xml dependency.

GWT 2.6 highlights:
- Java 7 source level is default.
- Fixed memory leakage in IE and when using FlexTable
  and DialogBox widgets (we use them a lot).
- Separate permutation for IE10.
- IE6-7 and Opera disabled by default (but we can still use it,
  it will be removed in next major release).
- Fixed memory leakage in development mode & firefox, which was
  a nightmare in last two stable releases.
