### PR TITLE
CORE, GUI: changed Perun's URL structure

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -742,14 +742,14 @@ public class Utils {
             URL urlObject = new URL(url);
 
             // use default if unknown rpc path
-            String path = "/perun-gui/";
+            String path = "/gui/";
 
-            if (urlObject.getPath().contains("/perun-rpc-krb/") || urlObject.getPath().contains("/krb/perun-rpc/")) {
-                path = "/krb/perun-gui/";
-            } else if (urlObject.getPath().contains("/perun-rpc-fed/") || urlObject.getPath().contains("/fed/perun-rpc/")) {
-                path = "/fed/perun-gui/";
-            } else if (urlObject.getPath().contains("/perun-rpc-cert/") || urlObject.getPath().contains("/cert/perun-rpc/")) {
-                path = "/cert/perun-gui/";
+            if (urlObject.getPath().contains("/krb/rpc/")) {
+                path = "/krb/gui/";
+            } else if (urlObject.getPath().contains("/fed/rpc/")) {
+                path = "/fed/gui/";
+            } else if (urlObject.getPath().contains("/cert/rpc/")) {
+                path = "/cert/gui/";
             }
 
             StringBuilder link = new StringBuilder();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -66,9 +66,10 @@ public class Utils {
         // always use URL of machine, where GUI runs
         String baseUrl = Window.Location.getProtocol()+"//"+ Window.Location.getHost();
 
-        final String URL_KRB = baseUrl+"/krb/perun-identity-consolidator/";
-        final String URL_FED = baseUrl+"/fed/perun-identity-consolidator/";
-        final String URL_CERT = baseUrl+"/cert/perun-identity-consolidator/";
+        // FIXME - production consolidator is still unsing old URL scheme
+        final String URL_KRB = baseUrl+"/perun-identity-consolidator-krb/";
+        final String URL_FED = baseUrl+"/perun-identity-consolidator-fed/";
+        final String URL_CERT = baseUrl+"/perun-identity-consolidator-cert/";
         String rpc = "";
         String link = "";
 
@@ -111,7 +112,7 @@ public class Utils {
         if (Utils.isDevel()) {
             baseLink = baseUrl+"/PasswordReset.html";
         } else {
-            baseLink = baseUrl+"/perun-password-reset/";
+            baseLink = baseUrl+"/pwd-reset/";
         }
 
         if (namespace != null && !namespace.isEmpty()) {

--- a/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/client/PerunWebConstants.properties
+++ b/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/client/PerunWebConstants.properties
@@ -1,8 +1,9 @@
-perunRpcUrl=/krb/perun-rpc-devel${gui.url.modifier}/jsonp/
-perunRpcUrlFed=/fed/perun-rpc-devel${gui.url.modifier}/jsonp/
-perunRpcUrlCert=/cert/perun-rpc-devel${gui.url.modifier}/jsonp/
-perunRpcUrlKrb=/krb/perun-rpc-devel${gui.url.modifier}/jsonp/
-perunRpcUrlKrbEinfra=/krb-einfra/perun-rpc-devel${gui.url.modifier}/jsonp/
+perunRpcUrl=/krb/rpc${gui.url.modifier}/jsonp/
+perunRpcUrlFed=/fed/rpc${gui.url.modifier}/jsonp/
+perunRpcUrlCert=/cert/rpc${gui.url.modifier}/jsonp/
+perunRpcUrlKrb=/krb/rpc${gui.url.modifier}/jsonp/
+perunRpcUrlKrbEinfra=/krb-einfra/rpc${gui.url.modifier}/jsonp/
+# devel doesn't use special url for password reset since it's fake anyway.
 perunRpcUrlForceAuthFed=
 jsonTimeout=30000
 pendingRequestsRefreshInterval=3000

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/client/PerunWebConstants.properties
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/client/PerunWebConstants.properties
@@ -1,9 +1,10 @@
-perunRpcUrl=/non/perun-rpc/jsonp/
-perunRpcUrlFed=/fed/perun-rpc/jsonp/
-perunRpcUrlCert=/cert/perun-rpc/jsonp/
-perunRpcUrlKrb=/krb/perun-rpc/jsonp/
-perunRpcUrlKrbEinfra=/krb-einfra/perun-rpc/jsonp/
-perunRpcUrlForceAuthnFed=/perun-password-reset/jsonp/
+perunRpcUrl=/non/rpc/jsonp/
+perunRpcUrlFed=/fed/rpc/jsonp/
+perunRpcUrlCert=/cert/rpc/jsonp/
+perunRpcUrlKrb=/krb/rpc/jsonp/
+# einfra is not used this way in production, but better still keep it
+perunRpcUrlKrbEinfra=/krb-einfra/rpc/jsonp/
+perunRpcUrlForceAuthnFed=/fed-force/rpc/jsonp/
 jsonTimeout=30000
 pendingRequestsRefreshInterval=3000
 footerPerunLink=http://perun.cesnet.cz/web/


### PR DESCRIPTION
- Use new URLs in GUI and CORE.
- Devel config files: perun-rpc-lib.properties and
  perun-registrar-lib.properties are already updated.

New URL scheme for devel:

/[authz]/rpc[-personal_login]/
/gui[-personal_login]/

New URL scheme for production:

/[authz]/rpc/
/[authz]/gui/
/[authz]/registrar/
/[authz]/pwd-reset/ (Fed for now leads forceFedAuth URL,
                     others leads to normal RPC)
/perun-identity-consolidator-[authz]/ (back to old scheme, will be implemented later)
