### PR TITLE
GUI: post instance name in RT reports

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -274,6 +274,23 @@ public class Utils {
 	}
 
 	/**
+	 * Returns name of Perun Instance if present in config or "UNKNOWN INSTANCE" if not present.
+	 *
+	 * @return name of Perun Instance as string
+	 */
+	public static String perunInstanceName() {
+
+		if (PerunWebSession.getInstance().getConfiguration() != null) {
+			String value = PerunWebSession.getInstance().getConfiguration().getCustomProperty("perunInstanceName");
+			if (value != null && !value.isEmpty()) {
+				return value;
+			}
+		}
+		return "UNKNOWN INSTANCE";
+
+	}
+
+	/**
 	 * Returns default RT queue for errors reporting
 	 *
 	 * @return default RT queue for errors reporting as string

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -85,6 +85,7 @@ public class JsonErrorHandler {
 
 				String text = error.getErrorId() + " - " + error.getName() + "\n";
 				text += error.getErrorInfo() + "\n\n";
+				text += Utils.perunInstanceName()+ "\n";
 				text += "Request: " + error.getRequestURL() + "\n";
 				if (postObject != null) text += "Post data: " + postObject.toString() + "\n";
 				text += "Application state: " + status + "\n\n";


### PR DESCRIPTION
- If user submits error report, paste also name of Perun instance.
- Value is stored in /etc/perun/perun-web-gui.properties as
  perunInstanceName=[some_value]
  If not present, "UNKNOWN INSTANCE" is returned.
