### PR TITLE
GUI: removed force federation authz for password reset

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/PerunWebConstants.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/PerunWebConstants.java
@@ -40,12 +40,6 @@ public interface PerunWebConstants extends Constants {
 	String perunRpcUrlKrb();
 
 	/**
-	 * Federation RPC URL for forceAuth
-	 * @return RPC URL string
-	 */
-	String perunRpcUrlForceAuthFed();
-
-	/**
 	 * Kerberos authz with EINFRA namespace
 	 *
 	 * @return RPC URL string

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/PerunWebSession.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/PerunWebSession.java
@@ -116,10 +116,8 @@ public class PerunWebSession {
 			rpcUrl = PerunWebConstants.INSTANCE.perunRpcUrlKrb();
 		}else if (rpcType.equals("fed")){
 			rpcUrl = PerunWebConstants.INSTANCE.perunRpcUrlFed();
-		}else if (rpcType.equals("cert")){
+		}else if (rpcType.equals("cert")) {
 			rpcUrl = PerunWebConstants.INSTANCE.perunRpcUrlCert();
-		}else if (rpcType.equals("forceAuthn-fed")){
-			rpcUrl = PerunWebConstants.INSTANCE.perunRpcUrlForceAuthFed();
 		}else if (rpcType.equals("einfra")){
 			rpcUrl = PerunWebConstants.INSTANCE.perunRpcUrlKrbEinfra();
 		}else{

--- a/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/client/PerunWebConstants.properties
+++ b/perun-web-gui/src/main/resources/devel/cz/metacentrum/perun/webgui/client/PerunWebConstants.properties
@@ -3,8 +3,6 @@ perunRpcUrlFed=/fed/rpc${gui.url.modifier}/jsonp/
 perunRpcUrlCert=/cert/rpc${gui.url.modifier}/jsonp/
 perunRpcUrlKrb=/krb/rpc${gui.url.modifier}/jsonp/
 perunRpcUrlKrbEinfra=/krb-einfra/rpc${gui.url.modifier}/jsonp/
-# devel doesn't use special url for password reset since it's fake anyway.
-perunRpcUrlForceAuthFed=
 pendingRequestsRefreshInterval=3000
 footerPerunLink=http://perun.cesnet.cz/web/
 footerPerunLicense=license

--- a/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/client/PerunWebConstants.properties
+++ b/perun-web-gui/src/main/resources/production/cz/metacentrum/perun/webgui/client/PerunWebConstants.properties
@@ -4,7 +4,6 @@ perunRpcUrlCert=/cert/rpc/jsonp/
 perunRpcUrlKrb=/krb/rpc/jsonp/
 # einfra is not used this way in production, but better still keep it
 perunRpcUrlKrbEinfra=/krb-einfra/rpc/jsonp/
-perunRpcUrlForceAuthFed=/fed-force/rpc/jsonp/
 pendingRequestsRefreshInterval=3000
 footerPerunLink=http://perun.cesnet.cz/web/
 footerPerunLicense=license

--- a/perun-web-gui/src/main/webapp/PasswordResetFed.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetFed.html
@@ -26,7 +26,7 @@
 
     <!--  RPC definition -->
     <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "forceAuthn-fed";
+        RPC_SERVER = "fed";
     </script>
 
     <!--  jQuery -->


### PR DESCRIPTION
- This feature is not supported in IdP and SP
  communication. Hence we can't force user to re-login.
  Using it in current scheme causes all requests to
  end on WAYF page (not respecting successful authz).
  
  Normal federated login is now used when accessing pwd-reset.
