### PR TITLE
GUI: Don't specify linker for GWT

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/application-form.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/application-form.gwt.xml
@@ -47,6 +47,4 @@
 	<source path='tabs' />
 	<source path='widgets' />
 
-    <add-linker name="xsiframe"/>
-
 </module>

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/password-reset.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/password-reset.gwt.xml
@@ -47,6 +47,4 @@
 	<source path='tabs' />
 	<source path='widgets' />
 
-    <add-linker name="xsiframe"/>
-
 </module>

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web.gwt.xml
@@ -47,6 +47,4 @@
 	<source path='tabs' />
 	<source path='widgets' />
 
-    <add-linker name="xsiframe"/>
-
 </module>


### PR DESCRIPTION
- In GWT 2.7 we don't have to specify linker, since
  XSI linker is default.