### PR TITLE
Fix spring component scan by tasks-lib

### DIFF
--- a/perun-tasks-lib/src/main/resources/perun-tasks-lib-applicationcontext.xml
+++ b/perun-tasks-lib/src/main/resources/perun-tasks-lib-applicationcontext.xml
@@ -14,7 +14,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
     <aop:aspectj-autoproxy/>
 
     <!-- Scans for @Repository, @Service and @Component -->
-    <context:component-scan base-package="cz.metacentrum.perun.taskslib"/>  
+    <context:component-scan base-package="cz.metacentrum.perun.taskslib.service.impl"/>  
     
     <!-- DAOs -->
     <bean id="taskDao" class="cz.metacentrum.perun.taskslib.dao.jdbc.TaskDaoJdbc">


### PR DESCRIPTION
- Due: component scan use "base-package" which is not recursive or fail because two different paths of one package
- Use more specific base_package for taskManager in tasks-lib application context
