### PR TITLE
Fix of using SimpleDateFormat object (date formatter)

### DIFF
--- a/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
+++ b/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
@@ -453,7 +453,7 @@ public class AuditParser {
 		else {
 			Date date;
 			try {
-				date = BeansUtils.DATE_FORMATTER.parse(BeansUtils.eraseEscaping(beanAttr.get("createdDate")));
+				date = BeansUtils.getDateFormatter().parse(BeansUtils.eraseEscaping(beanAttr.get("createdDate")));
 			} catch (ParseException ex) {
 				throw new InternalErrorException("Error when date was parsing from String to Date.", ex);
 			}

--- a/perun-beans/src/main/java/cz/metacentrum/perun/cabinet/model/Authorship.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/cabinet/model/Authorship.java
@@ -230,7 +230,7 @@ public class Authorship extends PerunBean implements Serializable {
 		StringBuilder str = new StringBuilder();
 
 		String dateString;
-		if(getCreatedDate() != null) dateString = BeansUtils.DATE_FORMATTER.format(getCreatedDate());
+		if(getCreatedDate() != null) dateString = BeansUtils.getDateFormatter().format(getCreatedDate());
 		else dateString = "\\0";
 
 		return str.append(this.getClass().getSimpleName()).append(":[").append(

--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Auditable.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Auditable.java
@@ -196,14 +196,14 @@ public abstract class Auditable extends PerunBean {
 		}
 		Date date1;
 		try {
-			date1 = BeansUtils.DATE_FORMATTER.parse(createdAt);
+			date1 = BeansUtils.getDateFormatter().parse(createdAt);
 		} catch (Exception ex) {
 			throw new InternalErrorRuntimeException("There is problem with parsing createdAt in object " + this,ex);
 		}
 
 		Date date2;
 		try {
-			date2 = BeansUtils.DATE_FORMATTER.parse(auditable.getCreatedAt());
+			date2 = BeansUtils.getDateFormatter().parse(auditable.getCreatedAt());
 		} catch (Exception ex) {
 			throw new InternalErrorRuntimeException("There is problem with parsing createdAt in object " + auditable,ex);
 		}
@@ -217,14 +217,14 @@ public abstract class Auditable extends PerunBean {
 		}
 		Date date1;
 		try {
-			date1 = BeansUtils.DATE_FORMATTER.parse(modifiedAt);
+			date1 = BeansUtils.getDateFormatter().parse(modifiedAt);
 		} catch (Exception ex) {
 			throw new InternalErrorRuntimeException("There is problem with parsing createdAt in object " + this,ex);
 		}
 
 		Date date2;
 		try {
-			date2 = BeansUtils.DATE_FORMATTER.parse(auditable.getModifiedAt());
+			date2 = BeansUtils.getDateFormatter().parse(auditable.getModifiedAt());
 		} catch (Exception ex) {
 			throw new InternalErrorRuntimeException("There is problem with parsing createdAt in object " + auditable,ex);
 		}

--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -22,7 +22,6 @@ public class BeansUtils {
 	private final static Pattern patternForCommonNameParsing = Pattern.compile("(([\\w]*. )*)([\\p{L}-']+) ([\\p{L}-']+)[, ]*(.*)");
 	public static final char LIST_DELIMITER = ',';
 	public static final char KEY_VALUE_DELIMITER = ':';
-	public final static DateFormat DATE_FORMATTER = getDateFormatter();
 
 	/**
 	 * Method create formatter with default settings for perun timestamps and set lenient on false
@@ -30,9 +29,11 @@ public class BeansUtils {
 	 *
 	 * Lenient on false means that formatter will be more strict to creating timestamp from string
 	 *
+	 * IMPORTANT: SimpleDateFormat is not thread safe !!!
+	 *
 	 * @return date formatter
 	 */
-	private static DateFormat getDateFormatter() {
+	public static DateFormat getDateFormatter() {
 		DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
 		df.setLenient(false);
 		return df;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1063,7 +1063,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 								}
 
 								if (memberExpiration != null && memberExpiration.getValue() != null) {
-									Date currentMembershipExpirationDate = BeansUtils.DATE_FORMATTER.parse((String) memberExpiration.getValue());
+									Date currentMembershipExpirationDate = BeansUtils.getDateFormatter().parse((String) memberExpiration.getValue());
 
 									if (currentMembershipExpirationDate.before(now)) {
 										//disabled members which are after expiration date will be expired
@@ -1745,7 +1745,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 
 		//Set correct format of currentTimestamp
-		String currectTimestampString = BeansUtils.DATE_FORMATTER.format(currentTimestamp);
+		String currectTimestampString = BeansUtils.getDateFormatter().format(currentTimestamp);
 
 		//Get both attribute defintion lastSynchroTimestamp and lastSynchroState
 		//Get definitions and values, set values

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1452,7 +1452,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		// Does the user have expired membership, if yes, then for canExtendMembership return true
 		if (!setAttributeValue && membershipExpirationAttribute.getValue() != null) {
 			try {
-				Date currentMemberExpiration = BeansUtils.DATE_FORMATTER.parse((String) membershipExpirationAttribute.getValue());
+				Date currentMemberExpiration = BeansUtils.getDateFormatter().parse((String) membershipExpirationAttribute.getValue());
 
 				Calendar currentMemberExpirationCalendar = Calendar.getInstance();
 				currentMemberExpirationCalendar.setTime(currentMemberExpiration);
@@ -1602,7 +1602,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 							// If we do not need to set the attribute value, only check if the current member's expiration time is not in grace period
 							if (!setAttributeValue && membershipExpirationAttribute.getValue() != null) {
 								try {
-									Date currentMemberExpiration = BeansUtils.DATE_FORMATTER.parse((String) membershipExpirationAttribute.getValue());
+									Date currentMemberExpiration = BeansUtils.getDateFormatter().parse((String) membershipExpirationAttribute.getValue());
 									// subtracts grace period from the currentMemberExpiration
 									Calendar currentMemberExpirationCalendar = Calendar.getInstance();
 									currentMemberExpirationCalendar.setTime(currentMemberExpiration);
@@ -1637,7 +1637,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 			// Set new value of the membershipExpiration for the member
 			if (setAttributeValue) {
-				membershipExpirationAttribute.setValue(BeansUtils.DATE_FORMATTER.format(calendar.getTime()));
+				membershipExpirationAttribute.setValue(BeansUtils.getDateFormatter().format(calendar.getTime()));
 				try {
 					getPerunBl().getAttributesManagerBl().setAttribute(sess, member, membershipExpirationAttribute);
 				} catch (WrongAttributeValueException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
@@ -82,7 +82,7 @@ public class Synchronizer {
 					// Read membershipExpiration and check it
 					Attribute membersExpiration = perunBl.getAttributesManagerBl().getAttribute(sess, member, "urn:perun:member:attribute-def:def:membershipExpiration");
 					if (membersExpiration.getValue() != null) {
-						currentMembershipExpirationDate = BeansUtils.DATE_FORMATTER.parse((String) membersExpiration.getValue());
+						currentMembershipExpirationDate = BeansUtils.getDateFormatter().parse((String) membersExpiration.getValue());
 						if (currentMembershipExpirationDate.before(now)) {
 							// Expired membership, set status to expired only if the user hasn't been in suspended state
 							if (!member.getStatus().equals(Status.EXPIRED) && !member.getStatus().equals(Status.SUSPENDED)) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationTimestamp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationTimestamp.java
@@ -36,7 +36,7 @@ public class urn_perun_group_attribute_def_def_lastSynchronizationTimestamp exte
 		//test of timestamp format
 		String attrValue = (String) attribute.getValue();
 		try {
-			Date date = BeansUtils.DATE_FORMATTER.parse(attrValue);
+			Date date = BeansUtils.getDateFormatter().parse(attrValue);
 		} catch (ParseException ex) {
 			throw new WrongAttributeValueException(attribute, group, "Format of timestamp is not correct and can't be parsed correctly. Ex. 'dd-MM-yyyy HH:mm:ss'", ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_organizationsWithLoa.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_organizationsWithLoa.java
@@ -65,7 +65,7 @@ public class urn_perun_user_attribute_def_virt_organizationsWithLoa extends User
 				Date lastUsedDate = null;
 				boolean parsed = true;
 				try {
-					testingDate = BeansUtils.DATE_FORMATTER.parse(uES.getCreatedAt());
+					testingDate = BeansUtils.getDateFormatter().parse(uES.getCreatedAt());
 				} catch (Exception ex) {
 					//Not Parsed correctly
 					parsed = false;
@@ -74,7 +74,7 @@ public class urn_perun_user_attribute_def_virt_organizationsWithLoa extends User
 					if(userExtSourceForCreating == null || userExtSourceForCreating.getCreatedAt() == null) userExtSourceForCreating = uES;
 					else {
 						try {
-							lastUsedDate = BeansUtils.DATE_FORMATTER.parse(userExtSourceForCreating.getCreatedAt());
+							lastUsedDate = BeansUtils.getDateFormatter().parse(userExtSourceForCreating.getCreatedAt());
 							if(testingDate != null && testingDate.compareTo(lastUsedDate) < 0) {
 								userExtSourceForCreating = uES;
 							}
@@ -91,7 +91,7 @@ public class urn_perun_user_attribute_def_virt_organizationsWithLoa extends User
 				Date lastUsedDate = null;
 				boolean parsed = true;
 				try {
-					testingDate = BeansUtils.DATE_FORMATTER.parse(uES.getModifiedAt());
+					testingDate = BeansUtils.getDateFormatter().parse(uES.getModifiedAt());
 				} catch (Exception ex) {
 					//Not Parsed correctly
 					parsed = false;
@@ -100,7 +100,7 @@ public class urn_perun_user_attribute_def_virt_organizationsWithLoa extends User
 					if(userExtSourceForModifiing == null || userExtSourceForModifiing.getModifiedAt() == null) userExtSourceForModifiing = uES;
 					else {
 						try {
-							lastUsedDate = BeansUtils.DATE_FORMATTER.parse(userExtSourceForModifiing.getModifiedAt());
+							lastUsedDate = BeansUtils.getDateFormatter().parse(userExtSourceForModifiing.getModifiedAt());
 							if(testingDate != null && testingDate.compareTo(lastUsedDate) < 0) {
 								userExtSourceForModifiing = uES;
 							}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -353,7 +353,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Attribute membershipAttribute = attributesManagerEntry.getAttribute(sess, createdMember, AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration");
 
-		Date extendedDate = BeansUtils.DATE_FORMATTER.parse((String) membershipAttribute.getValue());
+		Date extendedDate = BeansUtils.getDateFormatter().parse((String) membershipAttribute.getValue());
 		Calendar extendedCalendar = Calendar.getInstance();
 		extendedCalendar.setTime(extendedDate);
 
@@ -388,7 +388,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Attribute membershipAttribute = attributesManagerEntry.getAttribute(sess, createdMember, AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration");
 
-		Date extendedDate = BeansUtils.DATE_FORMATTER.parse((String) membershipAttribute.getValue());
+		Date extendedDate = BeansUtils.getDateFormatter().parse((String) membershipAttribute.getValue());
 		Calendar extendedCalendar = Calendar.getInstance();
 		extendedCalendar.setTime(extendedDate);
 
@@ -428,7 +428,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Attribute membershipAttribute = attributesManagerEntry.getAttribute(sess, createdMember, AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration");
 
-		Date extendedDate = BeansUtils.DATE_FORMATTER.parse((String) membershipAttribute.getValue());
+		Date extendedDate = BeansUtils.getDateFormatter().parse((String) membershipAttribute.getValue());
 		Calendar extendedCalendar = Calendar.getInstance();
 		extendedCalendar.setTime(extendedDate);
 
@@ -470,7 +470,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Attribute membershipAttribute = attributesManagerEntry.getAttribute(sess, createdMember, AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration");
 
-		Date extendedDate = BeansUtils.DATE_FORMATTER.parse((String) membershipAttribute.getValue());
+		Date extendedDate = BeansUtils.getDateFormatter().parse((String) membershipAttribute.getValue());
 		Calendar extendedCalendar = Calendar.getInstance();
 		extendedCalendar.setTime(extendedDate);
 
@@ -511,7 +511,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Attribute membershipAttribute = attributesManagerEntry.getAttribute(sess, createdMember, AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration");
 
-		Date extendedDate = BeansUtils.DATE_FORMATTER.parse((String) membershipAttribute.getValue());
+		Date extendedDate = BeansUtils.getDateFormatter().parse((String) membershipAttribute.getValue());
 		Calendar extendedCalendar = Calendar.getInstance();
 		extendedCalendar.setTime(extendedDate);
 
@@ -544,7 +544,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		Attribute membershipExpirationAttribute = new Attribute(attributesManagerEntry.getAttributeDefinition(sess, AttributesManager.NS_MEMBER_ATTR_DEF+":membershipExpiration"));
 		Calendar nowCalendar = Calendar.getInstance();
-		membershipExpirationAttribute.setValue(BeansUtils.DATE_FORMATTER.format(nowCalendar.getTime()));
+		membershipExpirationAttribute.setValue(BeansUtils.getDateFormatter().format(nowCalendar.getTime()));
 		attributesManagerEntry.setAttribute(sess, createdMember, membershipExpirationAttribute);
 
 		// Set LOA 1 for member
@@ -566,7 +566,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		assertNotNull("membership attribute must be set", membershipAttribute);
 		assertEquals("membership attribute value must contains same value as before extension.",
-				BeansUtils.DATE_FORMATTER.format(nowCalendar.getTime()), membershipAttribute.getValue()); // Attribute cannot contain any value
+				BeansUtils.getDateFormatter().format(nowCalendar.getTime()), membershipAttribute.getValue()); // Attribute cannot contain any value
 	}
 
 	@Test
@@ -605,7 +605,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 		membershipAttribute = attributesManagerEntry.getAttribute(sess, createdMember, AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration");
 
-		Date extendedDate = BeansUtils.DATE_FORMATTER.parse((String) membershipAttribute.getValue());
+		Date extendedDate = BeansUtils.getDateFormatter().parse((String) membershipAttribute.getValue());
 		Calendar extendedCalendar = Calendar.getInstance();
 		extendedCalendar.setTime(extendedDate);
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -812,7 +812,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 			if (parms.contains("member")) {
 				Date d = ac.getMembersManager().getNewExtendMembership(ac.getSession(),ac.getMemberById(parms.readInt("member")));
 				if (d != null) {
-					return BeansUtils.DATE_FORMATTER.format(d);
+					return BeansUtils.getDateFormatter().format(d);
 				}
 				return null;
 			} else if (parms.contains("user") && parms.contains("vo")) {
@@ -820,7 +820,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 						ac.getVoById(parms.readInt("vo")), ac.getUserById(parms.readInt("user")));
 				Date d = ac.getMembersManager().getNewExtendMembership(ac.getSession(), m);
 				if (d != null) {
-					return BeansUtils.DATE_FORMATTER.format(d);
+					return BeansUtils.getDateFormatter().format(d);
 				}
 				return null;
 			} else if (parms.contains("vo") && parms.contains("loa")) {
@@ -828,7 +828,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 						ac.getVoById(parms.readInt("vo")),
 						parms.readString("loa"));
 				if (d != null) {
-					return BeansUtils.DATE_FORMATTER.format(d);
+					return BeansUtils.getDateFormatter().format(d);
 				}
 				return null;
 			} else {


### PR DESCRIPTION
 - SimpleDateFormat is not thread safe and need to used new for every
   separate call
 - remove old static object of formatter and use method with constructor
   of formatter instead