### PR TITLE
RPC-LIB: Change to prevent NullPointerException

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
@@ -169,13 +169,13 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 			//If ldapc is interrupted
 		} catch (InterruptedException e) {
 			Date date = new Date();
-			log.error("Last message has ID='" + message.getMsg()+ "' and was INTERRUPTED at " + DATE_FORMAT.format(date) + " due to interrupting.");
+			log.error("Last message has ID='" + message.getId()+ "' and was INTERRUPTED at " + DATE_FORMAT.format(date) + " due to interrupting.");
 			running = false;
 			Thread.currentThread().interrupt();
 			//If some other exception is thrown
 		} catch (Exception e) {
 			Date date = new Date();
-			log.error("Last message has ID='" + message.getMsg() + "' and was bad PARSED or EXECUTE at " + DATE_FORMAT.format(date) + " due to exception " + e.toString());
+			log.error("Last message has ID='" + message.getId() + "' and was bad PARSED or EXECUTE at " + DATE_FORMAT.format(date) + " due to exception " + e.toString());
 			throw new RuntimeException(e);
 		}
 	}

--- a/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/Rpc.java
+++ b/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/Rpc.java
@@ -104,6 +104,7 @@ public class Rpc {
 
 			try {
 				Deserializer deserializer = rpcCaller.call("auditMessagesManager", "pollConsumerMessagesForParser", params);
+				// FIXME - this is check to prevent NullPointerException caused by communication with RPC.
 				if (deserializer == null) throw new RpcException(RpcException.Type.UNCATCHED_EXCEPTION, "Unable to create deserializer.");
 				return deserializer.readList(AuditMessage.class);
 			} catch (InternalErrorException e) {


### PR DESCRIPTION
- When polling for AuditMessages from RPC (on RPC re-deployment).
- Fixed error message in LDAPC.
