### PR TITLE
GUI: fixed behavior on member's status change

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/FindCompleteRichMembers.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/FindCompleteRichMembers.java
@@ -111,6 +111,8 @@ public class FindCompleteRichMembers implements JsonCallbackSearchFor, JsonCallb
 	 */
 	public void retrieveData() {
 
+		if (searchString == null || searchString.isEmpty()) return;
+
 		String param = "";
 		if (PerunEntity.VIRTUAL_ORGANIZATION.equals(entity)) {
 			param = "vo=" + entityId+"&searchString=" + this.searchString;
@@ -140,8 +142,8 @@ public class FindCompleteRichMembers implements JsonCallbackSearchFor, JsonCallb
 	public void searchFor(String searchString) {
 		if (searchString != null && !searchString.isEmpty()) {
 			loaderImage.setEmptyResultMessage("No member matching '"+searchString+"' found.");
-			this.searchString = searchString;
 			clearTable();
+			this.searchString = searchString;
 			retrieveData();
 		}
 	}
@@ -247,7 +249,7 @@ public class FindCompleteRichMembers implements JsonCallbackSearchFor, JsonCallb
 			table.addColumn(checkBoxColumn,checkBoxHeader);
 		}
 
-		MemberColumnProvider columnProvider = new MemberColumnProvider(this, table, tableFieldUpdater);
+		MemberColumnProvider columnProvider = new MemberColumnProvider(dataProvider, null, table, tableFieldUpdater);
 		IsClickableCell<RichMember> authz = new IsClickableCell<RichMember>() {
 			@Override
 			public boolean isClickable(RichMember object) {
@@ -309,6 +311,7 @@ public class FindCompleteRichMembers implements JsonCallbackSearchFor, JsonCallb
 	 */
 	public void clearTable(){
 		loaderImage.loadingStart();
+		searchString = "";
 		list.clear();
 		selectionModel.clear();
 		dataProvider.flush();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/GetCompleteRichMembers.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/GetCompleteRichMembers.java
@@ -219,7 +219,7 @@ public class GetCompleteRichMembers implements JsonCallback, JsonCallbackTable<R
 			table.addColumn(checkBoxColumn,checkBoxHeader);
 		}
 
-		MemberColumnProvider columnProvider = new MemberColumnProvider(this, table, tableFieldUpdater);
+		MemberColumnProvider columnProvider = new MemberColumnProvider(dataProvider, backupList, table, tableFieldUpdater);
 		IsClickableCell<RichMember> authz = new IsClickableCell<RichMember>() {
 			@Override
 			public boolean isClickable(RichMember object) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichMember.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/RichMember.java
@@ -215,14 +215,22 @@ public class RichMember extends JavaScriptObject {
 			return this.status;
 		}-*/;
 
+	/**
+	 * Set the status of this item in Perun system as String
+	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 *
+	 * @param status string which defines item status
+	 */
+	public final native void setStatus(String status) /*-{
+        this.status = status;
+    }-*/;
 
 		/**
 		 * Compares to another object
 		 * @param o Object to compare
 		 * @return true, if they are the same
 		 */
-		public final boolean equals(RichMember o)
-		{
+		public final boolean equals(RichMember o) {
 			return (o.getId() == this.getId()) && (o.getUser().getId() == this.getUser().getId());
 		}
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
@@ -19,7 +19,6 @@ import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
 import cz.metacentrum.perun.webgui.json.groupsManager.RemoveMember;
-import cz.metacentrum.perun.webgui.json.membersManager.FindCompleteRichMembers;
 import cz.metacentrum.perun.webgui.json.membersManager.GetCompleteRichMembers;
 import cz.metacentrum.perun.webgui.model.Group;
 import cz.metacentrum.perun.webgui.model.RichMember;
@@ -64,7 +63,7 @@ public class GroupMembersTabItem implements TabItem, TabItemWithUrl{
 	final SimplePanel pageWidget = new SimplePanel();
 	// members table wrapper
 	ScrollPanel tableWrapper = new ScrollPanel();
-
+	private boolean wasDisabled = false;
 	String searchString = "";
 
 	/**
@@ -114,12 +113,12 @@ public class GroupMembersTabItem implements TabItem, TabItemWithUrl{
 		// DISABLED CHECKBOX
 		final CheckBox disabled = new CheckBox(WidgetTranslation.INSTANCE.showDisabledMembers());
 		disabled.setTitle(WidgetTranslation.INSTANCE.showDisabledMembersTitle());
-
-		JsonCallbackEvents disableCheckboxEvent = JsonCallbackEvents.disableCheckboxEvents(disabled);
+		disabled.setValue(wasDisabled);
 
 		// CALLBACKS
-		final GetCompleteRichMembers members = new GetCompleteRichMembers(PerunEntity.GROUP, groupId, null, disableCheckboxEvent);
+		final GetCompleteRichMembers members = new GetCompleteRichMembers(PerunEntity.GROUP, groupId, null, JsonCallbackEvents.disableCheckboxEvents(disabled));
 		members.setIndirectCheckable(false);
+		members.excludeDisabled(!disabled.getValue());
 		if (!session.isGroupAdmin(groupId) && !session.isVoAdmin(group.getVoId())) members.setCheckable(false);
 
 		// refreshMembers

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeStatusTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeStatusTabItem.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.webgui.tabs.memberstabs;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -114,7 +115,13 @@ public class ChangeStatusTabItem implements TabItem {
 		changeButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				SetStatus request = new SetStatus(memberId, JsonCallbackEvents.closeTabDisableButtonEvents(changeButton, tab, events));
+				SetStatus request = new SetStatus(memberId, JsonCallbackEvents.disableButtonEvents(changeButton, JsonCallbackEvents.mergeEvents(events, new JsonCallbackEvents(){
+					@Override
+					public void onFinished(JavaScriptObject jso) {
+						// close without refresh
+						session.getTabManager().closeTab(tab, false);
+					}
+				})));
 				request.setStatus(lb.getValue(lb.getSelectedIndex()));
 			}
 		});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberDetailTabItem.java
@@ -156,20 +156,7 @@ public class MemberDetailTabItem implements TabItem, TabItemWithUrl {
 
 		tabPanel.clear();
 
-		// Event for refreshing the whole tab
-		final JsonCallbackEvents refreshEvent = new JsonCallbackEvents() {
-			@Override
-			public void onFinished(JavaScriptObject jso) {
-				new GetEntityById(PerunEntity.RICH_MEMBER, memberId, new JsonCallbackEvents(){
-					public void onFinished(JavaScriptObject jso){
-						member = jso.cast();
-						draw();
-					}
-				}).retrieveData();
-			}
-		};
-
-		tabPanel.add(new MemberOverviewTabItem(member, groupId, refreshEvent), "Overview");
+		tabPanel.add(new MemberOverviewTabItem(member, groupId), "Overview");
 		tabPanel.add(new MemberGroupsTabItem(member, groupId), "Groups");
 		tabPanel.add(new MemberResourcesTabItem(member, groupId), "Resources");
 		tabPanel.add(new MemberApplicationsTabItem(member, groupId), "Applications");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfVosTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfVosTabItem.java
@@ -300,14 +300,14 @@ public class SelfVosTabItem implements TabItem, TabItemWithUrl {
 				// fill inner layout
 				PerunStatusWidget<Member> statusWidget;
 				if (session.isVoAdmin(vo.getId())) {
-					SetStatus statCall = new SetStatus(m.getId(), new JsonCallbackEvents(){
+					JsonCallbackEvents event = new JsonCallbackEvents(){
 						@Override
 						public void onFinished(JavaScriptObject jso) {
 							// REFRESH PARENT TAB
 							draw();
 						}
-					});
-					statusWidget = new PerunStatusWidget<Member>(m, user.getFullName(), statCall);
+					};
+					statusWidget = new PerunStatusWidget<Member>(m, user.getFullName(), event);
 				} else {
 					statusWidget = new PerunStatusWidget<Member>(m, user.getFullName(), null);
 				}


### PR DESCRIPTION
- Cell displaying membership status will now refresh itself,
  so we don't have to refresh whole table.
- Unified MembershipStatus widget implementation and fixed
  events chain, that was broken on member's detail tab.
- Remember checkbox state and display loading state in table
  when tab is refreshed using refresh button in top-right corner.
- Pass checkbox state to "list all" callback, when user check it
  first and then load vo members.
