### PR TITLE
DB: converted VARCHAR2 to NVARCHAR2

### DIFF
--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.14
+-- database version 3.1.15 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -11,12 +11,12 @@ connect perunv3
 
 create table vos (
 	id integer not null,
-	name varchar2(128) not null,
-	short_name varchar2(32) not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	name nvarchar2(128) not null,
+	short_name nvarchar2(32) not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -24,15 +24,15 @@ create table vos (
 
 create table users (
 	id integer not null,
-	first_name varchar2(64),
-	last_name varchar2(64),
-	middle_name varchar2(64),
-	title_before varchar2(20),
-	title_after varchar2(20),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	first_name nvarchar2(64),
+	last_name nvarchar2(64),
+	middle_name nvarchar2(64),
+	title_before nvarchar2(20),
+	title_after nvarchar2(20),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	service_acc char(1) default '0' not null,
 	created_by_uid integer,
@@ -41,21 +41,21 @@ create table users (
 
 create table owners (
 	id integer not null,
-	name varchar2(128) not null,
-	contact varchar2(100),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	name nvarchar2(128) not null,
+	contact nvarchar2(100),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
-	type varchar2(128) not null,
+	type nvarchar2(128) not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table cabinet_categories (
 	id integer not null,
-	name varchar2(128) not null,
+	name nvarchar2(128) not null,
 	rank number(38,1) not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -63,12 +63,12 @@ create table cabinet_categories (
 
 create table cabinet_publication_systems (
 	id integer not null,
-	friendlyName varchar2(128) not null,
-	url varchar2(128) not null,
-	username varchar2(64),
-	password varchar2(64),
-	loginNamespace varchar2(128) not null,
-	type varchar2(128) not null,
+	friendlyName nvarchar2(128) not null,
+	url nvarchar2(128) not null,
+	username nvarchar2(64),
+	password nvarchar2(64),
+	loginNamespace nvarchar2(128) not null,
+	type nvarchar2(128) not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -77,16 +77,16 @@ create table cabinet_publications (
 	id integer not null,
 	externalId integer not null,
 	publicationSystemId integer not null,
-	title varchar2(1024) not null,
+	title nvarchar2(1024) not null,
 	year integer not null,
-	main varchar2(4000),
-	isbn varchar2(32),
+	main nvarchar2(4000),
+	isbn nvarchar2(32),
 	categoryId integer not null,
-	createdBy varchar2(1024) default user not null,
+	createdBy nvarchar2(1024) default user not null,
 	createdDate date not null,
-	rank  number (38,1) default 0 not null,
-	doi varchar2(256),
-	locked varchar2(1) default 0 not null  ,
+	rank number (38,1) default 0 not null,
+	doi nvarchar2(256),
+	locked nvarchar2(1) default 0 not null ,
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -95,7 +95,7 @@ create table cabinet_authorships (
 	id integer not null,
 	publicationId integer not null,
 	userId integer not null,
-	createdBy varchar2(1024) default user not null,
+	createdBy nvarchar2(1024) default user not null,
 	createdDate date not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -105,7 +105,7 @@ create table cabinet_thanks (
 	id integer not null,
 	publicationid integer not null,
 	ownerId integer not null,
-	createdBy varchar2(1024) default user not null,
+	createdBy nvarchar2(1024) default user not null,
 	createdDate date not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -113,11 +113,11 @@ create table cabinet_thanks (
 
 create table facilities (
 	id integer not null,
-	name varchar2(128) not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	name nvarchar2(128) not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -126,12 +126,12 @@ create table facilities (
 create table resources (
 	id integer not null,
 	facility_id integer not null,
-	name varchar2(128) not null,
-	dsc varchar2(1024),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	name nvarchar2(128) not null,
+	dsc nvarchar2(1024),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	vo_id integer not null,
 	created_by_uid integer,
@@ -140,12 +140,12 @@ create table resources (
 
 create table destinations (
 	id integer not null,
-	destination varchar2(1024) not null,
-	type varchar2(20) not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	destination nvarchar2(1024) not null,
+	type nvarchar2(20) not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -153,11 +153,11 @@ create table destinations (
 
 create table facility_owners (
 	facility_id integer not null,
-	owner_id  integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	owner_id integer not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -165,13 +165,13 @@ create table facility_owners (
 
 create table groups (
 	id integer not null,
-	name varchar2(128) not null,
-	dsc varchar2(1024),
+	name nvarchar2(128) not null,
+	dsc nvarchar2(1024),
 	vo_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	parent_group_id integer,
 	created_by_uid integer,
@@ -182,10 +182,10 @@ create table members (
 	id integer not null,
 	user_id integer not null,
 	vo_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -193,24 +193,24 @@ create table members (
 
 create table routing_rules (
 	id integer not null,
-	routing_rule varchar2(512) not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	routing_rule nvarchar2(512) not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table dispatcher_settings (
-	ip_address varchar2(40) not null,
+	ip_address nvarchar2(40) not null,
 	port integer not null,
 	last_check_in date default (sysdate),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -218,13 +218,13 @@ create table dispatcher_settings (
 
 create table engines (
 	id integer not null,
-	ip_address varchar2(40) not null,
+	ip_address nvarchar2(40) not null,
 	port integer not null,
 	last_check_in date default (sysdate),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -233,10 +233,10 @@ create table engines (
 create table engine_routing_rule (
 	engine_id integer not null,
 	routing_rule_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -244,11 +244,11 @@ create table engine_routing_rule (
 
 create table processing_rules (
 	id integer not null,
-	processing_rule varchar2(1024) not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	processing_rule nvarchar2(1024) not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -256,39 +256,39 @@ create table processing_rules (
 
 create table roles (
 	id integer not null,
-	name varchar2 (32) not null,
+	name nvarchar2(32) not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table action_types (
 	id integer not null,
-	action_type varchar2(20) not null,
-	description varchar2(1024)
+	action_type nvarchar2(20) not null,
+	description nvarchar2(1024)
 );
 
 create table membership_types (
 	id integer not null,
-	membership_type varchar2(10) not null,
-	description varchar2(1024)
+	membership_type nvarchar2(10) not null,
+	description nvarchar2(1024)
 );
 
 create table attr_names (
 	id integer not null,
 	default_attr_id integer,
-	attr_name varchar2(384) not null,
-	friendly_name varchar2(128) not null,
-	namespace varchar2(256) not null,
-	type varchar2(256) not null,
-	dsc varchar2(1024),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_name nvarchar2(384) not null,
+	friendly_name nvarchar2(128) not null,
+	namespace nvarchar2(256) not null,
+	type nvarchar2(256) not null,
+	dsc nvarchar2(1024),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer,
-	display_name varchar2(256)
+	display_name nvarchar2(256)
 );
 
 create table attributes_authz (
@@ -314,13 +314,13 @@ create table authz (
 
 create table hosts (
 	id integer not null,
-	hostname varchar2(128) not null,
+	hostname nvarchar2(128) not null,
 	facility_id integer not null,
-	dsc varchar2(1024),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	dsc nvarchar2(1024),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -329,11 +329,11 @@ create table hosts (
 create table host_attr_values (
 	host_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -342,24 +342,24 @@ create table host_attr_values (
 
 create table auditer_consumers (
 	id integer not null,
-	name varchar2(256) not null,
+	name nvarchar2(256) not null,
 	last_processed_id integer,
 	created_at date default sysdate not null,
-	created_by varchar2(1024) default user not null,
-	modified_at  date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	created_by nvarchar2(1024) default user not null,
+	modified_at date default sysdate not null,
+	modified_by nvarchar2(1024) default user not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table services (
 	id integer not null,
-	name varchar2(128) not null,
+	name nvarchar2(128) not null,
 	owner_id integer,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -368,10 +368,10 @@ create table services (
 create table service_processing_rule (
 	service_id integer not null,
 	processing_rule_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -380,10 +380,10 @@ create table service_processing_rule (
 create table service_required_attrs (
 	service_id integer not null,
 	attr_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -404,12 +404,12 @@ create table exec_services (
 	default_delay integer not null,
 	enabled char(1) not null,
 	default_recurrence integer not null,
-	script varchar2(256) not null,
-	type varchar2(10) not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	script nvarchar2(256) not null,
+	type nvarchar2(10) not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -420,10 +420,10 @@ create table service_denials (
 	exec_service_id integer not null,
 	facility_id integer,
 	destination_id integer,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -432,23 +432,23 @@ create table service_denials (
 create table service_dependencies (
 	exec_service_id integer not null,
 	dependency_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer,
-	type varchar2(16) default 'SERVICE' not null
+	type nvarchar2(16) default 'SERVICE' not null
 );
 
 create table resource_services (
 	service_id integer not null,
 	resource_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -458,17 +458,17 @@ create table application (
 	id integer not null,
 	vo_id integer not null,
 	user_id integer,
-	apptype varchar2(128) not null,
-	extSourceName varchar2(4000),
-	extSourceType varchar2(4000),
-	fed_info varchar2(4000),
-	state varchar2(128),
+	apptype nvarchar2(128) not null,
+	extSourceName nvarchar2(4000),
+	extSourceType nvarchar2(4000),
+	fed_info nvarchar2(4000),
+	state nvarchar2(128),
 	extSourceLoa integer,
 	group_id integer,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -478,7 +478,7 @@ create table application_form (
 	vo_id integer not null,
 	automatic_approval char(1),
 	automatic_approval_extension char(1),
-	module_name varchar2(128),
+	module_name nvarchar2(128),
 	group_id integer,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -488,30 +488,30 @@ create table application_form_items (
 	id integer not null,
 	form_id integer not null,
 	ordnum integer not null,
-	shortname varchar2(128) not null,
+	shortname nvarchar2(128) not null,
 	required char(1),
-	type varchar2(128),
-	fed_attr varchar2(128),
-	dst_attr varchar2(384),
-	regex varchar2(4000),
+	type nvarchar2(128),
+	fed_attr nvarchar2(128),
+	dst_attr nvarchar2(384),
+	regex nvarchar2(4000),
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table application_form_item_apptypes (
 	item_id integer not null,
-	apptype varchar2(128) not null,
+	apptype nvarchar2(128) not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table application_form_item_texts (
 	item_id integer not null,
-	locale varchar2(128) not null,
-	label varchar2(4000),
-	options varchar2(4000),
-	help varchar2(4000),
-	error_message varchar2(4000),
+	locale nvarchar2(128) not null,
+	label nvarchar2(4000),
+	options nvarchar2(4000),
+	help nvarchar2(4000),
+	error_message nvarchar2(4000),
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -520,9 +520,9 @@ create table application_data (
 	id integer not null,
 	app_id integer not null,
 	item_id integer,
-	shortname varchar2(128),
-	value varchar2(4000 char),
-	assurance_level varchar2(128),
+	shortname nvarchar2(128),
+	value nvarchar2(4000),
+	assurance_level nvarchar2(128),
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -530,27 +530,27 @@ create table application_data (
 create table application_mails (
 	id integer not null,
 	form_id integer not null,
-	app_type varchar2(30) not null,
-	mail_type varchar2(30) not null,
-	send varchar2(1) not null,
+	app_type nvarchar2(30) not null,
+	mail_type nvarchar2(30) not null,
+	send nvarchar2(1) not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table application_mail_texts (
 	mail_id integer not null,
-	locale varchar2(10) not null,
-	subject varchar2(1024),
-	text varchar2(4000),
+	locale nvarchar2(10) not null,
+	subject nvarchar2(1024),
+	text nvarchar2(4000),
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table application_reserved_logins (
-	login varchar2(256) not null,
-	namespace varchar2(30) not null,
+	login nvarchar2(256) not null,
+	namespace nvarchar2(30) not null,
 	app_id integer not null,
-	created_by varchar2(1024) default user not null,
+	created_by nvarchar2(1024) default user not null,
 	created_at date default sysdate not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -560,24 +560,24 @@ create table facility_service_destinations (
 	service_id integer not null,
 	facility_id integer not null,
 	destination_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer,
-	propagation_type varchar2(10) default 'PARALLEL'
+	propagation_type nvarchar2(10) default 'PARALLEL'
 );
 
 create table entityless_attr_values (
-	subject varchar2(256) not null,
+	subject nvarchar2(256) not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -587,11 +587,11 @@ create table entityless_attr_values (
 create table facility_attr_values (
 	facility_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -601,11 +601,11 @@ create table facility_attr_values (
 create table group_attr_values (
 	group_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -615,11 +615,11 @@ create table group_attr_values (
 create table resource_attr_values (
 	resource_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -630,11 +630,11 @@ create table group_resource_attr_values (
 	group_id integer not null,
 	resource_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -644,10 +644,10 @@ create table group_resource_attr_values (
 create table groups_members (
 	group_id integer not null,
 	member_id integer not null,
-	created_at  date default sysdate not null,
-	created_by varchar2(1024) default user not null,
-	modified_at  date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
+	modified_at date default sysdate not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer,
@@ -658,10 +658,10 @@ create table groups_members (
 create table groups_resources (
 	group_id integer not null,
 	resource_id integer not null,
-	created_at  date default sysdate not null,
-	created_by varchar2(1024) default user not null,
-	modified_at  date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
+	modified_at date default sysdate not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -670,11 +670,11 @@ create table groups_resources (
 create table member_attr_values (
 	member_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -685,11 +685,11 @@ create table member_resource_attr_values (
 	member_id integer not null,
 	resource_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -699,11 +699,11 @@ create table member_resource_attr_values (
 create table user_attr_values (
 	user_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -714,11 +714,11 @@ create table user_facility_attr_values (
 	user_id integer not null,
 	facility_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -728,11 +728,11 @@ create table user_facility_attr_values (
 create table vo_attr_values (
 	vo_id integer not null,
 	attr_id integer not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	attr_value_text clob,
 	created_by_uid integer,
@@ -741,12 +741,12 @@ create table vo_attr_values (
 
 create table ext_sources (
 	id integer not null,
-	name varchar2(256) not null,
-	type varchar2(64),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	name nvarchar2(256) not null,
+	type nvarchar2(64),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -754,12 +754,12 @@ create table ext_sources (
 
 create table ext_sources_attributes (
 	ext_sources_id integer not null,
-	attr_name varchar2(128) not null,
-	attr_value varchar2(4000 char),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	attr_name nvarchar2(128) not null,
+	attr_value nvarchar2(4000),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -768,10 +768,10 @@ create table ext_sources_attributes (
 create table vo_ext_sources (
 	vo_id integer not null,
 	ext_sources_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -780,12 +780,12 @@ create table vo_ext_sources (
 create table user_ext_sources (
 	id integer not null,
 	user_id integer not null,
-	login_ext varchar2(256) not null,
+	login_ext nvarchar2(256) not null,
 	ext_sources_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	loa integer,
 	last_access date default sysdate not null,
@@ -795,12 +795,12 @@ create table user_ext_sources (
 
 create table service_packages (
 	id integer not null,
-	name varchar2(128) not null,
-	description varchar2(512),
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	name nvarchar2(128) not null,
+	description nvarchar2(512),
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -809,10 +809,10 @@ create table service_packages (
 create table service_service_packages (
 	service_id integer not null,
 	package_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -820,17 +820,17 @@ create table service_service_packages (
 
 create table tasks (
 	id integer not null,
-	exec_service_id  integer not null,
-	facility_id  integer not null,
+	exec_service_id integer not null,
+	facility_id integer not null,
 	schedule date not null,
 	recurrence integer not null,
 	delay integer not null,
-	status varchar2(16) not null,
+	status nvarchar2(16) not null,
 	start_time date,
 	end_time date,
 	engine_id integer not null,
-	created_at date  default sysdate not null,
-	err_message varchar2(4000),
+	created_at date default sysdate not null,
+	err_message nvarchar2(4000),
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -839,16 +839,16 @@ create table tasks_results (
 	id integer not null,
 	task_id integer not null,
 	destination_id integer not null,
-	status varchar2(16) not null,
-	err_message varchar2(4000),
-	std_message varchar2(4000),
+	status nvarchar2(16) not null,
+	err_message nvarchar2(4000),
+	std_message nvarchar2(4000),
 	return_code integer,
 	timestamp date,
 	engine_id integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -856,7 +856,7 @@ create table tasks_results (
 create table auditer_log (
 	id integer not null,
 	msg clob not null,
-	actor varchar2(256) not null,
+	actor nvarchar2(256) not null,
 	created_at date default sysdate not null ,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -865,22 +865,22 @@ create table auditer_log (
 
 create table service_principals (
 	id integer not null,
-	description varchar2(1024),
-	name varchar2(128) not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	description nvarchar2(1024),
+	name nvarchar2(128) not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table reserved_logins (
-	login varchar2(256),
-	namespace varchar2(128),
-	application varchar2(256),
-	id varchar2(1024),
+	login nvarchar2(256),
+	namespace nvarchar2(128),
+	application nvarchar2(256),
+	id nvarchar2(1024),
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -894,9 +894,9 @@ create table pn_audit_message (
 
 create table pn_object (
 	id integer NOT NULL,
-	name varchar2(256),
-	properties varchar2(4000),
-	class_name varchar2(512),
+	name nvarchar2(256),
+	properties nvarchar2(4000),
+	class_name nvarchar2(512),
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -905,39 +905,39 @@ create table pn_pool_message (
 	id integer NOT NULL,
 	regex_id integer NOT NULL,
 	template_id integer NOT NULL,
-	key_attributes varchar2(4000) NOT NULL,
+	key_attributes nvarchar2(4000) NOT NULL,
 	created date default sysdate NOT NULL,
-	notif_message varchar2(1000) NOT NULL,
+	notif_message nvarchar2(1000) NOT NULL,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table pn_receiver (
 	id integer NOT NULL,
-	target varchar2(256) NOT NULL,
-	type_of_receiver varchar2(256) NOT NULL,
+	target nvarchar2(256) NOT NULL,
+	type_of_receiver nvarchar2(256) NOT NULL,
 	template_id integer NOT NULL,
 	created_by_uid integer,
 	modified_by_uid integer,
-	locale varchar2(512)
+	locale nvarchar2(512)
 );
 
 create table pn_regex (
 	id integer NOT NULL,
-	note varchar2(256),
-	regex varchar2(4000) NOT NULL,
+	note nvarchar2(256),
+	regex nvarchar2(4000) NOT NULL,
 	created_by_uid integer,
 	modified_by_uid integer
 );
 
 create table pn_template (
 	id integer NOT NULL,
-	primary_properties varchar2(4000) NOT NULL,
-	notify_trigger varchar2(100),
+	primary_properties nvarchar2(4000) NOT NULL,
+	notify_trigger nvarchar2(100),
 	youngest_message_time integer,
 	oldest_message_time integer,
-	name varchar2(512),
-	sender varchar2(4000),
+	name nvarchar2(512),
+	sender nvarchar2(4000),
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -945,11 +945,11 @@ create table pn_template (
 create table pn_template_message (
 	id integer NOT NULL,
 	template_id integer NOT NULL,
-	locale varchar2(5) NOT NULL,
-	message varchar2(4000),
+	locale nvarchar2(5) NOT NULL,
+	message nvarchar2(4000),
 	created_by_uid integer,
 	modified_by_uid integer,
-	subject varchar2(512)
+	subject nvarchar2(512)
 );
 
 create table pn_template_regex (
@@ -972,20 +972,20 @@ create table groups_groups (
 	group_id integer not null,
 	parent_group_id integer not null,
 	group_mode integer not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null
+	modified_by nvarchar2(1024) default user not null
 );
 
 create table res_tags (
 	id integer not null,
 	vo_id integer not null,
-	tag_name varchar2 (1024) not null,
-	created_at date  default sysdate not null,
-	created_by varchar2(1024) default user not null,
+	tag_name nvarchar2(1024) not null,
+	created_at date default sysdate not null,
+	created_by nvarchar2(1024) default user not null,
 	modified_at date default sysdate not null,
-	modified_by varchar2(1024) default user not null,
+	modified_by nvarchar2(1024) default user not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -996,8 +996,8 @@ create table tags_resources (
 );
 
 create table configurations (
-	property varchar2(32) not null,
-	value varchar2(128) not null
+	property nvarchar2(32) not null,
+	value nvarchar2(128) not null
 );
 
 create table mailchange (
@@ -1011,7 +1011,7 @@ create table mailchange (
 
 create table pwdreset (
 	id integer not null,
-	namespace varchar2(512) not null,
+	namespace nvarchar2(512) not null,
 	user_id integer not null,
 	created_at date default sysdate not null,
 	created_by varchar(1024) default user not null,
@@ -1029,7 +1029,7 @@ create sequence GROUPS_ID_SEQ maxvalue 1.0000E+28;
 create sequence HOSTS_ID_SEQ maxvalue 1.0000E+28;
 create sequence MEMBERS_ID_SEQ maxvalue 1.0000E+28;
 create sequence OWNERS_ID_SEQ maxvalue 1.0000E+28;
-create sequence PROCESSING_RULES_ID_SEQ  maxvalue 1.0000E+28;
+create sequence PROCESSING_RULES_ID_SEQ maxvalue 1.0000E+28;
 create sequence RESOURCES_ID_SEQ maxvalue 1.0000E+28;
 create sequence ROUTING_RULES_ID_SEQ maxvalue 1.0000E+28;
 create sequence SERVICES_ID_SEQ maxvalue 1.0000E+28;
@@ -1506,29 +1506,29 @@ alter table reserved_logins add (
 constraint RESERVLOGINS_PK primary key (login,namespace)
 );
 
-alter table  pn_audit_message add (
+alter table pn_audit_message add (
 constraint PN_AUDMSG_PK primary key (id)
 );
 
-alter table  pn_object add (
+alter table pn_object add (
 constraint PN_OBJECT_PK primary key (id)
 );
 
-alter table  pn_template add (
+alter table pn_template add (
 constraint PN_TMPL_PK primary key (id)
 );
 
-alter table  pn_pool_message add (
+alter table pn_pool_message add (
 constraint PN_POOLMSG_PK primary key (id),
 constraint PN_POOLMSG_TMPL_FK foreign key (template_id) references pn_template(id)
 );
 
-alter table  pn_receiver add (
+alter table pn_receiver add (
 constraint PN_RECEIVER_PK primary key (id),
 constraint PN_RECEIVER_TMPL_FK foreign key (template_id) references pn_template(id)
 );
 
-alter table  pn_regex add (
+alter table pn_regex add (
 constraint PN_REGEX_PK primary key (id)
 );
 
@@ -1584,7 +1584,7 @@ constraint RESTAGS_VOS_FK foreign key (vo_id) references vos(id)
 alter table tags_resources add (
 constraint TAGS_RES_PK primary key (tag_id,resource_id),
 constraint TAGS_RES_TAGS_FK foreign key (tag_id) references res_tags(id),
-constraint TAGS_RES_RES_FK  foreign key (resource_id) references resources(id)
+constraint TAGS_RES_RES_FK foreign key (resource_id) references resources(id)
 );
 
 alter table configurations add (
@@ -1601,3 +1601,6 @@ alter table pwdreset add (
 constraint pwdreset_pk primary key (id),
 constraint pwdreset_u_fk foreign key (user_id) references users(id)
 );
+
+-- set initial Perun DB version
+insert into configurations values ('DATABASE VERSION','3.1.15');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,11 +1,11 @@
--- database version 3.1.14
+-- database version 3.1.15 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table "vos" (
 	id integer not null,
 	name varchar(128) not null,   -- full name of VO
 	short_name varchar(32) not null, -- commonly used name
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -37,7 +37,7 @@ create table "owners" (
 	id integer not null,
 	name varchar(128) not null, --name of owner
 	contact varchar(100),       --contact email or phone
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -82,9 +82,9 @@ create table "cabinet_publications" (
 	categoryId integer not null, --identifier of category (cabinet_categories.id)
 	createdBy varchar(1024) default user not null,
 	createdDate timestamp not null,
-	rank  numeric (38,1) default 0 not null,
+	rank numeric (38,1) default 0 not null,
 	doi varchar(256),
-	locked varchar(1) default 0 not null  ,
+	locked varchar(1) default 0 not null,
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -116,7 +116,7 @@ create table "cabinet_thanks" (
 create table "facilities" (
 	id integer not null,
 	name varchar(128) not null, --unique name of facility
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -131,7 +131,7 @@ create table "resources" (
 	facility_id integer not null, --facility identifier (facility.id)
 	name varchar(128) not null,   --name of resource
 	dsc varchar(1024),            --purpose and description
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -146,7 +146,7 @@ create table "destinations" (
 	id integer not null,
 	destination varchar(1024) not null, --value of destination (hostname,email,URL...)
 	type varchar(20) not null, --type (host,URL...)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -158,8 +158,8 @@ create table "destinations" (
 -- FACILITY_OWNERS - one or more institutions which own the facility
 create table "facility_owners" (
 	facility_id integer not null, --identifier of facility (facilities.id)
-	owner_id  integer not null,   --identifier of owner (owners.id)
-	created_at timestamp  default now() not null,
+	owner_id integer not null,   --identifier of owner (owners.id)
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -174,7 +174,7 @@ create table "groups" (
 	name varchar(128) not null, --group name
 	dsc varchar(1024),          --purpose and description
 	vo_id integer not null,     --identifier of VO (vos.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -189,7 +189,7 @@ create table "members" (
 	id integer not null,
 	user_id integer not null,  --user's identifier (users.id)
 	vo_id integer not null,    --identifier of VO (vos.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -202,7 +202,7 @@ create table "members" (
 create table "routing_rules" (
 	id integer not null,
 	routing_rule varchar(512) not null, --string for matching
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -216,7 +216,7 @@ create table "dispatcher_settings" (
 	ip_address varchar(40) not null, --IP address
 	port integer not null,           -- port
 	last_check_in timestamp default (now()), --time of last activation
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -231,7 +231,7 @@ create table "engines" (
 	ip_address varchar(40) not null, --IP address
 	port integer not null, --port
 	last_check_in timestamp default (now()), --time of last activation
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -244,7 +244,7 @@ create table "engines" (
 create table "engine_routing_rule" (
 	engine_id integer not null,   --engine identifier (engines.id)
 	routing_rule_id integer not null, --identifier of rule (routing_rules.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -257,7 +257,7 @@ create table "engine_routing_rule" (
 create table "processing_rules" (
 	id integer not null,
 	processing_rule varchar(1024) not null, --string for matching
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -297,7 +297,7 @@ create table "attr_names" (
 	namespace varchar(256) not null,  --access of attribute to the entity
 	type varchar(256) not null,       --type o0f attribute data (strig,number,array...)
 	dsc varchar(1024),                --purpose,description
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -336,7 +336,7 @@ create table "hosts" (
 	hostname varchar(128) not null,  --full name of machine
 	facility_id integer not null,    --identifier of facility containing the host (facilities.id)
 	dsc varchar(1024),  --description
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -350,7 +350,7 @@ create table "host_attr_values" (
 	host_id integer not null,  --identifier of host (hosts.id)
 	attr_id integer not null,  --identifier of attributes (attr_names.id)
 	attr_value varchar(4000),  --value of attribute
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -367,7 +367,7 @@ create table "auditer_consumers" (
 	last_processed_id integer,
 	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
-	modified_at  timestamp default now() not null,
+	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -378,7 +378,7 @@ create table "services" (
 	id integer not null,
 	name varchar(128) not null,    --name of service
 	owner_id integer,              --identifier of service owner (owners.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -391,7 +391,7 @@ create table "services" (
 create table "service_processing_rule" (
 	service_id integer not null,          --identifier of service (services.id)
 	processing_rule_id integer not null,  --identifier of processing rule (processing_rules.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -404,7 +404,7 @@ create table "service_processing_rule" (
 create table "service_required_attrs" (
 	service_id integer not null,   --identifier of service (services.id)
 	attr_id integer not null,      --identifier of attribute (attr_names.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -432,7 +432,7 @@ create table "exec_services" (
 	default_recurrence integer not null,  --number of repeating in case of error
 	script varchar(256) not null,   --name of executable service script
 	type varchar(10) not null,      --part of service (SEND/GENERATE)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -447,7 +447,7 @@ create table "service_denials" (
 	exec_service_id integer not null,  --identifier of service (exec_services.id)
 	facility_id integer,               --identifier of facility (facilities.id)
 	destination_id integer,            --identifier of destination (destinations.id) if service is not excluded on whole facility
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -460,7 +460,7 @@ create table "service_denials" (
 create table "service_dependencies" (
 	exec_service_id integer not null,  --identifier of service which must be finished finished first (exec_services.id)
 	dependency_id integer not null,    --identifier of service which can be executed after finishing exec_service_id (exec_services.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -474,7 +474,7 @@ create table "service_dependencies" (
 create table "resource_services" (
 	service_id integer not null,   --identifier of service (services.id)
 	resource_id integer not null,  --identifier of resource (resources.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -495,7 +495,7 @@ create table "application" (
 	state varchar(128),           --state of application (new/verified/approveed/rejected)
 	extSourceLoa integer,  --level of assurance of user by external source
 	group_id integer,      --identifier of group (groups.id) if application is for group
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -599,7 +599,7 @@ create table "facility_service_destinations" (
 	service_id integer not null,   --identifier of service (services.id)
 	facility_id integer not null,  --identifier of facility (facilities.id)
 	destination_id integer not null, --identifier of destination (destinations.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -614,7 +614,7 @@ create table "entityless_attr_values" (
 	subject varchar(256) not null,  --indicator of subject assigned with attribute
 	attr_id integer not null,       --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),       --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -629,7 +629,7 @@ create table "facility_attr_values" (
 	facility_id integer not null,   --identifier of facility (facilities.id)
 	attr_id integer not null,       --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),       --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -644,7 +644,7 @@ create table "group_attr_values" (
 	group_id integer not null,     --identifier of group (groups.id)
 	attr_id integer not null,      --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),      --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -659,7 +659,7 @@ create table "resource_attr_values" (
 	resource_id integer not null,   --identifier of resource (resources.id)
 	attr_id integer not null,       --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),       --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -675,7 +675,7 @@ create table "group_resource_attr_values" (
 	resource_id integer not null,  --identifier of resource (resources.id)
 	attr_id integer not null,      --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),      --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -689,9 +689,9 @@ create table "group_resource_attr_values" (
 create table "groups_members" (
 	group_id integer not null,   --identifier of group (groups.id)
 	member_id integer not null,  --identifier of member (members.id)
-	created_at  timestamp default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
-	modified_at  timestamp default now() not null,
+	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
@@ -704,9 +704,9 @@ create table "groups_members" (
 create table "groups_resources" (
 	group_id integer not null,     --identifier of group (groups.id)
 	resource_id integer not null,  --identifier of resource (resources.id)
-	created_at  timestamp default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
-	modified_at  timestamp default now() not null,
+	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
 	status char(1) default '0' not null,
 	created_by_uid integer,
@@ -718,7 +718,7 @@ create table "member_attr_values" (
 	member_id integer not null,   --identifier of member (members.id)
 	attr_id integer not null,     --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),     --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -734,7 +734,7 @@ create table "member_resource_attr_values" (
 	resource_id integer not null, --identifier of resource (resources.id)
 	attr_id integer not null,     --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),     --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -749,7 +749,7 @@ create table "user_attr_values" (
 	user_id integer not null,  --identifier of user (users.id)
 	attr_id integer not null,  --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),  --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -765,7 +765,7 @@ create table "user_facility_attr_values" (
 	facility_id integer not null, --identifier of facility (facilities.id)
 	attr_id integer not null,     --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),     --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -780,7 +780,7 @@ create table "vo_attr_values" (
 	vo_id integer not null,    --identifier of VO (vos.id)
 	attr_id integer not null,  --identifier of attribute (attr_names.id)
 	attr_value varchar(4000),  --attribute value
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -795,7 +795,7 @@ create table "ext_sources" (
 	id integer not null,
 	name varchar(256) not null,    --name of source
 	type varchar(64),              --type of source (LDAP/IdP...)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -809,7 +809,7 @@ create table "ext_sources_attributes" (
 	ext_sources_id integer not null,   --identifier of ext. source (ext_sources.id)
 	attr_name varchar(128) not null,   --name of attribute at ext. source
 	attr_value varchar(4000),          --value of attribute
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -822,7 +822,7 @@ create table "ext_sources_attributes" (
 create table "vo_ext_sources" (
 	vo_id integer not null,          --identifier of VO (vos.id)
 	ext_sources_id integer not null, --identifier of ext. source (ext_sources.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -837,7 +837,7 @@ create table "user_ext_sources" (
 	user_id integer not null,          --identifier of user (users.id)
 	login_ext varchar(256) not null,   --logname from his home system
 	ext_sources_id integer not null,   --identifier of ext. source (ext_sources.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -853,7 +853,7 @@ create table "service_packages" (
 	id integer not null,
 	name varchar(128) not null,   --name of service package
 	description varchar(512),     --purpose,description
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -866,7 +866,7 @@ create table "service_packages" (
 create table "service_service_packages" (
 	service_id integer not null,   --identifier of service (services.id)
 	package_id integer not null,   --identifier of package (service_packages.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -878,8 +878,8 @@ create table "service_service_packages" (
 -- TASKS - contains planned services and services finished at near past
 create table "tasks" (
 	id integer not null,
-	exec_service_id  integer not null,  --identifier of executed service (exec_services.id)
-	facility_id  integer not null,      --identifier of target facility (facilities.id)
+	exec_service_id integer not null,  --identifier of executed service (exec_services.id)
+	facility_id integer not null,      --identifier of target facility (facilities.id)
 	schedule timestamp not null,        --planned time for starting task
 	recurrence integer not null,        --number of repeating of task in case of error
 	delay integer not null,             --delay after next executing in case of error
@@ -887,7 +887,7 @@ create table "tasks" (
 	start_time timestamp,                    --real start time of task
 	end_time timestamp,                      --real end time of task
 	engine_id integer not null, --identifier of engine which executing the task (engines.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	err_message varchar(4000),          --return message in case of error
 	created_by_uid integer,
 	modified_by_uid integer
@@ -904,7 +904,7 @@ create table "tasks_results" (
 	return_code integer,              --returned value
 	timestamp timestamp,                   --real time of executing
 	engine_id integer not null,       --identifier of executing engine (engines.id)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -927,7 +927,7 @@ create table "service_principals" (
 	id integer not null,
 	description varchar(1024),    --description
 	name varchar(128) not null,   --name of principal
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -1046,7 +1046,7 @@ create table groups_groups (
 	group_id integer not null,         --identifier of group
 	parent_group_id integer not null,  --identifier of parent group
 	group_mode integer not null,
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null
@@ -1057,7 +1057,7 @@ create table res_tags (
 	id integer not null,
 	vo_id integer not null,            --identifier of VO
 	tag_name varchar (1024) not null,  --name of tag (computationl node/storage...)
-	created_at timestamp  default now() not null,
+	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1024) default user not null,
@@ -1536,7 +1536,7 @@ alter table res_tags add constraint restags_vos_fk foreign key (vo_id) reference
 
 alter table tags_resources add constraint tags_res_pk primary key (tag_id,resource_id);
 alter table tags_resources add constraint tags_res_tags_fk foreign key (tag_id) references res_tags(id);
-alter table tags_resources add constraint tags_res_res_fk  foreign key (resource_id) references resources(id);
+alter table tags_resources add constraint tags_res_res_fk foreign key (resource_id) references resources(id);
 
 alter table tasks add constraint task_pk primary key (id);
 alter table tasks add constraint task_exsrv_fk foreign key (exec_service_id) references exec_services(id);
@@ -1559,7 +1559,7 @@ alter table authz add constraint authz_group_fk foreign key (group_id) reference
 alter table authz add constraint authz_service_fk foreign key (service_id) references services(id);
 alter table authz add constraint authz_res_fk foreign key (resource_id) references resources(id);
 alter table authz add constraint authz_ser_princ_fk foreign key (service_principal_id) references service_principals(id);
-alter table authz add constraint authz_user_serprinc_autgrp_chk check ((user_id is not null and service_principal_id is null and authorized_group_id is null) or (user_id is null and service_principal_id is not null and authorized_group_id is null) or (user_id is null and service_principal_id is null and authorized_group_id is  not null));
+alter table authz add constraint authz_user_serprinc_autgrp_chk check ((user_id is not null and service_principal_id is null and authorized_group_id is null) or (user_id is null and service_principal_id is not null and authorized_group_id is null) or (user_id is null and service_principal_id is null and authorized_group_id is not null));
 alter table configurations add constraint config_pk primary key (property);
 alter table configurations add constraint config_prop_chk check (property in ('DATABASE VERSION'));
 alter table mailchange add constraint mailchange_pk primary key (id);
@@ -1650,3 +1650,6 @@ grant all on tags_resources to perun;
 grant all on configurations to perun;
 grant all on mailchange to perun;
 grant all on pwdreset to perun;
+
+-- set initial Perun DB version
+insert into configurations values ('DATABASE VERSION','3.1.15');


### PR DESCRIPTION
- On Oracle use NVARCHAR2 instead of VARCHAR2, since it ensures data
  are in UTF-8 format + column limit semantic means characters, not bytes.
  Limit of 4000 bytes on data in column is still present.
- Updated DB version to 3.1.15
- Added insert with current DB version to end of file, since it's value is
  expected to be present even in empty DB.
- Removed some whitespace from inside SQL statements.
