### PR TITLE
Allow engine to read assigned resources

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -392,6 +392,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group) &&
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, group) &&
 				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
 			throw new PrivilegeException(sess, "getAssignedResources");
@@ -514,6 +515,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN) && !AuthzResolver.isAuthorized(sess, Role.VOADMIN, member)
+				&& !AuthzResolver.isAuthorized(sess, Role.ENGINE)
 				&& !AuthzResolver.isAuthorized(sess, Role.SELF, member) && !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, member)) {
 			throw new PrivilegeException(sess, "getAllowedResources");
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -162,7 +162,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN) && !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN) && !AuthzResolver.isAuthorized(sess, Role.ENGINE) && !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER)) {
 
 			throw new PrivilegeException(sess, "getAssignedResources");
 		}


### PR DESCRIPTION
Add engine to the list of roles allowed to call getAssignedResources() and getAllowedResources() in ResourcesManager and ServicesManager
