### PR TITLE
Create new attributes for synchronization information about group

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -20,6 +20,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceException;
 import cz.metacentrum.perun.core.api.exceptions.GroupExistsException;
@@ -37,6 +38,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import java.util.Date;
 
 /**
  * <p>Groups manager can do all work about groups in VOs.</p>
@@ -936,4 +938,23 @@ public interface GroupsManagerBl {
 	 */
 	RichGroup getRichGroupByIdWithAttributesByNames(PerunSession sess, int groupId, List<String> attrNames) throws InternalErrorException, GroupNotExistsException;
 
+	/**
+	 * This method will set currentTimestamp and exceptionMessage to group attributes for the group.
+	 * 
+	 * IMPORTANT: This method runs in new transaction (because of using in synchronization of groups)
+	 * 
+	 * Set timestamp to attribute "group_def_lastSynchronizationTimestamp"
+	 * Set exception message to attribute "group_def_lastSynchronizationState"
+	 * 
+	 * @param sess perun session
+	 * @param group the group for synchronization
+	 * @param currentTimestamp timestamp of last synchronization
+	 * @param exceptionMessage message of an exception, ok if everything is ok
+	 * @throws AttributeNotExistsException
+	 * @throws InternalErrorException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongAttributeValueException 
+	 */
+	void saveInformationAboutGroupSynchronization(PerunSession sess, Group group, Date currentTimestamp, String exceptionMessage) throws AttributeNotExistsException, InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeValueException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationState.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationState.java
@@ -1,0 +1,39 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.VosManager;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+
+/**
+ * Last synchronization state module
+ *
+ * If group is synchronized, there will be information about state of last synchronization.
+ * If everything is ok, information will be 'OK'.
+ * If there is some error, there will be text of an error.
+ *
+ * If group has never been synchronized, this attribute will be empty.
+ *
+ * @author Michal Stava  stavamichal@gmail.com
+ */
+public class urn_perun_group_attribute_def_def_lastSynchronizationState extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("lastSynchronizationState");
+		attr.setDisplayName("Last synchronization State");
+		attr.setType(String.class.getName());
+		attr.setDescription("If group is synchronized, there will be information about state of last synchronization.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationTimestamp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationTimestamp.java
@@ -1,0 +1,55 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.VosManager;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Last synchronization timestamp
+ *
+ * If group is synchronized, there will be the last timestamp of group synchronization.
+ * Timestamp will be saved even if synchronization failed.
+ * Timestamp will be empty only if group has never been synchronized.
+ *
+ * @author Michal Stava  stavamichal@gmail.com
+ */
+public class urn_perun_group_attribute_def_def_lastSynchronizationTimestamp extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+		//Null value is ok, means no settings for group
+		if(attribute.getValue() == null) return;
+
+		//test of timestamp format
+		String attrValue = (String) attribute.getValue();
+		try {
+			Date date = BeansUtils.DATE_FORMATTER.parse(attrValue);
+		} catch (ParseException ex) {
+			throw new WrongAttributeValueException(attribute, group, "Format of timestamp is not correct and can't be parsed correctly. Ex. 'dd-MM-yyyy HH:mm:ss'", ex);
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("lastSynchronizationTimestamp");
+		attr.setDisplayName("Last synchronization timestamp");
+		attr.setType(String.class.getName());
+		attr.setDescription("If group is synchronized, there will be the last timestamp of group synchronization.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+
+/**
+ * Synchronization enabled
+ *
+ * true if synchronization is enabled
+ * false if not
+ * empty if there is no setting (means not synchronized)
+ *
+ * @author Michal Stava  stavamichal@gmail.com
+ */
+public class urn_perun_group_attribute_def_def_synchronizationEnabled extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+		//Null value is ok, means no settings for group
+		if(attribute.getValue() == null) return;
+
+		String attrValue = (String) attribute.getValue();
+
+		if(!attrValue.equals("true") && !attrValue.equals("false")) {
+			throw new WrongAttributeValueException(attribute, group, "If attribute is not null, only string 'true' or 'false' is correct format.");
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("synchronizationEnabled");
+		attr.setDisplayName("Synchronization Enabled");
+		attr.setType(String.class.getName());
+		attr.setDescription("Enables group synchronization from external source.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/resources/perun-beans.xml
+++ b/perun-core/src/main/resources/perun-beans.xml
@@ -20,6 +20,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
       <aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ExtSourceSql.*(..))"/>
       <aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.Auditer.flush(..))"/>
       <aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.Auditer.storeMessageToDb(..))"/>
+			<aop:advisor advice-ref="txAdviceRequiresNewTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupSynchronization(..))"/>
     </aop:config>
 
     <tx:advice id="txAdviceCommon" transaction-manager="perunTransactionManager">
@@ -45,6 +46,11 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
     <tx:advice id="txAdviceReadOnly" transaction-manager="perunTransactionManager">
       <tx:attributes>
         <tx:method name="*" read-only="true" rollback-for="Exception" />
+      </tx:attributes>
+    </tx:advice>
+		<tx:advice id="txAdviceRequiresNewTransaction" transaction-manager="perunTransactionManager">
+      <tx:attributes>
+        <tx:method name="*" read-only="false" propagation="REQUIRES_NEW"/>
       </tx:attributes>
     </tx:advice>
 


### PR DESCRIPTION
- create new module for existing attribute synchronizationEnabled,
  testing value (true, false or null)
- create new module for new attribute lastSynchronizationState, no check
  needed, only information about attribute
- create new module for new attribute lastSynchronizationTimestamp,
  check if timestamp is in correct format
- use new attributes in GroupSynchronizerThread in GroupsManagerBlImpl,
  method run, try to save information about synchronization of this
  group
- create new method saveInformationAboutGroupSynchronization in
  GroupsManagerBlImpl running in the new transaction (use in
  GroupSynchronizerThread)

---

IMPORTANT: Need to do after merging this commit

1] create two new attributeDefinitions
- urn_perun_group_attribute_def_def_lastSynchronizationState
- urn_perun_group_attribute_def_def_lastSynchronizationTimestamp
  2] set rights for these two attributeDefinitions
  3] add these information to the changeLog
