### PR TITLE
GUI: disabled translation for PerunWeb and PasswordReset

### DIFF
--- a/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
+++ b/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
@@ -23,7 +23,7 @@
     <!--<inherits name="gwtquery.plugins.droppable.Droppable"/>-->
 
 	<!-- Allow translations - 'default' = English strings, add 'cs' = Czech strings -->
-	<extend-property name="locale" values="cs" />
+	<!-- <extend-property name="locale" values="cs" /> -->
 	<!-- <extend-property name="locale" values="en"/> -->
 	<!-- <set-property-fallback name="locale" value="en"/> -->
 

--- a/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
+++ b/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
@@ -23,7 +23,7 @@
     <!--<inherits name="gwtquery.plugins.droppable.Droppable"/>-->
 
 	<!-- Allow translations - 'default' = English strings, add 'cs' = Czech strings -->
-	<extend-property name="locale" values="cs" />
+	<!-- <extend-property name="locale" values="cs" /> -->
 	<!-- <extend-property name="locale" values="en"/> -->
 	<!-- <set-property-fallback name="locale" value="en"/> -->
 

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
@@ -23,7 +23,7 @@
     <!--<inherits name="gwtquery.plugins.droppable.Droppable"/>-->
 
 	<!-- Allow translations - 'default' = English strings, add 'cs' = Czech strings -->
-	<extend-property name="locale" values="cs" />
+	<!-- <extend-property name="locale" values="cs" /> -->
 	<!-- <extend-property name="locale" values="en"/> -->
 	<!-- <set-property-fallback name="locale" value="en"/> -->
 

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
@@ -22,7 +22,7 @@
     <!--<inherits name="gwtquery.plugins.droppable.Droppable"/>-->
 
 	<!-- Allow translations - 'default' = English strings, add 'cs' = Czech strings -->
-	<extend-property name="locale" values="cs" />
+	<!-- <extend-property name="locale" values="cs" /> -->
 	<!-- <extend-property name="locale" values="en"/> -->
 	<!-- <set-property-fallback name="locale" value="en"/> -->
 


### PR DESCRIPTION
- We do not plan to translate PerunWebGui or PasswordReset,
  so we can use only default language (English) and save up
  many compilation permutations (6 dev / 10 prod).
