### PR TITLE
CLI: use ENV to determine RPC type

### DIFF
--- a/perun-rpc/src/main/perl/Perun/Agent.pm
+++ b/perun-rpc/src/main/perl/Perun/Agent.pm
@@ -55,6 +55,12 @@ sub new {
 	# Extract login/password from ENV if available
 	my ($login,$pass) = split '/',$ENV{PERUN_USER} if $ENV{PERUN_USER};
 
+	# Extrat RPC type from ENV (if not defined, use "Perun RPC")
+	my $rpcType = "Perun RPC";
+	if (defined($ENV{PERUN_RPC_TYPE})) {
+		$rpcType = $ENV{PERUN_RPC_TYPE};
+	}
+
 	$self->{_lwpUserAgent} = LWP::UserAgent->new(agent => "Agent.pm/$agentVersion");
 	# Enable cookies if the HOME env is available
 	if (defined($ENV{HOME})) {
@@ -68,7 +74,7 @@ sub new {
 	if (defined($login)) {
 		my $uri = URI->new($self->{_url});
 		my $port = defined($uri->port) ? $uri->port : $uri->schema == "https" ? 443 : 80;
-		$self->{_lwpUserAgent}->credentials($uri->host.":".$port, 'Kerberos META', $login => $pass);
+		$self->{_lwpUserAgent}->credentials($uri->host.":".$port, $rpcType, $login => $pass);
 	}
 
 	# Connect to the Perun server

--- a/perun-rpc/src/main/perl/README
+++ b/perun-rpc/src/main/perl/README
@@ -4,6 +4,7 @@ V prostredi MetaCentra staci nahrat modul perunv3. Nasledne staci spustit prikaz
 
 Pro jina prostredi je nutne nastavit:
 - Enviromentalni promennou PERUN_URL: Adresa serveru se servletem perun-rpc
+- Enviromentalni promennou PERUN_RPC_TYPE: "Kerberos META", když chybí, tak použije "Perun RPC" (Musí odpovídat položce AuthName z konfigurace Apache pro danou PERUN_URL).
 - Pokud nepouzivame GSSAPI, pak je nutne nastavit PERUN_USER - login/pass
 - Knihovny (adresar lib) zahrnout do cest s perlovymi moduly (napr. pridanim cesty do enviromentalni promenne PERL5LIB nebo zkopirovani do adresare, kde se perlove moduly hledaji).
 - Skripty (adresar bin) zahrnout do enviromentalni promenne PATH.


### PR DESCRIPTION
- Take RPC type from environmental variable PERUN_RPC_TYPE.
- Value must match AuthName property of Apache sites configuration
  for URL specified by PERUN_URL environmental variable.
- If not set, "Perun RPC" is used as default, which matches our
  basic auth used for service components on virtual appliances.

Before putting this script on devel/production instance, please set
this ENV in start_engine.sh script to "Kerberos META" value.
- Updated readme.
