### PR TITLE
REGISTRAR,GUI: disable check for similar users for non-authz

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.registrar.exceptions.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -2108,7 +2107,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				// with registrar session, since only VO admin can approve application
 
 				// initial for VO - let's check similar users
-				if (AppType.INITIAL.equals(type) && app.getGroup() == null) {
+				if (AppType.INITIAL.equals(type) && app.getGroup() == null && !app.getExtSourceName().equalsIgnoreCase("LOCAL")) {
 					List<RichUser> list = checkForSimilarUsers(registrarSession, app.getId());
 					if (!list.isEmpty()) {
 						// found similar

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
@@ -164,8 +164,8 @@ public class ApplicationFormPage extends ApplicationPage {
 		formContent.setStyleName("formContentTable");
 		submittedOrError = false;
 
-		// try to get user for initial application if not found
-		if (type.equalsIgnoreCase("INITIAL") && (session.getUser() == null || session.getPerunPrincipal().getExtSource().equalsIgnoreCase("LOCAL"))) {
+		// try to get user for VOs initial application (only for authz origin)
+		if (type.equalsIgnoreCase("INITIAL") && group == null && session.getUser() == null && !session.getPerunPrincipal().getExtSource().equalsIgnoreCase("LOCAL")) {
 			tryToFindUserByName(null);
 		}
 
@@ -334,8 +334,9 @@ public class ApplicationFormPage extends ApplicationPage {
 
 		submittedOrError = true;
 
-		if (session.getUser() == null || session.getPerunPrincipal().getExtSource().equalsIgnoreCase("LOCAL")) {
+		if (type.equalsIgnoreCase("INITIAL") && group == null && session.getUser() == null && !session.getPerunPrincipal().getExtSource().equalsIgnoreCase("LOCAL")) {
 			// if not yet user of perun, retry search for similar users after app submit
+			// only for VO initial applications
 			tryToFindUserByName(jso);
 		}
 


### PR DESCRIPTION
- When identity is taken from extSource "LOCAL", user came in by non-authz way.
  Then we can't offer joining of identity on application form or when auto-approving
  application.
