### PR TITLE
Fix javadoc in rpc - AuthzResolver method manager

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -26,12 +26,15 @@ public enum AuthzResolverMethod implements ManagerMethod {
 		}
 	},
 
-	/*# Set role for user or authorized group and complementary object or objects
+	/*#
+	 * Set role for user or authorized group and complementary object or objects
 	 *
 	 * If some complementary object is wrong for the role, throw an exception.
 	 * For role "perunadmin" ignore complementary object.
 	 *
 	 * IMPORTANT: refresh authz only if user in session is affected
+	 *
+	 * @return void
 	 */
 	setRole {
 		@Override
@@ -83,12 +86,15 @@ public enum AuthzResolverMethod implements ManagerMethod {
 		}
 	},
 
-	/*# Unset role for user or authorized group and complementary object or objects
+	/*#
+	 * Unset role for user or authorized group and complementary object or objects
 	 *
 	 * If some complementary object is wrong for the role, throw an exception.
 	 * For role "perunadmin" ignore complementary object.
 	 *
 	 * IMPORTANT: refresh authz only if user in session is affected
+	 *
+	 * @return void
 	 */
 	unsetRole {
 		@Override


### PR DESCRIPTION
- problem with parsing javadoc where text of javadoc is on the same row
  like chars for start of javadoc "/*#"
- move text on the next row
