### PR TITLE
PHP: Fixed processing of requests with params

### DIFF
--- a/perun-php/PerunRpcClient.php
+++ b/perun-php/PerunRpcClient.php
@@ -50,6 +50,8 @@ class PerunRpcClient{
 		if ($vars != NULL) {
 			curl_setopt($this -> curl, CURLOPT_POST, 1);
 			curl_setopt($this -> curl, CURLOPT_POSTFIELDS, json_encode($vars));
+			// Allow correct processing of POST request and response
+			curl_setopt($this -> curl, CURLOPT_HTTPHEADER, array('Content-type: text/javascript;charset=utf-8'));
 		}
 
 		$response = curl_exec($this -> curl);


### PR DESCRIPTION
- By default curl uses "application/x-www-form-urlencoded"
  for POST fields which we don't use, since examples are
  using JSON data format.

  Set HTTP header Content-type manually to "text/javascript;charset=utf-8"
  which is used by our client apps and server also performs compression
  of data.