### PR TITLE
GUI: Enable GWT 2.6.0

### DIFF
--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <!-- Convenience property to set the GWT version -->
-        <gwtVersion>2.5.1</gwtVersion>
+        <gwtVersion>2.6.0</gwtVersion>
         <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
         <gui.url.modifier></gui.url.modifier>
     </properties>
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>2.6.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -223,7 +223,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>gwt-maven-plugin</artifactId>
-                        <version>2.5.1</version>
+                        <version>2.6.0</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/ApplicationForm.gwt.xml
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/ApplicationForm.gwt.xml
@@ -42,7 +42,7 @@
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
-    <!-- <extend-property name="user.agent" values="ie10" /> IE 10 -->
+    <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
 	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PasswordReset.gwt.xml
@@ -39,7 +39,7 @@
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
-    <!-- <extend-property name="user.agent" values="ie10" /> IE 10 -->
+    <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
     <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/PerunWeb.gwt.xml
@@ -38,7 +38,7 @@
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
-    <!--  <extend-property name="user.agent" values="ie10" /> IE 10 -->
+    <extend-property name="user.agent" values="ie10" /> <!--  IE 10 -->
     <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->


### PR DESCRIPTION
- Update GWT 2.5.1 -> 2.6.0
- Added ie10 permutation.
- Should bring better performance and stability
  to both dev-mode and runtime.
- Fixed issue in PerunAttributeValueCell when event.currentTarget
  was not filled by jQuery, but was required by GWT to handle
  events. So now removing value from list/map attributes in
  table correctly calls update to the attr object itself.
- Source format of PerunAttributeValueCell.
