### PR TITLE
Add auditer consumers to getPerunStatus page

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuditMessagesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuditMessagesManager.java
@@ -4,6 +4,7 @@ import java.util.List;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.WrongRangeOfCountException;
+import java.util.Map;
 
 
 /**
@@ -113,4 +114,24 @@ public interface AuditMessagesManager {
 	 * @throws PrivilegeException
 	 */
 	void log(PerunSession sess, String message) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Get all auditer consumers like name=last_processed_id (map) from database.
+	 *
+	 * @param sess
+	 * @return map string to integer where string is name of consumer and int is last_processed_id of consumer
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	Map<String, Integer> getAllAuditerConsumers(PerunSession sess) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Get last message id from auditer_log.
+	 *
+	 * @param sess
+	 * @return last message id
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	int getLastMessageId(PerunSession sess) throws InternalErrorException, PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AuditMessagesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AuditMessagesManagerBl.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * UsersManager manages users.
@@ -92,4 +93,21 @@ public interface AuditMessagesManagerBl {
 	 * @throws PrivilegeException
 	 */
 	void log(PerunSession sess, String message) throws InternalErrorException;
+
+	/**
+	 * Get all auditer consumers like name=last_processed_id (map) from database.
+	 *
+	 * @param sess
+	 * @return map string to integer where string is name of consumer and int is last_processed_id of consumer
+	 * @throws InternalErrorException
+	 */
+	Map<String, Integer> getAllAuditerConsumers(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * Get last message id from auditer_log.
+	 *
+	 * @return last message id
+	 * @throws InternalErrorException
+	 */
+	int getLastMessageId() throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuditMessagesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuditMessagesManagerBlImpl.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Auditer;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * AuditMessagesManager manages audit messages (logs). Implementation of
@@ -79,5 +80,15 @@ public class AuditMessagesManagerBlImpl implements AuditMessagesManagerBl {
 	public void log(PerunSession sess, String message) throws InternalErrorException {
 
 		perunBl.getAuditer().log(sess, message);
+	}
+
+	public Map<String, Integer> getAllAuditerConsumers(PerunSession sess) throws InternalErrorException {
+
+		return perunBl.getAuditer().getAllAuditerConsumers(sess);
+	}
+
+	public int getLastMessageId() throws InternalErrorException {
+
+		return perunBl.getAuditer().getLastMessageId();
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
@@ -5,7 +5,6 @@ import java.util.List;
 import cz.metacentrum.perun.core.api.AuditMessage;
 import cz.metacentrum.perun.core.api.AuditMessagesManager;
 import cz.metacentrum.perun.core.api.AuthzResolver;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -13,6 +12,7 @@ import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.WrongRangeOfCountException;
 import cz.metacentrum.perun.core.bl.AuditMessagesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import java.util.Map;
 
 
 
@@ -101,6 +101,24 @@ public class AuditMessagesManagerEntry implements AuditMessagesManager {
 		}
 
 		getAuditMessagesManagerBl().log(sess, message);
+	}
+
+	public Map<String, Integer> getAllAuditerConsumers(PerunSession sess) throws InternalErrorException, PrivilegeException {
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+			throw new PrivilegeException(sess, "getAllAuditerConsumers");
+		}
+
+		return getAuditMessagesManagerBl().getAllAuditerConsumers(sess);
+	}
+
+	public int getLastMessageId(PerunSession sess) throws InternalErrorException, PrivilegeException {
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+			throw new PrivilegeException(sess, "getLastMessageId");
+		}
+
+		return getAuditMessagesManagerBl().getLastMessageId();
 	}
 
 	/**

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -405,12 +405,20 @@ public class Api extends HttpServlet {
 				Date date = new Date();
 				Timestamp timestamp = new Timestamp(date.getTime());
 
+				Map<String, Integer> auditerConsumers;
+				auditerConsumers = (Map<String, Integer>) caller.call("auditMessagesManager", "getAllAuditerConsumers", des);
+
 				List<String> perunStatus = new ArrayList<>();
 				perunStatus.add("Version of PerunDB: " + caller.call("databaseManager", "getCurrentDatabaseVersion", des));
 				perunStatus.add("Version of Servlet: " + getServletContext().getServerInfo());
 				perunStatus.add("Version of DB-driver: " + caller.call("databaseManager", "getDatabaseDriverInformation", des));
 				perunStatus.add("Version of DB: " + caller.call("databaseManager", "getDatabaseInformation", des));
 				perunStatus.add("Version of Java platform: " + System.getProperty("java.version"));
+				for(String consumerName: auditerConsumers.keySet()) {
+					Integer lastProcessedId = auditerConsumers.get(consumerName);
+					perunStatus.add("AuditerConsumer: '" + consumerName + "' with last processed id='" + lastProcessedId + "'");
+				}
+				perunStatus.add("LastMessageId: " + caller.call("auditMessagesManager", "getLastMessageId", des));
 				perunStatus.add("Timestamp: " + timestamp);
 				ser.write(perunStatus);
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuditMessagesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuditMessagesManagerMethod.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import java.util.List;
+import java.util.Map;
 
 public enum AuditMessagesManagerMethod implements ManagerMethod {
 
@@ -111,6 +112,28 @@ public enum AuditMessagesManagerMethod implements ManagerMethod {
 
 			ac.getAuditMessagesManager().createAuditerConsumer(ac.getSession(), parms.readString("consumerName"));
 			return null;
+		}
+	},
+
+	/*#
+	 * Get all auditer consumers from database. In map is String = name and Integer = lastProcessedId.
+	 */
+	getAllAuditerConsumers {
+		@Override
+		public Map<String, Integer> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getAuditMessagesManager().getAllAuditerConsumers(ac.getSession());
+		}
+	},
+
+	/*#
+	 * Get last message id from auditer_log.
+	 */
+	getLastMessageId {
+		@Override
+		public Integer call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getAuditMessagesManager().getLastMessageId(ac.getSession());
 		}
 	},
 


### PR DESCRIPTION
 - craete new method getAllAuditerConsumers (get map string to integer
   from database, where string is name of consumer and integer is last
   processed id)
 - add method getLastMessageId to Api,Entry,Bl and BlImpl (was only in
   Auditer on impl)
 - use these two methods in getPerunStatus page in Api.java class