### PR TITLE
GUI: logout from application form gui

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/ApplicationFormGui.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/ApplicationFormGui.java
@@ -280,7 +280,7 @@ public class ApplicationFormGui implements EntryPoint {
                     public void onFinished(JavaScriptObject jso) {
 
                         // non authz user - is used URL same as default URL (non on production) ?
-                        if (session.getRpcUrl().equalsIgnoreCase(PerunWebConstants.INSTANCE.perunRpcUrl())) {
+                        if (session.getRpcUrl().equals(PerunWebConstants.INSTANCE.perunRpcUrl())) {
 
                             // CHALLENGE WITH CAPTCHA
 
@@ -541,6 +541,8 @@ public class ApplicationFormGui implements EntryPoint {
                 });
                 request.retrieveData();
 
+                leftMenu.addLogoutItem();
+
                 return;
 
             }
@@ -598,6 +600,8 @@ public class ApplicationFormGui implements EntryPoint {
             a.fireEvent(new ClickEvent(){});
             //formPage.menuClick(); // load application form
         }
+
+        leftMenu.addLogoutItem();
 
     }
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/ApplicationFormLeftMenu.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/ApplicationFormLeftMenu.java
@@ -1,15 +1,28 @@
 package cz.metacentrum.perun.webgui.client.applicationresources;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.Cookies;
+import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.ui.*;
+import cz.metacentrum.perun.webgui.client.PerunWebConstants;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.applicationresources.pages.ApplicationPage;
 import cz.metacentrum.perun.webgui.client.localization.ApplicationMessages;
 import cz.metacentrum.perun.webgui.client.resources.LargeIcons;
+import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.authzResolver.Logout;
+import cz.metacentrum.perun.webgui.widgets.LogoutWidget;
 
 import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * Left menu used in application form gui
@@ -51,7 +64,7 @@ public class ApplicationFormLeftMenu extends Composite{
 		
 		// creating the section
 		stackPanel.add(menuContantsWrapper, header.getElement().getString(), true);
-		stackPanel.setHeight("100%");
+        stackPanel.setHeight("100%");
 		stackPanel.setWidth("280px");
 		
 		menuContents.setWidth("100%");
@@ -68,8 +81,8 @@ public class ApplicationFormLeftMenu extends Composite{
 	 * @param w
      * @return anochor we can click on
 	 */
-	private Anchor addMenuContents(String label, ImageResource res, final Widget w)
-	{
+	private Anchor addMenuContents(String label, ImageResource res, final Widget w) {
+
 		int i = menuContents.getRowCount();
 
         Image img = new Image(res);
@@ -101,6 +114,35 @@ public class ApplicationFormLeftMenu extends Composite{
 
         return link;
 	}
+
+    public void addLogoutItem() {
+
+        // if not anonymous identity
+        if (!PerunWebSession.getInstance().getRpcUrl().equals(PerunWebConstants.INSTANCE.perunRpcUrl())) {
+
+            int i = menuContents.getRowCount();
+            menuContents.setWidget(i, 0, new Image(SmallIcons.INSTANCE.doorOutIcon()));
+            Anchor a = new Anchor(ApplicationMessages.INSTANCE.logout());
+            a.addClickHandler(new ClickHandler() {
+                @Override
+                public void onClick(ClickEvent event) {
+                    Logout call = new Logout(new JsonCallbackEvents(){
+                        @Override
+                        public void onFinished(JavaScriptObject jso) {
+                            Utils.clearFederationCookies();
+                            History.newItem("logout");
+                            RootLayoutPanel.get().clear();
+                            RootLayoutPanel.get().add(new LogoutWidget());
+                        }
+                    });
+                    call.retrieveData();
+                }
+            });
+            menuContents.setWidget(i, 1, a);
+
+        }
+
+    }
 	
 	/**
 	 * Adds the item

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages.java
@@ -204,4 +204,7 @@ public interface ApplicationMessages extends Messages {
     @DefaultMessage("In order to apply for group membership, you must be VO member first.")
     String mustBeVoMemberFirst();
 
+    @DefaultMessage("Logout")
+    String logout();
+
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -1,5 +1,9 @@
 package cz.metacentrum.perun.webgui.client.resources;
 
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
+import com.google.gwt.user.client.Cookies;
 import com.google.gwt.user.client.Window;
 import cz.metacentrum.perun.webgui.client.PerunWebConstants;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -66,7 +70,7 @@ public class Utils {
         // always use URL of machine, where GUI runs
         String baseUrl = Window.Location.getProtocol()+"//"+ Window.Location.getHost();
 
-        // FIXME - production consolidator is still unsing old URL scheme
+        // FIXME - production consolidator is still using old URL scheme
         final String URL_KRB = baseUrl+"/perun-identity-consolidator-krb/";
         final String URL_FED = baseUrl+"/perun-identity-consolidator-fed/";
         final String URL_CERT = baseUrl+"/perun-identity-consolidator-cert/";
@@ -231,6 +235,30 @@ public class Utils {
 
     }
 
+    /**
+     * Clear all cookies provided by federation IDP in user's browser.
+     */
+    public static void clearFederationCookies() {
+
+        final String SHIBBOLETH_COOKIE_FORMAT = "^_shib.+$";
+
+        // retrieves all the cookies
+        Collection<String> cookies = Cookies.getCookieNames();
+
+        // regexp
+        RegExp regExp = RegExp.compile(SHIBBOLETH_COOKIE_FORMAT);
+
+        for(String cookie : cookies) {
+            // shibboleth cookie?
+            MatchResult matcher = regExp.exec(cookie);
+            boolean matchFound = (matcher != null); // equivalent to regExp.test(inputStr);
+            if(matchFound){
+                // remove it
+                Cookies.removeCookieNative(cookie, "/");
+            }
+        }
+
+    }
 
     public static final native String unAccent(String str) /*-{
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -71,6 +71,7 @@ public class JsonErrorHandler {
         // build confirm
         Confirm conf = new Confirm(getCaption(type) + ((!error.getErrorId().equals("")) ? " ("+error.getErrorId()+")" : ""), layout, okClickHandler, reportClickHandler, okLabel, reportLabel, true);
         conf.setNonScrollable(true);
+        conf.setAutoHide(false);
         conf.setCancelIcon(SmallIcons.INSTANCE.emailIcon());
 
         conf.show();
@@ -143,6 +144,7 @@ public class JsonErrorHandler {
 
                         Confirm c = new Confirm("Error report is not working", layout, true);
                         c.setNonScrollable(true);
+                        c.setAutoHide(false);
                         c.show();
 
                     };
@@ -156,7 +158,7 @@ public class JsonErrorHandler {
         FlexTable baseLayout = new FlexTable();
         baseLayout.setStyleName("alert-box-table");
 
-        baseLayout.setHTML(0, 0, "You can provide any message for this error report (e.g. describing what you tried to do). When you are done, click on send button.");
+        baseLayout.setHTML(0, 0, "<p>You can provide any message for this error report (e.g. describing what you tried to do). When you are done, click on send button.");
         baseLayout.setHTML(1, 0, "<strong>Message:</strong>");
         baseLayout.setWidget(2, 0, messageTextBox);
 
@@ -164,6 +166,7 @@ public class JsonErrorHandler {
         final Confirm conf = new Confirm(WidgetTranslation.INSTANCE.jsonClientSendErrorButton(), baseLayout, sendReportHandler, WidgetTranslation.INSTANCE.jsonClientSendErrorButton(), true);
         conf.setOkIcon(SmallIcons.INSTANCE.emailIcon());
         conf.setNonScrollable(true);
+        conf.setAutoHide(false);
         conf.show();
 
         messageTextBox.setFocus(true);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/CreateApplication.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/CreateApplication.java
@@ -53,8 +53,7 @@ public class CreateApplication {
 	 * @param application
 	 * @param formData
 	 */
-	public void createApplication(Application application, ArrayList<ApplicationFormItemData> formData)
-	{
+	public void createApplication(Application application, ArrayList<ApplicationFormItemData> formData) {
 		this.application = application;
 		this.formData = formData;
 
@@ -95,8 +94,7 @@ public class CreateApplication {
 	 * Prepares a JSON object.
 	 * @return JSONObject - the whole query
 	 */
-	private JSONObject prepareJSONObject()
-	{
+	private JSONObject prepareJSONObject() {
 		// data to JSON array
 		JSONArray data = new JSONArray();
 		for(int i = 0; i<formData.size(); i++){

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/LogoutButton.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/LogoutButton.java
@@ -3,18 +3,14 @@ package cz.metacentrum.perun.webgui.widgets;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.regexp.shared.MatchResult;
-import com.google.gwt.regexp.shared.RegExp;
-import com.google.gwt.user.client.Cookies;
+import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.RootLayoutPanel;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.authzResolver.Logout;
-import cz.metacentrum.perun.webgui.model.PerunError;
-
-import java.util.Collection;
 
 /**
  * Logout button with image
@@ -23,8 +19,6 @@ import java.util.Collection;
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
 public class LogoutButton extends Composite {
-
-    static final String SHIBBOLETH_COOKIE_FORMAT = "^_shib.+$";
 
     private CustomButton button;
 
@@ -49,40 +43,18 @@ public class LogoutButton extends Composite {
      */
     private void logout() {
 
-        Logout call = new Logout(new JsonCallbackEvents(){
+        Logout call = new Logout(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents(){
             @Override
             public void onFinished(JavaScriptObject jso){
 
-                // retrieves all the cookies
-                Collection<String> cookies = Cookies.getCookieNames();
+                Utils.clearFederationCookies();
 
-                // regexp
-                RegExp regExp = RegExp.compile(SHIBBOLETH_COOKIE_FORMAT);
+                History.newItem("logout");
 
-                for(String cookie : cookies)
-                {
-                    // shibboleth cookie?
-                    MatchResult matcher = regExp.exec(cookie);
-                    boolean matchFound = (matcher != null); // equivalent to regExp.test(inputStr);
-                    if(matchFound){
-                        // remove it
-                        Cookies.removeCookieNative(cookie, "/");
-                    }
-                }
-
-                button.setProcessing(false);
                 RootLayoutPanel.get().clear();
                 RootLayoutPanel.get().add(new LogoutWidget());
             }
-            @Override
-            public void onError(PerunError error){
-                button.setProcessing(false);
-            }
-            @Override
-            public void onLoadingStart() {
-                button.setProcessing(true);
-            }
-        });
+        }));
         // do the logout
         call.retrieveData();
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/LogoutWidget.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/LogoutWidget.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.webgui.widgets;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -57,6 +58,7 @@ public class LogoutWidget extends Composite {
             CustomButton loginButton = new CustomButton("Log-in back to Perun", SmallIcons.INSTANCE.arrowLeftIcon(), new ClickHandler() {
                 @Override
                 public void onClick(ClickEvent event) {
+                    History.back();
                     Window.Location.reload();
                 }
             });
@@ -66,6 +68,7 @@ public class LogoutWidget extends Composite {
                     Window.Location.replace("http://perun.metacentrum.cz/web/guide.php");
                 }
             });
+            perunWebButton.setImageAlign(true);
 
             links.setWidget(0, 0, loginButton);
             links.setWidget(0, 1, perunWebButton);

--- a/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages_cs.properties
+++ b/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages_cs.properties
@@ -79,3 +79,5 @@ group=Skupina
 clickOnApplicationToSee=Kliknutím na přihlášku zobrazíte její detail.
 
 mustBeVoMemberFirst=Před podáním přihlášky do skupiny již musíte být členem Virtuální organizace.
+
+logout=Odhlásit

--- a/perun-web-gui/src/main/webapp/ApplicationForm.css
+++ b/perun-web-gui/src/main/webapp/ApplicationForm.css
@@ -203,6 +203,35 @@ input[type=text], input[type=password] {
     max-width: 550px;
 }
 
+/* AlertBox content */
+.alert-box-image {
+    padding-right: 10px;
+}
+.alert-box-table td {
+    text-align: left;
+    vertical-align: top;
+    padding-top: 10px;
+}
+.alert-box-table td.itemName {
+    font-weight: bolder;
+    vertical-align: middle;
+    padding-right: 10px;
+}
+
+.formContent {
+
+    padding-left: 10px !important;
+
+    /* Firefox */
+    width: -moz-calc(100% - 10px) !important;
+    /* WebKit */
+    width: -webkit-calc(100% - 10px) !important;
+    /* Opera */
+    width: -o-calc(100% - 10px) !important;
+    /* Standard */
+    width: calc(100% - 10px) !important;
+}
+
 /* ======== TAB MENU 2 ========== */
 
 /* Buttons position */


### PR DESCRIPTION
- Added logout link to menu in application form.
- When form is submitted, but not stored (hard error),
  allow users to get back to app form without losing
  what they already filled in.
- Code simplification in logout widget.
- Clear shibboleth cookies method is now in Utils.
- Fixed "Go to perun web" button align on logout widget.
- Prevent accidental close of error reporting widgets created
  by json calls when clicking outside of the box. User must select
  desired action by click on button. This ensures, that user will be
  able to read error message.
- Source format.
