### PR TITLE
RPC: Fixed perl CLI for notification's template.

### DIFF
--- a/perun-rpc/src/main/perl/Perun/beans/NotifTemplate.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/NotifTemplate.pm
@@ -193,7 +193,7 @@ sub getCommonArrayRepresentation {
 
   my $hashInString = "";
   for (keys $object->getPrimaryProperties) {
-      $hashInString = $hashInString . $_ . "=" . ${${$object->getPrimaryProperties}{$_}}[0] . ";";
+      $hashInString = $hashInString . $_ . "=" . join("/", @{${$object->getPrimaryProperties}{$_}}) . "; ";
   }
 
   return ($object->getId, $object->getName, $hashInString, $object->getNotifyTrigger, 

--- a/perun-rpc/src/main/perl/createNotifTemplate
+++ b/perun-rpc/src/main/perl/createNotifTemplate
@@ -12,7 +12,7 @@ Creates a NotifTemplate. Notify trigger and at least one primary property are re
 --------------------------------------
 Available options:
  --name                | -n name
- --primaryProperty     | -p primary property (key and value divide by '=', more properties allowed)
+ --primaryProperty     | -p primary property (key and value divide by '=', values divide by '/', more properties allowed)
  --sender              | -s sender
  --batch               | -b batch
  --help                | -h prints this help
@@ -42,11 +42,11 @@ $object->setOldestMessageTime(0);
 $object->setYoungestMessageTime(0);
 $object->setSender($sender);
 
-my (%hashedProperties, @list, @values);
+my (%hashedProperties, @list);
 
 foreach (@properties) {
     @list = split('=', $_);
-    $values[0] = $list[1];
+    my @values = split('/', $list[1]);
     $hashedProperties{$list[0]} = \@values;
 }
 

--- a/perun-rpc/src/main/perl/updateNotifTemplate
+++ b/perun-rpc/src/main/perl/updateNotifTemplate
@@ -13,7 +13,7 @@ Updates a NotifTemplate. Id of the updated Template is required field.
 Available options:
  --id                  | -i id of the updated NotifTemplate
  --name                | -n name
- --primaryProperty     | -p primary property (key and value divide by '=', more properties allowed)
+ --primaryProperty     | -p primary property (key and value divide by '=', values divide by '/', more properties allowed)
  --locale              | -l locale
  --sender              | -s sender
  --batch               | -b batch
@@ -61,11 +61,11 @@ if (defined($sender)) {
 }
 
 if (@properties) {
-    my (%hashedProperties, @list, @values);
+    my (%hashedProperties, @list);
 
     foreach (@properties) {
         @list = split('=', $_);
-        $values[0] = $list[1];
+        my @values = split('/', $list[1]);
         $hashedProperties{$list[0]} = \@values;
     }
 


### PR DESCRIPTION
Fixed using of primary properties in NotifTemplate - now it is possible
to add multiple values for one attribute using '/'.
