### PR TITLE
GUI: Update to GWT 2.7.0

### DIFF
--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -25,7 +25,7 @@
 
 	<properties>
 		<!-- Convenience property to set the GWT version -->
-		<gwtVersion>2.6.1</gwtVersion>
+		<gwtVersion>2.7.0</gwtVersion>
 		<webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
 		<gui.url.modifier></gui.url.modifier>
 	</properties>
@@ -107,13 +107,11 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>gwt-maven-plugin</artifactId>
-				<version>2.6.1</version>
+				<version>2.7.0</version>
 				<executions>
 					<execution>
 						<goals>
 							<goal>compile</goal>
-							<goal>generateAsync</goal>
-							<goal>test</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -234,12 +232,11 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>gwt-maven-plugin</artifactId>
-						<version>2.6.1</version>
+						<version>2.7.0</version>
 						<executions>
 							<execution>
 								<goals>
 									<goal>compile</goal>
-									<goal>generateAsync</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/application-form-prod.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/application-form-prod.gwt.xml
@@ -9,7 +9,7 @@
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
     <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
-	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
+	<extend-property name="user.agent" values="ie11" /> <!-- IE 11 -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/application-form.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/application-form.gwt.xml
@@ -37,7 +37,6 @@
 
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
-	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
 	<!-- Other possibilities are 'ie8', 'ie9', 'ie10', 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/password-reset-prod.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/password-reset-prod.gwt.xml
@@ -8,7 +8,7 @@
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
     <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
-    <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
+    <extend-property name="user.agent" values="ie11" /> <!-- IE 11 -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/password-reset.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/password-reset.gwt.xml
@@ -37,7 +37,6 @@
 
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
-	<extend-property name="user.agent" values="opera" /> <!-- OPERA -->
     <!-- Other possibilities are 'ie8', 'ie9', 'ie10', 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web-prod.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web-prod.gwt.xml
@@ -11,7 +11,7 @@
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
     <extend-property name="user.agent" values="ie10" /> <!--  IE 10 -->
-    <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
+	<extend-property name="user.agent" values="ie11" /> <!--  IE 11 -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web.gwt.xml
@@ -37,7 +37,6 @@
 
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
     <extend-property name="user.agent" values="safari" /> <!-- CHROME -->
-    <extend-property name="user.agent" values="opera" /> <!-- OPERA -->
     <!-- Other possibilities are 'ie8', 'ie9', 'ie10', 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 

--- a/perun-web-gui/src/main/webapp/ApplicationForm.css
+++ b/perun-web-gui/src/main/webapp/ApplicationForm.css
@@ -315,6 +315,17 @@ input[type=text], input[type=password], input[type=text]:disabled, input[type=pa
     padding-top: 4px !important;
     padding-bottom: 4px !important;
 }
+/* GWT TABLE CELL STYLES - GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRowCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRowCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableFirstColumn,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableLastColumn,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell {
+	border: 0px !important; /* disable borders */
+	padding-top: 4px !important;
+	padding-bottom: 4px !important;
+}
 
 /* GWT GRID TABLE STYLES*/
 .GPBYFDEDG, .GPBYFDEEG, .GPBYFDEEH, .GPBYFDEBG, .GPBYFDEDG, .GPBYFDEEH, .GPBYFDEKG {
@@ -351,6 +362,14 @@ input[type=text], input[type=password], input[type=text]:disabled, input[type=pa
 .GALD-WOKD .customClickableTextCell, .GPBYFDEBE .customClickableTextCell, .GPBYFDEBE .customClickableTextCell a,tr .GPBYFDEBE, tr .GPBYFDEBE td, .GEATBOKCOC .customClickableTextCell,.GEATBOKCAD .customClickableTextCell, .GEATBOKCCE .customClickableTextCell {
     color:#fff !important;
     background: none repeat scroll 0 0 #628CD5 !important;
+}
+/* FIX COLORING OF SELECTED ROWS WHEN RECOLORED - GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell .customClickableTextCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell .customClickableTextCell a,
+tr .com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell,
+tr .com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell td {
+	color:#fff !important;
+	background: none repeat scroll 0 0 #628CD5 !important;
 }
 
 /* COLOR STYLES for ROWS and CELLS */

--- a/perun-web-gui/src/main/webapp/ApplicationForm.html
+++ b/perun-web-gui/src/main/webapp/ApplicationForm.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/ApplicationFormCert.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormCert.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/ApplicationFormFed.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormFed.html
@@ -70,10 +70,15 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/ApplicationFormKrb.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormKrb.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/ApplicationFormKrbEinfra.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormKrbEinfra.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PasswordReset.html
+++ b/perun-web-gui/src/main/webapp/PasswordReset.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PasswordResetCert.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetCert.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PasswordResetFed.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetFed.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PasswordResetKrb.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetKrb.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PasswordResetKrbEinfra.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetKrbEinfra.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PerunWeb.css
+++ b/perun-web-gui/src/main/webapp/PerunWeb.css
@@ -432,12 +432,15 @@ table.inputFormFlexTableDark {
 .GPBYFDEFD input, th .GPBYFDEIG .GPBYFDEGG input, th .GPBYFDEHG .GPBYFDEFG input {
     position:relative;
 }
+/* PerunTable checkbox header - GWT 2.7+ */
+th .com-google-gwt-user-cellview-client-CellTable-Style-cellTableHeader .com-google-gwt-user-cellview-client-CellTable-Style-cellTableFirstColumnHeader input {
+	position: relative;
+}
 
 /* Checkboxes style */
 .gwt-CheckBox, .gwt-CheckBox input {
     vertical-align: middle;
     margin-right: 10px;
-
 }
 
 /* GUI Listboxes with objects */
@@ -474,6 +477,15 @@ input[type=text], input[type=password], input[type=text]:disabled, input[type=pa
 .GPBYFDEPC input[type=text], .GPBYFDEPD  input[type=text], .GPBYFDEPC input[type=text]:disabled, .GPBYFDEPD  input[type=text]:disabled {
     display: block;
     width: 100%;
+}
+
+/* input-text in CellTables is 100% width by default - GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRowCell input[type=text],
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRowCell input[type=text],
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRowCell input[type=text]:disabled,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRowCell input[type=text]:disabled {
+	display: block;
+	width: 100%;
 }
 
 /* Extended text box error text padding */
@@ -865,6 +877,15 @@ td.header {
 .GPBYFDEAE, .GPBYFDEOC, .GPBYFDEAD, .GPBYFDEBD, .GPBYFDECE, .GPBYFDEID, .GPBYFDEKD, .GPBYFDEHD, .GPBYFDEOC {
     border: 0px !important; /* disable borders */
 }
+/* GWT TABLE CELL STYLES - GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRowCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRowCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableFirstColumn,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableLastColumn,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell {
+	border: 0px !important; /* disable borders */
+}
 
 /* Display all cells with padding */
 /* min height of all rows is based on rows with checkboxes */
@@ -874,16 +895,42 @@ td.header {
     padding-bottom: 4px;
 }
 
+/* Display all cells with padding */
+/* min height of all rows is based on rows with checkboxes - GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRow td,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRow td,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRow td {
+	min-height: 22px;
+	padding-top: 4px;
+	padding-bottom: 4px;
+}
+
 .GPBYFDEPC td div, .GPBYFDEPD td div {
     height: 100%;
     width: 100%;
     min-height: 22px;
     line-height: 22px;
 }
+/* GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRow td div,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRow td div,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRow td div {
+	height: 100%;
+	width: 100%;
+	min-height: 22px;
+	line-height: 22px;
+}
 
 .GPBYFDEPC td div > *, .GPBYFDEPD td div > * {
     width: auto;
     height: auto;
+}
+/* GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRow td div > *,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRow td div > *,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRow td div > * {
+	width: auto;
+	height: auto;
 }
 
 .GPBYFDEPC td div > *.customClickableTextCell, .GPBYFDEPD td div > *.customClickableTextCell {
@@ -892,7 +939,15 @@ td.header {
     padding-top: 0px;
     padding-bottom: 0px;
 }
-
+/* GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRow td div > *.customClickableTextCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRow td div > *.customClickableTextCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRow td div > *.customClickableTextCell {
+	min-height: 22px;
+	line-height: 22px;
+	padding-top: 0px;
+	padding-bottom: 0px;
+}
 
 .GPBYFDEPC td div a.customClickableTextCell, .GPBYFDEPD td div a.customClickableTextCell {
 
@@ -919,6 +974,34 @@ td.header {
     width: calc(100% + 15px) !important;
 
 }
+/* GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableEvenRow td div a.customClickableTextCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableOddRow td div a.customClickableTextCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRow td div a.customClickableTextCell {
+
+	display: block;
+	min-height: 22px;
+	line-height: 22px;
+	position: relative;
+	left: -15px;
+	top: 0px;
+
+	padding-left: 15px !important;
+	padding-right: 15px !important;
+	padding-top: 0px !important;
+	padding-bottom: 0px !important;
+	height: 100% !important;
+
+	/* Firefox */
+	width: -moz-calc(100% + 15px) !important;
+	/* WebKit */
+	width: -webkit-calc(100% + 15px) !important;
+	/* Opera */
+	width: -o-calc(100% + 15px) !important;
+	/* Standard */
+	width: calc(100% + 15px) !important;
+
+}
 
 a.customClickableTextCell:hover {
     text-decoration: none;
@@ -930,8 +1013,8 @@ td div.customTextCell {
     word-break: break-all;
 }
 
-/* header row cell */
-.GPBYFDEFD {
+/* header row cell + GWT 2.7+ */
+.GPBYFDEFD, .com-google-gwt-user-cellview-client-CellTable-Style-cellTableHeader .com-google-gwt-user-cellview-client-CellTable-Style-cellTableSortableHeader {
     padding-left: 15px !important;
     padding-right: 15px !important;
 }
@@ -1019,6 +1102,14 @@ td div.customTextCell {
 .GALD-WOKD .customClickableTextCell, .GPBYFDEBE .customClickableTextCell, .GPBYFDEBE .customClickableTextCell a,tr .GPBYFDEBE, tr .GPBYFDEBE td, .GEATBOKCOC .customClickableTextCell,.GEATBOKCAD .customClickableTextCell, .GEATBOKCCE .customClickableTextCell {
     color:#fff !important;
     background: none repeat scroll 0 0 #628CD5 !important;
+}
+/* FIX COLORING OF SELECTED ROWS WHEN RECOLORED - GWT 2.7+ */
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell .customClickableTextCell,
+.com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell .customClickableTextCell a,
+tr .com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell,
+tr .com-google-gwt-user-cellview-client-CellTable-Style-cellTableSelectedRowCell td {
+	color:#fff !important;
+	background: none repeat scroll 0 0 #628CD5 !important;
 }
 
 .hyperlink-active{

--- a/perun-web-gui/src/main/webapp/PerunWeb.html
+++ b/perun-web-gui/src/main/webapp/PerunWeb.html
@@ -70,10 +70,14 @@
 
 		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
 		if (document.all && !document.querySelector) {
 			// Is IE < 8
-			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
 		}
 
 	</script>

--- a/perun-web-gui/src/main/webapp/PerunWebCert.html
+++ b/perun-web-gui/src/main/webapp/PerunWebCert.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PerunWebFed.html
+++ b/perun-web-gui/src/main/webapp/PerunWebFed.html
@@ -70,10 +70,14 @@
 
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PerunWebKrb.html
+++ b/perun-web-gui/src/main/webapp/PerunWebKrb.html
@@ -70,10 +70,14 @@
         }
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>

--- a/perun-web-gui/src/main/webapp/PerunWebKrbEinfra.html
+++ b/perun-web-gui/src/main/webapp/PerunWebKrbEinfra.html
@@ -70,10 +70,14 @@
         }
         $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 10+, Safari 3.2
+        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
 	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera or Safari");
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+        }
+        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+        if (isOperaBefore15) {
+	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>


### PR DESCRIPTION
- Update to GWT 2.7.0 in order to speed up development.
  No need to run codeserver and web sever separately,
  incremental compilation, rebuild on page refresh.

- Support for Opera before 15 is dropped (Presto engine).
  Added check and warning to JS on page.

- Updated CSS for CellTable since base cell styles changed.