### PR TITLE
Add chmod and chown on files created in script sshkeys

### DIFF
--- a/perun-services/slave/debian/changelog
+++ b/perun-services/slave/debian/changelog
@@ -1,3 +1,10 @@
+perun-slave (3.0.0-0.0.80) stable; urgency=low
+
+   * fix ownership and permissions on newly created files and dirs in slave
+     skript ssh_keys
+
+ -- Michal Stava <stavamichal@gmail.com> Thu, 18 Sep 2014 11:30:00 +0200
+
 perun-slave (3.0.0-0.0.79) stable; urgency=low
 
    * fix error and info messages in service ssh_keys


### PR DESCRIPTION
- modify slave script sshkeys: if .ssh directory or .ssh/authorized_keys
  file is created by this script, change ownership on this file and
  directory to USER (to who belongs to). Also change permissions on file
  to 644 and directory to 755 if they are newly created there.
