### PR TITLE
RPC: Fixed param reading when force delete VO

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -45,7 +45,7 @@ public enum VosManagerMethod implements ManagerMethod {
 			ac.stateChangingCheck();
 
 			if (parms.contains("force")) {
-				ac.getVosManager().deleteVo(ac.getSession(), ac.getVoById(parms.readInt("vo")), true);
+				ac.getVosManager().deleteVo(ac.getSession(), ac.getVoById(parms.readInt("vo")), parms.readInt("force") == 1);
 			} else {
 				ac.getVosManager().deleteVo(ac.getSession(), ac.getVoById(parms.readInt("vo")));
 			}


### PR DESCRIPTION
- Actually use param value reading when trying to delete VO by force.
  It was previously forced just when was parameter present.
  Now method conforms it's own javadoc.