### PR TITLE
GUI: Do not autoselect first item in suggestion list

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/TabMenu.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/TabMenu.java
@@ -230,6 +230,7 @@ public class TabMenu extends Composite {
 	public <T extends SuggestOracle> SuggestOracle addFilterWidget(ExtendedSuggestBox box, final PerunSearchEvent filterEvent, final String title) {
 
 		final ExtendedSuggestBox suggest = box;
+		suggest.getSuggestBox().setAutoSelectEnabled(false);
 
 		// search box on enter
 		suggest.getSuggestBox().addKeyUpHandler(new KeyUpHandler() {


### PR DESCRIPTION
- When filtering tables, do not autoselect first of displayed
  suggestions. Hitting enter key then can submit value inserted
  by user, not by suggestion.