### PR TITLE
BEANS,CORE: removed SERVICE role

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Role.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Role.java
@@ -7,7 +7,6 @@ public enum Role {
 	GROUPADMIN ("groupadmin"),
 	SELF ("self"),
 	FACILITYADMIN ("facilityadmin"),
-	SERVICE	("service"),
 	SYNCHRONIZER ("synchronizer"),
 	REGISTRAR ("registrar"),
 	ENGINE ("engine"),

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -191,7 +191,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		}
 
 		// Engine and Service can read attributes
-		if ((sess.getPerunPrincipal().getRoles().hasRole(Role.ENGINE) || sess.getPerunPrincipal().getRoles().hasRole(Role.SERVICE)) && actionType.equals(ActionType.READ)) {
+		if (sess.getPerunPrincipal().getRoles().hasRole(Role.ENGINE) && actionType.equals(ActionType.READ)) {
 			return true;
 		}
 
@@ -224,7 +224,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				throw new InternalErrorException("There is unrecognized object in primaryHolder.");
 			}
 		} else {
-			throw new InternalErrorException("Aiding attribtue must have perunBean which is not null.");
+			throw new InternalErrorException("Adding attribute must have perunBean which is not null.");
 		}
 
 		//Get object for secondaryHolder
@@ -1236,12 +1236,6 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		if (sess.getPerunPrincipal().getActor().equals(perunRpcAdmin)) {
 			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.RPC);
 			log.trace("AuthzResolver.init: Perun RPC {} loaded", perunRpcAdmin);
-		}
-
-		List<String> perunServiceAdmins = new ArrayList<String>(Arrays.asList(Utils.getPropertyFromConfiguration("perun.service.principals").split("[ \t]*,[ \t]*")));
-		if (perunServiceAdmins.contains(sess.getPerunPrincipal().getActor())) {
-			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.SERVICE);
-			log.trace("AuthzResolver.init: Perun Service {} loaded", perunServiceAdmins);
 		}
 
 		List<String> perunEngineAdmins = new ArrayList<String>(Arrays.asList(Utils.getPropertyFromConfiguration("perun.engine.principals").split("[ \t]*,[ \t]*")));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -87,7 +87,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE) &&
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.RPC)) {
 			throw new PrivilegeException(sess, "getFacilityById");
 				}
@@ -103,7 +103,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE) &&
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.RPC)) {
 			throw new PrivilegeException(sess, "getFacilityByName");
 				}
@@ -137,7 +137,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		List<Facility> facilities = getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SERVICE) &&
+		if (!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.RPC)) {
 			throw new PrivilegeException(sess, "getFacilitiesByDestination");
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -167,7 +167,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, resource) &&
 				!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, resource) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getFacility");
 				}
 
@@ -197,7 +197,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getVo");
 				}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -109,7 +109,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE) &&
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.RPC)) {
 			throw new PrivilegeException(sess, "getServiceById");
 				}
@@ -123,7 +123,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getServiceByName");
 				}
 
@@ -176,7 +176,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getHierarchicalData");
 		}
 
@@ -190,7 +190,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getFlatData");
 		}
 
@@ -204,7 +204,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getDataWithGroups");
 		}
 
@@ -218,7 +218,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getDataWithVos");
 		}
 
@@ -536,7 +536,7 @@ public class ServicesManagerEntry implements ServicesManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getDestinationById");
 				}
 
@@ -550,7 +550,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOADMIN) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getDestinations");
 				}
 
@@ -579,7 +579,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility) &&
 				!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN) &&
 				!AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER) &&
-				!AuthzResolver.isAuthorized(perunSession, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(perunSession, Role.ENGINE)) {
 			throw new PrivilegeException(perunSession, "getAllRichDestinations");
 				}
 
@@ -604,7 +604,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility) &&
 				!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN) &&
 				!AuthzResolver.isAuthorized(perunSession, Role.VOOBSERVER) &&
-				!AuthzResolver.isAuthorized(perunSession, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(perunSession, Role.ENGINE)) {
 			throw new PrivilegeException(perunSession, "getRichDestinations");
 				}
 
@@ -654,10 +654,9 @@ public class ServicesManagerEntry implements ServicesManager {
 
 		//Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility) &&
-		    !AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getAssignedServices");
-				}
+		}
 
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -68,7 +68,7 @@ public class UsersManagerEntry implements UsersManager {
 		if(!AuthzResolver.isAuthorized(sess, Role.VOADMIN) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER) &&
 				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE) &&
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.SELF, user) &&
 				!AuthzResolver.isAuthorized(sess, Role.RPC)) {
 			throw new PrivilegeException(sess, "getUserById");
@@ -353,7 +353,7 @@ public class UsersManagerEntry implements UsersManager {
 		if(!AuthzResolver.isAuthorized(sess, Role.VOADMIN) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER) &&
 				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE) &&
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.RPC) &&
 				!AuthzResolver.isAuthorized(sess, Role.SELF, user)) {
 			throw new PrivilegeException(sess, "getUserExtSources");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -179,9 +179,9 @@ public class VosManagerEntry implements VosManager {
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.TOPGROUPCREATOR, vo) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE)) {
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getVoByShortName");
-				}
+		}
 
 		return vo;
 	}
@@ -194,7 +194,7 @@ public class VosManagerEntry implements VosManager {
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo) &&
-				!AuthzResolver.isAuthorized(sess, Role.SERVICE) &&
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.RPC) &&
 				!AuthzResolver.isAuthorized(sess, Role.SELF)) {
 			throw new PrivilegeException(sess, "getVoById");

--- a/perun-core/src/main/resources/perun-beans.xml
+++ b/perun-core/src/main/resources/perun-beans.xml
@@ -293,7 +293,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
             <props>
             	<prop key="perun.admins">perunTests, perunController, perunEngine, perunRegistrar, perunSynchronizer, perunCabinet</prop>
                 <prop key="perun.grouper.toplevelstem">perunMeta</prop>
-                <prop key="perun.service.principals">perunv3/engine@META</prop>
                 <prop key="perun.engine.principals">perunv3/engine@META</prop>
                 <prop key="perun.synchronizer.principals">perunSynchronizer</prop>
                 <prop key="perun.registrar.principals">perunv3-registrar@META</prop>

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -253,7 +253,6 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 		assertTrue( ! AuthzResolver.isAuthorized(sess1, Role.FACILITYADMIN, createdVo));
 		assertTrue( ! AuthzResolver.isAuthorized(sess1, Role.GROUPADMIN, createdVo));
-		assertTrue( ! AuthzResolver.isAuthorized(sess1, Role.SERVICE, createdVo));
 		assertTrue( ! AuthzResolver.isAuthorized(sess1, Role.SELF, createdVo));
 		assertTrue( ! AuthzResolver.isAuthorized(sess1, Role.PERUNADMIN, createdVo));
 	}


### PR DESCRIPTION
- Removed all usage of SERVICE role in Perun.
- In authorization is role replaced by ENGINE role.

IMPORTANT: Before applying this, role must be removed from all users 
(should be only shongo-system user and engine (in perun.properties))
and also removed from DB itself.
