### PR TITLE
GUI: Allow to set "IdP Category" as federative attribute

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
@@ -337,6 +337,7 @@ public class EditFormItemTabItem implements TabItem {
 		federationAttributes.addItem("First name", "givenName");
 		federationAttributes.addItem("Sure name", "sn");
 		federationAttributes.addItem("EPPN", "eppn");
+		federationAttributes.addItem("IdP Category", "md_entityCategory");
 
 		// application types
 		GetAttributesDefinition attrDef = new GetAttributesDefinition(new JsonCallbackEvents() {


### PR DESCRIPTION
- Form items can be now pre-filled from "md_entityCategory" attribute,
  which is named "IdP Category" in GUI.