### PR TITLE
New workflow for getting admins

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/PerunBeanNotSupportedException.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/PerunBeanNotSupportedException.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.PerunBean;
+
+/**
+ * Checked version of PerunBeanNotSupportedException.
+ *
+ * This exception is thrown when somewhere in code is object PerunBean but
+ * this one is not supported there for some reason.
+ *
+ * @author Michal Stava
+ */
+public class PerunBeanNotSupportedException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	private PerunBean complementaryObject;
+
+	public PerunBeanNotSupportedException(String message) {
+		super(message);
+	}
+
+	public PerunBeanNotSupportedException(String message, PerunBean complementaryObject) {
+		super(message);
+		this.complementaryObject = complementaryObject;
+	}
+
+	public PerunBeanNotSupportedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public PerunBeanNotSupportedException(String message, PerunBean complementaryObject, Throwable cause) {
+		super(message, cause);
+		this.complementaryObject = complementaryObject;
+	}
+
+	public PerunBeanNotSupportedException(Throwable cause) {
+		super(cause);
+	}
+
+	public PerunBeanNotSupportedException(Throwable cause, PerunBean complementaryObject) {
+		super(cause);
+		this.complementaryObject = complementaryObject;
+	}
+
+	public PerunBean getComplementaryObject() {
+		return this.complementaryObject;
+	}
+}

--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/RoleNotSupportedException.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/RoleNotSupportedException.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Role;
+
+/**
+ * Checked version of RoleNotSupportedException.
+ *
+ * This exception is thrown when somewhere in code is object Role but
+ * this role is not supported there for some reason.
+ *
+ * @author Michal Stava
+ */
+public class RoleNotSupportedException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	private Role role;
+
+	public RoleNotSupportedException(String message) {
+		super(message);
+	}
+
+	public RoleNotSupportedException(String message, Role role) {
+		super(message);
+		this.role = role;
+	}
+
+	public RoleNotSupportedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public RoleNotSupportedException(String message, Role role, Throwable cause) {
+		super(message, cause);
+		this.role = role;
+	}
+
+	public RoleNotSupportedException(Throwable cause) {
+		super(cause);
+	}
+
+	public RoleNotSupportedException(Throwable cause, Role role) {
+		super(cause);
+		this.role = role;
+	}
+
+	public Role getRole() {
+		return this.role;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -623,6 +623,49 @@ public interface FacilitiesManager {
 	void removeAdmin(PerunSession sess, Facility facility, Group group) throws InternalErrorException, FacilityNotExistsException, GroupNotExistsException, PrivilegeException, GroupNotAdminException;
 
 	/**
+	 * Get list of all user administrators for supported role and given facility.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: FacilityAdmin
+	 *
+	 * @param perunSession
+	 * @param facility
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given facility for supported role
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws FacilityNotExistsException
+	 */
+	List<User> getAdmins(PerunSession perunSession, Facility facility, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
+
+	/**
+	 * Get list of all richUser administrators for the facility and supported role with specific attributes.
+	 *
+	 * Supported roles: FacilityAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param group
+	 *
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the facility and supported role with attributes
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws FacilityNotExistsException
+	 */
+	List<RichUser> getRichAdmins(PerunSession perunSession, Facility facility, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, UserNotExistsException, PrivilegeException, FacilityNotExistsException;
+
+	/**
 	 * Gets list of all user administrators of the Facility.
 	 * If some group is administrator of the given group, all members are included in the list.
 	 *
@@ -632,6 +675,7 @@ public interface FacilitiesManager {
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession sess, Facility facility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
 
 	/**
@@ -645,6 +689,7 @@ public interface FacilitiesManager {
 	 * @throws PrivilegeException
 	 * @throws FacilityNotExistsException
 	 */
+	@Deprecated
 	List<User> getDirectAdmins(PerunSession perunSession, Facility facility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
 
 	/**
@@ -668,6 +713,7 @@ public interface FacilitiesManager {
 	 * @throws UserNotExistsException
 	 * @throws PrivilegeException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession sess, Facility facility) throws InternalErrorException, UserNotExistsException, FacilityNotExistsException, PrivilegeException;
 
 	/**
@@ -681,6 +727,7 @@ public interface FacilitiesManager {
 	 * @throws PrivilegeException
 	 * @throws FacilityNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithAttributes(PerunSession sess, Facility facility) throws InternalErrorException, UserNotExistsException, PrivilegeException, FacilityNotExistsException;
 
 	/**
@@ -695,6 +742,7 @@ public interface FacilitiesManager {
 	 * @throws PrivilegeException
 	 * @throws VoNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Facility facility, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
 
 	/**
@@ -709,8 +757,8 @@ public interface FacilitiesManager {
 	 * @throws PrivilegeException
 	 * @throws VoNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Facility facility, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
-
 
 	/**
 	 * Returns list of Facilities, where the user is an admin.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -13,11 +13,9 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.NotMemberOfParentGroupException;
-import cz.metacentrum.perun.core.api.exceptions.NotServiceUserExpectedException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
@@ -481,6 +479,49 @@ public interface GroupsManager {
 	void removeAdmin(PerunSession perunSession, Group group, Group authorizedGroup) throws InternalErrorException, PrivilegeException, GroupNotExistsException, GroupNotAdminException;
 
 	/**
+	 * Get list of all user administrators for supported role and specific group.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: GroupAdmin
+	 *
+	 * @param perunSession
+	 * @param group
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given group for supported role
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws GroupNotExistsException
+	 */
+	List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
+
+	/**
+	 * Get list of all richUser administrators for the group and supported role with specific attributes.
+	 *
+	 * Supported roles: GroupAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param group
+	 *
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the group and supported role with attributes
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws GroupNotExistsException
+	 */
+	List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, UserNotExistsException, PrivilegeException, GroupNotExistsException;
+
+	/**
 	 * Gets list of all user administrators of this group.
 	 * If some group is administrator of the given group, all members are included in the list.
 	 *
@@ -492,6 +533,7 @@ public interface GroupsManager {
 	 * @throws GroupNotExistsException
 	 * @throws InternalErrorRuntimeException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
 
 	/**
@@ -506,6 +548,7 @@ public interface GroupsManager {
 	 * @throws GroupNotExistsException
 	 * @throws InternalErrorRuntimeException
 	 */
+	@Deprecated
 	List<User> getDirectAdmins(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
 
 	/**
@@ -535,6 +578,7 @@ public interface GroupsManager {
 	 * @throws UserNotExistsException
 	 * @throws InternalErrorRuntimeException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException;
 
 	/**
@@ -549,6 +593,7 @@ public interface GroupsManager {
 	 * @throws UserNotExistsException
 	 * @throws InternalErrorRuntimeException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithAttributes(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException;
 
 	/**
@@ -564,6 +609,7 @@ public interface GroupsManager {
 	 * @throws VoNotExistsException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Group group, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException;
 
 	/**
@@ -579,6 +625,7 @@ public interface GroupsManager {
 	 * @throws VoNotExistsException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Group group, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException;
 
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RoleNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
@@ -215,6 +216,69 @@ public interface VosManager {
 	 */
 	void removeAdmin(PerunSession perunSession, Vo vo, Group group) throws InternalErrorException, PrivilegeException, VoNotExistsException, GroupNotAdminException, GroupNotExistsException;
 
+	/**
+	 * Get list of all user administrators for supported role and specific vo.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * @param perunSession
+	 * @param vo
+	 * @param role supported role
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given vo for supported role
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws RoleNotSupportedException
+	 * @throws VoNotExistsException
+	 */
+	List<User> getAdmins(PerunSession perunSession, Vo vo, Role role, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, VoNotExistsException, RoleNotSupportedException;
+
+	/**
+	 * Get list of all richUser administrators for the vo and supported role with specific attributes.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the vo for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param vo
+	 *
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the vo and supported role with attributes
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws VoNotExistsException
+	 * @throws RoleNotSupportedException
+	 * @throws UserNotExistsException
+	 */
+	List<RichUser> getRichAdmins(PerunSession perunSession, Vo vo, Role role, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, VoNotExistsException, RoleNotSupportedException, UserNotExistsException;
+
+	/**
+	 * Get list of group administrators of the given VO.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * @param perunSession
+	 * @param vo
+	 * @param role
+	 *
+	 * @return List of groups, who are administrators of the Vo with supported role. Returns empty list if there is no VO group admin.
+	 *
+	 * @throws VoNotExistsException
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws RoleNotSupportedException
+	 */
+	List<Group> getAdminGroups(PerunSession perunSession, Vo vo, Role role) throws InternalErrorException, PrivilegeException, VoNotExistsException, RoleNotSupportedException;
 
 	/**
 	 * Get list of Vo administrators.
@@ -227,6 +291,7 @@ public interface VosManager {
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException;
 
 	/**
@@ -240,6 +305,7 @@ public interface VosManager {
 	 * @throws PrivilegeException
 	 * @throws VoNotExistsException
 	 */
+	@Deprecated
 	List<User> getDirectAdmins(PerunSession perunSession, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException;
 
 	/**
@@ -252,6 +318,7 @@ public interface VosManager {
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 */
+	@Deprecated
 	List<Group> getAdminGroups(PerunSession perunSession, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException;
 
 
@@ -268,6 +335,7 @@ public interface VosManager {
 	 * @throws VoNotExistsException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Vo vo, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException;
 
 	/**
@@ -283,6 +351,7 @@ public interface VosManager {
 	 * @throws VoNotExistsException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Vo vo, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException;
 
 	/**
@@ -296,6 +365,7 @@ public interface VosManager {
 	 * @throws UserNotExistsException
 	 * @throws PrivilegeException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession perunSession, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException;
 
 	/**
@@ -309,5 +379,6 @@ public interface VosManager {
 	 * @throws UserNotExistsException
 	 * @throws PrivilegeException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithAttributes(PerunSession perunSession, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -3,12 +3,10 @@ package cz.metacentrum.perun.core.bl;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
-import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -580,6 +578,45 @@ public interface FacilitiesManagerBl {
 	void removeAdmin(PerunSession sess, Facility facility, Group group) throws InternalErrorException, GroupNotAdminException;
 
 	/**
+	 * Get list of all user administrators for supported role and given facility.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: FacilityAdmin
+	 *
+	 * @param perunSession
+	 * @param facility
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given facility for supported role
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<User> getAdmins(PerunSession perunSession, Facility facility, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
+
+	/**
+	 * Get list of all richUser administrators for the facility and supported role with specific attributes.
+	 *
+	 * Supported roles: FacilityAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param group
+	 *
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the facility and supported role with attributes
+	 *
+	 * @throws InternalErrorException
+	 * @throws UserNotExistsException
+	 */
+	List<RichUser> getRichAdmins(PerunSession perunSession, Facility facility, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, UserNotExistsException;
+
+	/**
 	 * Gets list of all user administrators of the Facility.
 	 * If some group is administrator of the given group, all members are included in the list.
 	 *
@@ -588,6 +625,7 @@ public interface FacilitiesManagerBl {
 	 * @return list of Users who are admins in the facility
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession sess, Facility facility) throws InternalErrorException;
 
 	/**
@@ -599,6 +637,7 @@ public interface FacilitiesManagerBl {
 	 *
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<User> getDirectAdmins(PerunSession perunSession, Facility facility) throws InternalErrorException;
 
 	/**
@@ -620,6 +659,7 @@ public interface FacilitiesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession sess, Facility facility) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -631,6 +671,7 @@ public interface FacilitiesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdmins(PerunSession sess, Facility facility) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -642,6 +683,7 @@ public interface FacilitiesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithAttributes(PerunSession sess, Facility facility) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -654,6 +696,7 @@ public interface FacilitiesManagerBl {
 	 * @return list of RichUsers with specific attributes.
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Facility facility, List<String> specificAttributes) throws InternalErrorException;
 
 	/**
@@ -666,6 +709,7 @@ public interface FacilitiesManagerBl {
 	 * @return list of RichUsers with specific attributes.
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Facility facility, List<String> specificAttributes) throws InternalErrorException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -528,6 +528,45 @@ public interface GroupsManagerBl {
 	void removeAdmin(PerunSession perunSession, Group group, Group authorizedGroup) throws InternalErrorException, GroupNotAdminException;
 
 	/**
+	 * Get list of all user administrators for supported role and specific group.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: GroupAdmin
+	 *
+	 * @param perunSession
+	 * @param group
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given group for supported role
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins) throws InternalErrorException;
+
+	/**
+	 * Get list of all richUser administrators for the group and supported role with specific attributes.
+	 *
+	 * Supported roles: GroupAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param group
+	 *
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the group and supported role with attributes
+	 *
+	 * @throws InternalErrorException
+	 * @throws UserNotExistsException
+	 */
+	List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, UserNotExistsException;
+
+	/**
 	 * Gets list of all user administrators of this group.
 	 * If some group is administrator of the given group, all members are included in the list.
 	 *
@@ -538,6 +577,7 @@ public interface GroupsManagerBl {
 	 *
 	 * @return list of administrators
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, Group group) throws InternalErrorException;
 
 	/**
@@ -551,6 +591,7 @@ public interface GroupsManagerBl {
 	 *
 	 * @return list of direct administrators
 	 */
+	@Deprecated
 	List<User> getDirectAdmins(PerunSession perunSession, Group group) throws InternalErrorException;
 
 	/**
@@ -574,6 +615,7 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 * @throws  UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession perunSession, Group group) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -585,6 +627,7 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 * @throws  UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdmins(PerunSession perunSession, Group group) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -596,6 +639,7 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithAttributes(PerunSession perunSession, Group group) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -609,6 +653,7 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Group group, List<String> specificAttributes) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -622,8 +667,8 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Group group, List<String> specificAttributes) throws InternalErrorException, UserNotExistsException;
-
 
 	/**
 	 * Get all groups of users under the VO.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
@@ -1,22 +1,18 @@
 package cz.metacentrum.perun.core.bl;
 
-import cz.metacentrum.perun.core.api.AttributeDefinition;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
-import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -180,6 +176,61 @@ public interface VosManagerBl {
 	void removeAdmin(PerunSession perunSession, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException;
 
 	/**
+	 * Get list of all user administrators for supported role and specific vo.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * @param perunSession
+	 * @param vo
+	 * @param role supported role
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given vo for supported role
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<User> getAdmins(PerunSession perunSession, Vo vo, Role role, boolean onlyDirectAdmins) throws InternalErrorException;
+
+	/**
+	 * Get list of all richUser administrators for the vo and supported role with specific attributes.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the vo for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param vo
+	 *
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the vo and supported role with attributes
+	 *
+	 * @throws InternalErrorException
+	 * @throws UserNotExistsException
+	 */
+	List<RichUser> getRichAdmins(PerunSession perunSession, Vo vo, Role role, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, UserNotExistsException;
+
+	/**
+	 * Get list of group administrators of the given VO.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * @param perunSession
+	 * @param vo
+	 * @param role
+	 *
+	 * @return List of groups, who are administrators of the Vo with supported role. Returns empty list if there is no VO group admin.
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAdminGroups(PerunSession perunSession, Vo vo, Role role) throws InternalErrorException;
+
+	/**
 	 * Get list of Vo administrators.
 	 * If some group is administrator of the VO, all members are included in the list.
 	 *
@@ -188,6 +239,7 @@ public interface VosManagerBl {
 	 * @return List of users, who are administrators of the Vo. Returns empty list if there is no VO admin.
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession perunSession, Vo vo) throws InternalErrorException;
 
 	/**
@@ -199,6 +251,7 @@ public interface VosManagerBl {
 	 *
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<User> getDirectAdmins(PerunSession perunSession, Vo vo) throws InternalErrorException;
 
 	/**
@@ -209,6 +262,7 @@ public interface VosManagerBl {
 	 * @return List of groups, who are administrators of the Vo. Returns empty list if there is no VO group admin.
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<Group> getAdminGroups(PerunSession perunSession, Vo vo) throws InternalErrorException;
 
 
@@ -221,6 +275,7 @@ public interface VosManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdmins(PerunSession perunSession, Vo vo) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -232,6 +287,7 @@ public interface VosManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdmins(PerunSession perunSession, Vo vo) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -243,6 +299,7 @@ public interface VosManagerBl {
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithAttributes(PerunSession perunSession, Vo vo) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -256,6 +313,7 @@ public interface VosManagerBl {
 	 * @throws UserNotExistsException
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Vo vo, List<String> specificAttributes) throws InternalErrorException, UserNotExistsException;
 
 	/**
@@ -269,6 +327,7 @@ public interface VosManagerBl {
 	 * @throws UserNotExistsException
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Vo vo, List<String> specificAttributes) throws InternalErrorException, UserNotExistsException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -521,10 +521,37 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		getPerunBl().getAuditer().log(sess, "Group {} was removed from admins of {}.", authorizedGroup, group);
 	}
 
+	public List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins) throws InternalErrorException {
+		if(onlyDirectAdmins) {
+			return getGroupsManagerImpl().getDirectAdmins(perunSession, group);
+		} else {
+			return getGroupsManagerImpl().getAdmins(perunSession, group);
+		}
+	}
+
+	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, UserNotExistsException {
+		List<User> users = this.getAdmins(perunSession, group, onlyDirectAdmins);
+		List<RichUser> richUsers;
+
+		if(allUserAttributes) {
+			richUsers = perunBl.getUsersManagerBl().getRichUsersWithAttributesFromListOfUsers(perunSession, users);
+		} else {
+			try {
+				richUsers = getPerunBl().getUsersManagerBl().convertUsersToRichUsersWithAttributes(perunSession, perunBl.getUsersManagerBl().getRichUsersFromListOfUsers(perunSession, users), getPerunBl().getAttributesManagerBl().getAttributesDefinition(perunSession, specificAttributes));
+			} catch (AttributeNotExistsException ex) {
+				throw new InternalErrorException("One of Attribute not exist.", ex);
+			}
+		}
+
+		return richUsers;
+	}
+
+	@Deprecated
 	public List<User> getAdmins(PerunSession sess, Group group) throws InternalErrorException {
 		return getGroupsManagerImpl().getAdmins(sess, group);
 	}
 
+	@Deprecated
 	@Override
 	public List<User> getDirectAdmins(PerunSession sess, Group group) throws InternalErrorException {
 		return getGroupsManagerImpl().getDirectAdmins(sess, group);
@@ -535,24 +562,28 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		return getGroupsManagerImpl().getGroupAdmins(sess, group);
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group) throws InternalErrorException, UserNotExistsException {
 		List<User> users = this.getAdmins(perunSession, group);
 		List<RichUser> richUsers = perunBl.getUsersManagerBl().getRichUsersFromListOfUsers(perunSession, users);
 		return richUsers;
 	}
 
+	@Deprecated
 	public List<RichUser> getDirectRichAdmins(PerunSession perunSession, Group group) throws InternalErrorException, UserNotExistsException {
 		List<User> users = this.getDirectAdmins(perunSession, group);
 		List<RichUser> richUsers = perunBl.getUsersManagerBl().getRichUsersFromListOfUsers(perunSession, users);
 		return richUsers;
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdminsWithAttributes(PerunSession perunSession, Group group) throws InternalErrorException, UserNotExistsException {
 		List<User> users = this.getAdmins(perunSession, group);
 		List<RichUser> richUsers = perunBl.getUsersManagerBl().getRichUsersWithAttributesFromListOfUsers(perunSession, users);
 		return richUsers;
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Group group, List<String> specificAttributes) throws InternalErrorException, UserNotExistsException {
 		try {
 			return getPerunBl().getUsersManagerBl().convertUsersToRichUsersWithAttributes(perunSession, this.getRichAdmins(perunSession, group), getPerunBl().getAttributesManagerBl().getAttributesDefinition(perunSession, specificAttributes));
@@ -561,6 +592,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 	}
 
+	@Deprecated
 	public List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Group group, List<String> specificAttributes) throws InternalErrorException, UserNotExistsException {
 		try {
 			return getPerunBl().getUsersManagerBl().convertUsersToRichUsersWithAttributes(perunSession, this.getDirectRichAdmins(perunSession, group), getPerunBl().getAttributesManagerBl().getAttributesDefinition(perunSession, specificAttributes));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -645,6 +645,33 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 
 	}
 
+	public List<User> getAdmins(PerunSession perunSession, Facility facility, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, FacilityNotExistsException {
+		Utils.checkPerunSession(perunSession);
+		getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(perunSession, "getAdmins");
+		}
+
+		return getFacilitiesManagerBl().getAdmins(perunSession, facility, onlyDirectAdmins);
+	}
+
+
+	public List<RichUser> getRichAdmins(PerunSession perunSession, Facility facility, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, UserNotExistsException, PrivilegeException, FacilityNotExistsException {
+		Utils.checkPerunSession(perunSession);
+		getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);
+		if(!allUserAttributes) Utils.notNull(specificAttributes, "specificAttributes");
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(perunSession, "getRichAdmins");
+		}
+
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, getFacilitiesManagerBl().getRichAdmins(perunSession, facility, specificAttributes, allUserAttributes, onlyDirectAdmins));
+	}
+
+	@Deprecated
 	public List<User> getAdmins(PerunSession sess, Facility facility) throws InternalErrorException, FacilityNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
@@ -657,6 +684,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		return getFacilitiesManagerBl().getAdmins(sess, facility);
 	}
 
+	@Deprecated
 	@Override
 	public List<User> getDirectAdmins(PerunSession sess, Facility facility) throws InternalErrorException, FacilityNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
@@ -683,6 +711,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		return getFacilitiesManagerBl().getAdminGroups(sess, facility);
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdmins(PerunSession sess, Facility facility) throws InternalErrorException, UserNotExistsException, FacilityNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
@@ -695,6 +724,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getFacilitiesManagerBl().getRichAdmins(sess, facility));
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdminsWithAttributes(PerunSession sess, Facility facility) throws InternalErrorException, UserNotExistsException, FacilityNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
@@ -707,6 +737,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getFacilitiesManagerBl().getRichAdminsWithAttributes(sess, facility));
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Facility facility, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, FacilityNotExistsException {
 		Utils.checkPerunSession(perunSession);
 
@@ -719,6 +750,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, getFacilitiesManagerBl().getRichAdminsWithSpecificAttributes(perunSession, facility, specificAttributes));
 	}
 
+	@Deprecated
 	public List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Facility facility, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, FacilityNotExistsException {
 		Utils.checkPerunSession(perunSession);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -35,7 +35,6 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MembershipMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.NotMemberOfParentGroupException;
-import cz.metacentrum.perun.core.api.exceptions.NotServiceUserExpectedException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
@@ -414,20 +413,54 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().removeAdmin(sess, group, authorizedGroup);
 	}
 
+	public List<User> getAdmins(PerunSession perunSession, Group group, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, GroupNotExistsException {
+		Utils.checkPerunSession(perunSession);
+		getGroupsManagerBl().checkGroupExists(perunSession, group);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, group) &&
+		    !AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER, group) &&
+		    !AuthzResolver.isAuthorized(perunSession, Role.GROUPADMIN, group)) {
+			throw new PrivilegeException(perunSession, "getAdmins");
+		}
+
+		return getGroupsManagerBl().getAdmins(perunSession, group, onlyDirectAdmins);
+	}
+
+	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException {
+		Utils.checkPerunSession(perunSession);
+		getGroupsManagerBl().checkGroupExists(perunSession, group);
+		//list of specific attributes must be not null if filtering is needed
+		if(!allUserAttributes) {
+			Utils.notNull(specificAttributes, "specificAttributes");
+		}
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, group) &&
+				!AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER, group) &&
+				!AuthzResolver.isAuthorized(perunSession, Role.GROUPADMIN, group)) {
+			throw new PrivilegeException(perunSession, "getRichAdmins");
+		}
+
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, getGroupsManagerBl().getRichAdmins(perunSession, group, specificAttributes, allUserAttributes, onlyDirectAdmins));
+	}
+
+	@Deprecated
 	public List<User> getAdmins(PerunSession sess, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
-				&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, group)
-				&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group) &&
+				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, group) &&
+				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
 			throw new PrivilegeException(sess, "getAdmins");
 				}
 
 		return getGroupsManagerBl().getAdmins(sess, group);
 	}
 
+	@Deprecated
 	@Override
 	public List<User> getDirectAdmins(PerunSession sess, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException {
 		Utils.checkPerunSession(sess);
@@ -457,6 +490,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		return getGroupsManagerBl().getAdminGroups(sess, group);
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException {
 		Utils.checkPerunSession(perunSession);
 		getGroupsManagerBl().checkGroupExists(perunSession, group);
@@ -471,6 +505,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, getGroupsManagerBl().getRichAdmins(perunSession, group));
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdminsWithAttributes(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException {
 		Utils.checkPerunSession(perunSession);
 		getGroupsManagerBl().checkGroupExists(perunSession, group);
@@ -485,6 +520,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, getGroupsManagerBl().getRichAdminsWithAttributes(perunSession, group));
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession perunSession, Group group, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException {
 		Utils.checkPerunSession(perunSession);
 		getGroupsManagerBl().checkGroupExists(perunSession, group);
@@ -499,6 +535,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, getGroupsManagerBl().getRichAdminsWithSpecificAttributes(perunSession, group, specificAttributes));
 	}
 
+	@Deprecated
 	public List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession perunSession, Group group, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, GroupNotExistsException, UserNotExistsException {
 		Utils.checkPerunSession(perunSession);
 		getGroupsManagerBl().checkGroupExists(perunSession, group);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -22,6 +22,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RoleNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
@@ -286,6 +287,71 @@ public class VosManagerEntry implements VosManager {
 		vosManagerBl.removeAdmin(sess, vo, group);
 	}
 
+	public List<User> getAdmins(PerunSession perunSession, Vo vo, Role role, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, VoNotExistsException, RoleNotSupportedException {
+		Utils.checkPerunSession(perunSession);
+		Utils.notNull(role, "role");
+		vosManagerBl.checkVoExists(perunSession, vo);
+
+		//Role can be only supported one (TopGroupCreator, VoAdmin or VoObserver)
+		if(!role.equals(Role.TOPGROUPCREATOR) && 
+						!(role.equals(Role.VOADMIN) &&
+						!(role.equals(role.VOOBSERVER)))) {
+			throw new RoleNotSupportedException("Supported roles are VoAdmin, VoObserver and TopGroupCreator.", role);
+		}
+
+		//  Authorization - Vo admin required
+		if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, vo) &&
+				!AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER, vo)) {
+			throw new PrivilegeException(perunSession, "getAdmins");
+		}
+
+		return vosManagerBl.getAdmins(perunSession, vo, role, onlyDirectAdmins);
+	}
+
+	public List<RichUser> getRichAdmins(PerunSession perunSession, Vo vo, Role role, List<String> specificAttributes, boolean allUserAttributes, boolean onlyDirectAdmins) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException, RoleNotSupportedException {
+		Utils.notNull(perunSession, "perunSession");
+		Utils.notNull(role, "role");
+		vosManagerBl.checkVoExists(perunSession, vo);
+
+		//Role can be only supported one (TopGroupCreator, VoAdmin or VoObserver)
+		if(!role.equals(Role.TOPGROUPCREATOR) && 
+						!(role.equals(Role.VOADMIN) &&
+						!(role.equals(role.VOOBSERVER)))) {
+			throw new RoleNotSupportedException("Supported roles are VoAdmin, VoObserver and TopGroupCreator.", role);
+		}
+
+		//  Authorization - Vo admin required
+		if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, vo) &&
+				!AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER, vo)) {
+			throw new PrivilegeException(perunSession, "getDirectRichAdminsWithSpecificAttributes");
+		}
+
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(perunSession, vosManagerBl.getRichAdmins(perunSession, vo, role, specificAttributes, allUserAttributes, onlyDirectAdmins));
+	}
+
+	public List<Group> getAdminGroups(PerunSession perunSession, Vo vo, Role role) throws InternalErrorException, PrivilegeException, VoNotExistsException, RoleNotSupportedException {
+		Utils.checkPerunSession(perunSession);
+		Utils.notNull(role, "role");
+		vosManagerBl.checkVoExists(perunSession, vo);
+
+		//Role can be only supported one (TopGroupCreator, VoAdmin or VoObserver)
+		if(!role.equals(Role.TOPGROUPCREATOR) && 
+						!(role.equals(Role.VOADMIN) &&
+						!(role.equals(role.VOOBSERVER)))) {
+			throw new RoleNotSupportedException("Supported roles are VoAdmin, VoObserver and TopGroupCreator.", role);
+		}
+
+		//  Authorization - Vo admin required
+		if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, vo) &&
+				!AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER, vo)) {
+			throw new PrivilegeException(perunSession, "getAdminGroups");
+				}
+
+		return vosManagerBl.getAdminGroups(perunSession, vo, role);
+	}
+
+
+	@Deprecated
 	public List<User> getAdmins(PerunSession sess, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException {
 		Utils.notNull(sess, "sess");
 		vosManagerBl.checkVoExists(sess, vo);
@@ -299,6 +365,7 @@ public class VosManagerEntry implements VosManager {
 		return vosManagerBl.getAdmins(sess, vo);
 	}
 
+	@Deprecated
 	@Override
 	public List<User> getDirectAdmins(PerunSession sess, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException {
 		Utils.notNull(sess, "sess");
@@ -313,6 +380,7 @@ public class VosManagerEntry implements VosManager {
 		return vosManagerBl.getDirectAdmins(sess, vo);
 	}
 
+	@Deprecated
 	@Override
 	public List<Group> getAdminGroups(PerunSession sess, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException {
 		Utils.notNull(sess, "sess");
@@ -327,6 +395,7 @@ public class VosManagerEntry implements VosManager {
 		return vosManagerBl.getAdminGroups(sess, vo);
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdmins(PerunSession sess, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException {
 		Utils.notNull(sess, "sess");
 		vosManagerBl.checkVoExists(sess, vo);
@@ -340,6 +409,7 @@ public class VosManagerEntry implements VosManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, vosManagerBl.getRichAdmins(sess, vo));
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdminsWithAttributes(PerunSession sess, Vo vo) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException {
 		Utils.notNull(sess, "sess");
 		vosManagerBl.checkVoExists(sess, vo);
@@ -353,6 +423,7 @@ public class VosManagerEntry implements VosManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, vosManagerBl.getRichAdminsWithAttributes(sess, vo));
 	}
 
+	@Deprecated
 	public List<RichUser> getRichAdminsWithSpecificAttributes(PerunSession sess, Vo vo, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException {
 		Utils.notNull(sess, "sess");
 		vosManagerBl.checkVoExists(sess, vo);
@@ -366,6 +437,7 @@ public class VosManagerEntry implements VosManager {
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, vosManagerBl.getRichAdminsWithSpecificAttributes(sess, vo, specificAttributes));
 	}
 
+	@Deprecated
 	public List<RichUser> getDirectRichAdminsWithSpecificAttributes(PerunSession sess, Vo vo, List<String> specificAttributes) throws InternalErrorException, PrivilegeException, VoNotExistsException, UserNotExistsException {
 		Utils.notNull(sess, "sess");
 		vosManagerBl.checkVoExists(sess, vo);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/VosManagerImplApi.java
@@ -6,6 +6,7 @@ import java.util.List;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
@@ -95,6 +96,44 @@ public interface VosManagerImplApi {
 	Vo getVoById(PerunSession perunSession, int id) throws VoNotExistsException, InternalErrorException;
 
 	/**
+	 * Get list of user administrators of specific vo for specific role.
+	 * If some group is administrator of the VO, all members are included in the list.
+	 *
+	 * @param sess
+	 * @param vo
+	 * @param role
+	 *
+	 * @return List of users who are administrators of the vo with specific role. Empty list if there is no such administrator
+	 *
+	 * @throws InternalErrorException
+	 */
+	public List<User> getAdmins(PerunSession sess, Vo vo, Role role) throws InternalErrorException;
+
+	/**
+	 * Get list of direct user administrators of specific vo for specific role.
+	 * 'Direct' means, there aren't included users, who are members of group administrators, in the returned list.
+	 *
+	 * @param sess
+	 * @param vo
+	 * @param role
+	 *
+	 * @return List of direct users who are administrators of the vo with specific role. Empty list if there is no such administrator
+	 *
+	 * @throws InternalErrorException
+	 */
+	public List<User> getDirectAdmins(PerunSession sess, Vo vo, Role role) throws InternalErrorException;
+
+	/**
+	 * Get list of group administrators of the given VO for specific role.
+	 *
+	 * @param sess
+	 * @param vo
+	 * @return List of groups, who are administrators of the Vo with specific role. Returns empty list if there is no such authorized group.
+	 * @throws InternalErrorException
+	 */
+	public List<Group> getAdminGroups(PerunSession sess, Vo vo, Role role) throws InternalErrorException;
+
+	/**
 	 * Get list of Vo administrators.
 	 * If some group is administrator of the VO, all members are included in the list.
 	 *
@@ -103,6 +142,7 @@ public interface VosManagerImplApi {
 	 * @return List of users, who are administrators of the Vo. Returns empty list if there is no VO admin.
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<User> getAdmins(PerunSession sess, Vo vo) throws InternalErrorException;
 
 	/**
@@ -114,6 +154,7 @@ public interface VosManagerImplApi {
 	 *
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<User> getDirectAdmins(PerunSession perunSession, Vo vo) throws InternalErrorException;
 
 	/**
@@ -124,6 +165,7 @@ public interface VosManagerImplApi {
 	 * @return List of groups, who are administrators of the Vo. Returns empty list if there is no VO group admin.
 	 * @throws InternalErrorException
 	 */
+	@Deprecated
 	List<Group> getAdminGroups(PerunSession sess, Vo vo) throws InternalErrorException;
 
 	/**

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.PerunBean;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
@@ -25,6 +26,58 @@ public enum AuthzResolverMethod implements ManagerMethod {
 			return cz.metacentrum.perun.core.api.AuthzResolver.getPrincipalRoleNames(ac.getSession());
 		}
 	},
+	/*#
+	 * Get all richUser administrators for complementary object and role with specify attributes.
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the complementary object for role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @return list of richUser administrators for complementary object and role with specify attributes.
+	 */
+	getRichAdmins {
+		@Override
+		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			//get role by name
+			String roleName = parms.readString("role");
+			Role role;
+			try {
+				role = Role.valueOf(roleName);
+			} catch (IllegalArgumentException ex) {
+				throw new RpcException(RpcException.Type.WRONG_PARAMETER, "wrong parameter in role, not exists role with this name " + roleName);
+			}
+
+			return cz.metacentrum.perun.core.api.AuthzResolver.getRichAdmins(ac.getSession(),
+							parms.readInt("complementaryObjectId"),
+							parms.readString("complementaryObjectName"),
+							parms.readList("specificAttributes", String.class),
+							role, parms.readInt("onlyDirectAdmins") == 1,
+							parms.readInt("allUserAttributes") == 1);
+		}
+	},
+
+	/*#
+	 * Get all authorizedGroups for complementary object and role.
+	 *
+	 * @return list of authoriedGroups for complementary object and role
+	 */
+	getAdminGroups {
+		@Override
+		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
+		//get role by name
+			String roleName = parms.readString("role");
+			Role role;
+			try {
+				role = Role.valueOf(roleName);
+			} catch (IllegalArgumentException ex) {
+				throw new RpcException(RpcException.Type.WRONG_PARAMETER, "wrong parameter in role, not exists role with this name " + roleName);
+			}
+
+			return cz.metacentrum.perun.core.api.AuthzResolver.getAdminGroups(ac.getSession(),
+							parms.readInt("complementaryObjectId"),
+							parms.readString("complementaryObjectName"),
+							role);
+		}
+	},
 
 	/*#
 	 * Set role for user or authorized group and complementary object or objects
@@ -39,6 +92,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 	setRole {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
 			//get role by name
 			String roleName = parms.readString("role");
 			Role role;
@@ -59,7 +113,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 					cz.metacentrum.perun.core.api.AuthzResolver.setRole(ac.getSession(),
 								ac.getUserById(parms.readInt("user")),
 								role,
-								parms.readListPerunBeans("complementaryObjects[]"));
+								parms.readListPerunBeans("complementaryObjects"));
 					return null;
 				} else {
 					throw new RpcException(RpcException.Type.MISSING_VALUE, "list of complementary objects or complementary object");
@@ -75,7 +129,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 					cz.metacentrum.perun.core.api.AuthzResolver.setRole(ac.getSession(),
 								ac.getGroupById(parms.readInt("authorizedGroup")),
 								role,
-								parms.readListPerunBeans("complementaryObjects[]"));
+								parms.readListPerunBeans("complementaryObjects"));
 					return null;
 				} else {
 					throw new RpcException(RpcException.Type.MISSING_VALUE, "list of complementary objects or complementary object");
@@ -99,6 +153,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 	unsetRole {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
 			//get role by name
 			String roleName = parms.readString("role");
 			Role role;
@@ -119,7 +174,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 					cz.metacentrum.perun.core.api.AuthzResolver.unsetRole(ac.getSession(),
 								ac.getUserById(parms.readInt("user")),
 								role,
-								parms.readListPerunBeans("complementaryObjects[]"));
+								parms.readListPerunBeans("complementaryObjects"));
 					return null;
 				} else {
 					throw new RpcException(RpcException.Type.MISSING_VALUE, "list of complementary objects or complementary object");
@@ -135,7 +190,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 					cz.metacentrum.perun.core.api.AuthzResolver.unsetRole(ac.getSession(),
 								ac.getGroupById(parms.readInt("authorizedGroup")),
 								role,
-								parms.readListPerunBeans("complementaryObjects[]"));
+								parms.readListPerunBeans("complementaryObjects"));
 					return null;
 				} else {
 					throw new RpcException(RpcException.Type.MISSING_VALUE, "list of complementary objects or complementary object");

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -563,7 +563,22 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Get list of all user administrators for supported role and given facility.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: FacilityAdmin
+	 *
+	 * @param perunSession
+	 * @param facility
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given facility for supported role
+	 */
+	/*#
 	 * Get all Facility admins.
+	 *
+	 * !!! DEPRECATED version !!!
 	 *
 	 * @param facility int Facility ID
 	 * @return List<User> List of Users who are admins in the facility.
@@ -573,17 +588,26 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
-			return ac.getFacilitiesManager().getAdmins(ac.getSession(),
+			if(parms.contains("onlyDirectAdmins")) {
+				return ac.getFacilitiesManager().getAdmins(ac.getSession(),
+					ac.getFacilityById(parms.readInt("facility")),
+					parms.readInt("onlyDirectAdmins") ==1);
+			} else {
+				return ac.getFacilitiesManager().getAdmins(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")));
+			}
 		}
 	},
 
 	/*#
 	 * Get all Facility direct admins.
 	 *
+	 * !!! DEPRECATED version !!!
+	 *
 	 * @param facility int Facility ID
 	 * @return List<User> list of admins of the facility
 	 */
+	@Deprecated
 	getDirectAdmins {
 
 		@Override
@@ -611,8 +635,26 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Get list of all richUser administrators for the facility and supported role with specific attributes.
+	 *
+	 * Supported roles: FacilityAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param group
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the facility and supported role with attributes
+	 */
+	/*#
     * Get all Facility admins as RichUsers
     *
+		* !!! DEPRECATED version !!!
+		*
     * @param facility int Facility ID
     * @return List<RichUser> admins
     */
@@ -621,17 +663,28 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
-			return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
+			if(parms.contains("onlyDirectAdmins")) {
+				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
+					ac.getFacilityById(parms.readInt("facility")),
+					parms.readList("specificAttributes", String.class),
+					parms.readInt("allUserAttributes") ==1,
+					parms.readInt("onlyDirectAdmins") ==1);
+			} else {
+				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")));
+			}
 		}
 	},
 
 	/*#
 	* Get all Facility admins as RichUsers with all their non-null user attributes
 	*
+	* !!! DEPRECATED version !!!
+	*
 	* @param facility int Facility ID
 	* @return List<RichUser> admins with attributes
 	*/
+	@Deprecated
 	getRichAdminsWithAttributes {
 
 		@Override
@@ -645,10 +698,13 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	/*#
 	* Get all Facility admins as RichUsers with specific attributes (from user namespace)
 	*
+	* !!! DEPRECATED version !!!
+	*
 	* @param facility int Facility ID
 	* @param specificAttributes List<String> list of attributes URNs
 	* @return List<RichUser> admins with attributes
 	*/
+	@Deprecated
 	getRichAdminsWithSpecificAttributes {
 
 		@Override
@@ -664,10 +720,13 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	* Get all Facility admins, which are assigned directly,
 	* as RichUsers with specific attributes (from user namespace)
 	*
+	* !!! DEPRECATED version !!!
+	*
 	* @param facility int Facility ID
 	* @param specificAttributes List<String> list of attributes URNs
 	* @return List<RichUser> direct admins with attributes
 	*/
+	@Deprecated
 	getDirectRichAdminsWithSpecificAttributes {
 
 		@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -382,7 +382,22 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Get list of all user administrators for supported role and specific group.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: GroupAdmin
+	 *
+	 * @param perunSession
+	 * @param group
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given group for supported role
+	 */
+	/*#
 	 * Returns administrators of a group.
+	 *
+	 * !!! DEPRECATED version !!!
 	 *
 	 * @param group int Group ID
 	 * @return List<User> Group admins
@@ -391,17 +406,26 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getGroupsManager().getAdmins(ac.getSession(),
+			if(parms.contains("onlyDirectAdmins")) {
+				return ac.getGroupsManager().getAdmins(ac.getSession(),
+					ac.getGroupById(parms.readInt("group")),
+					parms.readInt("onlyDirectAdmins") == 1);
+			} else {
+				return ac.getGroupsManager().getAdmins(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")));
+			}
 		}
 	},
 
 	/*#
 	 * Returns direct administrators of a group.
 	 *
+	 * !!! DEPRECATED version !!!
+	 *
 	 * @param group int Group ID
 	 * @return List<User> Group admins
 	 */
+	@Deprecated
 	getDirectAdmins {
 
 		@Override
@@ -427,7 +451,26 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Get list of all richUser administrators for the group and supported role with specific attributes.
+	 *
+	 * Supported roles: GroupAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param group
+	 *
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the group and supported role with attributes
+	 */
+	/*#
 	* Get all Group admins as RichUsers
+	*
+	* !!! DEPRECATED version !!!
 	*
 	* @param group int Group ID
 	* @return List<RichUser> admins
@@ -436,17 +479,28 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getGroupsManager().getRichAdmins(ac.getSession(),
+			if(parms.contains("onlyDirectAdmins")) {
+				return ac.getGroupsManager().getRichAdmins(ac.getSession(),
+								ac.getGroupById(parms.readInt("group")),
+								parms.readList("specificAttribtues", String.class),
+								parms.readInt("allUserAttributes") == 1,
+								parms.readInt("onlyDirectAdmins") == 1);
+			} else {
+				return ac.getGroupsManager().getRichAdmins(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")));
+			}
 		}
 	},
 
 	/*#
 	* Get all Group admins as RichUsers with all their non-null user attributes
 	*
+	* !!! DEPRECATED version !!!
+	*
 	* @param group int Group ID
 	* @return List<RichUser> admins with attributes
 	*/
+	@Deprecated
 	getRichAdminsWithAttributes {
 
 		@Override
@@ -459,10 +513,13 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	/*#
 	* Get all Group admins as RichUsers with specific attributes (from user namespace)
 	*
+	* !!! DEPRECATED version !!!
+	*
 	* @param group int Group ID
 	* @param specificAttributes List<String> list of attributes URNs
 	* @return List<RichUser> admins with attributes
 	*/
+	@Deprecated
 	getRichAdminsWithSpecificAttributes {
 
 		@Override
@@ -478,10 +535,13 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	* Get all Group admins, which are assigned directly,
 	*  as RichUsers with specific attributes (from user namespace)
 	*
+	* !!! DEPRECATED version !!!
+	*
 	* @param group int Group ID
 	* @param specificAttributes List<String> list of attributes URNs
 	* @return List<RichUser> direct admins with attributes
 	*/
+	@Deprecated
 	getDirectRichAdminsWithSpecificAttributes {
 
 		@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -200,27 +200,60 @@ public enum VosManagerMethod implements ManagerMethod {
 		}
 	},
 
+
+	/*#
+	 * Get list of all user administrators for supported role and specific vo.
+	 *
+	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * @param perunSession
+	 * @param vo
+	 * @param role supported role
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of all user administrators of the given vo for supported role
+	 */
 	/*#
 	 * Returns administrators of a VO.
+	 *
+	 * !!! DEPRECATED version !!!
 	 *
 	 * @param vo int VO ID
 	 * @return List<User> VO admins
 	 */
 	getAdmins {
 		@Override
-		public List<User> call(ApiCaller ac, Deserializer parms)
-				throws PerunException {
-			return ac.getVosManager().getAdmins(ac.getSession(),
+		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if(parms.contains("role")) {
+				String roleName = parms.readString("role");
+				Role role;
+				try {
+					role = Role.valueOf(roleName);
+				} catch (IllegalArgumentException ex) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "wrong parameter in role, not exists role with this name " + roleName);
+				}
+
+				return ac.getVosManager().getAdmins(ac.getSession(),
+					ac.getVoById(parms.readInt("vo")),
+					role, parms.readInt("onlyDirectAdmins") == 1);
+			} else {
+				return ac.getVosManager().getAdmins(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")));
+			}
 		}
 	},
 
 	/*#
 	 * Returns direct administrators of a VO.
 	 *
+	 * !!! DEPRECATED version !!!
+	 *
 	 * @param vo int VO ID
 	 * @return List<User> VO admins
 	 */
+	@Deprecated
 	getDirectAdmins {
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms)
@@ -231,40 +264,102 @@ public enum VosManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Get list of group administrators of the given VO.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * @param perunSession
+	 * @param vo
+	 * @param role
+	 *
+	 * @return List of groups, who are administrators of the Vo with supported role. Returns empty list if there is no VO group admin.
+	 */
+	/*#
 	 * Returns group administrators of a VO.
+	 *
+	 * !!! DEPRECATED version !!!
 	 *
 	 * @param vo int VO ID
 	 * @return List<User> VO admins
 	 */
 	getAdminGroups {
 		@Override
-		public List<Group> call(ApiCaller ac, Deserializer parms)
-				throws PerunException {
-			return ac.getVosManager().getAdminGroups(ac.getSession(),
+		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if(parms.contains("role")) {
+				String roleName = parms.readString("role");
+				Role role;
+				try {
+					role = Role.valueOf(roleName);
+				} catch (IllegalArgumentException ex) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "wrong parameter in role, not exists role with this name " + roleName);
+				}
+
+				return ac.getVosManager().getAdminGroups(ac.getSession(),
+					ac.getVoById(parms.readInt("vo")), role);
+			} else {
+				return ac.getVosManager().getAdminGroups(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")));
+			}
 		}
 	},
 
 	/*#
+	 * Get list of all richUser administrators for the vo and supported role with specific attributes.
+	 *
+	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
+	 *
+	 * If "onlyDirectAdmins" is "true", return only direct users of the vo for supported role with specific attributes.
+	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 *
+	 * @param perunSession
+	 * @param vo
+	 *
+	 * @param specificAttributes list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 *
+	 * @return list of RichUser administrators for the vo and supported role with attributes
+	 */
+	/*#
 	 * Returns administrators of a VO.
+	 *
+	 * !!! DEPRECATED version !!!
 	 *
 	 * @param vo int VO ID
 	 * @return List<RichUser> VO admins
 	 */
 	getRichAdmins {
 		@Override
-		public List<RichUser> call(ApiCaller ac, Deserializer parms)
-				throws PerunException {
-			return ac.getVosManager().getRichAdmins(ac.getSession(),
+		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if(parms.contains("role")) {
+				String roleName = parms.readString("role");
+				Role role;
+				try {
+					role = Role.valueOf(roleName);
+				} catch (IllegalArgumentException ex) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER, "wrong parameter in role, not exists role with this name " + roleName);
+				}
+
+				return ac.getVosManager().getRichAdmins(ac.getSession(),
+					ac.getVoById(parms.readInt("vo")),
+					role, parms.readList("specificAttributes", String.class),
+					parms.readInt("allUserAttributes") == 1,
+					parms.readInt("onlyDirectAdmins") == 1);
+			} else {
+				return ac.getVosManager().getRichAdmins(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")));
+			}
 		}
 	},
 	/*#
 	 * Returns administrators of a VO with additional information.
 	 *
+	 * !!! DEPRECATED version !!!
+	 *
 	 * @param vo int VO ID
 	 * @return List<RichUser> VO admins
 	 */
+	@Deprecated
 	getRichAdminsWithAttributes {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms)
@@ -277,10 +372,13 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns administrators of a VO with additional information.
 	 *
+	 * !!! DEPRECATED version !!!
+	 *
 	 * @param vo int VO ID
 	 * @param specificAttributes List<String> list of attributes URNs
 	 * @return List<RichUser> VO rich admins with attributes
 	 */
+	@Deprecated
 	getRichAdminsWithSpecificAttributes {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
@@ -295,10 +393,13 @@ public enum VosManagerMethod implements ManagerMethod {
 	 * Returns administrators of a VO, which are directly assigned
 	 * with additional information.
 	 *
+	 * !!! DEPRECATED version !!!
+	 *
 	 * @param vo int VO ID
 	 * @param specificAttributes List<String> list of attributes URNs
 	 * @return List<RichUser> VO rich admins with attributes
 	 */
+	@Deprecated
 	getDirectRichAdminsWithSpecificAttributes {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {


### PR DESCRIPTION
IMPORTANT changes:
 - create new methods in Facilities, Groups and Vos managers for getting
   admins, richAdmins and authorizedGroups
 - deprecated set for all old methods in Facilities, Groups and Vos
   managers
 - add methods for working with othe than voadmin role to Vos Manager
   Impl (VoObserver and TopGroupCreator)
 - create new methods in AuthzResolver for uniform workflow with getting
   admins
  - method getRichAdmins
  - method getAdminGroups
 - create two new exceptions needed for working with admins and their
   roles
 - add all new methods to RPC
 - deprecated set for all these old methods in RPC because of too many
   methods for the same workflow with only minor differencies

Less Important changes:
 - remove some not used Imports in modified files