### PR TITLE
RPC: Optimized param reading from URL.

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -35,7 +35,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * Returns chosen VO attributes. Returns only non-empty attributes.
 	 *
 	 * @param vo int VO ID
-	 * @param attrNames List<String> Attribute names
+	 * @param attrNames[] List<String> Attribute names
 	 * @return List<Attribute> Attributes
 	 */
 	/*#
@@ -106,6 +106,13 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Attributes
 	 */
 	/*#
+	 * Returns chosen Group attributes. Returns only non-empty attributes.
+	 *
+	 * @param group int Group ID
+	 * @param attrNames[] List<String> Attribute names
+	 * @return List<Attribute> Attributes
+	 */
+	/*#
 	 * Returns Host attributes. Returns only non-empty attributes.
 	 *
 	 * @param host int Host ID
@@ -125,7 +132,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							ac.getFacilityById(parms.readInt("facility")));
 				}
 			} else if (parms.contains("vo")) {
-				if (parms.contains("attrNames[]")) {
+				if (parms.contains("attrNames")) {
 					return ac.getAttributesManager().getAttributes(ac.getSession(),
 							ac.getVoById(parms.readInt("vo")),
 							parms.readList("attrNames", String.class));
@@ -155,7 +162,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				}
 			} else if (parms.contains("member")) {
 				if (parms.contains("workWithUserAttributes")){
-					if (parms.contains("attrNames[]")) {
+					if (parms.contains("attrNames")) {
 						return ac.getAttributesManager().getAttributes(ac.getSession(),
 								ac.getMemberById(parms.readInt("member")),
 								parms.readList("attrNames", String.class),
@@ -164,7 +171,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 						return ac.getAttributesManager().getAttributes(ac.getSession(),
 								ac.getMemberById(parms.readInt("member")), parms.readInt("workWithUserAttributes") == 1);
 					}
-				} else if (parms.contains("attrNames[]")) {
+				} else if (parms.contains("attrNames")) {
 					return ac.getAttributesManager().getAttributes(ac.getSession(),
 							ac.getMemberById(parms.readInt("member")),
 							parms.readList("attrNames", String.class));
@@ -173,7 +180,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							ac.getMemberById(parms.readInt("member")));
 				}
 			} else if (parms.contains("user")) {
-				if (parms.contains("attrNames[]")) {
+				if (parms.contains("attrNames")) {
 					return ac.getAttributesManager().getAttributes(ac.getSession(),
 							ac.getUserById(parms.readInt("user")),
 							parms.readList("attrNames", String.class));
@@ -182,7 +189,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							ac.getUserById(parms.readInt("user")));
 				}
 			} else if (parms.contains("group")) {
-				if (parms.contains("attrNames[]")) {
+				if (parms.contains("attrNames")) {
 					return ac.getAttributesManager().getAttributes(ac.getSession(),
 							ac.getGroupById(parms.readInt("group")),
 							parms.readList("attrNames", String.class));
@@ -1185,7 +1192,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				} else {
 					throw new RpcException(RpcException.Type.MISSING_VALUE, "host, resource or facility");
 				}
-			} else if (parms.contains("services[]")) {
+			} else if (parms.contains("services")) {
 				// get list of services
 				List<Service> services = new ArrayList<Service>();
 				List<Integer> servIds = parms.readList("services", Integer.class);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -109,7 +109,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 								parms.readPerunBean("complementaryObject"),
 								role);
 					return null;
-				} else if(parms.contains("complementaryObjects[]")) {
+				} else if(parms.contains("complementaryObjects")) {
 					cz.metacentrum.perun.core.api.AuthzResolver.setRole(ac.getSession(),
 								ac.getUserById(parms.readInt("user")),
 								role,
@@ -125,7 +125,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 								parms.readPerunBean("complementaryObject"),
 								role);
 					return null;
-				} else if(parms.contains("complementaryObjects[]")) {
+				} else if(parms.contains("complementaryObjects")) {
 					cz.metacentrum.perun.core.api.AuthzResolver.setRole(ac.getSession(),
 								ac.getGroupById(parms.readInt("authorizedGroup")),
 								role,
@@ -170,7 +170,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 								parms.readPerunBean("complementaryObject"),
 								role);
 					return null;
-				} else if (parms.contains("complementaryObjects[]")) {
+				} else if (parms.contains("complementaryObjects")) {
 					cz.metacentrum.perun.core.api.AuthzResolver.unsetRole(ac.getSession(),
 								ac.getUserById(parms.readInt("user")),
 								role,
@@ -186,7 +186,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 								parms.readPerunBean("complementaryObject"),
 								role);
 					return null;
-				} else if (parms.contains("complementaryObjects[]")) {
+				} else if (parms.contains("complementaryObjects")) {
 					cz.metacentrum.perun.core.api.AuthzResolver.unsetRole(ac.getSession(),
 								ac.getGroupById(parms.readInt("authorizedGroup")),
 								role,

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -268,8 +268,8 @@ public enum MembersManagerMethod implements ManagerMethod {
 		public List<RichMember> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
 			if(parms.contains("vo")) {
-				if (parms.contains("allowedStatuses[]")) {
-					if (parms.contains("attrsNames[]")) {
+				if (parms.contains("allowedStatuses")) {
+					if (parms.contains("attrsNames")) {
 						// with selected attributes
 						return ac.getMembersManager().getCompleteRichMembers(ac.getSession(),
 								ac.getVoById(parms.readInt("vo")),
@@ -282,7 +282,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 								parms.readList("allowedStatuses", String.class));
 					}
 				} else {
-					if (parms.contains("attrsNames[]")) {
+					if (parms.contains("attrsNames")) {
 						// with selected attributes
 						return ac.getMembersManager().getCompleteRichMembers(ac.getSession(),
 								ac.getVoById(parms.readInt("vo")),
@@ -294,8 +294,8 @@ public enum MembersManagerMethod implements ManagerMethod {
 					}
 				}
 			} else {
-				if (parms.contains("allowedStatuses[]")) {
-					if (parms.contains("attrsNames[]")) {
+				if (parms.contains("allowedStatuses")) {
+					if (parms.contains("attrsNames")) {
 						// with selected attributes
 						return ac.getMembersManager().getCompleteRichMembers(ac.getSession(),
 								ac.getGroupById(parms.readInt("group")),
@@ -311,7 +311,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 								parms.readInt("lookingInParentGroup") == 1);
 					}
 				} else {
-					if (parms.contains("attrsNames[]")) {
+					if (parms.contains("attrsNames")) {
 						// with selected attributes
 						return ac.getMembersManager().getCompleteRichMembers(ac.getSession(),
 								ac.getGroupById(parms.readInt("group")),
@@ -657,7 +657,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichMember> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if(parms.contains("vo")) {
-				if(parms.contains("allowedStatuses[]")) {
+				if(parms.contains("allowedStatuses")) {
 					return ac.getMembersManager().findCompleteRichMembers(ac.getSession(),
 							ac.getVoById(parms.readInt("vo")),
 							parms.readList("attrsNames", String.class),
@@ -670,7 +670,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 							parms.readString("searchString"));
 				}
 			} else {
-				if(parms.contains("allowedStatuses[]")) {
+				if(parms.contains("allowedStatuses")) {
 					return ac.getMembersManager().findCompleteRichMembers(ac.getSession(),
 							ac.getGroupById(parms.readInt("group")),
 							parms.readList("attrsNames", String.class),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -416,7 +416,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<Application> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			if (parms.contains("state[]")) {
+			if (parms.contains("state")) {
 				return ac.getRegistrarManager().getApplicationsForVo(ac.getSession(), ac.getVoById(parms.readInt("vo")), parms.readList("state", String.class));
 			} else {
 				return ac.getRegistrarManager().getApplicationsForVo(ac.getSession(), ac.getVoById(parms.readInt("vo")), null);
@@ -443,7 +443,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<Application> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			if (parms.contains("state[]")) {
+			if (parms.contains("state")) {
 				return ac.getRegistrarManager().getApplicationsForGroup(ac.getSession(), ac.getGroupById(parms.readInt("group")), parms.readList("state", String.class));
 			} else {
 				return ac.getRegistrarManager().getApplicationsForGroup(ac.getSession(), ac.getGroupById(parms.readInt("group")), null);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -277,7 +277,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
-			if (parms.contains("attrsNames[]")) {
+			if (parms.contains("attrsNames")) {
 				return ac.getUsersManager().getAllRichUsersWithAttributes(ac.getSession(),
 						parms.readInt("includedServiceUsers") == 1,
 						parms.readList("attrsNames", String.class));
@@ -299,7 +299,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
-			if (parms.contains("attrsNames[]")) {
+			if (parms.contains("attrsNames")) {
 				return ac.getUsersManager().findRichUsersWithAttributes(ac.getSession(),
 						parms.readString("searchString"),
 						parms.readList("attrsNames", String.class));
@@ -321,7 +321,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
-			if (parms.contains("attrsNames[]")) {
+			if (parms.contains("attrsNames")) {
 				return ac.getUsersManager().getRichUsersWithoutVoWithAttributes(ac.getSession(),
 						parms.readList("attrsNames", String.class));
 			} else {
@@ -342,7 +342,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
-			if (parms.contains("attrsNames[]")) {
+			if (parms.contains("attrsNames")) {
 				return ac.getUsersManager().findRichUsersWithoutSpecificVoWithAttributes(ac.getSession(),
 						ac.getVoById(parms.readInt("vo")),
 						parms.readString("searchString"),
@@ -631,7 +631,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if (parms.contains("attributeName")) {
-				if (parms.contains("attributeValue") || parms.contains("attributeValue[]")) {
+				if (parms.contains("attributeValue")) {
 					String attributeName = parms.readString("attributeName");
 					Attribute attr = new Attribute(ac.getAttributesManager().getAttributeDefinition(ac.getSession(), attributeName));
 


### PR DESCRIPTION
- Updated UrlDeserializer. Checking for presence of value in URL is now
  done with and without list decoration "[]". Also reading such value first
  try key with list decoration and then without list decoration.

  This change allows us to use presence checks without "[]" and this fixes
  API usage with POST calls where all params are passed inside request body
  and list params are always without any decoration.

  So as result. All GET calls can optionally omit list decoration for params
  and all POST calls are properly handled when checking and reading list params.

- Added missing RPC javadoc for getAttributes(group, listOfAttrs).