### PR TITLE
CORE: Removed unused role SYNCHRONIZER

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Role.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/Role.java
@@ -7,7 +7,6 @@ public enum Role {
 	GROUPADMIN ("groupadmin"),
 	SELF ("self"),
 	FACILITYADMIN ("facilityadmin"),
-	SYNCHRONIZER ("synchronizer"),
 	REGISTRAR ("registrar"),
 	ENGINE ("engine"),
 	RPC ("rpc"),

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1222,12 +1222,6 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			log.trace("AuthzResolver.init: Perun Engine {} loaded", perunEngineAdmins);
 		}
 
-		List<String> perunSynchronizers = new ArrayList<String>(Arrays.asList(Utils.getPropertyFromConfiguration("perun.synchronizer.principals").split("[ \t]*,[ \t]*")));
-		if (perunSynchronizers.contains(sess.getPerunPrincipal().getActor())) {
-			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.SYNCHRONIZER);
-			log.trace("AuthzResolver.init: Perun Synchronizer {} loaded", perunSynchronizers);
-		}
-
 		List<String> perunNotifications = new ArrayList<String>(Arrays.asList(Utils.getPropertyFromConfiguration("perun.notification.principals").split("[ \t]*,[ \t]*")));
 		if (perunNotifications.contains(sess.getPerunPrincipal().getActor())) {
 			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.NOTIFICATIONS);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -824,9 +824,8 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SYNCHRONIZER)
-				&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)
-				&& !AuthzResolver.isAuthorized(sess, Role.VOADMIN, group))  {
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
+				&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group))  {
 			throw new PrivilegeException(sess, "synchronizeGroup");
 		}
 
@@ -837,7 +836,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SYNCHRONIZER))  {
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN))  {
 			throw new PrivilegeException(sess, "synchronizeGroups");
 		}
 


### PR DESCRIPTION
- Removed role SYNCHRONIZER from enum.
- Removed setting of this role to session authz.
- We do not use force-sync of all groups from outside anymore.
  If required, PERUNADMIN can call it.
  Each group still can be synchronized by VO/GROUPADMIN.