### PR TITLE
GUI: fixed password change for service user

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfAuthenticationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfAuthenticationsTabItem.java
@@ -155,7 +155,7 @@ public class SelfAuthenticationsTabItem implements TabItem, TabItemWithUrl {
 							fw.addStyleName("padding-vertical");
 							CustomButton cb = new CustomButton("Change password", SmallIcons.INSTANCE.keyIcon(), new ClickHandler(){
 								public void onClick(ClickEvent event) {
-									session.getTabManager().addTabToCurrentTab(new SelfPasswordTabItem(a.getFriendlyNameParameter(), a.getValue(), SelfPasswordTabItem.Actions.CHANGE));
+									session.getTabManager().addTabToCurrentTab(new SelfPasswordTabItem(user, a.getFriendlyNameParameter(), a.getValue(), SelfPasswordTabItem.Actions.CHANGE));
 								}
 							});
 							CustomButton cb2 = new CustomButton("Reset password", SmallIcons.INSTANCE.keyIcon(), new ClickHandler(){


### PR DESCRIPTION
- Password change from GUI caused change of password
  for logged user, instead of his service user identity.
