### PR TITLE
REGISTRAR: removed usage of vo/group appFormUrl attribute

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -1485,7 +1485,10 @@ public class MailManagerImpl implements MailManager {
 
 		// replace invitation link
 		if (mailText.contains("{invitationLink}")) {
-			mailText = mailText.replace("{invitationLink}", buildInviteURL(vo, group, isMember, getPerunUrl(vo, group)));
+			String url = getPerunUrl(vo, group);
+			if (!url.endsWith("/")) url += "/";
+			url += "registrar/";
+			mailText = mailText.replace("{invitationLink}", buildInviteURL(vo, group, isMember, url));
 		}
 		if (mailText.contains("{invitationLinkFed}")) {
 			mailText = mailText.replace("{invitationLinkFed}", buildInviteURL(vo, group, isMember, getPropertyFromConfiguration("registrarGuiFed")));
@@ -1526,7 +1529,7 @@ public class MailManagerImpl implements MailManager {
 
 					if (url != null && !url.isEmpty()) {
 						if (!url.endsWith("/")) url += "/";
-						url += namespace + "/";
+						url += namespace + "/registrar/";
 						newValue = buildInviteURL(vo, group, isMember, url);
 					}
 


### PR DESCRIPTION
- Removed usage of appFormUrl attribute for {invitationLink[Authz]} tag.
  Value is taken from perun configuration. For custom URLs now
  can be used new attribute registrarURL and {invitationLink} tag.
