### PR TITLE
Fix method getGroupByName to use fullName of group

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -56,6 +56,7 @@ public interface GroupsManager {
 	public static final String GROUPSYNCHROINTERVAL_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":synchronizationInterval";
 
 	public static final String GROUP_SHORT_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+$";
+	public static final String GROUP_FULL_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+([:][-a-zA-Z.0-9_ ]+)*";
 	/**
 	 * Creates a new top-level group and associate it with the VO.
 	 *
@@ -199,6 +200,8 @@ public interface GroupsManager {
 
 	/**
 	 * Search for the group with specified name in specified VO.
+	 *
+	 * IMPORTANT: need to use full name of group (ex. 'toplevel:a:b', not the shortname which is in this example 'b')
 	 *
 	 * @param perunSession
 	 * @param vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -184,6 +184,8 @@ public interface GroupsManagerBl {
 	/**
 	 * Search for the group with specified name in specified VO.
 	 *
+	 * IMPORTANT: need to use full name of group (ex. 'toplevel:a:b', not the shortname which is in this example 'b')
+	 * 
 	 * @param perunSession
 	 * @param vo
 	 * @param name

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -205,6 +205,11 @@ public class GroupsManagerEntry implements GroupsManager {
 	public Group getGroupByName(PerunSession sess, Vo vo, String name) throws GroupNotExistsException, InternalErrorException, PrivilegeException, VoNotExistsException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
+		Utils.notNull(name, "name");
+
+		if (!name.matches(GroupsManager.GROUP_FULL_NAME_REGEXP)) {
+			throw new InternalErrorException(new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_FULL_NAME_REGEXP));
+		}
 
 		Group group = getGroupsManagerBl().getGroupByName(sess, vo, name);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -388,7 +388,7 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 
 	public Group getGroupByName(PerunSession sess, Vo vo, String name) throws GroupNotExistsException, InternalErrorException {
 		try {
-			return jdbc.queryForObject("select " + groupMappingSelectQuery_compat + " from groups " + groupQNameJoinQuery + " where groups.name=? and groups.vo_id=?",
+			return jdbc.queryForObject("select " + groupMappingSelectQuery_compat + " from groups " + groupQNameJoinQuery + " where qn_groups.name=? and groups.vo_id=?",
 					GROUP_MAPPER, name, vo.getId());
 		} catch (EmptyResultDataAccessException err) {
 			throw new GroupNotExistsException("Group name=" + name + ", vo id=" + vo.getId());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -108,6 +108,8 @@ public interface GroupsManagerImplApi {
 	/**
 	 * Search for the group with specified name in specified VO
 	 *
+	 * IMPORTANT: need to use full name of group (ex. 'toplevel:a:b', not the shortname which is in this example 'b')
+	 *
 	 * @param perunSession
 	 * @param vo
 	 * @param name

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -501,25 +501,44 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	}
 
+	@Test
+	public void getSubGroupByName() throws Exception {
+		System.out.println("GroupsManager.getSubGroupByName");
+
+		vo = setUpVo();
+		setUpGroup(vo);
+		Group subGroup = new Group(group.getId(), group.getName(), group.getDescription());
+		subGroup = groupsManager.createGroup(sess, group, subGroup);
+		assertEquals("SubGroup must have name like 'name:name'", group.getName() + ":" + group.getName(), subGroup.getName());
+
+		Group returnedGroup = groupsManager.getGroupByName(sess, vo, group.getName());
+		Group returnedSubGroup = groupsManager.getGroupByName(sess, vo, subGroup.getName());
+		assertNotNull(returnedGroup);
+		assertNotNull(returnedSubGroup);
+
+		assertEquals("Both groups should be the same",returnedGroup,group);
+		assertEquals("Both groups should be the same",returnedSubGroup,subGroup);
+	}
+
 	@Test (expected=VoNotExistsException.class)
-		public void getGroupByNameWhenVoNotExists() throws Exception {
-			System.out.println("GroupsManager.getGroupByNameWhenVoNotExists");
+	public void getGroupByNameWhenVoNotExists() throws Exception {
+		System.out.println("GroupsManager.getGroupByNameWhenVoNotExists");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			groupsManager.getGroupByName(sess, new Vo(), group.getName());
+		groupsManager.getGroupByName(sess, new Vo(), group.getName());
 
-		}
+	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getGroupByNameWhenGroupNotExists() throws Exception {
+	public void getGroupByNameWhenGroupNotExists() throws Exception {
 
-			vo = setUpVo();
+		vo = setUpVo();
 
-			groupsManager.getGroupByName(sess, vo, "");
+		groupsManager.getGroupByName(sess, vo, "GroupsManagerEntryIntegrationTest:test:test:test");
 
-		}
+	}
 
 	@Test
 	public void addMember() throws Exception {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -143,6 +143,8 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns a group by VO and Group name.
 	 *
+	 * IMPORTANT: need to use full name of group (ex. 'toplevel:a:b', not the shortname which is in this example 'b')
+	 *
 	 * @param vo int VO ID
 	 * @param name String Group name
 	 * @return Group Found group


### PR DESCRIPTION
- return always only 1 group if exists and use fullName of group for
  searching
- add info to javadoc
- add regex for testing variable name of group in method getGroupByName
- add test for more than one groups with the same shortName but
  different Name
- fix formating of two existing tests (getGroupByNameWhenGroupNotExists
  and getGroupByNameWhenVoNotExists)
