### PR TITLE
GUI: updated ReCaptcha workflow & Confirm widget button focus

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -140,6 +140,7 @@ public class JsonErrorHandler {
 		conf.setOkIcon(SmallIcons.INSTANCE.emailIcon());
 		conf.setNonScrollable(true);
 		conf.setAutoHide(false);
+		conf.setFocusOkButton(true);
 		conf.show();
 
 		messageTextBox.setFocus(true);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/Confirm.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/Confirm.java
@@ -86,6 +86,9 @@ public class Confirm {
 	private ImageResource okIcon;
 	private ImageResource cancelIcon;
 
+	// if OK button should be focused instead of cancel (by default).
+	private boolean focusOkButton = false;
+
 	/**
 	 * Confirm box caption
 	 */
@@ -275,6 +278,22 @@ public class Confirm {
 		this.cancelIcon = cancelIcon;
 	}
 
+	public boolean isFocusOkButton() {
+		return focusOkButton;
+	}
+
+	/**
+	 * Set to TRUE if OK button should be focused instead of cancel (default action).
+	 *
+	 * If OK button is only one in Confirm widget, then it's focused without
+	 * regarding this value.
+	 *
+	 * @param focusOkButton TRUE to focus OK button
+	 */
+	public void setFocusOkButton(boolean focusOkButton) {
+		this.focusOkButton = focusOkButton;
+	}
+
 	/**
 	 * @return the value
 	 */
@@ -289,6 +308,16 @@ public class Confirm {
 		this.eventCalled = false;
 		this.buildWidget();
 		dialogBox.show();
+
+		// focus on default action
+		Scheduler.get().scheduleDeferred(new Command() {
+			@Override
+			public void execute() {
+				if (cancelButton != null) cancelButton.setFocus(true);
+				if ((cancelButton == null && okButton != null) || focusOkButton) okButton.setFocus(true);
+			}
+		});
+
 	}
 
 
@@ -410,6 +439,7 @@ public class Confirm {
 		// generates the resize command
 		Command c = new Command() {
 			public void execute() {
+
 				if(content.getParent() == null) return;
 
 				if(!nonScrollable){

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/recaptcha/RecaptchaWidget.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/recaptcha/RecaptchaWidget.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.webgui.widgets.recaptcha;
 
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.TextBox;
 
 /**
  * RecaptchaWidget wrapps reCaptcha itself to behave like GWT widget
@@ -9,7 +10,10 @@ import com.google.gwt.user.client.ui.HTML;
  * Original source code was taken from: http://code.google.com/p/gwt-recaptcha/
  * ORIGINAL LICENSE: Apache License 2.0
  *
+ * Modified for Perun's purpose.
+ *
  * @author Claudius Hauptmann <claudiushauptmann.com@googlemail.com>
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class RecaptchaWidget extends Composite {
 
@@ -25,6 +29,8 @@ public class RecaptchaWidget extends Composite {
 	private String customTheme;
 	private RecaptchaTranslation customTranslation;
 	private int tabIndex;
+
+	private TextBox ownTextBox;
 
 	/**
 	 * This Constructor is used to create an default reCAPTCHA widget
@@ -274,6 +280,7 @@ public class RecaptchaWidget extends Composite {
 	}
 
 	public void reload() {
+		if (ownTextBox != null) ownTextBox.setText("");
 		Recaptcha.reload();
 	}
 
@@ -281,7 +288,14 @@ public class RecaptchaWidget extends Composite {
 		return Recaptcha.getChallenge();
 	}
 
+	/**
+	 * Return users response (if ownTextBox is set,
+	 * then value from ownTextBox is used)
+	 *
+	 * @return users captcha response
+	 */
 	public String getResponse() {
+		if (ownTextBox != null) return ownTextBox.getValue().trim();
 		return Recaptcha.getResponse();
 	}
 
@@ -296,4 +310,13 @@ public class RecaptchaWidget extends Composite {
 	public void switchType(String newType) {
 		Recaptcha.switchType(newType);
 	}
+
+	public TextBox getOwnTextBox() {
+		return ownTextBox;
+	}
+
+	public void setOwnTextBox(TextBox ownTextBox) {
+		this.ownTextBox = ownTextBox;
+	}
+
 }

--- a/perun-web-gui/src/main/webapp/ApplicationForm.css
+++ b/perun-web-gui/src/main/webapp/ApplicationForm.css
@@ -381,3 +381,15 @@ input[type=text], input[type=password] {
 .notDetermined .notDetermined:hover {
     background: #ffffff !important;
 }
+
+/* HIDE RE-CAPTCHA INPUT FIELD - we use or own TextBox */
+.recaptcha_input_area {
+    display: none !important;
+}
+.recaptchatable, .recaptcha_theme_clean {
+    border: none !important;
+}
+#recaptcha_response_field {
+    visibility:hidden !important;
+    background:blue !important;
+}


### PR DESCRIPTION
- Updated ReCaptcha widget, which was unable to set keyDown event
  on it's input. Now it uses GWT's TextBox instead of Google's.
  Original input is hidden by CSS in ApplicationForm.css file.
- User can now submit ReCaptcha value by Enter key.
- Implemented default action focusing on all Confirm based dialogs.
  Default action is cancel (if both buttons are present) or ok, if
  only one button is present. Focus preference can be set manually
  before displaying (like for error report widget, where 'submit'
  is considered default).
