### PR TITLE
CORE: Fixed setting of attributes in synchronizer

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1199,6 +1199,23 @@ public interface AttributesManagerBl {
 	void setAttribute(PerunSession sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Store the particular attribute associated with the member. Core attributes can't be set this way.
+	 *
+	 * This method creates nested transaction to prevent storing value to DB if it throws any exception.
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param attribute attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute or if it is core attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributeInNestedTransaction(PerunSession sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+
+	/**
 	 * Store the attribute associated with the facility and user combination.  Core attributes can't be set this way.
 	 *
 	 * @param sess perun session
@@ -1214,7 +1231,7 @@ public interface AttributesManagerBl {
 	void setAttribute(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
-	 * Store the attribute associated with the user.  Core attributes can't be set this way.
+	 * Store the attribute associated with the user. Core attributes can't be set this way.
 	 *
 	 * @param sess perun session
 	 * @param user user to set on
@@ -1226,6 +1243,23 @@ public interface AttributesManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	void setAttribute(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Store the attribute associated with the user. Core attributes can't be set this way.
+	 *
+	 * This method creates nested transaction to prevent storing value to DB if it throws any exception.
+	 *
+	 * @param sess perun session
+	 * @param user user to set on
+	 * @param attribute attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not user-facility attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributeInNestedTransaction(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
 
 	/**
 	 * Just store the attribute associated with the user, doesn't preform any value check.  Core attributes can't be set this way.
@@ -2972,6 +3006,25 @@ public interface AttributesManagerBl {
 	 */
 	public Attribute mergeAttributeValue(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException,
 				 WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+
+	/**
+	 * Merges attribute value if the attribute type is list or map. In other cases it only stores new value.
+	 * If the type is list, new values are added to the current stored list.
+	 * It the type is map, new values are added and existing are overwritten with new values, but only if there is some change.
+	 *
+	 * This method creates nested transaction to prevent storing value to DB if it throws any exception.
+	 *
+	 * @param sess
+	 * @param user
+	 * @param attribute
+	 * @return attribute with updated value
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	public Attribute mergeAttributeValueInNestedTransaction(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException,
+			WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 
 	/**
 	 * Merges attributes values if the attribute type is list or map. In other cases it only stores new value.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1453,6 +1453,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 	}
 
+	public void setAttributeInNestedTransaction(PerunSession sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		setAttribute(sess, member, attribute);
+	}
+
 	public boolean setAttributeWithoutCheck(PerunSession sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR);
 
@@ -1507,6 +1511,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			checkAttributeValue(sess, user, attribute);
 			this.checkAttributeDependencies(sess, new RichAttribute(user, null, attribute));
 		}
+	}
+
+	public void setAttributeInNestedTransaction(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		setAttribute(sess, user, attribute);
 	}
 
 	public boolean setAttributeWithoutCheck(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -3568,6 +3576,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 					 }
 
 					 return attribute;
+	}
+
+	public Attribute mergeAttributeValueInNestedTransaction(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		return mergeAttributeValue(sess, user, attribute);
 	}
 
 	private boolean findAndSetValueInList(List<Attribute> attributes, AttributeDefinition attributeDefinition, Object value) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -990,7 +990,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 										// value differs, so store the new one
 										memberAttribute.setValue(subjectAttributeValue);
 										try {
-											getPerunBl().getAttributesManagerBl().setAttribute(sess, member, memberAttribute);
+											getPerunBl().getAttributesManagerBl().setAttributeInNestedTransaction(sess, member, memberAttribute);
 										} catch (AttributeValueException e) {
 											// There is a problem with attribute value, so set INVALID status for the member
 											getPerunBl().getMembersManagerBl().invalidateMember(sess, member);
@@ -1015,7 +1015,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 											userAttribute.setValue(subjectAttributeValue);
 											try {
-												getPerunBl().getAttributesManagerBl().mergeAttributeValue(sess, richMember.getUser(), userAttribute);
+												getPerunBl().getAttributesManagerBl().mergeAttributeValueInNestedTransaction(sess, richMember.getUser(), userAttribute);
 											} catch (AttributeValueException e) {
 												// There is a problem with attribute value, so set INVALID status for the member
 												getPerunBl().getMembersManagerBl().invalidateMember(sess, member);
@@ -1035,7 +1035,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 										// look if the attribute definition exists
 										attributeDefinition = getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, attributeName);
 									} catch (AttributeNotExistsException e) {
-										log.error("Atttribute {} doesn't exists.", attributeName);
+										log.error("Attribute {} doesn't exists.", attributeName);
 										throw new ConsistencyErrorException(e);
 									}
 
@@ -1046,7 +1046,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 										if (attributeDefinition.getEntity().equals(AttributesManager.ENTITY_MEMBER)) {
 											try {
 												// Try to set member's attributes
-												getPerunBl().getAttributesManagerBl().setAttribute(sess, member, newAttribute);
+												getPerunBl().getAttributesManagerBl().setAttributeInNestedTransaction(sess, member, newAttribute);
 											} catch (AttributeValueException e) {
 												// There is a problem with attribute value, so set INVALID status for the member
 												getPerunBl().getMembersManagerBl().invalidateMember(sess, member);
@@ -1054,13 +1054,13 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 										} else if (attributeDefinition.getEntity().equals(AttributesManager.ENTITY_USER)) {
 											try {
 												// Try to set user's attributes
-												getPerunBl().getAttributesManagerBl().setAttribute(sess, richMember.getUser(), newAttribute);
+												getPerunBl().getAttributesManagerBl().setAttributeInNestedTransaction(sess, richMember.getUser(), newAttribute);
 											} catch (AttributeValueException e) {
 												// There is a problem with attribute value, so set INVALID status of the member
 												getPerunBl().getMembersManagerBl().invalidateMember(sess, member);
 												try {
 													// The member is invalid, so try to set the value again, and check if the change has influence also on other members
-													getPerunBl().getAttributesManagerBl().setAttribute(sess, richMember.getUser(), newAttribute);
+													getPerunBl().getAttributesManagerBl().setAttributeInNestedTransaction(sess, richMember.getUser(), newAttribute);
 												} catch (AttributeValueException e1) {
 													// The change of the attribute value influences also members in other VOs, so we have to invalidate the whole user
 													//FIXME invalidate all members

--- a/perun-core/src/main/resources/perun-beans.xml
+++ b/perun-core/src/main/resources/perun-beans.xml
@@ -14,6 +14,8 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
       <aop:advisor advice-ref="txAdviceReadOnly" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getHierarchicalData(..))"/>
       <aop:advisor advice-ref="txAdviceReadOnly" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getDataWithGroups(..))"/>
       <aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.entry.*.*(..))"/>
+      <aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl.setAttributeInNestedTransaction(..))"/>
+      <aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl.mergeAttributeValueInNestedTransaction(..))"/>
       <aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.validateMember(..))"/>
       <aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.createMemberSync(..))"/>
       <aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.synchronizeGroup(..))"/>


### PR DESCRIPTION
- Always use nested transaction when setting attributes to member/user
  in synchronization to prevent storing value on any exception.

  Reason - invalidation of member is not enough, because validation checks
  only required attributes. We could invalidate member because of
  exception related to non-required attribute which then stayed in a wrong
  state, because value was kept in DB, since whole sync succeeded.

- Added method setAttributeInNestedTransaction() for user/member and
  mergeAttributeInValueNestedTransaction() for user to AttributesManagerBl.
  They are set to run in nested transaction by spring config in perun-beans.xml.