### PR TITLE
CABINET: pubs with same ISBN are no longer considered same

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/service/impl/PublicationServiceImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/service/impl/PublicationServiceImpl.java
@@ -122,11 +122,6 @@ public class PublicationServiceImpl implements IPublicationService {
 			filter.setPublicationSystemId(p.getPublicationSystemId());
 			return publicationDao.findPublicationsByFilter(filter).size() >= 1;
 		}
-		if (p.getIsbn() != null && p.getIsbn() != "") {
-			Publication filter = new Publication();
-			filter.setIsbn(p.getIsbn());
-			return publicationDao.findPublicationsByFilter(filter).size() >= 1;
-		}
 		return false;
 	}
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/CabinetManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/CabinetManagerMethod.java
@@ -441,16 +441,11 @@ public enum CabinetManagerMethod implements ManagerMethod {
 					// externalId and publicationSystemId are unique and checked before so we can safely return first and only publication.
 					return ac.getCabinetManager().findRichPublicationsByFilter(filter, null).get(0);
 					// for internal pubs
-				} else {
-					filter.setIsbn(pub.getIsbn());
-					// isbn is unique and checked before so we can safely return first and only publication
-					return ac.getCabinetManager().findRichPublicationsByFilter(filter, null).get(0);
 				}
-			} else {
-				// else create one
-				int id = ac.getCabinetManager().createPublication(ac.getSession(), parms.read("publication", Publication.class));
-				return ac.getCabinetManager().findRichPublicationById(id);
 			}
+			// else create one
+			int id = ac.getCabinetManager().createPublication(ac.getSession(), parms.read("publication", Publication.class));
+			return ac.getCabinetManager().findRichPublicationById(id);
 		}
 	},
 


### PR DESCRIPTION
- Publications with same ISBN are not considered same anymore.
  It caused confusion to users, when they were automatically added
  as authors of someone's else publication.
  It's common, that reported publication is in fact an article in
  publication, so many reports can have same ISBN.
