### PR TITLE
CORE: fixed synchronization with LDAP

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -28,7 +28,7 @@ import cz.metacentrum.perun.core.implApi.UsersManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 
 /**
- * UsersManager buisness logic
+ * UsersManager business logic
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  * @author Slavek Licehammer glory@ics.muni.cz
@@ -54,7 +54,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	/**
 	 * Constructor.
 	 *
-	 * @param perunPool connection pool
+	 * @param usersManagerImpl connection pool
 	 */
 	public UsersManagerBlImpl(UsersManagerImplApi usersManagerImpl) {
 		this.usersManagerImpl = usersManagerImpl;
@@ -263,7 +263,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		try {
 			es = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, ExtSourcesManager.EXTSOURCE_NAME_PERUN);
 		} catch (ExtSourceNotExistsException e1) {
-			throw new ConsistencyErrorException("Default extSource PERUN must exists! It is created in ExtSourcesManagerImpl.init fucntion.",e1);
+			throw new ConsistencyErrorException("Default extSource PERUN must exists! It is created in ExtSourcesManagerImpl.init function.",e1);
 		}
 		UserExtSource ues = new UserExtSource(es, 0, String.valueOf(user.getId()));
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package cz.metacentrum.perun.core.impl;
 
 import java.util.ArrayList;
@@ -21,6 +18,8 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
+import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,12 +27,15 @@ import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
+ * Ext source implementation for LDAP.
+ *
  * @author Michal Prochazka michalp@ics.muni.cz
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class ExtSourceLdap extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
+
 	private Map<String, String> mapping;
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceLdap.class);
@@ -104,7 +106,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceSimpleApi {
 		String ldapGroupName = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 
 		try {
-			log.trace("LDAP External Source: searching for group subjects [{}]", ldapGroupName );
+			log.trace("LDAP External Source: searching for group subjects [{}]", ldapGroupName);
 
 			String attrName;
 			if (getAttributes().containsKey("memberAttribute")) {
@@ -131,7 +133,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceSimpleApi {
 				for (int i=0; i < ldapAttribute.size(); i++) {
 					String ldapSubjectDN = (String) ldapAttribute.get(i);
 					ldapGroupSubjects.add(ldapSubjectDN);
-					log.trace("LDAP Exteranl Source: found group subject [{}].", ldapSubjectDN);
+					log.trace("LDAP External Source: found group subject [{}].", ldapSubjectDN);
 				}
 			}
 
@@ -146,7 +148,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceSimpleApi {
 
 		} catch (NamingException e) {
 			log.error("LDAP exception during running query '{}'", ldapGroupName);
-			throw new InternalErrorException(e);
+			throw new InternalErrorException("Entry '"+ldapGroupName+"' was not found in LDAP." , e);
 		} finally {
 			try {
 				if (results != null) { results.close(); }
@@ -213,7 +215,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceSimpleApi {
 				String ldapAttributeName = ldapAttributeNameRaw.replaceAll("\\{([^\\}]*)\\}", "$1"); // ldapAttributeNameRaw is encapsulate with {}, so remove it
 				// Replace {ldapAttrName} with the value
 				value = value.replace(ldapAttributeNameRaw, getLdapAttributeValue(attributes, ldapAttributeName));
-				log.trace("ExtSourceLDAP: Retrived value {} of attribute {} for {} and storing into the key {}.", new Object[]{value, ldapAttributeName, ldapAttributeNameRaw, key});
+				log.trace("ExtSourceLDAP: Retrieved value {} of attribute {} for {} and storing into the key {}.", new Object[]{value, ldapAttributeName, ldapAttributeNameRaw, key});
 			}
 
 			map.put(key, value);
@@ -355,7 +357,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceSimpleApi {
 
 		} catch (NamingException e) {
 			log.error("LDAP exception during running query '{}'", query);
-			throw new InternalErrorException(e);
+			throw new InternalErrorException("LDAP exception during running query: "+query+".", e);
 		} finally {
 			try {
 				if (results != null) { results.close(); }
@@ -376,4 +378,16 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceSimpleApi {
 			}
 		}
 	}
+
+	@Override
+	public List<Map<String, String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjects(searchString, 0);
+	}
+
+	@Override
+	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		// We can call original implementation, since LDAP always return whole entry and not just login
+		return findSubjectsLogins(searchString, maxResults);
+	}
+
 }


### PR DESCRIPTION
- Improved group synchronization with LDAP. If entry doesn't exists
  it print it's name into error message.

- Use ExtSourceApi interface for LDAP, since we can retrieve whole
  user entry by one call and don't need to load logins separately.

- Fix group synchronization, when missing login was checked using "==".

- Speed up group synchronization. It previously didn't use new way of
  querying external source (improved because of XML source). It was
  used only for finding candidates.

- Fixed typos in log messages and javadoc.

- Added more comments on querying source and finding candidates.