### PR TITLE
CORE: Added method getMembersByExpiration()

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/Searcher.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/Searcher.java
@@ -5,6 +5,8 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+
+import java.util.Calendar;
 import java.util.List;
 
 
@@ -95,5 +97,22 @@ public interface Searcher {
 	 * @throws PrivilegeException
 	 */
 	List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws PrivilegeException, InternalErrorException;
+
+	/**
+	 * Return members with expiration date set, which will expire on specified date.
+	 * You can specify operator for comparison (by default "=") returning exact match.
+	 * So you can get all expired members (including today) using "<=" and current date.
+	 * or using "<" and tomorrow date.
+	 *
+	 * Method ignores current member state, just compares expiration date !
+	 *
+	 * @param sess PerunSession
+	 * @param operator One of "=", "<", ">", "<=", ">=". If null, "=" is anticipated.
+	 * @param date Date to compare expiration with (if null, current date is used).
+	 * @return Members with expiration relative to method params.
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date) throws PrivilegeException, InternalErrorException;
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/Searcher.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/Searcher.java
@@ -78,4 +78,22 @@ public interface Searcher {
 	 * @throws PrivilegeException
 	 */
 	List<User> getUsersForCoreAttributes(PerunSession sess, Map<String, String> coreAttributesWithSearchingValues) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, PrivilegeException;
+
+	/**
+	 * Return members with expiration date set, which will expire on today +/- X days.
+	 * You can specify operator for comparison (by default "=") returning exact match.
+	 * So you can get all expired members (including today) using "<=" and zero days shift.
+	 * or using "<" and +1 day shift.
+	 *
+	 * Method ignores current member state, just compares expiration date !
+	 *
+	 * @param sess PerunSession
+	 * @param operator One of "=", "<", ">", "<=", ">=". If null, "=" is anticipated.
+	 * @param days X days before/after today
+	 * @return Members with expiration relative to method params.
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws PrivilegeException, InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
@@ -69,5 +70,21 @@ public interface SearcherBl {
 	 * @throws InternalErrorException
 	 */
 	List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws InternalErrorException;
+
+	/**
+	 * Return members with expiration date set, which will expire on specified date.
+	 * You can specify operator for comparison (by default "=") returning exact match.
+	 * So you can get all expired members (including today) using "<=" and today date.
+	 * or using "<" and tomorrow date.
+	 *
+	 * Method ignores current member state, just compares expiration date !
+	 *
+	 * @param sess PerunSession
+	 * @param operator One of "=", "<", ">", "<=", ">=". If null, "=" is anticipated.
+	 * @param date Date to compare expiration with (if null, current date is used).
+	 * @return Members with expiration relative to method params.
+	 * @throws InternalErrorException
+	 */
+	List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date) throws InternalErrorException;
 	
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
@@ -1,11 +1,13 @@
 package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+
 import java.util.List;
 import java.util.Map;
 
@@ -29,7 +31,7 @@ public interface SearcherBl {
 	 *        when attribute is type List<String>, so value is String and we are looking for at least one total or partial matching element
 	 *        when attribute is type Map<String> so value is String in format "key=value" and we are looking total match of both or if is it "key" so we are looking for total match of key
 	 *        IMPORTANT: In map there is not allowed char '=' in key. First char '=' is delimiter in MAP item key=value!!!
-	 * @return list of users who have attributes with specific values (behaviour above)
+	 * @return list of users who have attributes with specific values (behavior above)
 	 *        if no user exist, return empty list of users
 	 *        if attributeWithSearchingValues is empty, return allUsers
 	 *
@@ -51,4 +53,21 @@ public interface SearcherBl {
 	 * @throws WrongAttributeAssignmentException
 	 */
 	List<User> getUsersForCoreAttributes(PerunSession sess, Map<String, String> coreAttributesWithSearchingValues) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Return members with expiration date set, which will expire on today +/- X days.
+	 * You can specify operator for comparison (by default "=") returning exact match.
+	 * So you can get all expired members (including today) using "<=" and zero days shift.
+	 * or using "<" and +1 day shift.
+	 *
+	 * Method ignores current member state, just compares expiration date !
+	 * 
+	 * @param sess PerunSession
+	 * @param operator One of "=", "<", ">", "<=", ">=". If null, "=" is anticipated.
+	 * @param days X days before/after today
+	 * @return Members with expiration relative to method params.
+	 * @throws InternalErrorException
+	 */
+	List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws InternalErrorException;
+	
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SearcherBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SearcherBlImpl.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.core.blImpl;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -10,12 +12,15 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.SearcherBl;
 import cz.metacentrum.perun.core.implApi.SearcherImplApi;
+
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +81,11 @@ public class SearcherBlImpl implements SearcherBl {
 		return this.getUsersForCoreAttributesByMapOfAttributes(sess, mapOfCoreAttributesWithValues);
 	}
 
+	@Override
+	public List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws InternalErrorException {
+		return getSearcherImpl().getMembersByExpiration(sess, operator, days);
+	}
+
 	/**
 	 * This method take map of coreAttributes with search values and return all
 	 * users who have the specific match for all of these core attributes.
@@ -128,4 +138,5 @@ public class SearcherBlImpl implements SearcherBl {
 	public void setPerunBl(PerunBl perunBl) {
 		this.perunBl = perunBl;
 	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SearcherBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SearcherBlImpl.java
@@ -83,7 +83,12 @@ public class SearcherBlImpl implements SearcherBl {
 
 	@Override
 	public List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws InternalErrorException {
-		return getSearcherImpl().getMembersByExpiration(sess, operator, days);
+		return getSearcherImpl().getMembersByExpiration(sess, operator, null, days);
+	}
+
+	@Override
+	public List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date) throws InternalErrorException {
+		return getSearcherImpl().getMembersByExpiration(sess, operator, date, 0);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SearcherEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SearcherEntry.java
@@ -123,6 +123,18 @@ public class SearcherEntry implements Searcher {
 		return searcherBl.getUsersForCoreAttributes(sess, coreAttributesWithSearchingValues);
 	}
 
+	@Override
+	public List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws PrivilegeException, InternalErrorException {
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+			throw new PrivilegeException(sess, "getMembersByExpiration");
+		}
+
+		return getPerunBl().getSearcherBl().getMembersByExpiration(sess, operator, days);
+
+	}
+
 	public SearcherBl getSearcherBl() {
 		return this.searcherBl;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SearcherEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SearcherEntry.java
@@ -19,11 +19,8 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.SearcherBl;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,6 +129,18 @@ public class SearcherEntry implements Searcher {
 		}
 
 		return getPerunBl().getSearcherBl().getMembersByExpiration(sess, operator, days);
+
+	}
+
+	@Override
+	public List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date) throws PrivilegeException, InternalErrorException {
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+			throw new PrivilegeException(sess, "getMembersByExpiration");
+		}
+
+		return getPerunBl().getSearcherBl().getMembersByExpiration(sess, operator, date);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -166,10 +166,6 @@ public class SearcherImpl implements SearcherImplApi {
 
 			return jdbcTemplate.query(query.toString(), MembersManagerImpl.MEMBER_MAPPER, def.getId());
 
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<Member>();
-		} catch (RuntimeException e) {
-			throw new InternalErrorException(e);
 		} catch (Exception e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -143,13 +143,13 @@ public class SearcherImpl implements SearcherImplApi {
 	}
 
 	@Override
-	public List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws InternalErrorException {
+	public List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date, int days) throws InternalErrorException {
 
 		// this would default to now
-		Calendar calendar = Calendar.getInstance();
-		calendar.add(Calendar.DAY_OF_MONTH, days);
+		if (date == null) date = Calendar.getInstance();
+		date.add(Calendar.DAY_OF_MONTH, days);
 		// create sql toDate()
-		String compareDate = BeansUtils.getDateFormatterWithoutTime().format(calendar.getTime());
+		String compareDate = BeansUtils.getDateFormatterWithoutTime().format(date.getTime());
 		compareDate = "TO_DATE('"+compareDate+"','yyyy-MM-dd')";
 
 		if (operator == null || operator.isEmpty()) operator = "=";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -1,20 +1,26 @@
 package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.implApi.SearcherImplApi;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import javax.sql.DataSource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
 import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.bl.PerunBl;
+
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 /**
@@ -27,9 +33,11 @@ public class SearcherImpl implements SearcherImplApi {
 	private final static Logger log = LoggerFactory.getLogger(SearcherImpl.class);
 
 	private static NamedParameterJdbcTemplate jdbc;
+	private static JdbcTemplate jdbcTemplate;
 
 	public SearcherImpl(DataSource perunPool) {
 		jdbc = new NamedParameterJdbcTemplate(perunPool);
+		jdbcTemplate = new JdbcTemplate(perunPool);
 	}
 
 	public List<User> getUsers(PerunSession sess, Map<Attribute, String> attributesWithSearchingValues) throws InternalErrorException {
@@ -133,4 +141,39 @@ public class SearcherImpl implements SearcherImplApi {
 			throw new InternalErrorException(e);
 		}
 	}
+
+	@Override
+	public List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws InternalErrorException {
+
+		// this would default to now
+		Calendar calendar = Calendar.getInstance();
+		calendar.add(Calendar.DAY_OF_MONTH, days);
+		// create sql toDate()
+		String compareDate = BeansUtils.getDateFormatterWithoutTime().format(calendar.getTime());
+		compareDate = "TO_DATE('"+compareDate+"','yyyy-MM-dd')";
+
+		if (operator == null || operator.isEmpty()) operator = "=";
+
+		if (!operator.equals("<") && !operator.equals("<=") && !operator.equals("=") && !operator.equals(">=") && !operator.equals(">"))
+			throw new InternalErrorException("Operator '"+operator+"' is not allowed in SQL.");
+
+		try {
+
+			AttributeDefinition def = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:member:attribute-def:def:membershipExpiration");
+
+			String query = "select distinct " + MembersManagerImpl.memberMappingSelectQuery + " from members left join member_attr_values val on " +
+					"val.member_id=members.id and val.attr_id=? where TO_DATE(val.attr_value, 'yyyy-MM-dd')"+operator+compareDate;
+
+			return jdbcTemplate.query(query.toString(), MembersManagerImpl.MEMBER_MAPPER, def.getId());
+
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<Member>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		} catch (Exception e) {
+			throw new InternalErrorException(e);
+		}
+
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
@@ -1,36 +1,27 @@
 package cz.metacentrum.perun.core.impl;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import cz.metacentrum.perun.core.api.exceptions.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.MemberNotValidYetException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
-import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.core.api.BeansUtils;
 
 /**
  * Synchronizer, general tool for synchronization tasks.
  *
  * @author Michal Prochazka <michalp@ics.muni.cz>
- *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class Synchronizer {
 
@@ -45,17 +36,21 @@ public class Synchronizer {
 
 	public Synchronizer(PerunBl perunBl) throws InternalErrorException {
 		this.perunBl = perunBl;
-
 		initialize();
 	}
 
+	/**
+	 * Start synchronization of groups if not running.
+	 *
+	 * Method is triggered by Spring scheduler (every 5 minutes).
+	 */
 	public void synchronizeGroups() {
 		if (synchronizeGroupsRunning.compareAndSet(false, true)) {
 			try {
 				log.debug("Synchronizer starting synchronizing the groups");
 				this.perunBl.getGroupsManagerBl().synchronizeGroups(this.sess);
 				if (!synchronizeGroupsRunning.compareAndSet(true, false)) {
-					log.error("Synchonizer: group synchronization out of sync, resetting.");
+					log.error("Synchronizer: group synchronization out of sync, resetting.");
 					synchronizeGroupsRunning.set(false);
 				}
 			} catch (InternalErrorException e) {
@@ -68,68 +63,90 @@ public class Synchronizer {
 	}
 
 	/**
-	 * Iterate through all VALID members and check whether they are still in valid period.
+	 * Perform check on members status and switch it between VALID and EXPIRED (if necessary).
+	 * Switching is based on current date and their value of membership expiration.
+	 *
+	 * Method also log audit messages, that membership will expired in X days or expired X days ago.
+	 *
+	 * Method is triggered by Spring scheduler (at midnight everyday).
 	 */
 	public void checkMembersState() {
-		Date now = new Date();
 
-		// Get all VO's
 		try {
-			for (Vo vo: perunBl.getVosManagerBl().getVos(this.sess)) {
-				// Get all members
-				for (Member member: perunBl.getMembersManagerBl().getMembers(sess, vo)) {
-					Date currentMembershipExpirationDate;
-					// Read membershipExpiration and check it
-					Attribute membersExpiration = perunBl.getAttributesManagerBl().getAttribute(sess, member, "urn:perun:member:attribute-def:def:membershipExpiration");
-					if (membersExpiration.getValue() != null) {
-						currentMembershipExpirationDate = BeansUtils.getDateFormatterWithoutTime().parse((String) membersExpiration.getValue());
-						if (currentMembershipExpirationDate.before(now)) {
-							// Expired membership, set status to expired only if the user hasn't been in suspended state
-							if (!member.getStatus().equals(Status.EXPIRED) && !member.getStatus().equals(Status.SUSPENDED)) {
-								try {
-									perunBl.getMembersManagerBl().expireMember(sess, member);
-									log.info("Switching {} to EXPIRE state, due to expiration {}.", member, (String) membersExpiration.getValue());
-									log.debug("Switching member to EXPIRE state, additional info: membership expiration date='{}', system now date='{}'", currentMembershipExpirationDate, now);
-								} catch (MemberNotValidYetException e) {
-									log.error("Consistency error while trying to expire member {}, exception {}", member, e);
-								}
-							}
-						} else if (member.getStatus().equals(Status.EXPIRED) || member.getStatus().equals(Status.DISABLED)) {
-							// Validate member only if the previous status was EXPIRED or DISABLED
-							try {
-								perunBl.getMembersManagerBl().validateMember(sess, member);
-								log.info("Switching {} to VALID state, due to changed expiration {}.", member, (String) membersExpiration.getValue());
-								log.debug("Switching member to VALID state, additional info: membership expiration date='{}', system now date='{}'", currentMembershipExpirationDate, now);
-							} catch (WrongAttributeValueException e) {
-								log.error("Error during validating member {}, exception {}", member, e);
-							} catch (WrongReferenceAttributeValueException e) {
-								log.error("Error during validating member {}, exception {}", member, e);
-							}
-						}
 
-						//check for members' expiration in the future on in the past
-						int daysToExpire = (int) TimeUnit.DAYS.convert(currentMembershipExpirationDate.getTime() - now.getTime(), TimeUnit.MILLISECONDS);
-						switch(daysToExpire) {
-							case 30: case 14: case 7: case 1:
-									getPerun().getAuditer().log(sess, "{} will expire in {} days in {}.", member, daysToExpire, vo);
-									break;
-							case -7:
-									getPerun().getAuditer().log(sess, "{} has expired {} days ago in {}.", member, daysToExpire*(-1), vo);
-									break;
-						}
+			// get all available VOs
+			List<Vo> vos = perunBl.getVosManagerBl().getVos(sess);
+			Map<Integer, Vo> vosMap = new HashMap<Integer, Vo>();
+			for (Vo vo : vos) {
+				vosMap.put(vo.getId(), vo);
+			}
+
+			// log message for all members which will expire in 30 days
+			List<Member> expireIn30Days = perunBl.getSearcherBl().getMembersByExpiration(sess, "=", 30);
+			for (Member m : expireIn30Days) {
+				getPerun().getAuditer().log(sess, "{} will expire in {} days in {}.", m, 30, vosMap.get(m.getVoId()));
+			}
+
+			// log message for all members which will expire in 14 days
+			List<Member> expireIn14Days = perunBl.getSearcherBl().getMembersByExpiration(sess, "=", 14);
+			for (Member m : expireIn14Days) {
+				getPerun().getAuditer().log(sess, "{} will expire in {} days in {}.", m, 14, vosMap.get(m.getVoId()));
+			}
+
+			// log message for all members which will expire in 7 days
+			List<Member> expireIn7Days = perunBl.getSearcherBl().getMembersByExpiration(sess, "=", 7);
+			for (Member m : expireIn7Days) {
+				getPerun().getAuditer().log(sess, "{} will expire in {} days in {}.", m, 7, vosMap.get(m.getVoId()));
+			}
+
+			// log message for all members which will expire tomorrow
+			List<Member> expireIn1Days = perunBl.getSearcherBl().getMembersByExpiration(sess, "=", 1);
+			for (Member m : expireIn1Days) {
+				getPerun().getAuditer().log(sess, "{} will expire in {} days in {}.", m, 1, vosMap.get(m.getVoId()));
+			}
+
+			// log message for all members which expired 7 days ago
+			List<Member> expired7DaysAgo = perunBl.getSearcherBl().getMembersByExpiration(sess, "=", -7);
+			for (Member m : expired7DaysAgo) {
+				getPerun().getAuditer().log(sess, "{} has expired {} days ago in {}.", m, 7, vosMap.get(m.getVoId()));
+			}
+
+			// switch members, which expire today
+			List<Member> shouldBeExpired = perunBl.getSearcherBl().getMembersByExpiration(sess, "<=", 0);
+			for (Member member : shouldBeExpired) {
+				if (member.getStatus().equals(Status.VALID)) {
+					try {
+						perunBl.getMembersManagerBl().expireMember(sess, member);
+						log.info("Switching {} to EXPIRE state, due to expiration {}.", member, (String) perunBl.getAttributesManagerBl().getAttribute(sess, member, "urn:perun:member:attribute-def:def:membershipExpiration").getValue());
+					} catch (MemberNotValidYetException e) {
+						log.error("Consistency error while trying to expire member {}, exception {}", member, e);
 					}
 				}
-
 			}
+
+			// switch members, which shouldn't be expired
+			List<Member> shouldntBeExpired = perunBl.getSearcherBl().getMembersByExpiration(sess, ">", 0);
+			for (Member member : shouldntBeExpired) {
+				if (member.getStatus().equals(Status.EXPIRED)) {
+					try {
+						perunBl.getMembersManagerBl().validateMember(sess, member);
+						log.info("Switching {} to VALID state, due to changed expiration {}.", member, (String) perunBl.getAttributesManagerBl().getAttribute(sess, member, "urn:perun:member:attribute-def:def:membershipExpiration").getValue());
+					} catch (WrongAttributeValueException e) {
+						log.error("Error during validating member {}, exception {}", member, e);
+					} catch (WrongReferenceAttributeValueException e) {
+						log.error("Error during validating member {}, exception {}", member, e);
+					}
+				}
+			}
+
 		} catch (InternalErrorException e) {
 			log.error("Synchronizer: checkMembersState, exception {}", e);
 		} catch (AttributeNotExistsException e) {
 			log.warn("Synchronizer: checkMembersState, attribute definition for membershipExpiration doesn't exist, exception {}", e);
 		} catch (WrongAttributeAssignmentException e) {
 			log.error("Synchronizer: checkMembersState, attribute name is from wrong namespace, exception {}", e);
-		} catch (ParseException e) {
-			log.error("Synchronizer: checkMembersState, member expiration String cannot be parsed, exception {}", e);
 		}
+
 	}
 
 	public void initialize() throws InternalErrorException {
@@ -144,4 +161,5 @@ public class Synchronizer {
 	public void setPerun(PerunBl perunBl) {
 		this.perunBl = perunBl;
 	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SearcherImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SearcherImplApi.java
@@ -1,9 +1,13 @@
 package cz.metacentrum.perun.core.implApi;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+
 import java.util.List;
 import java.util.Map;
 
@@ -13,6 +17,7 @@ import java.util.Map;
  * @author Michal Stava <stavamichal@gmail.com>
  */
 public interface SearcherImplApi {
+
 	/**
 	 * This method get Map of Attributes with searching values and try to find all users, which have specific attributes in format.
 	 * Better information about format below. When there are more than 1 attribute in Map, it means all must be true "looking for all of them" (AND)
@@ -26,11 +31,28 @@ public interface SearcherImplApi {
 	 *        when attribute is type List<String>, so value is String and we are looking for at least one total or partial matching element
 	 *        when attribute is type Map<String> so value is String in format "key=value" and we are looking total match of both or if is it "key" so we are looking for total match of key
 	 *        IMPORTANT: In map there is not allowed char '=' in key. First char '=' is delimiter in MAP item key=value!!!
-	 * @return list of users who have attributes with specific values (behaviour above)
+	 * @return list of users who have attributes with specific values (behavior above)
 	 *        if no user exist, return empty list of users
 	 *        if attributeWithSearchingValues is empty, return allUsers
 	 *
 	 * @throws InternalErrorException
 	 */
 	List<User> getUsers(PerunSession sess, Map<Attribute, String> attributesWithSearchingValues) throws InternalErrorException;
+
+	/**
+	 * Return members with expiration date set, which will expire on today +/- X days.
+	 * You can specify operator for comparison (by default "=") returning exact match.
+	 * So you can get all expired members (including today) using "<=" and zero days shift.
+	 * or using "<" and +1 day shift.
+	 *
+	 * Method ignores current member state, just compares expiration date !
+	 *
+	 * @param sess PerunSession
+	 * @param operator One of "=", "<", ">", "<=", ">=". If null, "=" is anticipated.
+	 * @param days X days before/after today
+	 * @return Members with expiration relative to method params.
+	 * @throws InternalErrorException
+	 */
+	List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SearcherImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SearcherImplApi.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +41,7 @@ public interface SearcherImplApi {
 	List<User> getUsers(PerunSession sess, Map<Attribute, String> attributesWithSearchingValues) throws InternalErrorException;
 
 	/**
-	 * Return members with expiration date set, which will expire on today +/- X days.
+	 * Return members with expiration date set, which will expire on date +/- X days.
 	 * You can specify operator for comparison (by default "=") returning exact match.
 	 * So you can get all expired members (including today) using "<=" and zero days shift.
 	 * or using "<" and +1 day shift.
@@ -49,10 +50,11 @@ public interface SearcherImplApi {
 	 *
 	 * @param sess PerunSession
 	 * @param operator One of "=", "<", ">", "<=", ">=". If null, "=" is anticipated.
-	 * @param days X days before/after today
+	 * @param date Date to compare expiration with (if null, current date is used).
+	 * @param days X days before/after today.
 	 * @return Members with expiration relative to method params.
 	 * @throws InternalErrorException
 	 */
-	List<Member> getMembersByExpiration(PerunSession sess, String operator, int days) throws InternalErrorException;
+	List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date, int days) throws InternalErrorException;
 
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
@@ -221,12 +221,12 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 	// PRIVATE METHODS -----------------------------------------------------------
 
 	private void setUpUser1() throws Exception {
-		member1 = perun.getMembersManagerBl().createMember(sess, vo, candidate1);
+		member1 = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate1);
 		user1 = perun.getUsersManagerBl().getUserByMember(sess, member1);
 	}
 
 	private void setUpUser2() throws Exception {
-		member2 = perun.getMembersManagerBl().createMember(sess, vo, candidate2);
+		member2 = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate2);
 		user2 = perun.getUsersManagerBl().getUserByMember(sess, member2);
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
@@ -178,6 +178,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getMembersByExpiration() throws Exception {
+		System.out.println("Searcher.getMembersByExpiration");
 
 		// setup required attribute if not exists
 		try {
@@ -215,6 +216,25 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 		assertTrue("Member with expiration yesterday was found for = tomorrow.", !perun.getSearcher().getMembersByExpiration(sess, "=", 1).contains(member2));
 		assertTrue("Member with expiration today was found for > tomorrow.", !perun.getSearcher().getMembersByExpiration(sess, ">", 1).contains(member1));
 		assertTrue("Member with expiration yesterday was not found for < tomorrow.", perun.getSearcher().getMembersByExpiration(sess, "<", 1).contains(member2));
+
+		// check members by expiration date
+		assertTrue("Member with expiration yesterday was not found for = yesterday.", perun.getSearcher().getMembersByExpiration(sess, "=", calendar).contains(member2));
+		assertTrue("Member with expiration today was not found for > yesterday.", perun.getSearcher().getMembersByExpiration(sess, ">", calendar).contains(member1));
+		assertTrue("Member with expiration today was not found for >= yesterday.", perun.getSearcher().getMembersByExpiration(sess, ">=", calendar).contains(member1));
+		assertTrue("Member with expiration yesterday was not found for >= yesterday.", perun.getSearcher().getMembersByExpiration(sess, ">=", calendar).contains(member2));
+
+		calendar.add(Calendar.DAY_OF_MONTH, 1);
+
+		assertTrue("Member with expiration today was not found for = today.", perun.getSearcher().getMembersByExpiration(sess, "=", calendar).contains(member1));
+		assertTrue("Member with expiration today was not found for <= today.", perun.getSearcher().getMembersByExpiration(sess, "<=", calendar).contains(member1));
+		assertTrue("Member with expiration yesterday was not found for <= today.", perun.getSearcher().getMembersByExpiration(sess, "<=", calendar).contains(member2));
+
+		calendar.add(Calendar.DAY_OF_MONTH, 1);
+
+		assertTrue("Member with expiration today was found for = tomorrow.", !perun.getSearcher().getMembersByExpiration(sess, "=", calendar).contains(member1));
+		assertTrue("Member with expiration yesterday was found for = tomorrow.", !perun.getSearcher().getMembersByExpiration(sess, "=", calendar).contains(member2));
+		assertTrue("Member with expiration today was found for > tomorrow.", !perun.getSearcher().getMembersByExpiration(sess, ">", calendar).contains(member1));
+		assertTrue("Member with expiration yesterday was not found for < tomorrow.", perun.getSearcher().getMembersByExpiration(sess, "<", calendar).contains(member2));
 
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/SynchronizerIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/SynchronizerIntegrationTest.java
@@ -1,0 +1,211 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for Synchronizer component.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class SynchronizerIntegrationTest extends AbstractPerunIntegrationTest {
+
+	private final static String EXPIRATION_URN = "urn:perun:member:attribute-def:def:membershipExpiration";
+	private ExtSource extSource = new ExtSource(0, "testExtSource", ExtSourcesManager.EXTSOURCE_INTERNAL);
+	private Vo vo = new Vo(0, "SynchronizerTestVo", "SyncTestVo");
+
+	@Before
+	public void setUp() throws Exception {
+
+		setUpExtSource();
+		setUpVo();
+
+		try {
+			perun.getAttributesManager().getAttributeDefinition(sess, EXPIRATION_URN);
+		} catch (AttributeNotExistsException ex) {
+			setUpMembershipExpirationAttribute();
+		}
+
+	}
+
+	@Test
+	public void checkMembersState() throws Exception {
+		System.out.println("SynchronizerIntegrationTest.checkMembersState");
+
+		// setup expiration date
+		Calendar calendar = Calendar.getInstance();
+		String today = BeansUtils.getDateFormatterWithoutTime().format(calendar.getTime());
+
+		calendar.add(Calendar.DAY_OF_MONTH, 1);
+		String tomorrow = BeansUtils.getDateFormatterWithoutTime().format(calendar.getTime());
+
+		calendar.add(Calendar.DAY_OF_MONTH, -2);
+		String yesterday = BeansUtils.getDateFormatterWithoutTime().format(calendar.getTime());
+
+		Member member1 = setUpMember();
+		Member member2 = setUpMember();
+		Member member3 = setUpMember();
+		Member member4 = setUpMember();
+		Member member5 = setUpMember();
+		Member member6 = setUpMember();
+		Member member7 = setUpMember();
+		Member member8 = setUpMember();
+		Member member9 = setUpMember();
+		Member member10 = setUpMember();
+		Member member11 = setUpMember();
+		Member member12 = setUpMember();
+		Member member13 = setUpMember();
+		Member member14 = setUpMember();
+		Member member15 = setUpMember();
+
+		// set expiration for today
+		Attribute expiration = new Attribute(perun.getAttributesManager().getAttributeDefinition(sess, EXPIRATION_URN));
+		expiration.setValue(today);
+		perun.getAttributesManager().setAttribute(sess, member1, expiration);
+		perun.getAttributesManager().setAttribute(sess, member2, expiration);
+		perun.getAttributesManager().setAttribute(sess, member3, expiration);
+		perun.getAttributesManager().setAttribute(sess, member4, expiration);
+		perun.getAttributesManager().setAttribute(sess, member5, expiration);
+
+		// set tomorrow expiration
+		Attribute expirationTomorrow = new Attribute(perun.getAttributesManager().getAttributeDefinition(sess, EXPIRATION_URN));
+		expirationTomorrow.setValue(tomorrow);
+		perun.getAttributesManager().setAttribute(sess, member6, expirationTomorrow);
+		perun.getAttributesManager().setAttribute(sess, member7, expirationTomorrow);
+		perun.getAttributesManager().setAttribute(sess, member8, expirationTomorrow);
+		perun.getAttributesManager().setAttribute(sess, member9, expirationTomorrow);
+		perun.getAttributesManager().setAttribute(sess, member10, expirationTomorrow);
+
+		// set yesterday expiration
+		Attribute expirationYesterday = new Attribute(perun.getAttributesManager().getAttributeDefinition(sess, EXPIRATION_URN));
+		expirationYesterday.setValue(yesterday);
+		perun.getAttributesManager().setAttribute(sess, member11, expirationYesterday);
+		perun.getAttributesManager().setAttribute(sess, member12, expirationYesterday);
+		perun.getAttributesManager().setAttribute(sess, member13, expirationYesterday);
+		perun.getAttributesManager().setAttribute(sess, member14, expirationYesterday);
+		perun.getAttributesManager().setAttribute(sess, member15, expirationYesterday);
+
+		// set status synchronizer should switch
+		perun.getMembersManager().setStatus(sess, member1, Status.VALID);   // expiration today
+		perun.getMembersManager().setStatus(sess, member6, Status.EXPIRED); // expiration tomorrow
+		perun.getMembersManager().setStatus(sess, member11, Status.VALID);  // expiration yesterday
+
+		// set statuses synchronizer should ignore
+		perun.getMembersManager().setStatus(sess, member2, Status.DISABLED);
+		perun.getMembersManager().setStatus(sess, member3, Status.INVALID);
+		perun.getMembersManager().setStatus(sess, member4, Status.SUSPENDED);
+		perun.getMembersManager().setStatus(sess, member7, Status.DISABLED);
+		perun.getMembersManager().setStatus(sess, member8, Status.INVALID);
+		perun.getMembersManager().setStatus(sess, member9, Status.SUSPENDED);
+		perun.getMembersManager().setStatus(sess, member12, Status.DISABLED);
+		perun.getMembersManager().setStatus(sess, member13, Status.INVALID);
+		perun.getMembersManager().setStatus(sess, member14, Status.SUSPENDED);
+
+		// set status synchronizer should keep
+		perun.getMembersManager().setStatus(sess, member5, Status.EXPIRED);  // expiration today
+		perun.getMembersManager().setStatus(sess, member10, Status.VALID);   // expiration tomorrow
+		perun.getMembersManager().setStatus(sess, member15, Status.EXPIRED); // expiration yesterday
+
+		// start switching members based on their state
+		Synchronizer synchronizer = new Synchronizer(perun);
+		synchronizer.checkMembersState();
+
+		// check results
+
+		Member returnedMember1 = perun.getMembersManager().getMemberById(sess, member1.getId());
+		assertEquals("Member1 should be expired now (from valid)!", returnedMember1.getStatus(), Status.EXPIRED);
+
+		Member returnedMember2 = perun.getMembersManager().getMemberById(sess, member2.getId());
+		assertEquals("Member2 should be kept disabled!", returnedMember2.getStatus(), Status.DISABLED);
+
+		Member returnedMember3 = perun.getMembersManager().getMemberById(sess, member3.getId());
+		assertEquals("Member3 should be kept invalid!", returnedMember3.getStatus(), Status.INVALID);
+
+		Member returnedMember4 = perun.getMembersManager().getMemberById(sess, member4.getId());
+		assertEquals("Member4 should be kept suspended!", returnedMember4.getStatus(), Status.SUSPENDED);
+
+		Member returnedMember5 = perun.getMembersManager().getMemberById(sess, member5.getId());
+		assertEquals("Member5 should be kept expired!", returnedMember5.getStatus(), Status.EXPIRED);
+
+		Member returnedMember6 = perun.getMembersManager().getMemberById(sess, member6.getId());
+		assertEquals("Member6 should be valid now (from expired)!", returnedMember6.getStatus(), Status.VALID);
+
+		Member returnedMember7 = perun.getMembersManager().getMemberById(sess, member7.getId());
+		assertEquals("Member7 should be kept disabled!", returnedMember7.getStatus(), Status.DISABLED);
+
+		Member returnedMember8 = perun.getMembersManager().getMemberById(sess, member8.getId());
+		assertEquals("Member8 should be kept invalid!", returnedMember8.getStatus(), Status.INVALID);
+
+		Member returnedMember9 = perun.getMembersManager().getMemberById(sess, member9.getId());
+		assertEquals("Member9 should be kept suspended!", returnedMember9.getStatus(), Status.SUSPENDED);
+
+		Member returnedMember10 = perun.getMembersManager().getMemberById(sess, member10.getId());
+		assertEquals("Member10 should be kept valid!", returnedMember10.getStatus(), Status.VALID);
+
+		Member returnedMember11 = perun.getMembersManager().getMemberById(sess, member11.getId());
+		assertEquals("Member11 should be expired now (from valid)!", returnedMember11.getStatus(), Status.EXPIRED);
+
+		Member returnedMember12 = perun.getMembersManager().getMemberById(sess, member12.getId());
+		assertEquals("Member12 should be kept disabled!", returnedMember12.getStatus(), Status.DISABLED);
+
+		Member returnedMember13 = perun.getMembersManager().getMemberById(sess, member13.getId());
+		assertEquals("Member13 should be kept invalid!", returnedMember13.getStatus(), Status.INVALID);
+
+		Member returnedMember14 = perun.getMembersManager().getMemberById(sess, member14.getId());
+		assertEquals("Member14 should be kept suspended!", returnedMember14.getStatus(), Status.SUSPENDED);
+
+		Member returnedMember15 = perun.getMembersManager().getMemberById(sess, member15.getId());
+		assertEquals("Member15 should be kept expired!", returnedMember15.getStatus(), Status.EXPIRED);
+
+	}
+
+	// ----------------- PRIVATE METHODS -------------------------------------------
+
+	private Member setUpMember() throws Exception {
+
+		Candidate candidate = new Candidate();
+		candidate.setFirstName(Long.toHexString(Double.doubleToLongBits(Math.random())));
+		candidate.setId(0);
+		candidate.setMiddleName("");
+		candidate.setLastName(Long.toHexString(Double.doubleToLongBits(Math.random())));
+		candidate.setTitleBefore("");
+		candidate.setTitleAfter("");
+		final UserExtSource userExtSource = new UserExtSource(extSource, Long.toHexString(Double.doubleToLongBits(Math.random())));
+		candidate.setUserExtSource(userExtSource);
+		candidate.setAttributes(new HashMap<String,String>());
+
+		return perun.getMembersManagerBl().createMemberSync(sess, vo, candidate);
+
+	}
+
+	private void setUpExtSource() throws Exception {
+		extSource = perun.getExtSourcesManager().createExtSource(sess, extSource);
+	}
+
+	private void setUpVo() throws Exception {
+		vo = perun.getVosManager().createVo(sess, vo);
+		perun.getExtSourcesManager().addExtSource(sess, vo, extSource);
+	}
+
+	private AttributeDefinition setUpMembershipExpirationAttribute() throws Exception {
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace("urn:perun:member:attribute-def:def");
+		attr.setFriendlyName("membershipExpiration");
+		attr.setType(String.class.getName());
+		attr.setDisplayName("Membership expiration");
+		attr.setDescription("Membership expiration date.");
+
+		return perun.getAttributesManager().createAttribute(sess, attr);
+
+	}
+
+}


### PR DESCRIPTION
- Added method getMembersByExpiration() to searcher. It returns
  all members with expiration date set, relative to input.
  Default is "=" and current date. You can specify different
  comparison sign and set shift in days relative to current date.

  Method ignores members state or VO, everything is based on
  attribute value comparison only (in DB).

- Added test for new method.

- Synchronizer now doesn't iterate through all VOs and their members,
  and uses method getMembersByExpiration() to select only such
  members, which are required to take action on.

- Synchonizer now doesn't touch members in INVALID, SUSPENDED
  and DISABLED state, because their status is not relevant to
  the expiration.
  E.g. from now DISABLED members are not switched to
  EXPIRED state or back to VALID state, since disabling is
  manual action by administrator and shouldn't be overridden
  by some automatic tool.