### PR TITLE
CORE: use only group for authz in forceGroupSynchronization()

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -787,12 +787,10 @@ public class GroupsManagerEntry implements GroupsManager {
 					 Utils.checkPerunSession(sess);
 					 getGroupsManagerBl().checkGroupExists(sess, group);
 
-					 Vo vo = getGroupsManagerBl().getVo(sess, group);
-
 					 // Authorization
 					 if (!AuthzResolver.isAuthorized(sess, Role.SYNCHRONIZER)
-					    && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, vo)
-					    && !AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo))  {
+					    && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)
+					    && !AuthzResolver.isAuthorized(sess, Role.VOADMIN, group))  {
 						 throw new PrivilegeException(sess, "synchronizeGroup");
 					 }
 


### PR DESCRIPTION
- AuthzResolver can use Group for authorization, there is no need
  to load VO from DB. Also using VO and GROUPADMIN is too weak, since
  I could then trigger synchronization of not my group in same VO.
