### PR TITLE
REGISTRAR, CORE: fixed parsing common name

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -451,12 +451,12 @@ public class Utils {
 				lastName = rawName.trim();
 			} else {
 				Matcher matcher = patternForCommonNameParsing.matcher(rawName);
-				matcher.find();
-
-				titleBefore = matcher.group(1).trim();
-				firstName = matcher.group(3);
-				lastName = matcher.group(4);
-				titleAfter = matcher.group(5);
+				if (matcher.find()) {
+					titleBefore = matcher.group(1).trim();
+					firstName = matcher.group(3);
+					lastName = matcher.group(4);
+					titleAfter = matcher.group(5);
+				}
 			}
 		} catch (Exception ex) {
 			throw new InternalErrorException("Problem with parsing of rawName='" + rawName + "'", ex);

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
@@ -210,20 +210,23 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 					name = item.getValue();
 					// use parsed name to drop mistakes on IDP side
 					try {
-						Map<String, String> nameMap = Utils.parseCommonName(name);
-						// drop name titles to spread search
-						String newName = "";
-						if (nameMap.get("firstName") != null
-								&& !nameMap.get("firstName").isEmpty()) {
-							newName += nameMap.get("firstName") + " ";
-						}
-						if (nameMap.get("lastName") != null
-								&& !nameMap.get("lastName").isEmpty()) {
-							newName += nameMap.get("lastName");
-						}
-						// fill parsed name instead of input
-						if (newName != null && !newName.isEmpty()) {
-							name = newName;
+						if (name != null && !name.isEmpty()) {
+							// parse only valid input
+							Map<String, String> nameMap = Utils.parseCommonName(name);
+							// drop name titles to spread search
+							String newName = "";
+							if (nameMap.get("firstName") != null
+									&& !nameMap.get("firstName").isEmpty()) {
+								newName += nameMap.get("firstName") + " ";
+							}
+							if (nameMap.get("lastName") != null
+									&& !nameMap.get("lastName").isEmpty()) {
+								newName += nameMap.get("lastName");
+							}
+							// fill parsed name instead of input
+							if (newName != null && !newName.isEmpty()) {
+								name = newName;
+							}
 						}
 					} catch (Exception ex) {
 						log.error("[REGISTRAR] Unable to parse new user's display/common name when searching for similar users. Exception: {}", ex);


### PR DESCRIPTION
CORE
- Parse parts of common name only if matcher.find() returns true.
- This cause method to return map with "namePart"=null on no match
  instead of throwing an exception.

REGISTRAR
- Added checks to call parseCommonName() only on non-empty and != null input.
