### PR TITLE
Fix possible collidation of userExtSource logins

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -327,6 +327,19 @@ public interface UsersManagerBl {
 	void updateUserExtSourceLastAccess(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException;
 
 	/**
+	 * Gets list of all users external sources by specific type and extLogin.
+	 *
+	 * @param sess
+	 * @param extType - type of extSource (ex. 'IDP')
+	 * @param extLogin - extLogin of userExtSource
+	 *
+	 * @return list of userExtSources with type and login, empty list if no such userExtSource exists
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<UserExtSource> getAllUserExtSourcesByTypeAndLogin(PerunSession sess, String extType, String extLogin) throws InternalErrorException;
+
+	/**
 	 * Gets list of all user's external sources of the user.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -420,6 +420,10 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		return getUsersManagerImpl().getUserExtSourceById(sess, id);
 	}
 
+	public List<UserExtSource> getAllUserExtSourcesByTypeAndLogin(PerunSession sess, String extType, String extLogin) throws InternalErrorException {
+		return getUsersManagerImpl().getAllUserExtSourcesByTypeAndLogin(sess, extType, extLogin);
+	}
+
 	public UserExtSource addUserExtSource(PerunSession sess, User user, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceExistsException {
 		// Check if the userExtSource already exists
 		try {
@@ -427,6 +431,15 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			throw new UserExtSourceExistsException("UserExtSource " + userExtSource + " already exists.");
 		} catch (UserExtSourceNotExistsException e) {
 			// this is OK
+		}
+
+		// Check if userExtsource is type of IDP (special testing behavior)
+		if (userExtSource.getExtSource().getType().equals(ExtSourcesManager.EXTSOURCE_IDP)) {
+			// If extSource of this userExtSource is type of IDP, test uniqueness of login in this extSource type for all users
+			String login = userExtSource.getLogin();
+			List<UserExtSource> userExtSources = getAllUserExtSourcesByTypeAndLogin(sess, ExtSourcesManager.EXTSOURCE_IDP, login);
+			if(userExtSources.size() == 1) throw new InternalErrorException("ExtLogin: " + login + " is already in used for extSourceType: " + ExtSourcesManager.EXTSOURCE_IDP);
+			else if(userExtSources.size() > 1) throw new ConsistencyErrorException("There are " + userExtSources.size() + "   extLogins: " + login + " for  extSourceType: " + ExtSourcesManager.EXTSOURCE_IDP);
 		}
 
 		userExtSource = getUsersManagerImpl().addUserExtSource(sess, user, userExtSource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -380,6 +380,11 @@ public class UsersManagerEntry implements UsersManager {
 
 	public UserExtSource addUserExtSource(PerunSession sess, User user, UserExtSource userExtSource) throws InternalErrorException, UserNotExistsException, PrivilegeException, UserExtSourceExistsException {
 		Utils.checkPerunSession(sess);
+		Utils.notNull(userExtSource, "userExtSource");
+		Utils.notNull(user, "user");
+		Utils.notNull(userExtSource.getExtSource(), "ExtSource in UserExtSource");
+		Utils.notNull(userExtSource.getLogin(), "Login in UserExtSource");
+		Utils.notNull(userExtSource.getExtSource().getType(), "Type of ExpSource in UserExtSource");
 
 		// Authorization
 		if(!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
@@ -396,8 +401,6 @@ public class UsersManagerEntry implements UsersManager {
 		} catch (UserExtSourceNotExistsException e) {
 			// This is ok
 		}
-
-		Utils.notNull(userExtSource, "userExtSource");
 
 		return getUsersManagerBl().addUserExtSource(sess, user, userExtSource);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -483,6 +483,18 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		}
 	}
 
+	public List<UserExtSource> getAllUserExtSourcesByTypeAndLogin(PerunSession sess, String extType, String extLogin) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + userExtSourceMappingSelectQuery + "," + ExtSourcesManagerImpl.extSourceMappingSelectQuery +
+							" from user_ext_sources left join ext_sources on user_ext_sources.ext_sources_id=ext_sources.id where" +
+							" ext_sources.type=? and user_ext_sources.login_ext=?", USEREXTSOURCE_MAPPER, extType, extLogin);
+		} catch(EmptyResultDataAccessException ex) {
+			return new ArrayList<UserExtSource>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public List<UserExtSource> getUserExtsourcesByIds(PerunSession sess, List<Integer> ids) throws InternalErrorException {
 		if (ids.size() == 0) {
 			return new ArrayList<UserExtSource>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -262,6 +262,19 @@ public interface UsersManagerImplApi {
 	List<Integer> getUserExtSourcesIds(PerunSession perunSession, User user) throws InternalErrorException;
 
 	/**
+	 * Gets list of all users external sources by specific type and extLogin.
+	 *
+	 * @param sess
+	 * @param extType - type of extSource (ex. 'IDP')
+	 * @param extLogin - extLogin of userExtSource
+	 *
+	 * @return list of userExtSources with type and login, empty list if no such userExtSource exists
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<UserExtSource> getAllUserExtSourcesByTypeAndLogin(PerunSession sess, String extType, String extLogin) throws InternalErrorException;
+
+	/**
 	 * Get the user ext source by its id.
 	 *
 	 * @param sess

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -338,6 +338,24 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 			// shouldn't find user
 		}
 
+	@Test (expected=InternalErrorException.class)
+	public void addIDPExtSourcesWithSameLogin() throws Exception {
+		System.out.println("UsersManager.addIDPExtSourcesWithSameLogin");
+
+		ExtSource ext1 = new ExtSource("test1", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+		ExtSource ext2 = new ExtSource("test2", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+
+		ext1 = perun.getExtSourcesManagerBl().createExtSource(sess, ext1);
+		ext2 = perun.getExtSourcesManagerBl().createExtSource(sess, ext2);
+
+		UserExtSource ues1 = new UserExtSource(ext1, 1, "testExtLogin@test");
+		UserExtSource ues2 = new UserExtSource(ext2, 1, "testExtLogin@test");
+
+
+		ues1 = usersManager.addUserExtSource(sess, user, ues1);
+		ues2 = usersManager.addUserExtSource(sess, user, ues2);
+	}
+
 	@Test
 	public void addUserExtSource() throws Exception {
 		System.out.println("UsersManager.addUserExtSource");


### PR DESCRIPTION
- only for extSource type 'IDP'
- now every login in userExtSource type of IDP is unique
- add some notNull testing to method addUserExtSource in entry
