### PR TITLE
SERVICES: Fixed ldap service for dc base

### DIFF
--- a/perun-services/gen/ldap
+++ b/perun-services/gen/ldap
@@ -10,7 +10,7 @@ sub processGroupMembership;
 
 local $::SERVICE_NAME = "ldap";
 local $::PROTOCOL_VERSION = "3.0.0";
-my $SCRIPT_VERSION = "3.0.1";
+my $SCRIPT_VERSION = "3.0.2";
 
 perunServicesInit::init;
 my $DIRECTORY = perunServicesInit::getDirectory;
@@ -124,6 +124,8 @@ if ($facilityAttributes{$A_F_BASE_DN} =~ m/^dc=/) {
 		$dc = substr $facilityAttributes{$A_F_BASE_DN}, 3, $position-3;
 	}
 	print FILE "dc: " . $dc . "\n";
+	print FILE "objectclass: top\n";
+	print FILE "objectclass: domain\n";  # we need at least one structural class
 	print FILE "objectclass: dcObject\n";
 }
 # IF base start with ou=[something]

--- a/perun-services/slave/process-ldap.sh
+++ b/perun-services/slave/process-ldap.sh
@@ -30,7 +30,7 @@ function process {
 	BASE_DN=`head -n 1 "${WORK_DIR}/baseDN"`
 
 	# list only entries that service should manage
-	LDAP_FILTER="(&(|(objectclass=organizationalunit)(objectclass=perunEduroamUser))(!(ou=authz))(!(ou=users))(!(ou=policies))(!(ou=groups)))"
+	LDAP_FILTER="(&(|(objectclass=organizationalunit)(objectclass=perunEduroamUser)(objectclass=dcObject))(!(ou=authz))(!(ou=users))(!(ou=policies))(!(ou=groups)))"
 
 	# Create lock
 	create_lock


### PR DESCRIPTION
- When dc object is base of perun entries, we must add it
  at least one structural class (domain).
- When getting current ldap state, load also dc object using
  filter on objectclass=dcObject.
