### PR TITLE
REGISTRAR: fixed behavior for group applications with auto-approve

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1928,6 +1928,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		if (allValidated) {
 			// mark VERIFIED
 			markApplicationVerified(app.getId());
+			app.setState(AppState.VERIFIED);
 			// try to APPROVE if auto approve
 			tryToAutoApproveApplication(sess, app);
 		} else {
@@ -1997,10 +1998,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			}
 		}
 
-		String appState = jdbc.queryForObject("select state from application where id=?", String.class, app.getId());
-
 		try {
-			if (AppState.VERIFIED.toString().equals(appState)) {
+			if (AppState.VERIFIED.equals(app.getState())) {
 				// with registrar session, since only VO admin can approve application
 				approveApplication(registrarSession, app.getId());
 			}


### PR DESCRIPTION
- Do not try to (auto-)approve applications for group when user is not member of VO.
- When VO admin approves VO application, then try to approve all user's group
  applications with auto-approve mode (search by user-ext-source too, to get 
  all applications of user which was submited before user creation). Skip NEW
  applications, they will be approved once user 
