### PR TITLE
GUI: load also new group sync attribute

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoGroupsTabItem.java
@@ -104,6 +104,7 @@ public class VoGroupsTabItem implements TabItem, TabItemWithUrl{
 		attrNames.add("urn:perun:group:attribute-def:def:synchronizationEnabled");
 		attrNames.add("urn:perun:group:attribute-def:def:synchronizationInterval");
 		attrNames.add("urn:perun:group:attribute-def:def:lastSynchronizationState");
+		attrNames.add("urn:perun:group:attribute-def:def:lastSuccessSynchronizationTimestamp");
 		attrNames.add("urn:perun:group:attribute-def:def:lastSynchronizationTimestamp");
 		attrNames.add("urn:perun:group:attribute-def:def:authoritativeGroup");
 		final GetAllRichGroups groups = new GetAllRichGroups(voId, attrNames);


### PR DESCRIPTION
- Load also new Group sync attribute in order to display
  sync results correctly.