### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Ignore Maven target #
 
 **/target
+dependency-reduced-pom.xml
 
 # Ignore IntelliJ project files #
 


### PR DESCRIPTION
- Ignore also dependency-reduced-pom.xml which is created in
  perun-core root folder by maven-shade-plugin.
