### PR TITLE
CORE: do not store empty strings from Candidate's attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -350,7 +350,14 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 					throw new InternalErrorException(ex);
 				}
 				Attribute attribute = new Attribute(attributeDefinition);
-				attribute.setValue(getPerunBl().getAttributesManagerBl().stringToAttributeValue(candidate.getAttributes().get(attributeName), attribute.getType()));
+				// convert empty strings to null for compatibility Oracle/Postgres
+				String attrValue = candidate.getAttributes().get(attributeName);
+				if (attrValue != null && attrValue.isEmpty()) {
+					attribute.setValue(null);
+				} else {
+					// process standard or null values
+					attribute.setValue(getPerunBl().getAttributesManagerBl().stringToAttributeValue(attrValue, attribute.getType()));
+				}
 				if (getPerunBl().getAttributesManagerBl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR_DEF) ||
 						getPerunBl().getAttributesManagerBl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR_OPT)) {
 					// This is member's attribute


### PR DESCRIPTION
- When storing attributes from Candidate (on Member/User creation),
  convert all empty string values to null in order to keep compatibility
  between Oracle and Postgres DB.
