### PR TITLE
GUI: fixed application form

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
@@ -605,6 +605,7 @@ public class ApplicationFormPage extends ApplicationPage {
 
 		confirm.setOkButtonText(ApplicationMessages.INSTANCE.joinIdentity());
 		confirm.setOkIcon(SmallIcons.INSTANCE.userGreenIcon());
+		confirm.setCancelButtonText(ApplicationMessages.INSTANCE.notJoinIdentity());
 		confirm.show();
 
 	}
@@ -613,7 +614,7 @@ public class ApplicationFormPage extends ApplicationPage {
 
         var linker = $wnd.jQuery("#cesnet_linker_placeholder");
 
-		if (linker != null) {
+        if (!$('#cesnet_linker_placeholder').is(':empty')){
 
             $wnd.jQuery("#cesnet_linker_placeholder").remove();
             $wnd.jQuery("body").append(linker);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages.java
@@ -189,6 +189,9 @@ public interface ApplicationMessages extends Messages {
 	@DefaultMessage("Join identity")
 	String joinIdentity();
 
+	@DefaultMessage("No, thanks")
+	String notJoinIdentity();
+
 	@DefaultMessage("Created date")
 	String createdDate();
 

--- a/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages_cs.properties
+++ b/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages_cs.properties
@@ -71,6 +71,7 @@ insufficientLoaForExtension=<h2>Váš stupeň ověření (Level of Assurance) ne
 outsideExtensionPeriod=<h2>Členství nyní nelze prodloužit.</h2><h2>Prodlužování je obvykle aktivní po určitou dobu před vypršením platnosti členství.</h2>
 
 joinIdentity=Spojit identity
+notJoinIdentity=Ne, děkuji
 
 # applications table
 createdDate=Podáno dne


### PR DESCRIPTION
- Do not move app form down if linker is not present.
- Use "No, thanks" instead of "Cancel" when user is offered to join
  identities on registration form.
