### PR TITLE
CORE: Allow public access to auditer methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
@@ -104,20 +104,12 @@ public class AuditMessagesManagerEntry implements AuditMessagesManager {
 	}
 
 	public Map<String, Integer> getAllAuditerConsumers(PerunSession sess) throws InternalErrorException, PrivilegeException {
-		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
-			throw new PrivilegeException(sess, "getAllAuditerConsumers");
-		}
-
+		// anybody can call this method
 		return getAuditMessagesManagerBl().getAllAuditerConsumers(sess);
 	}
 
 	public int getLastMessageId(PerunSession sess) throws InternalErrorException, PrivilegeException {
-		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
-			throw new PrivilegeException(sess, "getLastMessageId");
-		}
-
+		// anybody can call this method
 		return getAuditMessagesManagerBl().getLastMessageId();
 	}
 


### PR DESCRIPTION
- Allow public access to methods getAllAuditerConsumers()
  and getLastMessageId().