### PR TITLE
GUI: Removed IE11 permutation

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/application-form-prod.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/application-form-prod.gwt.xml
@@ -9,7 +9,6 @@
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
     <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
-	<extend-property name="user.agent" values="ie11" /> <!-- IE 11 -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/password-reset-prod.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/password-reset-prod.gwt.xml
@@ -8,7 +8,6 @@
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
     <extend-property name="user.agent" values="ie10" /> <!-- IE 10 -->
-    <extend-property name="user.agent" values="ie11" /> <!-- IE 11 -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web-prod.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web-prod.gwt.xml
@@ -11,7 +11,6 @@
 	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
 	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
     <extend-property name="user.agent" values="ie10" /> <!--  IE 10 -->
-	<extend-property name="user.agent" values="ie11" /> <!--  IE 11 -->
 	<!-- Other possibilities are 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 


### PR DESCRIPTION
- Since GWT 2.7.0 has bug in cell widgets for IE11, remove
  it's permutation from compiler. It should work anyway,
  just without some optimization.