### PR TITLE
New Synchronizer workflow

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/ParserException.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/ParserException.java
@@ -1,0 +1,43 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+
+/**
+ * This exception raises when some parsing problem occur (regex, matcher, pattern, etc.)
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
+public class ParserException extends InternalErrorException {
+	static final long serialVersionUID = 0;
+	private String parsedValue;
+
+	public ParserException(String message) {
+		super(message);
+	}
+	
+	public ParserException(String message, String parsedValue) {
+		super(message);
+		this.parsedValue = parsedValue;
+	}
+
+	public ParserException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ParserException(String message, Throwable cause, String parsedValue) {
+		super(message, cause);
+		this.parsedValue = parsedValue;
+	}
+
+	public ParserException(Throwable cause) {
+		super(cause);
+	}
+
+	public ParserException(Throwable cause, String parsedValue) {
+		super(cause);
+		this.parsedValue = parsedValue;
+	}
+
+	public String getParsedValue() {
+		return parsedValue;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -65,8 +65,10 @@ public interface MembersManager {
 	 * @throws VoNotExistsException  the vo not exist in perun yet
 	 * @throws PrivilegeException
 	 * @throws UserNotExistsException some user from the list not exists
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 */
-	Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, PrivilegeException, UserNotExistsException;
+	Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, PrivilegeException, UserNotExistsException;
 
 	/**
 	 * Creates a new member and sets all member's attributes from the candidate.
@@ -84,8 +86,10 @@ public interface MembersManager {
 	 * @throws AlreadyMemberException
 	 * @throws VoNotExistsException
 	 * @throws PrivilegeException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 */
-	Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, String login, Candidate candidate) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, PrivilegeException;
+	Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, String login, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, PrivilegeException;
 
 	/**
 	 * Creates a new member and sets all member's attributes from the candidate.
@@ -104,8 +108,10 @@ public interface MembersManager {
 	 * @throws AlreadyMemberException
 	 * @throws VoNotExistsException
 	 * @throws PrivilegeException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 */
-	Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int extSourceLoa, String login, Candidate candidate) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, PrivilegeException;
+	Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int extSourceLoa, String login, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, PrivilegeException;
 
 	/**
 	 * Creates a new member from candidate returned by the method VosManager.findCandidates which fills Candidate.userExtSource.
@@ -119,8 +125,10 @@ public interface MembersManager {
 	 * @throws AlreadyMemberException
 	 * @throws VoNotExistsException
 	 * @throws PrivilegeException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 */
-	Member createMember(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, PrivilegeException;
+	Member createMember(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, PrivilegeException;
 
 	/**
 	 * Creates a new member from user.
@@ -136,7 +144,7 @@ public interface MembersManager {
 	 * @throws VoNotExistsException
 	 * @throws PrivilegeException
 	 */
-	Member createMember(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, UserNotExistsException, PrivilegeException;
+	Member createMember(PerunSession sess, Vo vo, User user) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, UserNotExistsException, PrivilegeException;
 
 	/**
 	 * Find member of this Vo by his login in external source

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -712,16 +712,19 @@ public interface GroupsManagerBl {
 
 	/**
 	 * Synchronizes the group with the external group without checking if the synchronization is already in progress.
+	 * If some members from extSource of this group were skipped, return info about them.
+	 * if not, return empty string instead, which means all members was successfully load from extSource.
 	 *
 	 * @param sess
 	 * @param group
+	 * @return List of strings with skipped users with reasons why were skipped
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws WrongAttributeAssignmentException
 	 * @throws MemberAlreadyRemovedException if there is at least one member who need to be deleted, but DB returns 0 affected rows
 	 */
-	void synchronizeGroup(PerunSession sess, Group group) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, MemberAlreadyRemovedException;
+	List<String> synchronizeGroup(PerunSession sess, Group group) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, MemberAlreadyRemovedException;
 
 	/**
 	 * Synchronize the group with external group. It checks if the synchronization of the same group is already in progress.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -64,9 +64,11 @@ public interface MembersManagerBl {
 	 * @param serviceUserOwners list of users who own serviceUser (can't be empty or contain service user)
 	 * @return newly created member (of service User)
 	 * @throws InternalErrorException if serviceUserOwners is empty or if unexpected exception occur
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 * @throws AlreadyMemberException
 	 */
-	Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, AlreadyMemberException;
+	Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException;
 
 	/**
 	 * Creates a new member and sets all member's attributes from the candidate.
@@ -82,9 +84,11 @@ public interface MembersManagerBl {
 	 * @param login user's login within extSource
 	 * @return newly created member, who has set all his/her attributes
 	 * @throws InternalErrorException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 * @throws AlreadyMemberException
 	 */
-	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, String login, Candidate candidate) throws InternalErrorException, AlreadyMemberException;
+	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, String login, Candidate candidate) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException, AlreadyMemberException;
 
 	/**
 	 * Creates a new member and sets all member's attributes from the candidate.
@@ -101,8 +105,10 @@ public interface MembersManagerBl {
 	 * @return newly created member, who has set all his/her attributes
 	 * @throws InternalErrorException
 	 * @throws AlreadyMemberException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 */
-	Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int extSourceLoa, String login, Candidate candidate) throws InternalErrorException, AlreadyMemberException;
+	Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int extSourceLoa, String login, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException;
 
 	/**
 	 * Creates a new member from candidate returned by the method VosManager.findCandidates which fills Candidate.userExtSource.
@@ -114,9 +120,11 @@ public interface MembersManagerBl {
 	 * @return newly created members
 	 * @throws InternalErrorException
 	 * @throws AlreadyMemberException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 * @see cz.metacentrum.perun.core.bl.MembersManagerBl#createMember(PerunSession, Vo, boolean, Candidate)
 	 */
-	Member createMember(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, AlreadyMemberException;
+	Member createMember(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException;
 
 	/**
 	 * Creates a new member from candidate returned by the method VosManager.findCandidates which fills Candidate.userExtSource.
@@ -129,9 +137,11 @@ public interface MembersManagerBl {
 	 * @return newly created members
 	 * @throws InternalErrorException
 	 * @throws AlreadyMemberException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 * @see cz.metacentrum.perun.core.bl.MembersManagerBl#createMember(PerunSession, Vo, Candidate)
 	 */
-	Member createMember(PerunSession sess, Vo vo, boolean serviceUser, Candidate candidate) throws InternalErrorException, AlreadyMemberException;
+	Member createMember(PerunSession sess, Vo vo, boolean serviceUser, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException;
 
 	/**
 	 * Creates Service Member.
@@ -139,13 +149,13 @@ public interface MembersManagerBl {
 	 *
 	 * @see cz.metacentrum.perun.core.bl.MembersManagerBl#createServiceMember(PerunSession, Vo, Candidate, List<User>)
 	 */
-	Member createServiceMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, AlreadyMemberException;
+	Member createServiceMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException;
 
 	/**
 	 * Creates member. Runs synchronously.
 	 * @see cz.metacentrum.perun.core.bl.MembersManagerBl#createMember(PerunSession, Vo, boolean, Candidate)
 	 */
-	Member createMemberSync(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, AlreadyMemberException;
+	Member createMemberSync(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException;
 
 	/**
 	 * Creates a new member from user.
@@ -157,8 +167,10 @@ public interface MembersManagerBl {
 	 * @return newly created member
 	 * @throws InternalErrorException
 	 * @throws AlreadyMemberException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
 	 */
-	Member createMember(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyMemberException;
+	Member createMember(PerunSession sess, Vo vo, User user) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException;
 
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -202,7 +202,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return member;
 	}
 
-	public Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, AlreadyMemberException {
+	public Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException {
 		candidate.setFirstName("(Service)");
 		Member member = createMember(sess, vo, true, candidate);
 		member.getUserId();
@@ -217,7 +217,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return member;
 	}
 
-	public Member createMemberSync(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, AlreadyMemberException {
+	public Member createMemberSync(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException {
 		Member member = createMember(sess, vo, false, candidate);
 
 		//Validate synchronously
@@ -230,7 +230,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return member;
 	}
 
-	public Member createServiceMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, AlreadyMemberException {
+	public Member createServiceMemberSync(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException {
 		Member member = createServiceMember(sess, vo, candidate, serviceUserOwners);
 
 		//Validate synchronously
@@ -243,11 +243,11 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return member;
 	}
 
-	public Member createMember(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, AlreadyMemberException {
+	public Member createMember(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException {
 		return createMember(sess, vo, false, candidate);
 	}
 
-	public Member createMember(PerunSession sess, Vo vo, boolean serviceUser, Candidate candidate) throws InternalErrorException, AlreadyMemberException {
+	public Member createMember(PerunSession sess, Vo vo, boolean serviceUser, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException {
 		log.debug("Creating member for VO {} from candidate {}", vo, candidate);
 
 		// Get the user
@@ -346,13 +346,8 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		try {
 			getPerunBl().getAttributesManagerBl().setAttributes(sess, member, membersAttributes);
 			getPerunBl().getAttributesManagerBl().mergeAttributesValues(sess, user, usersAttributes);
-
-		} catch (WrongAttributeValueException e) {
-			throw new ConsistencyErrorException(e); //Member is not valid, so he couldn't have truly required atributes, neither he couldn't have influence on user attributes
 		} catch (WrongAttributeAssignmentException e) {
 			throw new InternalErrorException(e);
-		} catch (WrongReferenceAttributeValueException e) {
-			throw new ConsistencyErrorException(e); //Member is not valid, so he couldn't have truly required atributes, neither he couldn't have influence on user attributes
 		}
 
 		// Set the initial membershipExpiration
@@ -371,7 +366,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	 * This method with support of LoA finally has to call this.createMember(PerunSession sess, Vo vo, UserExtSource userExtSource)
 	 * @see cz.metacentrum.perun.core.api.MembersManager#createMember(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.Vo, java.lang.String, java.lang.String, java.lang.String, cz.metacentrum.perun.core.api.Candidate)
 	 */
-	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int loa, String login, Candidate candidate) throws InternalErrorException, AlreadyMemberException {
+	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int loa, String login, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException {
 		// Create ExtSource object
 		ExtSource extSource = new ExtSource();
 		extSource.setName(extSourceName);
@@ -393,7 +388,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	 * This method finally has to call this.createMember(PerunSession sess, Vo vo, UserExtSource userExtSource)
 	 * @see cz.metacentrum.perun.core.api.MembersManager#createMember(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.Vo, java.lang.String, java.lang.String, java.lang.String, cz.metacentrum.perun.core.api.Candidate)
 	 */
-	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, String login, Candidate candidate) throws InternalErrorException, AlreadyMemberException {
+	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, String login, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException {
 		// Create ExtSource object
 		ExtSource extSource = new ExtSource();
 		extSource.setName(extSourceName);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -87,7 +87,7 @@ public class MembersManagerEntry implements MembersManager {
 		getMembersManagerBl().deleteAllMembers(sess, vo);
 	}
 
-	public Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, PrivilegeException, UserNotExistsException {
+	public Member createServiceMember(PerunSession sess, Vo vo, Candidate candidate, List<User> serviceUserOwners) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, PrivilegeException, UserNotExistsException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -105,7 +105,7 @@ public class MembersManagerEntry implements MembersManager {
 		return getMembersManagerBl().createServiceMember(sess, vo, candidate, serviceUserOwners);
 	}
 
-	public Member createMember(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, PrivilegeException {
+	public Member createMember(PerunSession sess, Vo vo, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -119,7 +119,7 @@ public class MembersManagerEntry implements MembersManager {
 		return getMembersManagerBl().createMember(sess, vo, candidate);
 	}
 
-	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, String login, Candidate candidate) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, PrivilegeException {
+	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, String login, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		//TODO Authorization
@@ -131,7 +131,7 @@ public class MembersManagerEntry implements MembersManager {
 		return getMembersManagerBl().createMember(sess, vo, extSourceName, extSourceType, login, candidate);
 	}
 
-	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int extSourceLoa, String login, Candidate candidate) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, PrivilegeException {
+	public Member createMember(PerunSession sess, Vo vo, String extSourceName, String extSourceType, int extSourceLoa, String login, Candidate candidate) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, AlreadyMemberException, VoNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		//TODO Authorization
@@ -143,7 +143,7 @@ public class MembersManagerEntry implements MembersManager {
 		return getMembersManagerBl().createMember(sess, vo, extSourceName, extSourceType, extSourceLoa, login, candidate);
 	}
 
-	public Member createMember(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyMemberException, VoNotExistsException, UserNotExistsException, PrivilegeException{
+	public Member createMember(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyMemberException, WrongAttributeValueException, WrongReferenceAttributeValueException, VoNotExistsException, UserNotExistsException, PrivilegeException{
 		Utils.checkPerunSession(sess);
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo)) {


### PR DESCRIPTION
- synchronizer will synchronize only those extSource members with
  correct informations and attributes
- method getCandidate from extSource and login will change firstName
  and lastName on null if in not correct format
- methods createMember\* will throw WrongAttributeValueException and
  WrongReferenceAttributeValueException instead of consistency
  exception, because this is not the same
- new ParserException created for parser errors in Perun
- method synchronizeGroup will return String with info about skipped
  members and the reason why were skipped
- method synchronizeGroups will set exception to attribute for this
  purpose to inform user about skipped extSource's members
- when some problem occurs (like parserException,
  attributeValueException, candidateNotExistsException) in
  synchronization, member of extSource which create this exception will
  be skipped and information about this skipping will be add to
  attribute with info about last synchronization of group
