### PR TITLE
RPC: Use @deprecated in our javadoc

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
@@ -53,7 +53,18 @@ public class UrlDeserializer extends Deserializer {
 	public Boolean readBoolean(String name) throws RpcException {
 		if (!contains(name)) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
 
-		return Boolean.parseBoolean(req.getParameter(name));
+		try {
+			// check if parameter in URL isn't passed as number
+			// if yes, conform JsonDeserializer implementation
+			// => only 0 is considered FALSE, other numbers are TRUE
+			int number = Integer.parseInt(req.getParameter(name));
+			if (number == 0) return false;
+			return true;
+		} catch (NumberFormatException ex) {
+			// parameter is passed in URL as a String
+			return Boolean.parseBoolean(req.getParameter(name));
+		}
+
 	}
 
 	@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -53,11 +53,11 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Attributes
 	 */
 	/*#
-	 * Returns all Group-Resource attributes. Returns only non-empty attributes. Returns also group attributes if workWithGroupAttributes == 1.
+	 * Returns all Group-Resource attributes. Returns only non-empty attributes. Returns also group attributes if workWithGroupAttributes == true.
 	 *
 	 * @param group int Group ID
 	 * @param resource int Resource ID
-	 * @param workWithGroupAttributes int Work with group attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithGroupAttributes boolean Work with group attributes. False is default value.
 	 * @return List<Attribute> Attributes
 	 */
 	/*#
@@ -73,10 +73,10 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Attributes
 	 */
 	/*#
-	 * Returns all Member attributes. Returns only non-empty attributes. Returns also user attributes if workWithUserAttributes == 1.
+	 * Returns all Member attributes. Returns only non-empty attributes. Returns also user attributes if workWithUserAttributes == true.
 	 *
 	 * @param member int Member ID
-	 * @param workWithUserAttributes int  Work with user attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @return List<Attribute> Attributes
 	 */
 	/*#
@@ -150,7 +150,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 						return ac.getAttributesManager().getAttributes(ac.getSession(),
 								ac.getResourceById(parms.readInt("resource")),
 								ac.getGroupById(parms.readInt("group")),
-								parms.readInt("workWithGroupAttributes") == 1);
+								parms.readBoolean("workWithGroupAttributes"));
 					} else {
 						return ac.getAttributesManager().getAttributes(ac.getSession(),
 								ac.getResourceById(parms.readInt("resource")),
@@ -166,10 +166,10 @@ public enum AttributesManagerMethod implements ManagerMethod {
 						return ac.getAttributesManager().getAttributes(ac.getSession(),
 								ac.getMemberById(parms.readInt("member")),
 								parms.readList("attrNames", String.class),
-								parms.readInt("workWithUserAttributes") == 1);
+								parms.readBoolean("workWithUserAttributes"));
 					} else {
 						return ac.getAttributesManager().getAttributes(ac.getSession(),
-								ac.getMemberById(parms.readInt("member")), parms.readInt("workWithUserAttributes") == 1);
+								ac.getMemberById(parms.readInt("member")), parms.readBoolean("workWithUserAttributes"));
 					}
 				} else if (parms.contains("attrNames")) {
 					return ac.getAttributesManager().getAttributes(ac.getSession(),
@@ -258,7 +258,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @param member int Member ID
 	 * @param resource int Resource ID
-	 * @param workWithUserAttributes int Work with user attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @param attributes List<Attribute> List of attributes
 	 */
 	/*#
@@ -273,7 +273,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @param group int Group ID
 	 * @param resource int Resource ID
-	 * @param workWithGroupAttributes int Work with group attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithGroupAttributes boolean Work with group attributes. False is default value.
 	 * @param attributes List<Attribute> List of attributes
 	 */
 	/*#
@@ -286,7 +286,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * Sets the attributes.
 	 *
 	 * @param member int Member ID
-	 * @param workWithUserAttributes int Work with user attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @param attributes List<Attribute> List of attributes
 	 */
 	/*#
@@ -351,7 +351,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 								ac.getResourceById(parms.readInt("resource")),
 								ac.getMemberById(parms.readInt("member")),
 								parms.readList("attributes", Attribute.class),
-								parms.readInt("workWithUserAttributes") == 1);
+								parms.readBoolean("workWithUserAttributes"));
 					} else {
 						ac.getAttributesManager().setAttributes(ac.getSession(),
 								ac.getResourceById(parms.readInt("resource")),
@@ -364,7 +364,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 								ac.getResourceById(parms.readInt("resource")),
 								ac.getGroupById(parms.readInt("group")),
 								parms.readList("attributes", Attribute.class),
-								parms.readInt("workWithGroupAttributes") == 1);
+								parms.readBoolean("workWithGroupAttributes"));
 					} else {
 						ac.getAttributesManager().setAttributes(ac.getSession(),
 								ac.getResourceById(parms.readInt("resource")),
@@ -378,7 +378,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				}
 			} else if (parms.contains("member")) {
 				if(parms.contains("workWithUserAttributes")){
-					if(parms.readInt("workWithUserAttributes")!=1){
+					if(!parms.readBoolean("workWithUserAttributes")){
 						ac.getAttributesManager().setAttributes(ac.getSession(),
 								ac.getMemberById(parms.readInt("member")),
 								parms.readList("attributes", Attribute.class),
@@ -1056,7 +1056,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param member int Member ID
 	 * @param service int Service ID
 	 * @param resource int Resource ID
-	 * @param workWithUserAttributes int Work with user attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
@@ -1107,7 +1107,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @param member int Member ID
 	 * @param resource int Resource ID
-	 * @param workWithUserAttributes int Work with user attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
@@ -1139,7 +1139,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * Returns required attributes.
 	 *
 	 * @param member int Member ID
-	 * @param workWithUserAttributes int Work with user attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
@@ -1160,7 +1160,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 									ac.getServiceById(parms.readInt("service")),
 									ac.getResourceById(parms.readInt("resource")),
 									ac.getMemberById(parms.readInt("member")),
-									parms.readInt("workWithUserAttributes") == 1);
+									parms.readBoolean("workWithUserAttributes"));
 						} else {
 							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 									ac.getServiceById(parms.readInt("service")),
@@ -1216,7 +1216,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 					if (parms.contains("workWithUserAttributes")) {
 						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")), parms.readInt("workWithUserAttributes") == 1);
+								ac.getMemberById(parms.readInt("member")), parms.readBoolean("workWithUserAttributes"));
 					} else {
 						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 								ac.getResourceById(parms.readInt("resource")),
@@ -1238,7 +1238,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("member")) {
 				if (parms.contains("workWithUserAttributes")){
 					return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-							ac.getMemberById(parms.readInt("member")), parms.readInt("workWithUserAttributes") == 1);
+							ac.getMemberById(parms.readInt("member")), parms.readBoolean("workWithUserAttributes"));
 				} else {
 					return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 							ac.getMemberById(parms.readInt("member")), false);
@@ -1268,14 +1268,14 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Gets member-resource attributes and also user, user-facility and member attributes, if workWithUserAttributes == 1.
+	 * Gets member-resource attributes and also user, user-facility and member attributes, if workWithUserAttributes == true.
 	 * It returns attributes required by all services assigned to specified resource. Both empty and non-empty attributes are returned.
 	 *
 	 * @param resourceToGetServicesFrom int Resource to get services from ID
 	 * @param resource int Resource ID
 	 * @param member int Member ID
-	 * @param workWithUserAttributes int Work with user attributes integer (1 = true, 0 = false). 0 is default value.
-	 * @return List<Attribute> Member-resource attributes (if workWithUserAttributes == 1 also user, user-facility and member attributes)
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
+	 * @return List<Attribute> Member-resource attributes (if workWithUserAttributes == true also user, user-facility and member attributes)
 	 */
 	/*#
 	 * Gets member-resource attributes.
@@ -1312,14 +1312,14 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> User's attributes
 	 */
 	/*#
-	 * Gets group-resource and also group attributes, if workWithGroupAttributes == 1.
+	 * Gets group-resource and also group attributes, if workWithGroupAttributes == true.
 	 * It returns attributes required by all services assigned to specified resource. Both empty and non-empty attributes are returned.
 	 *
 	 * @param resourceToGetServicesFrom int Resource to get services from ID
 	 * @param group int Group ID
 	 * @param resource int Resource ID
-	 * @param workWithGroupAttributes int Work with group attributes integer (1 = true, 0 = false). 0 is default value.
-	 * @return List<Attribute> Group-resource and (if workWithGroupAttributes == 1) group required attributes
+	 * @param workWithGroupAttributes boolean Work with group attributes. False is default value.
+	 * @return List<Attribute> Group-resource and (if workWithGroupAttributes == true) group required attributes
 	 */
 	/*#
 	 * Gets group-resource attributes.
@@ -1349,7 +1349,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							return	ac.getAttributesManager().getResourceRequiredAttributes(ac.getSession(),
 									ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
 									ac.getResourceById(parms.readInt("resource")),
-									ac.getMemberById(parms.readInt("member")), parms.readInt("workWithUserAttributes") == 1);
+									ac.getMemberById(parms.readInt("member")), parms.readBoolean("workWithUserAttributes"));
 						} else {
 							return ac.getAttributesManager().getResourceRequiredAttributes(ac.getSession(),
 									ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
@@ -1379,7 +1379,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 									ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
 									ac.getResourceById(parms.readInt("resource")),
 									ac.getGroupById(parms.readInt("group")),
-									parms.readInt("workWithGroupAttributes") == 1);
+									parms.readBoolean("workWithGroupAttributes"));
 						} else {
 							return ac.getAttributesManager().getResourceRequiredAttributes(ac.getSession(),
 									ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
@@ -1544,12 +1544,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> attributes which MAY have filled value
 	 */
 	/*#
-	 * Tries to fill member-resource attributes and also user and user-facility attributes, if workWithUserAttributes == 1.
+	 * Tries to fill member-resource attributes and also user and user-facility attributes, if workWithUserAttributes == true.
 	 *
 	 * @param resource int Resource ID
 	 * @param member int Member ID
 	 * @param attributes List<Attribute> List of attributes
-	 * @param workWithUserAttributes int Work with user attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @return List<Attribute> attributes which MAY have filled value
 	 */
 	/*#
@@ -1640,7 +1640,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				} else if (parms.contains("member")) {
 					Member member = ac.getMemberById(parms.readInt("member"));
 					if (parms.contains("workWithUserAttributes")) {
-						if(parms.readInt("workWithUserAttributes") != 1) {
+						if(!parms.readBoolean("workWithUserAttributes")) {
 							return ac.getAttributesManager().fillAttributes(ac.getSession(),
 									resource,
 									member,
@@ -1899,7 +1899,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @param resource int Resource ID
 	 * @param group int Group ID
-	 * @param workWithGroupAttributes int Work with group attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithGroupAttributes boolean Work with group attributes. False is default value.
 	 * @param attributes List<Integer> List of attributes IDs to remove
 	 */
 	/*#
@@ -1926,7 +1926,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * member, user (optional)
 	 *
 	 * @param member int Member ID
-	 * @param workWithUserAttributes int Set to 1 if you want to remove also user attributes. 0 is default value.
+	 * @param workWithUserAttributes boolean Set to true if you want to remove also user attributes. False is default value.
 	 * @param attributes List<Integer> List of attributes IDs to remove
 	 */
 	/*#
@@ -2003,7 +2003,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				} else if (parms.contains("group")) {
 					Group group = ac.getGroupById(parms.readInt("group"));
 					if (parms.contains("workWithGroupAttributes")) {
-						ac.getAttributesManager().removeAttributes(ac.getSession(), resource, group, attributes, parms.readInt("workWithGroupAttributes") == 1 );
+						ac.getAttributesManager().removeAttributes(ac.getSession(), resource, group, attributes, parms.readBoolean("workWithGroupAttributes"));
 					} else {
 						ac.getAttributesManager().removeAttributes(ac.getSession(), resource, group, attributes);
 					}
@@ -2022,7 +2022,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("member")) {
 				if (parms.contains("workWithUserAttributes")) {
 					Member member = ac.getMemberById(parms.readInt("member"));
-					if(parms.readInt("workWithUserAttributes") != 1) {
+					if(!parms.readBoolean("workWithUserAttributes")) {
 						ac.getAttributesManager().removeAttributes(ac.getSession(), member, false, attributes);
 					} else {
 						ac.getAttributesManager().removeAttributes(ac.getSession(), member, true, attributes);
@@ -2207,10 +2207,10 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param user int User ID
 	 */
 	/*#
-	 * Unset all attributes for the facility and also user-facility attributes if workWithUserAttributes == 1.
+	 * Unset all attributes for the facility and also user-facility attributes if workWithUserAttributes == true.
 	 *
 	 * @param facility int Facility ID
-	 * @param workWithUserAttributes int Remove also user facility attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithUserAttributes boolean Remove also user facility attributes. False is default value.
 	 */
 	/*#
 	 * Unset all attributes for the facility.
@@ -2229,11 +2229,11 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param resource int Resource ID
 	 */
 	/*#
-	 * Unset all group-resource attributes and also group attributes if WorkWithGroupAttributes == 1.
+	 * Unset all group-resource attributes and also group attributes if WorkWithGroupAttributes == true.
 	 *
 	 * @param group int Group ID
 	 * @param resource int Resource ID
-	 * @param workWithGroupAttributes int Work with group attributes integer (1 = true, 0 = false). 0 is default value.
+	 * @param workWithGroupAttributes boolean Work with group attributes. False is default value.
 	 */
 	/*#
 	 * Unset all group-resource attributes.
@@ -2279,7 +2279,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							facility, ac.getUserById(parms.readInt("user")));
 				} else if (parms.contains("workWithUserAttributes")) {
 					ac.getAttributesManager().removeAllAttributes(ac.getSession(),
-							facility, parms.readInt("workWithUserAttributes") == 1);
+							facility, parms.readBoolean("workWithUserAttributes"));
 				} else {
 					ac.getAttributesManager().removeAllAttributes(ac.getSession(),
 							facility);
@@ -2302,7 +2302,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 						ac.getAttributesManager().removeAllAttributes(ac.getSession(),
 								ac.getResourceById(parms.readInt("resource")),
 								ac.getGroupById(parms.readInt("group")),
-								parms.readInt("workWithGroupAttributes") == 1);
+								parms.readBoolean("workWithGroupAttributes"));
 					} else {
 						ac.getAttributesManager().removeAllAttributes(ac.getSession(),
 								ac.getResourceById(parms.readInt("resource")),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -285,7 +285,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 	/*#
 	 * Returns "OK" string.
 	 * Helper method for GUI to keep connection alive
-	 * @exampleResponse OK
+	 * @exampleResponse "OK"
 	 * @return String "OK"
 	 */
 	keepAlive {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -27,12 +27,11 @@ public enum AuthzResolverMethod implements ManagerMethod {
 		}
 	},
 	/*#
-	 * Get all richUser administrators for complementary object and role with specify attributes.
+	 * Get all RichUser administrators for complementary object and role with specify attributes.
 	 *
-	 * If "onlyDirectAdmins" is "true", return only direct users of the complementary object for role with specific attributes.
-	 * If "allUserAttributes" is "true", do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
-	 *
-	 * @return list of richUser administrators for complementary object and role with specify attributes.
+	 * @param onlyDirectAdmins boolean When true, return only direct users of the complementary object for role with specific attributes.
+	 * @param allUserAttributes boolean When true, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 * @return List of RichUser administrators for complementary object and role with specify attributes.
 	 */
 	getRichAdmins {
 		@Override
@@ -50,15 +49,18 @@ public enum AuthzResolverMethod implements ManagerMethod {
 							parms.readInt("complementaryObjectId"),
 							parms.readString("complementaryObjectName"),
 							parms.readList("specificAttributes", String.class),
-							role, parms.readInt("onlyDirectAdmins") == 1,
-							parms.readInt("allUserAttributes") == 1);
+							role, parms.readBoolean("onlyDirectAdmins"),
+							parms.readBoolean("allUserAttributes"));
 		}
 	},
 
 	/*#
 	 * Get all authorizedGroups for complementary object and role.
 	 *
-	 * @return list of authoriedGroups for complementary object and role
+	 * @param role String Expected Role to filter authorizedGroups by.
+	 * @param complementaryObjectId int ID of complementary object to get authorizedGroups for.
+	 * @param complementaryObjectName String BeanName of complementary object = type.
+	 * @return list of authorizedGroups for complementary object and role
 	 */
 	getAdminGroups {
 		@Override
@@ -204,6 +206,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 
 	/*#
 	 * Returns 1 if user is a VO admin.
+	 * @exampleResponse 1
 	 * @return int 1 = true, 0 = false
 	 */
 	isVoAdmin {
@@ -217,6 +220,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 
 	/*#
 	 * Returns 1 if user is a Group admin.
+	 * @exampleResponse 1
 	 * @return int 1 = true, 0 = false
 	 */
 	isGroupAdmin {
@@ -230,6 +234,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 
 	/*#
 	 * Returns 1 if user is a Facility admin.
+	 * @exampleResponse 1
 	 * @return int 1 = true, 0 = false
 	 */
 	isFacilityAdmin {
@@ -243,6 +248,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 
 	/*#
 	 * Returns 1 if user is a Perun admin.
+	 * @exampleResponse 1
 	 * @return int 1 = true, 0 = false
 	 */
 	isPerunAdmin {
@@ -279,7 +285,7 @@ public enum AuthzResolverMethod implements ManagerMethod {
 	/*#
 	 * Returns "OK" string.
 	 * Helper method for GUI to keep connection alive
-	 *
+	 * @exampleResponse OK
 	 * @return String "OK"
 	 */
 	keepAlive {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/CabinetManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/CabinetManagerMethod.java
@@ -502,17 +502,17 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-		* Locks and unlocks publications.
-		* @param publications List<Publication> Publications
-		* @param lock int 1 = lock, 0 = unlock
-		* @return int Number of updated rows
-		*/
+	 * Locks and unlocks publications.
+	 * @param publications List<Publication> Publications
+	 * @param lock boolean true = lock, false = unlock
+	 * @return int Number of updated rows
+	 */
 	lockPublications {
 		public Integer call(ApiCaller ac, Deserializer parms) throws PerunException, CabinetException {
 			ac.stateChangingCheck();
 
 			List<Publication> pubs = parms.readList("publications", Publication.class);
-			boolean lockState = parms.readInt("lock") == 1 ? true : false;
+			boolean lockState = parms.readBoolean("lock");
 			return ac.getCabinetManager().lockPublications(ac.getSession(), lockState, pubs);
 
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/DatabaseManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/DatabaseManagerMethod.java
@@ -8,9 +8,10 @@ import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 public enum DatabaseManagerMethod implements ManagerMethod {
 
 	/*#
-	 * Gets current version DB like string (ex. 1.1.1)
+	 * Gets current version of DB schema like String (ex. 1.1.1).
 	 *
-	 * @return Object current version DB like String
+	 * @exampleResponse "3.1.21"
+	 * @return String Current version of DB schema like String
 	 */
 	getCurrentDatabaseVersion {
 
@@ -24,7 +25,8 @@ public enum DatabaseManagerMethod implements ManagerMethod {
 	/*#
 	 * Gets current database driver name and version
 	 *
-	 * @return Object current database driver name and version
+	 *@exampleResponse "PostgreSQL Native Driver-PostgreSQL 9.0 JDBC4 (build 801)"
+	 * @return String Current database driver name and version
 	 */
 	getDatabaseDriverInformation {
 
@@ -38,7 +40,8 @@ public enum DatabaseManagerMethod implements ManagerMethod {
 	/*#
 	 * Gets current database name and version
 	 *
-	 * @return Object current database name and version
+	 * @exampleResponse "PostgreSQL-9.1.15"
+	 * @return String Current database name and version
 	 */
 	getDatabaseInformation {
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -579,8 +579,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	/*#
 	 * Get all Facility admins.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param facility int Facility ID
 	 * @return List<User> List of Users who are admins in the facility.
 	 */
@@ -603,12 +602,10 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	/*#
 	 * Get all Facility direct admins.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param facility int Facility ID
 	 * @return List<User> list of admins of the facility
 	 */
-	@Deprecated
 	getDirectAdmins {
 
 		@Override
@@ -652,9 +649,8 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	 */
 	/*#
     * Get all Facility admins as RichUsers
-    *
-	* !!! DEPRECATED version !!!
 	*
+	* @deprecated
     * @param facility int Facility ID
     * @return List<RichUser> admins
     */
@@ -679,12 +675,10 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	/*#
 	* Get all Facility admins as RichUsers with all their non-null user attributes
 	*
-	* !!! DEPRECATED version !!!
-	*
+	* @deprecated
 	* @param facility int Facility ID
 	* @return List<RichUser> admins with attributes
 	*/
-	@Deprecated
 	getRichAdminsWithAttributes {
 
 		@Override
@@ -698,13 +692,11 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	/*#
 	* Get all Facility admins as RichUsers with specific attributes (from user namespace)
 	*
-	* !!! DEPRECATED version !!!
-	*
+	* @deprecated
 	* @param facility int Facility ID
 	* @param specificAttributes List<String> list of attributes URNs
 	* @return List<RichUser> admins with attributes
 	*/
-	@Deprecated
 	getRichAdminsWithSpecificAttributes {
 
 		@Override
@@ -720,13 +712,11 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	* Get all Facility admins, which are assigned directly,
 	* as RichUsers with specific attributes (from user namespace)
 	*
-	* !!! DEPRECATED version !!!
-	*
+	* @deprecated
 	* @param facility int Facility ID
 	* @param specificAttributes List<String> list of attributes URNs
 	* @return List<RichUser> direct admins with attributes
 	*/
-	@Deprecated
 	getDirectRichAdminsWithSpecificAttributes {
 
 		@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -567,12 +567,12 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	/*#
 	 * Get list of all facility administrators for supported role and given facility.
 	 *
-	 * If onlyDirectAdmins is == 1, return only direct admins of the group for supported role.
+	 * If onlyDirectAdmins is == true, return only direct admins of the group for supported role.
 	 *
 	 * Supported roles: FacilityAdmin
 	 *
 	 * @param facility int Facility ID
-	 * @param onlyDirectAdmins int if == 1, get only direct facility administrators (if != 1, get both direct and indirect)
+	 * @param onlyDirectAdmins boolean if true, get only direct facility administrators (if false, get both direct and indirect)
 	 *
 	 * @return List<User> list of all facility administrators of the given facility for supported role
 	 */
@@ -591,7 +591,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 			if(parms.contains("onlyDirectAdmins")) {
 				return ac.getFacilitiesManager().getAdmins(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")),
-					parms.readInt("onlyDirectAdmins") ==1);
+					parms.readBoolean("onlyDirectAdmins"));
 			} else {
 				return ac.getFacilitiesManager().getAdmins(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")));
@@ -637,13 +637,13 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	 *
 	 * Supported roles: FacilityAdmin
 	 *
-	 * If "onlyDirectAdmins" is == 1, return only direct admins of the facility for supported role with specific attributes.
-	 * If "allUserAttributes" is == 1, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 * If "onlyDirectAdmins" is true, return only direct admins of the facility for supported role with specific attributes.
+	 * If "allUserAttributes" is true, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
 	 *
 	 * @param facility int Facility ID
 	 * @param specificAttributes List<String> list of specified attributes which are needed in object richUser
-	 * @param allUserAttributes int if == 1, get all possible user attributes and ignore list of specificAttributes (if != 1, get only specific attributes)
-	 * @param onlyDirectAdmins int if == 1, get only direct facility administrators (if != 1, get both direct and indirect)
+	 * @param allUserAttributes int if == true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins int if == true, get only direct facility administrators (if false, get both direct and indirect)
 	 *
 	 * @return List<RichUser> list of RichUser administrators for the facility and supported role with attributes
 	 */
@@ -663,8 +663,8 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")),
 					parms.readList("specificAttributes", String.class),
-					parms.readInt("allUserAttributes") == 1,
-					parms.readInt("onlyDirectAdmins") == 1);
+					parms.readBoolean("allUserAttributes"),
+					parms.readBoolean("onlyDirectAdmins"));
 			} else {
 				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")));

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GeneralServiceManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GeneralServiceManagerMethod.java
@@ -190,6 +190,7 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 	 *
 	 * @param execService int ExecService ID
 	 * @param facility int Facility ID
+	 * @exampleResponse 1
 	 * @return int 1 = true - the execService is denied on the facility, 0 = false - the execService in NOT denied on the facility
 	 */
 	isExecServiceDeniedOnFacility {
@@ -206,6 +207,7 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 	 *
 	 * @param service int Service ID
 	 * @param facility int Facility ID
+	 * @exampleResponse 1
 	 * @return int 1 = true - the service is denied on the facility, 0 = false - the service in NOT denied on the facility
 	 */
 	isServiceDeniedOnFacility {
@@ -227,6 +229,7 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 	 *
 	 * @param execService int ExecService ID
 	 * @param destination int Destination ID
+	 * @exampleResponse 1
 	 * @return int 1 = true - the execService is denied on the destination, 0 = false - the execService in NOT denied on the destination
 	 */
 	isExecServiceDeniedOnDestination {
@@ -326,6 +329,7 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 	 *
 	 * @param dependantExecService int DependantExecService ID
 	 * @param execService int ExecService ID
+	 * @exampleResponse 1
 	 * @return int 1 = true - yes, there is such a dependency, 0 = false - no, there is not such a dependency
 	 */
 	isThereDependency {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -56,15 +56,15 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Deletes a group.
+	 * Deletes a group. Group is not deleted, if contains members or is assigned to any resource.
 	 *
 	 * @param group int Group ID
 	 */
 	/*#
-	 * Deletes a group (force).
+	 * Forcefully deletes a group (remove all group members, remove group from resources).
 	 *
 	 * @param group int Group ID
-	 * @param force int Force must be 1
+	 * @param force boolean If true use force delete.
 	 */
 	deleteGroup {
 
@@ -72,7 +72,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
-			if(parms.contains("force") && parms.readInt("force") == 1) {
+			if(parms.contains("force") && parms.readBoolean("force")) {
 				ac.getGroupsManager().deleteGroup(ac.getSession(),
 						ac.getGroupById(parms.readInt("group")), true);
 				return null;
@@ -83,12 +83,12 @@ public enum GroupsManagerMethod implements ManagerMethod {
 			}
 		}
 	},
-	
+
 	/*#
-	 * Delete groups (force).
+	 * Forcefully deletes a list of groups (remove all group members, remove group from resources).
 	 *
-	 * @param groups list of groups
-	 * @param forceDelete int 
+	 * @param groups int[] Array of Group IDs
+	 * @param forceDelete boolean If true use force delete.
 	 */
 	deleteGroups {
 		
@@ -105,7 +105,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 			
 			ac.getGroupsManager().deleteGroups(ac.getSession(),
 					groups,
-					parms.readInt("forceDelete") == 1);
+					parms.readBoolean("forceDelete"));
 			return null;
 		}
 	},
@@ -384,12 +384,12 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	/*#
 	 * Get list of all group administrators for supported role and specific group.
 	 *
-	 * If onlyDirectAdmins is == 1, return only direct admins of the group for supported role.
+	 * If onlyDirectAdmins is == true, return only direct admins of the group for supported role.
 	 *
 	 * Supported roles: GroupAdmin
 	 *
 	 * @param group int Group ID
-	 * @param onlyDirectAdmins int if == 1, get only direct user administrators (if == 0, get both direct and indirect)
+	 * @param onlyDirectAdmins int if == true, get only direct user administrators (if == false, get both direct and indirect)
 	 *
 	 * @return List<User> list of all group administrators of the given group for supported role
 	 */
@@ -407,7 +407,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 			if(parms.contains("onlyDirectAdmins")) {
 				return ac.getGroupsManager().getAdmins(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")),
-					parms.readInt("onlyDirectAdmins") == 1);
+					parms.readBoolean("onlyDirectAdmins"));
 			} else {
 				return ac.getGroupsManager().getAdmins(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")));
@@ -451,13 +451,13 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 *
 	 * Supported roles: GroupAdmin
 	 *
-	 * If "onlyDirectAdmins" is == 1, return only direct admins of the group for supported role with specific attributes.
-	 * If "allUserAttributes" is == 1, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 * If "onlyDirectAdmins" is == true, return only direct admins of the group for supported role with specific attributes.
+	 * If "allUserAttributes" is == true, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
 	 *
 	 * @param group int Group ID
 	 * @param specificAttributes List<String> list of specified attributes which are needed in object richUser
-	 * @param allUserAttributes int if == 1, get all possible user attributes and ignore list of specificAttributes (if != 1, get only specific attributes)
-	 * @param onlyDirectAdmins int if == 1, get only direct group administrators (if != 1, get both direct and indirect)
+	 * @param allUserAttributes int if == true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins int if == true, get only direct group administrators (if false, get both direct and indirect)
 	 *
 	 * @return List<RichUser> list of RichUser administrators for the group and supported role with attributes
 	 */
@@ -476,8 +476,8 @@ public enum GroupsManagerMethod implements ManagerMethod {
 				return ac.getGroupsManager().getRichAdmins(ac.getSession(),
 								ac.getGroupById(parms.readInt("group")),
 								parms.readList("specificAttributes", String.class),
-								parms.readInt("allUserAttributes") == 1,
-								parms.readInt("onlyDirectAdmins") == 1);
+								parms.readBoolean("allUserAttributes"),
+								parms.readBoolean("onlyDirectAdmins"));
 			} else {
 				return ac.getGroupsManager().getRichAdmins(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")));

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -396,8 +396,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns administrators of a group.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param group int Group ID
 	 * @return List<User> Group admins
 	 */
@@ -419,12 +418,10 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns direct administrators of a group.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param group int Group ID
 	 * @return List<User> Group admins
 	 */
-	@Deprecated
 	getDirectAdmins {
 
 		@Override
@@ -467,8 +464,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	/*#
 	* Get all Group admins as RichUsers
 	*
-	* !!! DEPRECATED version !!!
-	*
+	* @deprecated
 	* @param group int Group ID
 	* @return List<RichUser> admins
 	*/
@@ -492,12 +488,10 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	/*#
 	* Get all Group admins as RichUsers with all their non-null user attributes
 	*
-	* !!! DEPRECATED version !!!
-	*
+	* @deprecated
 	* @param group int Group ID
 	* @return List<RichUser> admins with attributes
 	*/
-	@Deprecated
 	getRichAdminsWithAttributes {
 
 		@Override
@@ -510,13 +504,11 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	/*#
 	* Get all Group admins as RichUsers with specific attributes (from user namespace)
 	*
-	* !!! DEPRECATED version !!!
-	*
+	* @deprecated
 	* @param group int Group ID
 	* @param specificAttributes List<String> list of attributes URNs
 	* @return List<RichUser> admins with attributes
 	*/
-	@Deprecated
 	getRichAdminsWithSpecificAttributes {
 
 		@Override
@@ -532,13 +524,11 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	* Get all Group admins, which are assigned directly,
 	*  as RichUsers with specific attributes (from user namespace)
 	*
-	* !!! DEPRECATED version !!!
-	*
+	* @deprecated
 	* @param group int Group ID
 	* @param specificAttributes List<String> list of attributes URNs
 	* @return List<RichUser> direct admins with attributes
 	*/
-	@Deprecated
 	getDirectRichAdminsWithSpecificAttributes {
 
 		@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -234,7 +234,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 *
  	 * @param vo int Vo ID
  	 * @param attrsNames List<String> Attribute names
- 	 * @return list of richMembers with specific attributes from Vo
+ 	 * @return List<RichMember> List of RichMembers with specific attributes from Vo
  	 */
 	/*#
  	 * Get all RichMembers with attributes specific for list of attrsNames from the group and have only
@@ -248,7 +248,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 * @param group int Group ID
  	 * @param attrsNames List<String> Attribute names
  	 * @param allowedStatuses List<String> Allowed Statuses
- 	 * @param lookingInParentGroup int 1 = True, 0 = False
+ 	 * @param lookingInParentGroup boolean If true, look up in a parent group
  	 * @return List<RichMember> List of richMembers with specific attributes from group
  	 */
 	/*#
@@ -260,7 +260,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 *
  	 * @param group int Group ID
  	 * @param attrsNames List<String> Attribute names
- 	 * @param lookingInParentGroup int 1 = True, 0 = False
+ 	 * @param lookingInParentGroup If true, look up in a parent group
  	 * @return List<RichMember> List of richMembers with specific attributes from Group
  	 */
 	getCompleteRichMembers {
@@ -301,14 +301,14 @@ public enum MembersManagerMethod implements ManagerMethod {
 								ac.getGroupById(parms.readInt("group")),
 								parms.readList("attrsNames", String.class),
 								parms.readList("allowedStatuses", String.class),
-								parms.readInt("lookingInParentGroup") == 1);
+								parms.readBoolean("lookingInParentGroup"));
 					} else {
 						// with all attributes
 						return ac.getMembersManager().getCompleteRichMembers(ac.getSession(),
 								ac.getGroupById(parms.readInt("group")),
 								null,
 								parms.readList("allowedStatuses", String.class),
-								parms.readInt("lookingInParentGroup") == 1);
+								parms.readBoolean("lookingInParentGroup"));
 					}
 				} else {
 					if (parms.contains("attrsNames")) {
@@ -316,13 +316,13 @@ public enum MembersManagerMethod implements ManagerMethod {
 						return ac.getMembersManager().getCompleteRichMembers(ac.getSession(),
 								ac.getGroupById(parms.readInt("group")),
 								parms.readList("attrsNames", String.class),
-								parms.readInt("lookingInParentGroup") == 1);
+								parms.readBoolean("lookingInParentGroup"));
 					} else {
 						// with all attributes
 						return ac.getMembersManager().getCompleteRichMembers(ac.getSession(),
 								ac.getGroupById(parms.readInt("group")),
 								null,
-								parms.readInt("lookingInParentGroup") == 1);
+								parms.readBoolean("lookingInParentGroup"));
 					}
 				}
 			}
@@ -637,7 +637,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 * @param attrsNames List<String> Attribute names
  	 * @param allowedStatuses List<String> Allowed statuses
  	 * @param searchString String String to search by
- 	 * @param lookingInParentGroup int 1 = True, 0 = False
+ 	 * @param lookingInParentGroup If true, look up in a parent group
  	 * @return List<RichMember> List of founded richMembers with specific attributes from Group for searchString
  	 */
 	/*#
@@ -650,7 +650,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 * @param group int Group ID
  	 * @param attrsNames List<String> Attribute names
  	 * @param searchString String String to search by
- 	 * @param lookingInParentGroup int 1 = True, 0 = False
+ 	 * @param lookingInParentGroup If true, look up in a parent group
  	 * @return List<RichMember> List of founded richMembers with specific attributes from Group for searchString
  	 */
 	findCompleteRichMembers {
@@ -676,13 +676,13 @@ public enum MembersManagerMethod implements ManagerMethod {
 							parms.readList("attrsNames", String.class),
 							parms.readList("allowedStatuses", String.class),
 							parms.readString("searchString"),
-							parms.readInt("lookingInParentGroup") == 1);
+							parms.readBoolean("lookingInParentGroup"));
 				} else {
 					return ac.getMembersManager().findCompleteRichMembers(ac.getSession(),
 							ac.getGroupById(parms.readInt("group")),
 							parms.readList("attrsNames", String.class),
 							parms.readString("searchString"),
-							parms.readInt("lookingInParentGroup") == 1);
+							parms.readBoolean("lookingInParentGroup"));
 				}
 			}
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -655,7 +655,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	 *
 	 * @param m String Parameter m
 	 * @param i String Parameter i
-	 * @return bool True for validated, false for non-valid
+	 * @return boolean True for validated, false for non-valid
 	 */
 	validateEmail {
 
@@ -1062,7 +1062,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	 *
 	 *	@param challenge String Captcha challenge
 	 *	@param response String User response
-	 *	@return bool True if it is valid, False if failed
+	 *	@return boolean True if it is valid, False if failed
 	 */
 	verifyCaptcha {
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -1039,7 +1039,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	 * Enable or disable sending for list of mail definitions.
 	 *
 	 * @param mails List<ApplicationMail> Mail definitions to update
-	 * @param enabled int 1 for enabled, 0 for disabled
+	 * @param enabled boolean true for enabled, false for disabled
 	 * @return Object Always null
 	 */
 	setSendingEnabled {
@@ -1050,7 +1050,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 			ac.getRegistrarManager().getMailManager().setSendingEnabled(ac.getSession(),
 					parms.readList("mails", ApplicationMail.class),
-					parms.readInt("enabled")==1 ? true : false);
+					parms.readBoolean("enabled"));
 
 			return null;
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -34,6 +34,14 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 		}
 	},
 
+	/*#
+     * Returns resource by its name, Vo ID and Facility ID.
+     *
+     * @param vo int VO ID
+     * @param facility int Facility ID
+     * @param name String resource name
+     * @return Resource Found Resource based on the input.
+     */
 	getResourceByName {
 		@Override
 		public Resource call(ApiCaller ac, Deserializer parms) throws PerunException {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -194,7 +194,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			return ac.getUsersManager().getAllRichUsers(ac.getSession(),
-					parms.readInt("includedServiceUsers") == 1);
+					parms.readBoolean("includedServiceUsers"));
 		}
 	},
 
@@ -209,7 +209,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			return ac.getUsersManager().getAllRichUsersWithAttributes(ac.getSession(),
-					parms.readInt("includedServiceUsers") == 1);
+					parms.readBoolean("includedServiceUsers"));
 		}
 	},
 
@@ -279,11 +279,11 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 			if (parms.contains("attrsNames")) {
 				return ac.getUsersManager().getAllRichUsersWithAttributes(ac.getSession(),
-						parms.readInt("includedServiceUsers") == 1,
+						parms.readBoolean("includedServiceUsers"),
 						parms.readList("attrsNames", String.class));
 			} else {
 				return ac.getUsersManager().getAllRichUsersWithAttributes(ac.getSession(),
-						parms.readInt("includedServiceUsers") == 1, null);
+						parms.readBoolean("includedServiceUsers"), null);
 			}
 		}
 	},
@@ -356,16 +356,16 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Deletes a user.
+	 * Deletes a user. User is not deleted, if is member of any VO or is associated with any service identity.
 	 *
 	 * @param user int User ID
 	 */
 	/*#
 	 * Deletes a user (force).
-	 * Also removes associeted members.
+	 * Also removes associated members.
 	 *
 	 * @param user int User ID
-	 * @param force int Parameter force must == 1
+	 * @param force boolean If true, use force deletion.
 	 */
 	deleteUser {
 
@@ -373,7 +373,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
-			if (parms.contains("force") && parms.readInt("force") == 1) {
+			if (parms.contains("force") && parms.readBoolean("force")) {
 				ac.getUsersManager().deleteUser(ac.getSession(),
 						ac.getUserById(parms.readInt("user")), true);
 			} else {
@@ -782,6 +782,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 *
 	 * @param loginNamespace String Namespace
 	 * @param login String Login
+	 * @exampleResponse 1
 	 * @return int 1: login available, 0: login not available
 	 */
 	isLoginAvailable {
@@ -831,7 +832,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param user int User ID
 	 * @param loginNamespace String Namespace
 	 * @param newPassword String New password
-	 * @param checkOldPassword int checkOldPassword must be 0
+	 * @param checkOldPassword boolean Must be false
 	 */
 	/*#
 	 * Changes user password in defined login-namespace.
@@ -841,14 +842,14 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param loginNamespace String Namespace
 	 * @param oldPassword String Old password which will be checked.
 	 * @param newPassword String New password
-	 * @param checkOldPassword int checkOldPassword must be 1
+	 * @param checkOldPassword boolean Must be true
 	 */
 	changePassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			User user = ac.getUserById(parms.readInt("user"));
 
-			if (parms.readInt("checkOldPassword") == 1) {
+			if (parms.readBoolean("checkOldPassword")) {
 				ac.getUsersManager().changePassword(ac.getSession(), user, parms.readString("loginNamespace"), parms.readString("oldPassword"), parms.readString("newPassword"), true);
 			} else {
 				ac.getUsersManager().changePassword(ac.getSession(), user, parms.readString("loginNamespace"), parms.readString("oldPassword"), parms.readString("newPassword"), false);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -37,7 +37,7 @@ public enum VosManagerMethod implements ManagerMethod {
 	 * Deletes a VO (force).
 	 *
 	 * @param vo int VO ID
-	 * @param force int Force must be 1
+	 * @param force boolean Force must be true
 	 */
 	deleteVo {
 		@Override
@@ -45,7 +45,7 @@ public enum VosManagerMethod implements ManagerMethod {
 			ac.stateChangingCheck();
 
 			if (parms.contains("force")) {
-				ac.getVosManager().deleteVo(ac.getSession(), ac.getVoById(parms.readInt("vo")), parms.readInt("force") == 1);
+				ac.getVosManager().deleteVo(ac.getSession(), ac.getVoById(parms.readInt("vo")), parms.readBoolean("force"));
 			} else {
 				ac.getVosManager().deleteVo(ac.getSession(), ac.getVoById(parms.readInt("vo")));
 			}
@@ -206,13 +206,13 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Get list of all vo administrators for supported role and specific vo.
 	 *
-	 * If onlyDirectAdmins is == 1, return only direct admins of the vo for supported role.
+	 * If onlyDirectAdmins is true, return only direct admins of the vo for supported role.
 	 *
 	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
 	 *
 	 * @param vo int VO ID
 	 * @param role String supported role name
-	 * @param onlyDirectAdmins int if == 1, get only direct VO administrators (if != 1, get both direct and indirect)
+	 * @param onlyDirectAdmins boolean if true, get only direct VO administrators (if false, get both direct and indirect)
 	 *
 	 * @return List<User> list of all user administrators of the given vo for supported role
 	 */
@@ -237,7 +237,7 @@ public enum VosManagerMethod implements ManagerMethod {
 
 				return ac.getVosManager().getAdmins(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")),
-					role, parms.readInt("onlyDirectAdmins") == 1);
+					role, parms.readBoolean("onlyDirectAdmins"));
 			} else {
 				return ac.getVosManager().getAdmins(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")));
@@ -304,14 +304,14 @@ public enum VosManagerMethod implements ManagerMethod {
 	 *
 	 * Supported roles: VoObserver, TopGroupCreator, VoAdmin
 	 *
-	 * If "onlyDirectAdmins" is == 1, return only direct admins of the vo for supported role with specific attributes.
-	 * If "allUserAttributes" is == 1, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
+	 * If "onlyDirectAdmins" is == true, return only direct admins of the vo for supported role with specific attributes.
+	 * If "allUserAttributes" is == true, do not specify attributes through list and return them all in objects richUser. Ignoring list of specific attributes.
 	 *
 	 * @param vo int VO Id
 	 * @param role String role name
 	 * @param specificAttributes List<String> list of specified attributes which are needed in object richUser
-	 * @param allUserAttributes int if == 1, get all possible user attributes and ignore list of specificAttributes (if != 1, get only specific attributes)
-	 * @param onlyDirectAdmins int if == 1, get only direct vo administrators (if != 1, get both direct and indirect)
+	 * @param allUserAttributes boolean if == true, get all possible user attributes and ignore list of specificAttributes (if false, get only specific attributes)
+	 * @param onlyDirectAdmins boolean if == true, get only direct vo administrators (if false, get both direct and indirect)
 	 *
 	 * @return List<RichUser> list of RichUser administrators for the vo and supported role with attributes
 	 */
@@ -337,8 +337,8 @@ public enum VosManagerMethod implements ManagerMethod {
 				return ac.getVosManager().getRichAdmins(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")),
 					role, parms.readList("specificAttributes", String.class),
-					parms.readInt("allUserAttributes") == 1,
-					parms.readInt("onlyDirectAdmins") == 1);
+					parms.readBoolean("allUserAttributes"),
+					parms.readBoolean("onlyDirectAdmins"));
 			} else {
 				return ac.getVosManager().getRichAdmins(ac.getSession(),
 					ac.getVoById(parms.readInt("vo")));

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -219,8 +219,7 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns administrators of a VO.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param vo int VO ID
 	 * @return List<User> VO admins
 	 */
@@ -249,12 +248,10 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns direct administrators of a VO.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param vo int VO ID
 	 * @return List<User> VO admins
 	 */
-	@Deprecated
 	getDirectAdmins {
 		@Override
 		public List<User> call(ApiCaller ac, Deserializer parms)
@@ -277,8 +274,7 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns group administrators of a VO.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param vo int VO ID
 	 * @return List<User> VO admins
 	 */
@@ -322,8 +318,7 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns administrators of a VO.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param vo int VO ID
 	 * @return List<RichUser> VO admins
 	 */
@@ -353,12 +348,10 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns administrators of a VO with additional information.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param vo int VO ID
 	 * @return List<RichUser> VO admins
 	 */
-	@Deprecated
 	getRichAdminsWithAttributes {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms)
@@ -371,13 +364,11 @@ public enum VosManagerMethod implements ManagerMethod {
 	/*#
 	 * Returns administrators of a VO with additional information.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param vo int VO ID
 	 * @param specificAttributes List<String> list of attributes URNs
 	 * @return List<RichUser> VO rich admins with attributes
 	 */
-	@Deprecated
 	getRichAdminsWithSpecificAttributes {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {
@@ -392,13 +383,11 @@ public enum VosManagerMethod implements ManagerMethod {
 	 * Returns administrators of a VO, which are directly assigned
 	 * with additional information.
 	 *
-	 * !!! DEPRECATED version !!!
-	 *
+	 * @deprecated
 	 * @param vo int VO ID
 	 * @param specificAttributes List<String> list of attributes URNs
 	 * @return List<RichUser> VO rich admins with attributes
 	 */
-	@Deprecated
 	getDirectRichAdminsWithSpecificAttributes {
 		@Override
 		public List<RichUser> call(ApiCaller ac, Deserializer parms) throws PerunException {


### PR DESCRIPTION
- Use @deprecated in our javadoc instead of comment in
  main description. It's ok for old docs parser and will be used
  for new one.

- When RPC reads boolean values it can parse also string and
  number. Use it in necessary methods instead of reading int.

  There is only one logical change, since previously only 1 was
  considered TRUE and other numbers FALSE. Now only 0 is considered
  FALSE and any other number is considered TRUE.

- UrlDeserializer now also conform above description.

- Added @exampleResponse tag to our javadoc. It's useful for methods,
  which return generic type but with specific meaning.

- Fixed documentation of few methods in RPC javadoc.