### PR TITLE
Optimalization of get*Data* methods.

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.api;
 
+import java.util.HashMap;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.exceptions.*;
@@ -1948,6 +1949,85 @@ public interface AttributesManager {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException;
+
+	/**
+	 * Get member-resource, member, user-facility and user attributes which are required by service for each member in list of members.
+	 * If workWithUserAttributes is false return only member-resource attributes.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param resource you get attributes for this resource
+	 * @param members you get attributes for this list of members
+	 * @param workWithUserAttributes if true method can process also user, user-facility and member attributes
+	 * @return map of member objects and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException if methods checkMemberIsFromTheSameVoLikeResource finds that user is not from same vo like resource
+	 */
+	HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Resource resource, List<Member> members, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, ServiceNotExistsException, ResourceNotExistsException, MemberNotExistsException, FacilityNotExistsException;
+
+	/**
+	 * Get member-resource attributes which are required by service for each member in list of members.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param resource you get attributes for this resource and the members
+	 * @param members you get attributes for this list of members and the resource
+	 * @return map of memberID and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ResourceNotExistsException if the resource doesn't exists in underlying data source
+	 * @throws ServiceNotExistsException if the service doesn't exists in underlying data source
+	 * @throws MemberNotExistsException if the member doesn't have access to this resource
+	 */
+	HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Resource resource, List<Member> members) throws InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException;
+
+	/**
+	 * Get member attributes which are required by service for each member in list of members.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param resource resource only to get allowed members
+	 * @param members you get attributes for this list of members
+	 * @return map of memberID and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ServiceNotExistsException if the service doesn't exists in underlying data source
+	 * @throws ResourceNotExistsException if the resource doesn't exists in underlying data source
+	 * @throws MemberNotExistsException if the member doesn't have access to this resource
+	 */
+	HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Resource resource, Service service, List<Member> members) throws InternalErrorException, ServiceNotExistsException, ResourceNotExistsException, MemberNotExistsException;
+
+
+	/**
+	 * Get user-facility attributes which are required by the service for each user in list of users.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param facility you get attributes for this facility and user
+	 * @param users you get attributes for this user and facility
+	 * @return map of user and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ServiceNotExistsException if the service doesn't exists in underlying data source
+	 * @throws FacilityNotExistsException if the facility wasn't created from this resource
+	 * @throws UserNotExistsException if the host doesn't exists in the underlying data source
+	 */
+	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, List<User> users) throws InternalErrorException, ServiceNotExistsException, FacilityNotExistsException, UserNotExistsException;
+
+	/**
+	 * Get user attributes which are required by the service for each user in list of users.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param users you get attributes for this user and facility
+	 * @return map of user and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ServiceNotExistsException if the service doesn't exists in underlying data source
+	 * @throws UserNotExistsException
+	 */
+	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException, ServiceNotExistsException, UserNotExistsException;
 
 	/**
 	 * Get member attributes which are required by the service.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1631,6 +1631,7 @@ public interface AttributesManagerBl {
 	/**
 	 * Get member-resource, member, user-facility and user attributes which are required by service for each member in list of members.
 	 * If workWithUserAttributes is false return only member-resource attributes.
+	 * !!! Method checks if members list is not empty (returns empty HashMap)!!!
 	 *
 	 * @param sess perun session
 	 * @param service attribute required by this service
@@ -1646,6 +1647,7 @@ public interface AttributesManagerBl {
 
 	/**
 	 * Get member-resource attributes which are required by service for each member in list of members.
+	 * !!! Method checks if members list is not empty (returns empty HashMap)!!!
 	 *
 	 * @param sess perun session
 	 * @param service attribute required by this service
@@ -1659,6 +1661,7 @@ public interface AttributesManagerBl {
 
 	/**
 	 * Get member attributes which are required by service for each member in list of members.
+	 * !!! Method checks if members list is not empty (returns empty HashMap)!!!
 	 *
 	 * @param sess perun session
 	 * @param service attribute required by this service
@@ -1672,6 +1675,7 @@ public interface AttributesManagerBl {
 
 	/**
 	 * Get user-facility attributes which are required by the service for each user in list of users.
+	 * !!! Method checks if members list is not empty (returns empty HashMap)!!!
 	 *
 	 * @param sess perun session
 	 * @param service attribute required by this service
@@ -1685,6 +1689,7 @@ public interface AttributesManagerBl {
 
 	/**
 	 * Get user attributes which are required by the service for each user in list of users.
+	 * !!! Method checks if members list is not empty (returns empty HashMap)!!!
 	 *
 	 * @param sess perun session
 	 * @param service attribute required by this service

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -4,6 +4,8 @@
 package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.ActionType;
+
+import java.util.HashMap;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
@@ -1625,6 +1627,73 @@ public interface AttributesManagerBl {
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get member-resource, member, user-facility and user attributes which are required by service for each member in list of members.
+	 * If workWithUserAttributes is false return only member-resource attributes.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param resource you get attributes for this resource
+	 * @param members you get attributes for this list of members
+	 * @param workWithUserAttributes if true method can process also user, user-facility and member attributes
+	 * @return map of member objects and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException if methods checkMemberIsFromTheSameVoLikeResource finds that user is not from same vo like resource
+	 */
+	HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, List<Member> members, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get member-resource attributes which are required by service for each member in list of members.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param resource you get attributes for this resource and the members
+	 * @param members you get attributes for this list of members and the resource
+	 * @return map of member objects and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Resource resource, List<Member> members) throws InternalErrorException;
+
+	/**
+	 * Get member attributes which are required by service for each member in list of members.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param resource resource only to get allowed members
+	 * @param members you get attributes for this list of members
+	 * @return map of member objects and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Resource resource, Service service, List<Member> members) throws InternalErrorException;
+
+	/**
+	 * Get user-facility attributes which are required by the service for each user in list of users.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param facility you get attributes for this facility and user
+	 * @param users you get attributes for this user and facility
+	 * @return map of user and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, List<User> users) throws InternalErrorException;
+
+	/**
+	 * Get user attributes which are required by the service for each user in list of users.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param users you get attributes for this user and facility
+	 * @return map of user and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException;
 
 	/**
 	 * Get memner, user, member-resource, user-facility attributes which are required by the service.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -14,6 +14,8 @@ import static cz.metacentrum.perun.core.api.AttributesManager.NS_VO_ATTR;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -1846,6 +1848,108 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, user));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, user));
 		return attributes;
+	}
+
+	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, List<Member> members, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException {
+		// check if members are from the same VO as resource
+		for (Member m : members) {
+			this.checkMemberIsFromTheSameVoLikeResource(sess, m, resource);
+		}
+
+		if(!workWithUserAttributes) {
+			HashMap<Member, List<Attribute>> resourceMemberAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
+			HashMap<Member, List<Attribute>> memberAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
+
+			for (Member mem : memberAttributes.keySet()) {
+				if (!resourceMemberAttributes.containsKey(mem)) {
+					resourceMemberAttributes.put(mem, memberAttributes.get(mem));
+				} else {
+					resourceMemberAttributes.get(mem).addAll(memberAttributes.get(mem));
+				}
+			}
+			return resourceMemberAttributes;
+		}
+
+		// get list of users, save user id as a key and list of member objects as a value
+		List<User> users = new ArrayList<>();
+		HashMap<User, List<Member>> userMemberIdMap = new HashMap<>();
+
+		// Maps user ids to member objects and fills list of users
+		for (Member m : members) {
+			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, m);
+			users.add(user);
+			if (userMemberIdMap.containsKey(user)) {
+				userMemberIdMap.get(user).add(m);
+			} else {
+				userMemberIdMap.put(user, Arrays.asList(m));
+			}
+		}
+
+		// get facility if null
+		if (facility == null) {
+			facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+		}
+
+		// get 4 maps from Impl getRequiredAttributes
+		HashMap<Member, List<Attribute>> resourceMemberAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
+		HashMap<Member, List<Attribute>> memberAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
+		HashMap<User, List<Attribute>> userFacilityAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users);
+		HashMap<User, List<Attribute>> userAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, service, users);
+
+		for (Member mem : memberAttributes.keySet()) {
+			if (!resourceMemberAttributes.containsKey(mem)) {
+				resourceMemberAttributes.put(mem, memberAttributes.get(mem));
+			} else {
+				resourceMemberAttributes.get(mem).addAll(memberAttributes.get(mem));
+			}
+		}
+
+		for (User user : userFacilityAttributes.keySet()) {
+			// List of members for given user
+			List<Member> mems = userMemberIdMap.get(user);
+			for (Member mem : mems) {
+				if (!resourceMemberAttributes.containsKey(mem)) {
+					resourceMemberAttributes.put(mem, userFacilityAttributes.get(user));
+				} else {
+					resourceMemberAttributes.get(mem).addAll(userFacilityAttributes.get(user));
+				}
+			}
+		}
+
+		for (User user : userAttributes.keySet()) {
+			// List of members for given user
+			List<Member> mems = userMemberIdMap.get(user);
+			for (Member mem : mems) {
+				if (!resourceMemberAttributes.containsKey(mem)) {
+					resourceMemberAttributes.put(mem, userAttributes.get(user));
+				} else {
+					resourceMemberAttributes.get(mem).addAll(userAttributes.get(user));
+				}
+			}
+		}
+
+		return resourceMemberAttributes;
+
+	}
+
+	@Override
+	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Resource resource, List<Member> members) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
+	}
+
+	@Override
+	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Resource resource, Service service, List<Member> members) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
+	}
+
+	@Override
+	public HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, List<User> users) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users);
+	}
+
+	@Override
+	public HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredAttributes(sess, service, users);
 	}
 
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1852,6 +1852,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, List<Member> members, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException {
 		// check if members are from the same VO as resource
+		if (members.isEmpty()) {
+			return new HashMap<>();
+		}
+
 		for (Member m : members) {
 			this.checkMemberIsFromTheSameVoLikeResource(sess, m, resource);
 		}
@@ -1934,22 +1938,34 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	@Override
 	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Resource resource, List<Member> members) throws InternalErrorException {
-		return getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
+		if (!members.isEmpty()) {
+			return getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
+		}
+		return new HashMap<>();
 	}
 
 	@Override
 	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Resource resource, Service service, List<Member> members) throws InternalErrorException {
-		return getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
+		if (!members.isEmpty()) {
+			return getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
+		}
+		return new HashMap<>();
 	}
 
 	@Override
 	public HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, List<User> users) throws InternalErrorException {
-		return getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users);
+		if (!users.isEmpty()) {
+			return getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users);
+		}
+		return new HashMap<>();
 	}
 
 	@Override
 	public HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException {
-		return getAttributesManagerImpl().getRequiredAttributes(sess, service, users);
+		if (!users.isEmpty()) {
+			return getAttributesManagerImpl().getRequiredAttributes(sess, service, users);
+		}
+		return new HashMap<>();
 	}
 
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -21,9 +21,7 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.ServiceAttributes;
-import cz.metacentrum.perun.core.api.ServicesManager;
 import cz.metacentrum.perun.core.api.ServicesPackage;
-import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.VosManager;
@@ -123,12 +121,21 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 		List<Member> members;
 		members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
-		for (Member member: members) {
-			resourceServiceAttributes.addChildElement(getData(sess, service, resource, member));
+		HashMap<Member, List<Attribute>> attributes;
+
+		try {
+			attributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, null, resource, members, true);
+		} catch(WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+		for (Member mem : attributes.keySet()) {
+			ServiceAttributes serviceAttributes = new ServiceAttributes();
+			serviceAttributes.addAttributes(attributes.get(mem));
+			resourceServiceAttributes.addChildElement(serviceAttributes);
 		}
 
 		return resourceServiceAttributes;
-
 	}
 
 	private ServiceAttributes getData(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException {
@@ -137,8 +144,18 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 		List<Member> members;
 		members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
-		for (Member member: members) {
-			resourceServiceAttributes.addChildElement(getData(sess, service, facility, resource, member));
+		HashMap<Member, List<Attribute>> attributes;
+
+		try {
+			attributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility, resource, members, true);
+		} catch(WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+		for (Member mem : attributes.keySet()) {
+			ServiceAttributes serviceAttributes = new ServiceAttributes();
+			serviceAttributes.addAttributes(attributes.get(mem));
+			resourceServiceAttributes.addChildElement(serviceAttributes);
 		}
 
 		return resourceServiceAttributes;
@@ -152,9 +169,18 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		ServiceAttributes membersAbstractSA = new ServiceAttributes();
 		Map<Member, ServiceAttributes> memberAttributes = new HashMap<Member, ServiceAttributes>();
 		List<Member> members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
-		for(Member member : members) {
-			ServiceAttributes tmpAttributes = getData(sess, service, facility, resource, member);
-			memberAttributes.put(member, tmpAttributes);
+		HashMap<Member, List<Attribute>> attributes;
+
+		try {
+			attributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility, resource, members, true);
+		} catch(WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+		for (Member mem : attributes.keySet()) {
+			ServiceAttributes tmpAttributes = new ServiceAttributes();
+			tmpAttributes.addAttributes(attributes.get(mem));
+			memberAttributes.put(mem, tmpAttributes);
 			membersAbstractSA.addChildElement(tmpAttributes);
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -1577,7 +1577,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 		for (Member member : members) {
 			getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-			}
+		}
 		HashMap<Member, List<Attribute>> result = getAttributesManagerBl().getRequiredAttributes(sess, service, facility, resource, members, workWithUserAttributes);
 		for (Member member : result.keySet()) {
 			Iterator<Attribute> attrIter = result.get(member).iterator();
@@ -1620,7 +1620,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		for (Member member : members) {
 			getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-			}
+		}
 		HashMap<Member, List<Attribute>> result = getAttributesManagerBl().getRequiredAttributes(sess, service, resource, members);
 		for (Member member : result.keySet()) {
 			Iterator<Attribute> attrIter = result.get(member).iterator();
@@ -1647,7 +1647,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		for (Member member : members) {
 			getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-			}
+		}
 		HashMap<Member, List<Attribute>> result = getAttributesManagerBl().getRequiredAttributes(sess, resource, service, members);
 		for (Member member : result.keySet()) {
 			Iterator<Attribute> attrIter = result.get(member).iterator();
@@ -1674,7 +1674,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 		for (User user : users) {
 			getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
-			}
+		}
 		HashMap<User, List<Attribute>> result = getAttributesManagerBl().getRequiredAttributes(sess, service, facility, users);
 		for (User user : result.keySet()) {
 			Iterator<Attribute> attrIter = result.get(user).iterator();
@@ -1700,7 +1700,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
 		for (User user : users) {
 			getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
-			}
+		}
 		HashMap<User, List<Attribute>> result = getAttributesManagerBl().getRequiredAttributes(sess, service, users);
 		for (User user : result.keySet()) {
 			Iterator<Attribute> attrIter = result.get(user).iterator();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import java.util.HashMap;
 import java.util.ServiceLoader;
 
 import cz.metacentrum.perun.core.api.ActionType;
@@ -22,6 +23,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
 
+import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.core.api.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +32,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -146,8 +150,6 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			lobHandler = new DefaultLobHandler();
 		}
 	}
-
-
 
 	protected final static String attributeDefinitionMappingSelectQuery = "attr_names.id as attr_names_id, attr_names.friendly_name as attr_names_friendly_name, " +
 		"attr_names.namespace as attr_names_namespace, attr_names.type as attr_names_type, attr_names.display_name as attr_names_display_name," +
@@ -3075,6 +3077,175 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	private static class MemberAttributeExtractor implements ResultSetExtractor<HashMap<Member, List<Attribute>>> {
+		private final PerunSession sess;
+		private final AttributesManagerImpl attributesManager;
+		private final List<Member> members;
+
+		/**
+		 * Sets up parameters for data extractor
+		 *
+		 * @param sess perun session
+		 * @param attributesManager attribute manager
+		 * @param members list of members
+		 */
+		public MemberAttributeExtractor(PerunSession sess, AttributesManagerImpl attributesManager, List<Member> members) {
+			this.sess = sess;
+			this.attributesManager = attributesManager;
+			this.members = members;
+		}
+
+		public HashMap<Member, List<Attribute>> extractData(ResultSet rs) throws SQLException, DataAccessException {
+			HashMap<Member, List<Attribute>> map = new HashMap<>();
+			HashMap<Integer, Member> memberObjectMap = new HashMap<>();
+		 	List<Attribute> memAttrs;
+
+			for(Member member : members) {
+				memberObjectMap.put(member.getId(), member);
+			}
+
+			while (rs.next()) {
+				// fetch from map by ID
+				Integer id = rs.getInt("id");
+				Member mem = memberObjectMap.get(id);
+
+				memAttrs = map.get(mem);
+				if(memAttrs == null){
+					// if not present, put in map
+					memAttrs = new ArrayList<>();
+					map.put(mem, memAttrs);
+				}
+
+				AttributeRowMapper attributeRowMapper = new AttributeRowMapper(sess, attributesManager, mem);
+				Attribute attribute = attributeRowMapper.mapRow(rs, rs.getRow());
+
+				if (attribute != null) {
+					// add only if exists
+					map.get(mem).add(attribute);
+				}
+			}
+			return map;
+		}
+	}
+
+	private static class UserAttributeExtractor implements ResultSetExtractor<HashMap<User, List<Attribute>>> {
+		private final PerunSession sess;
+		private final AttributesManagerImpl attributesManager;
+		private final List<User> users;
+		private final Facility facility;
+
+		/**
+		 * Sets up parameters for data extractor
+		 *
+		 * @param sess perun session
+		 * @param attributesManager attribute manager
+		 * @param users list of users
+		 */
+		public UserAttributeExtractor(PerunSession sess, AttributesManagerImpl attributesManager, List<User> users, Facility facility) {
+			this.sess = sess;
+			this.attributesManager = attributesManager;
+			this.users = users;
+			this.facility = facility;
+		}
+
+		public UserAttributeExtractor(PerunSession sess, AttributesManagerImpl attributesManager, List<User> users) {
+			this(sess, attributesManager, users, null);
+		}
+
+		public HashMap<User, List<Attribute>> extractData(ResultSet rs) throws SQLException, DataAccessException {
+			HashMap<User, List<Attribute>> map = new HashMap<>();
+			HashMap<Integer, User> userObjectMap = new HashMap<>();
+			List<Attribute> userAttrs;
+
+			for(User user : users) {
+				userObjectMap.put(user.getId(), user);
+			}
+
+			while (rs.next()) {
+				// fetch from map by ID
+				Integer id = rs.getInt("id");
+				User user = userObjectMap.get(id);
+
+				userAttrs = map.get(user);
+				if(userAttrs == null){
+					// if not preset, put in map
+					userAttrs = new ArrayList<>();
+					map.put(user, userAttrs);
+				}
+
+				AttributeRowMapper attributeRowMapper = new AttributeRowMapper(sess, attributesManager, user, facility);
+				Attribute attribute = attributeRowMapper.mapRow(rs, rs.getRow());
+
+				if (attribute != null) {
+					// add only if exists
+					map.get(user).add(attribute);
+				}
+			}
+			return map;
+		}
+	}
+
+	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Resource resource, List<Member> members) throws InternalErrorException {
+		try {
+			return jdbc.query("SELECT " + getAttributeMappingSelectQuery("mem") + ", members.id FROM attr_names " +
+							"JOIN service_required_attrs ON attr_names.id=service_required_attrs.attr_id AND service_required_attrs.service_id=? " +
+							"JOIN members ON members.id IN (" + beanIdsToString(members) + ")" +
+							"LEFT JOIN member_resource_attr_values mem ON attr_names.id=mem.attr_id AND mem.resource_id=? " +
+							"AND mem.member_id=members.id WHERE namespace IN (?,?,?)",
+					new MemberAttributeExtractor(sess, this, members), service.getId(), resource.getId(),
+					AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF, AttributesManager.NS_MEMBER_RESOURCE_ATTR_OPT, AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT);
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Resource resource, Service service, List<Member> members) throws InternalErrorException {
+		try {
+			return jdbc.query("SELECT " + getAttributeMappingSelectQuery("mem") + ", members.id FROM attr_names " +
+							"JOIN service_required_attrs ON attr_names.id=service_required_attrs.attr_id AND service_required_attrs.service_id=? " +
+							"JOIN members ON members.id IN (" + beanIdsToString(members) + ")" +
+							"LEFT JOIN member_attr_values mem ON attr_names.id=mem.attr_id " +
+							"AND mem.member_id=members.id WHERE namespace IN (?,?,?,?)",
+					new MemberAttributeExtractor(sess, this, members), service.getId(),
+					AttributesManager.NS_MEMBER_ATTR_CORE, AttributesManager.NS_MEMBER_ATTR_DEF, AttributesManager.NS_MEMBER_ATTR_OPT, AttributesManager.NS_MEMBER_ATTR_VIRT);
+		} catch(EmptyResultDataAccessException ex) {
+			return new HashMap<Member, List<Attribute>>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, List<User> users) throws InternalErrorException {
+		try {
+			return jdbc.query("SELECT " + getAttributeMappingSelectQuery("usr_fac") + ", users.id FROM attr_names " +
+							"JOIN service_required_attrs ON attr_names.id=service_required_attrs.attr_id AND service_required_attrs.service_id=? " +
+							"JOIN users ON users.id IN (" + beanIdsToString(users) + ")" +
+							"LEFT JOIN user_facility_attr_values usr_fac ON attr_names.id=usr_fac.attr_id AND facility_id=? AND user_id=users.id " +
+							"WHERE namespace IN (?,?,?)",
+					new UserAttributeExtractor(sess, this, users, facility), service.getId(), facility.getId(), AttributesManager.NS_USER_FACILITY_ATTR_DEF, AttributesManager.NS_USER_FACILITY_ATTR_OPT, AttributesManager.NS_USER_FACILITY_ATTR_VIRT);
+		} catch(EmptyResultDataAccessException ex) {
+			return new HashMap<User, List<Attribute>>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException {
+		//user and user core attributes
+		try {
+			return jdbc.query("SELECT " + getAttributeMappingSelectQuery("usr") + ", users.id FROM attr_names " +
+							"JOIN service_required_attrs on attr_names.id=service_required_attrs.attr_id AND service_required_attrs.service_id=? " +
+							"JOIN users ON users.id IN (" + beanIdsToString(users) + ")" +
+							"LEFT JOIN user_attr_values usr ON attr_names.id=usr.attr_id AND user_id=users.id " +
+							"WHERE namespace IN (?,?,?,?)",
+					new UserAttributeExtractor(sess, this, users), service.getId(), AttributesManager.NS_USER_ATTR_CORE, AttributesManager.NS_USER_ATTR_DEF, AttributesManager.NS_USER_ATTR_OPT, AttributesManager.NS_USER_ATTR_VIRT);
+		} catch(EmptyResultDataAccessException ex) {
+			return new HashMap<User, List<Attribute>>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Host host) throws InternalErrorException {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("host") + " from attr_names " +
@@ -4633,6 +4804,22 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
+	}
+
+	/**
+	 * Convert list of beans to string of bean IDs
+	 *
+	 * @param beans List of beans to construct string with ids
+	 * @return string representation of list of ids
+	 */
+	private String beanIdsToString(List<? extends PerunBean> beans) {
+		StringBuilder stringBuilder = new StringBuilder();
+		for(PerunBean bean : beans) {
+			stringBuilder.append(",");
+			stringBuilder.append(bean.getId());
+			}
+		stringBuilder.deleteCharAt(0);
+		return stringBuilder.toString();
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -4,6 +4,8 @@
 package cz.metacentrum.perun.core.implApi;
 
 import cz.metacentrum.perun.core.api.ActionType;
+
+import java.util.HashMap;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
@@ -1055,6 +1057,57 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws InternalErrorException;
+
+	/**
+	 * Get member-resource attributes which are required by service for each member in list of members.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param resource you get attributes for this resource and the members
+	 * @param members you get attributes for this list of members and the resource
+	 * @return map of member and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Resource resource, List<Member> members) throws InternalErrorException;
+
+	/**
+	 * Get member attributes which are required by service for each member in list of members.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param resource resource only to get allowed members
+	 * @param members you get attributes for this list of members
+	 * @return map of member and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Resource resource, Service service, List<Member> members) throws InternalErrorException;
+
+	/**
+	 * Get user-facility attributes which are required by the service for each user in list of users.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param facility you get attributes for this facility and user
+	 * @param users you get attributes for this user and facility
+	 * @return map of userID and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, List<User> users) throws InternalErrorException;
+
+	/**
+	 * Get user attributes which are required by the service for each user in list of users.
+	 *
+	 * @param sess perun session
+	 * @param service attribute required by this service
+	 * @param users you get attributes for this user and facility
+	 * @return map of userID and his list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException;
 
 	/**
 	 * Get member attributes which are required by the service.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 
+import cz.metacentrum.perun.core.api.ResourcesManager;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -64,7 +65,6 @@ import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import java.util.LinkedList;
 import java.util.Set;
@@ -97,6 +97,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	// these are in DB only when setUp"Type"() and must be used in correct (this) order
 	private AttributesManager attributesManager;
+	private ResourcesManager resourcesManager;
 	private Vo vo;
 	private Member member;
 	private Facility facility;
@@ -143,6 +144,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	public void setUp() throws Exception {
 
 		attributesManager = perun.getAttributesManager();
+		resourcesManager = perun.getResourcesManager();
 		this.setUpWorld();
 
 	}
@@ -5063,6 +5065,28 @@ public void getRequiredMemberResourceAttributesFromOneService() throws Exception
 
 }
 
+@Test
+public void getRequiredMembersResourceAttributesFromOneService() throws Exception {
+	System.out.println("attributesManager.getRequiredMembersResourceAttributesFromOneService");
+
+	vo = setUpVo();
+	member = setUpMember();
+	List<Member> members = new ArrayList<>();
+	members.add(member);
+	facility = setUpFacility();
+	resource = setUpResource();
+	service = setUpService();
+	attributes = setUpRequiredAttributes();
+	group = setUpGroup(vo, member);
+	resourcesManager.assignGroupToResource(sess, group, resource);
+	perun.getResourcesManager().assignService(sess, resource, service);
+
+	HashMap<Member, List<Attribute>> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, members);
+	assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
+	assertTrue("should have only 1 req attribute", reqAttr.size() == 1);
+
+}
+
 @Test (expected=ServiceNotExistsException.class)
 	public void getRequiredMemberResourceAttributesFromOneServiceWhenServiceNotExists() throws Exception {
 		System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneServiceWhenServiceNotExists");
@@ -5164,6 +5188,28 @@ public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUser() thro
 
 		attributesManager.getRequiredAttributes(sess, service, resource, new Member(), true);
 		// shouldn't find member
+
+	}
+
+	@Test
+	public void getRequiredMembersAttributesFromOneService() throws Exception {
+		System.out.println("attributesManager.getRequiredMemberAttributesFromOneService");
+
+		vo = setUpVo();
+		member = setUpMember();
+		List<Member> members = new ArrayList<>();
+		members.add(member);
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		group = setUpGroup(vo, member);
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		HashMap<Member, List<Attribute>> reqAttr = attributesManager.getRequiredAttributes(sess, resource, service, members);
+		assertNotNull("unable to get required member attributes for one service",reqAttr);
+		assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
 
 	}
 
@@ -7304,7 +7350,6 @@ private Member setUpMember() throws Exception {
 	usersForDeletion.add(perun.getUsersManager().getUserByMember(sess, member));
 	// save user for deletion after test
 	return member;
-
 }
 
 private Facility setUpFacility() throws Exception {
@@ -7363,6 +7408,15 @@ private Group setUpGroup() throws Exception {
 
 	Group group = perun.getGroupsManager().createGroup(sess, vo, new Group("AttrTestGroup","AttrTestGroupDescription"));
 	assertNotNull("unable to create a group",group);
+	return group;
+
+}
+
+private Group setUpGroup(Vo vo, Member member) throws Exception {
+
+	Group group = new Group("ResourcesManagerTestGroup","");
+	group = perun.getGroupsManager().createGroup(sess, vo, group);
+	perun.getGroupsManager().addMember(sess, group, member);
 	return group;
 
 }


### PR DESCRIPTION
- loops through members in ServiceManagerBlImpl get*Data* methodes removed
- added 4 new getRequiredAttributes to AttributesManagerImpl which take
  list of members. They return map of member as a key and list of their
  attributes as value.
- added new getRequiredAttributes which takes list of members, it calls
  the 4 new getRequiredAttributes methods and combines their output into
  one hashMap.
- Added changes made by Pavel Zlamal:
  -- Fixed SQL when selecting user required attributes
  -- Method for creating string with list of IDs changed
     from handling only Users to all PerunBeans.
  -- Methods getRequiredAttributes() for list of users now return
     HashMap<User, List<Attribute>> instead of HashMap<Integer,
     List<Attribute>>,
     to be the same as member-like methods.
  -- Added missing authorization on retrieved attributes for new
     getRequiredAttributes() methods.
  -- Updated javadoc to respect above changes.