### PR TITLE
Fix minor bugs in unixGID modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGID_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGID_namespace.java
@@ -161,6 +161,9 @@ public class urn_perun_group_attribute_def_def_unixGID_namespace extends GroupAt
 				}
 			}
 
+			//Check if gid GID is within allowed range
+			sess.getPerunBl().getModulesUtilsBl().checkIfGIDIsWithinRange(sess, attribute);
+
 			//Prepare lists for all groups and resources with same GID in the same namespace
 			List<Group> allGroupsWithSameGIDInSameNamespace = new ArrayList<Group>();
 			List<Resource> allResourcesWithSameGIDInSameNamespace = new ArrayList<Resource>();
@@ -173,12 +176,8 @@ public class urn_perun_group_attribute_def_def_unixGID_namespace extends GroupAt
 			//Fill lists of Groups and Resources by data
 			allGroupsWithSameGIDInSameNamespace.addAll(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, groupGIDAttribute));
 			allResourcesWithSameGIDInSameNamespace.addAll(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, resourceGIDAttribute));
-
-			//If there is no group or resource with same GID in the same namespace, its ok so only check if gid is within range
-			if(allGroupsWithSameGIDInSameNamespace.isEmpty() && allResourcesWithSameGIDInSameNamespace.isEmpty()) {
-				sess.getPerunBl().getModulesUtilsBl().checkIfGIDIsWithinRange(sess, attribute);
-				return;
-			}
+			//remove this group
+			allGroupsWithSameGIDInSameNamespace.remove(group);
 
 			//Prepare list of GroupName attributes of this group
 			List <Attribute> groupNamesOfGroup = sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, group, A_G_unixGroupName_namespace + ":");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGID_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGID_namespace.java
@@ -110,6 +110,9 @@ public class urn_perun_resource_attribute_def_def_unixGID_namespace extends Reso
 				attrValue = (Integer) attribute.getValue();
 			}
 
+			//Check if GID is within allowed range
+			sess.getPerunBl().getModulesUtilsBl().checkIfGIDIsWithinRange(sess, attribute);
+
 			//check if gid is not already depleted
 			Attribute usedGids = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, gidNamespace, A_E_usedGids);
 			//null in value means there is no depleted or used gids
@@ -128,17 +131,13 @@ public class urn_perun_resource_attribute_def_def_unixGID_namespace extends Reso
 			//Prepare attributes for searching through groups and resources
 			Attribute resourceGIDAttribute = attribute;
 			Attribute groupGIDAttribute = new Attribute(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, A_G_unixGID_namespace + ":" + gidNamespace));
-			groupGIDAttribute.setValue(groupGIDAttribute.getValue());
+			groupGIDAttribute.setValue(resourceGIDAttribute.getValue());
 
 			//Fill lists of Groups and Resources by data
 			allGroupsWithSameGIDInSameNamespace.addAll(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, groupGIDAttribute));
 			allResourcesWithSameGIDInSameNamespace.addAll(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, resourceGIDAttribute));
-
-			//If there is no group or resource with same GID in the same namespace, its ok so only check if gid is within range
-			if(allGroupsWithSameGIDInSameNamespace.isEmpty() && allResourcesWithSameGIDInSameNamespace.isEmpty()) {
-				sess.getPerunBl().getModulesUtilsBl().checkIfGIDIsWithinRange(sess, attribute);
-				return;
-			}
+			//remove this resource
+			allResourcesWithSameGIDInSameNamespace.remove(resource);
 
 			//Prepare list of GroupName attributes of this resource
 			List <Attribute> groupNamesOfResource = sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, resource, A_R_unixGroupName_namespace + ":");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -180,6 +180,15 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		List<Resource> resources = new ArrayList<Resource>();
 		resources.add(resource);
 
+		Attribute minGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minGID"));
+		Attribute maxGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-maxGID"));
+
+		minGID.setValue(100);
+		maxGID.setValue(100500);
+
+		perun.getAttributesManagerBl().setAttribute(sess, namespace, minGID);
+		perun.getAttributesManagerBl().setAttribute(sess, namespace, maxGID);
+
 		List<Attribute> attributes = setUpGroupNamesAndGIDForGroupAndResource();
 		Attribute resourceGID = null;
 		for(Attribute a: attributes) {
@@ -205,6 +214,17 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 		List<Group> groups = new ArrayList<Group>();
 		groups.add(group);
+
+		Attribute minGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minGID"));
+		Attribute maxGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-maxGID"));
+
+		minGID.setValue(100);
+		maxGID.setValue(100500);
+
+		perun.getAttributesManagerBl().setAttribute(sess, namespace, minGID);
+		perun.getAttributesManagerBl().setAttribute(sess, namespace, maxGID);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
 
 		List<Attribute> attributes = setUpGroupNamesAndGIDForGroupAndResource();
 		Attribute groupGID = null;
@@ -461,7 +481,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		Attribute minGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minGID"));
 		Attribute maxGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-maxGID"));
 
-		minGID.setValue(100000);
+		minGID.setValue(100);
 		maxGID.setValue(100500);
 
 		perun.getAttributesManagerBl().setAttribute(sess, namespace, minGID);


### PR DESCRIPTION
 - check allowed range for gid always when check attribute value (not only if it is new GID)
 - remove self object (group or resource) from list of groups and resources with the same GID set (we don't want it there)
 - fix bad seting value for groupGIDAttribute in resource_unixGID_namespace module, we need to take value from the correct place, not from newly created empty attributeDefinition