### PR TITLE
Notification+RPC: STREAM mode disabled

### DIFF
--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifTemplateManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifTemplateManagerImpl.java
@@ -188,6 +188,10 @@ public class PerunNotifTemplateManagerImpl implements PerunNotifTemplateManager 
 					}
 				}
 				break;
+			// Not fully supported yet !
+			// TODO - create reliable workflow with regexes in the STREAM mode.
+			//      - need to work with more than one msg of the same regex
+			//      - need to ensure delivery of all the msgs required by the template message
 			case STREAM:
 
 				DateTime now = new DateTime();

--- a/perun-rpc/src/main/perl/createNotifTemplate
+++ b/perun-rpc/src/main/perl/createNotifTemplate
@@ -13,33 +13,33 @@ Creates a NotifTemplate. Notify trigger and at least one primary property are re
 Available options:
  --name                | -n name
  --primaryProperty     | -p primary property (key and value divide by '=', more properties allowed)
- --notifyTrigger       | -t notify trigger (ALL_REGEX_IDS / STREAM)
- --oldestMessageTime   | -o oldest message time in millis
- --youngestMessageTime | -y youngest message time in millis
  --sender              | -s sender
  --batch               | -b batch
  --help                | -h prints this help
 };
 }
 
-our $batch;
-my ($name, @properties, $notifyTrigger, $oldestMessageTime, $youngestMessageTime, $sender);
-GetOptions ("help|h" => sub { print help(); exit 0;} ,"batch|b" => \$batch,
- "name|n=s" => \$name, "primaryProperty|p=s" => \@properties, "notifyTrigger|t=s" => \$notifyTrigger,
-"oldestMessageTime|o=i" => \$oldestMessageTime, "youngestMessageTime|y=i" => \$youngestMessageTime,
-"sender|s=s" => \$sender) || die help(); 
+# for stream mode
+# --notifyTrigger       | -t notify trigger (ALL_REGEX_IDS / STREAM)
+# --oldestMessageTime   | -o oldest message time in millis
+# --youngestMessageTime | -y youngest message time in millis
 
-unless (defined($notifyTrigger)) {die "ERROR: PerunNotifTemplate: notifyTrigger is required\n"}
-if (($notifyTrigger !~ /^ALL_REGEX_IDS$/) and ($notifyTrigger !~ /^STREAM$/)) { die "ERROR: allowed notifyTrigger values are only ALL_REGEX_IDS or STREAM \n";}
+our $batch;
+my ($name, @properties, $sender);
+GetOptions ("help|h" => sub { print help(); exit 0;} ,"batch|b" => \$batch,
+ "name|n=s" => \$name, "primaryProperty|p=s" => \@properties, "sender|s=s" => \$sender) || die help(); 
+
+# unless (defined($notifyTrigger)) {die "ERROR: PerunNotifTemplate: notifyTrigger is required\n"}
+#if (($notifyTrigger !~ /^ALL_REGEX_IDS$/) and ($notifyTrigger !~ /^STREAM$/)) { die "ERROR: allowed notifyTrigger values are only ALL_REGEX_IDS or STREAM \n";}
 
 my $agent = Perun::Agent->new();
 my $notifAgent = $agent->getNotificationsAgent;
 
 my $object = Perun::beans::NotifTemplate->new;
 $object->setName($name);
-$object->setNotifyTrigger($notifyTrigger);
-$object->setOldestMessageTime($oldestMessageTime);
-$object->setYoungestMessageTime($youngestMessageTime);
+$object->setNotifyTrigger("ALL_REGEX_IDS");
+$object->setOldestMessageTime(0);
+$object->setYoungestMessageTime(0);
 $object->setSender($sender);
 
 my (%hashedProperties, @list, @values);

--- a/perun-rpc/src/main/perl/updateNotifTemplate
+++ b/perun-rpc/src/main/perl/updateNotifTemplate
@@ -14,9 +14,6 @@ Available options:
  --id                  | -i id of the updated NotifTemplate
  --name                | -n name
  --primaryProperty     | -p primary property (key and value divide by '=', more properties allowed)
- --notifyTrigger       | -t notify trigger (ALL_REGEX_IDS / STREAM)
- --oldestMessageTime   | -o oldest message time in millis
- --youngestMessageTime | -y youngest message time in millis
  --locale              | -l locale
  --sender              | -s sender
  --batch               | -b batch
@@ -25,12 +22,15 @@ Available options:
 };
 }
 
+# for stream mode
+# --notifyTrigger       | -t notify trigger (ALL_REGEX_IDS / STREAM)
+# --oldestMessageTime   | -o oldest message time in millis
+# --youngestMessageTime | -y youngest message time in millis
+
 our $batch;
-my ($id, $name, @properties, $notifyTrigger, $oldestMessageTime, $youngestMessageTime, $sender);
+my ($id, $name, @properties, $sender);
 GetOptions ("help|h" => sub { print help(); exit 0;} ,"batch|b" => \$batch, "id|i=i" => \$id,
- "name|n=s" => \$name, "primaryProperty|p=s" => \@properties, "notifyTrigger|t=s" => \$notifyTrigger,
- "oldestMessageTime|o=i" => \$oldestMessageTime, "youngestMessageTime|y=i" => \$youngestMessageTime,
- "sender|s=s" => \$sender) || die help(); 
+ "name|n=s" => \$name, "primaryProperty|p=s" => \@properties, "sender|s=s" => \$sender) || die help(); 
 
 my $agent = Perun::Agent->new();
 my $notifAgent = $agent->getNotificationsAgent;
@@ -43,18 +43,18 @@ if (defined($name)) {
    $object->setName($name);
 }
 
-if (defined($notifyTrigger)) {
-    if (($notifyTrigger !~ /^ALL_REGEX_IDS$/) and ($notifyTrigger !~ /^STREAM$/)) { die "ERROR: allowed notifyTrigger values are only ALL_REGEX_IDS or STREAM \n";}
-    $object->setNotifyTrigger($notifyTrigger);
-}
+# if (defined($notifyTrigger)) {
+#    if (($notifyTrigger !~ /^ALL_REGEX_IDS$/) and ($notifyTrigger !~ /^STREAM$/)) { die "ERROR: allowed notifyTrigger values are only ALL_REGEX_IDS or STREAM \n";}
+#   $object->setNotifyTrigger($notifyTrigger);
+#}
 
-if (defined($oldestMessageTime)) {
-    $object->setOldestMessageTime($oldestMessageTime);
-}
+#if (defined($oldestMessageTime)) {
+#    $object->setOldestMessageTime($oldestMessageTime);
+#}
 
-if (defined($youngestMessageTime)) {
-    $object->setYoungestMessageTime($youngestMessageTime);
-}
+#if (defined($youngestMessageTime)) {
+#    $object->setYoungestMessageTime($youngestMessageTime);
+#}
 
 if (defined($sender)) {
     $object->setSender($sender);


### PR DESCRIPTION
The STREAM mode of the notification module has been forbidden.
For the future smooth STREAM mode workflow is needed to do the following:
- create reliable workflow with regexes in the STREAM mode
- need to work with more than one msg of the same regex
- need to ensure delivery of all the msgs required by the template message
