### PR TITLE
GUI: Fixed selection of ServiceState on Facility detail

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/propagationStatsReader/GetFacilityServicesState.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/propagationStatsReader/GetFacilityServicesState.java
@@ -10,6 +10,7 @@ import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.view.client.DefaultSelectionEventManager;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.MultiSelectionModel;
+import com.google.gwt.view.client.ProvidesKey;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.resources.TableSorter;
 import cz.metacentrum.perun.webgui.json.*;
@@ -41,7 +42,7 @@ public class GetFacilityServicesState implements JsonCallback, JsonCallbackTable
 	private ArrayList<ServiceState> list = new ArrayList<ServiceState>();
 	private PerunTable<ServiceState> table;
 	// Selection model
-	final MultiSelectionModel<ServiceState> selectionModel = new MultiSelectionModel<ServiceState>(new GeneralKeyProvider<ServiceState>());
+	final MultiSelectionModel<ServiceState> selectionModel = new MultiSelectionModel<ServiceState>(new ServiceStateKeyProvider());
 	// loader image
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
 	// entities
@@ -428,6 +429,15 @@ public class GetFacilityServicesState implements JsonCallback, JsonCallbackTable
 
 	public MultiSelectionModel<ServiceState> getSelectionModel() {
 		return this.selectionModel;
+	}
+
+	public class ServiceStateKeyProvider implements ProvidesKey<ServiceState> {
+
+		public Object getKey(ServiceState object) {
+			// returns ID
+			return object.getService().getId();
+		}
+
 	}
 
 }

--- a/perun-web-gui/src/main/webapp/PerunWeb.css
+++ b/perun-web-gui/src/main/webapp/PerunWeb.css
@@ -1099,7 +1099,36 @@ td div.customTextCell {
 }
 
 /* FIX COLORING OF SELECTED ROWS WHEN RECOLORED */
-.GALD-WOKD .customClickableTextCell, .GPBYFDEBE .customClickableTextCell, .GPBYFDEBE .customClickableTextCell a,tr .GPBYFDEBE, tr .GPBYFDEBE td, .GEATBOKCOC .customClickableTextCell,.GEATBOKCAD .customClickableTextCell, .GEATBOKCCE .customClickableTextCell {
+.GALD-WOKD .customClickableTextCell,
+.GPBYFDEBE .customClickableTextCell,
+.GPBYFDEBE .customClickableTextCell a,
+/* Style of selected row */
+tr .GPBYFDEBE,
+tr .GPBYFDEBE td,
+/* Style of cell in selected row */
+td .GPBYFDECE,
+td .GPBYFDECE .GPBYFDEHD,
+.GEATBOKCOC .customClickableTextCell,
+.GEATBOKCAD .customClickableTextCell,
+.GEATBOKCCE .customClickableTextCell,
+/* cell of hovered row
+td .GPBYFDEHD,
+*/
+/* hovered row
+tr .GPBYFDEGD,
+tr .GPBYFDEGD td,
+tr:hover .GPBYFDEGD,
+tr:hover .GPBYFDEGD td
+*/
+.GPBYFDECE .customClickableTextCell,
+.GPBYFDECE .customClickableTextCell a,
+tr .GPBYFDECE,
+tr .GPBYFDECE td,
+.GPBYFDECE:hover .customClickableTextCell,
+.GPBYFDECE:hover .customClickableTextCell a,
+tr:hover .GPBYFDECE,
+tr:hover .GPBYFDECE td
+{
     color:#fff !important;
     background: none repeat scroll 0 0 #628CD5 !important;
 }


### PR DESCRIPTION
- Use custom key provider for ServiceState object in order to fix
  selection, if no Task exists yet (service was just assigned to facility).
- Fixed row selection CSS since production compile uses different style names
  than devel mode compile.