### PR TITLE
REGISTRAR: fixed delete of new application

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -814,6 +814,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				perun.getUsersManagerBl().deletePassword(sess, login.getRight(), login.getLeft());
 			}
 
+			// free any login from reservation when application is rejected
+			jdbc.update("delete from application_reserved_logins where app_id=?", app.getId());
+
 			// delete application and data on cascade
 			jdbc.update("delete from application where id=?", app.getId());
 


### PR DESCRIPTION
- If application is in state NEW and has some reserved logins,
  then logins must be deleted from DB before deleting application.
