### PR TITLE
APPS: Fixed members loading in edugain-group

### DIFF
--- a/perun-apps/apps/edugain-group/js/LoadMembers.js
+++ b/perun-apps/apps/edugain-group/js/LoadMembers.js
@@ -98,7 +98,6 @@ function loadAllMembers(vo) {
         if (data.name != "PrivilegeException") {
             (flowMessager.newMessage(data.name, data.message, "danger")).draw();
         } else {
-            allMembers = [];
             callBackAfter(loadAllMembers);
         }
     });


### PR DESCRIPTION
- When loading all vo members, we can't set allMembers to [],
  it must be undefined for other parts of code to work.
  Later when TOPGROUPCREATOR creates his first group, we can
  successfully load VO members and fills them instead of
  keeping empty list.