### PR TITLE
NOTIFICATIONS: fixed spring context for tests

### DIFF
--- a/perun-notification/src/test/resources/perun-notification-applicationcontext-jabber-test.xml
+++ b/perun-notification/src/test/resources/perun-notification-applicationcontext-jabber-test.xml
@@ -14,9 +14,10 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
     <context:annotation-config />
 
     <import resource="classpath:perun-datasources.xml"/>
+    <import resource="classpath:perun-beans.xml"/>
 
     <!-- IMPORTANT: Fill DB properties from TEST configuration files and override property placeholder from perun-core -->
-    <context:property-placeholder location='${perun.jdbc}, file:${perun.conf}/perun-notification-test.properties' order="0"/>
+    <context:property-placeholder ignore-resource-not-found="true" ignore-unresolvable="true" location='file:${perun.conf}/perun-notification-test.properties, file:${perun.conf}/perun-notification-test.properties' order="0"/>
 
     <bean id="dataSource2" class="org.apache.commons.dbcp.BasicDataSource">
         <property name="driverClassName" value="org.h2.Driver"/>
@@ -30,7 +31,11 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
         <property name="locations">
             <list>
                 <value>file:${perun.conf}/perun-notification-test.properties</value>
+                <value>file:${perun.conf.custom}/perun-notification-test.properties</value>
             </list>
+        </property>
+        <property name="ignoreResourceNotFound">
+            <value>true</value>
         </property>
     </bean>
 

--- a/perun-notification/src/test/resources/perun-notification-applicationcontext-jdbc-test.xml
+++ b/perun-notification/src/test/resources/perun-notification-applicationcontext-jdbc-test.xml
@@ -20,7 +20,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
     <!--</bean>-->
 
     <!-- IMPORTANT: Fill DB properties from TEST configuration files and override property placeholder from perun-core -->
-    <context:property-placeholder location='${perun.jdbc}, file:${perun.conf}/perun-notification-test.properties' order="0"/>
+    <context:property-placeholder ignore-resource-not-found="true" ignore-unresolvable="true" location='file:${perun.conf}/perun-notification-test.properties, file:${perun.conf.custom}/perun-notification-test.properties' order="0"/>
 
     <bean id="dataSource2" class="org.apache.commons.dbcp.BasicDataSource">
         <property name="driverClassName" value="org.h2.Driver"/>

--- a/perun-notification/src/test/resources/perun-notification-applicationcontext-test.xml
+++ b/perun-notification/src/test/resources/perun-notification-applicationcontext-test.xml
@@ -11,6 +11,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
     <context:annotation-config />
 
     <import resource="classpath:perun-datasources.xml"/>
+    <import resource="classpath:perun-beans.xml"/>
 
     <context:component-scan base-package="cz.metacentrum.perun.notif" />
 


### PR DESCRIPTION
- Fixed spring context to load proper *.properties file.
- It probably can be much better optimized in future.
- Tests still don't work, since DB schema used by code changed,
  but test-schema in *.sql files is unchanged.
