### PR TITLE
GUI: fixed URL for production password reset gui

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -112,7 +112,7 @@ public class Utils {
         if (Utils.isDevel()) {
             baseLink = baseUrl+"/PasswordReset.html";
         } else {
-            baseLink = baseUrl+"/pwd-reset/";
+            baseLink = baseUrl+"/fed-force/pwd-reset/";
         }
 
         if (namespace != null && !namespace.isEmpty()) {


### PR DESCRIPTION
- Change in order to use fed-force variant when pointing users from perun-gui to password-reset-gui
