### PR TITLE
sshkeys_root and k5login_root - the way of creating destination file and setting file permissions has been changed

### DIFF
--- a/perun-services/slave/debian/changelog
+++ b/perun-services/slave/debian/changelog
@@ -1,3 +1,16 @@
+perun-slave (3.0.0-0.0.84) stable; urgency=low
+
+   * Slave scripts sshkeys_root and k5login_root at first check if there 
+     already exist appropriate destination file. 
+     If it doesn't exist, the file permissions are at first set only for
+     the file in perun working directiory, then the permissions are checked 
+     and if setting is valid then diff_mv handles destination file creating,
+     otherwise function returns 1.
+     If it exists, then diff_mv handles changes propagation from file in the
+     working directory to destination file.
+     
+ -- Sona Mastrakova <sona.mastrakova@gmail.com> Thu, 15 Jan 2015 01:00 +0200
+
 perun-slave (3.0.0-0.0.83) stable; urgency=low
 
    * When data are rejected by the slave script on destination node

--- a/perun-services/slave/process-k5login_root.sh
+++ b/perun-services/slave/process-k5login_root.sh
@@ -9,17 +9,23 @@ function process {
 	### Status codes
 	I_CHANGED=(0 "${DST_FILE} updated")
 	I_NOT_CHANGED=(0 "${DST_FILE} has not changed")
+	E_CHOWN=(50 'Cannot chown on ${FROM_PERUN}')
+	E_CHMOD=(51 'Cannot chmod on ${FROM_PERUN}')
 
 	FROM_PERUN="${WORK_DIR}/k5login_root"
 
 	create_lock
 
+	# Destination file doesn't exist
+	if [ ! -f ${DST_FILE} ]; then
+		catch_error E_CHOWN chown root.root $FROM_PERUN
+		catch_error E_CHMOD chmod 0644 $FROM_PERUN
+	fi
+
 	# Create diff between old.perun and .new
 	diff_mv "${FROM_PERUN}" "${DST_FILE}"
 
 	if [ $? -eq 0 ]; then
-		chown root.root $DST_FILE
-		chmod 0644 $DST_FILE
 		log_msg I_CHANGED
 	else
 		log_msg I_NOT_CHANGED

--- a/perun-services/slave/process-sshkeys_root.sh
+++ b/perun-services/slave/process-sshkeys_root.sh
@@ -9,6 +9,8 @@ function process {
 	### Status codes
 	I_CHANGED=(0 "${DST_FILE} updated")
 	I_NOT_CHANGED=(0 "${DST_FILE} has not changed")
+	E_CHOWN=(50 'Cannot chown on ${FROM_PERUN}')
+	E_CHMOD=(51 'Cannot chmod on ${FROM_PERUN}')
 
 	FROM_PERUN="${WORK_DIR}/sshkeys_root"
 
@@ -17,12 +19,16 @@ function process {
 
 	create_lock
 
+	# Destination file doesn't exist
+	if [ ! -f ${DST_FILE} ]; then
+		catch_error E_CHOWN chown root.root $FROM_PERUN
+		catch_error E_CHMOD chmod 0644 $FROM_PERUN
+	fi
+
 	# Create diff between old.perun and .new
 	diff_mv "${FROM_PERUN}" "${DST_FILE}"
 
 	if [ $? -eq 0 ]; then
-		chown root.root $DST_FILE
-		chmod 0644 $DST_FILE
 		log_msg I_CHANGED
 	else
 		log_msg I_NOT_CHANGED


### PR DESCRIPTION
if destination file doesn't exist, permissions are set on the file in working directory and then propagated by diff_mv on destination file

if destination file exists, any changes are propagated by diff_mv from file in working directory to destination file

all the changes are described in changelog