### PR TITLE
CORE: fixed RichGroup object.

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/RichGroup.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/RichGroup.java
@@ -21,6 +21,7 @@ public class RichGroup extends Group {
 				group.getModifiedAt(), group.getModifiedBy(),
 				group.getParentGroupId(), group.getCreatedByUid(),
 				group.getModifiedByUid());
+		this.setVoId(group.getVoId());
 		this.groupAttributes = attrs;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -939,18 +939,17 @@ public class GroupsManagerEntry implements GroupsManager {
 
 	public RichGroup getRichGroupByIdWithAttributesByNames(PerunSession sess, int groupId, List<String> attrNames) throws InternalErrorException, GroupNotExistsException, VoNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
-		this.getGroupsManagerBl().checkGroupExists(sess, this.getGroupsManagerBl().getGroupById(sess, groupId));
 
 		Group group = groupsManagerBl.getGroupById(sess, groupId);
-		Vo vo = perunBl.getVosManagerBl().getVoById(sess, group.getVoId());
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo)
-		        && !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo)
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
+		        && !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, group)
 		        && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
 			throw new PrivilegeException(sess, "getRichGroupByIdWithAttributesByNames");
 		}
 
 		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getRichGroupByIdWithAttributesByNames(sess, groupId, attrNames));
+
 	}
 }


### PR DESCRIPTION
- RichGroup was missing voId parameter.
- simplified getRichGroupByIdWithAttributesByNames() where we don't need to
  get VO at all and there is no reason to check group for existence, since
  it's performed by select itself.
