### PR TITLE
GUI: Remove common application form header (kept in menu)

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
@@ -183,6 +183,8 @@ public class ApplicationFormPage extends ApplicationPage {
 			}
 		}
 
+		/*
+
 		String headerString = "";
 
 		// display application header
@@ -199,7 +201,10 @@ public class ApplicationFormPage extends ApplicationPage {
 				headerString = ApplicationMessages.INSTANCE.membershipExtensionForVo(vo.getName());
 			}
 		}
+
 		header.setHTML(row, 0, "<h1>" + headerString + "</h1>");
+
+		*/
 
 		// language button
 		prepareToggleLanguageButton();


### PR DESCRIPTION
Commented out setting common header on application form.

IMPORTANT: before accepting this change, for all non-empty application forms, header
must be created as two form items, one for initial and second for extension. Also header text
must be filled in Czech and English.
