### PR TITLE
GUI: url encode only twice for consolidator link

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -71,8 +71,8 @@ public class Utils {
 		if (value != null && !value.isEmpty()) {
 
 			if (target) {
-				// FIXME - ENCODE QUERY STRING 3 TIMES BECAUSE OF CONSOLIDATOR APP
-				value += "?target_url=" + Window.Location.getProtocol() + "//" + Window.Location.getHost() + Window.Location.getPath() +  URL.encodeQueryString(URL.encodeQueryString(URL.encodeQueryString(Window.Location.getQueryString())));
+				// FIXME - ENCODE QUERY STRING 2 TIMES BECAUSE OF CONSOLIDATOR APP
+				value += "?target_url=" + Window.Location.getProtocol() + "//" + Window.Location.getHost() + Window.Location.getPath() +  URL.encodeQueryString(URL.encodeQueryString(Window.Location.getQueryString()));
 			}
 			return value;
 
@@ -104,8 +104,8 @@ public class Utils {
 			}
 
 			if (target) {
-				// FIXME - ENCODE QUERY STRING 3 TIMES BECAUSE OF CONSOLIDATOR APP
-				link += "?target_url=" + Window.Location.getProtocol() + "//" + Window.Location.getHost() + Window.Location.getPath() +  URL.encodeQueryString(URL.encodeQueryString(URL.encodeQueryString(Window.Location.getQueryString())));
+				// FIXME - ENCODE QUERY STRING 2 TIMES BECAUSE OF CONSOLIDATOR APP
+				link += "?target_url=" + Window.Location.getProtocol() + "//" + Window.Location.getHost() + Window.Location.getPath() +  URL.encodeQueryString(URL.encodeQueryString(Window.Location.getQueryString()));
 			}
 
 			return link;
@@ -131,8 +131,8 @@ public class Utils {
 		if (value != null && !value.isEmpty()) {
 
 			if (target) {
-				// FIXME - ENCODE QUERY STRING 3 TIMES BECAUSE OF CONSOLIDATOR APP
-				value += "?target_url=" + Window.Location.getProtocol() + "//" + Window.Location.getHost() + Window.Location.getPath() +  URL.encodeQueryString(URL.encodeQueryString(URL.encodeQueryString(Window.Location.getQueryString())));
+				// FIXME - ENCODE QUERY STRING 2 TIMES BECAUSE OF CONSOLIDATOR APP
+				value += "?target_url=" + Window.Location.getProtocol() + "//" + Window.Location.getHost() + Window.Location.getPath() +  URL.encodeQueryString(URL.encodeQueryString(Window.Location.getQueryString()));
 			}
 			return value;
 
@@ -159,8 +159,8 @@ public class Utils {
 			}
 
 			if (target) {
-				// FIXME - ENCODE QUERY STRING 3 TIMES BECAUSE OF CONSOLIDATOR APP
-				link += "?target_url=" + Window.Location.getProtocol() + "//" + Window.Location.getHost() + Window.Location.getPath() +  URL.encodeQueryString(URL.encodeQueryString(URL.encodeQueryString(Window.Location.getQueryString())));
+				// FIXME - ENCODE QUERY STRING 2 TIMES BECAUSE OF CONSOLIDATOR APP
+				link += "?target_url=" + Window.Location.getProtocol() + "//" + Window.Location.getHost() + Window.Location.getPath() + URL.encodeQueryString(URL.encodeQueryString(Window.Location.getQueryString()));
 			}
 
 			return link;


### PR DESCRIPTION
- Hovering above return link (button) show decoded value
  in a browser, but url used by it is still encoded.
  So use encoding only twice for identity consolidator link.
