### PR TITLE
REGISTRAR: do not offer joining identities when user is known

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1841,9 +1841,16 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	public List<RichUser> checkForSimilarUsers(PerunSession sess) throws PerunException {
 
 		// if user known, doesn't actually search and offer joining.
-		if (sess.getPerunPrincipal().getUser() != null ||
-		    usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, sess.getPerunPrincipal().getExtSourceName(), sess.getPerunPrincipal().getActor()) != null) {
+		if (sess.getPerunPrincipal().getUser() != null) {
 			return new ArrayList<RichUser>();
+		}
+
+		// if user known, doesn't actually search and offer joining.
+		try {
+			usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, sess.getPerunPrincipal().getExtSourceName(), sess.getPerunPrincipal().getActor());
+			return new ArrayList<RichUser>();
+		} catch (Exception ex) {
+			// we don't care, that search failed. That is actually OK case.
 		}
 
 		String name = "";


### PR DESCRIPTION
- Backported and modified change from upstream/productionElixirFix.
  When checking for similar users, if user is known (by session or
  actor/extSource) we don't have to offer joining, since perun will
  join application on approval.
  
  Case when user is known by actor/extSource but not session is when
  user entry was created by previous application with auto-approval
  but session was not updated in GUI (linked app forms).
  
  Original version returned "no match" for any unknown user, which is not good.
  Check is not performed for non-authz users on GUI side, but this logic
  must be kept in registrar for users with federated identities which we can join
  and which might be found by name or email.
