### PR TITLE
Add methods for work with roles

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -1,11 +1,19 @@
 package cz.metacentrum.perun.core.api;
 
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.Utils;
+import java.util.ArrayList;
 
 public class AuthzResolver {
 
@@ -135,6 +143,201 @@ public class AuthzResolver {
 	 */
 	public static boolean hasRole(PerunPrincipal perunPrincipal, Role role) {
 		return cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.hasRole(perunPrincipal, role);
+	}
+
+	/**
+	 * Set role for user and all complementary objects.
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary objects.
+	 *
+	 * @param sess perun session
+	 * @param user the user for setting role
+	 * @param role role 
+	 * @param complementaryObjects objects for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws AlreadyAdminException
+	 * @throws GroupNotAdminException
+	 * @throws UserNotAdminException
+	 */
+	public static void setRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, PrivilegeException, UserNotExistsException, AlreadyAdminException, GroupNotAdminException, UserNotAdminException {
+		Utils.notNull(role, "role");
+		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
+		
+		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
+		cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.setRole(sess, user, role, complementaryObjects);
+	}
+
+	/**
+	 * Set role for user and one complementary object.
+	 *
+	 * If complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary object.
+	 *
+	 * @param sess perun session
+	 * @param user the user for setting role
+	 * @param role role
+	 * @param complementaryObject object for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws AlreadyAdminException
+	 */
+	public static void setRole(PerunSession sess, User user,PerunBean complementaryObject, Role role) throws  InternalErrorException, PrivilegeException, UserNotExistsException, AlreadyAdminException {
+		Utils.notNull(role, "role");
+		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
+
+		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
+		cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.setRole(sess, user,complementaryObject, role);
+	}
+
+	/**
+	 * Set role for auhtorizedGroup and all complementary objects.
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary objects.
+	 *
+	 * @param sess perun session
+	 * @param authorizedGroup the group for setting role
+	 * @param role role
+	 * @param complementaryObjects objects for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws GroupNotExistsException
+	 * @throws AlreadyAdminException
+	 */
+	public static void setRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, PrivilegeException, GroupNotExistsException, AlreadyAdminException {
+		Utils.notNull(role, "role");
+		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
+
+		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
+		cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.setRole(sess, authorizedGroup, role, complementaryObjects);
+	}
+
+	/**
+	 * Set role for authorizedGroup and one complementary object.
+	 *
+	 * If complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary object.
+	 *
+	 * @param sess perun session
+	 * @param authorizedGroup the group for setting role
+	 * @param role role
+	 * @param complementaryObject object for which role will be set
+	 * @param refreshAuthzInSession refresh authz in session if true, not if false
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws GroupNotExistsException
+	 * @throws AlreadyAdminException
+	 */
+	public static void setRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, Role role) throws  InternalErrorException, PrivilegeException, GroupNotExistsException, AlreadyAdminException {
+		Utils.notNull(role, "role");
+		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
+
+		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
+		cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.setRole(sess, authorizedGroup, complementaryObject, role);
+	}
+
+	/**
+	 * Unset role for user and all complementary objects
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary objects.
+	 *
+	 * @param sess perun session
+	 * @param user the user for setting role
+	 * @param role role
+	 * @param complementaryObjects objects for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws UserNotAdminException
+	 */
+	public static void unsetRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, PrivilegeException, UserNotExistsException, UserNotAdminException {
+		Utils.notNull(role, "role");
+		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
+		
+		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method unsetRole.");
+		cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.unsetRole(sess, user, role, complementaryObjects);
+	}
+
+	/**
+	 * Unset role for user and one complementary object.
+	 *
+	 * If complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary object.
+	 *
+	 * @param sess perun session
+	 * @param user the user for setting role
+	 * @param role role
+	 * @param complementaryObject object for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws UserNotAdminException
+	 */
+	public static void unsetRole(PerunSession sess, User user, PerunBean complementaryObject, Role role) throws  InternalErrorException, PrivilegeException, UserNotExistsException, UserNotAdminException {
+		Utils.notNull(role, "role");
+		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
+
+		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method unsetRole.");
+		cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.unsetRole(sess, user, complementaryObject, role);
+	}
+
+	/**
+	 * Unset role for group and all complementary objects
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary objects.
+	 *
+	 * @param sess perun session
+	 * @param group the group for setting role
+	 * @param role role
+	 * @param complementaryObjects objects for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws GroupNotExistsException
+	 * @throws GroupNotAdminException
+	 */
+	public static void unsetRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, PrivilegeException, GroupNotExistsException, GroupNotAdminException {
+		Utils.notNull(role, "role");
+		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
+
+		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
+		cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.unsetRole(sess, authorizedGroup, role, complementaryObjects);
+	}
+
+	/**
+	 * Unset role for group and one complementary object
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary object.
+	 *
+	 * @param sess perun session
+	 * @param group the group for setting role
+	 * @param role role
+	 * @param complementaryObject object for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws GroupNotExistsException
+	 * @throws GroupNotAdminException
+	 */
+	public static void unsetRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, Role role) throws  InternalErrorException, PrivilegeException, GroupNotExistsException, GroupNotAdminException {
+		Utils.notNull(role, "role");
+		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
+
+		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
+		cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.unsetRole(sess, authorizedGroup, complementaryObject, role);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -53,6 +53,9 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	private static AuthzResolverImplApi authzResolverImpl;
 	private static PerunBlImpl perunBlImpl;
 
+	private static final String UNSET_ROLE = "UNSET";
+	private static final String SET_ROLE = "SET";
+
 	/**
 	 * Retrieves information about the perun principal (in which VOs the principal is admin, ...)
 	 *
@@ -524,6 +527,327 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		return perunPrincipal.getRoles().hasRole(role);
 	}
 
+	/**
+	 * Set role for user and all complementary objects
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary objects.
+	 *
+	 * @param sess perun session
+	 * @param user user for setting role
+	 * @param role role
+	 * @param complementaryObjects objects for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws AlreadyAdminException
+	 */
+	public static void setRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, AlreadyAdminException {
+		if (complementaryObjects == null || complementaryObjects.isEmpty()) {
+			try {
+				manageRole(sess, SET_ROLE, null, user, role, null);
+				//These exceptions should never happen
+			} catch (GroupNotAdminException ex) {
+				throw new InternalErrorException(ex);
+			} catch (UserNotAdminException ex) {
+				throw new InternalErrorException(ex);
+			}
+		} else {
+			for(PerunBean compObject: complementaryObjects) {
+				try {
+					manageRole(sess, SET_ROLE, null, user, role, compObject);
+					//These exceptions should never happen
+				} catch (GroupNotAdminException ex) {
+					throw new InternalErrorException(ex);
+				} catch (UserNotAdminException ex) {
+					throw new InternalErrorException(ex);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @see #setRole(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.User, cz.metacentrum.perun.core.api.Role, java.util.List, boolean)
+	 * Only use 1 complementary object!
+	 */
+	public static void setRole(PerunSession sess, User user, PerunBean complementaryObject, Role role) throws InternalErrorException, AlreadyAdminException {
+		List<PerunBean> complementaryObjects = new ArrayList<>();
+		complementaryObjects.add(complementaryObject);
+		AuthzResolverBlImpl.setRole(sess, user, role, complementaryObjects);
+	}
+
+	/**
+	 * Set role for group and all complementary objects
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary objects.
+	 *
+	 * @param sess perun session
+	 * @param authorizedGroup group for setting role
+	 * @param role role
+	 * @param complementaryObjects objects for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws AlreadyAdminException
+	 */
+	public static void setRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, AlreadyAdminException {
+		if (complementaryObjects == null || complementaryObjects.isEmpty()) {
+			try {
+				manageRole(sess, SET_ROLE, authorizedGroup, null, role, null);
+				//These exceptions should never happen
+			} catch (GroupNotAdminException ex) {
+				throw new InternalErrorException(ex);
+			} catch (UserNotAdminException ex) {
+				throw new InternalErrorException(ex);
+			}
+		} else {
+			for(PerunBean compObject: complementaryObjects) {
+				try {
+					manageRole(sess, SET_ROLE, authorizedGroup, null, role, compObject);
+					//These exceptions should never happen
+				} catch (GroupNotAdminException ex) {
+					throw new InternalErrorException(ex);
+				} catch (UserNotAdminException ex) {
+					throw new InternalErrorException(ex);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @see #setRole(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.Group, cz.metacentrum.perun.core.api.Role, java.util.List, boolean)
+	 * Only use 1 complementary object!
+	 */
+	public static void setRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, Role role) throws InternalErrorException, AlreadyAdminException {
+		List<PerunBean> complementaryObjects = new ArrayList<>();
+		complementaryObjects.add(complementaryObject);
+		AuthzResolverBlImpl.setRole(sess, authorizedGroup, role, complementaryObjects);
+	}
+
+	/**
+	 * Unset role for user and all complementary objects
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary objects.
+	 *
+	 * @param sess perun session
+	 * @param user user for setting role
+	 * @param role role
+	 * @param complementaryObjects objects for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws UserNotAdminException
+	 */
+	public static void unsetRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, UserNotAdminException {
+		if (complementaryObjects == null || complementaryObjects.isEmpty()) {
+			try {
+				manageRole(sess, UNSET_ROLE, null, user, role, null);
+				//These exceptions should never happen
+			} catch (GroupNotAdminException ex) {
+				throw new InternalErrorException(ex);
+			} catch (AlreadyAdminException ex) {
+				throw new InternalErrorException(ex);
+			}
+		} else {
+			for(PerunBean compObject: complementaryObjects) {
+				try {
+					manageRole(sess, UNSET_ROLE, null, user, role, compObject);
+					//These exceptions should never happen
+				} catch (GroupNotAdminException ex) {
+					throw new InternalErrorException(ex);
+				} catch (AlreadyAdminException ex) {
+					throw new InternalErrorException(ex);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @see #unsetRole(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.User, cz.metacentrum.perun.core.api.Role, java.util.List, boolean) 
+	 * Only use 1 complementary object!
+	 */
+	public static void unsetRole(PerunSession sess, User user, PerunBean complementaryObject, Role role) throws InternalErrorException, UserNotAdminException {
+		List<PerunBean> complementaryObjects = new ArrayList<>();
+		complementaryObjects.add(complementaryObject);
+		AuthzResolverBlImpl.unsetRole(sess, user, role, complementaryObjects);
+	}
+
+	/**
+	 * Unset role for group and all complementary objects
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary objects.
+	 *
+	 * @param sess perun session
+	 * @param authorizedGroup group for setting role
+	 * @param role role
+	 * @param complementaryObjects objects for which role will be set
+	 *
+	 * @throws InternalErrorException
+	 * @throws GroupNotAdminException
+	 */
+	public static void unsetRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, GroupNotAdminException {
+		if (complementaryObjects == null || complementaryObjects.isEmpty()) {
+			try {
+				manageRole(sess, UNSET_ROLE, authorizedGroup, null, role, null);
+				//These exceptions should never happen
+			} catch (UserNotAdminException ex) {
+				throw new InternalErrorException(ex);
+			} catch (AlreadyAdminException ex) {
+				throw new InternalErrorException(ex);
+			}
+		} else {
+			for(PerunBean compObject: complementaryObjects) {
+				try {
+					manageRole(sess, UNSET_ROLE, authorizedGroup, null, role, compObject);
+					//These exceptions should never happen
+				} catch (UserNotAdminException ex) {
+					throw new InternalErrorException(ex);
+				} catch (AlreadyAdminException ex) {
+					throw new InternalErrorException(ex);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @see #unsetRole(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.Group, cz.metacentrum.perun.core.api.Role, java.util.List, boolean) 
+	 * Only use 1 complementary object!
+	 */
+	public static void unsetRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, Role role) throws InternalErrorException, GroupNotAdminException {
+		List<PerunBean> complementaryObjects = new ArrayList<>();
+		complementaryObjects.add(complementaryObject);
+		AuthzResolverBlImpl.unsetRole(sess, authorizedGroup, role, complementaryObjects);
+	}
+
+	/**
+	 * Set or unset role for user or authorized group and complementary object
+	 *
+	 * If user and authorizedGroup are null, throw exception. Only one can be filled at once, if both, throw exception.
+	 * If complementaryObject is null, throw an exception if the role is not PerunAdmin.
+	 *
+	 * IMPORTANT: refresh authz only if user in session is affected
+	 *
+	 * @param sess
+	 * @param user the user for set role
+	 * @param authorizedGroup the group for set role
+	 * @param operation 'SET' or 'UNSET'
+	 * @param role role to set
+	 * @param complementaryObject object for setting role on it
+	 * @throws InternalErrorException
+	 */
+	public static void manageRole(PerunSession sess, String operation, Group authorizedGroup, User user, Role role, PerunBean complementaryObject) throws InternalErrorException, AlreadyAdminException, UserNotAdminException, GroupNotAdminException {
+		if(authorizedGroup == null && user == null) throw new InternalErrorException("There is no object for setting role (user or authorizedGroup).");
+		if(authorizedGroup != null && user != null) throw new InternalErrorException("There are both authorizedGroup and user for setting role, only one is acceptable.");
+		if(!role.equals(Role.PERUNADMIN) && complementaryObject == null) throw new InternalErrorException("Complementary object can be null only for the role perunadmin.");
+
+		//Check operation
+		if(operation.equals(SET_ROLE)) {
+			//Check role
+			if(role.equals(Role.PERUNADMIN)) {
+				if(user != null) makeUserPerunAdmin(sess, user);
+				else throw new InternalErrorException("Not supported perunRole on authorizedGroup.");
+			} else if(role.equals(Role.VOOBSERVER)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't set VoObserver rights without Vo.");
+				} else if(complementaryObject instanceof Vo) {
+					if(user != null) addObserver(sess, (Vo) complementaryObject, user);
+					else addObserver(sess, (Vo) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for VoObserver role: " + complementaryObject);
+				}
+			} else if(role.equals(Role.VOADMIN)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't set VoAdmin rights without Vo.");
+				} else if(complementaryObject instanceof Vo) {
+					if(user != null) addAdmin(sess, (Vo) complementaryObject, user);
+					else addAdmin(sess, (Vo) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for VoAdmin: " + complementaryObject);
+				}
+			} else if(role.equals(Role.GROUPADMIN)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't set GroupAdmin rights without Group.");
+				} else if(complementaryObject instanceof Group) {
+					if(user != null) addAdmin(sess, (Group) complementaryObject, user);
+					else addAdmin(sess, (Group) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for GroupAdmin: " + complementaryObject);
+				}
+			} else if(role.equals(Role.FACILITYADMIN)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't set FacilityAdmin rights without Facility.");
+				} else if(complementaryObject instanceof Facility) {
+					if(user != null) addAdmin(sess, (Facility) complementaryObject, user);
+					else addAdmin(sess, (Facility) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for FacilityAdmin: " + complementaryObject);
+				}
+			} else {
+				throw new InternalErrorException("Not supported role: " + role);
+			}
+		// Check operation
+		} else if(operation.equals(UNSET_ROLE)) {
+			//Check role
+			if(role.equals(Role.PERUNADMIN)) {
+				if(user != null) removePerunAdmin(sess, user);
+				else throw new InternalErrorException("Not supported perunRole on authorizedGroup.");
+			} else if(role.equals(Role.VOOBSERVER)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't unset VoObserver rights without Vo this way.");
+				} else if(complementaryObject instanceof Vo) {
+					if(user != null) removeObserver(sess, (Vo) complementaryObject, user);
+					else removeObserver(sess, (Vo) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for VoObserver: " + complementaryObject);
+				}
+			} else if(role.equals(Role.VOADMIN)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't unset VoAdmin rights without Vo this way.");
+				} else if(complementaryObject instanceof Vo) {
+					if(user != null) removeAdmin(sess, (Vo) complementaryObject, user);
+					else removeAdmin(sess, (Vo) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for VoAdmin: " + complementaryObject);
+				}
+			} else if(role.equals(Role.GROUPADMIN)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't unset GroupAdmin rights without Group this way.");
+				} else if(complementaryObject instanceof Group) {
+					if(user != null) removeAdmin(sess, (Group) complementaryObject, user);
+					else removeAdmin(sess, (Group) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for GroupAdmin: " + complementaryObject);
+				}
+			} else if(role.equals(Role.FACILITYADMIN)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't unset FacilityAdmin rights without Facility this way.");
+				} else if(complementaryObject instanceof Facility) {
+					if(user != null) removeAdmin(sess, (Facility) complementaryObject, user);
+					else removeAdmin(sess, (Facility) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for FacilityAdmin: " + complementaryObject);
+				}
+			} else {
+				throw new InternalErrorException("Not supported role: " + role);
+			}
+		} else {
+			throw new InternalErrorException("Unsupported operation. Only set and unset are correct. Operation: " + operation);
+		}
+
+		//After set or unset role without exception, refresh authz if user in session is the same like user in parameter
+		if(user != null && sess.getPerunPrincipal() != null) {
+			if(user.getId() == sess.getPerunPrincipal().getUserId()) {
+				AuthzResolverBlImpl.refreshAuthz(sess);
+			}
+		//If there is authorized group instead of user, try to find intersection in members and if there is at least one, then refresh authz
+		} else if(authorizedGroup != null && sess.getPerunPrincipal() != null && sess.getPerunPrincipal().getUser() != null) {
+			List<Member> groupMembers = perunBlImpl.getGroupsManagerBl().getGroupMembers(sess, authorizedGroup);
+			List<Member> userMembers = perunBlImpl.getMembersManagerBl().getMembersByUser(sess, sess.getPerunPrincipal().getUser());
+			userMembers.retainAll(groupMembers);
+			if(!userMembers.isEmpty()) AuthzResolverBlImpl.refreshAuthz(sess);
+		}
+	}
+
 	public String toString() {
 		return getClass().getSimpleName() + ":[]";
 	}
@@ -703,97 +1027,98 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 
 	public static void removeAllAuthzForVo(PerunSession sess, Vo vo) throws InternalErrorException {
 		authzResolverImpl.removeAllAuthzForVo(sess, vo);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAllUserAuthz(PerunSession sess, User user) throws InternalErrorException {
 		authzResolverImpl.removeAllUserAuthz(sess, user);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAllAuthzForGroup(PerunSession sess, Group group) throws InternalErrorException {
 		authzResolverImpl.removeAllAuthzForGroup(sess, group);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAllAuthzForFacility(PerunSession sess, Facility facility) throws InternalErrorException {
 		authzResolverImpl.removeAllAuthzForFacility(sess, facility);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAllAuthzForResource(PerunSession sess, Resource resource) throws InternalErrorException {
 		authzResolverImpl.removeAllAuthzForResource(sess, resource);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAllAuthzForService(PerunSession sess, Service service) throws InternalErrorException {
 		authzResolverImpl.removeAllAuthzForService(sess, service);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void addAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, AlreadyAdminException {
 		authzResolverImpl.addAdmin(sess, facility, user);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void addAdmin(PerunSession sess, Facility facility, Group group) throws InternalErrorException, AlreadyAdminException {
 		authzResolverImpl.addAdmin(sess, facility, group);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, UserNotAdminException {
 		authzResolverImpl.removeAdmin(sess, facility, user);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAdmin(PerunSession sess, Facility facility, Group group) throws InternalErrorException, GroupNotAdminException {
 		authzResolverImpl.removeAdmin(sess, facility, group);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void addAdmin(PerunSession sess, Group group, User user) throws InternalErrorException, AlreadyAdminException {
 		authzResolverImpl.addAdmin(sess, group, user);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void addAdmin(PerunSession sess, Group group, Group authorizedGroup) throws InternalErrorException, AlreadyAdminException {
 		authzResolverImpl.addAdmin(sess, group, authorizedGroup);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAdmin(PerunSession sess, Group group, User user) throws InternalErrorException, UserNotAdminException {
 		authzResolverImpl.removeAdmin(sess, group, user);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAdmin(PerunSession sess, Group group, Group authorizedGroup) throws InternalErrorException, GroupNotAdminException {
 		authzResolverImpl.removeAdmin(sess, group, authorizedGroup);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void addAdmin(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyAdminException {
 		authzResolverImpl.addAdmin(sess, vo, user);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void addAdmin(PerunSession sess, Vo vo, Group group) throws InternalErrorException, AlreadyAdminException {
 		authzResolverImpl.addAdmin(sess, vo, group);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAdmin(PerunSession sess, Vo vo, User user) throws InternalErrorException, UserNotAdminException {
 		authzResolverImpl.removeAdmin(sess, vo, user);
-		AuthzResolverBlImpl.refreshAuthz(sess);
 	}
 
 	public static void removeAdmin(PerunSession sess, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException {
 		authzResolverImpl.removeAdmin(sess, vo, group);
-		AuthzResolverBlImpl.refreshAuthz(sess);
+	}
+
+	public static void addObserver(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyAdminException {
+		authzResolverImpl.addObserver(sess, vo, user);
+	}
+
+	public static void addObserver(PerunSession sess, Vo vo, Group group) throws InternalErrorException, AlreadyAdminException {
+		authzResolverImpl.addObserver(sess, vo, group);
+	}
+
+	public static void removeObserver(PerunSession sess, Vo vo, User user) throws InternalErrorException, UserNotAdminException {
+		authzResolverImpl.removeObserver(sess, vo, user);
+	}
+
+	public static void removeObserver(PerunSession sess, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException {
+		authzResolverImpl.removeObserver(sess, vo, group);
 	}
 
 	public static void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException {
 		authzResolverImpl.makeUserPerunAdmin(sess, user);
-		AuthzResolverBlImpl.refreshAuthz(sess);
+	}
+
+	public static void removePerunAdmin(PerunSession sess, User user) throws InternalErrorException, UserNotAdminException {
+		authzResolverImpl.removePerunAdmin(sess, user);
 	}
 
 	// Filled by Spring

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -27,6 +27,7 @@ import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichFacility;
 import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
@@ -480,7 +481,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	public void addAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, AlreadyAdminException {
-		AuthzResolverBlImpl.addAdmin(sess, facility, user);
+		AuthzResolverBlImpl.setRole(sess, user, facility, Role.FACILITYADMIN);
 		getPerunBl().getAuditer().log(sess, "{} was added as admin of {}.", user, facility);
 	}
 
@@ -489,12 +490,12 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 		List<Group> listOfAdmins = getAdminGroups(sess, facility);
 		if (listOfAdmins.contains(group)) throw new AlreadyAdminException(group);
 		
-		AuthzResolverBlImpl.addAdmin(sess, facility, group);
+		AuthzResolverBlImpl.setRole(sess, group, facility, Role.FACILITYADMIN);
 		getPerunBl().getAuditer().log(sess, "Group {} was added as admin of {}.", group, facility);
 	}
 
 	public void removeAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, UserNotAdminException {
-		AuthzResolverBlImpl.removeAdmin(sess, facility, user);
+		AuthzResolverBlImpl.unsetRole(sess, user, facility, Role.FACILITYADMIN);
 		getPerunBl().getAuditer().log(sess, "{} was removed from admins of {}.", user, facility);
 	}
 
@@ -503,7 +504,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 		List<Group> listOfAdmins = getAdminGroups(sess, facility);
 		if (!listOfAdmins.contains(group)) throw new GroupNotAdminException(group);
 		
-		AuthzResolverBlImpl.removeAdmin(sess, facility, group);
+		AuthzResolverBlImpl.unsetRole(sess, group, facility, Role.FACILITYADMIN);
 		getPerunBl().getAuditer().log(sess, "Group {} was removed from admins of {}.", group, facility);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -475,7 +475,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	public void addAdmin(PerunSession sess, Group group, User user) throws InternalErrorException, AlreadyAdminException {
-		AuthzResolverBlImpl.addAdmin(sess, group, user);
+		AuthzResolverBlImpl.setRole(sess, user, group, Role.GROUPADMIN);
 		getPerunBl().getAuditer().log(sess, "{} was added as admin of {}.", user, group);
 	}
 
@@ -484,12 +484,12 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<Group> listOfAdmins = getAdminGroups(sess, group);
 		if (listOfAdmins.contains(authorizedGroup)) throw new AlreadyAdminException(authorizedGroup);
 
-		AuthzResolverBlImpl.addAdmin(sess, group, authorizedGroup);
+		AuthzResolverBlImpl.setRole(sess, authorizedGroup, group, Role.GROUPADMIN);
 		getPerunBl().getAuditer().log(sess, "Group {} was added as admin of {}.", authorizedGroup, group);
 	}
 
 	public void removeAdmin(PerunSession sess, Group group, User user) throws InternalErrorException, UserNotAdminException {
-		AuthzResolverBlImpl.removeAdmin(sess, group, user);
+		AuthzResolverBlImpl.unsetRole(sess, user, group, Role.GROUPADMIN);
 		getPerunBl().getAuditer().log(sess, "{} was removed from admins of {}.", user, group);
 	}
 
@@ -498,7 +498,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<Group> listOfAdmins = getAdminGroups(sess, group);
 		if (!listOfAdmins.contains(authorizedGroup)) throw new GroupNotAdminException(authorizedGroup);
 
-		AuthzResolverBlImpl.removeAdmin(sess, group, authorizedGroup);
+		AuthzResolverBlImpl.unsetRole(sess, authorizedGroup, group, Role.GROUPADMIN);
 		getPerunBl().getAuditer().log(sess, "Group {} was removed from admins of {}.", authorizedGroup, group);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -704,7 +704,11 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	}
 
 	public void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException {
-		AuthzResolverBlImpl.makeUserPerunAdmin(sess, user);
+		try {
+			AuthzResolverBlImpl.setRole(sess, user, null, Role.PERUNADMIN);
+		} catch (AlreadyAdminException ex) {
+			throw new InternalErrorException(ex);
+		}
 	}
 
 	public boolean isUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
@@ -309,7 +310,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 	public void addAdmin(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyAdminException {
 		List<User> adminsOfVo = this.getAdmins(sess, vo);
 		if(adminsOfVo.contains(user)) throw new AlreadyAdminException(user, vo);
-		AuthzResolverBlImpl.addAdmin(sess, vo, user);
+		AuthzResolverBlImpl.setRole(sess, user, vo, Role.VOADMIN);
 		log.debug("User [{}] added like administrator to VO [{}]", user, vo);
 	}
 
@@ -317,14 +318,14 @@ public class VosManagerBlImpl implements VosManagerBl {
 	public void addAdmin(PerunSession sess, Vo vo, Group group) throws InternalErrorException, AlreadyAdminException {
 		List<Group> adminsOfVo = this.getAdminGroups(sess, vo);
 		if(adminsOfVo.contains(group)) throw new AlreadyAdminException(group, vo);
-		AuthzResolverBlImpl.addAdmin(sess, vo, group);
+		AuthzResolverBlImpl.setRole(sess, group, vo, Role.VOADMIN);
 		log.debug("Group [{}] added like administrator to VO [{}]", group, vo);
 	}
 
 	public void removeAdmin(PerunSession sess, Vo vo, User user) throws InternalErrorException, UserNotAdminException {
 		List<User> adminsOfVo = this.getAdmins(sess, vo);
 		if(!adminsOfVo.contains(user)) throw new UserNotAdminException(user);
-		AuthzResolverBlImpl.removeAdmin(sess, vo, user);
+		AuthzResolverBlImpl.unsetRole(sess, user, vo, Role.VOADMIN);
 		log.debug("User [{}] deleted like administrator from VO [{}]", user, vo);
 	}
 
@@ -332,7 +333,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 	public void removeAdmin(PerunSession sess, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException {
 		List<Group> adminsOfVo = this.getAdminGroups(sess, vo);
 		if(!adminsOfVo.contains(group)) throw new GroupNotAdminException(group);
-		AuthzResolverBlImpl.removeAdmin(sess, vo, group);
+		AuthzResolverBlImpl.unsetRole(sess, group, vo, Role.VOADMIN);
 		log.debug("Group [{}] deleted like administrator from VO [{}]", group, vo);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -330,6 +330,48 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		}
 	}
 
+	public void addObserver(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyAdminException {
+		try {
+			jdbc.update("insert into authz (user_id, role_id, vo_id) values (?, (select id from roles where name=?), ?)", user.getId(),
+					Role.VOOBSERVER.getRoleName(), vo.getId());
+		} catch (DataIntegrityViolationException e) {
+			throw new AlreadyAdminException("User id=" + user.getId() + " is already observer in vo " + vo, e, user, vo);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	public void addObserver(PerunSession sess, Vo vo, Group group) throws InternalErrorException, AlreadyAdminException {
+		try {
+			jdbc.update("insert into authz (role_id, vo_id, authorized_group_id) values ((select id from roles where name=?), ?, ?)",
+					Role.VOOBSERVER.getRoleName(), vo.getId(), group.getId());
+		} catch (DataIntegrityViolationException e) {
+			throw new AlreadyAdminException("Group id=" + group.getId() + " is already observer in vo " + vo, e, group, vo);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	public void removeObserver(PerunSession sess, Vo vo, User user) throws InternalErrorException, UserNotAdminException {
+		try {
+			if (0 == jdbc.update("delete from authz where user_id=? and vo_id=? and role_id=(select id from roles where name=?)", user.getId(), vo.getId(), Role.VOOBSERVER.getRoleName())) {
+				throw new UserNotAdminException("User id=" + user.getId() + " is not observer of the vo " + vo);
+			}
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	public void removeObserver(PerunSession sess, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException {
+		try {
+			if (0 == jdbc.update("delete from authz where authorized_group_id=? and vo_id=? and role_id=(select id from roles where name=?)", group.getId(), vo.getId(), Role.VOOBSERVER.getRoleName())) {
+				throw new GroupNotAdminException("Group id=" + group.getId() + " is not observer of the vo " + vo);
+			}
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
 	public void removeAdmin(PerunSession sess, Vo vo, User user) throws InternalErrorException, UserNotAdminException {
 		try {
 			if (0 == jdbc.update("delete from authz where user_id=? and vo_id=? and role_id=(select id from roles where name=?)", user.getId(), vo.getId(), Role.VOADMIN.getRoleName())) {
@@ -353,6 +395,16 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	public void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException {
 		try {
 			jdbc.update("insert into authz (user_id, role_id) values (?, (select id from roles where name=?))", user.getId(), Role.PERUNADMIN.getRoleName());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	public void removePerunAdmin(PerunSession sess, User user) throws InternalErrorException, UserNotAdminException {
+		try {
+			if (0 == jdbc.update("delete from authz where user_id=? and role_id=(select id from roles where name=?)", user.getId(), Role.PERUNADMIN.getRoleName())) {
+				throw new UserNotAdminException("User id=" + user.getId() + " is not perun admin.");
+			}
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -216,6 +216,50 @@ public interface AuthzResolverImplApi {
 	void removeAdmin(PerunSession sess, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException;
 
 	/**
+	 * Add user role vo observer for the vo
+	 *
+	 * @param sess
+	 * @param vo
+	 * @param user
+	 * @throws InternalErrorException
+	 * @throws AlreadyAdminException
+	 */
+	void addObserver(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyAdminException;
+
+	/**
+	 * Add group of users role vo observer for the vo
+	 *
+	 * @param sess
+	 * @param vo
+	 * @param group
+	 * @throws InternalErrorException
+	 * @throws AlreadyAdminException
+	 */
+	void addObserver(PerunSession sess, Vo vo, Group group) throws InternalErrorException, AlreadyAdminException;
+
+	/**
+	 * Remove user role vo observer for the vo
+	 *
+	 * @param sess
+	 * @param vo
+	 * @param user
+	 * @throws InternalErrorException
+	 * @throws UserNotAdminException
+	 */
+	void removeObserver(PerunSession sess, Vo vo, User user) throws InternalErrorException, UserNotAdminException;
+
+	/**
+	 * Remove group of users role vo observer for the vo
+	 *
+	 * @param sess
+	 * @param vo
+	 * @param group
+	 * @throws InternalErrorException
+	 * @throws GroupNotAdminException
+	 */
+	void removeObserver(PerunSession sess, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException;
+
+	/**
 	 * Make user to be perunAdmin
 	 *
 	 * @param sess
@@ -223,4 +267,13 @@ public interface AuthzResolverImplApi {
 	 * @throws InternalErrorException
 	 */
 	void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException;
+
+	/**
+	 * Remove role perunAdmin for user.
+	 *
+	 * @param sess
+	 * @param user 
+	 * @throws InternalErrorException
+	 */
+	void removePerunAdmin(PerunSession sess, User user) throws InternalErrorException, UserNotAdminException;
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -16,6 +16,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceAlreadyAssignedExceptio
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.AuthzRoles;
@@ -39,6 +40,76 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		System.out.println(CLASS_NAME + "isAuthorizedInvalidPrincipal()");
 
 		assertTrue(! AuthzResolver.isAuthorized(new PerunSessionImpl(perun, new PerunPrincipal("pepa", ExtSourcesManager.EXTSOURCE_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL)), Role.PERUNADMIN));
+	}
+
+	@Test
+	public void setRoleVoAdmin() throws Exception {
+		System.out.println(CLASS_NAME + "setRole()");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+
+		AuthzResolver.setRole(sess, createdUser, createdVo, Role.VOADMIN);
+
+		PerunSession sess1 = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(sess1);
+
+		assertTrue(AuthzResolver.isAuthorized(sess1, Role.VOADMIN,createdVo));
+	}
+
+	@Test
+	public void setRoleVoObserver() throws Exception {
+		System.out.println(CLASS_NAME + "setRole()");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+
+		AuthzResolver.setRole(sess, createdUser, createdVo, Role.VOOBSERVER);
+
+		PerunSession sess1 = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(sess1);
+
+		assertTrue(AuthzResolver.isAuthorized(sess1, Role.VOOBSERVER,createdVo));
+	}
+
+	@Test
+	public void unsetRoleVoAdmin() throws Exception {
+		System.out.println(CLASS_NAME + "unsetRole()");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+
+		AuthzResolver.setRole(sess, createdUser, createdVo, Role.VOADMIN);
+
+		PerunSession sess1 = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(sess1);
+
+		assertTrue(AuthzResolver.isAuthorized(sess1, Role.VOADMIN,createdVo));
+
+		AuthzResolver.unsetRole(sess, createdUser, createdVo, Role.VOADMIN);
+		AuthzResolver.refreshAuthz(sess1);
+
+		assertTrue(!AuthzResolver.isAuthorized(sess1, Role.VOADMIN,createdVo));
+	}
+
+	@Test (expected = UserNotAdminException.class)
+	public void unsetRoleWhichNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "unsetRole()");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+
+		AuthzResolver.unsetRole(sess, createdUser, createdVo, Role.VOADMIN);
+	}
+
+	@Test (expected = UserNotAdminException.class)
+	public void setUnsuportedRole() throws Exception {
+		System.out.println(CLASS_NAME + "setRole()");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+
+		AuthzResolver.unsetRole(sess, createdUser, createdVo, Role.VOADMIN);
 	}
 
 	@Test

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.rpc.deserializer;
 
+import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.rpc.RpcException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -73,6 +74,32 @@ public abstract class Deserializer {
 	 */
 	public <T> List<T> readList(String name, Class<T> valueType) throws RpcException {
 		throw new UnsupportedOperationException("readList(String name, Class<T> valueType)");
+	}
+
+	/**
+	 * Reads value with the specified name as {@code PerunBean}.
+	 *
+	 * @param name name of the value to read
+	 * @return the value as {@code PerunBean}
+	 *
+	 * @throws UnsupportedOperationException if this deserializer does not implement this method
+	 * @throws RpcException if the specified value cannot be parsed as {@code perunBean} or if it is not supplied
+	 */
+	public PerunBean readPerunBean(String name) throws RpcException {
+		throw new UnsupportedOperationException("readListPerunBeans(String name)");
+	}
+
+	/**
+	 * Reads array with the specified name as {@code List<PerunBean>}.
+	 *
+	 * @param name name of the array to read
+	 *
+	 * @return the value as {@code List<PerunBean>}
+	 * @throws UnsupportedOperationException if this deserializer does not implement this method
+	 * @throws RpcException if the specified value cannot be parsed as {@code perunBean} or if it is not supplied
+	 */
+	public List<PerunBean> readListPerunBeans(String name) throws RpcException {
+		throw new UnsupportedOperationException("readListPerunBeans(String name)");
 	}
 
 	/**

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -257,6 +257,67 @@ public class JsonDeserializer extends Deserializer {
 		}
 	}
 
+	@Override
+	public PerunBean readPerunBean(String name) throws RpcException {
+		JsonNode node = root.get(name);
+
+		if (node == null) {
+			throw new RpcException(RpcException.Type.MISSING_VALUE, name);
+		}
+		if (node.isNull()) {
+			return null;
+		}
+		if (!node.isObject()) {
+			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as PerunBean.");
+		}
+
+		try {
+			String beanName = "cz.metacentrum.perun.core.api." + node.get("beanName").getTextValue();
+
+			if(beanName == null) {
+				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - missing beanName info");
+			}
+			PerunBean obj = (PerunBean) mapper.readValue(node, Class.forName(beanName));
+			return obj;
+		} catch (ClassNotFoundException ex) {
+			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - class not found");
+		} catch (IOException ex) {
+			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as PerunBean");
+		}
+	}
+
+	@Override
+	public List<PerunBean> readListPerunBeans(String name) throws RpcException {
+		JsonNode node = root.get(name);
+
+		if (node == null) {
+			throw new RpcException(RpcException.Type.MISSING_VALUE, name);
+		}
+		if (node.isNull()) {
+			return null;
+		}
+		if (!node.isArray()) {
+			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - not an array");
+		}
+
+		try {
+			List<PerunBean> list = new ArrayList<PerunBean>(node.size());
+		for (JsonNode e : node) {
+			String beanName = "cz.metacentrum.perun.core.api." + e.get("beanName").getTextValue();
+
+			if(beanName == null) {
+				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - missing beanName info");
+			}
+			list.add((PerunBean) mapper.readValue(e, Class.forName(beanName)));
+		}
+			return list;
+		} catch (ClassNotFoundException ex) {
+			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - class not found");
+		} catch (IOException ex) {
+			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean>", ex);
+		}
+	}
+
 	public String readAll() throws RpcException {
 		return root.toString();
 	}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -1,12 +1,16 @@
 package cz.metacentrum.perun.rpc.methods;
 
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunBean;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
+import cz.metacentrum.perun.rpc.RpcException;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 
 public enum AuthzResolverMethod implements ManagerMethod {
@@ -19,6 +23,121 @@ public enum AuthzResolverMethod implements ManagerMethod {
 		@Override
 		public List<String> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			return cz.metacentrum.perun.core.api.AuthzResolver.getPrincipalRoleNames(ac.getSession());
+		}
+	},
+
+	/*# Set role for user or authorized group and complementary object or objects
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary object.
+	 *
+	 * IMPORTANT: refresh authz only if user in session is affected
+	 */
+	setRole {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			//get role by name
+			String roleName = parms.readString("role");
+			Role role;
+			try {
+				role = Role.valueOf(roleName);
+			} catch (IllegalArgumentException ex) {
+				throw new RpcException(RpcException.Type.WRONG_PARAMETER, "wrong parameter in role, not exists role with this name " + roleName);
+			}
+
+			if(parms.contains("user")) {
+				if(parms.contains("complementaryObject")) {
+					cz.metacentrum.perun.core.api.AuthzResolver.setRole(ac.getSession(),
+								ac.getUserById(parms.readInt("user")),
+								parms.readPerunBean("complementaryObject"),
+								role);
+					return null;
+				} else if(parms.contains("complementaryObjects[]")) {
+					cz.metacentrum.perun.core.api.AuthzResolver.setRole(ac.getSession(),
+								ac.getUserById(parms.readInt("user")),
+								role,
+								parms.readListPerunBeans("complementaryObjects[]"));
+					return null;
+				} else {
+					throw new RpcException(RpcException.Type.MISSING_VALUE, "list of complementary objects or complementary object");
+				}
+			} else if(parms.contains("authorizedGroup")) {
+				if(parms.contains("complementaryObject")) {
+					cz.metacentrum.perun.core.api.AuthzResolver.setRole(ac.getSession(),
+								ac.getGroupById(parms.readInt("authorizedGroup")),
+								parms.readPerunBean("complementaryObject"),
+								role);
+					return null;
+				} else if(parms.contains("complementaryObjects[]")) {
+					cz.metacentrum.perun.core.api.AuthzResolver.setRole(ac.getSession(),
+								ac.getGroupById(parms.readInt("authorizedGroup")),
+								role,
+								parms.readListPerunBeans("complementaryObjects[]"));
+					return null;
+				} else {
+					throw new RpcException(RpcException.Type.MISSING_VALUE, "list of complementary objects or complementary object");
+				}
+			} else {
+				 throw new RpcException(RpcException.Type.MISSING_VALUE, "user or authorizedGroup");
+			}
+		}
+	},
+
+	/*# Unset role for user or authorized group and complementary object or objects
+	 *
+	 * If some complementary object is wrong for the role, throw an exception.
+	 * For role "perunadmin" ignore complementary object.
+	 *
+	 * IMPORTANT: refresh authz only if user in session is affected
+	 */
+	unsetRole {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			//get role by name
+			String roleName = parms.readString("role");
+			Role role;
+			try {
+				role = Role.valueOf(roleName);
+			} catch (IllegalArgumentException ex) {
+				throw new RpcException(RpcException.Type.WRONG_PARAMETER, "wrong parameter in role, not exists role with this name " + roleName);
+			}
+
+			if(parms.contains("user")) {
+				if(parms.contains("complementaryObject")) {
+					cz.metacentrum.perun.core.api.AuthzResolver.unsetRole(ac.getSession(),
+								ac.getUserById(parms.readInt("user")),
+								parms.readPerunBean("complementaryObject"),
+								role);
+					return null;
+				} else if (parms.contains("complementaryObjects[]")) {
+					cz.metacentrum.perun.core.api.AuthzResolver.unsetRole(ac.getSession(),
+								ac.getUserById(parms.readInt("user")),
+								role,
+								parms.readListPerunBeans("complementaryObjects[]"));
+					return null;
+				} else {
+					throw new RpcException(RpcException.Type.MISSING_VALUE, "list of complementary objects or complementary object");
+				}		
+			} else if(parms.contains("authorizedGroup")) {
+				if(parms.contains("complementaryObject")) {
+					cz.metacentrum.perun.core.api.AuthzResolver.unsetRole(ac.getSession(),
+								ac.getGroupById(parms.readInt("authorizedGroup")),
+								parms.readPerunBean("complementaryObject"),
+								role);
+					return null;
+				} else if (parms.contains("complementaryObjects[]")) {
+					cz.metacentrum.perun.core.api.AuthzResolver.unsetRole(ac.getSession(),
+								ac.getGroupById(parms.readInt("authorizedGroup")),
+								role,
+								parms.readListPerunBeans("complementaryObjects[]"));
+					return null;
+				} else {
+					throw new RpcException(RpcException.Type.MISSING_VALUE, "list of complementary objects or complementary object");
+				}
+				
+			} else {
+				 throw new RpcException(RpcException.Type.MISSING_VALUE, "user or authorizedGroup");
+			}
 		}
 	},
 

--- a/perun-rpc/src/main/perl/Perun/AuthzResolverAgent.pm
+++ b/perun-rpc/src/main/perl/Perun/AuthzResolverAgent.pm
@@ -43,4 +43,14 @@ sub isPerunAdmin
 	return Perun::Common::callManagerMethod('isPerunAdmin', '', @_);
 }
 
+sub setRole
+{
+  return Perun::Common::callManagerMethod('setRole', '', @_);
+}
+
+sub unsetRole
+{
+	return Perun::Common::callManagerMethod('unsetRole', '', @_);
+}
+
 1;

--- a/perun-rpc/src/main/perl/Perun/beans/Facility.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/Facility.pm
@@ -50,7 +50,7 @@ sub TO_JSON
 		$name = undef;
 	}
 
-	return {id => $id, name => $name};
+	return {id => $id, name => $name, beanName => "Facility"};
 }
 
 sub getId

--- a/perun-rpc/src/main/perl/Perun/beans/Group.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/Group.pm
@@ -46,7 +46,7 @@ sub TO_JSON
 		$voId = 0;
 	}
 
-	return {id => $id, name => $name, description => $description, voId => $voId};
+	return {id => $id, name => $name, description => $description, voId => $voId, beanName => "Group"};
 }
 
 sub getId

--- a/perun-rpc/src/main/perl/Perun/beans/Resource.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/Resource.pm
@@ -59,7 +59,7 @@ sub TO_JSON
 		$description = undef;
 	}
 
-	return {id => $id, name => $name, description => $description};
+	return {id => $id, name => $name, description => $description, beanName => "Resource"};
 }
 
 sub getId

--- a/perun-rpc/src/main/perl/Perun/beans/Service.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/Service.pm
@@ -50,7 +50,7 @@ sub TO_JSON
 		$name = undef;
 	}
 
-	return {id => $id, name => $name};
+	return {id => $id, name => $name, beanName => "Service"};
 }
 
 sub getId

--- a/perun-rpc/src/main/perl/Perun/beans/Vo.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/Vo.pm
@@ -40,7 +40,7 @@ sub TO_JSON
 		$shortName = undef;
 	}
 
-	return {id => $id, name => $name, shortName => $shortName};
+	return {id => $id, name => $name, shortName => $shortName, beanName => "Vo"};
 }
 
 sub getId

--- a/perun-rpc/src/main/perl/setRole
+++ b/perun-rpc/src/main/perl/setRole
@@ -1,0 +1,117 @@
+#!/usr/bin/perl -w                                                                            
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::Agent;
+use Perun::Common qw(printMessage);
+
+sub help {
+  return qq{
+  Adds Role to user or authorizedGroup. User or group is required.
+	Role is required. Some complementaryObject is required if not PERUNADMIN.
+	For now only 1 object is supported to be set at once.
+  ------------------------------------
+  Available options:
+  --userId            | -u user id
+	--authorizedGroupId | -a authorizedGroup id
+	--role              | -R role name
+	--facilityId        | -f facility comp object id
+	--groupId           | -g group comp object id
+	--voId              | -v vo comp object id
+	--resourceId        | -r resource comp object id
+	--serviceId         | -s service comp object id
+  --batch             | -b batch
+  --help              | -h prints this help
+  };
+}
+
+our $batch;
+
+my ($userId, $authorizedGroupId, $role, $facilityId, $groupId, $voId, $resourceId, $serviceId);
+GetOptions ("help|h" => sub { print help(); exit 0;} ,"batch|b" => \$batch,
+	"userId|u=i" => \$userId,
+	"authorizedGroupId|a=i" => \$authorizedGroupId,
+	"role|R=s" => \$role,
+	"facilityId|f=i" => \$facilityId,
+	"groupId|g=i" => \$groupId,
+	"voId|v=i" => \$voId,
+	"resourceId|r=i" => \$resourceId,
+	"serviceId|s=i" => \$serviceId) || die help();
+
+my $agent = Perun::Agent->new();
+my $authzResolverAgent = $agent->getAuthzResolverAgent;
+#Check options
+
+#one of userId or authorizedGroupId must be set
+if(!defined($userId) && !defined($authorizedGroupId)) { die "ERROR: one of userId and authorizedGroupId is requried\n";}
+if(defined($userId) && defined($authorizedGroupId)) { die "ERROR: only one of userId and authorizedGroupId must be set at one moment\n";}
+
+#role must be set
+unless (defined($role)) { die "ERROR: role name is required"};
+if($role !~ /^[A-Z]+$/) { die "ERROR: role must be one word in uppercase format\n"; }
+
+#if role is perunadmin, no other object need to be set
+if($role eq "PERUNADMIN") {
+	if(defined($facilityId) || defined($voId) || defined($groupId) || defined($resourceId) || defined($serviceId)) {
+		die "ERROR: no other object needed when setting role $role\n";
+	}
+	if(defined($userId)) {
+		$authzResolverAgent->setRole(user => $userId, complementaryObject => undef, role => $role);
+	} else {
+		$authzResolverAgent->setRole(authorizedGroup => $authorizedGroupId, complementaryObject => undef, role => $role);
+	}
+#if there is other role, only one complementary object is needed
+} else {
+	#facility
+	if(defined($facilityId) && !defined($groupId) && !defined($voId) && !defined($resourceId) && !defined($serviceId)) {
+		my $facilitiesAgent = $agent->getFacilitiesAgent;
+    my $facility = $facilitiesAgent->getFacilityById(id => $facilityId);
+		if(defined($userId)) {
+    	$authzResolverAgent->setRole(user => $userId, complementaryObject => $facility, role => $role);
+  	} else {
+    	$authzResolverAgent->setRole(authorizedGroup => $authorizedGroupId, complementaryObject => $facility, role => $role);
+ 		}
+  #group
+	} elsif(!defined($facilityId) && defined($groupId) && !defined($voId) && !defined($resourceId) && !defined($serviceId)) {
+		my $groupsAgent = $agent->getGroupsAgent;
+		my $group = $groupsAgent->getGroupById(id => $groupId);
+		if(defined($userId)) {
+    	$authzResolverAgent->setRole(user => $userId, complementaryObject => $group, role => $role);
+  	} else {
+    	$authzResolverAgent->setRole(authorizedGroup => $authorizedGroupId, complementaryObject => $group, role => $role);
+ 		}
+	#vo
+	} elsif(!defined($facilityId) && !defined($groupId) && defined($voId) && !defined($resourceId) && !defined($serviceId)) {
+		my $vosAgent = $agent->getVosAgent;
+    my $vo = $vosAgent->getVoById(id => $voId);
+		if(defined($userId)) {
+    	$authzResolverAgent->setRole(user => $userId, complementaryObject => $vo, role => $role);
+  	} else {
+    	$authzResolverAgent->setRole(authorizedGroup => $authorizedGroupId, complementaryObject => $vo, role => $role);
+  	}
+	#resource
+	} elsif(!defined($facilityId) && !defined($groupId) && !defined($voId) && defined($resourceId) && !defined($serviceId)) {
+		my $resourcesAgent = $agent->getResourcesAgent;
+    my $resource = $resourcesAgent->getResourceById(id => $resourceId);
+		if(defined($userId)) {
+    	$authzResolverAgent->setRole(user => $userId, complementaryObject => $resource, role => $role);
+  	} else {
+    	$authzResolverAgent->setRole(authorizedGroup => $authorizedGroupId, complementaryObject => $resource, role => $role);
+  	}
+	#serviceId
+	} elsif(!defined($facilityId) && !defined($groupId) && !defined($voId) && !defined($resourceId) && defined($serviceId)) {
+		my $servicesAgent = $agent->getServicesAgent;
+    my $service = $servicesAgent->getServiceById(id => $serviceId);
+		if(defined($userId)) {
+    	$authzResolverAgent->setRole(user => $userId, complementaryObject => $service, role => $role);
+  	} else {
+    	$authzResolverAgent->setRole(authorizedGroup => $authorizedGroupId, complementaryObject => $service, role => $role);
+  	}
+	#no object or more than one
+	} else {
+		die "ERROR: only one of objects (facility,vo,group,resource,service) id need to be set\n";
+	}
+}
+
+

--- a/perun-rpc/src/main/perl/unsetRole
+++ b/perun-rpc/src/main/perl/unsetRole
@@ -1,0 +1,117 @@
+#!/usr/bin/perl -w                                                                            
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::Agent;
+use Perun::Common qw(printMessage);
+
+sub help {
+  return qq{
+  Remove Role from user or authorizedGroup. User or group is required.
+	Role is required. Some complementaryObject is required if not PERUNADMIN.
+	For now only 1 object is supported to be set at once.
+  ------------------------------------
+  Available options:
+  --userId            | -u user id
+	--authorizedGroupId | -a authorizedGroup id
+	--role              | -R role name
+	--facilityId        | -f facility comp object id
+	--groupId           | -g group comp object id
+	--voId              | -v vo comp object id
+	--resourceId        | -r resource comp object id
+	--serviceId         | -s service comp object id
+  --batch             | -b batch
+  --help              | -h prints this help
+  };
+}
+
+our $batch;
+
+my ($userId, $authorizedGroupId, $role, $facilityId, $groupId, $voId, $resourceId, $serviceId);
+GetOptions ("help|h" => sub { print help(); exit 0;} ,"batch|b" => \$batch,
+	"userId|u=i" => \$userId,
+	"authorizedGroupId|a=i" => \$authorizedGroupId,
+	"role|R=s" => \$role,
+	"facilityId|f=i" => \$facilityId,
+	"groupId|g=i" => \$groupId,
+	"voId|v=i" => \$voId,
+	"resourceId|r=i" => \$resourceId,
+	"serviceId|s=i" => \$serviceId) || die help();
+
+my $agent = Perun::Agent->new();
+my $authzResolverAgent = $agent->getAuthzResolverAgent;
+#Check options
+
+#one of userId or authorizedGroupId must be set
+if(!defined($userId) && !defined($authorizedGroupId)) { die "ERROR: one of userId and authorizedGroupId is requried\n";}
+if(defined($userId) && defined($authorizedGroupId)) { die "ERROR: only one of userId and authorizedGroupId must be set at one moment\n";}
+
+#role must be set
+unless (defined($role)) { die "ERROR: role name is required"};
+if($role !~ /^[A-Z]+$/) { die "ERROR: role must be one word in uppercase format\n"; }
+
+#if role is perunadmin, no other object need to be set
+if($role eq "PERUNADMIN") {
+	if(defined($facilityId) || defined($voId) || defined($groupId) || defined($resourceId) || defined($serviceId)) {
+		die "ERROR: no other object needed when setting role $role\n";
+	}
+	if(defined($userId)) {
+		$authzResolverAgent->unsetRole(user => $userId, complementaryObject => undef, role => $role);
+	} else {
+		$authzResolverAgent->unsetRole(authorizedGroup => $authorizedGroupId, complementaryObject => undef, role => $role);
+	}
+#if there is other role, only one complementary object is needed
+} else {
+	#facility
+	if(defined($facilityId) && !defined($groupId) && !defined($voId) && !defined($resourceId) && !defined($serviceId)) {
+		my $facilitiesAgent = $agent->getFacilitiesAgent;
+    my $facility = $facilitiesAgent->getFacilityById(id => $facilityId);
+		if(defined($userId)) {
+    	$authzResolverAgent->unsetRole(user => $userId, complementaryObject => $facility, role => $role);
+  	} else {
+    	$authzResolverAgent->unsetRole(authorizedGroup => $authorizedGroupId, complementaryObject => $facility, role => $role);
+ 		}
+  #group
+	} elsif(!defined($facilityId) && defined($groupId) && !defined($voId) && !defined($resourceId) && !defined($serviceId)) {
+		my $groupsAgent = $agent->getGroupsAgent;
+		my $group = $groupsAgent->getGroupById(id => $groupId);
+		if(defined($userId)) {
+    	$authzResolverAgent->unsetRole(user => $userId, complementaryObject => $group, role => $role);
+  	} else {
+    	$authzResolverAgent->unsetRole(authorizedGroup => $authorizedGroupId, complementaryObject => $group, role => $role);
+ 		}
+	#vo
+	} elsif(!defined($facilityId) && !defined($groupId) && defined($voId) && !defined($resourceId) && !defined($serviceId)) {
+		my $vosAgent = $agent->getVosAgent;
+    my $vo = $vosAgent->getVoById(id => $voId);
+		if(defined($userId)) {
+    	$authzResolverAgent->unsetRole(user => $userId, complementaryObject => $vo, role => $role);
+  	} else {
+    	$authzResolverAgent->unsetRole(authorizedGroup => $authorizedGroupId, complementaryObject => $vo, role => $role);
+  	}
+	#resource
+	} elsif(!defined($facilityId) && !defined($groupId) && !defined($voId) && defined($resourceId) && !defined($serviceId)) {
+		my $resourcesAgent = $agent->getResourcesAgent;
+    my $resource = $resourcesAgent->getResourceById(id => $resourceId);
+		if(defined($userId)) {
+    	$authzResolverAgent->unsetRole(user => $userId, complementaryObject => $resource, role => $role);
+  	} else {
+    	$authzResolverAgent->unsetRole(authorizedGroup => $authorizedGroupId, complementaryObject => $resource, role => $role);
+  	}
+	#serviceId
+	} elsif(!defined($facilityId) && !defined($groupId) && !defined($voId) && !defined($resourceId) && defined($serviceId)) {
+		my $servicesAgent = $agent->getServicesAgent;
+    my $service = $servicesAgent->getServiceById(id => $serviceId);
+		if(defined($userId)) {
+    	$authzResolverAgent->unsetRole(user => $userId, complementaryObject => $service, role => $role);
+  	} else {
+    	$authzResolverAgent->unsetRole(authorizedGroup => $authorizedGroupId, complementaryObject => $service, role => $role);
+  	}
+	#no object or more than one
+	} else {
+		die "ERROR: only one of objects (facility,vo,group,resource,service) id need to be set\n";
+	}
+}
+
+


### PR DESCRIPTION
- create setRole(authorizedGroup / User, complementaryObjects)
- create unsetRole(authorizedGroup / User, complementaryObjects)
- create manageRole (set and unset roles for 1 comp object)
- add new addAdminWithoutRefresh and removeAdminWithoutRefresh methods
- add new methods addObserver, removeObserver (for work with
  VoObserver)
- add methods setRole and unsetRole to RPC
- add method removePerunAdmin
- add small tests of these methods
- remove refreshAuthz from methods in AuthzResolver (addAdmin etc.)
- add refreshAuthz automaticly to method manageRole
- new CLI scripts setRole, unsetRole
- add new methods setRole and unsetRole to AuthzResolverAgent.pm
- new deserializer for PerunBean and listOfPerunBeans
- add beanName to JSON parser for objects (vo, resource, group,
  facility and service) in CLI
