### PR TITLE
New ExtSourceApi and optimization for extSources

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ExtSourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ExtSourcesManager.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.impl.Utils;
+import java.util.Map;
 
 /**
  * @author Michal Prochazka <michalp@ics.muni.cz>
@@ -197,6 +198,24 @@ public interface ExtSourcesManager {
 	 * @throws ExtSourceUnsupportedOperationException
 	 */
 	Candidate getCandidate(PerunSession perunSession, ExtSource source, String login) throws InternalErrorException, PrivilegeException, ExtSourceNotExistsException, CandidateNotExistsException,ExtSourceUnsupportedOperationException;
+
+	/**
+	 * Get the candidate from subjectData where at least login must exists.
+	 *
+	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
+	 *
+	 * @param perunSession
+	 * @param subjectData
+	 * @param source
+	 *
+	 * @return a Candidate object
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws ExtSourceNotExistsException
+	 * @throws CandidateNotExistsException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	Candidate getCandidate(PerunSession perunSession, Map<String,String> subjectData, ExtSource source) throws InternalErrorException, PrivilegeException, ExtSourceNotExistsException, CandidateNotExistsException,ExtSourceUnsupportedOperationException;
 
 	/**
 	 * Loads ext source definitions from the configuration file and updates entries stored in the DB.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import java.util.Map;
 
 /**
  * @author Michal Prochazka <michalp@ics.muni.cz>
@@ -163,6 +164,24 @@ public interface ExtSourcesManagerBl {
 	 * @throws ExtSourceUnsupportedOperationException
 	 */
 	Candidate getCandidate(PerunSession perunSession, ExtSource source, String login) throws InternalErrorException, ExtSourceNotExistsException, CandidateNotExistsException,ExtSourceUnsupportedOperationException;
+
+	/**
+	 * Get the candidate from subjectData where at least login must exists.
+	 *
+	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
+	 *
+	 * @param perunSession
+	 * @param subjectData
+	 * @param source
+	 * @param login
+	 *
+	 * @return a Candidate object
+	 * @throws InternalErrorException
+	 * @throws ExtSourceNotExistsException
+	 * @throws CandidateNotExistsException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	Candidate getCandidate(PerunSession perunSession, Map<String,String> subjectData ,ExtSource source, String login) throws InternalErrorException, ExtSourceNotExistsException, CandidateNotExistsException,ExtSourceUnsupportedOperationException;
 
 	void checkExtSourceExists(PerunSession sess, ExtSource extSource) throws InternalErrorException, ExtSourceNotExistsException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import cz.metacentrum.perun.core.bl.GroupsManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import cz.metacentrum.perun.core.implApi.GroupsManagerImplApi;
 import java.util.Comparator;
 import java.util.Date;
@@ -862,7 +862,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			// Get the subjects from the external group
 			List<Map<String, String>> subjects;
 			try {
-				subjects = ((ExtSourceApi) source).getGroupSubjects(attributes);
+				subjects = ((ExtSourceSimpleApi) source).getGroupSubjects(attributes);
 				log.debug("Group synchronization {}: external group contains {} members.", group, subjects.size());
 			} catch (ExtSourceUnsupportedOperationException e2) {
 				throw new InternalErrorException("ExtSrouce " + source.getName() + " doesn't support getGroupSubjects", e2);
@@ -1258,7 +1258,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		} finally {
 			if(membersSource != null) {
 				try {
-					((ExtSourceApi) membersSource).close();
+					((ExtSourceSimpleApi) membersSource).close();
 				} catch (ExtSourceUnsupportedOperationException e) {
 					// ExtSource doesn't support that functionality, so silently skip it.
 				} catch (InternalErrorException e) {
@@ -1267,7 +1267,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			}
 			if(source != null) {
 				try {
-					((ExtSourceApi) source).close();
+					((ExtSourceSimpleApi) source).close();
 				} catch (ExtSourceUnsupportedOperationException e) {
 					// ExtSource doesn't support that functionality, so silently skip it.
 				} catch (InternalErrorException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
@@ -28,6 +28,7 @@ import cz.metacentrum.perun.core.bl.ExtSourcesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.ExtSourcesManagerImplApi;
+import java.util.Map;
 
 /**
  * ExtSourcesManager entry logic.
@@ -236,5 +237,21 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		getExtSourcesManagerBl().checkExtSourceExists(sess, source);
 
 		return getExtSourcesManagerBl().getCandidate(sess, source, login);
+	}
+
+	@Override
+	public Candidate getCandidate(PerunSession perunSession, Map<String,String> subjectData, ExtSource source) throws InternalErrorException, PrivilegeException, ExtSourceNotExistsException, CandidateNotExistsException,ExtSourceUnsupportedOperationException {
+		Utils.checkPerunSession(perunSession);
+		Utils.notNull(subjectData, "subjectData");
+		Utils.notNull(subjectData.get("login"), "subjectLogin");
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(perunSession, Role.PERUNADMIN)) {
+			throw new PrivilegeException(perunSession, "getCandidate");
+		}
+
+		getExtSourcesManagerBl().checkExtSourceExists(perunSession, source);
+
+		return getExtSourcesManagerBl().getCandidate(perunSession, subjectData, source, subjectData.get("login"));
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -28,20 +28,20 @@ import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceISMU extends ExtSource implements ExtSourceApi {
+public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceISMU.class);
 
-	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
-	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
@@ -13,22 +13,22 @@ import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
  * Dummy ExtSource - IdP - Identity federation
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceIdp extends ExtSource implements ExtSourceApi {
+public class ExtSourceIdp extends ExtSource implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceIdp.class);
 
-	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		return findSubjects(searchString, 0);
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjectsLogins(searchString, 0);
 	}
 
-	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException,ExtSourceUnsupportedOperationException {
+	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException,ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
@@ -13,22 +13,22 @@ import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
  * Dummy ExtSource - Internal
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceInternal extends ExtSource implements ExtSourceApi {
+public class ExtSourceInternal extends ExtSource implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceInternal.class);
 
-	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		return findSubjects(searchString, 0);
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjectsLogins(searchString, 0);
 	}
 
-	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException,ExtSourceUnsupportedOperationException {
+	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException,ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
@@ -13,22 +13,22 @@ import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
  * Dummy ExtSource - Kerberos
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceKerberos extends ExtSource implements ExtSourceApi {
+public class ExtSourceKerberos extends ExtSource implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceKerberos.class);
 
-	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		return findSubjects(searchString, 0);
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjectsLogins(searchString, 0);
 	}
 
-	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -28,12 +28,12 @@ import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
+public class ExtSourceLdap extends ExtSource implements ExtSourceSimpleApi {
 	private Map<String, String> mapping;
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceLdap.class);
@@ -47,11 +47,11 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		return dirContext;
 	}
 
-	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException {
-		return findSubjects(searchString, 0);
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException {
+		return findSubjectsLogins(searchString, 0);
 	}
 
-	public List<Map<String,String>> findSubjects(String searchString, int maxResults) throws InternalErrorException {
+	public List<Map<String,String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException {
 		// Prepare searchQuery
 		// attributes.get("query") contains query template, e.g. (uid=?), ? will be replaced by the searchString
 		String query = (String) getAttributes().get("query");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -21,12 +21,12 @@ import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceSql extends ExtSource implements ExtSourceApi {
+public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceSql.class);
 	private static Map<String, String> attributeNameMapping;
@@ -50,11 +50,11 @@ public class ExtSourceSql extends ExtSource implements ExtSourceApi {
 		attributeNameMapping.put("d", ":attribute-def:def:");
 	}
 
-	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException {
-		return findSubjects(searchString, 0);
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException {
+		return findSubjectsLogins(searchString, 0);
 	}
 
-	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException {
+	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException {
 		String query = getAttributes().get("query");
 		if (query == null) {
 			throw new InternalErrorException("query attribute is required");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
@@ -13,22 +13,22 @@ import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
  * Dummy ExtSource - X.508
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceX509 extends ExtSource implements ExtSourceApi {
+public class ExtSourceX509 extends ExtSource implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceX509.class);
 
-	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		return findSubjects(searchString, 0);
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjectsLogins(searchString, 0);
 	}
 
-	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationExc
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import java.io.IOException;
 import javax.xml.xpath.XPathConstants;
 import java.util.HashMap;
@@ -54,12 +55,19 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 	//Pattern for looking replacement in regex string
 	private Pattern pattern = Pattern.compile("([^\\\\]|^)(\\\\\\\\)*\\/([^\\\\]|$)");
 
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjectsLogins(searchString, 0);
+	}
 
-	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException {
+	public List<Map<String,String>> findSubjectsLogins(String searchString, int maxResulsts) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("For XML is using this method not optimized, use findSubjects instead.");
+	}
+
+	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		return findSubjects(searchString, 0);
 	}
 
-	public List<Map<String,String>> findSubjects(String searchString, int maxResults) throws InternalErrorException {
+	public List<Map<String,String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		//prepare string for xpath (use concat for chars ' and  ")
 		searchString = convertToXpathSearchString(searchString);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceApi.java
@@ -1,63 +1,42 @@
 package cz.metacentrum.perun.core.implApi;
 
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import java.util.List;
 import java.util.Map;
 
-import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-
 /**
- * @author Michal Prochazka michalp@ics.muni.cz
+ * Definition of extSource api.
+ *
+ * This extSource can get information about all subjects with all attributes by
+ * one query.
+ *
+ * @author Michal Stava stavamichal@gmail.com
  */
-public interface ExtSourceApi {
+public interface ExtSourceApi extends ExtSourceSimpleApi {
+
 	/**
-	 * Finds all subjects in the external source, that contains searchString.
+	 * Finds all subjects with attributes in the external source, that contains searchString.
+	 *
+	 * This method is used for getting all logins of subjects in external source with all possible attributes.
 	 *
 	 * @param searchString
-	 * @return list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
+	 * @return list of maps, which contains attr_name-&gt;attr_value (for all extSource attributes)
 	 * @throws InternalErrorException
 	 * @throws ExtSourceUnsupportedOperationException
 	 */
 	List<Map<String, String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException;
 
 	/**
-	 * Finds all subjects in the external source, that contains searchString, limited by the maxResults
+	 * Finds all subjects with attributes in the external source, that contains searchString limited by the maxResults
+	 *
+	 * This method is used for getting all logins of subjects in external source with all possible attributes.
 	 *
 	 * @param searchString
-	 * @param maxResults limit returned results
-	 * @return list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
+	 * @param maxResults define max number of returned results, 0 means unlimited
+	 * @return list of maps, which contains attr_name-&gt;attr_value (for all extSource attributes)
 	 * @throws InternalErrorException
 	 * @throws ExtSourceUnsupportedOperationException
 	 */
 	List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException;
-
-	/**
-	 * Finds subject from the external source by the primary login used in external source.
-	 *
-	 * @param login login used in the external source
-	 * @return map which contains attr_name -&gt; attr_value, e.g. firstName-&gt;Michal
-	 * @throws InternalErrorException
-	 * @throws SubjectNotExistsException if the subject cannot be found
-	 * @throws ExtSourceUnsupportedOperationException
-	 */
-	Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException, ExtSourceUnsupportedOperationException;
-
-	/**
-	 * Get the list of the subjects in the external group.
-	 *
-	 * @param attributes map of attributes used for quering the external source
-	 * @return list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
-	 * @throws InternalErrorException
-	 * @throws ExtSourceUnsupportedOperationException
-	 */
-	List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException;
-
-	/**
-	 * If extSource needs to be closed, this method must be called.
-	 *
-	 * @throws InternalErrorException
-	 * @throws ExtSourceUnsupportedOperationException
-	 */
-	void close() throws InternalErrorException, ExtSourceUnsupportedOperationException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
@@ -1,0 +1,76 @@
+package cz.metacentrum.perun.core.implApi;
+
+import java.util.List;
+import java.util.Map;
+
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
+
+/**
+ * Definition of simple extSource api.
+ *
+ * Simple means: this extSource is not able to get all information about all subjects
+ * in one query. First need to get info about their logins and then for every login get
+ * info about subject from extSource.
+ *
+ * @author Michal Prochazka michalp@ics.muni.cz (extSourceApi)
+ * @author Michal Stava stavamichal@gmail.com (changed to ExtSourceSimpleApi)
+ */
+public interface ExtSourceSimpleApi {
+	/**
+	 * Finds all subjects logins in the external source, that contains searchString.
+	 *
+	 * This method is used for getting all logins of subjects in external source and then use them to searching
+	 * in external source for other subjects attributes.
+	 *
+	 * @param searchString
+	 * @return list of maps, which contains attr_name-&gt;attr_value but only for login definition eg. login;MichalS
+	 * @throws InternalErrorException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	List<Map<String, String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException;
+
+	/**
+	 * Finds all subjects logins in the external source, that contains searchString, limited by the maxResults.
+	 *
+	 * This method is used for getting all logins of subjects in external source and then use them to searching
+	 * in external source for other subjects attributes
+	 *
+	 * @param searchString
+	 * @param maxResults limit returned results
+	 * @return list of maps, which contains attr_name-&gt;attr_value but only for login definition eg. login;MichalS
+	 * @throws InternalErrorException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException;
+
+	/**
+	 * Finds subject from the external source by the primary login used in external source.
+	 *
+	 * @param login login used in the external source
+	 * @return map which contains attr_name -&gt; attr_value, e.g. firstName-&gt;Michal
+	 * @throws InternalErrorException
+	 * @throws SubjectNotExistsException if the subject cannot be found
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException, ExtSourceUnsupportedOperationException;
+
+	/**
+	 * Get the list of the subjects in the external group.
+	 *
+	 * @param attributes map of attributes used for quering the external source
+	 * @return list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
+	 * @throws InternalErrorException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException;
+
+	/**
+	 * If extSource needs to be closed, this method must be called.
+	 *
+	 * @throws InternalErrorException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	void close() throws InternalErrorException, ExtSourceUnsupportedOperationException;
+}


### PR DESCRIPTION
 - rename old ExtSourceApi to ExtSourceSimpleApi
 - rename old methods findSubjects to findSubjectsLogins and change
   javadoc for these methods
 - create new ExtSourceApi which extends ExtSourceApiImpl and define new
   methods findSubjects
 - all extSources implements ExtSourceSimpleApi except XMLExtSource
   which use ExtSourceApi because of better optimization when using
   method findSubjects instead of findSubjectsLogins
 - create new method getCandidate from extSource which need only
   prepared subject Data in Map structure and can create member without
   calling extSource again (in entry, api, bl and blimpl)
 - in method findCandidates change behavior depending on used extSource
   (simple or classic)
  - if ExtSourceSimple is used: use findSubjectsLogins method and for
    every subject get attributes by method getCandidate from extSource
  - if ExtSource is used: use findSubjects method and for every subject
    get attribtues by method getCandidate from subjectData (map with
    attributes)
  - for both now also test uniqness of logins (throw exception if some
    login is there more than once)