### PR TITLE
GUI: simplified URL for single tab

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/UrlMapper.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/UrlMapper.java
@@ -47,6 +47,17 @@ public class UrlMapper {
 
 		String[] parts = url.split(TAB_SEPARATOR);
 
+		// if url leads to tabs without any "active", add it to first of them
+		if (parts.length >= 1 && !url.contains("active=1")) {
+
+			if (parts[0].contains("?")) {
+				parts[0] = parts[0]+"&active=1";
+			} else {
+				parts[0] = parts[0]+"?active=1";
+			}
+
+		}
+
 		for(String tabString : parts) {
 			parseTab(tabString);
 		}


### PR DESCRIPTION
- when using tabs reference in URL, "active=1" part can be skipped
  and will be automatically added to the first tab when url is parsed.
