### PR TITLE
CORE: Optimized checks for removeAttribute(s)

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2399,10 +2399,11 @@ public interface AttributesManagerBl {
 	 * @param resource remove attribute from this resource
 	 * @param attribute attribute to remove
 	 *
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeAssignmentException if attribute isn't resource attribute or if it is core attribute
 	 */
-	void removeAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean removeAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
@@ -2603,10 +2604,11 @@ public interface AttributesManagerBl {
 	 * @param sess
 	 * @param key
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't entityless attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the facility without check of value.
@@ -2614,10 +2616,11 @@ public interface AttributesManagerBl {
 	 * @param sess
 	 * @param facility
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't facility attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the host without check of value.
@@ -2625,10 +2628,11 @@ public interface AttributesManagerBl {
 	 * @param sess
 	 * @param host
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't host attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the vo without check of value.
@@ -2636,10 +2640,11 @@ public interface AttributesManagerBl {
 	 * @param sess
 	 * @param vo
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't vo attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the group without check of value.
@@ -2647,10 +2652,11 @@ public interface AttributesManagerBl {
 	 * @param sess
 	 * @param group
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't group attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the resource without check of value.
@@ -2658,10 +2664,11 @@ public interface AttributesManagerBl {
 	 * @param sess
 	 * @param resource
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't resource attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the member-resource without check of value.
@@ -2670,10 +2677,11 @@ public interface AttributesManagerBl {
 	 * @param resource
 	 * @param member
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the member without check of value.
@@ -2681,10 +2689,11 @@ public interface AttributesManagerBl {
 	 * @param sess
 	 * @param member
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't member attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the user-facility without check of value.
@@ -2693,10 +2702,11 @@ public interface AttributesManagerBl {
 	 * @param facility
 	 * @param user
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't user-facility attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the user without check of value.
@@ -2704,10 +2714,11 @@ public interface AttributesManagerBl {
 	 * @param sess
 	 * @param user
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't user attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the group-resource without check of value.
@@ -2716,10 +2727,11 @@ public interface AttributesManagerBl {
 	 * @param resource
 	 * @param group
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't group-resource attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeWithoutCheck(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	void checkAttributeExists(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException, AttributeNotExistsException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2425,19 +2425,22 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		getAttributesManagerImpl().checkAttributeValue(sess, resource, attribute);
 	}
-	public void removeAttributeWithoutCheck(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_ENTITYLESS_ATTR);
-		getAttributesManagerImpl().removeAttribute(sess, key, attribute);
-		try {
-			getAttributesManagerImpl().changedAttributeHook(sess, key, new Attribute(attribute));
-		} catch (WrongAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, key, attribute);
+		if (changed) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, key, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, key);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, key);
+		return changed;
 	}
 
 	public void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
@@ -2450,101 +2453,105 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, key, attribute);
-		this.checkAttributeValue(sess, key, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(key, null, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, key, attribute)) {
+			this.checkAttributeValue(sess, key, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(key, null, new Attribute(attribute)));
+		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_FACILITY_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
-		getAttributesManagerImpl().removeAttribute(sess, facility, attribute);
-		try {
-			getAttributesManagerImpl().changedAttributeHook(sess, facility, new Attribute(attribute));
-		} catch (WrongAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, facility, attribute);
+		if (changed) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, facility, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, facility);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, facility);
+		return changed;
 	}
 
 	public void removeAttribute(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, facility, attribute);
-		this.checkAttributeValue(sess, facility, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(facility, null, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, facility, attribute)) {
+			this.checkAttributeValue(sess, facility, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(facility, null, new Attribute(attribute)));
+		}
 	}
 
 	public void removeAttributes(PerunSession sess, Member member, boolean workWithUserAttributes, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if(!workWithUserAttributes){
 			getAttributesManagerImpl().checkNamespace(sess, attributes, NS_MEMBER_ATTR);
-			List<Attribute> attributesList = attributesFromDefinitions(attributes);
-			for(AttributeDefinition attributeDefinition : attributes) {
+			List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
+			for(AttributeDefinition attribute : attributes) {
 				//skip core attributes
-				if(!getAttributesManagerImpl().isCoreAttribute(sess, attributeDefinition)) {
-					removeAttributeWithoutCheck(sess, member, attributeDefinition);
+				if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
+					if (removeAttributeWithoutCheck(sess, member, attribute)) attributesToCheck.add(attribute);
 				}
 			}
-			this.checkAttributesValue(sess, member, attributesList);
-			this.checkAttributesDependencies(sess, member, null, attributesList);
+			this.checkAttributesValue(sess, member, attributesFromDefinitions(attributesToCheck));
+			this.checkAttributesDependencies(sess, member, null, attributesFromDefinitions(attributesToCheck));
 		}else{
 			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-			List<Attribute> attributesList = attributesFromDefinitions(attributes);
-			for(AttributeDefinition attributeDef : attributes) {
+			List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
+			for(AttributeDefinition attribute : attributes) {
 				//skip core attributes
-				if(!getAttributesManagerImpl().isCoreAttribute(sess, attributeDef)) {
-
-					if(getAttributesManagerImpl().isFromNamespace(sess, attributeDef, AttributesManager.NS_MEMBER_ATTR)) {
-						removeAttributeWithoutCheck(sess, member, attributeDef);
-					} else if(getAttributesManagerImpl().isFromNamespace(sess, attributeDef, AttributesManager.NS_USER_ATTR)) {
-						removeAttributeWithoutCheck(sess, user, attributeDef);
+				if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
+					if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR)) {
+						if (removeAttributeWithoutCheck(sess, member, attribute)) attributesToCheck.add(attribute);
+					} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_ATTR)) {
+						if (removeAttributeWithoutCheck(sess, user, attribute)) attributesToCheck.add(attribute);
 					} else {
-						throw new WrongAttributeAssignmentException(attributeDef);
+						throw new WrongAttributeAssignmentException(attribute);
 					}
 				}
 			}
-			this.checkAttributesValue(sess, member, attributesList, true);
-			this.checkAttributesDependencies(sess, member, attributesList, workWithUserAttributes);
+			this.checkAttributesValue(sess, member, attributesFromDefinitions(attributesToCheck), true);
+			this.checkAttributesDependencies(sess, member, attributesFromDefinitions(attributesToCheck), workWithUserAttributes);
 		}
 	}
 
 	public void removeAttributes(PerunSession sess, Facility facility, List<? extends AttributeDefinition> attributesDefinition) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, WrongAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributesDefinition, NS_FACILITY_ATTR);
-		List<Attribute> attributes = attributesFromDefinitions(attributesDefinition);
-		for(AttributeDefinition attributeDefinition : attributesDefinition) {
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
+		for(AttributeDefinition attribute : attributesDefinition) {
 			//skip core attributes
-			if(!getAttributesManagerImpl().isCoreAttribute(sess, attributeDefinition)) {
-				removeAttributeWithoutCheck(sess, facility, attributeDefinition);
+			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
+				if (removeAttributeWithoutCheck(sess, facility, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		this.checkAttributesValue(sess, facility, attributes);
-		this.checkAttributesDependencies(sess, facility, null, attributes);
+		this.checkAttributesValue(sess, facility, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, facility, null, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException{
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
-		List<Attribute> attributesList = attributesFromDefinitions(attributes);
-		for(AttributeDefinition attributeDef : attributes) {
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
+		for(AttributeDefinition attribute : attributes) {
 			//skip core attributes
-			if(!getAttributesManagerImpl().isCoreAttribute(sess, attributeDef)) {
+			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
 
-				if(getAttributesManagerImpl().isFromNamespace(sess, attributeDef, AttributesManager.NS_MEMBER_ATTR)) {
-					removeAttributeWithoutCheck(sess, member, attributeDef);
-				} else if(getAttributesManagerImpl().isFromNamespace(sess, attributeDef, AttributesManager.NS_USER_ATTR)) {
-					removeAttributeWithoutCheck(sess, user, attributeDef);
-				} else if(getAttributesManagerImpl().isFromNamespace(sess, attributeDef, AttributesManager.NS_MEMBER_RESOURCE_ATTR)){
-					removeAttributeWithoutCheck(sess, resource, member, attributeDef);
-				} else if(getAttributesManagerImpl().isFromNamespace(sess, attributeDef, AttributesManager.NS_USER_FACILITY_ATTR)){
-					removeAttributeWithoutCheck(sess, facility, user, attributeDef);
+				if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR)) {
+					if (removeAttributeWithoutCheck(sess, member, attribute)) attributesToCheck.add(attribute);
+				} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_ATTR)) {
+					if (removeAttributeWithoutCheck(sess, user, attribute)) attributesToCheck.add(attribute);
+				} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)){
+					if (removeAttributeWithoutCheck(sess, resource, member, attribute)) attributesToCheck.add(attribute);
+				} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_FACILITY_ATTR)){
+					if (removeAttributeWithoutCheck(sess, facility, user, attribute)) attributesToCheck.add(attribute);
 				} else {
-					throw new WrongAttributeAssignmentException(attributeDef);
+					throw new WrongAttributeAssignmentException(attribute);
 				}
 			}
 		}
-		this.checkAttributesValue(sess, facility, resource, user, member, attributesList);
-		this.checkAttributesDependencies(sess, resource, member, user, facility, attributesList);
+		this.checkAttributesValue(sess, facility, resource, user, member, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, resource, member, user, facility, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAllAttributes(PerunSession sess, Facility facility) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -2611,45 +2618,49 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException {
-		removeAttributeWithoutCheck(sess, host, attribute);
-		checkAttributeValue(sess, host, new Attribute(attribute));
-		try {
-			this.checkAttributeDependencies(sess, new RichAttribute(host, null, new Attribute(attribute)));
-		} catch (WrongReferenceAttributeValueException ex) {
-			throw new WrongAttributeValueException(ex);
+		if (removeAttributeWithoutCheck(sess, host, attribute)) {
+			checkAttributeValue(sess, host, new Attribute(attribute));
+			try {
+				this.checkAttributeDependencies(sess, new RichAttribute(host, null, new Attribute(attribute)));
+			} catch (WrongReferenceAttributeValueException ex) {
+				throw new WrongAttributeValueException(ex);
+			}
 		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_HOST_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
 
-		getAttributesManagerImpl().removeAttribute(sess, host, attribute);
-		//TODO HOOK FOR HOSTS!
-		/*try {
-			getAttributesManagerImpl().changedAttributeHook(sess, host, new Attribute(attribute));
-			} catch (WrongAttributeValueException ex) {
-		//TODO better exception here
-		throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-		//TODO better exception here
-		throw new InternalErrorException(ex);
-		}*/
-		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, host);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, host, attribute);
+		if (changed) {
+			//TODO HOOK FOR HOSTS!
+			/*try {
+				getAttributesManagerImpl().changedAttributeHook(sess, host, new Attribute(attribute));
+				} catch (WrongAttributeValueException ex) {
+			//TODO better exception here
+			throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+			//TODO better exception here
+			throw new InternalErrorException(ex);
+			}*/
+			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, host);
+		}
+		return changed;
 	}
 
 	public void removeAttributes(PerunSession sess, Host host, List<? extends AttributeDefinition> attributesDefinition) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributesDefinition, AttributesManager.NS_HOST_ATTR);
-		List<Attribute> attributes = attributesFromDefinitions(attributesDefinition);
-		for(AttributeDefinition attributeDefinition : attributesDefinition) {
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
+		for(AttributeDefinition attribute : attributesDefinition) {
 			//skip core attributes
-			if(!getAttributesManagerImpl().isCoreAttribute(sess, attributeDefinition)) {
-				removeAttributeWithoutCheck(sess, host, attributeDefinition);
+			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
+				if (removeAttributeWithoutCheck(sess, host, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		this.checkAttributesValue(sess, host, attributes);
+		this.checkAttributesValue(sess, host, attributesFromDefinitions(attributesToCheck));
 		try {
-			this.checkAttributesDependencies(sess, host, null, attributes);
+			this.checkAttributesDependencies(sess, host, null, attributesFromDefinitions(attributesToCheck));
 		} catch (WrongReferenceAttributeValueException ex) {
 			throw new WrongAttributeValueException(ex);
 		}
@@ -2686,39 +2697,43 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, vo, attribute);
-		checkAttributeValue(sess, vo, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(vo, null, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, vo, attribute)) {
+			checkAttributeValue(sess, vo, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(vo, null, new Attribute(attribute)));
+		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_VO_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
 
-		getAttributesManagerImpl().removeAttribute(sess, vo, attribute);
-		try {
-			getAttributesManagerImpl().changedAttributeHook(sess, vo, new Attribute(attribute));
-		} catch (WrongAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, vo, attribute);
+		if (changed) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, vo, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, vo);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, vo);
+		return changed;
 	}
 
 	public void removeAttributes(PerunSession sess, Vo vo, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_VO_ATTR);
-
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributes) {
 			//skip core attributes
 			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
-				removeAttributeWithoutCheck(sess, vo, attribute);
+				if (removeAttributeWithoutCheck(sess, vo, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		checkAttributesValue(sess, vo, attributesFromDefinitions(attributes));
-		this.checkAttributesDependencies(sess, vo, null, attributesFromDefinitions(attributes));
+		checkAttributesValue(sess, vo, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, vo, null, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAllAttributes(PerunSession sess, Vo vo) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -2748,39 +2763,43 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, group, attribute);
-		checkAttributeValue(sess, group, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(group, null, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, group, attribute)) {
+			checkAttributeValue(sess, group, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(group, null, new Attribute(attribute)));
+		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_GROUP_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
 
-		getAttributesManagerImpl().removeAttribute(sess, group, attribute);
-		try {
-			getAttributesManagerImpl().changedAttributeHook(sess, group, new Attribute(attribute));
-		} catch (WrongAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, group, attribute);
+		if (changed) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, group, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, group);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, group);
+		return changed;
 	}
 
 	public void removeAttributes(PerunSession sess, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_GROUP_ATTR);
-
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributes) {
 			//skip core attributes
 			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
-				removeAttributeWithoutCheck(sess, group, attribute);
+				if (removeAttributeWithoutCheck(sess, group, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		checkAttributesValue(sess, group, attributesFromDefinitions(attributes));
-		this.checkAttributesDependencies(sess, group, null, attributesFromDefinitions(attributes));
+		checkAttributesValue(sess, group, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, group, null, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAllAttributes(PerunSession sess, Group group) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -2808,20 +2827,28 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 	}
 
-	public void removeAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, resource, attribute);
-		checkAttributeValue(sess, resource, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(resource, null, new Attribute(attribute)));
+	public boolean removeAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		boolean changed = removeAttributeWithoutCheck(sess, resource, attribute);
+		if (changed) {
+			checkAttributeValue(sess, resource, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(resource, null, new Attribute(attribute)));
+		}
+		return changed;
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_RESOURCE_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
-		try {
-			if(this.isVirtAttribute(sess, attribute)) getAttributesManagerImpl().removeVirtualAttribute(sess, resource, attribute);
-			else getAttributesManagerImpl().removeAttribute(sess, resource, attribute);
 
-			getAttributesManagerImpl().changedAttributeHook(sess, resource, new Attribute(attribute));
+		boolean changed = true;
+
+		try {
+			if (this.isVirtAttribute(sess, attribute)) {
+				changed = getAttributesManagerImpl().removeVirtualAttribute(sess, resource, attribute);
+			} else {
+				changed = getAttributesManagerImpl().removeAttribute(sess, resource, attribute);
+			}
+			if (changed) getAttributesManagerImpl().changedAttributeHook(sess, resource, new Attribute(attribute));
 		} catch (WrongAttributeValueException ex) {
 			//TODO better exception here
 			throw new InternalErrorException(ex);
@@ -2829,20 +2856,21 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			//TODO better exception here
 			throw new InternalErrorException(ex);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, resource);
+		if (changed) getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, resource);
+		return changed;
 	}
 
 	public void removeAttributes(PerunSession sess, Resource resource, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_RESOURCE_ATTR);
-
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributes) {
 			//skip core attributes
 			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
-				removeAttributeWithoutCheck(sess, resource, attribute);
+				if (removeAttributeWithoutCheck(sess, resource, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		checkAttributesValue(sess, resource, attributesFromDefinitions(attributes));
-		this.checkAttributesDependencies(sess, resource, null, attributesFromDefinitions(attributes));
+		checkAttributesValue(sess, resource, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, resource, null, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAllAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -2878,65 +2906,70 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, resource, member, attribute);
-		checkAttributeValue(sess, resource, member, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(resource, member, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, resource, member, attribute)) {
+			checkAttributeValue(sess, resource, member, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(resource, member, new Attribute(attribute)));
+		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_RESOURCE_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
 
-		getAttributesManagerImpl().removeAttribute(sess, resource, member, attribute);
-
-		try {
-			getAttributesManagerImpl().changedAttributeHook(sess, resource, member, new Attribute(attribute));
-		} catch (WrongAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, resource, member, attribute);
+		if (changed) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, resource, member, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {} and {}", attribute, resource, member);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {} and {}", attribute, resource, member);
+
+		return changed;
 	}
 
 	public void removeAttributes(PerunSession sess, Resource resource, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_MEMBER_RESOURCE_ATTR);
-
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributes) {
 			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
-				removeAttributeWithoutCheck(sess, resource, member, attribute);
+				if (removeAttributeWithoutCheck(sess, resource, member, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		checkAttributesValue(sess, resource, member, attributesFromDefinitions(attributes));
-		this.checkAttributesDependencies(sess, resource, member, attributesFromDefinitions(attributes));
+		checkAttributesValue(sess, resource, member, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, resource, member, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAttributes(PerunSession sess, Resource resource, Member member, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (!(workWithUserAttributes)) {
 			removeAttributes(sess, resource, member, attributes);
 		} else {
+			List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 			for (AttributeDefinition attribute : attributes) {
 				if (!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
 					Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 					User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 					if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-						removeAttributeWithoutCheck(sess, resource, member, attribute);
+						if (removeAttributeWithoutCheck(sess, resource, member, attribute)) attributesToCheck.add(attribute);
 					} else if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
-						removeAttributeWithoutCheck(sess, facility, user, attribute);
+						if (removeAttributeWithoutCheck(sess, facility, user, attribute)) attributesToCheck.add(attribute);
 					} else if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_ATTR)) {
-						removeAttributeWithoutCheck(sess, user, attribute);
+						if (removeAttributeWithoutCheck(sess, user, attribute)) attributesToCheck.add(attribute);
 					} else if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR)) {
-						removeAttributeWithoutCheck(sess, member, attribute);
+						if (removeAttributeWithoutCheck(sess, member, attribute)) attributesToCheck.add(attribute);
 					} else {
 						throw new WrongAttributeAssignmentException(attribute);
 					}
 				}
 			}
-			checkAttributesValue(sess, resource, member, attributesFromDefinitions(attributes), workWithUserAttributes);
-			this.checkAttributesDependencies(sess, resource, member, attributesFromDefinitions(attributes), workWithUserAttributes);
+			checkAttributesValue(sess, resource, member, attributesFromDefinitions(attributesToCheck), workWithUserAttributes);
+			this.checkAttributesDependencies(sess, resource, member, attributesFromDefinitions(attributesToCheck), workWithUserAttributes);
 		}
 	}
 
@@ -2968,39 +3001,46 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, member, attribute);
-		checkAttributeValue(sess, member, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(member, null, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, member, attribute)) {
+			checkAttributeValue(sess, member, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(member, null, new Attribute(attribute)));
+		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_ATTR);
 
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
 
-		getAttributesManagerImpl().removeAttribute(sess, member, attribute);
-		try {
-			getAttributesManagerImpl().changedAttributeHook(sess, member, new Attribute(attribute));
-		} catch (WrongAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, member, attribute);
+
+		if (changed) {
+			try {
+				if (changed) getAttributesManagerImpl().changedAttributeHook(sess, member, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, member);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, member);
+
+		return changed;
+
 	}
 
 	public void removeAttributes(PerunSession sess, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_MEMBER_ATTR);
-
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributes) {
 			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
-				removeAttributeWithoutCheck(sess, member, attribute);
+				if (removeAttributeWithoutCheck(sess, member, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		checkAttributesValue(sess, member, attributesFromDefinitions(attributes));
-		this.checkAttributesDependencies(sess, member, null, attributesFromDefinitions(attributes));
+		checkAttributesValue(sess, member, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, member, null, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAllAttributes(PerunSession sess, Member member) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -3030,46 +3070,53 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, facility, user, attribute);
-		checkAttributeValue(sess, facility, user, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(facility, user, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, facility, user, attribute)) {
+			checkAttributeValue(sess, facility, user, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(facility, user, new Attribute(attribute)));
+		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_USER_FACILITY_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
 
+		boolean changed = false;
+
 		if(getAttributesManagerImpl().isVirtAttribute(sess, attribute)) {
-			getAttributesManagerImpl().removeVirtualAttribute(sess, facility, user, attribute);
+			changed = getAttributesManagerImpl().removeVirtualAttribute(sess, facility, user, attribute);
 		} else {
-			getAttributesManagerImpl().removeAttribute(sess, facility, user, attribute);
+			changed = getAttributesManagerImpl().removeAttribute(sess, facility, user, attribute);
 		}
-		try {
-			getAttributesManagerImpl().changedAttributeHook(sess, facility, user, new Attribute(attribute));
-		} catch (WrongAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
+
+		if (changed) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, facility, user, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {} and {}", attribute, facility, user);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {} and {}", attribute, facility, user);
+		return changed;
 	}
 
 	public void removeAttributes(PerunSession sess, Facility facility, User user, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_USER_FACILITY_ATTR);
-
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributes) {
 			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
 				if(getAttributesManagerImpl().isVirtAttribute(sess, attribute)) {
-					getAttributesManagerImpl().removeVirtualAttribute(sess, facility, user, attribute);
+					if (getAttributesManagerImpl().removeVirtualAttribute(sess, facility, user, attribute)) attributesToCheck.add(attribute);
 				} else {
-					removeAttributeWithoutCheck(sess, facility, user, attribute);
+					if (removeAttributeWithoutCheck(sess, facility, user, attribute)) attributesToCheck.add(attribute);
 				}
 			}
 		}
-		checkAttributesValue(sess, facility, user, attributesFromDefinitions(attributes));
-		this.checkAttributesDependencies(sess, facility, user, attributesFromDefinitions(attributes));
+		checkAttributesValue(sess, facility, user, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, facility, user, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAllAttributes(PerunSession sess, Facility facility, User user) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -3137,39 +3184,43 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, user, attribute);
-		checkAttributeValue(sess, user, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(user, null, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, user, attribute)) {
+			checkAttributeValue(sess, user, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(user, null, new Attribute(attribute)));
+		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_USER_ATTR);
 
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
 
-		getAttributesManagerImpl().removeAttribute(sess, user, attribute);
-		try {
-			getAttributesManagerImpl().changedAttributeHook(sess, user, new Attribute(attribute));
-		} catch (WrongAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-			//TODO better exception here
-			throw new InternalErrorException(ex);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, user, attribute);
+		if (changed) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, user, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, user);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, user);
+		return changed;
 	}
 
 	public void removeAttributes(PerunSession sess, User user, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_USER_ATTR);
-
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributes) {
 			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
-				removeAttributeWithoutCheck(sess, user, attribute);
+				if (removeAttributeWithoutCheck(sess, user, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		checkAttributesValue(sess, user, attributesFromDefinitions(attributes));
-		this.checkAttributesDependencies(sess, user, null, attributesFromDefinitions(attributes));
+		checkAttributesValue(sess, user, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, user, null, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAllAttributes(PerunSession sess, User user) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -3199,19 +3250,24 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	public void removeAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		removeAttributeWithoutCheck(sess, resource, group, attribute);
-		checkAttributeValue(sess, resource, group, new Attribute(attribute));
-		this.checkAttributeDependencies(sess, new RichAttribute(resource, group, new Attribute(attribute)));
+		if (removeAttributeWithoutCheck(sess, resource, group, attribute)) {
+			checkAttributeValue(sess, resource, group, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(resource, group, new Attribute(attribute)));
+		}
 	}
 
-	public void removeAttributeWithoutCheck(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_GROUP_RESOURCE_ATTR);
+		boolean changed = false;
 		try {
-			if(this.isVirtAttribute(sess, attribute)) getAttributesManagerImpl().removeVirtualAttribute(sess, resource, group, attribute);
-			else getAttributesManagerImpl().removeAttribute(sess, resource, group, attribute);
+			if (this.isVirtAttribute(sess, attribute)) {
+				changed = getAttributesManagerImpl().removeVirtualAttribute(sess, resource, group, attribute);
+			} else {
+				changed = getAttributesManagerImpl().removeAttribute(sess, resource, group, attribute);
+			}
 
-			getAttributesManagerImpl().changedAttributeHook(sess, resource, group, new Attribute(attribute));
+			if (changed) getAttributesManagerImpl().changedAttributeHook(sess, resource, group, new Attribute(attribute));
 		} catch (WrongAttributeValueException ex) {
 			//TODO better exception here
 			throw new InternalErrorException(ex);
@@ -3219,17 +3275,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			//TODO better exception here
 			throw new InternalErrorException(ex);
 		}
-		getPerunBl().getAuditer().log(sess, "{} removed for {} and {}", attribute, group, resource);
+		if (changed) getPerunBl().getAuditer().log(sess, "{} removed for {} and {}", attribute, group, resource);
+		return changed;
 	}
 
 	public void removeAttributes(PerunSession sess, Resource resource, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//getAttributesManagerImpl().checkNamespace(sess, attributes, AttributesManager.NS_GROUP_RESOURCE_ATTR);
-
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributes) {
-			removeAttributeWithoutCheck(sess, resource, group, attribute);
+			if (removeAttributeWithoutCheck(sess, resource, group, attribute)) attributesToCheck.add(attribute);
 		}
-		checkAttributesValue(sess, resource, group, attributesFromDefinitions(attributes));
-		this.checkAttributesDependencies(sess, resource, group, attributesFromDefinitions(attributes));
+		checkAttributesValue(sess, resource, group, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, resource, group, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAttributes(PerunSession sess, Resource resource, Group group, List<? extends AttributeDefinition> attributes, boolean workWithGroupAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -3237,22 +3294,23 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			removeAttributes(sess, resource, group, attributes);
 		} else {
 
+			List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 			for (AttributeDefinition attribute : attributes) {
 				//skip core attributes
 				if (!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
 
 					if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_GROUP_RESOURCE_ATTR)) {
-						removeAttributeWithoutCheck(sess, resource, group, attribute);
+						if (removeAttributeWithoutCheck(sess, resource, group, attribute)) attributesToCheck.add(attribute);
 					} else if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_GROUP_ATTR)) {
-						removeAttributeWithoutCheck(sess, group, attribute);
+						if (removeAttributeWithoutCheck(sess, group, attribute)) attributesToCheck.add(attribute);
 					} else {
 						throw new WrongAttributeAssignmentException(attribute);
 					}
 				}
 
 			}
-			checkAttributesValue(sess, resource, group, attributesFromDefinitions(attributes), workWithGroupAttributes);
-			this.checkAttributesDependencies(sess, resource, group, attributesFromDefinitions(attributes), workWithGroupAttributes);
+			checkAttributesValue(sess, resource, group, attributesFromDefinitions(attributesToCheck), workWithGroupAttributes);
+			this.checkAttributesDependencies(sess, resource, group, attributesFromDefinitions(attributesToCheck), workWithGroupAttributes);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3441,11 +3441,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		//TODO
 	}
 
-	public void removeAttribute(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from entityless_attr_values where attr_id=? and subject=?", attribute.getId(), key)) {
 				log.info("Attribute (its value) with key was removed from entityless attributes. Attribute={}, key={}.", attribute, key);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3459,11 +3461,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 	
-	public void removeAttribute(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from facility_attr_values where attr_id=? and facility_id=?", attribute.getId(), facility.getId())) {
 				log.info("Attribute (its value) was removed from facility. Attribute={}, facility={}.", attribute, facility);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3479,11 +3483,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
-	public void removeAttribute(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException {
 		try {
-			if(0 > jdbc.update("delete from vo_attr_values where attr_id=? and vo_id=?", attribute.getId(), vo.getId())) {
+			if(0 < jdbc.update("delete from vo_attr_values where attr_id=? and vo_id=?", attribute.getId(), vo.getId())) {
 				log.info("Attribute (its value) was removed from vo. Attribute={}, vo={}.", attribute, vo);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3499,11 +3505,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
-	public void removeAttribute(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException {
 		try {
-			if(0 > jdbc.update("delete from group_attr_values where attr_id=? and group_id=?", attribute.getId(), group.getId())) {
+			if(0 < jdbc.update("delete from group_attr_values where attr_id=? and group_id=?", attribute.getId(), group.getId())) {
 				log.info("Attribute (its value) was removed from group. Attribute={}, group={}.", attribute, group);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3519,11 +3527,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
-	public void removeAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from resource_attr_values where attr_id=? and resource_id=?", attribute.getId(), resource.getId())) {
 				log.info("Attribute (its value) was removed from resource. Attribute={}, resource={}.", attribute, resource);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3539,11 +3549,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
-	public void removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from member_resource_attr_values where attr_id=? and member_id=? and resource_id=?", attribute.getId(), member.getId(), resource.getId())) {
 				log.info("Attribute (its value) was removed from member on resource. Attribute={}, member={}, resource=" + resource, attribute, member);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3559,11 +3571,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
-	public void removeAttribute(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from member_attr_values where attr_id=? and member_id=?", attribute.getId(), member.getId())) {
 				log.info("Attribute (its value) was removed from member. Attribute={}, member={}", attribute, member);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3579,11 +3593,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
-	public void removeAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from user_facility_attr_values where attr_id=? and user_id=? and facility_id=?", attribute.getId(), user.getId(), facility.getId())) {
 				log.info("Attribute (its value) was removed from user on facility. Attribute={}, user={}, facility=" + facility, attribute, user);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3620,23 +3636,25 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
-	public void removeVirtualAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
-		getFacilityUserVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, facility, user, attribute);
+	public boolean removeVirtualAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
+		return getFacilityUserVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, facility, user, attribute);
 	}
 
-	public void removeVirtualAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		getResourceVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, resource, attribute);
+	public boolean removeVirtualAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return getResourceVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, resource, attribute);
 	}
 
-	public void removeVirtualAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		getResourceGroupVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, resource, group, attribute);
+	public boolean removeVirtualAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return getResourceGroupVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, resource, group, attribute);
 	}
 
-	public void removeAttribute(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from user_attr_values where attr_id=? and user_id=?", attribute.getId(), user.getId())) {
 				log.info("Attribute (its value) was removed from user. Attribute={}, user={}", attribute, user);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3651,11 +3669,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 	}
-	public void removeAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from group_resource_attr_values where attr_id=? and resource_id=? and group_id=?", attribute.getId(),resource.getId(),group.getId())) {
 				log.info("Attribute (its value) was removed from group on resource. Attribute={}, group={}, resource=" + attribute, group, resource);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3670,11 +3690,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 	}
-	public void removeAttribute(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttribute(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException {
 		try {
 			if(0 < jdbc.update("delete from host_attr_values where attr_id=? and host_id=?", attribute.getId(), host.getId())) {
 				log.info("Attribute (its value) was removed from host. Attribute={}, host={}", attribute, host);
+				return true;
 			}
+			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
@@ -117,7 +117,8 @@ public class urn_perun_group_resource_attribute_def_virt_unixGID extends Resourc
 	}
 
 	@Override
-	public void removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return false;
 		/* This method remove attribute for Group not only GroupResource (we dont want it)
 			 Attribute unixGIDNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGIDNamespaceAttributeWithNotNullValue(sess, resource);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
@@ -118,7 +118,8 @@ public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends R
 	}
 
 	@Override
-	public void removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return false;
 		/* This method remove attribute for Group not only GroupResource (we dont want it)
 			 Attribute unixGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_unixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_unixGID.java
@@ -117,12 +117,12 @@ public class urn_perun_resource_attribute_def_virt_unixGID extends ResourceVirtu
 	}
 
 	@Override
-	public void removeAttributeValue(PerunSessionImpl sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		Attribute unixGIDNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGIDNamespaceAttributeWithNotNullValue(sess, resource);
 
 		try {
 			AttributeDefinition groupGidAttribute = sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:" + unixGIDNamespaceAttribute.getValue());
-			sess.getPerunBl().getAttributesManagerBl().removeAttribute(sess, resource, groupGidAttribute);
+			return sess.getPerunBl().getAttributesManagerBl().removeAttribute(sess, resource, groupGidAttribute);
 		} catch (AttributeNotExistsException ex) {
 			throw new InternalErrorException(ex);
 		} catch (WrongAttributeAssignmentException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_unixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_unixGroupName.java
@@ -117,12 +117,11 @@ public class urn_perun_resource_attribute_def_virt_unixGroupName extends Resourc
 	}
 
 	@Override
-	public void removeAttributeValue(PerunSessionImpl sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		Attribute unixGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
-
 		try {
 			AttributeDefinition groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:" + unixGroupNameNamespaceAttribute.getValue());
-			sess.getPerunBl().getAttributesManagerBl().removeAttribute(sess, resource, groupNameAttribute);
+			return sess.getPerunBl().getAttributesManagerBl().removeAttribute(sess, resource, groupNameAttribute);
 		} catch (AttributeNotExistsException ex) {
 			throw new InternalErrorException(ex);
 		} catch (WrongAttributeAssignmentException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_voShortName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_voShortName.java
@@ -34,7 +34,7 @@ public class urn_perun_resource_attribute_def_virt_voShortName extends ResourceV
 		throw new InternalErrorException("Can't set value of this virtual attribute this way. " + attribute);
 	}
 
-	public void removeAttributeValue(PerunSessionImpl sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException {
 		throw new InternalErrorException("Can't remove value of this virtual attribute this way. " + attribute);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UID.java
@@ -135,12 +135,6 @@ public class urn_perun_user_facility_attribute_def_virt_UID extends FacilityUser
 		}
 	}
 
-	/**
-	 * Not impelmented
-	 */
-	public void removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
-	}
-
 	@Override
 	public List<String> getStrongDependencies() {
 		List<String> StrongDependencies = new ArrayList<String>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_login.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_login.java
@@ -133,12 +133,6 @@ public class urn_perun_user_facility_attribute_def_virt_login extends FacilityUs
 		}
 	}
 
-	/**
-	 * Not impelmented
-	 */
-	public void removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
-	}
-
 	@Override
 	public List<String> getStrongDependencies() {
 		List<String> StrongDependencies = new ArrayList<String>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1433,9 +1433,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param facility remove attribute from this facility
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset particular entityless attribute with subject equals key.
@@ -1443,9 +1444,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param key subject of entityless attribute
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all attributes for the facility.
@@ -1471,9 +1473,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param vo remove attribute from this vo
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all attributes for the vo.
@@ -1491,9 +1494,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param group remove attribute from this group
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all attributes for the group.
@@ -1512,9 +1516,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param resource remove attribute from this resource
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all attributes for the resource.
@@ -1533,9 +1538,10 @@ public interface AttributesManagerImplApi {
 	 * @param resource remove attributes for this resource
 	 * @param member remove attribute from this member
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all (member-resource) attributes for the member on the resource.
@@ -1553,9 +1559,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param member
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all member attributes for the member.
@@ -1573,9 +1580,10 @@ public interface AttributesManagerImplApi {
 	 * @param facility
 	 * @param user
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all (user-facility) <b>non-virtual</b> attributes for the user on the facility.
@@ -1612,9 +1620,10 @@ public interface AttributesManagerImplApi {
 	 * @param facility
 	 * @param user
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeVirtualAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeVirtualAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset particular resource virtual attribute value.
@@ -1622,11 +1631,12 @@ public interface AttributesManagerImplApi {
 	 * @param sess
 	 * @param resource
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void removeVirtualAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean removeVirtualAttribute(PerunSession sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Unset particular group-resource virtual attribute value.
@@ -1635,11 +1645,12 @@ public interface AttributesManagerImplApi {
 	 * @param resource
 	 * @param group
 	 * @param attribute
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void removeVirtualAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException;
+	boolean removeVirtualAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException;
 
 	/**
 	 * Unset particular user attribute
@@ -1647,9 +1658,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param user
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all user attributes for the user.
@@ -1666,9 +1678,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param host
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException;
 	/**
 	 * Unset all user attributes for the host.
 	 *
@@ -1682,17 +1695,20 @@ public interface AttributesManagerImplApi {
 	 * Unset particular group_resource attribute
 	 *
 	 * @param sess perun session
-	 * @param
+	 * @param resource resource
+	 * @param group group
 	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all group_resource attributes
 	 *
 	 * @param sess perun session
-	 * @param
+	 * @param resource Resource
+	 * @param group Group
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	void removeAllAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/FacilityUserVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/FacilityUserVirtualAttributesModuleAbstract.java
@@ -31,8 +31,8 @@ public abstract class FacilityUserVirtualAttributesModuleAbstract extends Facili
 		return false;
 	}
 
-	public void removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
-
+	public boolean removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
+		return false;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/FacilityUserVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/FacilityUserVirtualAttributesModuleImplApi.java
@@ -48,9 +48,9 @@ public interface FacilityUserVirtualAttributesModuleImplApi extends FacilityUser
 	 * @param facility facility which is needed for computing the value
 	 * @param user user which is needed for computing the value
 	 * @param attribute attribute to operate on
-	 * @return
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceGroupVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceGroupVirtualAttributesModuleAbstract.java
@@ -31,8 +31,8 @@ public abstract class ResourceGroupVirtualAttributesModuleAbstract extends Resou
 		return false;
 	}
 
-	public void removeAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-
+	public boolean removeAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return false;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceGroupVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceGroupVirtualAttributesModuleImplApi.java
@@ -49,9 +49,9 @@ public interface ResourceGroupVirtualAttributesModuleImplApi extends ResourceGro
 	 * @param resource resource which is needed for computing the value
 	 * @param group group which is needed for computing the value
 	 * @param attribute attribute to operate on
-	 * @return
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceVirtualAttributesModuleAbstract.java
@@ -31,8 +31,8 @@ public abstract class ResourceVirtualAttributesModuleAbstract extends ResourceAt
 		return false;
 	}
 
-	public void removeAttributeValue(PerunSessionImpl perunSession, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-
+	public boolean removeAttributeValue(PerunSessionImpl perunSession, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return false;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceVirtualAttributesModuleImplApi.java
@@ -46,10 +46,11 @@ public interface ResourceVirtualAttributesModuleImplApi extends ResourceAttribut
 	 * @param sess PerunSession
 	 * @param resource resource which is needed for computing the value
 	 * @param attribute attribute to operate on
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws WrongAttributeValueException
 	 */
-	void removeAttributeValue(PerunSessionImpl sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 }


### PR DESCRIPTION
- removeAttribute() in Impl now return true if value was really deleted from DB
  or false when was not present in a first place.

- removeAttributeWithoutCheck() in Bl takes such value from Impl and performs
  changedAttributeHook and stores auditer message only if value was actually changed.

- removeAttribute() in Bl uses above method and perform checkAttributeValue and
  checkAttributeDependency only when value was changed. In some cases (methods
  used by virt attr modules) this method also return changed state. Most of them
  still return void since we don't need such information in bl/entry layer.

- removeVirtualAttribute() for resource, user_facility and group now return boolean
  if value was really deleted or not. Default implementation returns false. Modules
  return proper value. Removed implementation for u_f_UID and u_f_login since they
  didn't do anything => return false as abstract method.

- Fixed (0 > jdbc.update()) to (0 < jdbc.update()) when removing attribute
  for VO and Group. It previously prevent log message about removing attribute
  from being logged. Now it's logged and returns proper state.

- removeAttributes() now performs checkAttributesValue and checkAttributesDependencies
  only on modified (deleted) attributes. Core attributes are now excluded, since they
  can't be changed that way.

- Methods removeAllAttributes() are untouched, since they actually delete only
  attributes with some values, hence they hook/check/dependency on all of them.

- Above implementation should perform less unnecessary checks for attr values
  as well as to prevent unnecessary auditer messages from being stored
  ("attribute was removed" even if it was already null).