### PR TITLE
VOOT, BEANS, CORE: fixed toString() and getGroupByName()

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/ActionType.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/ActionType.java
@@ -3,7 +3,7 @@ package cz.metacentrum.perun.core.api;
 public enum ActionType {
 
 	WRITE ("write"),
-				READ ("read");
+	READ ("read");
 
 	private final String actionType;
 

--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Pair.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Pair.java
@@ -2,7 +2,7 @@ package cz.metacentrum.perun.core.api;
 
 import java.io.Serializable;
 
-public class Pair<L,R>  implements Serializable{
+public class Pair<L,R> implements Serializable {
 
 	private static final long serialVersionUID = -1483403913023086683L;
 
@@ -65,8 +65,7 @@ public class Pair<L,R>  implements Serializable{
 	@Override
 	public String toString() {
 		StringBuilder str = new StringBuilder();
-
-		return str.append(this.getClass().getSimpleName()).append("[Left:").append(this.getLeft()).append(", Right:").append(this.getRight()).append("]").toString();
+		return str.append(this.getClass().getSimpleName()).append(":[Left='").append(this.getLeft()).append("', Right='").append(this.getRight()).append("']").toString();
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/PerunPrincipal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/PerunPrincipal.java
@@ -65,13 +65,12 @@ public class PerunPrincipal {
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + ":[" +
-			"actor='" + actor + "' " +
-			"user='" + (user != null ? user : "null") + "' " +
-			"extSourceName='" + extSourceName + "' " +
-			"authzRoles='" + authzRoles +  "' " +
-			"authzInitialized='" + authzInitialized + "' " +
-			']';
+		return new StringBuilder(getClass().getSimpleName()).append(":[")
+				.append("actor='").append(actor).append("', ")
+				.append("user='").append((user != null ? user : "null")).append("', ")
+				.append("extSourceName='").append(extSourceName).append("', ")
+				.append("authzRoles='").append(authzRoles).append("', ")
+				.append("authzInitialized='").append(authzInitialized).append("']").toString();
 	}
 
 	public String getExtSourceName() {
@@ -113,7 +112,6 @@ public class PerunPrincipal {
 	public void setRoles(AuthzRoles authzRoles) {
 		this.authzRoles = authzRoles;
 	}
-
 
 	public Map<String, String> getAdditionalInformations() {
 		return additionalInformations;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/PerunSession.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/PerunSession.java
@@ -49,8 +49,7 @@ public abstract class PerunSession {
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + "[" +
-			"principal='" + principal +
-			"']";
+		return new StringBuilder(getClass().getSimpleName()).append(":[")
+				.append("principal='").append(principal).append("']").toString();
 	}
 }

--- a/perun-voot/src/main/java/cz/metacentrum/perun/voot/Email.java
+++ b/perun-voot/src/main/java/cz/metacentrum/perun/voot/Email.java
@@ -81,6 +81,8 @@ public class Email {
 
 	@Override
 	public String toString(){
-		return "Email:[type='" + type + "', value='" + value + "']";
+		return new StringBuilder().append(getClass().getSimpleName()).append(":[")
+				.append("type='").append(getType()).append("', ")
+				.append("value='").append(getValue()).append("']").toString();
 	}
 }

--- a/perun-voot/src/main/java/cz/metacentrum/perun/voot/Response.java
+++ b/perun-voot/src/main/java/cz/metacentrum/perun/voot/Response.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.voot;
 
+import java.util.Arrays;
+
 /**
  * Structure of response with information about startIndex, totalResult, itemsPerPage and results of request.
  * Results are items, e.g. array of members or groups.
@@ -102,16 +104,11 @@ public class Response {
 
 	@Override
 	public String toString(){
-		StringBuilder sb = new StringBuilder("Response:[startIndex='" + startIndex + ", totalResults='" + totalResults + ", itemsPerPage='" + itemsPerPage + ", entry=['");
-
-		for(int i=0;i<entry.length;i++){
-			sb.append(entry[i] + ", ");
-		}
-
-		sb.deleteCharAt(sb.length() - 2);
-		sb.append("']");
-
-		return sb.toString();
+		return new StringBuilder().append(getClass().getSimpleName()).append(":[")
+				.append("startIndex='").append(getStartIndex()).append("', ")
+				.append("totalResults='").append(getTotalResults()).append("', ")
+				.append("itemsPerPage='").append(getItemsPerPage()).append("', ")
+				.append("entry='").append(Arrays.toString(getEntry())).append("']").toString();
 	}
 
 }

--- a/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOT.java
+++ b/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOT.java
@@ -3,18 +3,15 @@ package cz.metacentrum.perun.voot;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.bl.GroupsManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.voot.comparators.vootgroupcomparator.VOOTGroupDefaultDescComparator;
@@ -35,14 +32,10 @@ import cz.metacentrum.perun.voot.comparators.vootmembercomparator.VOOTMemberMemb
 import cz.metacentrum.perun.voot.comparators.vootmembercomparator.VOOTMemberMembershipRoleDescComparator;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -189,7 +182,7 @@ public class VOOT {
 	 * then method returns original array of items.
 	 *
 	 * @param items   array of items, that could be limited
-	 * @param response  response, in which are setted indexes.
+	 * @param response  response, in which are set indexes.
 	 * @return          array of limited items or original array of items
 	 */
 	private Object[] limitResult(Object[] items, Response response){
@@ -254,7 +247,7 @@ public class VOOT {
 
 	/**
 	 * This method creates members used by VOOT, that are represented to end-user. They are created from members by provider and membership role
-	 * is setted by relationship of member and specific group.
+	 * is set by relationship of member and specific group.
 	 *
 	 * @param members           members by provider
 	 * @param group             specific group
@@ -299,7 +292,7 @@ public class VOOT {
 	}
 
 	/**
-	 * Return email adresses of specific user. Now is only preferred mail required. If user has not email, then is returned empty array.
+	 * Return email addresses of specific user. Now is only preferred mail required. If user has not email, then is returned empty array.
 	 *
 	 * @param user              specific user
 	 * @return                  emails of user, if user has not emails is returned empty array
@@ -315,10 +308,10 @@ public class VOOT {
 		try{
 			preferredEmailAttribute = perun.getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF + ":preferredMail");
 			if(preferredEmailAttribute.getValue() != null){
-				Email preferedEmail = new Email();
-				preferedEmail.setType("mail");
-				preferedEmail.setValue((String) preferredEmailAttribute.getValue());
-				emails[0] = preferedEmail;
+				Email email = new Email();
+				email.setType("mail");
+				email.setValue((String) preferredEmailAttribute.getValue());
+				emails[0] = email;
 			}else{
 				emails = null;
 			}
@@ -353,12 +346,12 @@ public class VOOT {
 	 */
 	private Group getGroupByName(String name) throws VOOTException{
 
-		String[] groupNames = name.split(":");
+		String voName = name.split(":")[0];
 
 		Vo vo = null;
 
 		try{
-			vo = perun.getVosManagerBl().getVoByShortName(session, groupNames[0]);
+			vo = perun.getVosManagerBl().getVoByShortName(session, voName);
 		}catch(InternalErrorException ex){
 			throw new VOOTException("internal_server_error");
 		}catch(VoNotExistsException ex){
@@ -368,7 +361,7 @@ public class VOOT {
 		Group group = null;
 
 		try{
-			group = perun.getGroupsManagerBl().getGroupByName(session, vo, groupNames[groupNames.length - 1]);
+			group = perun.getGroupsManagerBl().getGroupByName(session, vo, name.substring(name.indexOf(":")+1, name.length()));
 		}catch(GroupNotExistsException ex){
 			throw new VOOTException("internal_server_error", "group not exists");
 		}catch(InternalErrorException ex){
@@ -802,7 +795,7 @@ public class VOOT {
 
 		}else if(filterByValue != null && filterValueValue == null){
 
-			if(!filterByValue.equals(PRESENT)) throw new VOOTException("internal_server_error", "invalid fielterValue field");
+			if(!filterByValue.equals(PRESENT)) throw new VOOTException("internal_server_error", "invalid filterValue field");
 
 			for(VOOTGroup filterGroup : vootGroups){
 

--- a/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOTException.java
+++ b/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOTException.java
@@ -7,7 +7,7 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
  *
  * @author Martin Malik <374128@mail.muni.cz>
  */
-public class VOOTException extends PerunException{
+public class VOOTException extends PerunException {
 	static final long serialVersionUID = 0;
 
 	String error;
@@ -36,16 +36,14 @@ public class VOOTException extends PerunException{
 		return error;
 	}
 
-	public String getError_description() {
+	public String getErrorDescription() {
 		return error_description;
 	}
 
 	@Override
 	public String toString(){
-		if(error_description != null){
-			return "error: " + error + ",error_description: " + error_description;
-		}else{
-			return "error: " + error;
-		}
+		return new StringBuilder(getClass().getName()).append(":[")
+				.append("error='").append(getError()).append("', ")
+				.append("error_description='").append(getErrorDescription()).append("']").toString();
 	}
 }

--- a/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOTGroup.java
+++ b/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOTGroup.java
@@ -1,7 +1,6 @@
 package cz.metacentrum.perun.voot;
 
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.bl.GroupsManagerBl;
 
 /**
  * Class defines group encoded according to the OpenSocial Social Data Specification.
@@ -69,7 +68,7 @@ public class VOOTGroup implements Comparable<VOOTGroup>{
 	}
 
 	/**
-	 * Return memberhip role of person in current group, e.g. 'admin', 'member'.
+	 * Return membership role of person in current group, e.g. 'admin', 'member'.
 	 *
 	 * @return    membership role of person in group
 	 */
@@ -132,6 +131,12 @@ public class VOOTGroup implements Comparable<VOOTGroup>{
 
 	@Override
 	public String toString(){
-		return "VOOTGroup:[id='" + id + "', title='" + title + "',description='" + description + "', voot_membership_role='" + voot_membership_role + "']";
+		StringBuilder sb = new StringBuilder();
+		sb.append(getClass().getSimpleName()).append(":[")
+				.append("id='").append(getId()).append("', ")
+				.append("title='").append(getTitle()).append("', ")
+				.append("description='").append(getDescription()).append("', ")
+				.append("voot_membership_role='").append(getVoot_membership_role()).append("']");
+		return sb.toString();
 	}
 }

--- a/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOTMember.java
+++ b/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOTMember.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.voot;
 
 import cz.metacentrum.perun.core.api.User;
 
+import java.util.Arrays;
+
 /**
  * Class defines person with membership encoded according to the OpenSocial Social Data Specification.
  * Attributes that are not part of specifiacation have namespace prefix 'voot_'.
@@ -9,7 +11,7 @@ import cz.metacentrum.perun.core.api.User;
  * @author Martin Malik<374128@mail.muni.cz>
  * @see <a href="http://opensocial-resources.googlecode.com/svn/spec/2.0.1/Social-Data.xml#Person">Social-Data-Person</a>
  */
-public class VOOTMember extends VOOTPerson{
+public class VOOTMember extends VOOTPerson {
 
 	private String voot_membership_role;
 
@@ -57,10 +59,13 @@ public class VOOTMember extends VOOTPerson{
 	}
 
 	@Override
-	public String toString(){
-		StringBuilder sb = new StringBuilder(super.toString());
-		sb.append(", voot_memberhip_role='" + voot_membership_role + "']");
-
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(this.getClass().getSimpleName()).append(":[")
+				.append("id='").append(getId()).append("', ")
+				.append("displayName='").append(getDisplayName()).append("', ")
+				.append("emails='").append(Arrays.toString(getEmails())).append("', ")
+				.append("voot_membership_role='").append(getVoot_membership_role()).append("']");
 		return sb.toString();
 	}
 }

--- a/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOTPerson.java
+++ b/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOTPerson.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.voot;
 
 import cz.metacentrum.perun.core.api.User;
 
+import java.util.Arrays;
+
 /**
  * Class defines Person encoded according to the OpenSocial Social Data Specification.
  * Attributes that are not part of specifiacation have namespace prefix 'voot_'.
@@ -101,18 +103,10 @@ public class VOOTPerson implements Comparable<VOOTPerson>{
 	@Override
 	public String toString(){
 		StringBuilder sb = new StringBuilder();
-
-		sb.append("VOOTPerson:[id='" + id + "', displayName='" + displayName +"', emails=['");
-
-		if(emails != null){
-			for(int i=0;i<emails.length;i++){
-				sb.append(emails[i] + ", ");
-			}
-		}
-
-		sb.deleteCharAt(sb.length() - 2);
-		sb.append("']]");
-
+		sb.append(this.getClass().getSimpleName()).append(":[")
+				.append("id='").append(getId()).append("', ")
+				.append("displayName='").append(getDisplayName()).append("', ")
+				.append("emails='").append(Arrays.toString(getEmails())).append("']");
 		return sb.toString();
 	}
 }


### PR DESCRIPTION
VOOT:
- getGroupByName() used old scheme when we searched by
  groups short name (last part of name). Now we correctly
  use whole group name.
- Use StringBuilder in toString() methods instead of +.
  Also fixed format to be the same as rest of Perun.
- Fixed typos in code and comments.

CORE, BEANS:
- Fixed toString() in Pair, PerunSession and PerunPrincipal.
- Fixed code indentation in ActionType.