### PR TITLE
Initialization manager changes schema by changelog

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/DBVersion.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/DBVersion.java
@@ -1,0 +1,79 @@
+package cz.metacentrum.perun.core.api;
+
+import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Object for representation of database version.
+ *
+ * @author Simona Kruppova 410315
+ * @author Oliver Mrazik 410035
+ */
+public class DBVersion implements Comparable<DBVersion>{
+	private String version;
+	private List<String> commands;
+
+	public DBVersion(String version) {
+		Pattern versionPattern = Pattern.compile("^[1-9][0-9]*[.][0-9]+[.][0-9]+");
+		if(!versionPattern.matcher(version).matches()){
+			throw new IllegalArgumentException("Version format is invalid.");
+		}
+		this.version = version;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public List<String> getCommands() {
+		return commands;
+	}
+
+	public void setCommands(List<String> commands) {
+		this.commands = commands;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+
+		return str.append(getClass().getSimpleName()).append(":[version='")
+				.append(version).append("', commands='").append(commands).append("']").toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		DBVersion dbVersion = (DBVersion) o;
+
+		if (!version.equals(dbVersion.version)) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return version.hashCode();
+	}
+
+	@Override
+	public int compareTo(DBVersion version) {
+		if(version == null) {
+			throw new InternalErrorRuntimeException(new NullPointerException("DBVersion version"));
+		}
+
+		String[] thisSplitVersion = this.version.split("\\.");
+		String[] splitVersion = version.getVersion().split("\\.");
+
+		//each version should have three numbers split by dots
+		for (int n = 0; n < 3; n++) {
+			if(Integer.parseInt(thisSplitVersion[n]) > Integer.parseInt(splitVersion[n])) return 1;
+			if(Integer.parseInt(thisSplitVersion[n]) < Integer.parseInt(splitVersion[n])) return -1;
+		}
+		return 0;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
@@ -1,7 +1,9 @@
 package cz.metacentrum.perun.core.bl;
 
-import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+
+import java.util.List;
 
 /**
  * Database manager can work with database version and upgraded state of perun DB.
@@ -12,30 +14,50 @@ public interface DatabaseManagerBl {
 	/**
 	 * Return current database version in string (ex. 3.0.1)
 	 * 
-	 * @param perunSession
 	 * @return return current database version
 	 * 
 	 * @throws InternalErrorException
 	 */
-	String getCurrentDatabaseVersion(PerunSession perunSession) throws InternalErrorException;
+	String getCurrentDatabaseVersion() throws InternalErrorException;
 	
 	/**
 	 * Get DB driver information from datasource (name-version)
 	 * 
-	 * @param sess
 	 * @return string information about database driver
 	 * 
 	 * @throws InternalErrorException 
 	 */
-	String getDatabaseDriverInformation(PerunSession sess) throws InternalErrorException;
+	String getDatabaseDriverInformation() throws InternalErrorException;
 	
 	/**
 	 * Get DB information from datasource (name-version)
 	 * 
-	 * @param sess
 	 * @return string information about database
 	 * 
 	 * @throws InternalErrorException 
 	 */
-	String getDatabaseInformation(PerunSession sess) throws InternalErrorException;
+	String getDatabaseInformation() throws InternalErrorException;
+
+	/**
+	 * Method updates database to the current code version. It takes list of dbVersions and executes all the commands from them.
+	 * Commands from the oldest (lowest) version are executed first.
+	 *
+	 * @param dbVersions list of dbVersion objects ordered by version descending, should not be empty
+	 *
+	 * @throws InternalErrorException if any of the commands fails to execute
+	 */
+	void updateDatabaseVersion(List<DBVersion> dbVersions) throws InternalErrorException;
+
+	/**
+	 * Parses all new database versions from DB changelog file and creates from them list of DBVersion objects.
+	 * The list contains all versions from currentDBVersion (without currentDBVersion itself) to now (the version at the top of the changelog file)
+	 *
+	 * @param currentDBVersion current DB version
+	 * @param fileName DB changelog file name, file should be in resources
+	 *
+	 * @return list of DBVersion objects ordered by version descending
+	 *
+	 * @throws InternalErrorException if 1.there is an error reading file, 2.currentDBVersion was not found 3.DBVersion does not match pattern 4.DB versions are not ordered as they should be
+	 */
+	List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/DatabaseManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/DatabaseManagerBlImpl.java
@@ -1,12 +1,14 @@
 package cz.metacentrum.perun.core.blImpl;
 
-import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.bl.DatabaseManagerBl;
-import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.Compatibility;
 import cz.metacentrum.perun.core.implApi.DatabaseManagerImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Database manager can work with database version and upgraded state of perun DB.
@@ -16,34 +18,75 @@ import org.slf4j.LoggerFactory;
 public class DatabaseManagerBlImpl implements DatabaseManagerBl {
 	final static Logger log = LoggerFactory.getLogger(DatabaseManagerBlImpl.class);
 
+	public static final String ORACLE_CHANGELOG = "oracleChangelog.txt";
+	public static final String POSTGRES_CHANGELOG = "postgresChangelog.txt";
+	public static final String HSQLDB_CHANGELOG = "hsqldbChangelog.txt";
 	private final DatabaseManagerImplApi databaseManagerImpl;
-	private PerunBl perunBl;
-	
+
 	public DatabaseManagerBlImpl(DatabaseManagerImplApi databaseManagerImpl) {
 		this.databaseManagerImpl = databaseManagerImpl;
 	}
 	
-	public String getCurrentDatabaseVersion(PerunSession sess) throws InternalErrorException {
-		return getDatabaseManagerImpl().getCurrentDatabaseVersion(sess);
+	public String getCurrentDatabaseVersion() throws InternalErrorException {
+		return getDatabaseManagerImpl().getCurrentDatabaseVersion();
 	}
 	
-	public String getDatabaseDriverInformation(PerunSession sess) throws InternalErrorException {
-		return getDatabaseManagerImpl().getDatabaseDriverInformation(sess);
+	public String getDatabaseDriverInformation() throws InternalErrorException {
+		return getDatabaseManagerImpl().getDatabaseDriverInformation();
 	}
 	
-	public String getDatabaseInformation(PerunSession sess) throws InternalErrorException {
-		return getDatabaseManagerImpl().getDatabaseInformation(sess);
+	public String getDatabaseInformation() throws InternalErrorException {
+		return getDatabaseManagerImpl().getDatabaseInformation();
 	}
-	
-	public void setPerunBl(PerunBl perunBl) {
-		this.perunBl = perunBl;
+
+	public void updateDatabaseVersion(List<DBVersion> dbVersions) throws InternalErrorException {
+		this.databaseManagerImpl.updateDatabaseVersion(dbVersions);
+	}
+
+	public List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException {
+		return this.databaseManagerImpl.getChangelogVersions(currentDBVersion, fileName);
+	}
+
+	protected void initialize() throws InternalErrorException {
+		log.debug("Initialize manager starts!");
+
+		String fileName = POSTGRES_CHANGELOG;
+
+		if (Compatibility.isOracle()) {
+			fileName = ORACLE_CHANGELOG;
+		} else if (Compatibility.isHSQLDB()) {
+			fileName = HSQLDB_CHANGELOG;
+		}
+
+		String currentDBVersion = getCurrentDatabaseVersion();
+		List<DBVersion> dbVersions = null;
+
+		//trying to parse db versions from changelog
+		try {
+			dbVersions = getChangelogVersions(currentDBVersion, fileName);
+		} catch (Exception e) {
+			//Call exception which kills the initialization process in spring
+			throw new InternalErrorException("Error parsing DB changelog file " + fileName, e);
+		}
+
+		String codeDBVersion = this.databaseManagerImpl.getCodeDatabaseVersion(dbVersions, currentDBVersion);
+
+		if(codeDBVersion.equals(currentDBVersion)) {
+			log.debug("DB version is up to date - CurrentVersion: " + currentDBVersion);
+		} else {
+			log.debug("DB version is not up to date! Updating database.");
+			try {
+				updateDatabaseVersion(dbVersions);
+				log.debug("DB version updated successfully. Current version: " + codeDBVersion);
+			} catch(Exception e){
+				//Call exception which kills the initialization process in spring
+				throw new InternalErrorException("DB version is NOT up to date, database update was unsuccessful! Look to the logs for more info.");
+			}
+		}
+		log.debug("Initialize manager ends!");
 	}
 	
 	public DatabaseManagerImplApi getDatabaseManagerImpl() {
 		return this.databaseManagerImpl;
-	}
-
-	public PerunBl getPerunBl() {
-		return this.perunBl;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntry.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * @author Michal Stava email:&lt;stavamichal@gmail.com&gt;
  */
 public class DatabaseManagerEntry implements DatabaseManager {
-	final static Logger log = LoggerFactory.getLogger(FacilitiesManagerEntry.class);
+	final static Logger log = LoggerFactory.getLogger(DatabaseManagerEntry.class);
 
 	private DatabaseManagerBl databaseManagerBl;
 	private PerunBl perunBl;
@@ -31,7 +31,7 @@ public class DatabaseManagerEntry implements DatabaseManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.SELF)) throw new PrivilegeException(sess, "getCurrentDatabaseVersion");
 		
-		return getDatabaseManagerBl().getCurrentDatabaseVersion(sess);
+		return getDatabaseManagerBl().getCurrentDatabaseVersion();
 	}
 	
 	public String getDatabaseDriverInformation(PerunSession sess) throws InternalErrorException, PrivilegeException {
@@ -40,31 +40,23 @@ public class DatabaseManagerEntry implements DatabaseManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.SELF)) throw new PrivilegeException(sess, "getDatabaseDriverInformation");
 		
-		return getDatabaseManagerBl().getDatabaseDriverInformation(sess);
+		return getDatabaseManagerBl().getDatabaseDriverInformation();
 	}
 	
 	public String getDatabaseInformation(PerunSession sess) throws InternalErrorException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SELF)) throw new PrivilegeException(sess, "getDatabaseDriverInformation");
+		if (!AuthzResolver.isAuthorized(sess, Role.SELF)) throw new PrivilegeException(sess, "getDatabaseInformation");
 		
-		return getDatabaseManagerBl().getDatabaseInformation(sess);
+		return getDatabaseManagerBl().getDatabaseInformation();
 	}
-	
+
 	public void setDatabaseManagerBl(DatabaseManagerBl databaseManagerBl) {
 		this.databaseManagerBl = databaseManagerBl;
 	}
 	
-	public void setPerunBl(PerunBl perunBl) {
-		this.perunBl = perunBl;
-	}
-
 	public DatabaseManagerBl getDatabaseManagerBl() {
 		return this.databaseManagerBl;
-	}
-	
-	public PerunBl getPerunBl() {
-		return this.perunBl;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/DatabaseManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/DatabaseManagerImpl.java
@@ -1,14 +1,24 @@
 package cz.metacentrum.perun.core.impl;
 
-import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.implApi.DatabaseManagerImplApi;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
 import javax.sql.DataSource;
 import org.apache.tomcat.dbcp.dbcp.BasicDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
@@ -21,14 +31,14 @@ import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 public class DatabaseManagerImpl implements DatabaseManagerImplApi {
 	final static Logger log = LoggerFactory.getLogger(DatabaseManagerImpl.class);
 	private static JdbcPerunTemplate jdbc;
-	
+
 	private static final String VERSION_PROPETY = "DATABASE VERSION";
 	
 	public DatabaseManagerImpl(DataSource perunPool) {
 		jdbc = new JdbcPerunTemplate(perunPool);
 	}
 	
-	public String getCurrentDatabaseVersion(PerunSession sess) throws InternalErrorException {
+	public String getCurrentDatabaseVersion() throws InternalErrorException {
 		try {
 			return jdbc.queryForObject("select value from configurations where property=?", String.class, VERSION_PROPETY);
 		} catch(EmptyResultDataAccessException ex) {
@@ -38,7 +48,7 @@ public class DatabaseManagerImpl implements DatabaseManagerImplApi {
 		}
 	}
 	
-	public String getDatabaseDriverInformation(PerunSession sess) throws InternalErrorException {
+	public String getDatabaseDriverInformation() throws InternalErrorException {
 		try {
 			Connection con;
 			// for tests
@@ -56,7 +66,7 @@ public class DatabaseManagerImpl implements DatabaseManagerImplApi {
 		}
 	}
 	
-	public String getDatabaseInformation(PerunSession sess) throws InternalErrorException {
+	public String getDatabaseInformation() throws InternalErrorException {
 		try {
 			Connection con;
 			// for tests
@@ -72,5 +82,108 @@ public class DatabaseManagerImpl implements DatabaseManagerImplApi {
 		} catch (Exception ex) {
 			throw new InternalErrorException(ex);
 		}
+	}
+
+	public String getCodeDatabaseVersion(List<DBVersion> dbVersions, String currentDBVersion) {
+		if(dbVersions.isEmpty()) return currentDBVersion;
+		return dbVersions.get(0).getVersion();
+	}
+
+	public void updateDatabaseVersion(List<DBVersion> dbVersions) throws InternalErrorException {
+		Collections.reverse(dbVersions);
+
+		for (DBVersion v : dbVersions) {
+			log.debug("Executing update commands of version " + v.getVersion());
+			List<String> successfulCommands = new ArrayList<>();
+			for (String c : v.getCommands()) {
+				try {
+					jdbc.execute(c);
+					log.debug("Command executed: " + c);
+					successfulCommands.add(c);
+				} catch(EmptyResultDataAccessException ex) {
+					log.error("Update unsuccessful. All versions before " + v.getVersion() + " were successfully executed. " +
+							"Error executing command in version " + v.getVersion() + ": " + c, ex);
+					log.error("Successful commands from " + v.getVersion() + ": " + successfulCommands);
+					throw new ConsistencyErrorException("Update unsuccessful. Error executing command in version " + v.getVersion() + ": " + c, ex);
+				} catch(RuntimeException ex) {
+					log.error("Update unsuccessful. All versions before " + v.getVersion() + " were successfully executed. " +
+							"Error executing command in version " + v.getVersion() + ": " + c, ex);
+					log.error("Successful commands from " + v.getVersion() + ": " + successfulCommands);
+					throw new InternalErrorException("Update unsuccessful. Error executing command in version " + v.getVersion() + ": " + c, ex);
+				}
+			}
+		}
+	}
+
+	public List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException {
+
+		Pattern versionPattern = Pattern.compile("^[1-9][0-9]*[.][0-9]+[.][0-9]+");
+		Pattern commentPattern = Pattern.compile("^--.*");
+
+		List<DBVersion> versions = new ArrayList<>();
+		boolean versionFound = false;
+
+		Resource resource = new ClassPathResource(fileName);
+
+		try(BufferedReader br = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
+
+			String line = br.readLine();
+			while (line != null){
+				line = line.trim();
+
+				// ignore empty lines and comments at the start of the file and between versions
+				if(line.isEmpty() || commentPattern.matcher(line).matches()) {
+					line = br.readLine();
+					continue;
+				}
+
+				if(versionPattern.matcher(line).matches()){
+
+					//saving version
+					DBVersion version = new DBVersion(line);
+
+					//comparing two last version numbers
+					if(!versions.isEmpty()) {
+						DBVersion previousVersion = versions.get(versions.size() - 1);
+						if(version.compareTo(previousVersion) >= 0) {
+							throw new InternalErrorException("Version numbers in changelog file are not increasing properly. " +
+									"Version " + previousVersion.getVersion() + " should be higher than " + version.getVersion());
+						}
+					}
+
+					//the current db version was found, all new versions and their commands were saved to versions list
+					if(line.equals(currentDBVersion)){
+						versionFound = true;
+						break;
+					}
+
+					List<String> commands = new ArrayList<>();
+
+					while((line = br.readLine()) != null) {
+						line = line.trim();
+
+						// empty line means end of current version
+						if(line.isEmpty()) {
+							break;
+						}
+						commands.add(line);
+					}
+
+					//saving version commands
+					version.setCommands(commands);
+
+					versions.add(version);
+				} else {
+					throw new InternalErrorException("Version does not match the pattern required in " + fileName);
+				}
+			}
+			if(!versionFound) {
+				throw new InternalErrorException("Version " + currentDBVersion + " not found in " + fileName);
+			}
+		} catch(IOException e) {
+			throw new InternalErrorException("Error reading " + fileName, e);
+		}
+
+		return versions;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/DatabaseManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/DatabaseManagerImplApi.java
@@ -1,7 +1,9 @@
 package cz.metacentrum.perun.core.implApi;
 
-import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+
+import java.util.List;
 
 /**
  * Database manager can work with database version and upgraded state of perun DB.
@@ -12,30 +14,60 @@ public interface DatabaseManagerImplApi {
 	/**
 	 * Return current database version in string (ex. 3.0.1)
 	 * 
-	 * @param perunSession
 	 * @return return current database version
 	 * 
 	 * @throws InternalErrorException
 	 */
-	String getCurrentDatabaseVersion(PerunSession perunSession) throws InternalErrorException;
+	String getCurrentDatabaseVersion() throws InternalErrorException;
 	
 	/**
 	 * Get DB driver information from datasource (name-version)
 	 * 
-	 * @param sess
 	 * @return string information about database driver
 	 * 
 	 * @throws InternalErrorException 
 	 */
-	String getDatabaseDriverInformation(PerunSession sess) throws InternalErrorException;
+	String getDatabaseDriverInformation() throws InternalErrorException;
 	
 	/**
 	 * Get DB information from datasource (name-version)
 	 * 
-	 * @param sess
 	 * @return string information about database
 	 * 
 	 * @throws InternalErrorException 
 	 */
-	String getDatabaseInformation(PerunSession sess) throws InternalErrorException;
+	String getDatabaseInformation() throws InternalErrorException;
+
+	/**
+	 * Returns current code version from dbVersions list (ex. 3.0.1) or currentDBVersion if list is empty (because in that case currentDBVersion = current code version)
+	 *
+	 * @param dbVersions list of DBVersion objects
+	 * @param currentDBVersion current DB version
+	 *
+	 * @return current code version
+	 */
+	String getCodeDatabaseVersion(List<DBVersion> dbVersions, String currentDBVersion);
+
+	/**
+	 * Method updates database to the current code version. It takes list of dbVersions and executes all the commands from them.
+	 * Commands from the oldest (lowest) version are executed first.
+	 *
+	 * @param dbVersions list of dbVersion objects ordered by version descending, should not be empty
+	 *
+	 * @throws InternalErrorException if any of the commands fails to execute
+	 */
+	void updateDatabaseVersion(List<DBVersion> dbVersions) throws InternalErrorException;
+
+	/**
+	 * Parses all new database versions from DB changelog file and creates from them list of DBVersion objects.
+	 * The list contains all versions from currentDBVersion (without currentDBVersion itself) to now (the version at the top of the changelog file)
+	 *
+	 * @param currentDBVersion current DB version
+	 * @param fileName DB changelog file name, file should be in resources
+	 *
+	 * @return list of DBVersion objects ordered by version descending
+	 *
+	 * @throws InternalErrorException if 1.there is error reading file, 2.currentDBVersion was not found 3.db version does not match pattern 4.db versions are not ordered as they should be
+	 */
+	List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException;
 }

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -1,0 +1,9 @@
+-- Changelog file should have the newest version at the top, the oldest at the bottom.
+-- Versions must be separated by empty lines, version number should consist of three numbers with dots between, f.e. 3.0.1 is ok, 3.1 or 3.1.1.1 is not.
+-- Directly under version number should be version commands. They will be executed in the order they are written here.
+-- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
+
+3.1.25
+alter table service_dependencies add constraint srvdep_u unique(exec_service_id,dependency_id);
+alter table service_denials add constraint srvden_u unique(exec_service_id,facility_id,destination_id);
+update configurations set value='3.1.25' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -1,0 +1,9 @@
+-- Changelog file should have the newest version at the top, the oldest at the bottom.
+-- Versions must be separated by empty lines, version number should consist of three numbers with dots between, f.e. 3.0.1 is ok, 3.1 or 3.1.1.1 is not.
+-- Directly under version number should be version commands. They will be executed in the order they are written here.
+-- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
+
+3.1.25
+alter table service_dependencies add constraint SRVDEP_U unique(exec_service_id,dependency_id);
+alter table service_denials add constraint SRVDEN_U unique(exec_service_id,facility_id,destination_id);
+update configurations set value='3.1.25' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/perun-beans-test.xml
+++ b/perun-core/src/main/resources/perun-beans-test.xml
@@ -7,10 +7,10 @@
 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
-	<import resource="classpath:perun-beans-appcontext-tests.xml"/>
+    <import resource="classpath:perun-beans-appcontext-tests.xml"/>
     <import resource="classpath:perun-transaction-manager.xml"/>
     <import resource="perun-datasources-test.xml"/>
-	
+
     <aop:config>
         <aop:advisor advice-ref="txAdviceReadOnly" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getHierarchicalData(..))"/>
         <aop:advisor advice-ref="txAdviceReadOnly" pointcut="execution(* cz.metacentrum.perun.core.entry.ServicesManagerEntry.getDataWithGroups(..))"/>
@@ -66,7 +66,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
     </bean>
 
     <!-- Perun implementation -->
-    <bean id="perun" class="cz.metacentrum.perun.core.blImpl.PerunBlImpl" scope="singleton" init-method="initialize" >
+    <bean id="perun" class="cz.metacentrum.perun.core.blImpl.PerunBlImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
         <property name="vosManagerBl" ref="vosManagerBl"/>
         <property name="usersManagerBl" ref="usersManagerBl"/>
         <property name="groupsManagerBl" ref="groupsManagerBl"/>
@@ -100,175 +100,173 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
         <property name="databaseManager" ref="databaseManager"/>
     </bean>
 
-    <bean id="vosManager" class="cz.metacentrum.perun.core.entry.VosManagerEntry" scope="singleton">
+    <bean id="vosManager" class="cz.metacentrum.perun.core.entry.VosManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="vosManagerBl" ref="vosManagerBl"/>
     </bean>
-    <bean id="usersManager" class="cz.metacentrum.perun.core.entry.UsersManagerEntry" scope="singleton">
+    <bean id="usersManager" class="cz.metacentrum.perun.core.entry.UsersManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="usersManagerBl" ref="usersManagerBl"/>
     </bean>
-    <bean id="groupsManager" class="cz.metacentrum.perun.core.entry.GroupsManagerEntry" scope="singleton">
+    <bean id="groupsManager" class="cz.metacentrum.perun.core.entry.GroupsManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="groupsManagerBl" ref="groupsManagerBl"/>
     </bean>
-    <bean id="facilitiesManager" class="cz.metacentrum.perun.core.entry.FacilitiesManagerEntry" scope="singleton">
+    <bean id="facilitiesManager" class="cz.metacentrum.perun.core.entry.FacilitiesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="facilitiesManagerBl" ref="facilitiesManagerBl"/>
     </bean>
     <bean id="databaseManager" class="cz.metacentrum.perun.core.entry.DatabaseManagerEntry" scope="singleton">
-        <property name="perunBl" ref="perun"/>
         <property name="databaseManagerBl" ref="databaseManagerBl"/>
     </bean>
-    <bean id="membersManager" class="cz.metacentrum.perun.core.entry.MembersManagerEntry" scope="singleton">
+    <bean id="membersManager" class="cz.metacentrum.perun.core.entry.MembersManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="membersManagerBl" ref="membersManagerBl"/>
     </bean>
-    <bean id="resourcesManager" class="cz.metacentrum.perun.core.entry.ResourcesManagerEntry" scope="singleton">
+    <bean id="resourcesManager" class="cz.metacentrum.perun.core.entry.ResourcesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="resourcesManagerBl" ref="resourcesManagerBl"/>
     </bean>
-    <bean id="extSourcesManager" class="cz.metacentrum.perun.core.entry.ExtSourcesManagerEntry" scope="singleton">
+    <bean id="extSourcesManager" class="cz.metacentrum.perun.core.entry.ExtSourcesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="extSourcesManagerBl" ref="extSourcesManagerBl"/>
     </bean>
-    <bean id="attributesManager" class="cz.metacentrum.perun.core.entry.AttributesManagerEntry" scope="singleton">
+    <bean id="attributesManager" class="cz.metacentrum.perun.core.entry.AttributesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="attributesManagerBl" ref="attributesManagerBl"/>
     </bean>
-    <bean id="servicesManager" class="cz.metacentrum.perun.core.entry.ServicesManagerEntry" scope="singleton">
+    <bean id="servicesManager" class="cz.metacentrum.perun.core.entry.ServicesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="servicesManagerBl" ref="servicesManagerBl"/>
     </bean>
-    <bean id="ownersManager" class="cz.metacentrum.perun.core.entry.OwnersManagerEntry" scope="singleton">
+    <bean id="ownersManager" class="cz.metacentrum.perun.core.entry.OwnersManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="ownersManagerBl" ref="ownersManagerBl"/>
     </bean>
-    <bean id="auditMessagesManager" class="cz.metacentrum.perun.core.entry.AuditMessagesManagerEntry" scope="singleton">
+    <bean id="auditMessagesManager" class="cz.metacentrum.perun.core.entry.AuditMessagesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="auditMessagesManagerBl" ref="auditMessagesManagerBl"/>
     </bean>
-    <bean id="RTMessagesManager" class="cz.metacentrum.perun.core.entry.RTMessagesManagerEntry" scope="singleton">
+    <bean id="RTMessagesManager" class="cz.metacentrum.perun.core.entry.RTMessagesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="RTMessagesManagerBl" ref="RTMessagesManagerBl"/>
     </bean>
-    <bean id="searcher" class="cz.metacentrum.perun.core.entry.SearcherEntry" scope="singleton">
+    <bean id="searcher" class="cz.metacentrum.perun.core.entry.SearcherEntry" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="searcherBl" ref="searcherBl"/>
     </bean>
 
-    <bean id="vosManagerBl" class="cz.metacentrum.perun.core.blImpl.VosManagerBlImpl" scope="singleton">
+    <bean id="vosManagerBl" class="cz.metacentrum.perun.core.blImpl.VosManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="vosManagerImpl" />
     </bean>
-    <bean id="usersManagerBl" class="cz.metacentrum.perun.core.blImpl.UsersManagerBlImpl" scope="singleton">
+    <bean id="usersManagerBl" class="cz.metacentrum.perun.core.blImpl.UsersManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="usersManagerImpl" />
     </bean>
-    <bean id="groupsManagerBl" class="cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl" scope="singleton">
+    <bean id="groupsManagerBl" class="cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="groupsManagerImpl" />
     </bean>
-    <bean id="facilitiesManagerBl" class="cz.metacentrum.perun.core.blImpl.FacilitiesManagerBlImpl" scope="singleton">
+    <bean id="facilitiesManagerBl" class="cz.metacentrum.perun.core.blImpl.FacilitiesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="facilitiesManagerImpl" />
     </bean>
-    <bean id="databaseManagerBl" class="cz.metacentrum.perun.core.blImpl.DatabaseManagerBlImpl" scope="singleton">
-        <property name="perunBl" ref="perun"/>
+    <bean id="databaseManagerBl" class="cz.metacentrum.perun.core.blImpl.DatabaseManagerBlImpl" scope="singleton" init-method="initialize">
         <constructor-arg ref="databaseManagerImpl" />
     </bean>
-    <bean id="membersManagerBl" class="cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl" scope="singleton">
+    <bean id="membersManagerBl" class="cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="membersManagerImpl" />
     </bean>
-    <bean id="resourcesManagerBl" class="cz.metacentrum.perun.core.blImpl.ResourcesManagerBlImpl" scope="singleton">
+    <bean id="resourcesManagerBl" class="cz.metacentrum.perun.core.blImpl.ResourcesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="resourcesManagerImpl" />
     </bean>
-    <bean id="extSourcesManagerBl" class="cz.metacentrum.perun.core.blImpl.ExtSourcesManagerBlImpl" scope="singleton">
+    <bean id="extSourcesManagerBl" class="cz.metacentrum.perun.core.blImpl.ExtSourcesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="extSourcesManagerImpl" />
     </bean>
-    <bean id="attributesManagerBl" class="cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl" scope="singleton" init-method="initialize">
+    <bean id="attributesManagerBl" class="cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="attributesManagerImpl" />
     </bean>
-    <bean id="servicesManagerBl" class="cz.metacentrum.perun.core.blImpl.ServicesManagerBlImpl" scope="singleton">
+    <bean id="servicesManagerBl" class="cz.metacentrum.perun.core.blImpl.ServicesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="servicesManagerImpl" />
     </bean>
-    <bean id="modulesUtilsBl" class="cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl" scope="singleton">
+    <bean id="modulesUtilsBl" class="cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
     </bean>
-    <bean id="ownersManagerBl" class="cz.metacentrum.perun.core.blImpl.OwnersManagerBlImpl" scope="singleton">
+    <bean id="ownersManagerBl" class="cz.metacentrum.perun.core.blImpl.OwnersManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="ownersManagerImpl" />
     </bean>
-    <bean id="auditMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.AuditMessagesManagerBlImpl" scope="singleton">
+    <bean id="auditMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.AuditMessagesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <property name="auditer" ref="auditer"/>
     </bean>
-    <bean id="RTMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.RTMessagesManagerBlImpl" scope="singleton">
+    <bean id="RTMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.RTMessagesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
     </bean>
-    <bean id="authzResolverBl" class="cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl" scope="singleton">
+    <bean id="authzResolverBl" class="cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl" scope="singleton" depends-on="databaseManagerBl">
     </bean>
-    <bean id="searcherBl" class="cz.metacentrum.perun.core.blImpl.SearcherBlImpl" scope="singleton">
+    <bean id="searcherBl" class="cz.metacentrum.perun.core.blImpl.SearcherBlImpl" scope="singleton" depends-on="databaseManagerBl">
         <property name="perunBl" ref="perun"/>
         <constructor-arg ref="searcherImpl" />
     </bean>
 
-    <bean id="vosManagerImpl" class="cz.metacentrum.perun.core.impl.VosManagerImpl" scope="singleton">
+    <bean id="vosManagerImpl" class="cz.metacentrum.perun.core.impl.VosManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="usersManagerImpl" class="cz.metacentrum.perun.core.impl.UsersManagerImpl" scope="singleton">
+    <bean id="usersManagerImpl" class="cz.metacentrum.perun.core.impl.UsersManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="groupsManagerImpl" class="cz.metacentrum.perun.core.impl.GroupsManagerImpl" scope="singleton">
+    <bean id="groupsManagerImpl" class="cz.metacentrum.perun.core.impl.GroupsManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="facilitiesManagerImpl" class="cz.metacentrum.perun.core.impl.FacilitiesManagerImpl" scope="singleton">
+    <bean id="facilitiesManagerImpl" class="cz.metacentrum.perun.core.impl.FacilitiesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
     <bean id="databaseManagerImpl" class="cz.metacentrum.perun.core.impl.DatabaseManagerImpl" scope="singleton">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="membersManagerImpl" class="cz.metacentrum.perun.core.impl.MembersManagerImpl" scope="singleton">
+    <bean id="membersManagerImpl" class="cz.metacentrum.perun.core.impl.MembersManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="resourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ResourcesManagerImpl" scope="singleton">
+    <bean id="resourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ResourcesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="extSourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl" scope="singleton">
+    <bean id="extSourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="attributesManagerImpl" class="cz.metacentrum.perun.core.impl.AttributesManagerImpl" scope="singleton" init-method="initialize">
+    <bean id="attributesManagerImpl" class="cz.metacentrum.perun.core.impl.AttributesManagerImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
         <property name="perun" ref="perun"/>
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="servicesManagerImpl" class="cz.metacentrum.perun.core.impl.ServicesManagerImpl" scope="singleton">
+    <bean id="servicesManagerImpl" class="cz.metacentrum.perun.core.impl.ServicesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="ownersManagerImpl" class="cz.metacentrum.perun.core.impl.OwnersManagerImpl" scope="singleton">
+    <bean id="ownersManagerImpl" class="cz.metacentrum.perun.core.impl.OwnersManagerImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="authzResolverImpl" class="cz.metacentrum.perun.core.impl.AuthzResolverImpl" scope="singleton" init-method="initialize">
+    <bean id="authzResolverImpl" class="cz.metacentrum.perun.core.impl.AuthzResolverImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
-    <bean id="searcherImpl" class="cz.metacentrum.perun.core.impl.SearcherImpl" scope="singleton">
+    <bean id="searcherImpl" class="cz.metacentrum.perun.core.impl.SearcherImpl" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="dataSource" />
     </bean>
 
-    <bean id="auditer" class="cz.metacentrum.perun.core.impl.Auditer" scope="singleton" init-method="initialize" depends-on="utilsProperties">
+    <bean id="auditer" class="cz.metacentrum.perun.core.impl.Auditer" scope="singleton" init-method="initialize" depends-on="utilsProperties,databaseManagerBl">
         <property name="perunPool" ref="dataSource"/>
     </bean>
 
-    <bean id="synchronizer" class="cz.metacentrum.perun.core.impl.Synchronizer" scope="singleton">
+    <bean id="synchronizer" class="cz.metacentrum.perun.core.impl.Synchronizer" scope="singleton" depends-on="databaseManagerBl">
         <constructor-arg ref="perun" />
     </bean>
 
     <!-- this bean is only for test -->
-    <bean id="auditerConsumer" class="cz.metacentrum.perun.core.impl.AuditerConsumer" scope="prototype">
+    <bean id="auditerConsumer" class="cz.metacentrum.perun.core.impl.AuditerConsumer" scope="prototype" depends-on="databaseManagerBl">
         <constructor-arg type="java.lang.String" value="consumerForTest" />
         <constructor-arg ref="dataSource" />
     </bean>

--- a/perun-core/src/main/resources/perun-beans.xml
+++ b/perun-core/src/main/resources/perun-beans.xml
@@ -68,7 +68,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	</bean>
 
 	<!-- Perun implementation -->
-	<bean id="perun" class="cz.metacentrum.perun.core.blImpl.PerunBlImpl" scope="singleton" init-method="initialize" >
+	<bean id="perun" class="cz.metacentrum.perun.core.blImpl.PerunBlImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
 		<property name="vosManagerBl" ref="vosManagerBl"/>
 		<property name="usersManagerBl" ref="usersManagerBl"/>
 		<property name="groupsManagerBl" ref="groupsManagerBl"/>
@@ -102,175 +102,173 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		<property name="databaseManager" ref="databaseManager"/>
 	</bean>
 
-	<bean id="vosManager" class="cz.metacentrum.perun.core.entry.VosManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="vosManagerBl" ref="vosManagerBl"/>
-	</bean>
-	<bean id="usersManager" class="cz.metacentrum.perun.core.entry.UsersManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="usersManagerBl" ref="usersManagerBl"/>
-	</bean>
-	<bean id="groupsManager" class="cz.metacentrum.perun.core.entry.GroupsManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="groupsManagerBl" ref="groupsManagerBl"/>
-	</bean>
-	<bean id="facilitiesManager" class="cz.metacentrum.perun.core.entry.FacilitiesManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="facilitiesManagerBl" ref="facilitiesManagerBl"/>
-	</bean>
-	<bean id="databaseManager" class="cz.metacentrum.perun.core.entry.DatabaseManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="databaseManagerBl" ref="databaseManagerBl"/>
-	</bean>
-	<bean id="membersManager" class="cz.metacentrum.perun.core.entry.MembersManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="membersManagerBl" ref="membersManagerBl"/>
-	</bean>
-	<bean id="resourcesManager" class="cz.metacentrum.perun.core.entry.ResourcesManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="resourcesManagerBl" ref="resourcesManagerBl"/>
-	</bean>
-	<bean id="extSourcesManager" class="cz.metacentrum.perun.core.entry.ExtSourcesManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="extSourcesManagerBl" ref="extSourcesManagerBl"/>
-	</bean>
-	<bean id="attributesManager" class="cz.metacentrum.perun.core.entry.AttributesManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="attributesManagerBl" ref="attributesManagerBl"/>
-	</bean>
-	<bean id="servicesManager" class="cz.metacentrum.perun.core.entry.ServicesManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="servicesManagerBl" ref="servicesManagerBl"/>
-	</bean>
-	<bean id="ownersManager" class="cz.metacentrum.perun.core.entry.OwnersManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="ownersManagerBl" ref="ownersManagerBl"/>
-	</bean>
-	<bean id="auditMessagesManager" class="cz.metacentrum.perun.core.entry.AuditMessagesManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="auditMessagesManagerBl" ref="auditMessagesManagerBl"/>
-	</bean>
-	<bean id="RTMessagesManager" class="cz.metacentrum.perun.core.entry.RTMessagesManagerEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="RTMessagesManagerBl" ref="RTMessagesManagerBl"/>
-	</bean>
-	<bean id="searcher" class="cz.metacentrum.perun.core.entry.SearcherEntry" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="searcherBl" ref="searcherBl"/>
-	</bean>
+    <bean id="vosManager" class="cz.metacentrum.perun.core.entry.VosManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="vosManagerBl" ref="vosManagerBl"/>
+    </bean>
+    <bean id="usersManager" class="cz.metacentrum.perun.core.entry.UsersManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="usersManagerBl" ref="usersManagerBl"/>
+    </bean>
+    <bean id="groupsManager" class="cz.metacentrum.perun.core.entry.GroupsManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="groupsManagerBl" ref="groupsManagerBl"/>
+    </bean>
+    <bean id="facilitiesManager" class="cz.metacentrum.perun.core.entry.FacilitiesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="facilitiesManagerBl" ref="facilitiesManagerBl"/>
+    </bean>
+		<bean id="databaseManager" class="cz.metacentrum.perun.core.entry.DatabaseManagerEntry" scope="singleton">
+        <property name="databaseManagerBl" ref="databaseManagerBl"/>
+    </bean>
+    <bean id="membersManager" class="cz.metacentrum.perun.core.entry.MembersManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="membersManagerBl" ref="membersManagerBl"/>
+    </bean>
+    <bean id="resourcesManager" class="cz.metacentrum.perun.core.entry.ResourcesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="resourcesManagerBl" ref="resourcesManagerBl"/>
+    </bean>
+    <bean id="extSourcesManager" class="cz.metacentrum.perun.core.entry.ExtSourcesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="extSourcesManagerBl" ref="extSourcesManagerBl"/>
+    </bean>
+    <bean id="attributesManager" class="cz.metacentrum.perun.core.entry.AttributesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="attributesManagerBl" ref="attributesManagerBl"/>
+    </bean>
+    <bean id="servicesManager" class="cz.metacentrum.perun.core.entry.ServicesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="servicesManagerBl" ref="servicesManagerBl"/>
+    </bean>
+    <bean id="ownersManager" class="cz.metacentrum.perun.core.entry.OwnersManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="ownersManagerBl" ref="ownersManagerBl"/>
+    </bean>
+    <bean id="auditMessagesManager" class="cz.metacentrum.perun.core.entry.AuditMessagesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="auditMessagesManagerBl" ref="auditMessagesManagerBl"/>
+    </bean>
+    <bean id="RTMessagesManager" class="cz.metacentrum.perun.core.entry.RTMessagesManagerEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="RTMessagesManagerBl" ref="RTMessagesManagerBl"/>
+    </bean>
+    <bean id="searcher" class="cz.metacentrum.perun.core.entry.SearcherEntry" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="searcherBl" ref="searcherBl"/>
+    </bean>
 
-	<bean id="vosManagerBl" class="cz.metacentrum.perun.core.blImpl.VosManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="vosManagerImpl" />
-	</bean>
-	<bean id="usersManagerBl" class="cz.metacentrum.perun.core.blImpl.UsersManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="usersManagerImpl" />
-	</bean>
-	<bean id="groupsManagerBl" class="cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="groupsManagerImpl" />
-	</bean>
-	<bean id="facilitiesManagerBl" class="cz.metacentrum.perun.core.blImpl.FacilitiesManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="facilitiesManagerImpl" />
-	</bean>
-	<bean id="databaseManagerBl" class="cz.metacentrum.perun.core.blImpl.DatabaseManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="databaseManagerImpl" />
-	</bean>
-	<bean id="membersManagerBl" class="cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="membersManagerImpl" />
-	</bean>
-	<bean id="resourcesManagerBl" class="cz.metacentrum.perun.core.blImpl.ResourcesManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="resourcesManagerImpl" />
-	</bean>
-	<bean id="extSourcesManagerBl" class="cz.metacentrum.perun.core.blImpl.ExtSourcesManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="extSourcesManagerImpl" />
-	</bean>
-	<bean id="attributesManagerBl" class="cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl" scope="singleton" init-method="initialize">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="attributesManagerImpl" />
-	</bean>
-	<bean id="servicesManagerBl" class="cz.metacentrum.perun.core.blImpl.ServicesManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="servicesManagerImpl" />
-	</bean>
-	<bean id="modulesUtilsBl" class="cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-	</bean>
-	<bean id="ownersManagerBl" class="cz.metacentrum.perun.core.blImpl.OwnersManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="ownersManagerImpl" />
-	</bean>
-	<bean id="auditMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.AuditMessagesManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<property name="auditer" ref="auditer"/>
-	</bean>
-	<bean id="RTMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.RTMessagesManagerBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-	</bean>
-	<bean id="authzResolverBl" class="cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl" scope="singleton">
-	</bean>
-	<bean id="searcherBl" class="cz.metacentrum.perun.core.blImpl.SearcherBlImpl" scope="singleton">
-		<property name="perunBl" ref="perun"/>
-		<constructor-arg ref="searcherImpl" />
-	</bean>
+    <bean id="vosManagerBl" class="cz.metacentrum.perun.core.blImpl.VosManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="vosManagerImpl" />
+    </bean>
+    <bean id="usersManagerBl" class="cz.metacentrum.perun.core.blImpl.UsersManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="usersManagerImpl" />
+    </bean>
+    <bean id="groupsManagerBl" class="cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="groupsManagerImpl" />
+    </bean>
+    <bean id="facilitiesManagerBl" class="cz.metacentrum.perun.core.blImpl.FacilitiesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="facilitiesManagerImpl" />
+    </bean>
+		<bean id="databaseManagerBl" class="cz.metacentrum.perun.core.blImpl.DatabaseManagerBlImpl" scope="singleton" init-method="initialize">
+        <constructor-arg ref="databaseManagerImpl" />
+    </bean>
+    <bean id="membersManagerBl" class="cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="membersManagerImpl" />
+    </bean>
+    <bean id="resourcesManagerBl" class="cz.metacentrum.perun.core.blImpl.ResourcesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="resourcesManagerImpl" />
+    </bean>
+    <bean id="extSourcesManagerBl" class="cz.metacentrum.perun.core.blImpl.ExtSourcesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="extSourcesManagerImpl" />
+    </bean>
+    <bean id="attributesManagerBl" class="cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="attributesManagerImpl" />
+    </bean>
+    <bean id="servicesManagerBl" class="cz.metacentrum.perun.core.blImpl.ServicesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="servicesManagerImpl" />
+    </bean>
+    <bean id="modulesUtilsBl" class="cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+    </bean>
+    <bean id="ownersManagerBl" class="cz.metacentrum.perun.core.blImpl.OwnersManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="ownersManagerImpl" />
+    </bean>
+    <bean id="auditMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.AuditMessagesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <property name="auditer" ref="auditer"/>
+    </bean>
+    <bean id="RTMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.RTMessagesManagerBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+    </bean>
+    <bean id="authzResolverBl" class="cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl" scope="singleton" depends-on="databaseManagerBl">
+    </bean>
+    <bean id="searcherBl" class="cz.metacentrum.perun.core.blImpl.SearcherBlImpl" scope="singleton" depends-on="databaseManagerBl">
+        <property name="perunBl" ref="perun"/>
+        <constructor-arg ref="searcherImpl" />
+    </bean>
 
-	<bean id="vosManagerImpl" class="cz.metacentrum.perun.core.impl.VosManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="usersManagerImpl" class="cz.metacentrum.perun.core.impl.UsersManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="groupsManagerImpl" class="cz.metacentrum.perun.core.impl.GroupsManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="facilitiesManagerImpl" class="cz.metacentrum.perun.core.impl.FacilitiesManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="databaseManagerImpl" class="cz.metacentrum.perun.core.impl.DatabaseManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="membersManagerImpl" class="cz.metacentrum.perun.core.impl.MembersManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="resourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ResourcesManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="extSourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="attributesManagerImpl" class="cz.metacentrum.perun.core.impl.AttributesManagerImpl" scope="singleton" init-method="initialize">
-		<property name="perun" ref="perun"/>
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="servicesManagerImpl" class="cz.metacentrum.perun.core.impl.ServicesManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="ownersManagerImpl" class="cz.metacentrum.perun.core.impl.OwnersManagerImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="authzResolverImpl" class="cz.metacentrum.perun.core.impl.AuthzResolverImpl" scope="singleton" init-method="initialize">
-		<constructor-arg ref="dataSource" />
-	</bean>
-	<bean id="searcherImpl" class="cz.metacentrum.perun.core.impl.SearcherImpl" scope="singleton">
-		<constructor-arg ref="dataSource" />
-	</bean>
+    <bean id="vosManagerImpl" class="cz.metacentrum.perun.core.impl.VosManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="usersManagerImpl" class="cz.metacentrum.perun.core.impl.UsersManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="groupsManagerImpl" class="cz.metacentrum.perun.core.impl.GroupsManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="facilitiesManagerImpl" class="cz.metacentrum.perun.core.impl.FacilitiesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+		<bean id="databaseManagerImpl" class="cz.metacentrum.perun.core.impl.DatabaseManagerImpl" scope="singleton">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="membersManagerImpl" class="cz.metacentrum.perun.core.impl.MembersManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="resourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ResourcesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="extSourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="attributesManagerImpl" class="cz.metacentrum.perun.core.impl.AttributesManagerImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
+        <property name="perun" ref="perun"/>
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="servicesManagerImpl" class="cz.metacentrum.perun.core.impl.ServicesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="ownersManagerImpl" class="cz.metacentrum.perun.core.impl.OwnersManagerImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="authzResolverImpl" class="cz.metacentrum.perun.core.impl.AuthzResolverImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
+    <bean id="searcherImpl" class="cz.metacentrum.perun.core.impl.SearcherImpl" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="dataSource" />
+    </bean>
 
-	<bean id="auditer" class="cz.metacentrum.perun.core.impl.Auditer" scope="singleton" init-method="initialize" depends-on="utilsProperties">
-		<property name="perunPool" ref="dataSource"/>
-	</bean>
+    <bean id="auditer" class="cz.metacentrum.perun.core.impl.Auditer" scope="singleton" init-method="initialize" depends-on="utilsProperties,databaseManagerBl">
+        <property name="perunPool" ref="dataSource"/>
+    </bean>
 
-	<bean id="synchronizer" class="cz.metacentrum.perun.core.impl.Synchronizer" scope="singleton">
-		<constructor-arg ref="perun" />
-	</bean>
+    <bean id="synchronizer" class="cz.metacentrum.perun.core.impl.Synchronizer" scope="singleton" depends-on="databaseManagerBl">
+        <constructor-arg ref="perun" />
+    </bean>
 
 	<!-- this bean is only for test -->
-	<bean id="auditerConsumer" class="cz.metacentrum.perun.core.impl.AuditerConsumer" scope="prototype">
+	<bean id="auditerConsumer" class="cz.metacentrum.perun.core.impl.AuditerConsumer" scope="prototype" depends-on="databaseManagerBl">
 		<constructor-arg type="java.lang.String" value="consumerForTest" />
 		<constructor-arg ref="dataSource" />
 	</bean>

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -1,0 +1,9 @@
+-- Changelog file should have the newest version at the top, the oldest at the bottom.
+-- Versions must be separated by empty lines, version number should consist of three numbers with dots between, f.e. 3.0.1 is ok, 3.1 or 3.1.1.1 is not.
+-- Directly under version number should be version commands. They will be executed in the order they are written here.
+-- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
+
+3.1.25
+alter table service_dependencies add constraint srvdep_u unique(exec_service_id,dependency_id);
+alter table service_denials add constraint srvden_u unique(exec_service_id,facility_id,destination_id);
+update configurations set value='3.1.25' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/test-data.sql
+++ b/perun-core/src/main/resources/test-data.sql
@@ -2143,7 +2143,7 @@ insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routin
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,2,timestamp '2011-11-15 14:43:13.3','PERUNV3',timestamp '2011-11-15 14:43:13.3','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6071,timestamp '2015-01-21 13:05:00.4',timestamp '2015-01-16 14:29:29.6','PERUNV3',timestamp '2015-01-16 14:29:29.6','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6060,timestamp '2015-01-16 14:25:00.6',timestamp '2015-01-16 09:39:07.6','PERUNV3',timestamp '2015-01-16 09:39:07.6','PERUNV3','0');
-insert into configurations (property,value) values ('DATABASE VERSION','3.1.23');
+insert into configurations (property,value) values ('DATABASE VERSION','3.1.25');
 
 drop sequence service_principals_id_seq;
 create sequence service_principals_id_seq start with 1;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntryIntegrationTest.java
@@ -33,7 +33,7 @@ public class DatabaseManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		System.out.println("DatabaseManager.getCurrentDBVersion");
 		String dbVersion = perun.getDatabaseManager().getCurrentDatabaseVersion(sess);
 		Matcher versionMatcher = versionPatter.matcher(dbVersion);
-		assertTrue("DbVersion must match to something like '1.0.0'", versionMatcher.matches());
+		assertTrue("DBVersion must match to something like '1.0.0'", versionMatcher.matches());
 	}
 	
 	@Test

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/DatabaseManagerImplIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/DatabaseManagerImplIntegrationTest.java
@@ -1,0 +1,67 @@
+package cz.metacentrum.perun.core.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.DBVersion;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.bl.DatabaseManagerBl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * @author Simona Kruppova 410315
+ * @author Oliver Mrazik 410035
+ */
+public class DatabaseManagerImplIntegrationTest extends AbstractPerunIntegrationTest{
+
+	private DatabaseManagerBl dbManager;
+
+	@Before
+	public void setUp() throws Exception {
+		dbManager = perun.getDatabaseManagerBl();
+	}
+
+	@Test(expected=InternalErrorException.class)
+	public void getChangelogVersionsOrder() throws Exception {
+		dbManager.getChangelogVersions("2.2.4", "changelogPatternTests/versionOrderTestFile.txt");
+	}
+
+	@Test(expected=InternalErrorException.class)
+	public void getChangelogVersionsTwoSame() throws Exception {
+		dbManager.getChangelogVersions("2.2.4", "changelogPatternTests/versionTwoSameTestFile.txt");
+	}
+
+	@Test(expected=InternalErrorException.class)
+	public void getChangelogVersionsEmptyFile() throws Exception {
+		dbManager.getChangelogVersions("", "changelogPatternTests/emptyTestFile.txt");
+	}
+
+	@Test(expected=InternalErrorException.class)
+	public void getChangelogVersionsDepth() throws Exception {
+		dbManager.getChangelogVersions("", "changelogPatternTests/vPatternTest-depth.txt");
+	}
+
+	@Test(expected=InternalErrorException.class)
+	public void getChangelogVersionsPeriod() throws Exception {
+		dbManager.getChangelogVersions("", "changelogPatternTests/vPatternTest-period.txt");
+	}
+
+	@Test(expected=InternalErrorException.class)
+	public void getChangelogVersionsSpace() throws Exception {
+		dbManager.getChangelogVersions("", "changelogPatternTests/vPatternTest-space.txt");
+	}
+
+	@Test(expected=InternalErrorException.class)
+	public void getChangelogVersionsZero() throws Exception {
+		dbManager.getChangelogVersions("", "changelogPatternTests/vPatternTest-zero.txt");
+	}
+
+	@Test
+	public void getChangelogVersions() throws Exception {
+		List<DBVersion> versions = dbManager.getChangelogVersions("2.2.4", "changelogPatternTests/correctTestFile.txt");
+		assertEquals("It should load 2 new database versions from a file", 2, versions.size());
+	}
+}

--- a/perun-core/src/test/resources/changelogPatternTests/correctTestFile.txt
+++ b/perun-core/src/test/resources/changelogPatternTests/correctTestFile.txt
@@ -1,0 +1,16 @@
+-- This is a comment.
+
+-- this is a comment, too.
+3.1.11
+DROP TABLE testInitMng
+
+-- I am a comment between versions.
+
+3.1.10
+ALTER TABLE testInitMng DROP text
+ALTER TABLE testInitMng ADD description varchar(255)
+
+2.2.4
+CREATE TABLE testInitMng (id int, text varchar(255) )
+INSERT INTO testInitMng (id, text) VALUES (4, 'random_text1')
+INSERT INTO testInitMng (id, text) VALUES (2, 'random_text2')

--- a/perun-core/src/test/resources/changelogPatternTests/vPatternTest-depth.txt
+++ b/perun-core/src/test/resources/changelogPatternTests/vPatternTest-depth.txt
@@ -1,0 +1,11 @@
+3.1.11.25
+DROP TABLE testInitMng
+
+3.1.10
+ALTER TABLE testInitMng DROP text
+ALTER TABLE testInitMng ADD description varchar(255)
+
+2.2.4
+CREATE TABLE testInitMng (id int, text varchar(255) )
+INSERT INTO testInitMng (id, text) VALUES (4, 'random_text1')
+INSERT INTO testInitMng (id, text) VALUES (2, 'random_text2')

--- a/perun-core/src/test/resources/changelogPatternTests/vPatternTest-period.txt
+++ b/perun-core/src/test/resources/changelogPatternTests/vPatternTest-period.txt
@@ -1,0 +1,11 @@
+31.11
+DROP TABLE testInitMng
+
+3.1.10
+ALTER TABLE testInitMng DROP text
+ALTER TABLE testInitMng ADD description varchar(255)
+
+2.2.4
+CREATE TABLE testInitMng (id int, text varchar(255) )
+INSERT INTO testInitMng (id, text) VALUES (4, 'random_text1')
+INSERT INTO testInitMng (id, text) VALUES (2, 'random_text2')

--- a/perun-core/src/test/resources/changelogPatternTests/vPatternTest-space.txt
+++ b/perun-core/src/test/resources/changelogPatternTests/vPatternTest-space.txt
@@ -1,0 +1,9 @@
+3.1.11
+DROP TABLE testInitMng
+3.1.10
+ALTER TABLE testInitMng DROP text
+ALTER TABLE testInitMng ADD description varchar(255)
+2.2.4
+CREATE TABLE testInitMng (id int, text varchar(255) )
+INSERT INTO testInitMng (id, text) VALUES (4, 'random_text1')
+INSERT INTO testInitMng (id, text) VALUES (2, 'random_text2')

--- a/perun-core/src/test/resources/changelogPatternTests/vPatternTest-zero.txt
+++ b/perun-core/src/test/resources/changelogPatternTests/vPatternTest-zero.txt
@@ -1,0 +1,11 @@
+0.1.11
+DROP TABLE testInitMng
+
+3.1.10
+ALTER TABLE testInitMng DROP text
+ALTER TABLE testInitMng ADD description varchar(255)
+
+2.2.4
+CREATE TABLE testInitMng (id int, text varchar(255) )
+INSERT INTO testInitMng (id, text) VALUES (4, 'random_text1')
+INSERT INTO testInitMng (id, text) VALUES (2, 'random_text2')

--- a/perun-core/src/test/resources/changelogPatternTests/versionOrderTestFile.txt
+++ b/perun-core/src/test/resources/changelogPatternTests/versionOrderTestFile.txt
@@ -1,0 +1,16 @@
+-- This is a comment.
+
+-- this is a comment, too.
+2.2.5
+DROP TABLE testInitMng
+
+-- I am a comment between versions.
+
+2.2.3
+ALTER TABLE testInitMng DROP text
+ALTER TABLE testInitMng ADD description varchar(255)
+
+2.2.4
+CREATE TABLE testInitMng (id int, text varchar(255) )
+INSERT INTO testInitMng (id, text) VALUES (4, 'random_text1')
+INSERT INTO testInitMng (id, text) VALUES (2, 'random_text2')

--- a/perun-core/src/test/resources/changelogPatternTests/versionTwoSameTestFile.txt
+++ b/perun-core/src/test/resources/changelogPatternTests/versionTwoSameTestFile.txt
@@ -1,0 +1,16 @@
+-- This is a comment.
+
+-- this is a comment, too.
+2.2.5
+DROP TABLE testInitMng
+
+-- I am a comment between versions.
+
+2.2.5
+ALTER TABLE testInitMng DROP text
+ALTER TABLE testInitMng ADD description varchar(255)
+
+2.2.4
+CREATE TABLE testInitMng (id int, text varchar(255) )
+INSERT INTO testInitMng (id, text) VALUES (4, 'random_text1')
+INSERT INTO testInitMng (id, text) VALUES (2, 'random_text2')


### PR DESCRIPTION
- initialization manager in DatabaseManagerBlImpl changes database version by changelog file in resources. It searches for the actual db version in the changelog file and executes all the commands of the newer version.
- DBVersion bean created for saving db versions with their commands
- tests to ensure that parsing of the changelog file works correctly were created. Test files created in resources in test folder.