### PR TITLE
Use safer move (diff move) for k5login file

### DIFF
--- a/perun-services/slave/perun
+++ b/perun-services/slave/perun
@@ -41,7 +41,30 @@ E_FROM_PERUN_FILE=(208 'FROM_PERUN file (to diff_update) does not exists or it i
 E_DESTINATION_FILE=(209 'Destination file (to diff_update) does not exists or do not have right persmissions')
 E_PERMISSIONS=(210 'Cannot set permissions')
 
+### declare list of all items in trap on exit
+declare -a on_exit_items
+
 ### Functions
+
+### for purpose of evaluating all on_exit items
+function on_exit()
+{
+    for i in "${on_exit_items[@]}"
+    do
+        eval $i
+    done
+}
+
+### add new on_exit item
+function add_on_exit()
+{
+    local n=${#on_exit_items[*]}
+    on_exit_items[$n]="$*"
+    if [[ $n -eq 0 ]]; then
+        trap on_exit EXIT
+    fi
+}
+
 function log_msg {
 	CODE=`eval echo '${'$1'[0]}'`
 	TEXT=`eval echo '${'$1'[1]}'`
@@ -96,7 +119,7 @@ function catch_error {
 
 function create_lock {
 	if mkdir "${LOCK_FILE}"; then
-		trap 'rm -r -f "${WORK_DIR}" "${LOCK_FILE}"' EXIT
+		add_on_exit 'rm -r -f "${LOCK_FILE}"'
 		catch_error E_LOCK_PIDFILE echo $$ > "$LOCK_PIDFILE"
 	else
 		# lock file exists, check for existence of concurrent process
@@ -108,7 +131,7 @@ function create_lock {
 			catch_error E_LOCK_DELETE rm -r "$LOCK_FILE"
 			echo "Invalid lock file found and deleted: $LOCK_FILE" >&2
 			catch_error E_LOCK_FILE mkdir "${LOCK_FILE}"
-			trap 'rm -r -f "${WORK_DIR}" "${LOCK_FILE}"' EXIT
+			add_on_exit 'rm -r -f "${LOCK_FILE}"'
 			catch_error E_LOCK_PIDFILE echo $$ > "$LOCK_PIDFILE"
 		fi
 	fi
@@ -227,7 +250,7 @@ function run_post_hooks {
 
 WORK_DIR=`mktemp -d ${TMPDIR:-/tmp}/${NAME}.XXXXXXXXXX`
 [ $? -ne 0 ] && log_msg E_WORK_DIR
-trap 'rm -r -f "${WORK_DIR}"' EXIT
+add_on_exit 'rm -r -f "${WORK_DIR}"'
 
 ### Receive and process data
 catch_error E_TAR_FILES tar --no-same-owner --no-same-permissions -x -C "${WORK_DIR}" <&0

--- a/perun-services/slave/process-k5login.sh
+++ b/perun-services/slave/process-k5login.sh
@@ -5,11 +5,16 @@ PROTOCOL_VERSION='3.0.0'
 
 function process {
 	### Status codes
-	I_K5LOGIN_CREATED=(0 '${HOME_DIR}/.k5login with entries ${PRINCIPALS} created.')
-	I_K5LOGIN_UPDATED=(0 '${HOME_DIR}/.k5login updated. Added entries are ${ADDED_PRINCIPALS}.')
+	I_K5LOGIN_CREATED=(0 '${K5LOGIN} with entries ${PRINCIPALS} created.')
+	I_K5LOGIN_UPDATED=(0 '${K5LOGIN} updated. Added entries are ${ADDED_PRINCIPALS}.')
+	I_K5LOGIN_NOT_UPDATED=(0 '${K5LOGIN} not updated. Nothing to add.')
 
 	E_DIR_NOT_EXISTS=(50 'Home directory ${HOME_DIR} does not exits.')
-	E_CHANGE_OWNER=(51 'Change owner on ${HOME_DIR}/.k5login failed.')
+	E_CHANGE_OWNER=(51 'Change owner on ${TMP_K5LOGIN} failed.')
+	E_K5LOGIN_NOT_CREATED=(52 'Move diff from ${TMP_K5LOGIN} to ${HOME_DIR}/.k5login failed.')
+	E_CANNOT_COPY_K5LOGIN=(53 'Cannot create copy of ${HOME_DIR}/.k5login to ${TMP_K5LOGIN}')
+	E_CANNOT_REMOVE_TMP_K5LOGIN=(54 'Cannot remove ${TMP_K5LOGIN} file.')
+	E_CANNOT_CREATE_TMP_K5LOGIN=(55 'Cannot create temporary ${TMP_K5LOGIN} file.')
 
 	FROM_PERUN="${WORK_DIR}/k5login"
 
@@ -20,44 +25,52 @@ function process {
 	do
 		HOME_DIR=`echo "${line}" | awk '{ print $1 };'`
 		PRINCIPALS=`echo "${line}" | sed -e 's/^[^\t]*[\t]//'`
+		K5LOGIN="${HOME_DIR}/.k5login"
+		TMP_K5LOGIN="${HOME_DIR}/.k5login-from-perun-$$.tmp"
+
+		add_on_exit 'rm -f "${TMP_K5LOGIN}"'
 
 		catch_error E_DIR_NOT_EXISTS cd "${HOME_DIR}"
 
-		# If .k5login doesn't exist, create it and fill it with proper principals
-		if [ ! -f "${HOME_DIR}/.k5login" ]; then
-			log_debug "File ${HOME_DIR}/.k5login not exists and need to be created."
-			for PRINCIPAL in ${PRINCIPALS}; do
-				echo "${PRINCIPAL}" >> "${HOME_DIR}/.k5login"
-			done
-			log_debug "If not exists, file ${HOME_DIR}/.k5login was created and ${PRINCIPALS} were added into it."
-
-			# Setup rights, the .k5login will have the same owner and group as user's home directory
-			F_USER=`ls -ld "${HOME_DIR}" | awk '{ print $3; }'`
-			F_GROUP=`ls -ld "${HOME_DIR}" | awk '{ print $4; }'`
-			catch_error E_CHANGE_OWNER chown ${F_USER}.${F_GROUP} "${HOME_DIR}/.k5login"
-
-			F_USER_REAL=`ls -ld "${HOME_DIR}" | awk '{ print $3; }'`
-			F_GROUP_REAL=`ls -ld "${HOME_DIR}" | awk '{ print $4; }'`
-			log_debug "Owner was changed for file ${HOME_DIR}/.k5login. New owner is ${F_USER_REAL}:${F_GROUP_REAL} (expected ${F_USER}:${F_GROUP})"
-
-			catch_error E_PERMISSIONS chmod 0644 "${HOME_DIR}/.k5login"
-			K5LOGIN_PERMISSIONS=`stat -L -c %a "${HOME_DIR}/.k5login"`
-			log_debug "Permissions was set to ${K5LOGIN_PERMISSIONS} for file ${HOME_DIR}/.k5login (expected 0644)"
-
-			log_msg I_K5LOGIN_CREATED
+		#create new tmp file
+		if [ ! -f "${K5LOGIN}" ]; then
+			catch_error E_CANNOT_CREATE_TMP_K5LOGIN touch ${TMP_K5LOGIN}
+			K5LOGIN_EXISTS=true
 		else
-			# .k5login exists. So only add missing entries.
-			ADDED_PRINCIPALS=""
-			for principal in ${PRINCIPALS}; do
-				grep "^${principal}\\s*\$" "${HOME_DIR}/.k5login" > /dev/null
-				if [ $? -eq 1 ]; then
-					ADDED_PRINCIPALS="$ADDED_PRINCIPALS ${principal}"
-					echo "${principal}" >> "${HOME_DIR}/.k5login"
-				fi
-			done
-			if [ -n "$ADDED_PRINCIPALS" ]; then
-				log_msg I_K5LOGIN_UPDATED
+			catch_error E_CANNOT_COPY_K5LOGIN cp -p "${K5LOGIN}" "${TMP_K5LOGIN}"
+			K5LOGIN_EXISTS=false
+		fi
+
+		#add not existing principals
+		ADDED_PRINCIPALS=""
+		for PRINCIPAL in ${PRINCIPALS}; do
+			grep "^${PRINCIPAL}\\s*\$" "${TMP_K5LOGIN}" > /dev/null
+			if [ $? -eq 1 ]; then
+				ADDED_PRINCIPALS="$ADDED_PRINCIPALS ${PRINCIPAL}"
+				echo "${PRINCIPAL}" >> "${TMP_K5LOGIN}"
 			fi
+		done 
+		
+		# Setup rights, the k5login temp file will have the same owner and group as user's home directory
+		F_USER=`ls -ld "${HOME_DIR}" | awk '{ print $3; }'`
+		F_GROUP=`ls -ld "${HOME_DIR}" | awk '{ print $4; }'`
+		catch_error E_CHANGE_OWNER chown ${F_USER}.${F_GROUP} "${TMP_K5LOGIN}"
+
+		F_USER_REAL=`ls -l "${TMP_K5LOGIN}" | awk '{ print $3; }'`
+		F_GROUP_REAL=`ls -l "${TMP_K5LOGIN}" | awk '{ print $4; }'`
+		log_debug "Owner was changed for file ${TMP_K5LOGIN}. New owner is ${F_USER_REAL}:${F_GROUP_REAL} (expected ${F_USER}:${F_GROUP})"
+
+		#if something to add, create or update k5login
+		if [ -n "$ADDED_PRINCIPALS" ]; then
+			catch_error E_K5LOGIN_NOT_UPDATED diff_mv "${TMP_K5LOGIN}" "${K5LOGIN}"
+			if [ ${K5LOGIN_EXISTS} == true ]; then
+				log_msg I_K5LOGIN_UPDATED
+			else
+				log_msg I_K5LOGIN_CREATED
+			fi
+		else
+			catch_error E_CANNOT_REMOVE_TMP_K5LOGIN rm -f "${TMP_K5LOGIN}"
+			log_msg I_K5LOGIN_NOT_UPDATED
 		fi
 	done < "${FROM_PERUN}"
 }


### PR DESCRIPTION
 - first create temporary k5login file in the same home (on the same
   file system), then move it to the right location (diff move for
   respecting linux acl)
 - new trap management (add method add_on_exit and on_exit for this
   puprose)