### PR TITLE
GUI: fixed create group dialog

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
@@ -124,6 +124,10 @@ public class CreateGroupTabItem implements TabItem {
 				} else {
 					createButton.setEnabled(true);
 				}
+				// call finished when user changed his mind
+				if (!asSubGroup.getValue()) {
+					createButton.setEnabled(true);
+				}
 			}
 			public void onLoadingStart(){
 				vosGroups.clear();
@@ -133,6 +137,9 @@ public class CreateGroupTabItem implements TabItem {
 			public void onError(PerunError error) {
 				vosGroups.clear();
 				vosGroups.addItem("Error while loading");
+				if (!asSubGroup.getValue()) {
+					createButton.setEnabled(true);
+				}
 			}
 		});
 
@@ -164,6 +171,7 @@ public class CreateGroupTabItem implements TabItem {
 					vosGroups.setVisible(false);
 					parentGroupText.setVisible(false);
 					createButton.setTitle(ButtonTranslation.INSTANCE.createGroup());
+					createButton.setEnabled(true);
 				}
 			}
 		});


### PR DESCRIPTION
- do not disable create button, when user switches from sub-group case
  to group case and no parent groups are available.
