### PR TITLE
Add new reserved logins and unix group names

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -215,12 +215,23 @@ public interface ModulesUtilsBl {
 	 * Check if value of groupName attribute is not reserved String.
 	 * If not, its ok.
 	 * If yes, throw WrongAttributeValueException.
-	 * If attribute is null, then its ok.
+	 * If attribute is null, then it's ok.
 	 *
 	 * @param groupName attribute unixGroupName-namespace
 	 * @throws WrongAttributeValueException
 	 */
-	void checkReservedNames(Attribute groupName) throws WrongAttributeValueException;
+	void checkReservedUnixGroupNames(Attribute groupNameAttribute) throws WrongAttributeValueException;
+
+	/**
+	 * Check if value of login attribute is unpermitted.
+	 * If not, its ok.
+	 * If yes, throw WrongAttributeValueException.
+	 * If attribute is null, then it's ok.
+	 * 
+	 * @param login attribute login-namespace
+	 * @throws WrongAttributeValueException 
+	 */
+	void checkUnpermittedUserLogins(Attribute loginAttribute) throws WrongAttributeValueException;
 
 	/**
 	 * Get value of attribute A_F_Def_unixGroupName-Namespace

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -49,10 +49,17 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	public static final String A_F_unixGroupName_namespace = AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGroupName-namespace";
 	private static final String A_E_usedGids = AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":usedGids";
 
-	public final static List<String> reservedNamesForUnixGroups = Arrays.asList("root", "daemon", "tty", "bin", "sys", "sudo", "nogroup");
+	public final static List<String> reservedNamesForUnixGroups = Arrays.asList("root", "daemon", "tty", "bin", "sys", "sudo", "nogroup",
+	          "hadoop", "hdfs", "mapred", "yarn", "hsqldb", "derby", "jetty", "hbase", "zookeeper", "users");
+	public final static List<String> unpermittedNamesForUserLogins = Arrays.asList("arraysvcs", "at", "backup", "bin", "daemon", "Debian-exim", "flexlm", "ftp", "games",
+		        "gdm", "glite", "gnats", "haldaemon", "identd", "irc", "libuuid", "list", "lp", "mail", "man",
+		        "messagebus", "news", "nobody", "ntp", "openslp", "pcp", "polkituser", "postfix", "proxy",
+		        "pulse", "puppet", "root", "saned", "smmsp", "smmta", "sshd", "statd", "suse-ncc", "sync",
+		        "sys", "uucp", "uuidd", "www-data", "wwwrun", "zenssh", "oneadmin", "tomcat6", "tomcat7", "tomcat8",
+		        "nn", "dn", "rm", "nm", "sn", "jn", "jhs", "http", "yarn", "hdfs", "mapred", "hadoop", "hsqldb", "derby",
+		        "jetty", "hbase", "zookeeper", "hive", "hue");
 
 	public ModulesUtilsBlImpl() {
-
 	}
 
 	public boolean isNamespaceEqualsToFacilityUnixGroupNameNamespace(PerunSessionImpl sess, Facility facility, String namespace) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException{
@@ -473,9 +480,14 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		return groupNameNamespaces;
 	}
 
-	public void checkReservedNames(Attribute groupName) throws WrongAttributeValueException {
-		if(groupName == null) return;
-		if(reservedNamesForUnixGroups.contains(groupName.getValue())) throw new WrongAttributeValueException(groupName, "This groupName is reserved.");
+	public void checkReservedUnixGroupNames(Attribute groupNameAttribute) throws WrongAttributeValueException {
+		if(groupNameAttribute == null) return;
+		if(reservedNamesForUnixGroups.contains(groupNameAttribute.getValue())) throw new WrongAttributeValueException(groupNameAttribute, "This groupName is reserved.");
+	}
+
+	public void checkUnpermittedUserLogins(Attribute loginAttribute) throws WrongAttributeValueException {
+		if(loginAttribute == null) return;
+		if(unpermittedNamesForUserLogins.contains(loginAttribute.getValue())) throw new WrongAttributeValueException(loginAttribute, "This login is not permitted.");
 	}
 
 	public Attribute getUnixGroupNameNamespaceAttributeWithNotNullValue(PerunSessionImpl sess, Resource resource) throws InternalErrorException, WrongReferenceAttributeValueException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGroupName_namespace.java
@@ -44,6 +44,9 @@ public class urn_perun_group_attribute_def_def_unixGroupName_namespace extends G
 			throw new WrongAttributeValueException(attribute,"GroupName attributte content invalid characters. Allowed are only letters, numbers and characters _ and -.");
 		}
 
+		//Check reserved unix group names
+		sess.getPerunBl().getModulesUtilsBl().checkReservedUnixGroupNames(attribute);
+
 		try {
 			//prepare attributes group and resource unixGroupName
 			Attribute groupUnixGroupName = attribute;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespace.java
@@ -34,8 +34,6 @@ public class urn_perun_resource_attribute_def_def_unixGroupName_namespace extend
 	private static final String A_R_unixGID_namespace = AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace";
 	private static final String A_G_unixGroupName_namespace = AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace";
 
-	final List<String> reservedNames = Arrays.asList("root", "daemon", "tty", "bin", "sys", "sudo", "nogroup");
-
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
 		//prepare namespace and groupName value variables
@@ -49,6 +47,9 @@ public class urn_perun_resource_attribute_def_def_unixGroupName_namespace extend
 		}else if(!groupName.matches("^[-_.a-zA-Z0-9]+$")){
 			throw new WrongAttributeValueException(attribute,"GroupName attributte content invalid characters. Allowed are only letters, numbers and characters _ and -.");
 		}
+
+		//Check reserved unix group names
+		sess.getPerunBl().getModulesUtilsBl().checkReservedUnixGroupNames(attribute);
 
 		try {
 			//prepare attributes group and resource unixGroupName

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
@@ -37,19 +37,12 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 	 */
 	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
 
-		String[] unpermittedLogins = {"arraysvcs", "at", "backup", "bin", "daemon", "Debian-exim", "flexlm", "ftp", "games",
-		        "gdm", "glite", "gnats", "haldaemon", "identd", "irc", "libuuid", "list", "lp", "mail", "man",
-		        "messagebus", "news", "nobody", "ntp", "openslp", "pcp", "polkituser", "postfix", "proxy",
-		        "pulse", "puppet", "root", "saned", "smmsp", "smmta", "sshd", "statd", "suse-ncc", "sync",
-		        "sys", "uucp", "uuidd", "www-data", "wwwrun", "zenssh", "oneadmin", "tomcat6", "tomcat7", "tomcat8"};
-
 		String userLogin = (String) attribute.getValue();
 		if (userLogin == null) throw new WrongAttributeValueException(attribute, user, "Value can't be nugll");
 		if(!userLogin.matches("^[a-zA-Z0-9][-A-z0-9_.@/]*$")) throw new WrongAttributeValueException(attribute, user, "Wrong format. ^[A-z0-9][-A-z0-9_.@/]*$ expected.");
 
-		for(String login: unpermittedLogins) {
-			if(userLogin.equals(login)) throw new WrongAttributeValueException(attribute, user, "Unpermitted login.");
-		}
+		//Check if user login is permitted or unpermitted
+		sess.getPerunBl().getModulesUtilsBl().checkUnpermittedUserLogins(attribute);
 
 		// Get all users who have set attribute urn:perun:member:attribute-def:def:login-namespace:[login-namespace], with the value.
 		List<User> usersWithSameLogin = sess.getPerunBl().getUsersManagerBl().getUsersByAttribute(sess, attribute);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -423,13 +423,13 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		Attribute attr = new Attribute();
 		attr.setValue(goodName);
 
-		modulesUtilsBl.checkReservedNames(attr);
+		modulesUtilsBl.checkReservedUnixGroupNames(attr);
 
 		attr.setValue(badName);
 		boolean ok = false;
 
 		try {
-			modulesUtilsBl.checkReservedNames(attr);
+			modulesUtilsBl.checkReservedUnixGroupNames(attr);
 			ok = false;
 		} catch (WrongAttributeValueException ex) {
 			ok = true;


### PR DESCRIPTION
- add new unpermitted logins and move them to ModulesUtilsBlImpl
- add new reserved unix group names to ModulesUtilsBlImpl and remove
  duplicit variable from unixGroupName-namespace module
- create method checkUnpermittedUserLogins which try if login attribute
  is permitted or not
- rename method checkReservedUnixGroupNames
- use checking of reserved unix group names in unixGroupName modules
