### PR TITLE
CORE, RPC, GUI: Support for Boolean attribute type

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Attribute.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Attribute.java
@@ -19,7 +19,7 @@ public class Attribute extends AttributeDefinition {
 
 	private final static Logger log = LoggerFactory.getLogger(Attribute.class);
 	/**
-	 * Value of the attribute, can be Map, List, String, Integer, ...
+	 * Value of the attribute, can be Map, List, String, Integer, Boolean...
 	 */
 	private Object value;
 

--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -170,6 +170,8 @@ public class BeansUtils {
 			return (String) attribute.getValue();
 		} else if(attribute.getType().equals(Integer.class.getName())) {
 			return Integer.toString((Integer) attribute.getValue());
+		} else if(attribute.getType().equals(Boolean.class.getName())) {
+			return Boolean.toString((Boolean) attribute.getValue());
 		} else if(attribute.getType().equals(ArrayList.class.getName())) {
 			StringBuilder sb = new StringBuilder();
 			for(String item : (List<String>) attribute.getValue()) {
@@ -288,6 +290,8 @@ public class BeansUtils {
 			return stringValue;
 		} else if(attributeClass.equals(Integer.class)) {
 			return Integer.parseInt(stringValue);
+		} else if(attributeClass.equals(Boolean.class)) {
+			return Boolean.parseBoolean(stringValue);
 		} else if(attributeClass.equals(ArrayList.class)) {
 			String[] array = stringValue.split(Character.toString(LIST_DELIMITER), -1);
 			List<String> attributeValue =  new ArrayList<String>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -3174,8 +3174,17 @@ public interface AttributesManagerBl {
 	/**
 	* Method returns attribute with null value if attribute has empty string;
 	* 
-	* @param attributeToConverting 
-	* @return
+	* @param attributeToConvert
+	* @return Attribute with original value or null value for empty string
 	*/
-	Attribute convertEmptyStringIntoNullInAttrValue(PerunSession sess, Attribute attributeToConverting);
+	Attribute convertEmptyStringIntoNullInAttrValue(Attribute attributeToConvert);
+
+	/**
+	 * Method returns attribute with null value if attribute value is boolean == false
+	 *
+	 * @param attributeToConvert
+	 * @return Attribute with original value or null value for boolean == false
+	 */
+	Attribute convertBooleanFalseIntoNullInAttrValue(Attribute attributeToConvert);
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -5378,13 +5378,26 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		return allDependencies;
 	}
 
-	public Attribute convertEmptyStringIntoNullInAttrValue(PerunSession sess, Attribute attributeToConverting) {
-		//if attributeToConverting has already null value, return it
-		if(attributeToConverting.getValue() == null) return attributeToConverting;
-		String testAttributeType = attributeToConverting.getType();
-		if (testAttributeType.equals(String.class.getName()) && attributeToConverting.getValue().equals("")) {
-			attributeToConverting.setValue(null);
+	@Override
+	public Attribute convertEmptyStringIntoNullInAttrValue(Attribute attributeToConvert) {
+		//if attributeToConvert has already null value, return it
+		if(attributeToConvert.getValue() == null) return attributeToConvert;
+		String testAttributeType = attributeToConvert.getType();
+		if (testAttributeType.equals(String.class.getName()) && attributeToConvert.getValue().equals("")) {
+			attributeToConvert.setValue(null);
 		}
-		return attributeToConverting;
+		return attributeToConvert;
 	}
+
+	@Override
+	public Attribute convertBooleanFalseIntoNullInAttrValue(Attribute attributeToConvert) {
+		//if attributeToConvert has already null value, return it
+		if(attributeToConvert.getValue() == null) return attributeToConvert;
+		String testAttributeType = attributeToConvert.getType();
+		if (testAttributeType.equals(Boolean.class.getName()) && attributeToConvert.getValue().equals(false)) {
+			attributeToConvert.setValue(null);
+		}
+		return attributeToConvert;
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -539,8 +539,8 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	private List<User> getUsersByVirtualAttribute(PerunSession sess, AttributeDefinition attributeDef, String attributeValue) throws InternalErrorException {
 		// try to find method in attribute module
-		UserVirtualAttributesModuleImplApi attributeModul = perunBl.getAttributesManagerBl().getUserVirtualAttributeModule(sess, attributeDef);
-		List<User> listOfUsers = attributeModul.searchInAttributesValues((PerunSessionImpl) sess, attributeValue);
+		UserVirtualAttributesModuleImplApi attributeModule = perunBl.getAttributesManagerBl().getUserVirtualAttributeModule(sess, attributeDef);
+		List<User> listOfUsers = attributeModule.searchInAttributesValues((PerunSessionImpl) sess, attributeValue);
 
 		if (listOfUsers != null) {
 			return listOfUsers;
@@ -601,8 +601,6 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			throw new ConsistencyErrorException("Attribute name:'"  + attributeName + "', value:'" + attributeValue + "' not exists ", e);
 		}
 	}
-
-
 
 	public List<User> findUsers(PerunSession sess, String searchString) throws InternalErrorException {
 		return this.getUsersManagerImpl().findUsers(sess, searchString);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -444,7 +444,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 
@@ -459,7 +460,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -473,7 +475,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -487,7 +490,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -502,7 +506,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -517,7 +522,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -544,7 +550,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		if(workWithUserAttributes) getPerunBl().getUsersManagerBl().checkUserExists(sess,getPerunBl().getUsersManagerBl().getUserByMember(sess, member));
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
@@ -570,7 +577,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -594,7 +602,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -609,7 +618,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -623,7 +633,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -637,7 +648,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getFacilitiesManagerBl().checkHostExists(sess, host);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -656,7 +668,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
@@ -671,7 +684,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 		for(Attribute attribute: attributes) {
-			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		}
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		if(!getPerunBl().getGroupsManagerBl().getVo(sess, group).equals(getPerunBl().getResourcesManagerBl().getVo(sess, resource))) {
@@ -963,7 +977,8 @@ public class AttributesManagerEntry implements AttributesManager {
 
 	public void setAttribute(PerunSession sess, Facility facility, Attribute attribute) throws PrivilegeException, InternalErrorException, FacilityNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, facility, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
@@ -973,7 +988,8 @@ public class AttributesManagerEntry implements AttributesManager {
 	public void setAttribute(PerunSession sess, Vo vo, Attribute attribute) throws PrivilegeException, InternalErrorException, VoNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, vo, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, vo, attribute);
@@ -982,7 +998,8 @@ public class AttributesManagerEntry implements AttributesManager {
 	public void setAttribute(PerunSession sess, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, group, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, group, attribute);
@@ -992,7 +1009,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, resource, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, resource, attribute);
 	}
@@ -1002,7 +1020,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, resource, member)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, resource, member, attribute);
 	}
@@ -1011,7 +1030,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, member, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, member, attribute);
 	}
@@ -1021,7 +1041,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, facility, user)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, facility, user, attribute);
 	}
@@ -1030,7 +1051,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, user, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, user, attribute);
 	}
@@ -1039,7 +1061,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getFacilitiesManagerBl().checkHostExists(sess, host);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, host, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		try {
 			getAttributesManagerBl().setAttribute(sess, host, attribute);
@@ -1053,7 +1076,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, resource, group)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, resource, group, attribute);
 
@@ -1061,7 +1085,8 @@ public class AttributesManagerEntry implements AttributesManager {
 
 	public void setAttribute(PerunSession sess, String key, Attribute attribute) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
-		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(sess, attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		Utils.notNull(key, "key");
 		if(key.isEmpty()) throw new InternalErrorException("key for entityless attribute can't be empty string");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -348,6 +348,8 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 						value = String.valueOf(value);
 					} else if(attribute.getType().equals(Integer.class.getName()) && !(value instanceof Integer)) {
 						//TODO try to cast to integer
+					} else if(attribute.getType().equals(Boolean.class.getName()) && !(value instanceof Boolean)) {
+						//TODO try to cast to boolean
 					} else if(attribute.getType().equals(ArrayList.class.getName()) && !(value instanceof ArrayList)) {
 						if(value instanceof List) {
 							value = new ArrayList<String>((List)value);
@@ -4563,7 +4565,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 			jdbc.update("insert into attr_names (id, attr_name, type, dsc, namespace, friendly_name, display_name, default_attr_id) values (?,?,?,?,?,?,?,NULL)",
 					attributeId, attribute.getName(), attribute.getType(), attribute.getDescription(), attribute.getNamespace(), attribute.getFriendlyName(), attribute.getDisplayName());
-			log.info("Attribute created during inicialization of attributesManager: {}", attribute);
+			log.info("Attribute created during initialization of attributesManager: {}", attribute);
 		} catch (DataIntegrityViolationException e) {
 			throw new ConsistencyErrorException("Attribute already exists: " + attribute, e);
 		} catch (RuntimeException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -71,6 +71,12 @@ public class SearcherImpl implements SearcherImplApi {
 					whereClauses.add("nam" + counter + ".type=:n" + counter + " ");
 					parameters.addValue("n" + counter, String.class.getName().toString());
 					parameters.addValue("v" + counter, BeansUtils.attributeValueToString(key));
+				} else if (key.getType().equals(Boolean.class.getName())) {
+					key.setValue(value);
+					whereClauses.add("lower("+Compatibility.convertToAscii("val" + counter + ".attr_value")+")=lower("+Compatibility.convertToAscii(":v"+counter)+") ");
+					whereClauses.add("nam" + counter + ".type=:n" + counter + " ");
+					parameters.addValue("n" + counter, Boolean.class.getName().toString());
+					parameters.addValue("v" + counter, BeansUtils.attributeValueToString(key));
 				} else if (key.getType().equals(ArrayList.class.getName())) {
 					List<String> list = new ArrayList<String>();
 					list.add(value);
@@ -78,7 +84,7 @@ public class SearcherImpl implements SearcherImplApi {
 					whereClauses.add("val" + counter + ".attr_value LIKE :v" + counter + " ");
 					whereClauses.add("nam" + counter + ".type=:n" + counter + " ");
 					parameters.addValue("n" + counter, ArrayList.class.getName().toString());
-					parameters.addValue("v" + counter, '%' + BeansUtils.attributeValueToString(key).substring(0, BeansUtils.attributeValueToString(key).length()-1) + '%');
+					parameters.addValue("v" + counter, '%' + BeansUtils.attributeValueToString(key).substring(0, BeansUtils.attributeValueToString(key).length() - 1) + '%');
 				} else if (key.getType().equals(LinkedHashMap.class.getName())) {
 					String[] splitMapItem = value.split("=");
 					if(splitMapItem.length == 0) throw new InternalErrorException("Value can't be split by char '='.");
@@ -99,7 +105,7 @@ public class SearcherImpl implements SearcherImplApi {
 					parameters.addValue("v" + counter, BeansUtils.attributeValueToString(key) + '%');
 					parameters.addValue("vv" + counter,  "%," +  BeansUtils.attributeValueToString(key) + '%');
 				} else {
-					throw new InternalErrorException(key + " is not type of integer, string, array or hashmap.");
+					throw new InternalErrorException(key + " is not type of integer, string, boolean, array or hashmap.");
 				}
 			}
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -589,16 +589,22 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		}
 	}
 
-	public List<User> getUsersByAttributeValue(PerunSession sess, AttributeDefinition attributeDefitintion, String attributeValue) throws InternalErrorException {
+	public List<User> getUsersByAttributeValue(PerunSession sess, AttributeDefinition attributeDefinition, String attributeValue) throws InternalErrorException {
 		String value = "";;
 		String operator = "=";
-		if (attributeDefitintion.getType().equals(String.class.getName())) {
+		if (attributeDefinition.getType().equals(String.class.getName())) {
 			value = attributeValue.trim();
 			operator = "=";
-		} else if (attributeDefitintion.getType().equals(ArrayList.class.getName())) {
+		} else if (attributeDefinition.getType().equals(Integer.class.getName())) {
+			value = attributeValue.trim();
+			operator = "=";
+		}  else if (attributeDefinition.getType().equals(Boolean.class.getName())) {
+			value = attributeValue.trim();
+			operator = "=";
+		} else if (attributeDefinition.getType().equals(ArrayList.class.getName())) {
 			value = "%" + attributeValue.trim() + "%";
 			operator = "like";
-		} else if (attributeDefitintion.getType().equals(LinkedHashMap.class.getName())) {
+		} else if (attributeDefinition.getType().equals(LinkedHashMap.class.getName())) {
 			value = "%" + attributeValue.trim() + "%";
 			operator = "like";
 		}
@@ -608,7 +614,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 		MapSqlParameterSource namedParams = new MapSqlParameterSource();
 		namedParams.addValue("value", value);
-		namedParams.addValue("attr_id", attributeDefitintion.getId());
+		namedParams.addValue("attr_id", attributeDefinition.getId());
 
 		try {
 			return namedParameterJdbcTemplate.query(query, namedParams, USER_MAPPER);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -35,6 +35,16 @@ public abstract class Deserializer {
 	public abstract String readString(String name) throws RpcException;
 
 	/**
+	 * Reads value with the specified name as {@code Boolean}.
+	 *
+	 * @param name name of the value to read
+	 * @return the value as {@code Boolean}
+	 *
+	 * @throws RpcException If the specified value cannot be parsed as {@code String} or if it is not supplied
+	 */
+	public abstract Boolean readBoolean(String name) throws RpcException;
+
+	/**
 	 * Reads value with the specified name as {@code int}.
 	 *
 	 * @param name name of the value to read

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -46,13 +46,13 @@ import javax.servlet.http.HttpServletRequest;
 public class JsonDeserializer extends Deserializer {
 
 	@JsonIgnoreProperties({"name","baseFriendlyName", "friendlyNameParameter", "entity", "beanName"})
-		private interface AttributeMixIn {}
+	private interface AttributeMixIn {}
 
 	@JsonIgnoreProperties({"name", "value", "baseFriendlyName", "friendlyNameParameter", "entity", "beanName"})
-		private interface AttributeDefinitionMixIn {}
+	private interface AttributeDefinitionMixIn {}
 
 	@JsonIgnoreProperties({"commonName", "displayName", "beanName"})
-		private interface UserMixIn {}
+	private interface UserMixIn {}
 
 	@JsonIgnoreProperties({"fullMessage"})
 	private interface AuditMessageMixIn {}
@@ -67,11 +67,10 @@ public class JsonDeserializer extends Deserializer {
 	private interface PerunExceptionMixIn {}
 
 	@JsonIgnoreProperties({"hostNameFromDestination", "beanName"})
-		private interface DestinationMixIn {}
+	private interface DestinationMixIn {}
 
 	@JsonIgnoreProperties({"shortName", "beanName"})
-		private interface GroupMixIn {}
-
+	private interface GroupMixIn {}
 
 	private interface MemberMixIn {
 		@JsonIgnore
@@ -319,14 +318,14 @@ public class JsonDeserializer extends Deserializer {
 
 		try {
 			List<PerunBean> list = new ArrayList<PerunBean>(node.size());
-		for (JsonNode e : node) {
-			String beanName = "cz.metacentrum.perun.core.api." + e.get("beanName").getTextValue();
+			for (JsonNode e : node) {
+				String beanName = "cz.metacentrum.perun.core.api." + e.get("beanName").getTextValue();
 
-			if(beanName == null) {
-				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - missing beanName info");
+				if(beanName == null) {
+					throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - missing beanName info");
+				}
+				list.add((PerunBean) mapper.readValue(e, Class.forName(beanName)));
 			}
-			list.add((PerunBean) mapper.readValue(e, Class.forName(beanName)));
-		}
 			return list;
 		} catch (ClassNotFoundException ex) {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - class not found");

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -163,6 +163,23 @@ public class JsonDeserializer extends Deserializer {
 	}
 
 	@Override
+	public Boolean readBoolean(String name) throws RpcException {
+		JsonNode node = root.get(name);
+
+		if (node == null) {
+			throw new RpcException(RpcException.Type.MISSING_VALUE, name);
+		}
+		if (node.isNull()) {
+			return null;
+		}
+		if (!node.isValueNode()) {
+			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as Boolean");
+		}
+
+		return node.getValueAsBoolean();
+	}
+
+	@Override
 	public int readInt(String name) throws RpcException {
 		JsonNode node = root.get(name);
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
@@ -50,6 +50,13 @@ public class UrlDeserializer extends Deserializer {
 	}
 
 	@Override
+	public Boolean readBoolean(String name) throws RpcException {
+		if (!contains(name)) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
+
+		return Boolean.parseBoolean(req.getParameter(name));
+	}
+
+	@Override
 	public int readInt(String name) throws RpcException {
 		if (!contains(name)) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
 
@@ -78,6 +85,8 @@ public class UrlDeserializer extends Deserializer {
 				list.add(valueType.cast(param));
 			} else if (valueType.isAssignableFrom(Integer.class)) {
 				list.add(valueType.cast(Integer.valueOf(param)));
+			} else if (valueType.isAssignableFrom(Boolean.class)) {
+				list.add(valueType.cast(Boolean.valueOf(param)));
 			} else if (valueType.isAssignableFrom(Float.class)) {
 				list.add(valueType.cast(Float.valueOf(param)));
 			}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -627,6 +627,13 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param attribute Attribute JSON object
 	 * @return List<User> Found users
 	 */
+	/*#
+	 * Returns all users who have set the attribute with the value. Searching only def and opt attributes.
+	 *
+	 * @param attributeName String URN of attribute to search by
+	 * @param attributeValue Object Value to search by (type of value must match attribute value type)
+	 * @return List<User> Found users
+	 */
 	getUsersByAttribute {
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
@@ -664,7 +671,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns all users who have attribute which have value which contains searchString.
 	 *
-	 * @param attribute Attribute JSON object
+	 * @param attributeName String URN of attribute to search by
+	 * @param attributeValue String Value to search by
 	 * @return List<User> Found users
 	 */
 	getUsersByAttributeValue {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -639,15 +639,15 @@ public enum UsersManagerMethod implements ManagerMethod {
 						attr.setValue(parms.readInt("attributeValue"));
 					} else if(attr.getType().equals(String.class.getName())) {
 						attr.setValue(parms.readString("attributeValue"));
-						return ac.getUsersManager().getUsersByAttribute(ac.getSession(),attr);
+					} else if(attr.getType().equals(Boolean.class.getName())) {
+						attr.setValue(parms.readBoolean("attributeValue"));
 					} else if(attr.getType().equals(ArrayList.class.getName())) {
 						attr.setValue(parms.readList("attributeValue", String.class));
 					} else if(attr.getType().equals(LinkedHashMap.class.getName())) {
 						attr.setValue(parms.read("attributeValue", LinkedHashMap.class));
 					} else {
-						throw new RpcException(RpcException.Type.CANNOT_SERIALIZE_VALUE, "attributeValue is not the same type like value of attribute with the attributeName.");
+						throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, "attributeValue is not the same type like value of attribute with the attributeName.");
 					}
-
 					return ac.getUsersManager().getUsersByAttribute(ac.getSession(),attr);
 				} else {
 					throw new RpcException(RpcException.Type.MISSING_VALUE, "attributeValue");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesDefinitionV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesDefinitionV2.java
@@ -6,10 +6,7 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent.ListHandler;
-import com.google.gwt.view.client.DefaultSelectionEventManager;
-import com.google.gwt.view.client.ListDataProvider;
-import com.google.gwt.view.client.MultiSelectionModel;
-import com.google.gwt.view.client.SelectionModel;
+import com.google.gwt.view.client.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.resources.TableSorter;
 import cz.metacentrum.perun.webgui.json.*;
@@ -100,14 +97,13 @@ public class GetAttributesDefinitionV2 implements JsonCallback, JsonCallbackTabl
 		ListHandler<Attribute> columnSortHandler = new ListHandler<Attribute>(dataProvider.getList());
 		table.addColumnSortHandler(columnSortHandler);
 
-		// table selection
-		table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager());
-
 		// set empty content & loader
 		table.setEmptyTableWidget(loaderImage);
 
 		// checkbox column column
 		if (checkable) {
+			// table selection
+			table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager(0));
 			table.addCheckBoxColumn();
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesDefinitionWithRights.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesDefinitionWithRights.java
@@ -102,14 +102,13 @@ public class GetAttributesDefinitionWithRights implements JsonCallback, JsonCall
 		ListHandler<Attribute> columnSortHandler = new ListHandler<Attribute>(dataProvider.getList());
 		table.addColumnSortHandler(columnSortHandler);
 
-		// table selection
-		table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager());
-
 		// set empty content & loader
 		table.setEmptyTableWidget(loaderImage);
 
 		// checkbox column column
 		if (checkable) {
+			// table selection
+			table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager(0));
 			table.addCheckBoxColumn();
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesV2.java
@@ -273,9 +273,6 @@ public class GetAttributesV2 implements JsonCallback, JsonCallbackTable<Attribut
 		ListHandler<Attribute> columnSortHandler = new ListHandler<Attribute>(dataProvider.getList());
 		table.addColumnSortHandler(columnSortHandler);
 
-		// table selection
-		table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager());
-
 		// set empty content & loader
 		table.setEmptyTableWidget(loaderImage);
 
@@ -321,6 +318,9 @@ public class GetAttributesV2 implements JsonCallback, JsonCallbackTable<Attribut
 					}
 				}
 			});
+
+			// table selection
+			table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager(0));
 
 			table.addColumn(checkBoxColumn, checkBoxHeader);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetRequiredAttributesV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetRequiredAttributesV2.java
@@ -179,9 +179,6 @@ public class GetRequiredAttributesV2 implements JsonCallback, JsonCallbackTable<
 		ListHandler<Attribute> columnSortHandler = new ListHandler<Attribute>(dataProvider.getList());
 		table.addColumnSortHandler(columnSortHandler);
 
-		// table selection
-		table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager());
-
 		// set empty content & loader
 		table.setEmptyTableWidget(loaderImage);
 		loaderImage.setEmptyResultMessage("No settings found. Use 'Add' button to add new setting.");
@@ -226,6 +223,9 @@ public class GetRequiredAttributesV2 implements JsonCallback, JsonCallbackTable<
 					}
 				}
 			});
+
+			// table selection
+			table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager(0));
 
 			table.addColumn(checkBoxColumn, checkBoxHeader);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetResourceRequiredAttributesV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetResourceRequiredAttributesV2.java
@@ -144,9 +144,6 @@ public class GetResourceRequiredAttributesV2 implements JsonCallback, JsonCallba
 		ListHandler<Attribute> columnSortHandler = new ListHandler<Attribute>(dataProvider.getList());
 		table.addColumnSortHandler(columnSortHandler);
 
-		// table selection
-		table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager());
-
 		// set empty content & loader
 		table.setEmptyTableWidget(loaderImage);
 
@@ -190,6 +187,9 @@ public class GetResourceRequiredAttributesV2 implements JsonCallback, JsonCallba
 					}
 				}
 			});
+
+			// table selection
+			table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Attribute> createCheckboxManager(0));
 
 			table.addColumn(checkBoxColumn, checkBoxHeader);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Attribute.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Attribute.java
@@ -29,206 +29,218 @@ public class Attribute extends JavaScriptObject {
 		return this.id;
 	}-*/;
 
-		/**
-		 * Gets friendly name of attribute
-		 *
-		 * @return friendly name of attribute
-		 */
-		public final native String getFriendlyName() /*-{
-			return this.friendlyName;
-		}-*/;
+	/**
+	 * Gets friendly name of attribute
+	 *
+	 * @return friendly name of attribute
+	 */
+	public final native String getFriendlyName() /*-{
+		return this.friendlyName;
+	}-*/;
 
-		/**
-		 * Gets namespace of attribute
-		 *
-		 * @return namespace of attribute
-		 */
-		public final native String getNamespace() /*-{
-			return this.namespace;
-		}-*/;
+	/**
+	 * Gets namespace of attribute
+	 *
+	 * @return namespace of attribute
+	 */
+	public final native String getNamespace() /*-{
+		return this.namespace;
+	}-*/;
 
-		/**
-		 * Get whole name of attribute (URN)
-		 *
-		 * @return whole name of attribute
-		 */
-		public final native String getName() /*-{
-			return this.namespace+':'+this.friendlyName;
-		}-*/;
+	/**
+	 * Get whole name of attribute (URN)
+	 *
+	 * @return whole name of attribute
+	 */
+	public final native String getName() /*-{
+		return this.namespace+':'+this.friendlyName;
+	}-*/;
 
-		/**
-		 * Get DisplayName of attribute used in GUI,
-		 * if not present, return friendlyName parameter
-		 *
-		 * @return display name of attribute definition
-		 */
-		public final native String getDisplayName() /*-{
-			if (!this.displayName) {
+	/**
+	 * Get DisplayName of attribute used in GUI,
+	 * if not present, return friendlyName parameter
+	 *
+	 * @return display name of attribute definition
+	 */
+	public final native String getDisplayName() /*-{
+		if (!this.displayName) {
 			return "";
-			} else {
+		} else {
 			return this.displayName;
-			}
-		}-*/;
+		}
+	}-*/;
 
-		/**
-		 * Set new display name of attribute definition
-		 *
-		 * @param displayName new display name of attribute definition
-		 */
-		public final native void setDisplayName(String displayName) /*-{
-			this.displayName = displayName;
-		}-*/;
+	/**
+	 * Set new display name of attribute definition
+	 *
+	 * @param displayName new display name of attribute definition
+	 */
+	public final native void setDisplayName(String displayName) /*-{
+		this.displayName = displayName;
+	}-*/;
 
-		/**
-		 * Get base friendly name of attribute
-		 *
-		 * e.g.: urn:perun:user:attribute-def:def:login-namespace:meta
-		 * return "login-namespace"
-		 *
-		 * if no parameter present, return whole friendlyName
-		 *
-		 * @return base friendly name of attribute
-		 */
-		public final native String getBaseFriendlyName() /*-{
-			return this.baseFriendlyName;
-		}-*/;
+	/**
+	 * Get base friendly name of attribute
+	 *
+	 * e.g.: urn:perun:user:attribute-def:def:login-namespace:meta
+	 * return "login-namespace"
+	 *
+	 * if no parameter present, return whole friendlyName
+	 *
+	 * @return base friendly name of attribute
+	 */
+	public final native String getBaseFriendlyName() /*-{
+		return this.baseFriendlyName;
+	}-*/;
 
-		/**
-		 * Get friendly name parameter of attribute
-		 *
-		 * e.g.: urn:perun:user:attribute-def:def:login-namespace:meta
-		 * return "meta"
-		 *
-		 * If no parameter present, return ":";
-		 *
-		 * @return friendly name parameter of attribute
-		 */
-		public final native String getFriendlyNameParameter() /*-{
-			return this.friendlyNameParameter;
-		}-*/;
+	/**
+	 * Get friendly name parameter of attribute
+	 *
+	 * e.g.: urn:perun:user:attribute-def:def:login-namespace:meta
+	 * return "meta"
+	 *
+	 * If no parameter present, return ":";
+	 *
+	 * @return friendly name parameter of attribute
+	 */
+	public final native String getFriendlyNameParameter() /*-{
+		return this.friendlyNameParameter;
+	}-*/;
 
-		/**
-		 * Get attribute def. entity (user, member,...)
-		 *
-		 * @return entity of attrDef
-		 */
-		public final native String getEntity() /*-{
-			return this.entity;
-		}-*/;
+	/**
+	 * Get attribute def. entity (user, member,...)
+	 *
+	 * @return entity of attrDef
+	 */
+	public final native String getEntity() /*-{
+		return this.entity;
+	}-*/;
 
-		/**
-		 * Gets description of attribute
-		 *
-		 * @return description of attribute
-		 */
-		public final native String getDescription() /*-{
-			return this.description;
-		}-*/;
+	/**
+	 * Gets description of attribute
+	 *
+	 * @return description of attribute
+	 */
+	public final native String getDescription() /*-{
+		return this.description;
+	}-*/;
 
-		/**
-		 * Return definition type of attribute def.
-		 * CORE, DEF, OPT, VIRT or "null" if not present
-		 *
-		 * @return definition type
-		 */
-		public final native String getDefinition() /*-{
-			var temp = new Array();
-			temp = this.namespace.split(":");
-			if (temp[4] == null ) { return "null"; }
-			return temp[4];
-		}-*/;
+	/**
+	 * Return definition type of attribute def.
+	 * CORE, DEF, OPT, VIRT or "null" if not present
+	 *
+	 * @return definition type
+	 */
+	public final native String getDefinition() /*-{
+		var temp = new Array();
+		temp = this.namespace.split(":");
+		if (temp[4] == null ) { return "null"; }
+		return temp[4];
+	}-*/;
 
-		/**
-		 * Gets type of attribute
-		 *
-		 * @return type of attribute
-		 */
-		public final native String getType() /*-{
-			return this.type;
-		}-*/;
+	/**
+	 * Gets type of attribute
+	 *
+	 * @return type of attribute
+	 */
+	public final native String getType() /*-{
+		return this.type;
+	}-*/;
 
-		/**
-		 * Check if attribute value is writable for user or not
-		 *
-		 * @return TRUE if writable / FALSE otherwise
-		 */
-		public final native boolean isWritable() /*-{
-			if (typeof this.writable == "undefined") {
+	/**
+	 * Check if attribute value is writable for user or not
+	 *
+	 * @return TRUE if writable / FALSE otherwise
+	 */
+	public final native boolean isWritable() /*-{
+		if (typeof this.writable == "undefined") {
 			// allow since PERUN-CORE can hadle this by itself
 			return true;
-			}
-			return this.writable;
-		}-*/;
+		}
+		return this.writable;
+	}-*/;
 
-		public final native void setWritable(boolean write) /*-{
-			this.writable = write;
-		}-*/;
+	public final native void setWritable(boolean write) /*-{
+		this.writable = write;
+	}-*/;
 
 
-		/**
-		 * Gets value of attribute
-		 *
-		 * @return value of attribute
-		 */
-		public final native String getValue() /*-{
-						if (this.value == null) { return "null"; }
-						return this.value.toString();
-					}-*/;
+	/**
+	 * Gets value of attribute
+	 *
+	 * @return value of attribute
+	 */
+	public final native String getValue() /*-{
+		if (this.value == null) { return "null"; }
+		return this.value.toString();
+	}-*/;
 
-		/**
-		 * Sets a new value to attribute. String input is checked
-		 * before setting for respecting value type
-		 *
-		 * @param newValue new value to be set to attribute
-		 * @return true if success (correct value)
-		 */
-		public final native boolean setValue(String newValue) /*-{
-						// add trim function
-			String.prototype.trim = function()
-			{
+	/**
+	 * Sets a new value to attribute. String input is checked
+	 * before setting for respecting value type
+	 *
+	 * @param newValue new value to be set to attribute
+	 * @return true if success (correct value)
+	 */
+	public final native boolean setValue(String newValue) /*-{
+		// add trim function
+		String.prototype.trim = function()
+		{
 			return this.replace(/(^\s*)|(\s*$)/g, "")
-			};
-						if (this.type == "java.lang.Integer") {
-						// true on any number format, false otherwise
+		};
+		if (this.type == "java.lang.Integer") {
+			// true on any number format, false otherwise
 			if (!isNaN(parseFloat(newValue)) && isFinite(newValue)) {
-			this.value = parseInt(newValue);
-			return true;
+				this.value = parseInt(newValue);
+				return true;
 			} else {
-			return false;
+				return false;
 			}
+		}
+		if (this.type == "java.lang.Boolean") {
+			// true on any number format, false otherwise
+			if (newValue == "true") {
+				this.value = true;
+				return true;
+			} else if (newValue == "false") {
+				this.value = false;
+				return true;
+			} else {
+				return false;
 			}
-						if (this.type == "java.util.ArrayList") {
-						this.value = [];
+		}
+		if (this.type == "java.util.ArrayList") {
+			this.value = [];
 			var count = 0;
 			var input = "";
-						for (var i=0; i<newValue.length; i++) {
-						// escaped ","
-			if (newValue[i] == "\\" && i+1 < newValue.length && newValue[i+1] == ",") {
-			i++;                         // skip escape char
-			input = input + newValue[i]  // add next
-			continue;                    // and continue
-			// normal ","
-			} else {
-			if (newValue[i] == ",") {
-			input = input.trim();          // trim whitespace on sides
-			if (input == "") { continue; } // skip empty values
-			this.value[count] = input;     // save previous value
-			count++;                       // update field counter
-			input = "";                    // clear input string
-			continue;                      // skip "," and continue
-			}
-			input = input + newValue[i]  	   // append letter
-			}
+			for (var i=0; i<newValue.length; i++) {
+				// escaped ","
+				if (newValue[i] == "\\" && i+1 < newValue.length && newValue[i+1] == ",") {
+					i++;                         // skip escape char
+					input = input + newValue[i]  // add next
+					continue;                    // and continue
+					// normal ","
+				} else {
+					if (newValue[i] == ",") {
+						input = input.trim();          // trim whitespace on sides
+						if (input == "") { continue; } // skip empty values
+						this.value[count] = input;     // save previous value
+						count++;                       // update field counter
+						input = "";                    // clear input string
+						continue;                      // skip "," and continue
+					}
+					input = input + newValue[i]  	   // append letter
+				}
 			}
 			input = input.trim();               // at end - trim value
 			if (input == "") { return false; }  // at end - do not save empty strings
 			this.value[count] = input;          // at end - save value
-						return true;
-			}
-						if (newValue == "") { return false; }   // do not save empty strings
-			this.value = newValue;
-						return true;
-					}-*/;
+			return true;
+		}
+		if (newValue == "") { return false; }   // do not save empty strings
+		this.value = newValue;
+		return true;
+	}-*/;
 
 
 		/*	public final ArrayList<String> getValueAsList(){
@@ -236,62 +248,70 @@ public class Attribute extends JavaScriptObject {
 				return JsonUtils.listFromJsArrayString(array);
 				}*/
 
-		public native final JsArrayString getValueAsJsArray() /*-{
-			return this.value;
-		}-*/;
+	public native final JsArrayString getValueAsJsArray() /*-{
+		return this.value;
+	}-*/;
 
-		public native final JavaScriptObject getValueAsJso() /*-{
-			return this.value;
-		}-*/;
+	public native final JavaScriptObject getValueAsJso() /*-{
+		return this.value;
+	}-*/;
 
-		public native final Object getValueAsObject() /*-{
-			return this.value;
-		}-*/;
+	public native final boolean getValueAsBoolean() /*-{
+		return this.value;
+	}-*/;
 
-		public native final void setValueAsJso(JavaScriptObject valueAsJso) /*-{
-			this.value = valueAsJso;
-		}-*/;
+	public native final Object getValueAsObject() /*-{
+		return this.value;
+	}-*/;
 
-		public native final void setValueAsString(String str) /*-{
-			this.value = str;
-		}-*/;
+	public native final void setValueAsJso(JavaScriptObject valueAsJso) /*-{
+		this.value = valueAsJso;
+	}-*/;
 
-		public native final void setValueAsNumber(int i) /*-{
-			this.value = i;
-		}-*/;
+	public native final void setValueAsString(String str) /*-{
+		this.value = str;
+	}-*/;
 
-		public native final void setValueAsJsArray(JsArrayString arr) /*-{
-			this.value = arr;
-		}-*/;
+	public native final void setValueAsNumber(int i) /*-{
+		this.value = i;
+	}-*/;
 
-		public native final void setAttributeValid(boolean valid) /*-{
-			this.attributeValid = valid;
-		}-*/;
+	public native final void setValueAsBoolean(boolean i) /*-{
+		this.value = i;
+	}-*/;
 
-		public native final boolean isAttributeValid() /*-{
-			return this.attributeValid;
-		}-*/;
+	public native final void setValueAsJsArray(JsArrayString arr) /*-{
+		this.value = arr;
+	}-*/;
 
-		/**
-		 * Returns unique ID for GUI
-		 * @return
-		 */
-		public native final String getGuiUniqueId() /*-{
-						if(typeof $wnd.perunAttributeCounter == "undefined"){
+	public native final void setAttributeValid(boolean valid) /*-{
+		this.attributeValid = valid;
+	}-*/;
+
+	public native final boolean isAttributeValid() /*-{
+		return this.attributeValid;
+	}-*/;
+
+	/**
+	 * Returns unique ID for GUI
+	 * @return
+	 */
+	public native final String getGuiUniqueId() /*-{
+		if(typeof $wnd.perunAttributeCounter == "undefined"){
 			$wnd.perunAttributeCounter = 0;
-			}
-									if(typeof this.guiUniqueId == "undefined"){
+		}
+		if(typeof this.guiUniqueId == "undefined"){
 			this.guiUniqueId = "attr-" + $wnd.perunAttributeCounter;
 			$wnd.perunAttributeCounter++;
-			}
-						return this.guiUniqueId;
-		}-*/;
-
-
-		public final Map<String, JSONValue> getValueAsMap()
-		{
-			return JsonUtils.parseJsonToMap(getValueAsJso());
 		}
+		return this.guiUniqueId;
+	}-*/;
+
+
+	public final Map<String, JSONValue> getValueAsMap()
+	{
+		return JsonUtils.parseJsonToMap(getValueAsJso());
+	}
 
 	/**
 	 * Returns Perun specific type of object
@@ -300,37 +320,37 @@ public class Attribute extends JavaScriptObject {
 	 */
 	public final native String getObjectType() /*-{
 		if (!this.beanName) {
-		return "JavaScriptObject"
+			return "JavaScriptObject"
 		}
 		return this.beanName;
 	}-*/;
 
-		/**
-		 * Sets Perun specific type of object
-		 *
-		 * @param type type of object
-		 */
-		public final native void setObjectType(String type) /*-{
-			this.beanName = type;
-		}-*/;
+	/**
+	 * Sets Perun specific type of object
+	 *
+	 * @param type type of object
+	 */
+	public final native void setObjectType(String type) /*-{
+		this.beanName = type;
+	}-*/;
 
-		/**
-		 * Returns the status of this item in Perun system as String
-		 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
-		 *
-		 * @return string which defines item status
-		 */
-		public final native String getStatus() /*-{
-			return this.status;
-		}-*/;
+	/**
+	 * Returns the status of this item in Perun system as String
+	 * VALID, INVALID, SUSPENDED, EXPIRED, DISABLED
+	 *
+	 * @return string which defines item status
+	 */
+	public final native String getStatus() /*-{
+		return this.status;
+	}-*/;
 
-		/**
-		 * Compares to another object
-		 * @param o Object to compare
-		 * @return true, if they are the same
-		 */
-		public final boolean equals(Attribute o) {
-			return o.getId() == this.getId();
-		}
+	/**
+	 * Compares to another object
+	 * @param o Object to compare
+	 * @return true, if they are the same
+	 */
+	public final boolean equals(Attribute o) {
+		return o.getId() == this.getId();
+	}
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/CreateAttributeDefinitionTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/CreateAttributeDefinitionTabItem.java
@@ -147,6 +147,7 @@ public class CreateAttributeDefinitionTabItem implements TabItem {
 
 		typeListBox.addItem("String", "java.lang.String");
 		typeListBox.addItem("Integer", "java.lang.Integer");
+		typeListBox.addItem("Boolean", "java.lang.Boolean");
 		typeListBox.addItem("Array", "java.util.ArrayList");
 		typeListBox.addItem("LinkedHashMap", "java.util.LinkedHashMap");
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunAttributeValueCell.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunAttributeValueCell.java
@@ -290,8 +290,14 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 	 * @return true if success
 	 */
 	private final native boolean generateValueFromBoolean(Attribute attr, String uniqueId) /*-{
-		attr.value = $wnd.jQuery("#" + uniqueId + " .checkbox-value").prop('checked')
-		console.log(attr.value);
+		var val = $wnd.jQuery("#" + uniqueId + " .checkbox-value").prop('checked')
+		if (val === true) {
+			// checked == true
+			attr.value = true;
+		} else {
+			// unchecked == null == false
+			attr.value = null;
+		}
 		return true;
 	}-*/;
 
@@ -449,11 +455,12 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 	 * @return
 	 */
 	private static String generateCheckBox(String value, boolean writable) {
-		// check for emptiness
-		if (value == null || value.equalsIgnoreCase("null") || value.equalsIgnoreCase("false")) {
-			value = "";
-		} else {
+		if (value != null && value.equalsIgnoreCase("true")) {
+			// only non-null true is considered checked
 			value = "checked=\"checked\"";
+		} else {
+			// other values are considered false == null
+			value = "";
 		}
 
 		if (writable) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunAttributeValueCell.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunAttributeValueCell.java
@@ -240,6 +240,9 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 		if (attr.getType().equals("java.lang.Integer")) {
 			return generateValueFromNumber(attr, getUniqueCellId(attr));
 		}
+		if (attr.getType().equals("java.lang.Boolean")) {
+			return generateValueFromBoolean(attr, getUniqueCellId(attr));
+		}
 		if (attr.getType().equals("java.util.ArrayList")) {
 			return generateValueFromList(attr, getUniqueCellId(attr));
 		}
@@ -270,14 +273,27 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 	 * @return true if success
 	 */
 	private final native boolean generateValueFromString(Attribute attr, String uniqueId) /*-{
-        var str = $wnd.jQuery("#" + uniqueId + " .textbox-value").val().trim();
-        if (str.length != 0) {
-            attr.value = str;
-        } else {
-            attr.value = null;
-        }
-        return true;
-    }-*/;
+		var str = $wnd.jQuery("#" + uniqueId + " .textbox-value").val().trim();
+		if (str.length != 0) {
+			attr.value = str;
+		} else {
+			attr.value = null;
+		}
+		return true;
+	}-*/;
+
+	/**
+	 * Gets the value from CheckBox and saves it to the object
+	 *
+	 * @param attr
+	 * @param uniqueId
+	 * @return true if success
+	 */
+	private final native boolean generateValueFromBoolean(Attribute attr, String uniqueId) /*-{
+		attr.value = $wnd.jQuery("#" + uniqueId + " .checkbox-value").prop('checked')
+		console.log(attr.value);
+		return true;
+	}-*/;
 
 	/**
 	 * Gets the value from Number TextBox and saves it to the object
@@ -287,24 +303,24 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 	 * @return true if success
 	 */
 	private final native boolean generateValueFromNumber(Attribute attr, String uniqueId) /*-{
-        // gets the value
-        var newValue = $wnd.jQuery("#" + uniqueId + " .numberbox-value").val().trim();
-        // true on any number format, false otherwise
-        if (!isNaN(parseFloat(newValue)) && isFinite(newValue)) {
-            $wnd.jQuery("#" + uniqueId + " .numberbox-value").css("border-color", "");
-            attr.value = parseInt(newValue);
-            return true;
-        }
-        // true on empty value
-        if (newValue.length == 0) {
-            $wnd.jQuery("#" + uniqueId + " .numberbox-value").css("border-color", "");
-            attr.value = null;
-            return true;
-        }
-        // wrong
-        $wnd.jQuery("#" + uniqueId + " .numberbox-value").css("border-color", "red");
-        return false;
-    }-*/;
+		// gets the value
+		var newValue = $wnd.jQuery("#" + uniqueId + " .numberbox-value").val().trim();
+		// true on any number format, false otherwise
+		if (!isNaN(parseFloat(newValue)) && isFinite(newValue)) {
+			$wnd.jQuery("#" + uniqueId + " .numberbox-value").css("border-color", "");
+			attr.value = parseInt(newValue);
+			return true;
+		}
+		// true on empty value
+		if (newValue.length == 0) {
+			$wnd.jQuery("#" + uniqueId + " .numberbox-value").css("border-color", "");
+			attr.value = null;
+			return true;
+		}
+		// wrong
+		$wnd.jQuery("#" + uniqueId + " .numberbox-value").css("border-color", "red");
+		return false;
+	}-*/;
 
 	/**
 	 * Gets the value from the list of TextBoxes and saves it to the object
@@ -314,21 +330,21 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 	 * @return true if success
 	 */
 	private final native boolean generateValueFromList(Attribute attr, String uniqueId) /*-{
-        attr.value = [];
-        var i = 0;
-        $wnd.jQuery("#" + uniqueId + " .list-item-value").each(function () {
-            var val = $wnd.jQuery(this).val();
-            if (val != null && typeof val != undefined && val != "" && val.length != 0) {
-                attr.value[i] = val.trim();
-                i++;
-            }
-        });
-        // empty value
-        if (i == 0) {
-            attr.value = null;
-        }
-        return true;
-    }-*/;
+		attr.value = [];
+		var i = 0;
+		$wnd.jQuery("#" + uniqueId + " .list-item-value").each(function () {
+			var val = $wnd.jQuery(this).val();
+			if (val != null && typeof val != undefined && val != "" && val.length != 0) {
+				attr.value[i] = val.trim();
+				i++;
+			}
+		});
+		// empty value
+		if (i == 0) {
+			attr.value = null;
+		}
+		return true;
+	}-*/;
 
 
 	/**
@@ -339,26 +355,26 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 	 * @return true if success
 	 */
 	private final native boolean generateValueFromMap(Attribute attr, String uniqueId) /*-{
-        attr.value = {};
-        var i = 0;
-        $wnd.jQuery("#" + uniqueId + " .map-entry").each(function () {
-            var key = $wnd.jQuery(this).find(".map-entry-key").val().trim();
-            var tempval = $wnd.jQuery(this).find(".map-entry-value").val().trim();
-            // necessary for CERTIFICATE VALUES
-            var val = tempval.replace(/\\n/g, '\n');
-            if (key != "") {
-                if (key != "Enter new key first!") {
-                    attr.value[key] = val;
-                }
-            }
-            i++;
-        });
-        // if empty
-        if (i == 0) {
-            attr.value = null;
-        }
-        return true;
-    }-*/;
+		attr.value = {};
+		var i = 0;
+		$wnd.jQuery("#" + uniqueId + " .map-entry").each(function () {
+			var key = $wnd.jQuery(this).find(".map-entry-key").val().trim();
+			var tempval = $wnd.jQuery(this).find(".map-entry-value").val().trim();
+			// necessary for CERTIFICATE VALUES
+			var val = tempval.replace(/\\n/g, '\n');
+			if (key != "") {
+				if (key != "Enter new key first!") {
+					attr.value[key] = val;
+				}
+			}
+			i++;
+		});
+		// if empty
+		if (i == 0) {
+			attr.value = null;
+		}
+		return true;
+	}-*/;
 
 
 	/**
@@ -375,9 +391,10 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 
 		if (attr.getType().equals("java.util.LinkedHashMap")) {
 			return generateMap(attr.getValueAsMap(), attr.isWritable());
-
 		} else if (attr.getType().equals("java.lang.Integer")) {
 			return generateNumberBox(attr.getValue(), attr.isWritable());
+		} else if (attr.getType().equals("java.lang.Boolean")) {
+			return generateCheckBox(attr.getValue(), attr.isWritable());
 		} else if (attr.getType().equals("java.util.ArrayList")) {
 			return generateList(attr.getValueAsJsArray(), attr.isWritable());
 		}
@@ -421,6 +438,28 @@ public class PerunAttributeValueCell extends AbstractSafeHtmlCell<Attribute> {
 			return "<input type=\"text\" style=\"width:100px\" class=\"numberbox-value gwt-TextBox\" value=\"" + value + "\" />";
 		} else {
 			return "<input title=\"" + WidgetTranslation.INSTANCE.notWritable() + "\" readonly type=\"text\" style=\"width:100px\" class=\"numberbox-value gwt-TextBox gwt-TextBox-readonly\" value=\"" + value + "\" />";
+		}
+
+	}
+
+	/**
+	 * CheckBox for number
+	 *
+	 * @param value
+	 * @return
+	 */
+	private static String generateCheckBox(String value, boolean writable) {
+		// check for emptiness
+		if (value == null || value.equalsIgnoreCase("null") || value.equalsIgnoreCase("false")) {
+			value = "";
+		} else {
+			value = "checked=\"checked\"";
+		}
+
+		if (writable) {
+			return "<input type=\"checkbox\" class=\"checkbox-value gwt-CheckBox\" " + value + " />";
+		} else {
+			return "<input title=\"" + WidgetTranslation.INSTANCE.notWritable() + "\" readonly type=\"checkbox\" class=\"checkbox-value gwt-CheckBox gwt-CheckBox-readonly\" " + value + " />";
 		}
 
 	}


### PR DESCRIPTION
RPC
- Allow Deserializer to read boolean values from URL and body (JSON).
- Fixed documentation and indentation.

CORE
- Added java.lang.Boolean as possible type for attributes.
- Entry layer converts non true value to null -> false == null.
- BeansUtils can convert string to attr value and back (for boolean).
- Support for boolean type in searcher, since it's string in DB anyway.
- Added support for boolean and integer to impl of getUsersByAttributeValue(),
  since it's string in db (uses exact match).

GUI
- Use checkbox widget for setting value (null is mapped to false).
- Fixed selection model for attribute tables since checkbox widget
  interfere with default createCheckboxManager(). We now specify first column.
- Added get/set methods for boolean to Attribute object.
- Source format.

NOTE: Perl CLI tools has no support for boolean type attribute right now.