### PR TITLE
DB: Fixed doubled service_dependencies table

### DIFF
--- a/perun-db/table_order_base
+++ b/perun-db/table_order_base
@@ -8,7 +8,6 @@ owners
 services
 service_required_attrs
 exec_services
-service_dependencies
 engines
 routing_rules
 engine_routing_rule


### PR DESCRIPTION
- When exporting data to Postgres using base table order,
  there was doubled service_dependencies table. Henc all
  ExecServices had two same dependencies.