### PR TITLE
Quota enabled attribute used in service fs_home

### DIFF
--- a/perun-services/gen/fs_home
+++ b/perun-services/gen/fs_home
@@ -57,6 +57,7 @@ our $A_MR_DATALIMIT;               *A_MR_DATALIMIT =                 \'urn:perun
 our $A_MR_DATAQUOTA;               *A_MR_DATAQUOTA =                 \'urn:perun:member_resource:attribute-def:def:dataQuota';
 our $A_MR_FILESLIMIT;              *A_MR_FILESLIMIT =                \'urn:perun:member_resource:attribute-def:def:filesLimit';
 our $A_MR_FILESQUOTA;              *A_MR_FILESQUOTA =                \'urn:perun:member_resource:attribute-def:def:filesQuota';
+our $A_F_QUOTAENABLED;             *A_F_QUOTAENABLED =               \'urn:perun:facility:attribute-def:def:quotaEnabled';
 
 #our $A_RESOURCE_UNIX_GROUP_NAME;  *A_RESOURCE_UNIX_GROUP_NAME =     \'urn:perun:resource:attribute-def:virt:unixGroupName';
 #our $A_RESOURCE_UNIX_GID;         *A_RESOURCE_UNIX_GID =            \'urn:perun:resource:attribute-def:virt:unixGID';
@@ -69,6 +70,7 @@ our $STRUC_GROUPS;   *STRUC_GROUPS =  \"groups";
 
 my $service_file_name = "$DIRECTORY/$::SERVICE_NAME";
 my $umask_file_name = "$DIRECTORY/umask";
+my $quota_enabled_file_name = "$DIRECTORY/quota_enabled";
 
 my $memberAttributesByLoginAndMount = {};
 
@@ -150,6 +152,12 @@ if(defined $facilityAttributes{$A_F_UMASK}) {
 	open UMASK_FH, ">$umask_file_name" or die "Cannot open $umask_file_name: $!\n";
 	print UMASK_FH $facilityAttributes{$A_F_UMASK}, "\n";
 	close UMASK_FH;
+}
+
+if(defined $facilityAttributes{$A_F_QUOTAENABLED}) {
+	open QUOTA_FH, ">$quota_enabled_file_name" or die "Cannot open $quota_enabled_file_name: $!\n";
+	print QUOTA_FH $facilityAttributes{$A_F_QUOTAENABLED}, "\n";
+	close QUOTA_FH;
 }
 #####################################################
 perunServicesInit::finalize;

--- a/perun-services/slave/process-fs_home.sh
+++ b/perun-services/slave/process-fs_home.sh
@@ -6,6 +6,7 @@ PROTOCOL_VERSION='3.6.0'
 function process {
 	FROM_PERUN="${WORK_DIR}/fs_home"
 	UMASK_FILE="${WORK_DIR}/umask"
+	QUOTA_ENABLED_FILE="${WORK_DIR}/quota_enabled"
 
 	I_DIR_CREATED=(0 'Home directory ${HOME_DIR} ($U_UID.$U_GID) created.')
 
@@ -22,7 +23,17 @@ function process {
 	UMASK=0755   #default pemissions
 	[ -f "$UMASK_FILE" ] && UMASK=`head -n 1 "$UMASK_FILE"`
 
-	[ -z "${QUOTA_ENABLED}" ] && QUOTA_ENABLED=0
+	#prescript quota has majority, if exists, let it be
+	#if prescript quota is not set, try to get info from quota_enabled file
+	#if file not exists, set quota_enabled to 0 (false)
+	if [ -z "${QUOTA_ENABLED}" ]; then
+		if [ -f "$QUOTA_ENABLED_FILE}" ]; then
+			QUOTA_ENABLED=`head -n 1 "$QUOTA_ENABLED_FILE"`
+		else
+			QUOTA_ENABLED=0
+		fi
+	fi
+	
 	if [ "${QUOTA_ENABLED}" -gt 0 ]; then
 		if [ ! -z "${SET_QUOTA_PROGRAM}" ]; then
 			if [ -x "${SET_QUOTA_PROGRAM}" ]; then


### PR DESCRIPTION
- if prescript quota is set, use this setting
- if prescript quota is not set, read from quota_enabled file
- if quota_enabled file not exists, use value 0 (false)
