### PR TITLE
Remove keystore/trustore settings from XMLExtSource

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -339,7 +339,7 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 	private InputStream createTwoWaySSLConnection(String uri) throws IOException, InternalErrorException {
 		if(uri == null || uri.isEmpty()) throw new InternalErrorException("Uri must be filled, can't be null or empty.");
 		
-		//KeyStore data
+		/*//KeyStore data
 		String keyStore =  getAttributes().get("keyStore");
 		String keyStorePass = getAttributes().get("keyStorePass");
 		String keyStoreType = getAttributes().get("keyStoreType");
@@ -363,7 +363,7 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 		System.setProperty("javax.net.ssl.trustStore", trustStore);
 		System.setProperty("javax.net.ssl.trustStorePassword", trustStorePass);
 		// register a https protocol handler  - this may be required for previous JDK versions
-		System.setProperty("java.protocol.handler.pkgs","com.sun.net.ssl.internal.www.protocol");
+		System.setProperty("java.protocol.handler.pkgs","com.sun.net.ssl.internal.www.protocol");*/
 
 		//prepare sslFactory
 		SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();


### PR DESCRIPTION
- because settings by System in java change variables at all not only
  on this place
- now all settings will be at script starting tomcat with perun
  application
