### PR TITLE
Core: Fix of bug in method deleteResource() from ResourceManagerBl

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -87,6 +87,18 @@ public interface AttributesManagerBl {
 	List<Attribute> getAttributes(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
+	 * Remove all non-virtual group-resource attributes assigned to resource
+	 * 
+	 * @param sess
+	 * @param resource
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
 	 * Get all <b>non-empty</b> attributes associated with the member on the resource.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2323,6 +2323,15 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, key);
 	}
 
+	public void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		List<Group> groups = this.getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
+		for (Group group : groups) {
+			this.getPerunBl().getAttributesManagerBl().removeAllAttributes(sess, resource, group);
+		}
+		this.attributesManagerImpl.removeAllGroupResourceAttributes(sess, resource);
+		this.getPerunBl().getAuditer().log(sess, "All non-virtual group-resource attributes removed for all groups and {}", resource);
+	}
+
 	public void removeAttribute(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		removeAttributeWithoutCheck(sess, key, attribute);
 		this.checkAttributeValue(sess, key, new Attribute(attribute));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -108,6 +108,16 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 			throw new ConsistencyErrorException("All services are removed from this resource. There is no required attribute. So all attribtes for this resource can be removed withou problem.", ex);
 		}
 
+		// Remove group-resource attr values for all group and resource
+		try {
+			this.perunBl.getAttributesManagerBl().removeAllGroupResourceAttributes(sess, resource);
+		} catch (WrongAttributeValueException ex) {
+			throw new InternalErrorException(ex);
+		} catch (WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		} catch (WrongReferenceAttributeValueException ex) {
+			throw new InternalErrorException(ex);
+		}	
 		//Remove all resources tags
 		this.removeAllResourcesTagFromResource(sess, resource);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3316,6 +3316,14 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	public void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException {
+		try {
+			jdbc.update("delete from group_resource_attr_values where resource_id=?", resource.getId());
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+	
 	public void removeAttribute(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from facility_attr_values where attr_id=? and facility_id=?", attribute.getId(), facility.getId())) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1403,6 +1403,15 @@ public interface AttributesManagerImplApi {
 	void removeAllAttributes(PerunSession sess, Facility facility) throws InternalErrorException;
 
 	/**
+	 * Remove all non-virtual group-resource attribute on selected resource
+	 * 
+	 * @param sess
+	 * @param resource
+	 * @throws InternalErrorException 
+	 */
+	void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException;
+
+	/**
 	 * Unset particular attribute for the vo.
 	 *
 	 * @param sess perun session


### PR DESCRIPTION
- moddified deleteResource() in ResourceManagerBlImpl
  - deleteResource() now remove all non-virtual resource-group attributes from database
- added new method removeAllGroupResourceAttributes() into AttributesManager
