### PR TITLE
attributes for fs_replicas created

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -293,4 +293,14 @@ public interface ModulesUtilsBl {
 	 * @return true if the name of email is valid
 	 */
 	boolean isNameOfEmailValid(PerunSessionImpl sess, String email);
+
+	/**
+	 * Checks fully qualified domain name and returns true, if it is valid.
+	 *
+	 * @param sess
+	 * @param fqdn fully qualified domain name
+	 *
+	 * @return true if the fqdn is valid
+	 */
+	boolean isFQDNValid(PerunSessionImpl sess, String fqdn);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -556,6 +556,17 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		return false;
 	}
 
+	@Override
+	public boolean isFQDNValid(PerunSessionImpl sess, String fqdn) {
+		if (fqdn == null) return false;
+
+		Pattern fqdnPattern = Pattern.compile("^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}\\.?$");
+		Matcher fqdnMatcher = fqdnPattern.matcher(fqdn);
+		if (fqdnMatcher.find()) return true;
+
+		return false;
+	}
+
 	public void checkFormatOfShell(String shell, Attribute attribute) throws WrongAttributeValueException {
 		//previous regex ^/[-a-zA-Z0-9_/]*$"
 		Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestination.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestination.java
@@ -18,11 +18,11 @@ public class urn_perun_resource_attribute_def_def_replicaDestination extends Res
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
 
 		if(attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute);
+			throw new WrongAttributeValueException(attribute, resource, "This attribute can't be empty");
 		}
 
 		if (!perunSession.getPerunBl().getModulesUtilsBl().isFQDNValid(perunSession, (String) attribute.getValue())) {
-			throw new WrongAttributeValueException(attribute, "Bad replicaDestination attribute format " + attribute.getValue() + ". It should be" +
+			throw new WrongAttributeValueException(attribute, resource, "Bad replicaDestination attribute format " + attribute.getValue() + ". It should be" +
 					"fully qualified domain name.");
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestination.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestination.java
@@ -1,0 +1,39 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+
+/**
+ * @author Simona Kruppova, Oliver Mrazik
+ */
+public class urn_perun_resource_attribute_def_def_replicaDestination extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+
+		if(attribute.getValue() == null) {
+			throw new WrongAttributeValueException(attribute);
+		}
+
+		if (!perunSession.getPerunBl().getModulesUtilsBl().isFQDNValid(perunSession, (String) attribute.getValue())) {
+			throw new WrongAttributeValueException(attribute, "Bad replicaDestination attribute format " + attribute.getValue() + ". It should be" +
+					"fully qualified domain name.");
+		}
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("replicaDestination");
+		attr.setDisplayName("Replica destination");
+		attr.setType(String.class.getName());
+		attr.setDescription("Fully qualified domain name (FQDN) of the target storage");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPath.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPath.java
@@ -1,0 +1,43 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Simona Kruppova, Oliver Mrazik
+ */
+public class urn_perun_resource_attribute_def_def_replicaDestinationPath extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+
+		if(attribute.getValue() == null) {
+			throw new WrongAttributeValueException(attribute);
+		}
+
+		Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
+		Matcher match = pattern.matcher((String) attribute.getValue());
+		if (!match.matches()) {
+			throw new WrongAttributeValueException(attribute, "Bad replicaDestinationPath attribute format " + attribute.getValue());
+		}
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("replicaDestinationPath");
+		attr.setDisplayName("Replica destination path");
+		attr.setType(String.class.getName());
+		attr.setDescription("Absolute path in the target storage to copy to");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPath.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPath.java
@@ -21,13 +21,13 @@ public class urn_perun_resource_attribute_def_def_replicaDestinationPath extends
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
 
 		if(attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute);
+			throw new WrongAttributeValueException(attribute, resource, "This attribute can't be empty");
 		}
 
 		Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
 		Matcher match = pattern.matcher((String) attribute.getValue());
 		if (!match.matches()) {
-			throw new WrongAttributeValueException(attribute, "Bad replicaDestinationPath attribute format " + attribute.getValue());
+			throw new WrongAttributeValueException(attribute, resource, "Bad replicaDestinationPath attribute format " + attribute.getValue());
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaSourcePath.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaSourcePath.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
@@ -22,22 +23,23 @@ public class urn_perun_resource_attribute_def_def_replicaSourcePath extends Reso
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
-		Facility facility = perunSession.getPerunBl().getResourcesManagerBl().getFacility(perunSession, resource);
-		List<Attribute> attributes = perunSession.getPerunBl().getAttributesManagerBl().getAttributes(perunSession, facility);
-
-		Boolean found = false;
-
-		for (Attribute attr: attributes) {
-			if (attr.getFriendlyName().equals("homeMountPoints")) {
-				if(attr.getValue().equals(attribute.getValue())){
-					found = true;
-					break;
-				}
-			}
+		if(attribute.getValue() == null) {
+			throw new WrongAttributeValueException(attribute, resource, "This attribute can't be empty");
 		}
 
-		if(!found){
-			throw new WrongAttributeValueException(attribute, "ReplicaSourcePath has to be the same as one of the F:D:homeMountPoints");
+		Facility facility = perunSession.getPerunBl().getResourcesManagerBl().getFacility(perunSession, resource);
+
+		Attribute facilityAttr = null;
+		try {
+			facilityAttr = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":homeMountPoints");
+		} catch (AttributeNotExistsException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+		if(facilityAttr.getValue() != null) {
+			if (!((List<String>) facilityAttr.getValue()).containsAll((List<String>) attribute.getValue())) {
+				throw new WrongReferenceAttributeValueException(attribute, facilityAttr, resource, facility, "ReplicaSourcePath has to be the same as one of the F:D:homeMountPoints");
+			}
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaSourcePath.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaSourcePath.java
@@ -1,0 +1,53 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+import java.util.List;
+
+/**
+ * @author Simona Kruppova, Oliver Mrazik
+ */
+public class urn_perun_resource_attribute_def_def_replicaSourcePath extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+
+		Facility facility = perunSession.getPerunBl().getResourcesManagerBl().getFacility(perunSession, resource);
+		List<Attribute> attributes = perunSession.getPerunBl().getAttributesManagerBl().getAttributes(perunSession, facility);
+
+		Boolean found = false;
+
+		for (Attribute attr: attributes) {
+			if (attr.getFriendlyName().equals("homeMountPoints")) {
+				if(attr.getValue().equals(attribute.getValue())){
+					found = true;
+					break;
+				}
+			}
+		}
+
+		if(!found){
+			throw new WrongAttributeValueException(attribute, "ReplicaSourcePath has to be the same as one of the F:D:homeMountPoints");
+		}
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("replicaSourcePath");
+		attr.setDisplayName("Replica source path");
+		attr.setType(String.class.getName());
+		attr.setDescription("Absolute path in the filesystem to copy from");
+		return attr;
+	}
+}


### PR DESCRIPTION
- R:D:replicaSourcePath, R:D:replicaDestination and R:D:replicaDestinationPath were created
- added control that value of replicaSourcePath must be the same as one of the F:D:homeMountPoints
- replicaDestination and replicaDestinationPath are checked by regexes