### PR TITLE
SERVICES: perun now manages also baseDN ldap entry

### DIFF
--- a/perun-services/gen/ldap
+++ b/perun-services/gen/ldap
@@ -9,8 +9,8 @@ use Text::Unidecode;
 sub processGroupMembership;
 
 local $::SERVICE_NAME = "ldap";
-local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.0";
+local $::PROTOCOL_VERSION = "3.0.1";
+my $SCRIPT_VERSION = "3.0.1";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -109,6 +109,36 @@ close(FILE);
 # PRINT LDIF FILE
 #
 open FILE,">:encoding(UTF-8)","$fileName" or die "Cannot open $fileName: $! \n";
+
+# print base entry
+
+print FILE "dn: " . $facilityAttributes{$A_F_BASE_DN} . "\n";
+# IF base start with dc=[something]
+if ($facilityAttributes{$A_F_BASE_DN} =~ m/^dc=/) {
+
+	my $position = index($facilityAttributes{$A_F_BASE_DN}, ",");
+	print $facilityAttributes{$A_F_BASE_DN} . "\n";
+	print $position . "\n";
+	my $dc = undef;
+	if ($position > 0) {
+		$dc = substr $facilityAttributes{$A_F_BASE_DN}, 3, $position-3;
+	}
+	print FILE "dc: " . $dc . "\n";
+	print FILE "objectclass: dcObject\n";
+}
+# IF base start with ou=[something]
+if ($facilityAttributes{$A_F_BASE_DN} =~ m/^ou=/) {
+
+	my $position = index($facilityAttributes{$A_F_BASE_DN}, ",");
+	my $ou = undef;
+	if ($position > 0) {
+		$ou = substr($facilityAttributes{$A_F_BASE_DN}, 3, $position-3);
+	}
+	print FILE "ou: " . $ou . "\n";
+	print FILE "objectclass: organizationalunit\n"
+}
+
+print FILE "\n";
 
 # PRINT ou=people entry
 print FILE "dn: ou=people," . $facilityAttributes{$A_F_BASE_DN} . "\n";

--- a/perun-services/slave/process-ldap.sh
+++ b/perun-services/slave/process-ldap.sh
@@ -5,7 +5,7 @@
 # 2011-08-10 generification of script
 # 2013-06-20 prevent concurrent run
 
-PROTOCOL_VERSION='3.0.0'
+PROTOCOL_VERSION='3.0.1'
 
 function process {
 


### PR DESCRIPTION
- Manage also baseDN entry set on facility for LDAP service.
- Entry can be of type "ou" or "dc".
- This solves issues, when baseDN parent entry name/type matches
  any of entries managed by Perun.
- bumped protocol and script version to 3.0.1
