### PR TITLE
GUI: allow to use custom re-captcha public key

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/ApplicationFormGui.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/ApplicationFormGui.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.webgui.client.localization.ApplicationMessages;
 import cz.metacentrum.perun.webgui.client.resources.LargeIcons;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.GetGuiConfiguration;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
@@ -279,6 +280,9 @@ public class ApplicationFormGui implements EntryPoint {
 					@Override
 					public void onFinished(JavaScriptObject jso) {
 
+						// store configuration
+						session.setConfiguration((BasicOverlayType)jso.cast());
+
 						// non authz user - is used URL same as default URL (non on production) ?
 						if (session.getRpcUrl().equals(PerunWebConstants.INSTANCE.perunRpcUrl())) {
 
@@ -288,7 +292,20 @@ public class ApplicationFormGui implements EntryPoint {
 							ft.setSize("100%", "500px");
 
 							// captcha with public key
-							final RecaptchaWidget captcha = new RecaptchaWidget("6Lcbdt0SAAAAAGMnlJn57omFv1OCl3O-PbW0NrK7", LocaleInfo.getCurrentLocale().getLocaleName(), "clean");
+							String key = Utils.getReCaptchaPublicKey();
+							if (key == null) {
+
+								PerunError error = new JSONObject().getJavaScriptObject().cast();
+								error.setErrorId("0");
+								error.setName("Missing public key");
+								error.setErrorInfo("Public key for Re-Captcha service is missing. Please add public key to GUIs configuration file.");
+								error.setRequestURL("");
+								UiElements.generateError(error, "Missing public key", "Public key for Re-Captcha service is missing.<br />Accessing application form without authorization is not possible.");
+								loadingBox.hide();
+								return;
+							}
+
+							final RecaptchaWidget captcha = new RecaptchaWidget(key, LocaleInfo.getCurrentLocale().getLocaleName(), "clean");
 
 							cz.metacentrum.perun.webgui.widgets.CustomButton cb = new CustomButton();
 							cb.setIcon(SmallIcons.INSTANCE.arrowRightIcon());

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -189,6 +189,26 @@ public class Utils {
 	}
 
 	/**
+	 * Returns public key part of Re-Captcha widget (by GOOGLE)
+	 * which is used for anonymous access to application form.
+	 *
+	 * If public key is not present, return null
+	 *
+	 * @return Re-Captcha public key
+	 */
+	public static String getReCaptchaPublicKey() {
+
+		if (PerunWebSession.getInstance().getConfiguration() != null) {
+			String value = PerunWebSession.getInstance().getConfiguration().getCustomProperty("getReCaptchaPublicKey");
+			if (value != null && !value.isEmpty()) {
+				return value;
+			}
+		}
+		return null;
+
+	}
+
+	/**
 	 * Returns TRUE if logged to Devel instance of Perun
 	 *
 	 * @return TRUE if instance of Perun is Devel / FALSE otherwise

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -55,7 +55,7 @@ public class JsonErrorHandler {
 		// clear password fields if present
 		final JSONObject postObject = new JSONObject(JsonUtils.parseJson(error.getPostData()));
 
-		if (postObject != null) {
+		if (postObject.getJavaScriptObject() != null) {
 			Set<String> keys = postObject.keySet();
 			if (keys.contains("oldPassword")) {
 				postObject.put("oldPassword", new JSONString(""));
@@ -121,8 +121,6 @@ public class JsonErrorHandler {
 						c.show();
 
 					}
-
-					;
 				});
 
 				msg.sendMessage(SendMessageToRt.DEFAULT_QUEUE, "ERROR " + error.getErrorId() + ": " + error.getRequestURL(), text);
@@ -132,7 +130,7 @@ public class JsonErrorHandler {
 
 		FlexTable baseLayout = new FlexTable();
 		baseLayout.setStyleName("alert-box-table");
-
+		baseLayout.setWidth("350px");
 		baseLayout.setHTML(0, 0, "<p>You can provide any message for this error report (e.g. describing what you tried to do). When you are done, click on send button.");
 		baseLayout.setHTML(1, 0, "<strong>Message:</strong>");
 		baseLayout.setWidget(2, 0, messageTextBox);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonPostClient.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonPostClient.java
@@ -271,7 +271,9 @@ public class JsonPostClient {
 		} else {
 			PerunError e = (PerunError) JsonUtils.parseJson("{\"errorId\":\"0\",\"name\":\"Cross-site request\",\"type\":\"" + WidgetTranslation.INSTANCE.jsonClientAlertBoxErrorCrossSiteType() + "\",\"message\":\"" + WidgetTranslation.INSTANCE.jsonClientAlertBoxErrorCrossSiteText() + "\"}").cast();
 			session.getUiElements().setLogErrorText("Error while sending request: The response was null or cross-site request.");
-			JsonErrorHandler.alertBox(e);
+			if (!hidden) {
+				JsonErrorHandler.alertBox(e);
+			}
 		}
 		events.onError(null);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/rtMessagesManager/SendMessageToRt.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/rtMessagesManager/SendMessageToRt.java
@@ -114,8 +114,6 @@ public class SendMessageToRt {
 				events.onError(error);
 			}
 
-			;
-
 			public void onFinished(JavaScriptObject jso) {
 
 				RTMessage msg = jso.cast();
@@ -124,13 +122,9 @@ public class SendMessageToRt {
 				events.onFinished(jso);
 			}
 
-			;
-
 			public void onLoadingStart() {
 				events.onLoadingStart();
 			}
-
-			;
 
 		};
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PerunError.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PerunError.java
@@ -39,6 +39,15 @@ public class PerunError extends JavaScriptObject {
     }-*/;
 
 	/**
+	 * Set name of Exception
+	 *
+	 * @param name name of exception
+	 */
+	public final native void setName(String name) /*-{
+		this.name = name;
+	}-*/;
+
+	/**
 	 * Return TYPE of exception (e.g. for CabinetException)
 	 *
 	 * @return type of exception or empty string


### PR DESCRIPTION
- Read public key for Re-Captcha from perun-web-gui.properties
  stored on server side. This will allow us to use it in
  different Perun instances without need to share our private
  key part.
- If key not present, stop loading appForm gui and display error message.
- Updated PerunError object, so more properties can be set manually.
- Small updates to error reporting widget.
- When response on POST is null (error case) and callback is hidden,
  do not show error report widget.
