### PR TITLE
make engine ignore facilities alcor,aldor,ascor.ics.muni.cz 

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventProcessorImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventProcessorImpl.java
@@ -111,6 +111,12 @@ public class EventProcessorImpl implements EventProcessor {
 				log.debug("\t Resolved ExecServices[" + resultTest.getLeft() + "]");
 
 				if (resultTest != null && resultTest.getLeft() != null && resultTest.getRight() != null) {
+					if(resultTest.getRight().getName().equals("alcor.ics.muni.cz") ||
+							resultTest.getRight().getName().equals("aldor.ics.muni.cz") ||
+							resultTest.getRight().getName().equals("ascor.ics.muni.cz")) {
+						log.info("IGNORE:  Facility[" + resultTest.getRight() + "]");
+						continue;
+					}
 					for (ExecService execService : resultTest.getLeft()) {
 						log.debug("ADD to POOL: ExecService[" + execService.getId() + "] : Facility[" + resultTest.getRight() + "]");
 						schedulingPool.addToPool(new Pair<ExecService, Facility>(execService, resultTest.getRight()));

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskSchedulerImpl.java
@@ -56,6 +56,13 @@ public class TaskSchedulerImpl implements TaskScheduler {
 	public void propagateService(ExecService execService, Date time, Facility facility) throws InternalErrorException {
 		log.debug("Facility to be processed: " + facility.getId() + ", ExecService to be processed: " + execService.getId());
 
+		if(facility.getName().equals("alcor.ics.muni.cz") ||
+				facility.getName().equals("aldor.ics.muni.cz") ||
+				facility.getName().equals("ascor.ics.muni.cz")) {
+			log.info("IGNORE facility " + facility.getName());
+			return;
+		}	
+
 		// TODO: EDIT: Denials are to be resolved in TaskExecutorEngine class as well (for each destination)
 
 		Task previousTask = null;

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/service/impl/EngineManagerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/service/impl/EngineManagerImpl.java
@@ -126,6 +126,12 @@ public class EngineManagerImpl implements EngineManager {
 				String[] data = line.split(" ");
 				ExecService execService = Rpc.GeneralServiceManager.getExecService(getRpcCaller(), Integer.parseInt(data[1]));
 				Facility facility = Rpc.FacilitiesManager.getFacilityById(getRpcCaller(), Integer.parseInt(data[2]));
+				if(facility.getName().equals("alcor.ics.muni.cz") ||
+						facility.getName().equals("aldor.ics.muni.cz") ||
+						facility.getName().equals("ascor.ics.muni.cz")) {
+					log.info("IGNORE facility " + facility.getName());
+					continue;
+				}	
 				schedulingPool.addToPool(new Pair<ExecService, Facility>(execService, facility));
 			}
 		} catch (IOException e) {


### PR DESCRIPTION
For tests of new engine, exclude given facilities from the old engine:
- do not initialize the scheduling pool tasks for given facilities during startup
- ignore events containing the given facilities
- do not schedule propagations for the given facilities (in case the above is not enough)
