### PR TITLE
Use quota in fs_project service

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_quotaEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_quotaEnabled.java
@@ -1,0 +1,49 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
+
+/**
+ * Attribute with information if quota is enabled on facility
+ *
+ * @author Michal Šťava <stavamichal@gmail.com>
+ */
+public class urn_perun_facility_attribute_def_def_quotaEnabled extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi  {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		//Null means the same like 0 (not enabled)
+		if(attribute.getValue() == null) return;
+		
+		Integer quotaEnabled = (Integer) attribute.getValue();
+		if(quotaEnabled > 1 || quotaEnabled < 0) throw new WrongAttributeValueException(attribute, facility, null, "Attribute has only two possible options for quota: 0 - means not enabled, 1 - means enabled.");
+		 
+	}
+
+	public Attribute fillAttribute(PerunSessionImpl session, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+		//Default is 0, it means quota is not enabled (null means the same)
+		Attribute retAttr = new Attribute(attribute);
+		retAttr.setValue(0);
+		return retAttr;
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
+		attr.setFriendlyName("quotaEnabled");
+		attr.setDisplayName("Quota eanbled");
+		attr.setType(Integer.class.getName());
+		attr.setDescription("Attribute says if quota is enabled on facility.");
+		return attr;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimit.java
@@ -1,0 +1,153 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.math.BigDecimal;
+
+/**
+ * Project directory hard data quota module
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class urn_perun_group_resource_attribute_def_def_projectDataLimit extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+
+	private static final String A_GR_projectDataQuota = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectDataQuota";
+	Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
+	Pattern letterPattern = Pattern.compile("[A-Z]");
+	Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
+
+	//Definition of K = KB, M = MB etc.
+	long K = 1024;
+	long M = K * 1024;
+	long G = M * 1024;
+	long T = G * 1024;
+	long P = T * 1024;
+	long E = P * 1024;
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		Attribute attrProjectDataQuota = null;
+		String projectDataQuota = null;
+		String projectDataLimit = null;
+
+		String projectDataQuotaNumber = null;
+		String projectDataQuotaLetter = null;
+		String projectDataLimitNumber = null;
+		String projectDataLimitLetter = null;
+
+		//Check if attribute value has the right exp pattern (can be null)
+		if(attribute.getValue() != null) {
+			Matcher testMatcher = testingPattern.matcher((String) attribute.getValue());
+			if(!testMatcher.find()) throw new WrongAttributeValueException(attribute, resource, group, "Format of quota must be something like ex.: 1.30M or 2500K, but it is " + attribute.getValue());
+		} else return;
+
+		//Get ProjectDataQuota attribute
+		try {
+			attrProjectDataQuota = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, group, A_GR_projectDataQuota);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException("Attribute with projectDataQuota from resource " + resource.getId() + " and group + " + group.getId() + " could not obtain.", ex);
+		}
+
+		//Get ProjectDataLimit value
+		if (attribute.getValue() != null) {
+			projectDataLimit = (String) attribute.getValue();
+			Matcher numberMatcher = numberPattern.matcher(projectDataLimit);
+			Matcher letterMatcher = letterPattern.matcher(projectDataLimit);
+			numberMatcher.find();
+			letterMatcher.find();
+			try {
+				projectDataLimitNumber = projectDataLimit.substring(numberMatcher.start(), numberMatcher.end());
+			} catch (IllegalStateException ex) {
+				projectDataLimitNumber = null;
+			}
+			try {
+				projectDataLimitLetter = projectDataLimit.substring(letterMatcher.start(), letterMatcher.end());
+			} catch (IllegalStateException ex) {
+				projectDataLimitLetter = "G";
+			}
+		}
+		BigDecimal limitNumber;
+		if(projectDataLimitNumber != null) limitNumber = new BigDecimal(projectDataLimitNumber.replace(',', '.'));
+		else limitNumber = new BigDecimal("0");
+		if (limitNumber != null && limitNumber.compareTo(BigDecimal.valueOf(0)) < 0) {
+			throw new WrongAttributeValueException(attribute, attribute + " can't be less than 0.");
+		}
+
+		//Get ProjectDataQuota value
+		if (attrProjectDataQuota != null && attrProjectDataQuota.getValue() != null) {
+			projectDataQuota = (String) attrProjectDataQuota.getValue();
+			Matcher numberMatcher = numberPattern.matcher(projectDataQuota);
+			Matcher letterMatcher = letterPattern.matcher(projectDataQuota);
+			numberMatcher.find();
+			letterMatcher.find();
+			try {
+				projectDataQuotaNumber = projectDataQuota.substring(numberMatcher.start(), numberMatcher.end());
+			} catch (IllegalStateException ex) {
+				projectDataQuotaNumber = null;
+			}
+			try {
+				projectDataQuotaLetter = projectDataQuota.substring(letterMatcher.start(), letterMatcher.end());
+			} catch (IllegalStateException ex) {
+				projectDataQuotaLetter = "G";
+			}
+		}
+		BigDecimal quotaNumber;
+		if(projectDataQuotaNumber != null) quotaNumber = new BigDecimal(projectDataQuotaNumber.replace(',', '.'));
+		else quotaNumber = new BigDecimal("0");
+
+		if (quotaNumber != null && quotaNumber.compareTo(BigDecimal.valueOf(0)) < 0) {
+			throw new WrongReferenceAttributeValueException(attribute, attrProjectDataQuota, attrProjectDataQuota + " cant be less than 0.");
+		}
+
+		//Compare ProjectDataLimit with ProjectDataQuota
+		if (quotaNumber == null || quotaNumber.compareTo(BigDecimal.valueOf(0)) == 0) {
+			if (limitNumber != null && limitNumber.compareTo(BigDecimal.valueOf(0)) != 0) {
+				throw new WrongReferenceAttributeValueException(attribute, attrProjectDataQuota, "Try to set limited limit, but there is still set unlimited Quota.");
+			}
+		} else if ((quotaNumber != null && quotaNumber.compareTo(BigDecimal.valueOf(0)) != 0) && (limitNumber != null && limitNumber.compareTo(BigDecimal.valueOf(0)) != 0)) {
+
+			if(projectDataLimitLetter.equals("K")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(K));
+			else if(projectDataLimitLetter.equals("M")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(M));
+			else if(projectDataLimitLetter.equals("T")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(T));
+			else if(projectDataLimitLetter.equals("P")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(P));
+			else if(projectDataLimitLetter.equals("E")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(E));
+			else limitNumber = limitNumber.multiply(BigDecimal.valueOf(G));
+
+			if(projectDataQuotaLetter.equals("K")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(K));
+			else if(projectDataQuotaLetter.equals("M")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(M));
+			else if(projectDataQuotaLetter.equals("T")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(T));
+			else if(projectDataQuotaLetter.equals("P")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(P));
+			else if(projectDataQuotaLetter.equals("E")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(E));
+			else quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(G));
+
+			if (limitNumber.compareTo(quotaNumber) < 0) {
+				throw new WrongReferenceAttributeValueException(attribute, attrProjectDataQuota, attribute + " must be more than or equals to " + attrProjectDataQuota);
+			}
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("projectDataLimit");
+		attr.setDisplayName("Project soft data quota.");
+		attr.setType(String.class.getName());
+		attr.setDescription("Project hard quota including units (M,G,T, ...), G is default.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuota.java
@@ -1,0 +1,153 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.math.BigDecimal;
+
+/**
+ * Project directory soft data quota module
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class urn_perun_group_resource_attribute_def_def_projectDataQuota extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+
+	private static final String A_GR_projectDataLimit = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectDataLimit";
+	Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
+	Pattern letterPattern = Pattern.compile("[A-Z]");
+	Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
+
+	//Definition of K = KB, M = MB etc.
+	long K = 1024;
+	long M = K * 1024;
+	long G = M * 1024;
+	long T = G * 1024;
+	long P = T * 1024;
+	long E = P * 1024;
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		Attribute attrProjectDataLimit = null;
+		String projectDataQuota = null;
+		String projectDataLimit = null;
+
+		String projectDataQuotaNumber = null;
+		String projectDataQuotaLetter = null;
+		String projectDataLimitNumber = null;
+		String projectDataLimitLetter = null;
+
+		//Check if attribute value has the right exp pattern (can be null)
+		if(attribute.getValue() != null) {
+			Matcher testMatcher = testingPattern.matcher((String) attribute.getValue());
+			if(!testMatcher.find()) throw new WrongAttributeValueException(attribute, resource, group, "Format of quota must be something like ex.: 1.30M or 2500K, but it is " + attribute.getValue());
+		}
+
+		//Get ProjectDataLimit attribute
+		try {
+			attrProjectDataLimit = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, group, A_GR_projectDataLimit);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException("Attribute with projectDataLimit from resource " + resource.getId() + " and group " + group.getId() + " could not obtain.", ex);
+		}
+
+		//Get ProjectDataQuota value
+		if (attribute.getValue() != null) {
+			projectDataQuota = (String) attribute.getValue();
+			Matcher numberMatcher = numberPattern.matcher(projectDataQuota);
+			Matcher letterMatcher = letterPattern.matcher(projectDataQuota);
+			numberMatcher.find();
+			letterMatcher.find();
+			try {
+				projectDataQuotaNumber = projectDataQuota.substring(numberMatcher.start(), numberMatcher.end());
+			} catch (IllegalStateException ex) {
+				projectDataQuotaNumber = null;
+			}
+			try {
+				projectDataQuotaLetter = projectDataQuota.substring(letterMatcher.start(), letterMatcher.end());
+			} catch (IllegalStateException ex) {
+				projectDataQuotaLetter = "G";
+			}
+		}
+		BigDecimal quotaNumber;
+		if(projectDataQuotaNumber != null) quotaNumber = new BigDecimal(projectDataQuotaNumber.replace(',', '.'));
+		else quotaNumber = new BigDecimal("0");
+		if (quotaNumber != null && quotaNumber.compareTo(BigDecimal.valueOf(0)) < 0) {
+			throw new WrongAttributeValueException(attribute, attribute + " can't be less than 0.");
+		}
+
+		//Get ProjectDataLimit value
+		if (attrProjectDataLimit != null && attrProjectDataLimit.getValue() != null) {
+			projectDataLimit = (String) attrProjectDataLimit.getValue();
+			Matcher numberMatcher = numberPattern.matcher(projectDataLimit);
+			Matcher letterMatcher = letterPattern.matcher(projectDataLimit);
+			numberMatcher.find();
+			letterMatcher.find();
+			try {
+				projectDataLimitNumber = projectDataLimit.substring(numberMatcher.start(), numberMatcher.end());
+			} catch (IllegalStateException ex) {
+				projectDataLimitNumber = null;
+			}
+			try {
+				projectDataLimitLetter = projectDataLimit.substring(letterMatcher.start(), letterMatcher.end());
+			} catch (IllegalStateException ex) {
+				projectDataLimitLetter = "G";
+			}
+		}
+		BigDecimal limitNumber;
+		if(projectDataLimitNumber != null) limitNumber = new BigDecimal(projectDataLimitNumber.replace(',', '.'));
+		else limitNumber = new BigDecimal("0");
+
+		if (limitNumber != null && limitNumber.compareTo(BigDecimal.valueOf(0)) < 0) {
+			throw new WrongReferenceAttributeValueException(attribute, attrProjectDataLimit, attrProjectDataLimit + " cant be less than 0.");
+		}
+
+		//Compare ProjectDataQuota with ProjectDataLimit
+		if (quotaNumber == null || quotaNumber.compareTo(BigDecimal.valueOf(0)) == 0) {
+			if (limitNumber != null && limitNumber.compareTo(BigDecimal.valueOf(0)) != 0) {
+				throw new WrongReferenceAttributeValueException(attribute, attrProjectDataLimit, "Try to set unlimited quota, but limit is still " + projectDataLimitNumber + projectDataLimitLetter);
+			}
+		} else if (limitNumber != null && limitNumber.compareTo(BigDecimal.valueOf(0)) != 0) {
+
+			if(projectDataLimitLetter.equals("K")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(K));
+			else if(projectDataLimitLetter.equals("M")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(M));
+			else if(projectDataLimitLetter.equals("T")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(T));
+			else if(projectDataLimitLetter.equals("P")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(P));
+			else if(projectDataLimitLetter.equals("E")) limitNumber = limitNumber.multiply(BigDecimal.valueOf(E));
+			else limitNumber = limitNumber.multiply(BigDecimal.valueOf(G));
+
+			if(projectDataQuotaLetter.equals("K")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(K));
+			else if(projectDataQuotaLetter.equals("M")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(M));
+			else if(projectDataQuotaLetter.equals("T")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(T));
+			else if(projectDataQuotaLetter.equals("P")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(P));
+			else if(projectDataQuotaLetter.equals("E")) quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(E));
+			else quotaNumber = quotaNumber.multiply(BigDecimal.valueOf(G));
+
+			if (limitNumber.compareTo(quotaNumber) < 0) {
+				throw new WrongReferenceAttributeValueException(attribute, attrProjectDataLimit, attribute + " must be less than or equals to " + projectDataLimit);
+			}
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("projectDataQuota");
+		attr.setDisplayName("Project soft data quota.");
+		attr.setType(String.class.getName());		
+		attr.setDescription("Project soft quota including units (M, G, T, ...), G is default.");
+		return attr;
+	}
+}

--- a/perun-services/gen/fs_project
+++ b/perun-services/gen/fs_project
@@ -15,12 +15,19 @@ my $DIRECTORY = perunServicesInit::getDirectory;
 my $data = perunServicesInit::getDataWithGroups;
 
 #Constants
-our $A_F_GROUP_NAME_NAMESPACE; *A_F_GROUP_NAME_NAMESPACE = \'urn:perun:resource:attribute-def:def:unixGroupName-namespace';
 our $A_R_PROJECTS_BASE_PATH;   *A_R_PROJECTS_BASE_PATH   = \'urn:perun:resource:attribute-def:def:projectsBasePath';
 our $A_GR_PROJECT_NAME;        *A_GR_PROJECT_NAME        = \'urn:perun:group_resource:attribute-def:def:projectName';
 our $A_GR_PROJECT_DIR_PERMS;   *A_GR_PROJECT_DIR_PERMS   = \'urn:perun:group_resource:attribute-def:def:projectDirPermissions';
 our $A_GR_PROJECT_OWNER_LOGIN; *A_GR_PROJECT_OWNER_LOGIN = \'urn:perun:group_resource:attribute-def:def:projectOwnerLogin';
 our $A_V_GR_UNIX_GROUP_NAME;   *A_V_GR_UNIX_GROUP_NAME   = \'urn:perun:group_resource:attribute-def:virt:unixGroupName';
+our $A_V_GR_GID;               *A_V_GR_GID               = \'urn:perun:group_resource:attribute-def:virt:unixGID';
+our $A_GR_SOFT_QUOTA_DATA;     *A_GR_SOFT_QUOTA_DATA     = \'urn:perun:group_resource:attribute-def:def:projectDataQuota';
+our $A_GR_HARD_QUOTA_DATA;     *A_GR_HARD_QUOTA_DATA     = \'urn:perun:group_resource:attribute-def:def:projectDataLimit';
+our $A_F_QUOTA_ENABLED;        *A_F_QUOTA_ENABLED        = \'urn:perun:facility:attribute-def:def:quotaEnabled';
+
+
+our $PROJECT_FILE_QUOTA; *PROJECT_FILE_QUOTA = \'0';
+our $PROJECT_FILE_LIMIT;  *PROJECT_FILE_LIMIT = \'0';
 
 my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
 
@@ -46,7 +53,13 @@ foreach my $rData (@resourcesData) {
 		print SERVICE_FILE $groupAttributes{$A_GR_PROJECT_NAME} . "\t";
 		print SERVICE_FILE defined($groupAttributes{$A_GR_PROJECT_DIR_PERMS}) ? $groupAttributes{$A_GR_PROJECT_DIR_PERMS} . "\t" : "750\t";
 		print SERVICE_FILE defined($groupAttributes{$A_GR_PROJECT_OWNER_LOGIN}) ? $groupAttributes{$A_GR_PROJECT_OWNER_LOGIN} . "\t" : "nobody\t";
-		print SERVICE_FILE $groupAttributes{$A_V_GR_UNIX_GROUP_NAME} . "\n";
+		print SERVICE_FILE $groupAttributes{$A_V_GR_UNIX_GROUP_NAME} . "\t";
+		print SERVICE_FILE $groupAttributes{$A_V_GR_GID} . "\t";
+		print SERVICE_FILE quotaToKb($groupAttributes{$A_GR_SOFT_QUOTA_DATA}) . "\t";
+		print SERVICE_FILE quotaToKb($groupAttributes{$A_GR_HARD_QUOTA_DATA}) . "\t";
+		print SERVICE_FILE $PROJECT_FILE_QUOTA . "\t";
+		print SERVICE_FILE $PROJECT_FILE_LIMIT . "\t";
+		print SERVICE_FILE defined($facilityAttributes{$A_F_QUOTA_ENABLED}) ? $facilityAttributes{$A_F_QUOTA_ENABLED} . "\n" : "0\n";
 	}
 }
 close(SERVICE_FILE);

--- a/perun-services/slave/fs_project.d/example-pre_10_set_quota
+++ b/perun-services/slave/fs_project.d/example-pre_10_set_quota
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Set custom setquota program
+#SET_QUOTA_PROGRAM="/usr/lpp/mmfs/bin/mmsetquota"
+
+# Parameters template for custom set quota program
+# Available variables: $GID $SOFT_QUOTA_DATA $HARD_QUOTA_DATA $SOFT_QUOTA_FILES $HARD_QUOTA_FILES $QUOTA_FS
+# *_DATA are in kB
+# NOTE: value must be in single quotes
+#SET_QUOTA_TEMPLATE='--group ${GID} --disk_softquota ${SOFT_QUOTA_DATA}k --disk_hardquota ${HARD_QUOTA_DATA}k ${U_HOME_MNT_POINT}'

--- a/perun-services/slave/process-fs_project.sh
+++ b/perun-services/slave/process-fs_project.sh
@@ -16,15 +16,20 @@ function process {
 	E_CANNOT_CHANGE_PERMISSIONS_TO_NOBODY=(53 'Cannot change permissions on directory ${PREVIOUS_PROJECT_PATH}/${LINE} to 2000')
 	E_CANNOT_CHANGE_OWNER=(54 'Cannot change owner of directory ${PROJECT_PATH}/${PROJECT_NAME} to ${OWNER}:${UNIX_GROUP_NAME}')
 	E_CANNOT_CHANGE_OWNER_TO_NOBODY=(55 'Cannot change owner of directory ${PREVIOUS_PROJECT_PATH}/${LINE} to nobody:nogroup')
+	E_CANNOT_GET_QUOTAFS=(56 'Cannot get filesystem with set quota on')
+	E_CANNOT_SET_QUOTA=(57 'Cannot set quota on ${QUOTA_FS} for group ${GID}')
 
 	create_lock
 
 	#At start there is no project path declared
 	PROJECT_PATH_DECLARED=
 
+	#Load quota_enabled or set it to default 0 - quota not enabled
+	[ -z "${QUOTA_ENABLED}" ] && QUOTA_ENABLED=0
+
 	sort ${FROM_PERUN} > ${FROM_PERUN_SORTED}
 	#Sort lines by project_path
-	while IFS=`echo -e "\t"` read PROJECT_PATH PROJECT_NAME PERMISSIONS OWNER UNIX_GROUP_NAME; do
+	while IFS=`echo -e "\t"` read PROJECT_PATH PROJECT_NAME PERMISSIONS OWNER UNIX_GROUP_NAME GID SOFT_QUOTA_DATA HARD_QUOTA_DATA SOFT_QUOTA_FILES HARD_QUOTA_FILES QUOTA_ENABLED REST_OF_LINE; do
 		#If there is no directory project_path, end with error
 		if [ -d "$PROJECT_PATH" ]; then
 			#Project path is not declared on first start
@@ -56,6 +61,48 @@ function process {
 			#Set permissions and owners on this directory
 			catch_error E_CANNOT_CHANGE_PERMISSIONS chmod 2"$PERMISSIONS" "$PROJECT_PATH"/"$PROJECT_NAME"
 			catch_error E_CANNOT_CHANGE_OWNER chown "$OWNER":"$UNIX_GROUP_NAME" "$PROJECT_PATH"/"$PROJECT_NAME"
+
+			#Set settings for quota if enabled
+			if [ "${QUOTA_ENABLED}" -gt 0 ]; then
+				#If there is another program (not the default one) to set quota, use it, in other case use default one
+				if [ ! -z "${SET_QUOTA_PROGRAM}" ]; then
+					#If another program for set quota is executable, set it, in other set quota enabled on 0
+					if [ -x "${SET_QUOTA_PROGRAM}" ]; then
+						SET_QUOTA="${SET_QUOTA_PROGRAM}"
+						QUOTA_ENABLED=1
+						#If set quota template is empty, set quota enabled on 0
+						if [ -z "${SET_QUOTA_TEMPLATE}" ]; then
+							echo "Can't set group quotas by ${SET_QUOTA_PROGRAM}! Template for parameters is not set." 1>&2
+							QUOTA_ENABLED=0
+						fi
+					else
+						echo "Can't set group quotas! ${SET_QUOTA_PROGRAM} is not executable" 1>&2
+						QUOTA_ENABLED=0
+					fi
+				else
+					if [ -x /usr/sbin/setquota ]; then
+						SET_QUOTA=/usr/sbin/setquota
+						#setquota name block-softlimit block-hardlimit inode-softlimit inode-hardlimit filesystem
+						SET_QUOTA_TEMPLATE='--group $GID $SOFT_QUOTA_DATA $HARD_QUOTA_DATA $SOFT_QUOTA_FILES $HARD_QUOTA_FILES $QUOTA_FS'
+						QUOTA_ENABLED=1
+					else
+						echo "Can't set group quotas! /usr/sbin/setquota is not available" 1>&2
+						QUOTA_ENABLED=0
+					fi
+				fi
+			fi
+
+			#Set quota on this directory if quota enabled (use settings above)
+			if [ "${QUOTA_ENABLED}" -gt 0 ]; then
+				#Get file system information about project directory
+				QUOTA_FS=`df -P "$PROJECT_PATH"/"$PROJECT_NAME"`
+				[ $? -eq 0 ] || log_msg E_CANNOT_GET_QUOTAFS
+				QUOTA_FS=`echo $QUOTA_FS | tail -n 1 | sed -e 's/^.*\s//'`
+				#Set quota on directory
+				SET_QUOTA_PARAMS=`eval echo $SET_QUOTA_TEMPLATE`
+				catch_error E_CANNOT_SET_QUOTA $SET_QUOTA $SET_QUOTA_PARAMS
+			fi
+
 			#Set the last used projectPath for equaling in next step
 			PREVIOUS_PROJECT_PATH="$PROJECT_PATH"
 		else


### PR DESCRIPTION
- edit fs_project gen to use another attributes
- edit fs_project slave to use another attributes and set quota if enabled
- create example prescript for fs_project
- create new attributes used for setting quotas (for project)
- create attribute quotaEnabled for facility to set in Perun if quota is enabled on facility

NEED TO DO AFTER ACCEPTING POOL REQUEST:
- create new attribute: gr_d_projectDataQuota
- create new attribute: gr_d_projectDataLimit
- create new attribute: f_d_quotaEnabled
- set them rights for read and write
- add new attributes to required for fs_project service
