### PR TITLE
GUI: Handle also 403 error code

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonClient.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonClient.java
@@ -174,11 +174,11 @@ public class JsonClient {
 						runningRequests.remove(requestUrl);
 						return;
 
-					} else if (resp.getStatusCode() == 401) {
+					} else if (resp.getStatusCode() == 401 || resp.getStatusCode() == 403) {
 
 						PerunError error = new JSONObject().getJavaScriptObject().cast();
 						error.setErrorId("401");
-						error.setName("NotAuthorized");
+						error.setName("Not Authorized");
 						error.setErrorInfo("You are not authorized to server. Your session might have expired. Please refresh the browser window to re-login.");
 						error.setObjectType("PerunError");
 						error.setRequestURL(requestUrl);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonPostClient.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonPostClient.java
@@ -229,11 +229,11 @@ public class JsonPostClient {
 						onRequestError(error);
 						return;
 
-					} else if (resp.getStatusCode() == 401) {
+					} else if (resp.getStatusCode() == 401 || resp.getStatusCode() == 403) {
 
 						PerunError error = new JSONObject().getJavaScriptObject().cast();
 						error.setErrorId("401");
-						error.setName("NotAuthorized");
+						error.setName("Not Authorized");
 						error.setErrorInfo("You are not authorized to server. Your session might have expired. Please refresh the browser window to re-login.");
 						error.setObjectType("PerunError");
 						error.setRequestURL(requestUrl);


### PR DESCRIPTION
- When contacting Perun, handle also 403 Forbidden, which happens
  when you have valid session, but with different server or your
  session is expired but browser uses cache.
