### PR TITLE
CORE: Updated ExtendMembershipException

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/ExtendMembershipException.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/exceptions/ExtendMembershipException.java
@@ -9,13 +9,24 @@ import org.slf4j.LoggerFactory;
  * @author Michal Prochazka
  */
 public class ExtendMembershipException extends PerunException {
+
 	static final long serialVersionUID = 0;
 	private final static Logger log = LoggerFactory.getLogger(ExtendMembershipException.class);
 	private Reason reason;
+	private String expirationDate;
 
 	public ExtendMembershipException(Reason reason, String message) {
 		super(message);
 
+		this.reason = reason;
+
+		log.error("Internal Error Exception:", this);
+	}
+
+	public ExtendMembershipException(Reason reason, String expirationDate, String message) {
+		super(message);
+
+		this.expirationDate = expirationDate;
 		this.reason = reason;
 
 		log.error("Internal Error Exception:", this);
@@ -33,14 +44,34 @@ public class ExtendMembershipException extends PerunException {
 		log.error("Internal Error Exception:", this);
 	}
 
+	/**
+	 * Return reason why member can't extends his membership.
+	 *
+	 * @see cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException.Reason
+	 *
+	 * @return Reason why member can't extend membership
+	 */
 	public Reason getReason() {
 		return this.reason;
 	}
 
+	/**
+	 * Return string value of member's attribute "membership expiration date"
+	 * or null when expiration is not set.
+	 *
+	 * It's filled only when Reason is OUTSIDEEXTENSIONPERIOD.
+	 *
+	 * @return String value of membership expiration date
+	 */
+	public String getExpirationDate() {
+		return this.expirationDate;
+	}
+
 	public enum Reason {
 		NOUSERLOA, // User do not have LoA defined, byt VO has rules for membership expiration per LoA
-			INSUFFICIENTLOA, // User has LoA which is not allowed in the VO
-			INSUFFICIENTLOAFOREXTENSION, // User cannot extend membership because has insufficient LoA
-			OUTSIDEEXTENSIONPERIOD, // We are not in grace period, so do not allow extension
+		INSUFFICIENTLOA, // User has LoA which is not allowed in the VO
+		INSUFFICIENTLOAFOREXTENSION, // User cannot extend membership because has insufficient LoA
+		OUTSIDEEXTENSIONPERIOD, // We are not in grace period, so do not allow extension
 	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1612,7 +1612,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 									// if today is before that time, user can extend his period
 									if (currentMemberExpirationCalendar.after(Calendar.getInstance())) {
 										if (throwExceptions) {
-											throw new ExtendMembershipException(ExtendMembershipException.Reason.OUTSIDEEXTENSIONPERIOD,
+											throw new ExtendMembershipException(ExtendMembershipException.Reason.OUTSIDEEXTENSIONPERIOD, (String) membershipExpirationAttribute.getValue(),
 													"Member " + member + " cannot extend because we are outside grace period for VO id " + member.getVoId() + ".");
 										} else {
 											return new Pair<Boolean, Date>(false, null);


### PR DESCRIPTION
- Allow to set membership expiration date (string value of attribute)
  into ExtendMembershipException. It's useful for displaying notice
  in GUI - eg. when user can't extend membership, because is outside
  of grace period.