### PR TITLE
CORE: fixed typo in authz resolver

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -432,7 +432,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
             if(roles.contains(Role.FACILITYADMIN)); //Not allowed
             if(roles.contains(Role.SELF)) {
                 User u = getPerunBlImpl().getUsersManagerBl().getUserByMember(sess, member);
-                if(isAuthorized(sess, Role.SELF, user)) return true;
+                if(isAuthorized(sess, Role.SELF, u)) return true;
             }
         } else if(vo != null) {
             if(roles.contains(Role.VOADMIN)) {


### PR DESCRIPTION
- Fixed typo in authz resolver which caused member
  attributes to be writable to vo observer role.
