### PR TITLE
RPC: update for jetty plugin for local running of Perun

### DIFF
--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -74,19 +74,26 @@
             <plugin>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>7.6.15.v20140411</version>
+                <version>8.1.15.v20140411</version>
+
                 <configuration>
+                    <jettyXml>src/main/webapp/WEB-INF/jetty.xml</jettyXml>
                     <stopPort>9999</stopPort>
                     <stopKey>stop</stopKey>
-                    <connectors>
-                        <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                            <port>8081</port>
-                        </connector>
-                    </connectors>
                     <webAppConfig>
                         <contextPath>/perun-rpc-devel</contextPath>
                     </webAppConfig>
                 </configuration>
+
+                <!-- We must specify dependency to get AJP working -->
+                <dependencies>
+                    <dependency>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-ajp</artifactId>
+                        <version>8.1.15.v20140411</version>
+                    </dependency>
+                </dependencies>
+
             </plugin>
 
         </plugins>
@@ -232,19 +239,25 @@
                     <plugin>
                         <groupId>org.mortbay.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
-                        <version>7.6.15.v20140411</version>
+                        <version>8.1.15.v20140411</version>
+
                         <configuration>
+                            <jettyXml>src/main/webapp/WEB-INF/jetty.xml</jettyXml>
                             <stopPort>9999</stopPort>
                             <stopKey>stop</stopKey>
-                            <connectors>
-                                <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                                    <port>8081</port>
-                                </connector>
-                            </connectors>
                             <webAppConfig>
                                 <contextPath>/perun-rpc</contextPath>
                             </webAppConfig>
                         </configuration>
+
+                        <!-- We must specify dependency to get AJP working -->
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.eclipse.jetty</groupId>
+                                <artifactId>jetty-ajp</artifactId>
+                                <version>8.1.15.v20140411</version>
+                            </dependency></dependencies>
+
                     </plugin>
 
                 </plugins>

--- a/perun-rpc/src/main/webapp/WEB-INF/jetty.xml
+++ b/perun-rpc/src/main/webapp/WEB-INF/jetty.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+    <!-- access on AJP for using authz by Apache -->
+    <Call name="addConnector">
+        <Arg>
+            <New class="org.eclipse.jetty.ajp.Ajp13SocketConnector">
+                <Set name="port">8009</Set>
+            </New>
+        </Arg>
+    </Call>
+
+    <!-- access on HTTP without authz (perun wont work without changes in sources)
+    <Call name="addConnector">
+        <Arg>
+            <New class="org.eclipse.jetty.server.bio.SocketConnector">
+                <Set name="port">8081</Set>
+            </New>
+        </Arg>
+    </Call>
+     -->
+
+</Configure>


### PR DESCRIPTION
- Use jetty 8 maven plugin.
- Fixed position of commented DB connectors in pom.xml. They are probably not needed anyway.
- If you run perun locally via jetty, you must use: mvn jetty:run-exploded
  in order to run compiled sources, otherwise configuration is taken from
  your sources and no maven filtering is performed => you end up with
  an error about unresolvable ${perun.conf} property for log4j.
- Jetty is configured with AJP 1.3 connector on port 8009 which can consume ENV properties from
  our standard Apache configuration. Non-authz access is not possible anyway, without change in
  source code (http connector is commented in jetty.xml).

So for local running of Perun server behind https with authz you need:
- configured DB or SSH tunel to devel DB
- proper DB/Perun configuration in /etc/perun
- run mvn jetty:run-exploded in perun-rpc folder
- configured Apache with e.g. certificate authz
