### PR TITLE
Fix of typo in synchronize

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1430,7 +1430,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 					for(String skippedMember: skippedMembers) {
 						exceptionMessage+= skippedMember + ", ";
 					}
-					exceptionMessage = " }";
+					exceptionMessage+= " }";
 				}
 
 				log.debug("Synchronization thread for group {} has finished in {} ms.", group, System.currentTimeMillis()-startTime);


### PR DESCRIPTION
- fix of type when concating strings (need to use += instead of =)
