### PR TITLE
Fix file with table order

### DIFF
--- a/perun-db/table_order
+++ b/perun-db/table_order
@@ -66,10 +66,10 @@ service_principals
 reserved_logins
 pn_audit_message
 pn_object
-pn_pool_message
-pn_receiver
 pn_regex
 pn_template
+pn_receiver
+pn_pool_message
 pn_template_message
 pn_template_regex
 pn_regex_object


### PR DESCRIPTION
- bad order, pn_receiver must be in order after pn_template, because of
  template_id in pn_receiver table
- bad order, pn_pool_message must be in order after pn_template,
  because of template_id in pn_pool_message table
