### PR TITLE
Notifications: dynamic user locale recognition

### DIFF
--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/jdbc/PerunNotifTemplateDaoImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/jdbc/PerunNotifTemplateDaoImpl.java
@@ -93,7 +93,7 @@ public class PerunNotifTemplateDaoImpl extends JdbcDaoSupport implements PerunNo
 
 		int newPerunNotifReceiverId = Utils.getNewId(this.getJdbcTemplate(), "pn_receiver_id_seq");
 
-		this.getJdbcTemplate().update("insert into pn_receiver (id, target, type_of_receiver, template_id, locale) values (?, ?, ?, ?, ?)", newPerunNotifReceiverId, receiver.getTarget(), receiver.getTypeOfReceiver().getKey(), receiver.getTemplateId(), receiver.getLocale().getLanguage());
+		this.getJdbcTemplate().update("insert into pn_receiver (id, target, type_of_receiver, template_id, locale) values (?, ?, ?, ?, ?)", newPerunNotifReceiverId, receiver.getTarget(), receiver.getTypeOfReceiver().getKey(), receiver.getTemplateId(), receiver.getLocale());
 		receiver.setId(newPerunNotifReceiverId);
 
 		return receiver;
@@ -102,7 +102,7 @@ public class PerunNotifTemplateDaoImpl extends JdbcDaoSupport implements PerunNo
 	@Override
 	public PerunNotifReceiver updatePerunNotifReceiver(PerunNotifReceiver receiver) throws InternalErrorException {
 
-		this.getJdbcTemplate().update("update pn_receiver set target = ?, type_of_receiver = ?, template_id = ?, locale = ? where id = ?", receiver.getTarget(), receiver.getTypeOfReceiver().getKey(), receiver.getTemplateId(), receiver.getLocale().getLanguage(), receiver.getId());
+		this.getJdbcTemplate().update("update pn_receiver set target = ?, type_of_receiver = ?, template_id = ?, locale = ? where id = ?", receiver.getTarget(), receiver.getTypeOfReceiver().getKey(), receiver.getTemplateId(), receiver.getLocale(), receiver.getId());
 
 		return getPerunNotifReceiverById(receiver.getId());
 	}

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/entities/PerunNotifReceiver.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/entities/PerunNotifReceiver.java
@@ -50,7 +50,7 @@ public class PerunNotifReceiver {
 	 *
 	 * Column locale
 	 */
-	private Locale locale;
+	private String locale;
 
 	public PerunNotifTypeOfReceiver getTypeOfReceiver() {
 		return typeOfReceiver;
@@ -84,14 +84,13 @@ public class PerunNotifReceiver {
 		this.id = id;
 	}
 
-	public Locale getLocale() {
+	public String getLocale() {
 		return locale;
 	}
 
-	public void setLocale(Locale locale) {
+	public void setLocale(String locale) {
 		this.locale = locale;
 	}
-
 
 	public static final RowMapper<PerunNotifReceiver> PERUN_NOTIF_RECEIVER = new RowMapper<PerunNotifReceiver>() {
 
@@ -101,7 +100,7 @@ public class PerunNotifReceiver {
 			receiver.setTarget(rs.getString("target"));
 			receiver.setTypeOfReceiver(PerunNotifTypeOfReceiver.resolve(rs.getString("type_of_receiver")));
 			receiver.setTemplateId(rs.getInt("template_id"));
-			receiver.setLocale((rs.getString("locale") == null) ? null : new Locale(rs.getString("locale")));
+			receiver.setLocale(rs.getString("locale"));
 			receiver.setId(rs.getInt("id"));
 
 			return receiver;
@@ -116,7 +115,7 @@ public class PerunNotifReceiver {
 
 	@Override
 	public String toString() {
-		return "id: " + getId() + " target: " + getTarget() + " type_of_receiver: " + getTypeOfReceiver() + " template id: " + getTemplateId() + " locale: " + getLocale().getLanguage();
+		return "id: " + getId() + " target: " + getTarget() + " type_of_receiver: " + getTypeOfReceiver() + " template id: " + getTemplateId() + " locale: " + getLocale();
 	}
 
 	@Override

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManagerImpl.java
@@ -89,7 +89,10 @@ public class PerunNotifPoolMessageManagerImpl implements PerunNotifPoolMessageMa
 					Map<String, String> retrievedPrimaryProperties = new HashMap<String, String>();
 					Set<String> classNames = new HashSet<String>();
 					classNames.addAll(template.getPrimaryProperties().keySet());
-					classNames.add(template.getSender());
+					// recognize sender
+					if (!(template.getSender().contains("@"))) {
+						classNames.add(template.getSender());
+					}
 					for (PerunNotifReceiver receiver : template.getReceivers()) {
 						classNames.add(receiver.getTarget());
 					}

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifTemplateManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifTemplateManagerImpl.java
@@ -645,8 +645,16 @@ public class PerunNotifTemplateManagerImpl implements PerunNotifTemplateManager 
 		}
 
 		perunNotifTemplateDao.removePerunNotifReceiverById(id);
-
 		PerunNotifTemplate template = allTemplatesById.get(receiverToRemove.getTemplateId());
+
+		for (List<PerunNotifTemplate> listOftemplate: allTemplatesByRegexId.values()) {
+			for (PerunNotifTemplate t : listOftemplate) {
+				if (t.equals(template)) {
+					t.getReceivers().remove(receiverToRemove);
+				}
+			}
+		}
+
 		for (Iterator<PerunNotifReceiver> iter = template.getReceivers().iterator(); iter.hasNext();) {
 			PerunNotifReceiver myReceiver = iter.next();
 			if (myReceiver.getId().equals(receiverToRemove.getId())) {


### PR DESCRIPTION
- the locale and message language can be dynamically choosen
- with the key $user.preferredLanguage in locale of NotifReceiver will be messages sent with respect to the user attribute preferredLanguage

- bug fix: while removing NotifReceiver, it is removed from cache map  allTemplatesByRegexId too

- unnecessary log message error changed to info