### PR TITLE
Add new gen/slave for mailaliases (generic one)

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailaliasesTargetUser.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailaliasesTargetUser.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Checks mail aliases target user
+ *
+ * @author Michal Stava   <stavamichal@gmail.com>
+ */
+public class urn_perun_resource_attribute_def_def_mailaliasesTargetUser extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	Pattern userPattern = Pattern.compile("^[-a-zA-Z0-9_]+$");
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		if (attribute.getValue() != null) {
+			throw new WrongAttributeValueException(attribute, resource, null, "Attribute value can't be null.");
+		}
+
+		String targetUser = (String) attribute.getValue();
+		Matcher userMatcher = userPattern.matcher(targetUser);
+		if(!userMatcher.matches()) {
+			throw new WrongAttributeValueException(attribute, resource, null, "Matcher must match to ^[-a-zA-Z0-9_]+$ pattern.");
+		}
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("mailaliasesTargetUser");
+		attr.setDisplayName("Target user for mailaliases");
+		attr.setType(String.class.getName());
+		attr.setDescription("Target user for mailaliases settings.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mailaliasesGenericMail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mailaliasesGenericMail.java
@@ -1,0 +1,44 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
+import java.util.regex.Matcher;
+
+/**
+ * Checks generic mail for mail aliases
+ *
+ * @author Michal Šťava   <stava.michal@gmail.com>
+ */
+public class urn_perun_user_attribute_def_def_mailaliasesGenericMail extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
+
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		String attributeValue = null;
+
+		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "User generic mail for mailaliases can't be set to null.");
+		else attributeValue = (String) attribute.getValue();
+
+		Matcher emailMatcher = Utils.emailPattern.matcher(attributeValue);
+		if(!emailMatcher.find()) throw new WrongAttributeValueException(attribute, user, "Email is not in correct form.");
+	}
+
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("mailaliasesGenericMail");
+		attr.setDisplayName("Generic mailaliases mail");
+		attr.setType(String.class.getName());
+		attr.setDescription("User's generic mailaliases mail.");
+		return attr;
+	}
+}

--- a/perun-services/gen/mailaliases_generic
+++ b/perun-services/gen/mailaliases_generic
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use perunServicesInit;
+use perunServicesUtils;
+
+local $::SERVICE_NAME = "mailaliases_generic";
+local $::PROTOCOL_VERSION = "3.0.0";
+my $SCRIPT_VERSION = "3.0.0";
+
+perunServicesInit::init;
+my $DIRECTORY = perunServicesInit::getDirectory;
+my $data = perunServicesInit::getHierarchicalData;
+
+#Constants
+
+our $A_RESOURCE_MAILALIASES_TARGET_USER; *A_RESOURCE_MAILALIASES_TARGET_USER = \'urn:perun:resource:attribute-def:def:mailaliasesTargetUser';
+our $A_USER_MAILALIASES_GENERIC_MAIL;    *A_USER_MAILALIASES_GENERIC_MAIL    = \'urn:perun:user:attribute-def:def:mailaliasesGenericMail';
+our $A_USER_MAIL;                        *A_USER_MAIL =                        \'urn:perun:user:attribute-def:def:preferredMail';
+
+my $fileName = "$DIRECTORY/perun_generic";
+open FILE,">$fileName" or die "Cannot open $fileName: $! \n";
+
+my $sortingFunction = getAttributeSorting $A_RESOURCE_MAILALIASES_TARGET_USER, 1;
+
+my %mailByLogin;
+my @resourcesData = $data->getChildElements;
+foreach my $rData (@resourcesData) {
+	my %resourceAttributes = attributesToHash $rData->getAttributes;
+
+	my @membersData = $rData->getChildElements;
+	for my $memberAttributes (dataToAttributesHashes @membersData) {
+		if (defined $memberAttributes->{$A_USER_MAILALIASES_GENERIC_MAIL}) {
+			$mailByLogin{$resourceAttributes{$A_RESOURCE_MAILALIASES_TARGET_USER}}->{$memberAttributes->{$A_USER_MAILALIASES_GENERIC_MAIL}} = 1;
+		} else {
+			$mailByLogin{$resourceAttributes{$A_RESOURCE_MAILALIASES_TARGET_USER}}->{$memberAttributes->{$A_USER_MAIL}} = 1;
+		}
+	}
+}
+
+foreach my $login (sort keys %mailByLogin) {
+	print FILE $login . ": ";
+	print FILE join ',', keys %{$mailByLogin{$login}};
+	print FILE "\n";
+}
+
+close (FILE) or die "Cannot close $fileName: $! \n";
+perunServicesInit::finalize;

--- a/perun-services/send/mailaliases_generic
+++ b/perun-services/send/mailaliases_generic
@@ -1,0 +1,4 @@
+#!/bin/bash
+SERVICE_NAME="mailaliases_generic"
+
+. generic_send

--- a/perun-services/slave/debian/changelog
+++ b/perun-services/slave/debian/changelog
@@ -1,3 +1,11 @@
+perun-slave (3.0.0-0.0.84) stable; urgency=low
+
+   * New service mailaliases_generic. This service is able to set any alias
+     for assigned users. Also use generic alias mail insted of preferred mail
+     if needed. All data is save into the file /etc/aliases.d/perun_generic.
+
+ -- Michal Stava <stavamichal@gmail.com> Wed, 28 Jan 2015 9:00:00 +0200
+
 perun-slave (3.0.0-0.0.83) stable; urgency=low
 
    * When data are rejected by the slave script on destination node

--- a/perun-services/slave/process-mailaliases_generic.sh
+++ b/perun-services/slave/process-mailaliases_generic.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+PROTOCOL_VERSION='3.0.0'
+
+### Status codes
+I_CHANGED=(0 'Aliases updated')
+I_NOT_CHANGED=(0 'Aliases has not changed')
+E_DUPLICITS=(50 'Duplicits: "\"${DUPLICITS}\"" have been found in "\"${FILES}\"".')
+E_NOTEXISTING_ALIASESD_DIR=(51 'Directory "\"${ETC_ALIASESD_DIR}\"" not exists.')
+E_PERMISSIONS=(52 'Cannot set permissions "\"${PERMISSIONS}\"" to file "\"${FROM_PERUN}\"".')
+E_NOTEXISTING_ALIASES_FILE=(53 'File "\"${ETC_ALIASES}\"" not exists.')
+E_NEWALIASES=(54 'Command newaliases failed.')
+
+GENERIC_FILE="perun_generic"
+FROM_PERUN="${WORK_DIR}/${GENERIC_FILE}"
+
+ETC_ALIASES="/etc/aliases"
+ETC_ALIASESD_DIR="/etc/aliases.d/"
+PERMISSIONS="644"
+
+function process {
+	### Create lock
+	create_lock
+
+	### Set permisson for special case if destination file not exists
+	catch_error E_PERMISSIONS chmod "${PERMISSIONS}" "${FROM_PERUN}"
+
+	### try if /etc/aliases.d/ exists, if not, end with error
+	if [ ! -d "${ETC_ALIASESD_DIR}" ]; then
+		log_msg E_NOTEXISTING_ALIASESD_DIR
+	fi
+
+	### try if file /etc/aliases exists, if not, end with error
+	if [ ! -f "${ETC_ALIASES}" ]; then
+		log_msg E_NOTEXISTING_ALIASES_FILE
+	fi
+	
+	### Looking for duplicits in possible places (except perun_generic_file)
+	### take all files from /etc/aliases.d/ except old generic_file and all files with extension .db
+	fail_if_duplicits_found "${ETC_ALIASES}" "${FROM_PERUN}" `find "${ETC_ALIASESD_DIR}" -type f -not -name ${GENERIC_FILE} -not -name "*.db" -print`
+
+	### If no duplicits found, move new generic_file to /etc/aliases.d/
+	diff_mv "${FROM_PERUN}" "${ETC_ALIASESD_DIR}/${GENERIC_FILE}" && log_msg I_CHANGED || log_msg I_NOT_CHANGED
+
+	### call new aliases
+	newaliases
+	if [ $? -ne 0 ]; then
+    		log_msg E_NEWALIASES
+	fi
+}
+
+
+
+# This function looking for any non comment duplicit names of aliases 'name:email'
+# If any duplicit found, then end with error
+# Return 0 if no duplicit found
+function fail_if_duplicits_found {
+	FILES="$@"
+
+	DUPLICITS=`sed -e 's/^\s*#.*//g' -e 's/\s\+//g' -e 's/:.*$//g' ${FILES} | sort | uniq -d`
+	if [ -n "${DUPLICITS}" ]; then
+		log_msg E_DUPLICITS
+	fi
+
+	return 0
+}


### PR DESCRIPTION
 - create new attribute module for attribute R:D:mailaliasesTargetUser
  - this attribute choose which login will be used in mailaliases perun
    generic file for users in specific resource
 - create new attribute module for attribute U:D:mailaliasesGenericMail
  - this attribute is using for possibility for user to choose another
    mail for mailaliases perun generic file instead one in preferredMail
 - prepare new gen script - mailaliases_generic
  - generate data from facility using attributes mailaliasesTargetUser
    and mailaliasesGenericMail, create new file perun_generic with
    logins and emails using these attributes
 - prepare new send script - mailaliases_generic
 - prepare new slave script - process-mailaliases_generic.sh
  - take new generated perun_generic file and if do not find duplicites
    in other files, move it to /etc/aliases.d/