### PR TITLE
GUI: prevent doubling exception ID

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -164,23 +164,23 @@ public class JsonErrorHandler {
 
 		} else if ("WrongAttributeAssignmentException".equalsIgnoreCase(errorName)) {
 
-			return "Wrong attribute assignment (" + error.getErrorId() + ")";
+			return "Wrong attribute assignment";
 
 		} else if ("WrongAttributeValueException".equalsIgnoreCase(errorName)) {
 
-			return "Wrong attribute value (" + error.getErrorId() + ")";
+			return "Wrong attribute value";
 
 		} else if ("WrongReferenceAttributeValueException".equalsIgnoreCase(errorName)) {
 
-			return "Wrong value of related attributes (" + error.getErrorId() + ")";
+			return "Wrong value of related attributes";
 
 		} else if ("MissingRequiredDataException".equalsIgnoreCase(errorName)) {
 
-			return "IDP doesn't provide required data (" + error.getErrorId() + ")";
+			return "IDP doesn't provide required data";
 
 		} else if ("ApplicationNotCreatedException".equalsIgnoreCase(errorName)) {
 
-			return ApplicationMessages.INSTANCE.errorWhileCreatingApplication()+"(" + error.getErrorId() + ")";
+			return ApplicationMessages.INSTANCE.errorWhileCreatingApplication();
 
 		}
 


### PR DESCRIPTION
- Do not display error ID in report widget twice (as part of heading).
  ID is displayed by UiElements.generateAlert() itself.
