### PR TITLE
RPC: Fixed RPC javadoc

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -563,17 +563,16 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Get list of all user administrators for supported role and given facility.
+	 * Get list of all facility administrators for supported role and given facility.
 	 *
-	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 * If onlyDirectAdmins is == 1, return only direct admins of the group for supported role.
 	 *
 	 * Supported roles: FacilityAdmin
 	 *
-	 * @param perunSession
-	 * @param facility
-	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 * @param facility int Facility ID
+	 * @param onlyDirectAdmins int if == 1, get only direct facility administrators (if != 1, get both direct and indirect)
 	 *
-	 * @return list of all user administrators of the given facility for supported role
+	 * @return List<User> list of all facility administrators of the given facility for supported role
 	 */
 	/*#
 	 * Get all Facility admins.
@@ -639,22 +638,21 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	 *
 	 * Supported roles: FacilityAdmin
 	 *
-	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
-	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 * If "onlyDirectAdmins" is == 1, return only direct admins of the facility for supported role with specific attributes.
+	 * If "allUserAttributes" is == 1, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
 	 *
-	 * @param perunSession
-	 * @param group
-	 * @param specificAttributes list of specified attributes which are needed in object richUser
-	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
-	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 * @param facility int Facility ID
+	 * @param specificAttributes List<String> list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes int if == 1, get all possible user attributes and ignore list of specificAttributes (if != 1, get only specific attributes)
+	 * @param onlyDirectAdmins int if == 1, get only direct facility administrators (if != 1, get both direct and indirect)
 	 *
-	 * @return list of RichUser administrators for the facility and supported role with attributes
+	 * @return List<RichUser> list of RichUser administrators for the facility and supported role with attributes
 	 */
 	/*#
     * Get all Facility admins as RichUsers
     *
-		* !!! DEPRECATED version !!!
-		*
+	* !!! DEPRECATED version !!!
+	*
     * @param facility int Facility ID
     * @return List<RichUser> admins
     */
@@ -667,8 +665,8 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")),
 					parms.readList("specificAttributes", String.class),
-					parms.readInt("allUserAttributes") ==1,
-					parms.readInt("onlyDirectAdmins") ==1);
+					parms.readInt("allUserAttributes") == 1,
+					parms.readInt("onlyDirectAdmins") == 1);
 			} else {
 				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")));

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -382,17 +382,16 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Get list of all user administrators for supported role and specific group.
+	 * Get list of all group administrators for supported role and specific group.
 	 *
-	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 * If onlyDirectAdmins is == 1, return only direct admins of the group for supported role.
 	 *
 	 * Supported roles: GroupAdmin
 	 *
-	 * @param perunSession
-	 * @param group
-	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 * @param group int Group ID
+	 * @param onlyDirectAdmins int if == 1, get only direct user administrators (if == 0, get both direct and indirect)
 	 *
-	 * @return list of all user administrators of the given group for supported role
+	 * @return List<User> list of all group administrators of the given group for supported role
 	 */
 	/*#
 	 * Returns administrators of a group.
@@ -436,7 +435,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns group administrators of a group.
+	 * Returns administrator groups of a group.
 	 *
 	 * @param group int Group ID
 	 * @return List<Group> admins
@@ -455,17 +454,15 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 *
 	 * Supported roles: GroupAdmin
 	 *
-	 * If "onlyDirectAdmins" is "true", return only direct users of the group for supported role with specific attributes.
-	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 * If "onlyDirectAdmins" is == 1, return only direct admins of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is == 1, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
 	 *
-	 * @param perunSession
-	 * @param group
+	 * @param group int Group ID
+	 * @param specificAttributes List<String> list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes int if == 1, get all possible user attributes and ignore list of specificAttributes (if != 1, get only specific attributes)
+	 * @param onlyDirectAdmins int if == 1, get only direct group administrators (if != 1, get both direct and indirect)
 	 *
-	 * @param specificAttributes list of specified attributes which are needed in object richUser
-	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
-	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
-	 *
-	 * @return list of RichUser administrators for the group and supported role with attributes
+	 * @return List<RichUser> list of RichUser administrators for the group and supported role with attributes
 	 */
 	/*#
 	* Get all Group admins as RichUsers
@@ -482,7 +479,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 			if(parms.contains("onlyDirectAdmins")) {
 				return ac.getGroupsManager().getRichAdmins(ac.getSession(),
 								ac.getGroupById(parms.readInt("group")),
-								parms.readList("specificAttribtues", String.class),
+								parms.readList("specificAttributes", String.class),
 								parms.readInt("allUserAttributes") == 1,
 								parms.readInt("onlyDirectAdmins") == 1);
 			} else {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -202,18 +202,17 @@ public enum VosManagerMethod implements ManagerMethod {
 
 
 	/*#
-	 * Get list of all user administrators for supported role and specific vo.
+	 * Get list of all vo administrators for supported role and specific vo.
 	 *
-	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.
+	 * If onlyDirectAdmins is == 1, return only direct admins of the vo for supported role.
 	 *
 	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
 	 *
-	 * @param perunSession
-	 * @param vo
-	 * @param role supported role
-	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
+	 * @param vo int VO ID
+	 * @param role String supported role name
+	 * @param onlyDirectAdmins int if == 1, get only direct VO administrators (if != 1, get both direct and indirect)
 	 *
-	 * @return list of all user administrators of the given vo for supported role
+	 * @return List<User> list of all user administrators of the given vo for supported role
 	 */
 	/*#
 	 * Returns administrators of a VO.
@@ -264,15 +263,14 @@ public enum VosManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Get list of group administrators of the given VO.
+	 * Get list of administrator groups of the given VO.
 	 *
 	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
 	 *
-	 * @param perunSession
-	 * @param vo
-	 * @param role
+	 * @param vo int VO ID
+	 * @param role String Role name
 	 *
-	 * @return List of groups, who are administrators of the Vo with supported role. Returns empty list if there is no VO group admin.
+	 * @return List<Group> List of groups, who are administrators of the VO with supported role. Returns empty list if there is no VO group admin.
 	 */
 	/*#
 	 * Returns group administrators of a VO.
@@ -308,17 +306,16 @@ public enum VosManagerMethod implements ManagerMethod {
 	 *
 	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
 	 *
-	 * If "onlyDirectAdmins" is "true", return only direct users of the vo for supported role with specific attributes.
-	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 * If "onlyDirectAdmins" is == 1, return only direct admins of the vo for supported role with specific attributes.
+	 * If "allUserAttributes" is == 1, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
 	 *
-	 * @param perunSession
-	 * @param vo
+	 * @param vo int VO Id
+	 * @param role String role name
+	 * @param specificAttributes List<String> list of specified attributes which are needed in object richUser
+	 * @param allUserAttributes int if == 1, get all possible user attributes and ignore list of specificAttributes (if != 1, get only specific attributes)
+	 * @param onlyDirectAdmins int if == 1, get only direct vo administrators (if != 1, get both direct and indirect)
 	 *
-	 * @param specificAttributes list of specified attributes which are needed in object richUser
-	 * @param allUserAttributes if true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
-	 * @param onlyDirectAdmins if true, get only direct user administrators (if false, get both direct and indirect)
-	 *
-	 * @return list of RichUser administrators for the vo and supported role with attributes
+	 * @return List<RichUser> list of RichUser administrators for the vo and supported role with attributes
 	 */
 	/*#
 	 * Returns administrators of a VO.


### PR DESCRIPTION
- We can't use standard javadoc format for RPC javadoc.
- Added java types to params in javadoc, cleaned messages.
- Fixed param names and source format.