### PR TITLE
Use converted perunBean names in hasRole

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -20,6 +21,7 @@ import java.util.regex.Pattern;
 public class BeansUtils {
 
 	private final static Pattern patternForCommonNameParsing = Pattern.compile("(([\\w]*. )*)([\\p{L}-']+) ([\\p{L}-']+)[, ]*(.*)");
+	private final static Pattern richBeanNamePattern = Pattern.compile("^Rich([A-Z].*$)");
 	public static final char LIST_DELIMITER = ',';
 	public static final char KEY_VALUE_DELIMITER = ':';
 
@@ -371,6 +373,29 @@ public class BeansUtils {
 		} else {
 			throw new InternalErrorException("Unknown attribute type. ("+ attributeClass.toString() + ")");
 		}
+	}
 
+	/**
+	 * Take perunBean name and if it is RichObject, convert it to simple name.
+	 *
+	 * RichObject mean: starts with "Rich" and continue with Upper Letter [A-Z]
+	 *
+	 * Ex.: RichGroup -> Group, RichUser -> User
+	 * Ex.: RichardObject -> RichardObject
+	 * Ex.: Null -> Null
+	 *
+	 * @param beanName bean Name of PerunBean (simple name of object)
+	 *
+	 * @return converted beanName (without Rich part)
+	 */
+	public static String convertRichBeanNameToBeanName(String beanName) {
+		if(beanName == null || beanName.isEmpty()) return beanName;
+
+		Matcher richBeanNameMatcher = richBeanNamePattern.matcher(beanName);
+		if (richBeanNameMatcher.find()) {
+			return richBeanNameMatcher.group(1);
+		}
+
+		return beanName;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzRoles.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzRoles.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.Role;
 import java.util.HashSet;
@@ -80,13 +81,17 @@ public class AuthzRoles extends HashMap<Role, Map<String, Set<Integer>>> {
 	}
 
 	public boolean hasRole(Role role, PerunBean perunBean) {
-		return this.get(role).containsKey(perunBean.getBeanName())
-			&& this.get(role).get(perunBean.getBeanName()).contains(perunBean.getId());
+		//Use converted beanName instead of classic bean name, because for ex.: RichGroup is the same like Group for this purpose
+		String convertedBeanName = BeansUtils.convertRichBeanNameToBeanName(perunBean.getBeanName());
+		return this.get(role).containsKey(convertedBeanName)
+			&& this.get(role).get(convertedBeanName).contains(perunBean.getId());
 	}
 
 	public boolean hasRole(Role role, String perunBeanName, int id) {
-		return this.get(role).containsKey(perunBeanName)
-			&& this.get(role).get(perunBeanName).contains(id);
+		//Use converted beanName instead of classic bean name, because for ex.: RichGroup is the same like Group for this purpose
+		String convertedBeanName = BeansUtils.convertRichBeanNameToBeanName(perunBeanName);
+		return this.get(role).containsKey(convertedBeanName)
+			&& this.get(role).get(convertedBeanName).contains(id);
 	}
 
 	public boolean hasRole(Role role) {


### PR DESCRIPTION
 - method isAuthorized use method hasRole which need to take perunBean
   name (simple object name) and looking to AuthzRoles of user if he has
   such privilegies. For richObjects it takes name like "RichSomething"
   which is not the same like "Something"
 - add new method convertRichBeanNameToBeanName to BeansUtils which
   convert RichName to Name (ex. RichGroup -> Group)
 - use method convertRichBeanNameToBeanName in AuthzRoles object
   (methods hasRole) where is needed