### PR TITLE
REGISTRAR,GUI: support for custom native language

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.registrar.model;
 
 import java.util.*;
 
+import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.registrar.model.Application.AppType;
 
 /**
@@ -33,7 +34,21 @@ public class ApplicationFormItem {
 	private boolean forDelete = false;
 
 	public static final Locale EN = new Locale("en");
-	public static final Locale CS = new Locale("cs");
+	public static final Locale CS = new Locale(getNativeLanguage());
+
+	/**
+	 * Return code of native language defined in config file.
+	 * Return "cs" for Czech language if no native language set.
+	 *
+	 * @return String representation of native language
+	 */
+	public static String getNativeLanguage() {
+		try {
+			return Utils.getPropertyFromConfiguration("perun.native.language").split(",")[0];
+		} catch (Exception ex) {
+			return "cs";
+		}
+	}
 
 	public ApplicationFormItem(int id, String shortname, boolean required, Type type, String federationAttribute, String perunDestinationAttribute, String regex) {
 		this.id = id;
@@ -245,19 +260,17 @@ public class ApplicationFormItem {
 
 		@Override
 		public String toString() {
-			return "ItemTexts{" +
+			return getClass().getSimpleName() + ":[" +
 					"locale=" + locale +
 					", label='" + label + '\'' +
 					", options='" + options + '\'' +
 					", help='" + help + '\'' +
 					", errorMessage='" + errorMessage + '\'' +
-					'}';
+					']';
 		}
 	}
 
-
-	private Map<Locale,ItemTexts> i18n = new HashMap<Locale, ItemTexts>(3);
-	{
+	private Map<Locale,ItemTexts> i18n = new HashMap<Locale, ItemTexts>(3); {
 		// create with locale property set
 		i18n.put(CS,new ItemTexts(CS));
 		i18n.put(EN,new ItemTexts(EN));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
@@ -92,7 +92,7 @@ public class UiElements {
 	private ToggleButton logButton;
 	private SimplePanel logButtonWrapper = new SimplePanel();
 	private ToggleButton extendedInfoButton = new ToggleButton(new Image(SmallIcons.INSTANCE.attributesDisplayIcon()));
-	private ToggleButton languageButton = new ToggleButton(new Image(SmallIcons.INSTANCE.flagCzechBritainIcon()));
+	private ToggleButton languageButton = new ToggleButton(new Image(SmallIcons.INSTANCE.locateIcon()));
 
 	// Switch identity helping variabless
 	private int userCallcounter = 0;
@@ -1058,8 +1058,8 @@ public class UiElements {
 
 		languageButton.setVisible(true); // display for perun admin only in WebGui.class
 
-		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals("cs")) {
-			languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToCzech());
+		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0))) {
+			languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToCzech(Utils.getNativeLanguage().get(1)));
 		} else {
 			languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToEnglish());
 		}
@@ -1073,12 +1073,12 @@ public class UiElements {
 						// on OK
 						// set proper locale
 						String localeName = LocaleInfo.getCurrentLocale().getLocaleName();
-						if (!localeName.equals("cs")) {
-							localeName = "cs";
+						if (!localeName.equals(Utils.getNativeLanguage().get(0))) {
+							localeName = Utils.getNativeLanguage().get(0);
 							languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToEnglish());
 						} else {
 							localeName = "en";
-							languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToCzech());
+							languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToCzech(Utils.getNativeLanguage().get(1)));
 						}
 
 						// set locale param to URL or local storage

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
@@ -155,7 +155,7 @@ public class RegistrarFormItemGenerator {
 		this.strValue = strValue.trim();
 		this.prefilledValue = strValue.trim();  // store original value
 		this.item = item;
-		if (locale.equalsIgnoreCase("en") || locale.equalsIgnoreCase("cs")) {
+		if (locale.equalsIgnoreCase("en") || locale.equalsIgnoreCase(Utils.getNativeLanguage().get(0))) {
 			// set locale if correct
 			this.locale = locale;
 		}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.http.client.UrlBuilder;
+import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
@@ -17,6 +18,7 @@ import cz.metacentrum.perun.webgui.client.ApplicationFormGui;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.applicationresources.SendsApplicationForm;
 import cz.metacentrum.perun.webgui.client.localization.ApplicationMessages;
+import cz.metacentrum.perun.webgui.client.localization.WidgetTranslation;
 import cz.metacentrum.perun.webgui.client.resources.*;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonPostClient;
@@ -75,8 +77,7 @@ public class ApplicationFormPage extends ApplicationPage {
 	/**
 	 * Switch languages button
 	 */
-	private PushButton languageButtonCzech;
-	private PushButton languageButtonEnglish;
+	private PushButton languageButton;
 
 	private boolean submittedOrError = false;
 
@@ -101,46 +102,35 @@ public class ApplicationFormPage extends ApplicationPage {
 	/**
 	 * Prepares the buttons for local languages
 	 */
-
 	private void prepareToggleLanguageButton() {
 
-		languageButtonCzech = new PushButton(new Image(SmallIcons.INSTANCE.flagCzechRepublicIcon()));
-		languageButtonCzech.setTitle(ApplicationMessages.INSTANCE.changeLanguageToCzech());
-		languageButtonCzech.setStyleName("gwt-Button");
-		languageButtonCzech.setPixelSize(17, 17);
+		languageButton = new PushButton(new Image(SmallIcons.INSTANCE.locateIcon()));
 
-		languageButtonEnglish = new PushButton(new Image(SmallIcons.INSTANCE.flagGreatBritainIcon()));
-		languageButtonEnglish.setTitle(ApplicationMessages.INSTANCE.changeLanguageToEnglish());
-		languageButtonEnglish.setStyleName("gwt-Button");
-		languageButtonEnglish.setPixelSize(17, 17);
+		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0))) {
+			languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToCzech(Utils.getNativeLanguage().get(2)));
+		} else {
+			languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToEnglish());
+		}
+		languageButton.setStyleName("gwt-Button");
+		languageButton.setPixelSize(17, 17);
 
-		languageButtonCzech.addClickHandler(new ClickHandler() {
+		languageButton.addClickHandler(new ClickHandler() {
 			public void onClick(ClickEvent event) {
-				Confirm conf = new Confirm(languageButtonCzech.getTitle(), new HTML(ApplicationMessages.INSTANCE.changeLanguageText()), new ClickHandler(){
+				Confirm conf = new Confirm(languageButton.getTitle(), new HTML(ApplicationMessages.INSTANCE.changeLanguageText()), new ClickHandler() {
 					public void onClick(ClickEvent event) {
-						// on OK
-						UrlBuilder builder = Location.createUrlBuilder().setParameter("locale", "cs");
-						Window.Location.replace(builder.buildString());
 
-					}}, new ClickHandler(){
-					public void onClick(ClickEvent event) {
-						// on CANCEL
+						String localeName = LocaleInfo.getCurrentLocale().getLocaleName();
+						if (!localeName.equals(Utils.getNativeLanguage().get(0))) {
+							UrlBuilder builder = Location.createUrlBuilder().setParameter("locale", Utils.getNativeLanguage().get(0));
+							Window.Location.replace(builder.buildString());
+						} else {
+							UrlBuilder builder = Location.createUrlBuilder().setParameter("locale", "en");
+							Window.Location.replace(builder.buildString());
+						}
+						// on OK
+
 					}
-				}, true);
-				conf.setNonScrollable(true);
-				conf.show();
-			}
-		});
-
-		languageButtonEnglish.addClickHandler(new ClickHandler() {
-			public void onClick(ClickEvent event) {
-				Confirm conf = new Confirm(languageButtonEnglish.getTitle(), new HTML(ApplicationMessages.INSTANCE.changeLanguageText()), new ClickHandler(){
-					public void onClick(ClickEvent event) {
-						// on OK
-						UrlBuilder builder = Location.createUrlBuilder().setParameter("locale", "en");
-						Window.Location.replace(builder.buildString());
-
-					}}, new ClickHandler(){
+				}, new ClickHandler() {
 					public void onClick(ClickEvent event) {
 						// on CANCEL
 					}
@@ -203,8 +193,7 @@ public class ApplicationFormPage extends ApplicationPage {
 		prepareToggleLanguageButton();
 
 		FlexTable lang = new FlexTable();
-		lang.setWidget(0, 1, languageButtonCzech);
-		lang.setWidget(0, 2, languageButtonEnglish);
+		lang.setWidget(0, 1, languageButton);
 		header.setWidget(0, 1, lang);
 		header.getFlexCellFormatter().setHorizontalAlignment(0, 1, HasHorizontalAlignment.ALIGN_RIGHT);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages.java
@@ -138,13 +138,13 @@ public interface ApplicationMessages extends Messages {
 	@DefaultMessage("Your e-mail address has NOT been verified !<p>Wrong verification code !")
 	String emailValidationFail();
 
-	@DefaultMessage("Change language to Czech")
-	String changeLanguageToCzech();
+	@DefaultMessage("Change language to {0}")
+	String changeLanguageToCzech(String lang);
 
 	@DefaultMessage("Change language to English")
 	String changeLanguageToEnglish();
 
-	@DefaultMessage("<p>Changing language will reload whole application.</p><p><strong>All unsaved changes will be lost.</strong></p><p>Do you want to proceed ?</p><hr/><p>Změna jazyka způsobí znovunačtení celé aplikace.</p><p><strong>Všechny neuložené změny budou ztraceny.</strong></p><p>Přejete si pokračovat ?</p>")
+	@DefaultMessage("<p>Changing language will reload whole application.</p><p><strong>All unsaved changes will be lost.</strong></p><p>Do you want to proceed ?</p>")
 	String changeLanguageText();
 
 	@DefaultMessage("<h2>You have already sent your initial application to this VO / group.</h2><h2>Please wait until your application is either approved or rejected by VO / group administrator.</h2>")

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ButtonTranslation.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ButtonTranslation.java
@@ -80,10 +80,10 @@ public interface ButtonTranslation extends Messages {
 	String fillButton();
 
 	@DefaultMessage("List all")
-		String listAllMembersButton();
+	String listAllMembersButton();
 
 	@DefaultMessage("List all")
-		String listAllUsersButton();
+	String listAllUsersButton();
 
 	@DefaultMessage("Verify")
 	String verifyButton();
@@ -115,25 +115,25 @@ public interface ButtonTranslation extends Messages {
 	/* CUSTOM BUTTONS */
 
 	@DefaultMessage("Copy from VO")
-		String copyFromVoButton();
+	String copyFromVoButton();
 
 	@DefaultMessage("Copy from group")
-		String copyFromGroupButton();
+	String copyFromGroupButton();
 
 	@DefaultMessage("Notifications")
 	String emailNotificationsButton();
 
 	@DefaultMessage("E-mail footer")
-		String mailFooterButton();
+	String mailFooterButton();
 
 	@DefaultMessage("Create service member")
-		String createServiceMemberButton();
+	String createServiceMemberButton();
 
 	@DefaultMessage("Search in external sources")
-		String searchForMembersInExtSourcesButton();
+	String searchForMembersInExtSourcesButton();
 
 	@DefaultMessage("Search among existing users")
-		String searchForMembersInPerunUsersButton();
+	String searchForMembersInPerunUsersButton();
 
 	@DefaultMessage("Edit")
 	String editFormItemButton();
@@ -142,34 +142,34 @@ public interface ButtonTranslation extends Messages {
 	String undeleteFormItemButton();
 
 	@DefaultMessage("Switch to EXTENSION")
-		String switchToExtensionButton();
+	String switchToExtensionButton();
 
 	@DefaultMessage("Switch to INITIAL")
-		String switchToInitialButton();
+	String switchToInitialButton();
 
-	@DefaultMessage("Switch to Czech")
-		String switchToCzechButton();
+	@DefaultMessage("Switch to {0}")
+	String switchToCzechButton(String lang);
 
 	@DefaultMessage("Switch to English")
-		String switchToEnglishButton();
+	String switchToEnglishButton();
 
 	@DefaultMessage("Add member")
-		String addMemberButton();
+	String addMemberButton();
 
 	@DefaultMessage("Add manager")
-		String addManagerButton();
+	String addManagerButton();
 
 	@DefaultMessage("Create group")
-		String createGroupButton();
+	String createGroupButton();
 
 	@DefaultMessage("Add member to resource")
-		String addMemberToResourceButton();
+	String addMemberToResourceButton();
 
 	@DefaultMessage("Edit")
 	String editButton();
 
 	@DefaultMessage("Force propagation")
-		String forcePropagationButton();
+	String forcePropagationButton();
 
 	@DefaultMessage("Block")
 	String blockPropagationButton();
@@ -178,7 +178,7 @@ public interface ButtonTranslation extends Messages {
 	String allowPropagationButton();
 
 	@DefaultMessage("List users without VO")
-		String listUsersWithoutVoButton();
+	String listUsersWithoutVoButton();
 
 	@DefaultMessage("Logout")
 	String logoutButton();
@@ -191,503 +191,503 @@ public interface ButtonTranslation extends Messages {
 	/* ATTRIBUTES */
 
 	@DefaultMessage("Create new attribute definition")
-		String createAttributeDefinition();
+	String createAttributeDefinition();
 
 	@DefaultMessage("Delete selected attribute definitions")
-		String deleteAttributeDefinition();
+	String deleteAttributeDefinition();
 
 	@DefaultMessage("Filter attribute definitions by name")
-		String filterAttributeDefinition();
+	String filterAttributeDefinition();
 
 	@DefaultMessage("Save new attributes")
-		String saveNewAttributes();
+	String saveNewAttributes();
 
 	@DefaultMessage("Save changes in selected attributes")
-		String saveChangesInAttributes();
+	String saveChangesInAttributes();
 
 	@DefaultMessage("Set new attributes")
-		String setNewAttributes();
+	String setNewAttributes();
 
 	@DefaultMessage("Remove values from selected attributes")
-		String removeAttributes();
+	String removeAttributes();
 
 	/* VOS */
 
 	@DefaultMessage("Create new virtual organization")
-		String createVo();
+	String createVo();
 
 	@DefaultMessage("Delete selected virtual organizations")
-		String deleteVo();
+	String deleteVo();
 
 	@DefaultMessage("Filter virtual organizations by name")
-		String filterVo();
+	String filterVo();
 
 	/* SLDS */
 
 	@DefaultMessage("Create new Service Level Description")
-		String createSLD();
+	String createSLD();
 
 	@DefaultMessage("Delete selected SLDs")
-		String deleteSLD();
+	String deleteSLD();
 
 	/* MEMBERS */
 
 	@DefaultMessage("Add new member to VO")
-		String addMemberToVo();
+	String addMemberToVo();
 
 	@DefaultMessage("Add selected candidates to VO")
-		String addSelectedCandidateToVo();
+	String addSelectedCandidateToVo();
 
 	@DefaultMessage("Remove selected members from VO")
-		String removeMemberFromVo();
+	String removeMemberFromVo();
 
 	@DefaultMessage("Search for members in VO by name, email or login")
-		String searchMemberInVo();
+	String searchMemberInVo();
 
 	@DefaultMessage("Add new member to group")
-		String addMemberToGroup();
+	String addMemberToGroup();
 
 	@DefaultMessage("Add selected members to group")
-		String addSelectedMemberToGroup();
+	String addSelectedMemberToGroup();
 
 	@DefaultMessage("Remove selected members from group")
-		String removeMemberFromGroup();
+	String removeMemberFromGroup();
 
 	@DefaultMessage("Search for members in group by name, email or login")
-		String searchMemberInGroup();
+	String searchMemberInGroup();
 
 	@DefaultMessage("Search for members in parent group by name, email or login")
-		String searchMemberInParentGroup();
+	String searchMemberInParentGroup();
 
 	@DefaultMessage("List all members in VO")
-		String listAllMembersInVo();
+	String listAllMembersInVo();
 
 	@DefaultMessage("List all members in group")
-		String listAllMembersInGroup();
+	String listAllMembersInGroup();
 
 	@DefaultMessage("Create service member in VO (can have multiple users assigned)")
-		String createServiceMember();
+	String createServiceMember();
 
 	@DefaultMessage("Search in external sources like LDAP, SQL DB,...")
-		String searchForMembersInExtSources();
+	String searchForMembersInExtSources();
 
 	@DefaultMessage("Search among existing Perun users")
-		String searchForMembersInPerunUsers();
+	String searchForMembersInPerunUsers();
 
 	@DefaultMessage("Add member to specific resource")
-		String addMemberToResource();
+	String addMemberToResource();
 
 	@DefaultMessage("Filter members by name")
-		String filterMembers();
+	String filterMembers();
 
 	@DefaultMessage("Change membership status for {0}")
-		String changeStatus(String name);
+	String changeStatus(String name);
 
 	/* MANAGERS */
 
 	@DefaultMessage("Add new VO manager")
-		String addManagerToVo();
+	String addManagerToVo();
 
 	@DefaultMessage("Add selected users as VO`s managers")
-		String addSelectedManagersToVo();
+	String addSelectedManagersToVo();
 
 	@DefaultMessage("Remove selected VO managers")
-		String removeManagerFromVo();
+	String removeManagerFromVo();
 
 	@DefaultMessage("Add group as new VO manager")
-		String addManagerGroupToVo();
+	String addManagerGroupToVo();
 
 	@DefaultMessage("Add selected groups as VO`s managers")
-		String addSelectedManagersGroupToVo();
+	String addSelectedManagersGroupToVo();
 
 	@DefaultMessage("Remove selected groups from VO managers")
-		String removeManagerGroupFromVo();
+	String removeManagerGroupFromVo();
 
 	@DefaultMessage("Add new group manager")
-		String addManagerToGroup();
+	String addManagerToGroup();
 
 	@DefaultMessage("Add selected users as groups managers")
-		String addSelectedManagersToGroup();
+	String addSelectedManagersToGroup();
 
 	@DefaultMessage("Remove selected group managers")
-		String removeManagerFromGroup();
+	String removeManagerFromGroup();
 
 	@DefaultMessage("Add group as new group manager")
-		String addManagerGroupToGroup();
+	String addManagerGroupToGroup();
 
 	@DefaultMessage("Add selected groups as groups managers")
-		String addSelectedManagersGroupToGroup();
+	String addSelectedManagersGroupToGroup();
 
 	@DefaultMessage("Remove selected groups from group managers")
-		String removeManagerGroupFromGroup();
+	String removeManagerGroupFromGroup();
 
 	@DefaultMessage("Add new facility manager")
-		String addManagerToFacility();
+	String addManagerToFacility();
 
 	@DefaultMessage("Add selected users as facility managers")
-		String addSelectedManagersToFacility();
+	String addSelectedManagersToFacility();
 
 	@DefaultMessage("Remove selected facility managers")
-		String removeManagerFromFacility();
+	String removeManagerFromFacility();
 
 	@DefaultMessage("Add new group as facility manager")
-		String addManagerGroupToFacility();
+	String addManagerGroupToFacility();
 
 	@DefaultMessage("Add selected groups as facility managers")
-		String addSelectedManagersGroupToFacility();
+	String addSelectedManagersGroupToFacility();
 
 	@DefaultMessage("Remove selected groups from facility managers")
-		String removeManagerGroupFromFacility();
+	String removeManagerGroupFromFacility();
 
 	/* USERS */
 
 	@DefaultMessage("Search for users by name, email or login")
-		String searchUsers();
+	String searchUsers();
 
 	@DefaultMessage("List all users in Perun without VO")
-		String listUsersWithoutVo();
+	String listUsersWithoutVo();
 
 	/* RESOURCES */
 
 	@DefaultMessage("Create new resource for VO")
-		String createResource();
+	String createResource();
 
 	@DefaultMessage("Delete selected resources")
-		String deleteResource();
+	String deleteResource();
 
 	@DefaultMessage("Filter resources by name or tag")
-		String filterResources();
+	String filterResources();
 
 	@DefaultMessage("Edit resource details")
-		String editResourceDetails();
+	String editResourceDetails();
 
 	@DefaultMessage("Save changes in resource details")
-		String saveResourceDetails();
+	String saveResourceDetails();
 
 	@DefaultMessage("Assign new group to this resource")
-		String assignGroupToResource();
+	String assignGroupToResource();
 
 	@DefaultMessage("Assign group to selected resources")
-		String assignGroupToSelectedResources();
+	String assignGroupToSelectedResources();
 
 	@DefaultMessage("Assign this group to new resources")
-		String assignGroupToResources();
+	String assignGroupToResources();
 
 	@DefaultMessage("Assign new tags to this resource")
-		String assignTagsToResource();
+	String assignTagsToResource();
 
 	@DefaultMessage("Remove selected groups from this resource")
-		String removeGroupFromResource();
+	String removeGroupFromResource();
 
 	@DefaultMessage("Remove group from selected resources")
-		String removeGroupFromSelectedResources();
+	String removeGroupFromSelectedResources();
 
 	@DefaultMessage("Remove selected tags from this resource")
-		String removeSelectedTagsFromResource();
+	String removeSelectedTagsFromResource();
 
 	@DefaultMessage("Assign new service to this resource")
-		String assignServiceToResource();
+	String assignServiceToResource();
 
 	@DefaultMessage("Remove selected services from this resource")
-		String removeServiceFromResource();
+	String removeServiceFromResource();
 
 	@DefaultMessage("Assign selected groups to resource")
-		String assignSelectedGroupsToResource();
+	String assignSelectedGroupsToResource();
 
 	@DefaultMessage("Assign selected services to resource")
-		String assignSelectedServicesToResource();
+	String assignSelectedServicesToResource();
 
 	@DefaultMessage("Assign selected tags to resource")
-		String assignSelectedTagsToResource();
+	String assignSelectedTagsToResource();
 
 	@DefaultMessage("Fill values for all empty displayed attributes based on current configuration. Changes are not saved until you click on \"Save\" button.")
-		String fillResourceAttributes();
+	String fillResourceAttributes();
 
 	@DefaultMessage("Finish assigning of selected group")
-		String finishGroupAssigning();
+	String finishGroupAssigning();
 
 	/* RESOURCES TAGS */
 
 	@DefaultMessage("Save changes in resource`s tags names")
-		String updateResourceTag();
+	String updateResourceTag();
 
 	@DefaultMessage("Create new resource`s tag in VO")
-		String createResourceTag();
+	String createResourceTag();
 
 	@DefaultMessage("Delete selected resource`s tags from VO")
-		String deleteResourceTag();
+	String deleteResourceTag();
 
 
 	/* GROUPS */
 
 	@DefaultMessage("Create new group")
-		String createGroup();
+	String createGroup();
 
 	@DefaultMessage("Create new sub-group")
-		String createSubGroup();
+	String createSubGroup();
 
 	@DefaultMessage("Delete selected groups")
-		String deleteGroup();
+	String deleteGroup();
 
 	@DefaultMessage("Delete selected sub-groups")
-		String deleteSubGroup();
+	String deleteSubGroup();
 
 	@DefaultMessage("Filter groups by name")
-		String filterGroup();
+	String filterGroup();
 
 	@DefaultMessage("Edit group details")
-		String editGroupDetails();
+	String editGroupDetails();
 
 	@DefaultMessage("Save changes in group`s details")
-		String saveGroupDetails();
+	String saveGroupDetails();
 
 	/* EXT SOURCES */
 
 	@DefaultMessage("Add new external source of users")
-		String addExtSource();
+	String addExtSource();
 
 	@DefaultMessage("Add selected external sources of users")
-		String addSelectedExtSource();
+	String addSelectedExtSource();
 
 	@DefaultMessage("Remove selected external sources of users")
-		String removeExtSource();
+	String removeExtSource();
 
 	/* APPLICATIONS + NOTIFICATIONS */
 
 	@DefaultMessage("Verify selected applications")
-		String verifyApplication();
+	String verifyApplication();
 
 	@DefaultMessage("Approve selected applications (must be in state VERIFIED)")
-		String approveApplication();
+	String approveApplication();
 
 	@DefaultMessage("Reject selected applications")
-		String rejectApplication();
+	String rejectApplication();
 
 	@DefaultMessage("Delete selected applications (must be in state NEW or REJECTED)")
-		String deleteApplication();
+	String deleteApplication();
 
 	@DefaultMessage("Filter applications by user")
-		String filterApplications();
+	String filterApplications();
 
 	@DefaultMessage("Save changes made in application form")
-		String saveApplicationFormSettings();
+	String saveApplicationFormSettings();
 
 	@DefaultMessage("Add new application form item")
-		String addNewAppFormItem();
+	String addNewAppFormItem();
 
 	@DefaultMessage("Preview application form (with unsaved changes)")
-		String previewAppForm();
+	String previewAppForm();
 
 	@DefaultMessage("Change application form settings")
-		String changeAppFormSettings();
+	String changeAppFormSettings();
 
 	@DefaultMessage("Copy all form items from another VO into this")
-		String copyFromVo();
+	String copyFromVo();
 
 	@DefaultMessage("Copy all form items from another group into this")
-		String copyFromGroup();
+	String copyFromGroup();
 
 	@DefaultMessage("Manage e-mail notifications")
-		String emailNotifications();
+	String emailNotifications();
 
 	@DefaultMessage("Copy notifications from another VO into yours")
-		String copyMailsFromVo();
+	String copyMailsFromVo();
 
 	@DefaultMessage("Copy notifications from another group into yours")
-		String copyMailsFromGroup();
+	String copyMailsFromGroup();
 
 	@DefaultMessage("Add new mail notification")
-		String addMail();
+	String addMail();
 
 	@DefaultMessage("Remove selected mail notifications")
-		String removeMail();
+	String removeMail();
 
 	@DefaultMessage("Enable sending for selected mail notifications")
-		String enableMail();
+	String enableMail();
 
 	@DefaultMessage("Disable sending for selected mail notifications")
-		String disableMail();
+	String disableMail();
 
 	@DefaultMessage("Edit common footer, which can be added to each mail by mailFooter")
-		String editMailFooter();
+	String editMailFooter();
 
 	@DefaultMessage("Edit form item properties")
-		String editFormItem();
+	String editFormItem();
 
 	@DefaultMessage("Delete form item")
-		String deleteFormItem();
+	String deleteFormItem();
 
 	@DefaultMessage("Move form item up")
-		String moveFormItemUp();
+	String moveFormItemUp();
 
 	@DefaultMessage("Move form item down")
-		String moveFormItemDown();
+	String moveFormItemDown();
 
 	@DefaultMessage("Restore deleted form item")
-		String undeleteFormItem();
+	String undeleteFormItem();
 
 	@DefaultMessage("Create and configure new form item")
-		String createFormItem();
+	String createFormItem();
 
 	@DefaultMessage("Save local changes of form item")
-		String saveFormItem();
+	String saveFormItem();
 
 	@DefaultMessage("Switch between INITIAL and EXTENSION")
-		String switchBetweenInitialAndExtension();
+	String switchBetweenInitialAndExtension();
 
-	@DefaultMessage("Switch between Czech and English language")
-		String switchBetweenCzechAndEnglish();
+	@DefaultMessage("Switch between English and native language")
+	String switchBetweenCzechAndEnglish();
 
 	@DefaultMessage("Create new e-mail notification for application")
-		String createEmailNotificationForApplication();
+	String createEmailNotificationForApplication();
 
 	@DefaultMessage("Save changes in e-mail notification for application")
-		String saveEmailNotificationForApplication();
+	String saveEmailNotificationForApplication();
 
 	@DefaultMessage("Create empty application form")
-		String createEmptyApplicationForm();
+	String createEmptyApplicationForm();
 
 	@DefaultMessage("Add new item into selectionbox / combobox widget")
-		String addNewSelectionBoxItem();
+	String addNewSelectionBoxItem();
 
 	@DefaultMessage("Save changes in mail footer definition")
-		String saveMailFooter();
+	String saveMailFooter();
 
 	@DefaultMessage("Filter applications by VO or group")
-		String filterByVoOrGroup();
+	String filterByVoOrGroup();
 
 	/* OWNERS */
 
 	@DefaultMessage("Create new owner")
-		String createOwner();
+	String createOwner();
 
 	@DefaultMessage("Delete selected owners")
-		String deleteOwner();
+	String deleteOwner();
 
 	@DefaultMessage("Filter owners by name, contact or type")
-		String filterOwners();
+	String filterOwners();
 
 	@DefaultMessage("Add selected owners")
-		String addOwners();
+	String addOwners();
 
 	@DefaultMessage("Add new owners")
-		String addNewOwners();
+	String addNewOwners();
 
 	@DefaultMessage("Remove selected owners")
-		String removeSelectedOwners();
+	String removeSelectedOwners();
 
 	/* FACILITIES */
 
 	@DefaultMessage("Create new facility")
-		String createFacility();
+	String createFacility();
 
 	@DefaultMessage("Delete selected facilities")
-		String deleteFacilities();
+	String deleteFacilities();
 
 	@DefaultMessage("Filter facilities by name or owner")
-		String filterFacilities();
+	String filterFacilities();
 
 	@DefaultMessage("Edit facility details")
-		String editFacilityDetails();
+	String editFacilityDetails();
 
 	@DefaultMessage("Save changes in facility details")
-		String saveFacilityDetails();
+	String saveFacilityDetails();
 
 	@DefaultMessage("Finish configuration of facility")
-		String finishFacilityConfiguration();
+	String finishFacilityConfiguration();
 
 	@DefaultMessage("Refresh list of propagation results")
-		String refreshPropagationResults();
+	String refreshPropagationResults();
 
 	@DefaultMessage("Add new destination")
-		String addDestination();
+	String addDestination();
 
 	@DefaultMessage("Remove selected destinations")
-		String removeSelectedDestinations();
+	String removeSelectedDestinations();
 
 	@DefaultMessage("Filter destinations by name or service")
-		String filterDestination();
+	String filterDestination();
 
 	@DefaultMessage("Filter destinations by name or facility")
-		String filterDestinationByFacility();
+	String filterDestinationByFacility();
 
 	@DefaultMessage("Force propagation of selected services")
-		String forcePropagation();
+	String forcePropagation();
 
 	@DefaultMessage("Block propagation of selected services")
-		String blockServicesOnFacility();
+	String blockServicesOnFacility();
 
 	@DefaultMessage("Allow propagation of selected services")
-		String allowServicesOnFacility();
+	String allowServicesOnFacility();
 
 	@DefaultMessage("Add new hosts to facility")
-		String addHost();
+	String addHost();
 
 	@DefaultMessage("Remove selected hosts from facility")
-		String removeHosts();
+	String removeHosts();
 
 	@DefaultMessage("Filter hosts by name")
-		String filterHosts();
+	String filterHosts();
 
 	/* PERUN ADMIN */
 
 	@DefaultMessage("Refresh list of audit messages")
-		String refreshAuditMessages();
+	String refreshAuditMessages();
 
 	/* SERVICES */
 
 	@DefaultMessage("Create new service in Perun")
-		String createService();
+	String createService();
 
 	@DefaultMessage("Delete selected services from Perun")
-		String deleteSelectedServices();
+	String deleteSelectedServices();
 
 	@DefaultMessage("Add required attribute")
-		String addRequiredAttribute();
+	String addRequiredAttribute();
 
 	@DefaultMessage("Add selected attribute definitions between required by service")
-		String addSelectedRequiredAttribute();
+	String addSelectedRequiredAttribute();
 
 	@DefaultMessage("Remove selected attribute definitions from required by service")
-		String removeSelectedRequiredAttributes();
+	String removeSelectedRequiredAttributes();
 
 	@DefaultMessage("Add dependent exec service")
-		String addDependantExecService();
+	String addDependantExecService();
 
 	@DefaultMessage("Remove selected dependent services")
-		String removeSelectedDependantExecServices();
+	String removeSelectedDependantExecServices();
 
 	@DefaultMessage("Add dependent exec service")
-		String createExecService();
+	String createExecService();
 
 	@DefaultMessage("Remove selected dependent services")
-		String deleteSelectedExecServices();
+	String deleteSelectedExecServices();
 
 	@DefaultMessage("Filter services by name")
-		String filterServices();
+	String filterServices();
 
 	/* SERVICE PACKAGES */
 
 	@DefaultMessage("Create new service package in Perun")
-		String createServicePackage();
+	String createServicePackage();
 
 	@DefaultMessage("Delete selected service packages from Perun")
-		String deleteSelectedServicePackages();
+	String deleteSelectedServicePackages();
 
 	@DefaultMessage("Save changes in services packages")
-		String saveChangesInServicesPackages();
+	String saveChangesInServicesPackages();
 
 	/* TAGS */
 
 	@DefaultMessage("Filter resources tags by name")
-		String filterTags();
+	String filterTags();
 
 	/* ======= TITLES FOR DISABLED BUTTONS =============== */
 
 	@DefaultMessage("Click to logout from Perun GUI")
-		String logout();
+	String logout();
 
 	@DefaultMessage("Click to select identity")
-		String select();
+	String select();
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/WidgetTranslation.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/WidgetTranslation.java
@@ -15,115 +15,115 @@ public interface WidgetTranslation extends Messages {
 	/* AJAX LOADER WIDGET */
 
 	@DefaultMessage("No items found.")
-		String noItemsFound();
+	String noItemsFound();
 
 	@DefaultMessage("Request timeout exceeded, please try again later.")
-		String requestTimeout();
+	String requestTimeout();
 
 	@DefaultMessage("Server responded with an error.")
-		String serverRespondedWithError();
+	String serverRespondedWithError();
 
 	@DefaultMessage("Type the text to search form and click on the Search button.")
-		String emptySearch();
+	String emptySearch();
 
 	/* CUSTOM TEXTS FOR AJAX LOADER WIDGET */
 
 	@DefaultMessage("Type in user`s First name, Last name (or both) or Login or Email and press Search button.")
-		String emptySearchForUsers();
+	String emptySearchForUsers();
 
 	@DefaultMessage("Search member by name, login, email or click 'List all' to see all members.")
-		String emptySearchForMembers();
+	String emptySearchForMembers();
 
 	@DefaultMessage("Type in external identification (login) of people you want to add as members and press Search button.")
-		String emptySearchForCandidates();
+	String emptySearchForCandidates();
 
 	/* REST - CHECKBOX WIDGETS*/
 
 	@DefaultMessage("Show expired / disabled members")
-		String showDisabledMembers();
+	String showDisabledMembers();
 
 	@DefaultMessage("Show also members with expired / disabled membership")
-		String showDisabledMembersTitle();
+	String showDisabledMembersTitle();
 
 	@DefaultMessage("Offer available only")
-		String offerAvailableServicesOnly();
+	String offerAvailableServicesOnly();
 
 	@DefaultMessage("Offer only currently available services")
-		String offerAvailableServicesOnlyTitle();
+	String offerAvailableServicesOnlyTitle();
 
 	@DefaultMessage("Configure group(s) before assign")
-		String configureGroupBeforeAssign();
+	String configureGroupBeforeAssign();
 
 	@DefaultMessage("Configure group(s) and members settings before assigning to resource")
-		String configureGroupBeforeAssignTitle();
+	String configureGroupBeforeAssignTitle();
 
 	@DefaultMessage("Display all services")
-		String displayAllServices();
+	String displayAllServices();
 
 	@DefaultMessage("Display all possible services to create destination for")
-		String displayAllServicesTitle();
+	String displayAllServicesTitle();
 
 	@DefaultMessage("Use names of all facility`s hosts")
-		String useFacilityHostnames();
+	String useFacilityHostnames();
 
 	@DefaultMessage("Use names of all hosts on facility as destinations for selected service(s)")
-		String useFacilityHostnamesTitle();
+	String useFacilityHostnamesTitle();
 
 	/* CANT SAVE EMPTY LIST CONFIRM */
 
 	@DefaultMessage("No items selected")
-		String cantSaveEmptyListConfirmHeader();
+	String cantSaveEmptyListConfirmHeader();
 
 	@DefaultMessage("To make changes please select some items first.")
-		String cantSaveEmptyListConfirmMessage();
+	String cantSaveEmptyListConfirmMessage();
 
 	/* SEARCH STRING CANT BE EMPTY */
 
 	@DefaultMessage("Search string is empty")
-		String searchStringCantBeEmptyHeader();
+	String searchStringCantBeEmptyHeader();
 
 	@DefaultMessage("Can`t search for items by empty string.")
-		String searchStringCantBeEmptyMessage();
+	String searchStringCantBeEmptyMessage();
 
 	/* CANT SAVE EMPTY ATTRIBUTE */
 
 	@DefaultMessage("Wrong attribute value")
-		String cantSaveAttributeValueDialogBoxHeader();
+	String cantSaveAttributeValueDialogBoxHeader();
 
 	@DefaultMessage("Can`t save null or empty string as value for attribute <strong>{0}</strong>.<p>To safely remove value please use Remove button.")
-		String cantSaveAttributeValueDialogBoxWrongString(String attrName);
+	String cantSaveAttributeValueDialogBoxWrongString(String attrName);
 
 	@DefaultMessage("Can`t save \"Not a number\" as value for attribute <strong>{0}</strong>.<p>To safely remove value please use Remove button.")
-		String cantSaveAttributeValueDialogBoxWrongInteger(String attrName);
+	String cantSaveAttributeValueDialogBoxWrongInteger(String attrName);
 
 	@DefaultMessage("Can`t save empty list as value for attribute <strong>{0}</strong>.<p>To safely remove value please use Remove button.")
-		String cantSaveAttributeValueDialogBoxWrongList(String attrName);
+	String cantSaveAttributeValueDialogBoxWrongList(String attrName);
 
 	@DefaultMessage("Can`t parse value for attribute <strong>{0}</strong>.<p>Please try again or to safely remove value use Remove button.")
-		String cantSaveAttributeValueDialogBoxGeneral(String attrName);
+	String cantSaveAttributeValueDialogBoxGeneral(String attrName);
 
 	/* JSONCLIENT / JSONPOSTCLIENT ALERT BOX */
 
 	@DefaultMessage("Server responded with an error")
-		String jsonClientAlertBoxHeader();
+	String jsonClientAlertBoxHeader();
 
 	@DefaultMessage("Report error")
-		String jsonClientReportErrorButton();
+	String jsonClientReportErrorButton();
 
 	@DefaultMessage("You are not authorized")
-		String jsonClientNotAuthorizedHeader();
+	String jsonClientNotAuthorizedHeader();
 
 	@DefaultMessage("You are not authorized to perform this action. If you think you should have this right, send us report.")
-		String jsonClientNotAuthorizedMessage();
+	String jsonClientNotAuthorizedMessage();
 
 	@DefaultMessage("Send report to RT")
-		String jsonClientSendErrorButton();
+	String jsonClientSendErrorButton();
 
 	@DefaultMessage("Error type:")
-		String jsonClientAlertBoxErrorType();
+	String jsonClientAlertBoxErrorType();
 
 	@DefaultMessage("Error text:")
-		String jsonClientAlertBoxErrorText();
+	String jsonClientAlertBoxErrorText();
 
 	@DefaultMessage("Request:")
 	String jsonClientAlertBoxErrorRequest();
@@ -144,24 +144,24 @@ public interface WidgetTranslation extends Messages {
 	String jsonClientAlertBoxErrorMessage();
 
 	@DefaultMessage("Error while sending request")
-		String jsonClientAlertBoxErrorCrossSiteType();
+	String jsonClientAlertBoxErrorCrossSiteType();
 
 	@DefaultMessage("Response was null or blocked by browser (cross-site request).")
-		String jsonClientAlertBoxErrorCrossSiteText();
+	String jsonClientAlertBoxErrorCrossSiteText();
 
 	/* FOOTER SETTINGS BUTTONS */
 
-	@DefaultMessage("Change language to Czech")
-		String changeLanguageToCzech();
+	@DefaultMessage("Change language to {0}")
+	String changeLanguageToCzech(String lang);
 
 	@DefaultMessage("Change language to English")
-		String changeLanguageToEnglish();
+	String changeLanguageToEnglish();
 
 	@DefaultMessage("<p>Changing language will reload whole application.</p><p><strong>All unsaved changes will be lost.</strong></p><p class=\"inputFormInlineComment\">Function is experimental - only few strings are translated to Czech at the moment.</p><p>Do you want to proceed ?</p>")
-		String changeLanguageConfirmText();
+	String changeLanguageConfirmText();
 
 	@DefaultMessage("Show / hide extended information")
-		String showHideExtendedInfo();
+	String showHideExtendedInfo();
 
 	/* LISTBOX STANDARD PARAMS */
 
@@ -169,40 +169,40 @@ public interface WidgetTranslation extends Messages {
 	String listboxAll();
 
 	@DefaultMessage("Not selected")
-		String listboxNotSelected();
+	String listboxNotSelected();
 
 	/* LISTBOX STANDARD PARAMS */
 
 	@DefaultMessage("By selecting a member you switch to members settings")
-		String selectingMember();
+	String selectingMember();
 
 	/* PERUN ATTRIBUTE CELLS */
 
 	@DefaultMessage("Add new value")
-		String addValue();
+	String addValue();
 
 	@DefaultMessage("Remove this value")
-		String removeValue();
+	String removeValue();
 
 	@DefaultMessage("You are not allowed to change this value")
-		String notWritable();
+	String notWritable();
 
 	/* TAB PANEL BUTTONS */
 
 	@DefaultMessage("Refresh tab")
-		String refreshTabButton();
+	String refreshTabButton();
 
 	@DefaultMessage("Move to left")
-		String moveLeftButton();
+	String moveLeftButton();
 
 	@DefaultMessage("Move to right")
-		String moveRightButton();
+	String moveRightButton();
 
 	@DefaultMessage("Close other tabs")
-		String closeOthersButton();
+	String closeOthersButton();
 
 	@DefaultMessage("Close this tab")
-		String closeThisTab();
+	String closeThisTab();
 
 	/* CUSTOM BUTTON WIDGET */
 
@@ -212,19 +212,19 @@ public interface WidgetTranslation extends Messages {
 	/* DELETE CONFIRM WIDGET */
 
 	@DefaultMessage("Confirm delete action")
-		String deleteConfirmTitle();
+	String deleteConfirmTitle();
 
 	@DefaultMessage("Following items will be removed:")
-		String deleteConfirmText();
+	String deleteConfirmText();
 
 	/* APPLICATION FORM */
 
 	@DefaultMessage("Form doesn`t exists, do you wish to create new one ?")
-		String formDoesntExists();
+	String formDoesntExists();
 
 	/* SAVE CONFIRM WIDGET */
 
 	@DefaultMessage("Confirm save action")
-		String saveConfirmTitle();
+	String saveConfirmTitle();
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/SmallIcons.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/SmallIcons.java
@@ -2963,8 +2963,8 @@ public interface SmallIcons extends ClientBundle{
 	@Source("icons/16x16/flag_czech_republic.png")
 	ImageResource flagCzechRepublicIcon();
 
-	@Source("icons/16x16/flag_cze_gb.png")
-	ImageResource flagCzechBritainIcon();
+	//@Source("icons/16x16/flag_cze_gb.png")
+	//ImageResource flagCzechBritainIcon();
 
 	//@Source("icons/16x16/flag_denmark.png")
 	//ImageResource flagDenmarkIcon();
@@ -4406,8 +4406,8 @@ public interface SmallIcons extends ClientBundle{
 	//@Source("icons/16x16/livejournal.png")
 	//ImageResource livejournalIcon();
 
-	//@Source("icons/16x16/locate.png")
-	//ImageResource locateIcon();
+	@Source("icons/16x16/locate.png")
+	ImageResource locateIcon();
 
 	//@Source("icons/16x16/location_pin.png")
 	//ImageResource locationPinIcon();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -333,6 +333,29 @@ public class Utils {
 	}
 
 	/**
+	 * Returns list of Strings representing native language in order "code","native name","english name"
+	 *
+	 * e,g. "cs","Česky","Czech" for Czech language.
+	 *
+	 * @return list of strings representing native language
+	 */
+	public static ArrayList<String> getNativeLanguage() {
+
+		ArrayList<String> list = new ArrayList<String>();
+		if (PerunWebSession.getInstance().getConfiguration() != null) {
+			String value = PerunWebSession.getInstance().getConfiguration().getCustomProperty("nativeLanguage");
+			if (value != null && !value.isEmpty()) {
+				String[] parts = value.split(",");
+				for (int i=0; i<parts.length; i++) {
+					list.add(parts[i]);
+				}
+			}
+		}
+		return list;
+
+	}
+
+	/**
 	 * Returns address to perun support
 	 *
 	 * @return support email as string

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
@@ -6,6 +6,7 @@ import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.applicationresources.RegistrarFormItemGenerator;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallback;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonClient;
@@ -148,11 +149,11 @@ public class GetApplicationDataById implements JsonCallback{
 		ft.setWidth("100%");
 		ft.setCellPadding(10);
 		FlexCellFormatter fcf = ft.getFlexCellFormatter();
-		String locale = "en";
+		String locale;
 		if (LocaleInfo.getCurrentLocale().getLocaleName().equals("default") || LocaleInfo.getCurrentLocale().getLocaleName().equals("en")) {
 			locale = "en";
 		} else {
-			locale = "cs";
+			locale = Utils.getNativeLanguage().get(0);
 		}
 
 		int i = 0;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
@@ -14,6 +14,7 @@ import cz.metacentrum.perun.webgui.client.localization.WidgetTranslation;
 import cz.metacentrum.perun.webgui.client.resources.ButtonType;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallback;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonClient;
@@ -235,7 +236,7 @@ public class GetFormItems implements JsonCallback {
 		if (LocaleInfo.getCurrentLocale().getLocaleName().equals("default") || LocaleInfo.getCurrentLocale().getLocaleName().equals("en")) {
 			locale = "en";
 		} else {
-			locale = "cs";
+			locale = Utils.getNativeLanguage().get(0);
 		}
 
 		int i = 1;
@@ -542,12 +543,12 @@ public class GetFormItems implements JsonCallback {
 
 		FlexTable ft = new FlexTable();
 		FlexCellFormatter fcf = ft.getFlexCellFormatter();
-		String locale = "en";
+		String locale;
 
 		if (LocaleInfo.getCurrentLocale().getLocaleName().equals("default")) {
 			locale = "en";
 		} else {
-			locale = "cs";
+			locale = Utils.getNativeLanguage().get(0);
 		}
 
 		int i = 0;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.webgui.client.applicationresources.SendsApplicationF
 import cz.metacentrum.perun.webgui.client.localization.ApplicationMessages;
 import cz.metacentrum.perun.webgui.client.resources.LargeIcons;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallback;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonClient;
@@ -289,10 +290,10 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 		FlexCellFormatter fcf = ft.getFlexCellFormatter();
 		String locale;
 
-		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals("cs")) {
+		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0))) {
 			locale = "en";
 		} else {
-			locale = "cs";
+			locale = Utils.getNativeLanguage().get(0);
 		}
 
 		int i = 0;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/SetSendingEnabled.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/SetSendingEnabled.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.webgui.json.registrarManager;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.json.client.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonPostClient;
 import cz.metacentrum.perun.webgui.model.ApplicationMail;
@@ -108,7 +109,7 @@ public class SetSendingEnabled {
 			JSONObject mailTexts = new JSONObject();
 
 			// update texts
-			String locales[] = {"cs", "en"};
+			String locales[] = {Utils.getNativeLanguage().get(0), "en"};
 			for(String locale : locales){
 
 				MailText mt = appMail.getMessage(locale);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateApplicationMail.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateApplicationMail.java
@@ -6,6 +6,7 @@ import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonPostClient;
 import cz.metacentrum.perun.webgui.model.ApplicationMail;
@@ -103,7 +104,7 @@ public class UpdateApplicationMail {
 		JSONObject mailTexts = new JSONObject();
 
 		// update texts
-		String locales[] = {"cs", "en"};
+		String locales[] = {Utils.getNativeLanguage().get(0), "en"};
 		for(String locale : locales){
 
 			MailText mt = appMail.getMessage(locale);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItems.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItems.java
@@ -7,6 +7,7 @@ import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonPostClient;
 import cz.metacentrum.perun.webgui.model.ApplicationFormItem;
@@ -134,7 +135,7 @@ public class UpdateFormItems {
 			// recreate i18n
 			JSONObject i18n = new JSONObject();
 			i18n.put("en", new JSONObject(formItems.get(i).getItemTexts("en")));
-			i18n.put("cs", new JSONObject(formItems.get(i).getItemTexts("cs")));
+			i18n.put(Utils.getNativeLanguage().get(0), new JSONObject(formItems.get(i).getItemTexts(Utils.getNativeLanguage().get(0))));
 			newItem.put("i18n", i18n);
 
 			data.set(i, newItem);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItem.java
@@ -22,229 +22,230 @@ public class ApplicationFormItem extends JavaScriptObject {
 		return this.id;
 	}-*/;
 
-		/**
-		 * Get shorname
-		 * @return shortname
-		 */
-		public final native String getShortname() /*-{
-			if(typeof this.shortname == "undefined") return "";
-			return this.shortname;
-		}-*/;
+	/**
+	 * Get shortname
+	 * @return shortname
+	 */
+	public final native String getShortname() /*-{
+		if(typeof this.shortname == "undefined") return "";
+		return this.shortname;
+	}-*/;
 
-		/**
-		 * Set shorname
-		 */
-		public final native void setShortname(String shortname) /*-{
-			this.shortname = shortname;
-		}-*/;
+	/**
+	 * Set shortname
+	 * @param shortname
+	 */
+	public final native void setShortname(String shortname) /*-{
+		this.shortname = shortname;
+	}-*/;
 
-		/**
-		 * Is required
-		 * @return required
-		 */
-		public final native boolean isRequired() /*-{
-			if(typeof this.required == "undefined") return false;
-			return this.required;
-		}-*/;
+	/**
+	 * Is required
+	 * @return required
+	 */
+	public final native boolean isRequired() /*-{
+		if(typeof this.required == "undefined") return false;
+		return this.required;
+	}-*/;
 
-		/**
-		 * Set required
-		 */
-		public final native void setRequired(boolean required) /*-{
-			this.required = required;
-		}-*/;
+	/**
+	 * Set required
+	 */
+	public final native void setRequired(boolean required) /*-{
+		this.required = required;
+	}-*/;
 
-		/**
-		 * Get type
-		 * @return type
-		 */
-		public final native String getType() /*-{
-			return this.type;
-		}-*/;
+	/**
+	 * Get type
+	 * @return type
+	 */
+	public final native String getType() /*-{
+		return this.type;
+	}-*/;
 
-		/**
-		 * Get federationAttribute
-		 * @return federationAttribute
-		 */
-		public final native String getFederationAttribute() /*-{
-			if(typeof this.federationAttribute == "undefined") return "";
-			return this.federationAttribute;
-		}-*/;
+	/**
+	 * Get federationAttribute
+	 * @return federationAttribute
+	 */
+	public final native String getFederationAttribute() /*-{
+		if(typeof this.federationAttribute == "undefined") return "";
+		return this.federationAttribute;
+	}-*/;
 
-		/**
-		 * Set federationAttribute
-		 */
-		public final native void setFederationAttribute(String federationAttribute) /*-{
-			this.federationAttribute = federationAttribute;
-		}-*/;
+	/**
+	 * Set federationAttribute
+	 */
+	public final native void setFederationAttribute(String federationAttribute) /*-{
+		this.federationAttribute = federationAttribute;
+	}-*/;
 
-		/**
-		 * Get perunDestinationAttribute
-		 * @return perunDestinationAttribute
-		 */
-		public final native String getPerunDestinationAttribute() /*-{
-			if(typeof this.perunDestinationAttribute == "undefined") return "";
-			return this.perunDestinationAttribute;
-		}-*/;
+	/**
+	 * Get perunDestinationAttribute
+	 * @return perunDestinationAttribute
+	 */
+	public final native String getPerunDestinationAttribute() /*-{
+		if(typeof this.perunDestinationAttribute == "undefined") return "";
+		return this.perunDestinationAttribute;
+	}-*/;
 
-		/**
-		 * Set perunDestinationAttribute
-		 */
-		public final native void setPerunDestinationAttribute(String perunDestinationAttribute) /*-{
-			this.perunDestinationAttribute = perunDestinationAttribute;
-		}-*/;
+	/**
+	 * Set perunDestinationAttribute
+	 */
+	public final native void setPerunDestinationAttribute(String perunDestinationAttribute) /*-{
+		this.perunDestinationAttribute = perunDestinationAttribute;
+	}-*/;
 
-		/**
-		 * Get regex
-		 * @return regex
-		 */
-		public final native String getRegex() /*-{
-			if(typeof this.regex == "undefined") return "";
-			return this.regex;
-		}-*/;
+	/**
+	 * Get regex
+	 * @return regex
+	 */
+	public final native String getRegex() /*-{
+		if(typeof this.regex == "undefined") return "";
+		return this.regex;
+	}-*/;
 
-		/**
-		 * Set regex
-		 */
-		public final native void setRegex(String regex) /*-{
-			this.regex = regex;
-		}-*/;
+	/**
+	 * Set regex
+	 */
+	public final native void setRegex(String regex) /*-{
+		this.regex = regex;
+	}-*/;
 
-		/**
-		 * List of applicationTypes
-		 * @return applicationTypes
-		 */
-		public final native JsArrayString getApplicationTypes() /*-{
-			return this.applicationTypes;
-		}-*/;
+	/**
+	 * List of applicationTypes
+	 * @return applicationTypes
+	 */
+	public final native JsArrayString getApplicationTypes() /*-{
+		return this.applicationTypes;
+	}-*/;
 
-		/**
-		 * Set applicationTypes
-		 */
-		public final native void setApplicationTypes(JsArrayString applicationTypes) /*-{
-			this.applicationTypes = applicationTypes;
-		}-*/;
+	/**
+	 * Set applicationTypes
+	 */
+	public final native void setApplicationTypes(JsArrayString applicationTypes) /*-{
+		this.applicationTypes = applicationTypes;
+	}-*/;
 
-		/**
-		 * Set applicationTypes
-		 */
-		public final native void setApplicationTypes(JavaScriptObject applicationTypes) /*-{
-			this.applicationTypes = applicationTypes;
-		}-*/;
+	/**
+	 * Set applicationTypes
+	 */
+	public final native void setApplicationTypes(JavaScriptObject applicationTypes) /*-{
+		this.applicationTypes = applicationTypes;
+	}-*/;
 
-		/**
-		 * get ordnum
-		 * @return ordnum
-		 */
-		public final native int getOrdnum() /*-{
-			return this.ordnum;
-		}-*/;
+	/**
+	 * get ordnum
+	 * @return ordnum
+	 */
+	public final native int getOrdnum() /*-{
+		return this.ordnum;
+	}-*/;
 
-		/**
-		 * Set ordnum
-		 */
-		public final native void setOrdnum(int ordnum) /*-{
-			this.ordnum = ordnum;
-		}-*/;
+	/**
+	 * Set ordnum
+	 */
+	public final native void setOrdnum(int ordnum) /*-{
+		this.ordnum = ordnum;
+	}-*/;
 
-		/**
-		 * Get ItemTexts
-		 * @return
-		 */
-		public final native ItemTexts getItemTexts(String locale) /*-{
-			if(!(locale in this.i18n)){
+	/**
+	 * Get ItemTexts
+	 * @return
+	 */
+	public final native ItemTexts getItemTexts(String locale) /*-{
+		if(!(locale in this.i18n)){
 			this.i18n[locale] = {locale: locale, errorMessage : "", help : "", label : "", options : ""};
-			}
-			return this.i18n[locale];
-		}-*/;
-
-		/**
-		 * Set item texts
-		 */
-		public final native void setItemTexts(String locale, ItemTexts itemTexts) /*-{
-			this.i18n[locale] = itemTexts;
-		}-*/;
-
-		/**
-		 * get for delete state
-		 * @return for delete
-		 */
-		public final native boolean isForDelete() /*-{
-			if (!this.forDelete) { return false; }
-			return this.forDelete;
-		}-*/;
-
-		/**
-		 * Set deletion state
-		 * @param del true = delete / false = keep (default)
-		 */
-		public final native void setForDelete(boolean del) /*-{
-			this.forDelete = del;
-		}-*/;
-
-		/**
-		 * Return TRUE if item item was edited
-		 * (this property is for GUI purpose only)
-		 *
-		 * @return edited
-		 */
-		public final native boolean wasEdited() /*-{
-			if (!this.edited) { return false; }
-			return this.edited;
-		}-*/;
-
-		/**
-		 * Set edited state
-		 * (this property is for GUI purpose only)
-		 *
-		 * @param edited true = edited / false = not edited (default)
-		 */
-		public final native void setEdited(boolean edited) /*-{
-			this.edited = edited;
-		}-*/;
-
-
-
-		/**
-		 * Returns Perun specific type of object
-		 *
-		 * @return type of object
-		 */
-		public final native String getObjectType() /*-{
-			if (!this.beanName) {
-			return "JavaScriptObject"
-			}
-			return this.beanName;
-		}-*/;
-
-		/**
-		 * Sets Perun specific type of object
-		 *
-		 * @param type type of object
-		 */
-		public final native void setObjectType(String type) /*-{
-			this.beanName = type;
-		}-*/;
-
-		/**
-		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
-		 *
-		 * @return string which defines item status
-		 */
-		public final native String getStatus() /*-{
-			return this.status;
-		}-*/;
-
-		/**
-		 * Compares to another object
-		 * @param o Object to compare
-		 * @return true, if they are the same
-		 */
-		public final boolean equals(ApplicationFormItem o)
-		{
-			return o.getId() == this.getId();
 		}
+		return this.i18n[locale];
+	}-*/;
+
+	/**
+	 * Set item texts
+	 */
+	public final native void setItemTexts(String locale, ItemTexts itemTexts) /*-{
+		this.i18n[locale] = itemTexts;
+	}-*/;
+
+	/**
+	 * get for delete state
+	 * @return for delete
+	 */
+	public final native boolean isForDelete() /*-{
+		if (!this.forDelete) { return false; }
+		return this.forDelete;
+	}-*/;
+
+	/**
+	 * Set deletion state
+	 * @param del true = delete / false = keep (default)
+	 */
+	public final native void setForDelete(boolean del) /*-{
+		this.forDelete = del;
+	}-*/;
+
+	/**
+	 * Return TRUE if item item was edited
+	 * (this property is for GUI purpose only)
+	 *
+	 * @return edited
+	 */
+	public final native boolean wasEdited() /*-{
+		if (!this.edited) { return false; }
+		return this.edited;
+	}-*/;
+
+	/**
+	 * Set edited state
+	 * (this property is for GUI purpose only)
+	 *
+	 * @param edited true = edited / false = not edited (default)
+	 */
+	public final native void setEdited(boolean edited) /*-{
+		this.edited = edited;
+	}-*/;
+
+
+
+	/**
+	 * Returns Perun specific type of object
+	 *
+	 * @return type of object
+	 */
+	public final native String getObjectType() /*-{
+		if (!this.beanName) {
+			return "JavaScriptObject"
+		}
+		return this.beanName;
+	}-*/;
+
+	/**
+	 * Sets Perun specific type of object
+	 *
+	 * @param type type of object
+	 */
+	public final native void setObjectType(String type) /*-{
+		this.beanName = type;
+	}-*/;
+
+	/**
+	 * Returns the status of this item in Perun system as String
+	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 *
+	 * @return string which defines item status
+	 */
+	public final native String getStatus() /*-{
+		return this.status;
+	}-*/;
+
+	/**
+	 * Compares to another object
+	 * @param o Object to compare
+	 * @return true, if they are the same
+	 */
+	public final boolean equals(ApplicationFormItem o)
+	{
+		return o.getId() == this.getId();
+	}
 
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationFormItem.java
@@ -2,6 +2,9 @@ package cz.metacentrum.perun.webgui.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
+import cz.metacentrum.perun.webgui.json.JsonUtils;
+
+import java.util.ArrayList;
 
 /**
  * Overlay type for registrar: ApplicationFormItem
@@ -157,6 +160,27 @@ public class ApplicationFormItem extends JavaScriptObject {
 			this.i18n[locale] = {locale: locale, errorMessage : "", help : "", label : "", options : ""};
 		}
 		return this.i18n[locale];
+	}-*/;
+
+	/**
+	 * Get locales
+	 *
+	 * @return array of present locales
+	 */
+	public final ArrayList<String> getLocales() {
+		return JsonUtils.listFromJsArrayString(getLocalesNative());
+	}
+
+	/**
+	 * Get locales
+	 *
+	 * @return array of present locales
+	 */
+	public final native JsArrayString getLocalesNative() /*-{
+		if(typeof this.i18n !== 'undefined' && this.i18n !== null){
+			return Object.getOwnPropertyNames(this.i18n)
+		}
+		return null;
 	}-*/;
 
 	/**

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationMail.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ApplicationMail.java
@@ -1,9 +1,13 @@
 package cz.metacentrum.perun.webgui.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.json.client.JSONObject;
 import cz.metacentrum.perun.webgui.client.localization.ObjectTranslation;
+import cz.metacentrum.perun.webgui.json.JsonUtils;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -126,6 +130,29 @@ public class ApplicationMail extends JavaScriptObject {
 		}
 		this.message[locale] = message;
 	}-*/;
+
+
+	/**
+	 * Get locales
+	 *
+	 * @return array of present locales
+	 */
+	public final ArrayList<String> getLocales() {
+		return JsonUtils.listFromJsArrayString(getLocalesNative());
+	}
+
+	/**
+	 * Get locales
+	 *
+	 * @return array of present locales
+	 */
+	public final native JsArrayString getLocalesNative() /*-{
+		if(typeof this.message !== 'undefined' && this.message !== null){
+			return Object.getOwnPropertyNames(this.message)
+		}
+		return null;
+	}-*/;
+
 
 	/**
 	 * Get sending enabled

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
@@ -393,7 +393,7 @@ public class CreateMailTabItem implements TabItem {
 
 		// languages
 		ArrayList<String> languages = new ArrayList<String>();
-		languages.add("cs");
+		languages.add(Utils.getNativeLanguage().get(0));
 		languages.add("en");
 
 		// vertical panel

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
@@ -553,9 +553,9 @@ public class EditFormItemTabItem implements TabItem {
 		this.titleWidget.setText("Edit form item: " + item.getShortname());
 
 		// languages
-		ArrayList<String> languages = new ArrayList<String>();
-		languages.add(Utils.getNativeLanguage().get(0));
-		languages.add("en");
+		ArrayList<String> languages = item.getLocales();
+		if (!languages.contains(Utils.getNativeLanguage().get(0))) languages.add(Utils.getNativeLanguage().get(0));
+		if (!languages.contains("en")) languages.add("en");
 
 		// vertical panel
 		VerticalPanel vp = new VerticalPanel();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
@@ -17,6 +17,7 @@ import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
 import cz.metacentrum.perun.webgui.client.resources.ButtonType;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
 import cz.metacentrum.perun.webgui.client.resources.TableSorter;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
 import cz.metacentrum.perun.webgui.json.attributesManager.GetAttributesDefinition;
@@ -230,7 +231,7 @@ public class EditFormItemTabItem implements TabItem {
 
 			boxRow++;
 
-			Label boxContentLabel = new Label(item.getType().substring(0, 0)+item.getType().toLowerCase().substring(1)+" options:");
+			Label boxContentLabel = new Label(item.getType().substring(0, 1)+item.getType().toLowerCase().substring(1)+" options:");
 			boxItemTable.setWidget(boxRow, 0, boxContentLabel);
 			boxItemTable.getFlexCellFormatter().setStyleName(boxRow, 0, "itemName");
 			boxItemTable.getFlexCellFormatter().setColSpan(boxRow, 0, 4);
@@ -553,7 +554,7 @@ public class EditFormItemTabItem implements TabItem {
 
 		// languages
 		ArrayList<String> languages = new ArrayList<String>();
-		languages.add("cs");
+		languages.add(Utils.getNativeLanguage().get(0));
 		languages.add("en");
 
 		// vertical panel

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
 import cz.metacentrum.perun.webgui.client.resources.ButtonType;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.registrarManager.UpdateApplicationMail;
@@ -335,7 +336,7 @@ public class EditMailTabItem implements TabItem, TabItemWithUrl {
 
 		// languages
 		ArrayList<String> languages = new ArrayList<String>();
-		languages.add("cs");
+		languages.add(Utils.getNativeLanguage().get(0));
 		languages.add("en");
 
 		// vertical panel

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
@@ -335,9 +335,9 @@ public class EditMailTabItem implements TabItem, TabItemWithUrl {
 		this.titleWidget.setText("Edit notification");
 
 		// languages
-		ArrayList<String> languages = new ArrayList<String>();
-		languages.add(Utils.getNativeLanguage().get(0));
-		languages.add("en");
+		ArrayList<String> languages = appMail.getLocales();
+		if (!languages.contains(Utils.getNativeLanguage().get(0))) languages.add(Utils.getNativeLanguage().get(0));
+		if (!languages.contains("en")) languages.add("en");
 
 		// vertical panel
 		VerticalPanel vp = new VerticalPanel();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/PreviewFormTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/PreviewFormTabItem.java
@@ -95,17 +95,17 @@ public class PreviewFormTabItem implements TabItem, TabItemWithUrl {
 		});
 		menu.addWidget(switchType);
 
-		final CustomButton switchLocale = new CustomButton(ButtonTranslation.INSTANCE.switchToCzechButton(), ButtonTranslation.INSTANCE.switchBetweenCzechAndEnglish(), SmallIcons.INSTANCE.flagCzechBritainIcon());
+		final CustomButton switchLocale = new CustomButton(ButtonTranslation.INSTANCE.switchToCzechButton(Utils.getNativeLanguage().get(1)), ButtonTranslation.INSTANCE.switchBetweenCzechAndEnglish(), SmallIcons.INSTANCE.locateIcon());
 		menu.addWidget(switchLocale);
 		switchLocale.addClickHandler(new ClickHandler(){
 			public void onClick(ClickEvent event) {
 				// switch type
 				if (locale.equalsIgnoreCase("en")) {
-					locale = "cs";
+					locale = Utils.getNativeLanguage().get(0);
 					switchLocale.setText(ButtonTranslation.INSTANCE.switchToEnglishButton());
 				} else {
 					locale = "en";
-					switchLocale.setText(ButtonTranslation.INSTANCE.switchToCzechButton());
+					switchLocale.setText(ButtonTranslation.INSTANCE.switchToCzechButton(Utils.getNativeLanguage().get(1)));
 				}
 				// prepare new
 				prepareApplicationForm(sp);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/InviteUserTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/InviteUserTabItem.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.resources.ButtonType;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
@@ -90,7 +91,8 @@ public class InviteUserTabItem implements TabItem {
 
 		final ListBox languages = new ListBox();
 		languages.setWidth("200px");
-		languages.addItem("Czech", "cs");
+		//languages.addItem("Czech", "cs");
+		languages.addItem(Utils.getNativeLanguage().get(2), Utils.getNativeLanguage().get(0));
 		languages.addItem("English", "en");
 		languages.setSelectedIndex(1);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPersonalTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPersonalTabItem.java
@@ -120,7 +120,7 @@ public class SelfPersonalTabItem implements TabItem {
 		final ListBox preferredLanguage = new ListBox();
 
 		preferredLanguage.addItem("Not selected", "");
-		preferredLanguage.addItem("Czech", "cs");
+		preferredLanguage.addItem(Utils.getNativeLanguage().get(2), Utils.getNativeLanguage().get(0));
 		preferredLanguage.addItem("English", "en");
 
 		final ListBox timezone = new ListBox();
@@ -283,7 +283,7 @@ public class SelfPersonalTabItem implements TabItem {
 						// don't skip this null attribute
 						preferredUnixGroupNameWidget.setAttribute((Attribute)JsonUtils.clone(a).cast());
 					} else if (a.getFriendlyName().equalsIgnoreCase("preferredLanguage")) {
-						if (a.getValue().equals("cs")) {
+						if (a.getValue().equals(Utils.getNativeLanguage().get(0))) {
 							preferredLanguage.setSelectedIndex(1);
 						} else if (a.getValue().equals("en")) {
 							preferredLanguage.setSelectedIndex(2);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/NotUserOfPerunWidget.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/NotUserOfPerunWidget.java
@@ -23,11 +23,11 @@ public class NotUserOfPerunWidget extends Composite {
 
 		String text = "";
 
-		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals("cs")) {
+		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0))) {
 			// english for all
 			text = "<h3>You are not user of Perun or you don't have registered identity you used to log in.</h3><h3>For joining your identities please go to:</h3>";
 
-		} else {
+		} else if (Utils.getNativeLanguage().get(0).equals("cs")) {
 			// czech for czech
 			text = "<h3>Buď nejste evidováni v systemu Perun a nebo nemáte zaregistrovanou Vaši identitu, kterou jste se teď přihlasil(a).</h3>" +
 				"<h3>Pro spárování identit pokračujte na:</h3>";

--- a/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages_cs.properties
+++ b/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages_cs.properties
@@ -55,7 +55,7 @@ emailValidationMenuItem=Validace e-mailu
 emailValidationSuccess=Vaše e-mailová adresa byla ověřena !
 emailValidationFail=Vaše e-mailová adresa NEBYLA ověřena !<p>Špatný validační kód !
 # change language
-changeLanguageToCzech=Změnit jazyk na Češtinu
+changeLanguageToCzech=Změnit jazyk na {0}
 changeLanguageToEnglish=Změnit jazyk na Angličtinu
 changeLanguageText=<p>Změna jazyka způsobí znovunačtení celé aplikace.</p><p><strong>Všechny neuložené změny budou ztraceny.</strong></p><p>Přejete si pokračovat ?</p><hr/><p>Changing language will reload whole application.</p><p><strong>All unsaved changes will be lost.</strong></p><p>Do you want to proceed ?</p>
 

--- a/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/WidgetTranslation_cs.properties
+++ b/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/WidgetTranslation_cs.properties
@@ -56,7 +56,7 @@ jsonClientAlertBoxErrorCrossSiteType=Chyba při zpracování požadavku
 jsonClientAlertBoxErrorCrossSiteText=Odpověd byla prázdná nebo zablokována prohlížečem (cross-site request).
 
 # FOOTER SETTINGS BUTTONS
-changeLanguageToCzech=Změnit jazyk na Češtinu
+changeLanguageToCzech=Změnit jazyk na {0}
 changeLanguageToEnglish=Změnit jazyk na Angličtinu
 changeLanguageConfirmText=<p>Změna jazyka znovu načte celou aplikaci.</p><p><strong>Všechny neuložené změny budou ztraceny!</strong></p><p class="inputFormInlineComment">Funkce je experimentální - pouze některé prvky jsou přeloženy do češtiny.</p><p>Chcete pokračovat ?</p>
 showHideExtendedInfo=Zobrazit / schovat dodatečné informace


### PR DESCRIPTION
- Allow to set native language for notifications and registration
  in perun.properties and perun-web-gui.properties files.
- Show also unused (but stored) languages in form item texts and
  notifications to support native lang transition.
- On buttons, removed Czech flag when switching language, display
  native language name.
- Fixed calls to get/set form items and mail to send all possible languages.
- Properly handle native language when displaying form items.
- Offer custom native language as option on user detail - preferred language.