### PR TITLE
CORE: use isAuthorized() instead of isPerunAdmin()

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -2778,7 +2778,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeExists(perunSession, attributeDefinition);
 
 		//Choose if principal has access to update attribute
-		if(!AuthzResolver.isPerunAdmin(perunSession)) throw new PrivilegeException("Only PerunAdmin can update AttributeDefinition");
+		if(!AuthzResolver.isAuthorized(perunSession, Role.PERUNADMIN)) throw new PrivilegeException("Only PerunAdmin can update AttributeDefinition");
 
 		return getAttributesManagerBl().updateAttributeDefinition(perunSession, attributeDefinition);
 	}


### PR DESCRIPTION
- When updating attribute definition, use isAuthorized() as is default
  in all other methods. For some reason previous implementation returned
  false even if I was PerunAdmin (with data present in session and DB).