### PR TITLE
Core: fixed checkAttribute[s] for VOs

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2070,6 +2070,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void checkAttributeValue(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_VO_ATTR);
 
+                if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, vo, attribute)) return;
 		getAttributesManagerImpl().checkAttributeValue(sess, vo, attribute);
 	}
 
@@ -2077,6 +2078,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_VO_ATTR);
 
 		for(Attribute attribute : attributes) {
+			if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, vo, attribute)) return;
 			getAttributesManagerImpl().checkAttributeValue(sess, vo, attribute);
 		}
 	}
@@ -3247,6 +3249,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public boolean isTrulyRequiredAttribute(PerunSession sess, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		this.checkNamespace(sess, attributeDefinition, NS_FACILITY_ATTR);
 		return getAttributesManagerImpl().isAttributeRequiredByFacility(sess, facility, attributeDefinition);
+	}
+
+	public boolean isTrulyRequiredAttribute(PerunSession sess, Vo vo, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+		this.checkNamespace(sess, attributeDefinition, NS_FACILITY_ATTR);
+		return getAttributesManagerImpl().isAttributeRequiredByVo(sess, vo, attributeDefinition);
 	}
 
 	public boolean isTrulyRequiredAttribute(PerunSession sess, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3682,6 +3682,19 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	@Override
+	public boolean isAttributeRequiredByVo(PerunSession sess, Vo vo, AttributeDefinition attributeDefinition) throws InternalErrorException {
+		try {
+			return 0 < jdbc.queryForInt("select count(*) from service_required_attrs " +
+					"join resource_services on service_required_attrs.service_id=resource_services.service_id " +
+					"join resources on resource_services.resource_id=resources.id " +
+					"where service_required_attrs.attr_id=? and resources.vo_id=?",
+					attributeDefinition.getId(), vo.getId());
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public boolean isAttributeRequiredByGroup(PerunSession sess, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		try {
 			return 0 < jdbc.queryForInt("select count(*) from service_required_attrs " +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1816,6 +1816,18 @@ public interface AttributesManagerImplApi {
 	 */
 	boolean isAttributeRequiredByFacility(PerunSession sess, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException;
 
+        /**
+	 * Check if this attribute is currently required on this vo. Attribute can be from any namespace.
+	 *
+	 * @param sess
+	 * @param vo
+	 * @param attributeDefinition
+	 * @return
+	 *
+	 * @throws InternalErrorException
+	 */
+	boolean isAttributeRequiredByVo(PerunSession sess, Vo vo, AttributeDefinition attributeDefinition) throws InternalErrorException;
+
 	/**
 	 * Check if this attribute is currently required on this group. Attribute can be from any namespace.
 	 *


### PR DESCRIPTION
- now the checking of an attribute for VO runs only when the attribute is not null
  or is truly required (Task #1527)
