### PR TITLE
RPC-LIB: check for response code before processing response

### DIFF
--- a/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/impl/RpcCallerImpl.java
+++ b/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/impl/RpcCallerImpl.java
@@ -74,6 +74,16 @@ public class RpcCallerImpl implements RpcCaller {
 			this.processIOException(conn, e);
 		}
 
+		// If Perun's RPC is temporarily unavailable, and Apache respond in HTML instead of JSON
+		try {
+			int responseCode = conn.getResponseCode();
+			if (responseCode != HttpURLConnection.HTTP_OK) {
+				throw new RpcException(RpcException.Type.PERUN_RPC_SERVER_ERROR_HTTP_CODE, "Perun server on URL: " + perunUrl + " returned HTTP code: " + responseCode);
+			}
+		} catch (IOException ex) {
+			this.processIOException(conn, ex);
+		}
+
 		// Get the answer from the server
 		InputStream rpcServerAnswer = null;
 		try {


### PR DESCRIPTION
- We must check HTTP response code before processing response itself,
  since Apache can respond e.g. 503, and then HTML content is
  passed into JsonDeserializer and causes NullPointerException.
  
  If response code isn't HTTP_OK, then throw RpcException.
