### PR TITLE
Fix PbsmonJson gen script

### DIFF
--- a/perun-services/gen/pbsmon_json
+++ b/perun-services/gen/pbsmon_json
@@ -96,7 +96,7 @@ foreach my $facility (@facilities) {
 for my $item (sort { $b->{"attributes"}->{$A_FACILITY_LISTING_PRIORITY} <=> $a->{"attributes"}->{$A_FACILITY_LISTING_PRIORITY} } @facilitesAndAttrbutes) {
 	my $facility = $item->{"facility"};
 	my $facilityAttributes = $item->{"attributes"};
-	my @voShortNames = keys $item->{"shortNames"};
+	my @voShortNames = keys %{$item->{"shortNames"}};
 	my @owners = $facilitiesAgent->getOwners(facility => $facility->getId);
 
 	my %facilityStruc;


### PR DESCRIPTION
- problem with getting keys from scalar reference on hash (for older
  version of perl)
- need to use derefenrencing from scalar to hash ( %{} )
