### PR TITLE
Fix throwing exceptions in methods updateUser and updateNameTItles

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -285,8 +285,9 @@ public interface UsersManagerBl {
 	 * @param user
 	 * @return updated user
 	 * @throws InternalErrorException
+	 * @throws UserNotExistsException if user not exists when method trying to update him
 	 */
-	User updateUser(PerunSession perunSession, User user) throws InternalErrorException;
+	User updateUser(PerunSession perunSession, User user) throws InternalErrorException, UserNotExistsException;
 
 	/**
 	 *  Updates titles before/after users name.
@@ -299,8 +300,9 @@ public interface UsersManagerBl {
 	 * @param user
 	 * @return updated user with new titles before/after name
 	 * @throws InternalErrorException
+	 * @throws UserNotExistsException if user not exists when method trying to update him
 	 */
-	User updateNameTitles(PerunSession perunSession, User user) throws InternalErrorException;
+	User updateNameTitles(PerunSession perunSession, User user) throws InternalErrorException, UserNotExistsException;
 
 	/**
 	 *  Updates user's userExtSource in DB.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -373,17 +373,23 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		getPerunBl().getAuditer().log(sess, "{} deleted.", user);
 	}
 
-	public User updateUser(PerunSession sess, User user) throws InternalErrorException {
-		user = getUsersManagerImpl().updateUser(sess, user);
-		getPerunBl().getAuditer().log(sess, "{} updated.", user);
-		return user;
+	public User updateUser(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException {
+		User beforeUpdatingUser = getPerunBl().getUsersManagerBl().getUserById(sess, user.getId());
+		User afterUpdatingUser = getUsersManagerImpl().updateUser(sess, user);
+		
+		//Log only when something is changed
+		if(!beforeUpdatingUser.equals(afterUpdatingUser)) getPerunBl().getAuditer().log(sess, "{} updated.", user);
+		return afterUpdatingUser;
 	}
 
-	public User updateNameTitles(PerunSession sess, User user) throws InternalErrorException {
+	public User updateNameTitles(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException {
+		User beforeUpdatingUser = getPerunBl().getUsersManagerBl().getUserById(sess, user.getId());
+		User afterUpdatingUser = getUsersManagerImpl().updateNameTitles(sess, user);
+		
+		//Log only when something is changed		
 		// must audit like update user since it changes same object
-		user = getUsersManagerImpl().updateNameTitles(sess, user);
-		getPerunBl().getAuditer().log(sess, "{} updated.", user);
-		return user;
+		if(!beforeUpdatingUser.equals(afterUpdatingUser)) getPerunBl().getAuditer().log(sess, "{} updated.", user);
+		return afterUpdatingUser;
 	}
 
 	public UserExtSource updateUserExtSource(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -315,6 +315,7 @@ public class UsersManagerEntry implements UsersManager {
 		}
 
 		getUsersManagerBl().checkUserExists(sess, user);
+		if(user.getLastName() == null || user.getLastName().isEmpty()) throw new cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException("User lastName can't be null. It's required attribute.");
 
 		return getUsersManagerBl().updateUser(sess, user);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -335,48 +335,37 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 			if (userDb == null) {
 				throw new ConsistencyErrorException("Updating non existing user");
 			}
-			
-			boolean userChanged = false;
-			//Last name can't be null
-			if (user.getLastName() == null) throw new InternalErrorException("Last name in updated user can't be null " + user);
-			
+
 			if ((user.getFirstName() != null && !user.getFirstName().equals(userDb.getFirstName())) ||
 							(user.getFirstName() == null && userDb.getFirstName() != null)) {
 				jdbc.update("update users set first_name=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where id=?",
 						user.getFirstName(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), user.getId());
 				userDb.setFirstName(user.getFirstName());
-				userChanged = true;
 			}
 			if (user.getLastName() != null && !user.getLastName().equals(userDb.getLastName())) {
 				jdbc.update("update users set last_name=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where id=?",
 						user.getLastName(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), user.getId());
 				userDb.setLastName(user.getLastName());
-				userChanged = true;
 			}
 			if ((user.getMiddleName() != null && !user.getMiddleName().equals(userDb.getMiddleName())) ||
 							(user.getMiddleName() == null && userDb.getMiddleName() != null)) {
 				jdbc.update("update users set middle_name=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where id=?",
 						user.getMiddleName(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), user.getId());
 				userDb.setMiddleName(user.getMiddleName());
-				userChanged = true;
 			}
 			if ((user.getTitleBefore() != null && !user.getTitleBefore().equals(userDb.getTitleBefore())) || 
 							(user.getTitleBefore() == null && userDb.getTitleBefore() != null)) {
 				jdbc.update("update users set title_before=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where id=?",
 						user.getTitleBefore(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), user.getId());
 				userDb.setTitleBefore(user.getTitleBefore());
-				userChanged = true;
 			}
 			if ((user.getTitleAfter() != null && !user.getTitleAfter().equals(userDb.getTitleAfter())) ||
 							(user.getTitleAfter() == null && userDb.getTitleAfter() != null)) {
 				jdbc.update("update users set title_after=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where id=?",
 						user.getTitleAfter(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), user.getId());
 				userDb.setTitleAfter(user.getTitleAfter());
-				userChanged = true;
 			}
-			
-			if (!userChanged) throw new InternalErrorException("There is nothing to change for " + userDb);
-
+		
 			return userDb;
 		} catch (RuntimeException err) {
 			throw new InternalErrorException(err);
@@ -392,24 +381,19 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 			}
 
 			// changed condition to updateUser case to handle: fill, change and remove
-			boolean userChanged = false;
 			
 			if ((user.getTitleBefore() != null && !user.getTitleBefore().equals(userDb.getTitleBefore())) ||
 					(user.getTitleBefore() == null && userDb.getTitleBefore() != null)) {
 				jdbc.update("update users set title_before=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where id=?",
 						user.getTitleBefore(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), user.getId());
 				userDb.setTitleBefore(user.getTitleBefore());
-				userChanged = true;
 			}
 			if ((user.getTitleAfter() != null && !user.getTitleAfter().equals(userDb.getTitleAfter())) ||
 					((user.getTitleAfter() == null && userDb.getTitleAfter() != null))) {
 				jdbc.update("update users set title_after=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where id=?",
 						user.getTitleAfter(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), user.getId());
 				userDb.setTitleAfter(user.getTitleAfter());
-				userChanged = true;
 			}
-
-			if (!userChanged) throw new InternalErrorException("There is nothing to change for " + userDb);
 			
 			return userDb;
 		} catch (RuntimeException err) {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -311,7 +311,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 			assertEquals("users should be the same after update in DB", gettingUser, updatedUser);
 		}
 	
-	@Test (expected=InternalErrorException.class)
+	@Test (expected=cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException.class)
 		public void updateUserWithNullValueInLastName() throws Exception {
 			System.out.println("UsersManager.updateUserWithNullValueInLastName");
 			


### PR DESCRIPTION
- do not throw internalErrorException in impl when lastName is null, instead of it throw exception in entry and user IllegarlArgumentException
- if user is not updated, do not throw exception
- if user is not updated, do not log msg to auditerLog
- fix tests for these methods
