### PR TITLE
RPC: Fixed method change lost on source format

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -320,7 +320,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		public User call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
-			return ac.getUsersManager().updateNameTitles(ac.getSession(),
+			return ac.getUsersManager().updateUser(ac.getSession(),
 					parms.read("user", User.class));
 		}
 	},


### PR DESCRIPTION
- Fixed calling updateUser() when "usersrManager/updateUser" is called.
  Original fix was lost on source format.
