### PR TITLE
REGISTRAR,GUI: Support for Heading and Timezone in app form

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -8,6 +8,7 @@ import static cz.metacentrum.perun.registrar.model.ApplicationFormItem.Type.PASS
 import static cz.metacentrum.perun.registrar.model.ApplicationFormItem.Type.SUBMIT_BUTTON;
 import static cz.metacentrum.perun.registrar.model.ApplicationFormItem.Type.USERNAME;
 import static cz.metacentrum.perun.registrar.model.ApplicationFormItem.Type.VALIDATED_EMAIL;
+import static cz.metacentrum.perun.registrar.model.ApplicationFormItem.Type.HEADING;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -636,7 +637,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			for (ApplicationFormItemData itemData : data) {
 
 				Type itemType = itemData.getFormItem().getType();
-				if (itemType == HTML_COMMENT || itemType == SUBMIT_BUTTON || itemType == PASSWORD) continue;
+				if (itemType == HTML_COMMENT || itemType == SUBMIT_BUTTON || itemType == PASSWORD || itemType == HEADING) continue;
 
 				// Check if mails needs to be validated
 				if (itemType == VALIDATED_EMAIL) {

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
@@ -48,10 +48,10 @@ public class ApplicationFormItem {
 
 
 	public ApplicationFormItem(int id, String shortname, boolean required,
-			Type type, String federationAttribute,
-			String perunDestinationAttribute, String regex,
-			List<AppType> applicationTypes, Integer ordnum, boolean forDelete,
-			Map<Locale, ItemTexts> i18n) {
+	                           Type type, String federationAttribute,
+	                           String perunDestinationAttribute, String regex,
+	                           List<AppType> applicationTypes, Integer ordnum, boolean forDelete,
+	                           Map<Locale, ItemTexts> i18n) {
 		super();
 		this.id = id;
 		this.shortname = shortname;
@@ -107,60 +107,68 @@ public class ApplicationFormItem {
 		 * For inserting arbitrary HTML text into the form.
 		 */
 		HTML_COMMENT,
-			/**
-			 * For specifying a label for the submit button.
-			 */
-			SUBMIT_BUTTON,
-			/**
-			 * For read-only fields with values taken from identity federation.
-			 */
-			FROM_FEDERATION_SHOW,
-			/**
-			 * For hidden fields with values taken from identity federation.
-			 */
-			FROM_FEDERATION_HIDDEN,
-			/**
-			 * For password, which needs to be typed twice.
-			 */
-			PASSWORD,
-			/**
-			 * For an email address that must be validated by sending an email with a URL.
-			 */
-			VALIDATED_EMAIL,
-			/**
-			 * Standard HTML text field.
-			 */
-			TEXTFIELD,
-			/**
-			 * Standard HTML text area.
-			 */
-			TEXTAREA,
-			/**
-			 * Standard HTML checkbox, multiple values are allowed.
-			 */
-			CHECKBOX,
-			/**
-			 * Standard HTML radio button.
-			 */
-			RADIO,
-			/**
-			 * Standard HTML selection box, options are in for each locale in ItemTexts.label separated by | with values separated by #.
-			 * Thus a language selection box would have for English locale the label <code>cs#Czech|en#English</code>.
-			 */
-			SELECTIONBOX,
-			/**
-			 * A widget that is a combination of a drop-down list and a single-line editable textbox,
-			 * allowing the user to either type a value directly into the control or choose from a list of existing options.
-			 * See <a href="http://en.wikipedia.org/wiki/Combobox">Combobox</a> for description.<p>
-			 * The options are defined in the same way as for SELECTIONBOX.
-			 *
-			 */
-			COMBOBOX,
-			/**
-			 * Special type for specifying username. It needs to be treated separately from ordinary TEXTFIELD,
-			 * because initial applications by users who are already members of a VO need to display read-only.
-			 */
-			USERNAME
+		/**
+		 * For specifying a label for the submit button.
+		 */
+		SUBMIT_BUTTON,
+		/**
+		 * For read-only fields with values taken from identity federation.
+		 */
+		FROM_FEDERATION_SHOW,
+		/**
+		 * For hidden fields with values taken from identity federation.
+		 */
+		FROM_FEDERATION_HIDDEN,
+		/**
+		 * For password, which needs to be typed twice.
+		 */
+		PASSWORD,
+		/**
+		 * For an email address that must be validated by sending an email with a URL.
+		 */
+		VALIDATED_EMAIL,
+		/**
+		 * Standard HTML text field.
+		 */
+		TEXTFIELD,
+		/**
+		 * Standard HTML text area.
+		 */
+		TEXTAREA,
+		/**
+		 * Standard HTML checkbox, multiple values are allowed.
+		 */
+		CHECKBOX,
+		/**
+		 * Standard HTML radio button.
+		 */
+		RADIO,
+		/**
+		 * Standard HTML selection box, options are in for each locale in ItemTexts.label separated by | with values separated by #.
+		 * Thus a language selection box would have for English locale the label <code>cs#Czech|en#English</code>.
+		 */
+		SELECTIONBOX,
+		/**
+		 * A widget that is a combination of a drop-down list and a single-line editable textbox,
+		 * allowing the user to either type a value directly into the control or choose from a list of existing options.
+		 * See <a href="http://en.wikipedia.org/wiki/Combobox">Combobox</a> for description.<p>
+		 * The options are defined in the same way as for SELECTIONBOX.
+		 *
+		 */
+		COMBOBOX,
+		/**
+		 * Special type for specifying username. It needs to be treated separately from ordinary TEXTFIELD,
+		 * because initial applications by users who are already members of a VO need to display read-only.
+		 */
+		USERNAME,
+		/**
+		 * Special item defining Heading of application form.
+		 */
+		HEADING,
+		/**
+		 * Special item with pre-defined Timezone selection. Value is autoselected in GUI using Google's API
+		 */
+		TIMEZONE
 	}
 
 	public static class ItemTexts {
@@ -233,12 +241,12 @@ public class ApplicationFormItem {
 		@Override
 		public String toString() {
 			return "ItemTexts{" +
-				"locale=" + locale +
-				", label='" + label + '\'' +
-				", options='" + options + '\'' +
-				", help='" + help + '\'' +
-				", errorMessage='" + errorMessage + '\'' +
-				'}';
+					"locale=" + locale +
+					", label='" + label + '\'' +
+					", options='" + options + '\'' +
+					", help='" + help + '\'' +
+					", errorMessage='" + errorMessage + '\'' +
+					'}';
 		}
 	}
 
@@ -331,15 +339,15 @@ public class ApplicationFormItem {
 	@Override
 	public String toString() {
 		return this.getClass().getSimpleName()+":[" +
-			"id='" + getId() + '\'' +
-			", shortname='" + getShortname() + '\'' +
-			", ordnum='" + getOrdnum() + '\'' +
-			", required='" + isRequired() + '\'' +
-			", type='" + getType().toString() + '\'' +
-			", federationAttribute='" + getFederationAttribute() + '\'' +
-			", regex='" + getRegex() + '\'' +
-			", i18n='" + getI18n().toString() + '\'' +
-			"]";
+				"id='" + getId() + '\'' +
+				", shortname='" + getShortname() + '\'' +
+				", ordnum='" + getOrdnum() + '\'' +
+				", required='" + isRequired() + '\'' +
+				", type='" + getType().toString() + '\'' +
+				", federationAttribute='" + getFederationAttribute() + '\'' +
+				", regex='" + getRegex() + '\'' +
+				", i18n='" + getI18n().toString() + '\'' +
+				"]";
 	}
 
 	@Override

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
@@ -442,6 +442,15 @@ public class RegistrarFormItemGenerator {
 			return generateHtmlComment();
 		}
 
+		if(item.getType().equals("HEADING")){
+			showLabel = false;
+			return generateHtmlComment();
+		}
+
+		if(item.getType().equals("TIMEZONE")){
+			return generateTimezoneListBox();
+		}
+
 		if(item.getType().equals("FROM_FEDERATION_HIDDEN")){
 			this.visibleOnlyToAdmin = true;
 			this.visible = false;
@@ -802,10 +811,45 @@ public class RegistrarFormItemGenerator {
 		// when changed, update value
 		lbox.addChangeHandler(new ChangeHandler() {
 			public void onChange(ChangeEvent event) {
-
 				String value = lbox.getValue(lbox.getSelectedIndex());
-				strValueBox.setValue(value);
+				// fire change event to check for correct input
+				strValueBox.setValue(value, true);
+			}
+		});
 
+		if (lbox.getItemCount() != 0) {
+			// set default value
+			strValueBox.setText(lbox.getValue(lbox.getSelectedIndex()));
+		}
+
+		return lbox;
+	}
+
+	/**
+	 * Generates the listbox with Timezone selection.
+	 * @return
+	 */
+	private Widget generateTimezoneListBox() {
+
+		final ListBox lbox = new ListBox();
+		strValueBox = new ExtendedTextBox();
+
+		// add timezone option
+		lbox.addItem("Not selected", "");
+		int i = 1;
+		for(String key : Utils.getTimezones()){
+			boolean selected = strValue.equals(key);
+			lbox.addItem(key, key);
+			lbox.setItemSelected(i, selected);
+			i++;
+		}
+
+		// when changed, update value
+		lbox.addChangeHandler(new ChangeHandler() {
+			public void onChange(ChangeEvent event) {
+				String value = lbox.getValue(lbox.getSelectedIndex());
+				// fire change event to check for correct input
+				strValueBox.setValue(value, true);
 			}
 		});
 
@@ -968,7 +1012,7 @@ public class RegistrarFormItemGenerator {
 			public void onChange(ChangeEvent event) {
 
 				String value = lbox.getValue(lbox.getSelectedIndex());
-				strValueBox.setValue(value);
+				strValueBox.setValue(value, true);
 
 				// if other value selected, set textbox visible
 				textBox.setVisible(lbox.getSelectedIndex() == otherValueIndex);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
@@ -76,7 +76,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 	 * Creates a new method instance
 	 *
 	 * @param entity entity
-	 * @param id entity ID
+	 * @param id     entity ID
 	 */
 	public GetFormItemsWithPrefilledValues(PerunEntity entity, int id) {
 		this.id = id;
@@ -88,7 +88,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 	 * Creates a new method instance
 	 *
 	 * @param entity entity
-	 * @param id entity ID
+	 * @param id     entity ID
 	 * @param locale locale
 	 */
 	public GetFormItemsWithPrefilledValues(PerunEntity entity, int id, String locale) {
@@ -100,7 +100,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 	 * Creates a new method instance
 	 *
 	 * @param entity entity
-	 * @param id entity ID
+	 * @param id     entity ID
 	 * @param events Custom events
 	 */
 	public GetFormItemsWithPrefilledValues(PerunEntity entity, int id, JsonCallbackEvents events) {
@@ -112,7 +112,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 	 * Creates a new method instance
 	 *
 	 * @param entity entity
-	 * @param id entity ID
+	 * @param id     entity ID
 	 * @param events Custom events
 	 * @param locale Locale
 	 */
@@ -134,7 +134,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 			param = "group=" + this.id;
 		}
 
-		if(type.length() != 0){
+		if (type.length() != 0) {
 			param += "&type=" + type;
 		}
 
@@ -149,8 +149,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 	/**
 	 * Returns contents
 	 */
-	public Widget getContents()
-	{
+	public Widget getContents() {
 		return this.contents;
 	}
 
@@ -169,7 +168,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 
 		if (error.getName().equalsIgnoreCase("DuplicateRegistrationAttemptException")) {
 
-			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+ApplicationMessages.INSTANCE.duplicateRegistrationAttemptExceptionText());
+			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + ApplicationMessages.INSTANCE.duplicateRegistrationAttemptExceptionText());
 
 			if (Location.getParameter("targetnew") != null) {
 				Location.replace(Location.getParameter("targetnew"));
@@ -179,24 +178,24 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 
 			String missingItems = "<p>";
 			if (error.getFormItems() != null) {
-				for (int i=0; i<error.getFormItems().length(); i++) {
+				for (int i = 0; i < error.getFormItems().length(); i++) {
 					missingItems += ApplicationMessages.INSTANCE.missingIDPAttribute();
 					missingItems += error.getFormItems().get(i).getFormItem().getFederationAttribute();
 					missingItems += "<br />";
 				}
 			}
-			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+ApplicationMessages.INSTANCE.missingDataFromIDP()+missingItems);
+			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + ApplicationMessages.INSTANCE.missingDataFromIDP() + missingItems);
 
 		} else if (error.getName().equalsIgnoreCase("ExtendMembershipException")) {
 
 			if ("NOUSERLOA".equalsIgnoreCase(error.getReason())) {
-				ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+ApplicationMessages.INSTANCE.noUserLoa());
+				ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + ApplicationMessages.INSTANCE.noUserLoa());
 			} else if ("INSUFFICIENTLOA".equalsIgnoreCase(error.getReason())) {
-				ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+ApplicationMessages.INSTANCE.insufficientLoa());
+				ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + ApplicationMessages.INSTANCE.insufficientLoa());
 			} else if ("INSUFFICIENTLOAFOREXTENSION".equalsIgnoreCase(error.getReason())) {
-				ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+ApplicationMessages.INSTANCE.insufficientLoaForExtension());
+				ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + ApplicationMessages.INSTANCE.insufficientLoaForExtension());
 			} else if ("OUTSIDEEXTENSIONPERIOD".equalsIgnoreCase(error.getReason())) {
-				ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+ApplicationMessages.INSTANCE.outsideExtensionPeriod());
+				ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + ApplicationMessages.INSTANCE.outsideExtensionPeriod());
 
 				// redirect if possible
 				if (Location.getParameter("targetexisting") != null) {
@@ -206,7 +205,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 			}
 
 		} else {
-			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+"<h2>"+error.getErrorInfo()+"</h2>");
+			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + "<h2>" + error.getErrorInfo() + "</h2>");
 		}
 
 		ft.getFlexCellFormatter().setVerticalAlignment(0, 0, HasVerticalAlignment.ALIGN_MIDDLE);
@@ -237,7 +236,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 			// when there are no application form items
 			FlexTable ft = new FlexTable();
 			ft.setSize("100%", "300px");
-			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+ApplicationMessages.INSTANCE.noFormDefined());
+			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + ApplicationMessages.INSTANCE.noFormDefined());
 			ft.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_CENTER);
 			ft.getFlexCellFormatter().setVerticalAlignment(0, 0, HasVerticalAlignment.ALIGN_MIDDLE);
 
@@ -253,7 +252,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 			// when there are no application form items
 			FlexTable ft = new FlexTable();
 			ft.setSize("100%", "300px");
-			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+ApplicationMessages.INSTANCE.alreadyVoMember());
+			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon()) + ApplicationMessages.INSTANCE.alreadyVoMember());
 			ft.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_CENTER);
 			ft.getFlexCellFormatter().setVerticalAlignment(0, 0, HasVerticalAlignment.ALIGN_MIDDLE);
 
@@ -276,7 +275,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 	/**
 	 * Prepares the widgets from the items as A DISPLAY FOR THE USER
 	 */
-	public void prepareApplicationForm(){
+	public void prepareApplicationForm() {
 
 		FlexTable ft = new FlexTable();
 		ft.setCellPadding(10);
@@ -291,7 +290,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 		}
 
 		int i = 0;
-		for(final ApplicationFormItemWithPrefilledValue item : applFormItems){
+		for (final ApplicationFormItemWithPrefilledValue item : applFormItems) {
 
 
 			RegistrarFormItemGenerator gen = new RegistrarFormItemGenerator(item, locale);
@@ -305,20 +304,20 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 
 
 			// if button, add onclick
-			if(item.getFormItem().getType().equals("SUBMIT_BUTTON")){
+			if (item.getFormItem().getType().equals("SUBMIT_BUTTON")) {
 
 				this.sendButton = (CustomButton) gen.getWidget();
 				sendButton.addClickHandler(new ClickHandler() {
 					public void onClick(ClickEvent event) {
 
 						// revalidate again, with force validation
-						if(!validateFormValues(true)){
+						if (!validateFormValues(true)) {
 							Element elem = DOM.getElementById("input-status-error");
 							elem.scrollIntoView();
 							return;
 						}
 
-						if(sendFormHandler != null){
+						if (sendFormHandler != null) {
 							sendFormHandler.sendApplicationForm(sendButton);
 						}
 					}
@@ -328,12 +327,12 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 			// get localized texts
 			ItemTexts itemTexts = item.getFormItem().getItemTexts(locale);
 
-			if(!gen.isVisible()){
+			if (!gen.isVisible()) {
 				continue;
 			}
 
 			// WITH LABEL (input box ...)
-			if(gen.isLabelShown()){
+			if (gen.isLabelShown()) {
 
 				// 0 = label
 				if (item.getFormItem().isRequired() == true) {
@@ -353,8 +352,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 				ft.setWidget(i, 2, gen.getStatusWidget());
 
 				// 3 = HELP
-				if(itemTexts.getHelp() != null && itemTexts.getHelp().length() > 0)
-				{
+				if (itemTexts.getHelp() != null && itemTexts.getHelp().length() > 0) {
 					Label help = new Label(itemTexts.getHelp());
 					ft.setWidget(i, 3, help);
 				}
@@ -366,11 +364,9 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 				fcf.setStyleName(i, 3, "applicationFormHelp");
 				ft.setWidth("100%");
 
+				// ELSE HTML COMMENT, SUBMIT BUTTON, HEADING
 
-
-
-				// ELSE HTML COMMENT
-			}else{
+			} else {
 
 				ft.setWidget(i, 0, gen.getWidget());
 
@@ -393,17 +389,17 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 	 */
 	protected boolean validateFormValues(boolean forcedValidation) {
 
-		if(sendButton == null) return false;
+		if (sendButton == null) return false;
 
 		boolean valid = true;
 
 		sendButton.setEnabled(true);
-		for(RegistrarFormItemGenerator gen : applFormGenerators){
-			if(gen.getInputChecker().isValidating() || !gen.getInputChecker().isValid(forcedValidation)){
+		for (RegistrarFormItemGenerator gen : applFormGenerators) {
+			if (gen.getInputChecker().isValidating() || !gen.getInputChecker().isValid(forcedValidation)) {
 				sendButton.setEnabled(false);
 				valid = false;
 
-				if(!forcedValidation){
+				if (!forcedValidation) {
 					return false;
 				}
 			}
@@ -414,14 +410,14 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 
 	/**
 	 * Generates the values from the form
+	 *
 	 * @return
 	 */
-	public ArrayList<ApplicationFormItemData> getValues()
-	{
+	public ArrayList<ApplicationFormItemData> getValues() {
 		ArrayList<ApplicationFormItemData> formItemDataList = new ArrayList<ApplicationFormItemData>();
 
 		// goes through all the item generators and retrieves the value
-		for(RegistrarFormItemGenerator gen : applFormGenerators){
+		for (RegistrarFormItemGenerator gen : applFormGenerators) {
 
 			String value = gen.getValue();
 			String prefilled = gen.getPrefilledValue();
@@ -459,6 +455,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 
 	/**
 	 * Set callback as hidden (no popup on exception)
+	 *
 	 * @param hidden true = hidden
 	 */
 	public void setHidden(boolean hidden) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
  *
  * @author Vaclav Mach <374430@mail.muni.cz>
  */
-public class CreateFormItemTabItem implements TabItem{
+public class CreateFormItemTabItem implements TabItem {
 
 	/**
 	 * Perun web session
@@ -51,7 +51,7 @@ public class CreateFormItemTabItem implements TabItem{
 	/**
 	 * Input types
 	 */
-	static private final String[] INPUT_TYPES = {"TEXTFIELD", "TEXTAREA", "SELECTIONBOX", "COMBOBOX", "CHECKBOX", "USERNAME", "PASSWORD", "VALIDATED_EMAIL", "SUBMIT_BUTTON", "HTML_COMMENT", "FROM_FEDERATION_HIDDEN", "FROM_FEDERATION_SHOW"};
+	static private final String[] INPUT_TYPES = {"TEXTFIELD", "TEXTAREA", "SELECTIONBOX", "COMBOBOX", "CHECKBOX", "USERNAME", "PASSWORD", "VALIDATED_EMAIL", "SUBMIT_BUTTON", "HTML_COMMENT", "HEADING", "TIMEZONE", "FROM_FEDERATION_HIDDEN", "FROM_FEDERATION_SHOW"};
 
 	/**
 	 * Cropping length in select box after which item to add item
@@ -60,15 +60,13 @@ public class CreateFormItemTabItem implements TabItem{
 
 	/**
 	 * Creates a tab instance
-	 *
-	 *
 	 */
-	public CreateFormItemTabItem(ArrayList<ApplicationFormItem> sourceList, JsonCallbackEvents events){
+	public CreateFormItemTabItem(ArrayList<ApplicationFormItem> sourceList, JsonCallbackEvents events) {
 		this.sourceList = sourceList;
 		this.events = events;
 	}
 
-	public boolean isPrepared(){
+	public boolean isPrepared() {
 		return true;
 	}
 
@@ -76,7 +74,7 @@ public class CreateFormItemTabItem implements TabItem{
 
 		// vertical panel
 		VerticalPanel vp = new VerticalPanel();
-		vp.setSize("100%","100%");
+		vp.setSize("100%", "100%");
 
 		// flex table
 		FlexTable layout = new FlexTable();
@@ -103,7 +101,7 @@ public class CreateFormItemTabItem implements TabItem{
 
 		// select widget type
 		final ListBox typeListBox = new ListBox();
-		for(int i = 0; i < INPUT_TYPES.length; i++){
+		for (int i = 0; i < INPUT_TYPES.length; i++) {
 			String type = INPUT_TYPES[i];
 			typeListBox.addItem(type, type);
 		}
@@ -111,13 +109,13 @@ public class CreateFormItemTabItem implements TabItem{
 		// insert after
 		final ListBox insertAfterListBox = new ListBox();
 		insertAfterListBox.addItem(" - insert to the beginning - ", 0 + "");
-		for(int i = 0; i < sourceList.size(); i++){
+		for (int i = 0; i < sourceList.size(); i++) {
 			ApplicationFormItem item = sourceList.get(i);
 			RegistrarFormItemGenerator gen = new RegistrarFormItemGenerator(item, ""); // with default en locale
 			String label = gen.getFormItem().getShortname();
 
 			// crop length
-			if(label.length() > CROP_LABEL_LENGTH){
+			if (label.length() > CROP_LABEL_LENGTH) {
 				label = label.substring(0, CROP_LABEL_LENGTH);
 			}
 
@@ -132,7 +130,7 @@ public class CreateFormItemTabItem implements TabItem{
 		layout.setHTML(2, 0, "Insert after:");
 		layout.setWidget(2, 1, insertAfterListBox);
 
-		for (int i=0; i<layout.getRowCount(); i++) {
+		for (int i = 0; i < layout.getRowCount(); i++) {
 			cellFormatter.addStyleName(i, 0, "itemName");
 		}
 
@@ -214,9 +212,6 @@ public class CreateFormItemTabItem implements TabItem{
 		return result;
 	}
 
-	/**
-	 * @param obj
-	 */
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)
@@ -233,8 +228,7 @@ public class CreateFormItemTabItem implements TabItem{
 		return false;
 	}
 
-	public void open()
-	{
+	public void open() {
 	}
 
 	public boolean isAuthorized() {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
@@ -8,7 +8,6 @@ import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -37,7 +36,7 @@ import java.util.Map;
  * @author Vaclav Mach <374430@mail.muni.cz>
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-public class EditFormItemTabItem implements TabItem{
+public class EditFormItemTabItem implements TabItem {
 
 	/**
 	 * Perun web session
@@ -83,7 +82,7 @@ public class EditFormItemTabItem implements TabItem{
 	/**
 	 * KEY = locale, VALUE = Map<TextBox, TextBox> (key,value)
 	 */
-	private Map<String,Map<TextBox,TextBox>> optionsBoxes = new HashMap<String,Map<TextBox,TextBox>>();
+	private Map<String, Map<TextBox, TextBox>> optionsBoxes = new HashMap<String, Map<TextBox, TextBox>>();
 
 	private TabItem tab;
 
@@ -93,12 +92,12 @@ public class EditFormItemTabItem implements TabItem{
 	 * @param item
 	 * @param events
 	 */
-	public EditFormItemTabItem(ApplicationFormItem item, JsonCallbackEvents events){
+	public EditFormItemTabItem(ApplicationFormItem item, JsonCallbackEvents events) {
 		this.item = item;
 		this.events = events;
 	}
 
-	public boolean isPrepared(){
+	public boolean isPrepared() {
 		return true;
 	}
 
@@ -111,7 +110,7 @@ public class EditFormItemTabItem implements TabItem{
 	private Widget itemTextTab(String locale) {
 
 		ItemTexts itemTexts = item.getItemTexts(locale);
-		if(itemTexts == null){
+		if (itemTexts == null) {
 			// create empty item texts
 			JSONObject itemTextJson = new JSONObject();
 			itemTextJson.put("label", new JSONString(""));
@@ -149,37 +148,52 @@ public class EditFormItemTabItem implements TabItem{
 		// adding to table
 		int row = 0;
 
-		Label label = new Label("Label:");
-		ft.setWidget(row, 0, label);
-		ft.setWidget(row, 1, labelTextBox);
+		if ("HTML_COMMENT".equals(item.getType()) || "HEADING".equals(item.getType())) {
 
-		row++;
-		ft.setHTML(row, 1, "Label displayed to users to identify item on application form. If empty, \"Short name\" from basic settings is used as fallback. For HTML_COMMENT type is used as content to display.");
-		ftf.setStyleName(row, 1, "inputFormInlineComment");
+			Label label = new Label("Content:");
+			ft.setWidget(row, 0, label);
+			ft.setWidget(row, 1, labelTextBox);
 
-		row++;
+			row++;
+			ft.setHTML(row, 1, "HTML formatted content of form item. It spans through all columns to full form width.");
+			ftf.setStyleName(row, 1, "inputFormInlineComment");
 
-		Label helpLabel = new Label("Help:");
-		ft.setWidget(row, 0, helpLabel);
-		ft.setWidget(row, 1, helpTextBox);
+			row++;
 
-		row++;
-		ft.setHTML(row, 1, "Help text displayed to user along with input widget.");
-		ftf.setStyleName(row, 1, "inputFormInlineComment");
+		} else {
 
-		row++;
+			Label label = new Label("Label:");
+			ft.setWidget(row, 0, label);
+			ft.setWidget(row, 1, labelTextBox);
 
-		Label errorLabel = new Label("Error:");
-		ft.setWidget(row, 0, errorLabel);
-		ft.setWidget(row, 1, errorTextBox);
+			row++;
+			ft.setHTML(row, 1, "Label displayed to users to identify item on application form. If empty, \"Short name\" from basic settings is used as fallback.");
+			ftf.setStyleName(row, 1, "inputFormInlineComment");
 
-		row++;
-		ft.setHTML(row, 1, "Error message displayed to user when inputs wrong value.");
-		ftf.setStyleName(row, 1, "inputFormInlineComment");
+			row++;
 
+			Label helpLabel = new Label("Help:");
+			ft.setWidget(row, 0, helpLabel);
+			ft.setWidget(row, 1, helpTextBox);
+
+			row++;
+			ft.setHTML(row, 1, "Help text displayed to user along with input widget.");
+			ftf.setStyleName(row, 1, "inputFormInlineComment");
+
+			row++;
+
+			Label errorLabel = new Label("Error:");
+			ft.setWidget(row, 0, errorLabel);
+			ft.setWidget(row, 1, errorTextBox);
+
+			row++;
+			ft.setHTML(row, 1, "Error message displayed to user when inputs wrong value.");
+			ftf.setStyleName(row, 1, "inputFormInlineComment");
+
+		}
 
 		// style
-		for(int i = 0; i<ft.getRowCount(); i++){
+		for (int i = 0; i < ft.getRowCount(); i++) {
 			ftf.setStyleName(i, 0, "itemName");
 		}
 
@@ -187,11 +201,11 @@ public class EditFormItemTabItem implements TabItem{
 		final FlexTable boxItemTable = new FlexTable();
 
 		// final layout
-		VerticalPanel vp  = new VerticalPanel();
+		VerticalPanel vp = new VerticalPanel();
 		vp.add(ft);
 
 		// values for selection and combobox
-		if ("SELECTIONBOX".equalsIgnoreCase(item.getType())|| "COMBOBOX".equalsIgnoreCase(item.getType()) || "CHECKBOX".equalsIgnoreCase(item.getType())) {
+		if ("SELECTIONBOX".equalsIgnoreCase(item.getType()) || "COMBOBOX".equalsIgnoreCase(item.getType()) || "CHECKBOX".equalsIgnoreCase(item.getType())) {
 
 			boxItemTable.setStyleName("inputFormFlexTable");
 			boxItemTable.setWidth("550px");
@@ -221,13 +235,13 @@ public class EditFormItemTabItem implements TabItem{
 
 			// parse values from the item
 			String options = itemTexts.getOptions();
-			if(options != null) {
+			if (options != null) {
 				// for each value, add key-value
 				values.putAll(RegistrarFormItemGenerator.parseSelectionBox(options));
 			}
 
 			// for each add new row
-			for(Map.Entry<String, String> entry : values.entrySet()){
+			for (Map.Entry<String, String> entry : values.entrySet()) {
 
 				final TextBox keyTextBox = new TextBox();
 				final TextBox valueTextBox = new TextBox();
@@ -259,14 +273,14 @@ public class EditFormItemTabItem implements TabItem{
 
 					currentOptions.put(keyTextBox, valueTextBox);
 
-					boxItemTable.insertRow(r-1);
+					boxItemTable.insertRow(r - 1);
 
-					boxItemTable.setHTML(r-1, 0, "Value:");
-					boxItemTable.getFlexCellFormatter().setStyleName(r-1, 0, "itemName");
-					boxItemTable.setWidget(r-1, 1, keyTextBox);
-					boxItemTable.setHTML(r-1, 2, "Label:");
-					boxItemTable.getFlexCellFormatter().setStyleName(r-1, 2, "itemName");
-					boxItemTable.setWidget(r-1, 3, valueTextBox);
+					boxItemTable.setHTML(r - 1, 0, "Value:");
+					boxItemTable.getFlexCellFormatter().setStyleName(r - 1, 0, "itemName");
+					boxItemTable.setWidget(r - 1, 1, keyTextBox);
+					boxItemTable.setHTML(r - 1, 2, "Label:");
+					boxItemTable.getFlexCellFormatter().setStyleName(r - 1, 2, "itemName");
+					boxItemTable.setWidget(r - 1, 3, valueTextBox);
 
 					UiElements.runResizeCommands(tab);
 
@@ -312,7 +326,7 @@ public class EditFormItemTabItem implements TabItem{
 		federationAttributes.addItem("EPPN", "eppn");
 
 		// application types
-		GetAttributesDefinition attrDef = new GetAttributesDefinition(new JsonCallbackEvents(){
+		GetAttributesDefinition attrDef = new GetAttributesDefinition(new JsonCallbackEvents() {
 			@Override
 			public void onError(PerunError error) {
 				perunDestinationAttributeListBox.clear();
@@ -323,42 +337,44 @@ public class EditFormItemTabItem implements TabItem{
 					perunDestinationAttributeListBox.setSelectedIndex(1);
 				}
 			}
-		@Override
-		public void onFinished(JavaScriptObject jso) {
-			// clear
-			perunDestinationAttributeListBox.clear();
-			// set empty possibility
-			perunDestinationAttributeListBox.addItem("No item selected (empty value)", "");
 
-			ArrayList<AttributeDefinition> list = JsonUtils.jsoAsList(jso);
-			if (list != null && !list.isEmpty()) {
-				// sort
-				list = new TableSorter<AttributeDefinition>().sortByFriendlyName(list);
-				for (AttributeDefinition def : list) {
-					// add only member and user attributes
-					if (def.getEntity().equalsIgnoreCase("user") || def.getEntity().equalsIgnoreCase("member")) {
-						perunDestinationAttributeListBox.addItem(def.getFriendlyName()+" ("+def.getEntity()+" / "+def.getDefinition()+")", def.getName());
+			@Override
+			public void onFinished(JavaScriptObject jso) {
+				// clear
+				perunDestinationAttributeListBox.clear();
+				// set empty possibility
+				perunDestinationAttributeListBox.addItem("No item selected (empty value)", "");
+
+				ArrayList<AttributeDefinition> list = JsonUtils.jsoAsList(jso);
+				if (list != null && !list.isEmpty()) {
+					// sort
+					list = new TableSorter<AttributeDefinition>().sortByFriendlyName(list);
+					for (AttributeDefinition def : list) {
+						// add only member and user attributes
+						if (def.getEntity().equalsIgnoreCase("user") || def.getEntity().equalsIgnoreCase("member")) {
+							perunDestinationAttributeListBox.addItem(def.getFriendlyName() + " (" + def.getEntity() + " / " + def.getDefinition() + ")", def.getName());
+						}
+					}
+				} else {
+					// no attr def loaded, keep as it is set
+					if (item.getPerunDestinationAttribute() != null && !item.getPerunDestinationAttribute().isEmpty()) {
+						perunDestinationAttributeListBox.addItem(item.getPerunDestinationAttribute(), item.getPerunDestinationAttribute());
 					}
 				}
-			} else {
-				// no attr def loaded, keep as it is set
-				if (item.getPerunDestinationAttribute() != null && !item.getPerunDestinationAttribute().isEmpty()) {
-					perunDestinationAttributeListBox.addItem(item.getPerunDestinationAttribute(), item.getPerunDestinationAttribute());
+				// set selected
+				for (int i = 0; i < perunDestinationAttributeListBox.getItemCount(); i++) {
+					// set proper value as "selected"
+					if (perunDestinationAttributeListBox.getValue(i).equalsIgnoreCase(item.getPerunDestinationAttribute())) {
+						perunDestinationAttributeListBox.setSelectedIndex(i);
+						break;
+					}
 				}
 			}
-			// set selected
-			for (int i=0; i<perunDestinationAttributeListBox.getItemCount(); i++) {
-				// set proper value as "selected"
-				if (perunDestinationAttributeListBox.getValue(i).equalsIgnoreCase(item.getPerunDestinationAttribute())) {
-					perunDestinationAttributeListBox.setSelectedIndex(i);
-					break;
-				}
+
+			@Override
+			public void onLoadingStart() {
+				perunDestinationAttributeListBox.addItem("Loading...");
 			}
-		}
-		@Override
-		public void onLoadingStart() {
-			perunDestinationAttributeListBox.addItem("Loading...");
-		}
 		});
 
 		// layout
@@ -368,7 +384,7 @@ public class EditFormItemTabItem implements TabItem{
 
 		// fill values
 		shortNameTextBox.setText(item.getShortname());
-		for (int i=0; i<federationAttributes.getItemCount(); i++) {
+		for (int i = 0; i < federationAttributes.getItemCount(); i++) {
 			if (federationAttributes.getValue(i).equals(item.getFederationAttribute())) {
 				federationAttributes.setSelectedIndex(i);
 				break;
@@ -377,7 +393,7 @@ public class EditFormItemTabItem implements TabItem{
 		requiredCheckBox.setValue(item.isRequired());
 		regexTextBox.setText(item.getRegex());
 
-		for(Application.ApplicationType type : Application.ApplicationType.values()){
+		for (Application.ApplicationType type : Application.ApplicationType.values()) {
 			CheckBox cb = new CheckBox();
 			boolean checked = itemApplicationTypes.contains(type.toString());
 			cb.setValue(checked);
@@ -412,7 +428,7 @@ public class EditFormItemTabItem implements TabItem{
 		ftf.setStyleName(row, 1, "inputFormInlineComment");
 
 		// set colspan for tops
-		for (int i=0; i<ft.getRowCount(); i++) {
+		for (int i = 0; i < ft.getRowCount(); i++) {
 			ftf.setColSpan(i, 1, 2);
 		}
 
@@ -434,7 +450,7 @@ public class EditFormItemTabItem implements TabItem{
 			} else {
 				cb.setTitle("If checked, display form item on EXTENSION application");
 			}
-			ft.setWidget(row, i+1, cb);
+			ft.setWidget(row, i + 1, cb);
 			i++;
 		}
 
@@ -446,7 +462,7 @@ public class EditFormItemTabItem implements TabItem{
 		row++;
 
 		// IF BUTTON OR COMMENT, don't show these
-		if(!item.getType().equals("SUBMIT_BUTTON") && !item.getType().equals("HTML_COMMENT")) {
+		if (!item.getType().equals("SUBMIT_BUTTON") && !item.getType().equals("HTML_COMMENT") && !item.getType().equals("HEADING")) {
 
 			// load attr defs only when showed
 			attrDef.retrieveData();
@@ -485,7 +501,7 @@ public class EditFormItemTabItem implements TabItem{
 			ftf.setStyleName(row, 1, "inputFormInlineComment");
 			ftf.setColSpan(row, 1, 2);
 
-			if (!item.getType().equals("VALIDATED_EMAIL")) {
+			if (!item.getType().equals("VALIDATED_EMAIL") && !item.getType().equals("TIMEZONE")) {
 
 				row++;
 				Label regexLabel = new Label("Regular expression:");
@@ -503,7 +519,7 @@ public class EditFormItemTabItem implements TabItem{
 		}
 
 		// set styles
-		for (int n=0; n<ft.getRowCount(); n++) {
+		for (int n = 0; n < ft.getRowCount(); n++) {
 			ftf.setStyleName(n, 0, "itemName");
 		}
 
@@ -521,7 +537,7 @@ public class EditFormItemTabItem implements TabItem{
 
 		this.tab = this;
 
-		this.titleWidget.setText("Edit form item: "+item.getShortname());
+		this.titleWidget.setText("Edit form item: " + item.getShortname());
 
 		// languages
 		ArrayList<String> languages = new ArrayList<String>();
@@ -542,8 +558,8 @@ public class EditFormItemTabItem implements TabItem{
 		tabPanel.add(basicInformationTab(), "Basic settings");
 
 		// for each locale add tab
-		for(String locale : languages){
-			tabPanel.add(itemTextTab(locale), "Lang: "+locale);
+		for (String locale : languages) {
+			tabPanel.add(itemTextTab(locale), "Lang: " + locale);
 		}
 
 		// add menu
@@ -591,7 +607,7 @@ public class EditFormItemTabItem implements TabItem{
 
 		// shortName is required item !!
 		if (shortNameTextBox.getText() == null || (shortNameTextBox.getText().isEmpty())) {
-			Window.alert("shortName is required parameter and can't be empty !");
+			UiElements.generateAlert("Empty shortName", "'shortName' is required parameter and can't be empty !");
 			return;
 		}
 
@@ -614,7 +630,7 @@ public class EditFormItemTabItem implements TabItem{
 		int i = 0;
 		for (Application.ApplicationType type : Application.ApplicationType.values()) {
 			CheckBox cb = applicationTypesCheckBoxes.get(i);
-			if(cb.getValue()){
+			if (cb.getValue()) {
 				newApplicationTypesJson.set(pointer, new JSONString(type.toString()));
 				pointer++;
 			}
@@ -629,15 +645,15 @@ public class EditFormItemTabItem implements TabItem{
 		Map<String, ItemTexts> itemTextsMap = new HashMap<String, ItemTexts>();
 
 		// help
-		for(Map.Entry<String, TextArea> entry : helpTextBoxes.entrySet()){
+		for (Map.Entry<String, TextArea> entry : helpTextBoxes.entrySet()) {
 			String locale = entry.getKey();
 
 			ItemTexts itemTexts;
 
 			// if already
-			if(itemTextsMap.containsKey(locale)){
+			if (itemTextsMap.containsKey(locale)) {
 				itemTexts = itemTextsMap.get(locale);
-			}else{
+			} else {
 				itemTexts = new JSONObject().getJavaScriptObject().cast();
 			}
 
@@ -649,15 +665,15 @@ public class EditFormItemTabItem implements TabItem{
 		}
 
 		// label
-		for(Map.Entry<String, TextArea> entry : labelTextBoxes.entrySet()){
+		for (Map.Entry<String, TextArea> entry : labelTextBoxes.entrySet()) {
 			String locale = entry.getKey();
 
 			ItemTexts itemTexts;
 
 			// if already
-			if(itemTextsMap.containsKey(locale)){
+			if (itemTextsMap.containsKey(locale)) {
 				itemTexts = itemTextsMap.get(locale);
-			}else{
+			} else {
 				itemTexts = new JSONObject().getJavaScriptObject().cast();
 			}
 
@@ -669,15 +685,15 @@ public class EditFormItemTabItem implements TabItem{
 		}
 
 		// error
-		for(Map.Entry<String, TextArea> entry : errorTextBoxes.entrySet()){
+		for (Map.Entry<String, TextArea> entry : errorTextBoxes.entrySet()) {
 			String locale = entry.getKey();
 
 			ItemTexts itemTexts;
 
 			// if already
-			if(itemTextsMap.containsKey(locale)){
+			if (itemTextsMap.containsKey(locale)) {
 				itemTexts = itemTextsMap.get(locale);
-			}else{
+			} else {
 				itemTexts = new JSONObject().getJavaScriptObject().cast();
 			}
 
@@ -689,18 +705,16 @@ public class EditFormItemTabItem implements TabItem{
 		}
 
 		// OPTIONS
-		for(Map.Entry<String, Map<TextBox, TextBox>> localeTextboxes : optionsBoxes.entrySet())
-		{
+		for (Map.Entry<String, Map<TextBox, TextBox>> localeTextboxes : optionsBoxes.entrySet()) {
 			String locale = localeTextboxes.getKey();
 			Map<String, String> keyValue = new HashMap<String, String>();
 
 			// iterate over textboxes
-			for(Map.Entry<TextBox, TextBox> textBoxes : localeTextboxes.getValue().entrySet())
-			{
+			for (Map.Entry<TextBox, TextBox> textBoxes : localeTextboxes.getValue().entrySet()) {
 				String key = textBoxes.getKey().getText();
 				String value = textBoxes.getValue().getText();
 
-				if(!key.equals("") && !value.equals("")){
+				if (!key.equals("") && !value.equals("")) {
 					keyValue.put(key.trim(), value.trim());
 				}
 			}
@@ -711,9 +725,9 @@ public class EditFormItemTabItem implements TabItem{
 			ItemTexts itemTexts;
 
 			// if already
-			if(itemTextsMap.containsKey(locale)){
+			if (itemTextsMap.containsKey(locale)) {
 				itemTexts = itemTextsMap.get(locale);
-			}else{
+			} else {
 				itemTexts = new JSONObject().getJavaScriptObject().cast();
 			}
 
@@ -725,7 +739,7 @@ public class EditFormItemTabItem implements TabItem{
 		}
 
 		// FOR EACH ITEM TEXT, save it
-		for(Map.Entry<String, ItemTexts> entry : itemTextsMap.entrySet()){
+		for (Map.Entry<String, ItemTexts> entry : itemTextsMap.entrySet()) {
 			String locale = entry.getKey();
 			ItemTexts itemTexts = entry.getValue();
 
@@ -758,9 +772,6 @@ public class EditFormItemTabItem implements TabItem{
 		return result;
 	}
 
-	/**
-	 * @param obj
-	 */
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)
@@ -777,8 +788,7 @@ public class EditFormItemTabItem implements TabItem{
 		return false;
 	}
 
-	public void open()
-	{
+	public void open() {
 	}
 
 	public boolean isAuthorized() {


### PR DESCRIPTION
- Added new form item HEADING, which will be used as customizable
  heading of application form. Content is considered as HTML.
- HEADING is not saved with submitted application form.
- HTML_COMMENT and HEADING now have customized language pages
  on app form settings, since they only contain label and not
  error or help text.
- Added new form item TIMEZONE, which is pre-filled with
  existing timezones in GUI and user can manually select
  one or select "Not selected" option. When required, user
  must select one of timezones.
  Form item still must be manually linked to proper attribute,
  which is urn:perun:user:attribute-def:def:timezone.
- Fixed "onChange" behavior of all selection boxes on application
  form, since their validation was previously performed only on
  form submission. It's now performed on any selection change.
