### PR TITLE
Create member-group attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -200,7 +200,7 @@ public interface AttributesManager {
 	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException;
 
 	/**
-	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
+	 * Get all attributes (empty and virtual too)associated with the member in the group which have name in list attrNames.
 	 *
 	 * @param sess perun session
 	 * @param member to get the attributes from

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -32,6 +32,11 @@ public interface AttributesManager {
 	public static final String NS_MEMBER_RESOURCE_ATTR_OPT = "urn:perun:member_resource:attribute-def:opt";
 	public static final String NS_MEMBER_RESOURCE_ATTR_VIRT = "urn:perun:member_resource:attribute-def:virt";
 
+	public static final String NS_MEMBER_GROUP_ATTR = "urn:perun:member_group:attribute-def";
+	public static final String NS_MEMBER_GROUP_ATTR_DEF = "urn:perun:member_group:attribute-def:def";
+	public static final String NS_MEMBER_GROUP_ATTR_OPT = "urn:perun:member_group:attribute-def:opt";
+	public static final String NS_MEMBER_GROUP_ATTR_VIRT = "urn:perun:member_group:attribute-def:virt";
+
 	public static final String NS_MEMBER_ATTR_CORE = "urn:perun:member:attribute-def:core";
 	public static final String NS_MEMBER_ATTR = "urn:perun:member:attribute-def";
 	public static final String NS_MEMBER_ATTR_DEF = "urn:perun:member:attribute-def:def";
@@ -176,6 +181,59 @@ public interface AttributesManager {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get all <b>non-empty</b> attributes associated with the member in the group.
+	 * PRIVILEGE: Get only those attributes the principal has access to.
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group group to get the attributes from
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws GroupNotExistsException if the group doesn't exists in underlying data source
+	 * @throws MemberNotExistsException if the member doesn't have access to this resource
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group group to get the attributes from
+	 * @param attrNames list of attributes' names
+	 * @return list of attributes
+	 *
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws GroupNotExistsException if the group doesn't exists in underlying data source
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws MemberNotExistsException if the member doesn't have access to this resource
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
+	 * If workWithUserAttribute is true, return also all user attributes in list of attrNames (with virtual attributes too).
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group group to get the attributes from
+	 * @param attrNames list of attributes' names
+	 * @param workWithUserAttributes if true returns also user and member attributes (user is automatically get from member)
+	 * @return list of attributes
+	 *
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws GroupNotExistsException if the group doesn't exists in underlying data source
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws MemberNotExistsException if the member doesn't have access to this resource
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all entityless attributes with subject equaled String key
@@ -614,6 +672,50 @@ public interface AttributesManager {
 	void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Store the attributes associated with the member and group combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 *
+	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param group group to set on
+	 * @param attributes attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws GroupNotExistsException if the resource doesn't exists in the underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in the underlying data source
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, UserNotExistsException;
+
+	/**
+	 * Store the attributes associated with the member and group combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 * If workWithUserAttributes is true, the method stores also the attributes associated with user and member.
+	 *
+	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param group group to set on
+	 * @param attributes attribute to set
+	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws GroupNotExistsException if the resource doesn't exists in the underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in the underlying data source
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, UserNotExistsException;
+
+	/**
 	 * Store the attributes associated with member and user (which we get from this member) if workWithUserAttributes is true.
 	 * If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
 	 *
@@ -865,6 +967,26 @@ public interface AttributesManager {
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
 	 */
 	Attribute getAttribute(PerunSession sess, Resource resource, Member member, String attributeName) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get particular attribute for the member in this group.
+	 *
+	 * PRIVILEGE: Principal need to have access to attribute which wants to get.
+	 *
+	 * @param sess
+	 * @param member to get attribute from
+	 * @param group to get attribute from
+	 * @param attributeName attribute name defined in the particular manager
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws GroupNotExistsException if the resource doesn't exists in the underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in the underlying data source
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 */
+	Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get particular attribute for the member.
@@ -1131,6 +1253,26 @@ public interface AttributesManager {
 	Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException;
 
 	/**
+	 * Get particular attribute for the member in this group.
+	 *
+	 * PRIVILEGE: Principal need to have access to attribute which wants to get.
+	 *
+	 * @param sess perun session
+	 * @param member to get attribute from
+	 * @param group to get attribute from
+	 * @param id attribute id
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws GroupNotExistsException if the resource doesn't exists in the underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in the underlying data source
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 */
+	Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException;
+
+	/**
 	 * Get particular attribute for the member.
 	 *
 	 * PRIVILEGE: Principal need to have access to attribute which wants to get.
@@ -1335,6 +1477,27 @@ public interface AttributesManager {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	void setAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Store the particular attribute associated with the group and member combination. Core attributes can't be set this way.
+	 *
+	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param group group to set on
+	 * @param attribute attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws GroupNotExistsException if the resource doesn't exists in the underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in the underlying data source
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute or if it is core attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Store the particular attribute associated with the member.  Core attributes can't be set this way.
@@ -1565,6 +1728,49 @@ public interface AttributesManager {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get member-group attributes which are required by services defined on specified resource
+	 * Services are known from the resourceToGetServicesFrom.
+	 *
+	 * PRIVILEGE: Get only those required attributes principal has access to.
+	 *
+	 * @param sess perun session
+	 * @param resourceToGetServicesFrom getRequired attributes from services which are assigned on this resource
+	 * @param member you get attributes for this member and the group
+	 * @param group you get attributes for this group and the member
+	 * @return list of group-resource's attributes which are required by services defined on specified resource
+	 *
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ResourceNotExistsException
+	 * @throws MemberNotExistsException
+	 * @throws GroupNotExistsException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws PrivilegeException, InternalErrorException, WrongAttributeAssignmentException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException;
+
+	/**
+	 * Get member-group attributes which are required by services defined on specified resource and if workWithUserAttributes is true also user and member attributes.
+	 * Services are known from the resourceToGetServicesFrom.
+	 *
+	 * PRIVILEGE: Get only those required attributes principal has access to.
+	 *
+	 * @param sess perun session
+	 * @param resourceToGetServicesFrom getRequired attributes from services which are assigned on this resource
+	 * @param member you get attributes for this member and the group
+	 * @param group you get attributes for this group and the member
+	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
+	 * @return list of group-resource's attributes which are required by services defined on specified resource
+	 *
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ResourceNotExistsException
+	 * @throws MemberNotExistsException
+	 * @throws GroupNotExistsException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, WrongAttributeAssignmentException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException;
 
 	/**
 	 * Get member, user, member-resource and user-facility attributes which are required by services which are defined on "resourceToGetServicesFrom" resource.
@@ -1919,7 +2125,7 @@ public interface AttributesManager {
 	 * @throws ResourceNotExistsException if the resource doesn't exists
 	 * @throws ServiceNotExistsException if the service doesn't exists in underlying data source
 	 */
-	public List<Attribute> getRequiredAttributes(PerunSession sess, List<Service> services, Resource resource) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, List<Service> services, Resource resource) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException;
 
 	/**
 	 * Get member-resource attributes which are required by the service.
@@ -1948,6 +2154,32 @@ public interface AttributesManager {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException;
+
+	/**
+	 * Get member-group attributes which are required by the service.
+	 *
+	 * PRIVILEGE: Get only those required attributes principal has access to.
+	 *
+	 * @param sess perun session
+	 * @param member you get attributes for this member and the resource
+	 * @param group you get attributes for this group in which member is associated
+	 * @param service attribute required by this service you'll get
+	 * @return list of attributes which are required by the service.
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws MemberNotExistsException if the member doesn't exists in underlying data source
+	 * @throws ServiceNotExistsException if the service doesn't exists in underlying data source
+	 * @throws MemberNotExistsException if the member doesn't have access to this resource
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * PRIVILEGE: Get only those required attributes principal has access to.
+	 *
+	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException;
 
 	/**
 	 * Get member attributes which are required by the service.
@@ -2101,6 +2333,42 @@ public interface AttributesManager {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * This method tries to fill value of the member-group attribute. This value is automatically generated, but not all attributes can be filled this way.
+	 *
+	 * PRIVILEGE: Fill attribute only when principal has access to write on it.
+	 *
+	 * @param sess perun session
+	 * @param member attribute of this member (and resource) you want to fill
+	 * @param group attribute of this group you want to fill
+	 * @param attribute attribute to fill. If attributes already have set value, this value won't be overwritten. This means the attribute value must be empty otherwise this method won't fill it.
+	 * @return attribute which MAY have filled value
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws MemberNotExistsException if member doesn't exists in underlying data source or he doesn't have access to this resource
+	 * @throws GroupNotExistsException if group doesn't exists
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in underlying data source
+	 */
+	Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * PRIVILEGE: Fill attributes only when principal has access to write on them.
+	 *
+	 *  Batch version of fillAttribute. This method skips all attributes with not-null value.
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession,Member,Group,Attribute)
+	 */
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * PRIVILEGE: Fill attributes only when principal has access to write on them.
+	 *
+	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
+	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
+	 */
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException;
 
 	/**
 	 * This method tries to fill value of the user, member, member-resource and user-facility attributes. This value is automatically generated, but not all attributes can be filled this way.
@@ -2410,6 +2678,44 @@ public interface AttributesManager {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException;
+
+	/**
+	 * Check if value of this member-group attribute is valid.
+	 *
+	 * PRIVILEGE: Check attribute only when principal has access to write on it.
+	 *
+	 * @param sess perun session
+	 * @param group group for which (and for specified member) you want to check validity of attribute
+	 * @param member member for which (and for specified group) you want to check validity of attribute
+	 * @param attribute attribute to check
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws ResourceNotExistsException if the resource doesn't exists in underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws AttributeNotExistsException
+	 */
+	void checkAttributeValue(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException;
+
+	/**
+	 * PRIVILEGE: Check attributes only when principal has access to write on them.
+	 *
+	 * Batch version of fillAttribute
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession,Member,Group,Attribute)
+	 */
+	void checkAttributesValue(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException;
+
+	/**
+	 * PRIVILEGE: Check attributes only when principal has access to write on them.
+	 *
+	 * Batch version of fillAttribute
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession,Member,Group,Attribute)
+	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
+	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
+	 */
+	void checkAttributesValue(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException;
 
 	/**
 	 * Check if value of attributes is valid. Attributes can be from namespace: member, user, member-resource and user-facility.
@@ -2908,6 +3214,53 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException
 	 */
 	void removeAllAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, WrongAttributeAssignmentException, PrivilegeException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Unset particular attribute for the member in the group. Core attributes can't be removed this way.
+	 *
+	 * PRIVILEGE: Remove attribute only when principal has access to write on it.
+	 *
+	 * @param sess perun session
+	 * @param group remove attributes for this group
+	 * @param member remove attribute from this member
+	 * @param attribute attribute to remove
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in underlying data source
+	 * @throws GroupNotExistsException if the resource doesn't exists in underlying data source
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
+	 */
+	void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
+	 *
+	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
+	 * @throws AttributeNotExistsException if the any of attributes doesn't exists in underlying data source
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, Member, Group, AttributeDefinition)
+	 */
+	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Unset all attributes for the member in the group.
+	 *
+	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
+	 *
+	 * @param sess perun session
+	 * @param group remove attributes for this group
+	 * @param member remove attributes from this member
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws MemberNotExistsException if the member doesn't exists in underlying data source
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 * @throws GroupNotExistsException if the resource doesn't exists in underlying data source
+	 * @throws WrongAttributeAssignmentException
+	 */
+	void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException, PrivilegeException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Unset particular attribute for the member. Core attributes can't be removed this way.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -143,7 +143,7 @@ public interface AttributesManagerBl {
 	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
-	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
+	 * Get all attributes (empty and virtual too) associated with the member in the group which have name in list attrNames.
 	 *
 	 * @param sess perun session
 	 * @param member to get the attributes from

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -26,6 +26,7 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ModuleNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
@@ -127,6 +128,47 @@ public interface AttributesManagerBl {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get all <b>non-empty</b> attributes associated with the member in the group.
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group group to get the attributes from
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group group to get the attributes from
+	 * @param attrNames list of attributes' names
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get all attributes associated with the member in the group and if workWithUserAttributes is true, gets also all <b>non-empty</b> user and member attributes.
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group group to get the attributes from
+	 * @param workWithUserAttributes if true returns also user and member attributes (user is automatically get from member)
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the member and if workWithUserAttributes is
@@ -458,6 +500,22 @@ public interface AttributesManagerBl {
 	boolean setAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Just store the particular attribute associated with the member-group, doesn't preform any value check. Core attributes can't be set this way.
+	 *
+	 * @param sess
+	 * @param member
+	 * @param group
+	 * @param attribute
+	 * @param workWithUserAttributes
+	 * @return
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	boolean setAttributeWithoutCheck(PerunSession sess, Member member, Group group, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
 	 * Just store the particular attribute associated with the member, doesn't preform any value check. Core attributes can't be set this way.
 	 *
 	 * @param sess
@@ -575,6 +633,38 @@ public interface AttributesManagerBl {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Store the attributes associated with the resource and member combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param group group to set on
+	 * @param attributes attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, UserNotExistsException;
+
+	/**
+	 * Store the attributes associated with the resource and member combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 * If workWithUserAttributes is true, the method stores also the attributes associated with user and member.
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param group group to set on
+	 * @param attributes attribute to set
+	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, UserNotExistsException;
 
 	/**
 	 * Store the member, user, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -737,6 +827,21 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 */
 	Attribute getAttribute(PerunSession sess, Resource resource, Member member, String attributeName) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException;
+
+	/**
+	 * Get particular attribute for the member in this group.
+	 *
+	 * @param sess
+	 * @param member to get attribute from
+	 * @param group to get attribute from
+	 * @param attributeName attribute name defined in the particular manager
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 */
+	Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get particular attribute for the member.
@@ -930,6 +1035,21 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 */
 	Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException;
+
+	/**
+	 * Get particular attribute for the member in this group.
+	 *
+	 * @param sess
+	 * @param member to get attribute from
+	 * @param group to get attribute from
+	 * @param id attribute id
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 */
+	Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get particular attribute for the member.
@@ -1183,6 +1303,22 @@ public interface AttributesManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	void setAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Store the particular attribute associated with the group and member combination. Core attributes can't be set this way.
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param group group to set on
+	 * @param attribute attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute or if it is core attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Store the particular attribute associated with the member.  Core attributes can't be set this way.
@@ -1439,6 +1575,36 @@ public interface AttributesManagerBl {
 	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member, boolean workWithUserAttributes) throws WrongAttributeAssignmentException, InternalErrorException;
 
 	/**
+	 * Get member-group attributes which are required by services. Services are known from the resourceToGetServicesFrom.
+	 *
+	 * @param sess perun session
+	 * @param resourceToGetServicesFrom resource from which the services are taken
+	 * @param member you get attributes for this member
+	 * @param group you get attributes for this group and the member
+	 * @return list of member-group's attributes which are required by services defined on specified resource
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get member-group attributes which are required by services if workWithUserAttributes is true also user and member attributes.
+	 * Services are known from the resourceToGetServicesFrom.
+	 *
+	 * @param sess perun session
+	 * @param resourceToGetServicesFrom resource from which the services are taken
+	 * @param member you get attributes for this member
+	 * @param group you get attributes for this group and the member
+	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
+	 * @return list of member-group's attributes which are required by services defined on specified resource
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
 	 * Get member, user, member-resource and user-facility attributes which are required by services which are defined on "resourceToGetServicesFrom" resource.
 	 *
 	 * @param sess perun session
@@ -1685,6 +1851,21 @@ public interface AttributesManagerBl {
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
+	 * Get member-group attributes which are required by the service.
+	 *
+	 * @param sess perun session
+	 * @param member you get attributes for this member and the group
+	 * @param group you get attributes for this group in which member is associated
+	 * @param service attribute required by this service you'll get
+	 * @return list of attributes which are required by the service.
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
 	 * Get memner, user, member-resource, user-facility attributes which are required by the service.
 	 *
 	 *
@@ -1812,6 +1993,33 @@ public interface AttributesManagerBl {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * This method tries to fill value of the member-group attribute. This value is automatically generated, but not all attributes can be filled this way.
+	 *
+	 * @param sess perun session
+	 * @param member attribute of this member (and group) you want to fill
+	 * @param group attribute of this group (and member) you want to fill
+	 * @param attribute attribute to fill. If attributes already have set value, this value won't be overwritten. This means the attribute value must be empty otherwise this method won't fill it.
+	 * @return attribute which MAY have filled value
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 *  Batch version of fillAttribute. This method skips all attributes with not-null value.
+	 *  @throws WrongAttributeAssignmentException if any of attributes values is wrong/illegal
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession,Member,Group,Attribute)
+	 */
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * @param workWithUserAttributes method can process also user and memebr attributes (user is automatically get from member)
+	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
+	 */
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 *
@@ -2068,6 +2276,36 @@ public interface AttributesManagerBl {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+
+	/**
+	 * Check if value of this member-group attribute is valid.
+	 *
+	 * @param sess perun session
+	 * @param group group for which (and for specified member) you want to check validity of attribute
+	 * @param member member for which (and for specified group) you want to check validity of attribute
+	 * @param attribute attribute to check
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void checkAttributeValue(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
+	 *  Batch version of fillAttribute
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession,Member,Group,Attribute)
+	 */
+	void checkAttributesValue(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
+	 *  Batch version of fillAttribute
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession,Member,Group,Attribute)
+	 * @param workWithUserAttributes method can process also user and member attributes (user is automatically get from member)
+	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
+	 */
+	void checkAttributesValue(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of attributes is valied. Attributes can be from namespace: member, user, member-resource and user-facility.
@@ -2484,6 +2722,42 @@ public interface AttributesManagerBl {
 	void removeAllAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 
 	/**
+	 * Unset particular attribute for the member in the group. Core attributes can't be removed this way.
+	 *
+	 * @param sess perun session
+	 * @param group remove attributes for this group
+	 * @param member remove attribute from this member
+	 * @param attribute attribute to remove
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
+	 */
+	void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
+	 * @throws AttributeNotExistsException if the any of attributes doesn't exists in underlying data source
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, Member, Group, AttributeDefinition)
+	 */
+	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Unset all attributes for the member in the group.
+	 *
+	 * @param sess perun session
+	 * @param group remove attributes for this group
+	 * @param member remove attributes from this member
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
 	 * Unset particular attribute for the member. Core attributes can't be removed this way.
 	 *
 	 * @param sess perun session
@@ -2716,6 +2990,20 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Unset all attributes for the member-group without check of value.
+	 *
+	 * @param sess
+	 * @param member
+	 * @param group
+	 * @param attribute
+	 * @return
+	 *
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Unset all attributes for the member without check of value.
@@ -2971,6 +3259,20 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 */
 	boolean isTrulyRequiredAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Check if this the attribute is truly required for the member and the group right now. Truly means that the nothing (member, group...) is invalid.
+	 *
+	 * @param sess
+	 * @param member
+	 * @param group
+	 * @param attributeDefinition
+	 * @return
+	 *
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	boolean isTrulyRequiredAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Same as doTheMagic(sess, member, false);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1037,13 +1037,14 @@ public interface AttributesManagerBl {
 	Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException;
 
 	/**
-	 * Get particular attribute for the member in this group.
+	 * Get particular attribute for the member in this group. Also it can return only member or only user attribute
+	 * if attr definition is not from NS_MEMBER_GROUP_ATTR but from NS_MEMBER_ATTR or NS_GROUP_ATTR
 	 *
-	 * @param sess
+	 * @param sess perun session
 	 * @param member to get attribute from
 	 * @param group to get attribute from
 	 * @param id attribute id
-	 * @return attribute
+	 * @return memberGroup, member OR user attribute
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeAssignmentException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -167,17 +167,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	@Override
 	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException, WrongAttributeAssignmentException {
-		if(attrNames.isEmpty()) return new ArrayList<>();
-		// get virtual attributes
-		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, member, group);
-		// filter out virtual attributes witch are not in attrNames
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) {
-			if (!attrNames.contains(attributeIterator.next().getName())) attributeIterator.remove();
-		}
-		// adds non-empty non-virtual attributes
-		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, member, group, attrNames));
-		return attributes;
+		if (attrNames.isEmpty()) return new ArrayList<>();
+		// adds all attributes which names are in attrNames list (virtual and empty too)
+		return  getAttributesManagerImpl().getAttributes(sess, member, group, attrNames);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -339,7 +339,6 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			if(roles.contains(Role.SELF)) {
 				if(isAuthorized(sess, Role.SELF, member)) return true;
 			}
-			// kontrolovat groupAdmin pre membra ???
 			if(roles.contains(Role.GROUPADMIN)) {
 				if(isAuthorized(sess, Role.GROUPADMIN, group)) return true;
 			}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -286,47 +286,62 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			}
 			if(roles.contains(Role.SELF)); //Not Allowed
 		} else if(user != null && facility != null) {
-			if(roles.contains(Role.FACILITYADMIN)) if(isAuthorized(sess, Role.FACILITYADMIN, facility)) return true;
-			if(roles.contains(Role.SELF)) if(isAuthorized(sess, Role.SELF, user)) return true;
-			if(roles.contains(Role.VOADMIN)) {
+			if (roles.contains(Role.FACILITYADMIN)) if (isAuthorized(sess, Role.FACILITYADMIN, facility)) return true;
+			if (roles.contains(Role.SELF)) if (isAuthorized(sess, Role.SELF, user)) return true;
+			if (roles.contains(Role.VOADMIN)) {
 				List<Member> membersFromUser = getPerunBlImpl().getMembersManagerBl().getMembersByUser(sess, user);
 				HashSet<Resource> resourcesFromUser = new HashSet<Resource>();
-				for(Member memberElement: membersFromUser) {
+				for (Member memberElement : membersFromUser) {
 					resourcesFromUser.addAll(getPerunBlImpl().getResourcesManagerBl().getAssignedResources(sess, memberElement));
 				}
 				resourcesFromUser.retainAll(getPerunBlImpl().getFacilitiesManagerBl().getAssignedResources(sess, facility));
-				for(Resource resourceElement: resourcesFromUser) {
-					if(isAuthorized(sess, Role.VOADMIN, resourceElement)) return true;
+				for (Resource resourceElement : resourcesFromUser) {
+					if (isAuthorized(sess, Role.VOADMIN, resourceElement)) return true;
 				}
 			}
-			if(roles.contains(Role.VOOBSERVER)) {
+			if (roles.contains(Role.VOOBSERVER)) {
 				List<Member> membersFromUser = getPerunBlImpl().getMembersManagerBl().getMembersByUser(sess, user);
 				HashSet<Resource> resourcesFromUser = new HashSet<Resource>();
-				for(Member memberElement: membersFromUser) {
+				for (Member memberElement : membersFromUser) {
 					resourcesFromUser.addAll(getPerunBlImpl().getResourcesManagerBl().getAssignedResources(sess, memberElement));
 				}
 				resourcesFromUser.retainAll(getPerunBlImpl().getFacilitiesManagerBl().getAssignedResources(sess, facility));
-				for(Resource resourceElement: resourcesFromUser) {
-					if(isAuthorized(sess, Role.VOOBSERVER, resourceElement)) return true;
+				for (Resource resourceElement : resourcesFromUser) {
+					if (isAuthorized(sess, Role.VOOBSERVER, resourceElement)) return true;
 				}
 			}
-			if(roles.contains(Role.GROUPADMIN)) {
+			if (roles.contains(Role.GROUPADMIN)) {
 				//If groupManager has rights on "any group which is assigned to any resource from the facility" and "the user has also member in vo where exists this group"
 				List<Vo> userVos = getPerunBlImpl().getUsersManagerBl().getVosWhereUserIsMember(sess, user);
 				Set<Integer> userVosIds = new HashSet<>();
-				for(Vo voElement: userVos) {
+				for (Vo voElement : userVos) {
 					userVosIds.add(voElement.getId());
 				}
 
 				List<Resource> resourcesFromFacility = getPerunBlImpl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 				Set<Group> groupsFromFacility = new HashSet<Group>();
-				for(Resource resourceElement: resourcesFromFacility) {
+				for (Resource resourceElement : resourcesFromFacility) {
 					groupsFromFacility.addAll(getPerunBlImpl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement));
 				}
 
-				for(Group groupElement: groupsFromFacility) {
-					if(isAuthorized(sess, Role.GROUPADMIN, groupElement) && userVosIds.contains(groupElement.getVoId())) return true;
+				for (Group groupElement : groupsFromFacility) {
+					if (isAuthorized(sess, Role.GROUPADMIN, groupElement) && userVosIds.contains(groupElement.getVoId()))
+						return true;
 				}
+			}
+		} else if(member != null && group != null) {
+			if(roles.contains(Role.VOADMIN)) {
+				if(isAuthorized(sess, Role.VOADMIN, member)) return true;
+			}
+			if(roles.contains(Role.VOOBSERVER)) {
+				if(isAuthorized(sess, Role.VOOBSERVER, member)) return true;
+			}
+			if(roles.contains(Role.SELF)) {
+				if(isAuthorized(sess, Role.SELF, member)) return true;
+			}
+			// kontrolovat groupAdmin pre membra ???
+			if(roles.contains(Role.GROUPADMIN)) {
+				if(isAuthorized(sess, Role.GROUPADMIN, group)) return true;
 			}
 		} else if(user != null) {
 			if(roles.contains(Role.SELF)) if(isAuthorized(sess, Role.SELF, user)) return true;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -152,6 +152,70 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attributes;
 	}
 
+	@Override
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, member, group);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, new AttributeDefinition(attrNext), member, group)) attrIter.remove();
+			else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+		}
+
+		return attributes;
+	}
+
+	@Override
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, member, group, attrNames);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		// Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if (!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, new AttributeDefinition(attrNext), member, group)) attrIter.remove();
+			else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+		}
+
+		return attributes;
+	}
+
+	@Override
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames, boolean workWithUserAttributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, member, group, workWithUserAttributes);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		// Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_GROUP_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
+				User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, null));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
+			} else {
+				throw new ConsistencyErrorException("One of getting attributes is not correct type : " + attrNext);
+			}
+		}
+		return attributes;
+	}
+
 	public List<Attribute> getAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member) throws PrivilegeException, WrongAttributeAssignmentException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
@@ -517,6 +581,52 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().setAttributes(sess, resource, member, attributes);
 	}
 
+	@Override
+	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, UserNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		for (Attribute attribute : attributes) {
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
+		}
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		// Choose to which attributes has the principal access
+		for(Attribute attribute : attributes) {
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attribute), member, group)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
+		}
+		getAttributesManagerBl().setAttributes(sess, member, group, attributes);
+	}
+
+	@Override
+	public void setAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, UserNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+
+		for(Attribute attribute: attributes) {
+			attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+			attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
+		}
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		//Choose to which attributes has the principal access
+		for(Attribute attr: attributes) {
+			if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_MEMBER_GROUP_ATTR)) {
+				if (!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), member, group))
+					throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_MEMBER_ATTR_DEF)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), member, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_USER_ATTR)) {
+				User u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), u, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
+			} else {
+				throw new WrongAttributeAssignmentException("One of setting attribute has not correct type : " + new AttributeDefinition(attr));
+			}
+		}
+		getAttributesManagerBl().setAttributes(sess, member, group, attributes, workWithUserAttributes);
+	}
+
 	public void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
@@ -760,6 +870,20 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attr;
 	}
 
+	@Override
+	public Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(attributeName, "attributeName");
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		Attribute attribute = getAttributesManagerBl().getAttribute(sess, member, group, attributeName);
+		//Choose to which attributes has the principal access
+		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attribute, member, group)) throw	new PrivilegeException("Principal has no access to get attribute = " + new AttributeDefinition(attribute));
+		else attribute.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, member, group));
+
+		return attribute;
+	}
+
 	public Attribute getAttribute(PerunSession sess, Member member, String attributeName) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(attributeName, "attributeName");
@@ -910,6 +1034,19 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attr;
 	}
 
+	@Override
+	public Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws PrivilegeException, GroupNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		Attribute attribute = getAttributesManagerBl().getAttributeById(sess, member, group, id);
+		//Choose to which attributes has the principal access
+		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attribute, member, group)) throw new PrivilegeException("Principal has no access to get attribute = " + new AttributeDefinition(attribute));
+		else attribute.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, member, group));
+
+		return attribute;
+	}
+
 	public Attribute getAttributeById(PerunSession sess, Member member, int id) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -1024,6 +1161,18 @@ public class AttributesManagerEntry implements AttributesManager {
 		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, resource, member)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
 		getAttributesManagerBl().setAttribute(sess, resource, member, attribute);
+	}
+
+	@Override
+	public void setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, GroupNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		Utils.checkPerunSession(sess);
+		getAttributesManagerBl().checkAttributeExists(sess, attribute);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		attribute = this.perunBl.getAttributesManagerBl().convertEmptyStringIntoNullInAttrValue(attribute);
+		attribute = this.perunBl.getAttributesManagerBl().convertBooleanFalseIntoNullInAttrValue(attribute);
+		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, member, group)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
+		getAttributesManagerBl().setAttribute(sess, member, group, attribute);
 	}
 
 	public void setAttribute(PerunSession sess, Member member, Attribute attribute) throws PrivilegeException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
@@ -1171,6 +1320,53 @@ public class AttributesManagerEntry implements AttributesManager {
 				Facility f = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, f)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, f));
+			} else {
+				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
+			}
+		}
+		return attributes;
+	}
+
+	@Override
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws PrivilegeException, InternalErrorException, WrongAttributeAssignmentException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, group);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
+			else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+		}
+		return attributes;
+	}
+
+	@Override
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, WrongAttributeAssignmentException, ResourceNotExistsException, MemberNotExistsException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, group, workWithUserAttributes);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_GROUP_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
+				User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, null));
 			} else {
 				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
 			}
@@ -1594,6 +1790,54 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attributes;
 	}
 
+	@Override
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, member, group);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
+			else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+		}
+
+		return attributes;
+	}
+
+	@Override
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, member, group, workWithUserAttributes);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_GROUP_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
+				User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, null));
+			} else {
+				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
+			}
+		}
+		return attributes;
+	}
+
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, MemberNotExistsException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
@@ -1748,6 +1992,67 @@ public class AttributesManagerEntry implements AttributesManager {
 				User u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 				Facility f = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attrNext), u, f)) attrIter.remove();
+				else attrNext.setWritable(true);
+			} else {
+				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
+			}
+		}
+
+		return listOfAttributes;
+	}
+
+	@Override
+	public Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		//Choose to which attributes has the principal access
+		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attribute), group, member)) throw new PrivilegeException("Principal has no access to fill attribute = " + new AttributeDefinition(attribute));
+
+		Attribute attr = getAttributesManagerBl().fillAttribute(sess, member, group, attribute);
+		attr.setWritable(true);
+		return attr;
+	}
+
+	@Override
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		//Choose to which attributes has the principal access
+		List<Attribute> listOfAttributes = getAttributesManagerBl().fillAttributes(sess, member, group, attributes);
+		Iterator<Attribute> attrIter = listOfAttributes.iterator();
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attrNext), member, group)) attrIter.remove();
+			else attrNext.setWritable(true);
+		}
+
+		return listOfAttributes;
+	}
+
+	@Override
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		// Choose to which attributes has the principal access
+		List<Attribute> listOfAttributes = getAttributesManagerBl().fillAttributes(sess, member, group, attributes, workWithUserAttributes);
+		Iterator<Attribute> attrIter = listOfAttributes.iterator();
+
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_GROUP_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attrNext), member, group)) attrIter.remove();
+				else attrNext.setWritable(true);
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
+				User u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attrNext), u, null)) attrIter.remove();
+				else attrNext.setWritable(true);
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attrNext), member, null)) attrIter.remove();
 				else attrNext.setWritable(true);
 			} else {
 				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
@@ -2099,6 +2404,53 @@ public class AttributesManagerEntry implements AttributesManager {
 			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), resource , member)) throw new PrivilegeException("Principal has no access to check attribute = " + new AttributeDefinition(attr));
 		}
 		getAttributesManagerBl().checkAttributesValue(sess, resource, member, attributes);
+	}
+
+	@Override
+	public void checkAttributeValue(PerunSession sess, Member member, Group group, Attribute attribute) throws PrivilegeException, InternalErrorException, GroupNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException {
+		Utils.checkPerunSession(sess);
+		getAttributesManagerBl().checkAttributeExists(sess, attribute);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		//Choose to which attributes has the principal access
+		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attribute), member, group)) throw new PrivilegeException("Principal has no access to check attribute = " + new AttributeDefinition(attribute));
+
+		getAttributesManagerBl().checkAttributeValue(sess, member, group, attribute);
+	}
+
+	@Override
+	public void checkAttributesValue(PerunSession sess, Member member, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException {
+		Utils.checkPerunSession(sess);
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		//Choose to which attributes has the principal access
+		for(Attribute attribute: attributes) {
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attribute), member, group)) throw new PrivilegeException("Principal has no access to check attribute = " + new AttributeDefinition(attribute));
+		}
+		getAttributesManagerBl().checkAttributesValue(sess, member, group, attributes);
+	}
+
+	@Override
+	public void checkAttributesValue(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		//Choose to which attributes has the principal access
+		for(Attribute attr: attributes) {
+			if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_MEMBER_GROUP_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), member , group)) throw new PrivilegeException("Principal has no access to check attribute = " + new AttributeDefinition(attr));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_USER_ATTR)) {
+				User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), user , null)) throw new PrivilegeException("Principal has no access to check attribute = " + new AttributeDefinition(attr));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_MEMBER_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), member , null)) throw new PrivilegeException("Principal has no access to check attribute = " + new AttributeDefinition(attr));
+			} else {
+				throw new WrongAttributeAssignmentException("There is some attribute which is not type of any possible choice.");
+			}
+		}
+		getAttributesManagerBl().checkAttributesValue(sess, member, group, attributes, workWithUserAttributes);
 	}
 
 	public void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException {
@@ -2564,6 +2916,44 @@ public class AttributesManagerEntry implements AttributesManager {
 			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attr, resource , member)) throw new PrivilegeException("Principal has no access to remove attribute = " + new AttributeDefinition(attr));
 		}
 		getAttributesManagerBl().removeAllAttributes(sess, resource, member);
+	}
+
+	@Override
+	public void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getAttributesManagerBl().checkAttributeExists(sess, attribute);
+		//Choose to which attributes has the principal access
+		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, member, group)) throw new PrivilegeException("Principal has no access to remove attribute = " + new AttributeDefinition(attribute));
+
+		getAttributesManagerBl().removeAttribute(sess, member, group, attribute);
+	}
+
+	@Override
+	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		//Choose to which attributes has the principal access
+		for(AttributeDefinition attrDef: attributes) {
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrDef, member, group)) throw new PrivilegeException("Principal has no access to remove attribute = " + attrDef);
+		}
+		getAttributesManagerBl().removeAttributes(sess, member, group, attributes);
+	}
+
+	@Override
+	public void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException, PrivilegeException, MemberNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		//Choose to which attributes has the principal access
+		List<Attribute> allAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, member, group);
+		for(Attribute attr: allAttributes) {
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attr, member, group)) throw new PrivilegeException("Principal has no access to remove attribute = " + new AttributeDefinition(attr));
+		}
+		getAttributesManagerBl().removeAllAttributes(sess, member, group);
 	}
 
 	public void removeAttribute(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -878,7 +878,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 		Attribute attribute = getAttributesManagerBl().getAttribute(sess, member, group, attributeName);
 		//Choose to which attributes has the principal access
-		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attribute, member, group)) throw	new PrivilegeException("Principal has no access to get attribute = " + new AttributeDefinition(attribute));
+		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attribute, member, group)) throw new PrivilegeException("Principal has no access to get attribute = " + new AttributeDefinition(attribute));
 		else attribute.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, member, group));
 
 		return attribute;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
 
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberGroupAttributesModuleImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -758,6 +759,45 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	@Override
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException {
+		try {
+			//member-group attributes, member core attributes
+			return jdbc.query("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
+							"left join member_group_attr_values mem on attr_names.id=mem.attr_id and mem.group_id=? and member_id=? " +
+							"where namespace in (?,?) and (mem.attr_value is not null or mem.attr_value_text is not null)",
+					new AttributeRowMapper(sess, this, null), group.getId(), member.getId(),
+					AttributesManager.NS_MEMBER_GROUP_ATTR_DEF, AttributesManager.NS_MEMBER_GROUP_ATTR_OPT);
+		} catch(EmptyResultDataAccessException ex) {
+			log.debug("No attribute for member-group combination exists.");
+			return new ArrayList<Attribute>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException {
+		MapSqlParameterSource parameters = new MapSqlParameterSource();
+		parameters.addValue("mId", member.getId());
+		parameters.addValue("gId", group.getId());
+		parameters.addValue("nSO", AttributesManager.NS_MEMBER_GROUP_ATTR_OPT);
+		parameters.addValue("nSD", AttributesManager.NS_MEMBER_GROUP_ATTR_DEF);
+		parameters.addValue("nSV", AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
+		parameters.addValue("attrNames", attrNames);
+
+		try {
+			return namedParameterJdbcTemplate.query("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
+						"left join member_group_attr_values mem on id=mem.attr_id and member_id=:mId and group_id=:gId " +
+						"where namespace in ( :nSO,:nSD,:nSV ) and attr_names.attr_name in ( :attrNames )",
+						parameters, new AttributeRowMapper(sess, this, member, group));
+		} catch(EmptyResultDataAccessException ex) {
+			return new ArrayList<Attribute>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public List<Attribute> getAttributes(PerunSession sess, Member member) throws InternalErrorException {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
@@ -917,6 +957,20 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					new AttributeRowMapper(sess, this, user, facility), AttributesManager.NS_USER_FACILITY_ATTR_VIRT);
 		} catch(EmptyResultDataAccessException ex) {
 			log.debug("No virtual attribute for user-facility combination exists.");
+			return new ArrayList<Attribute>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public List<Attribute> getVirtualAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + attributeDefinitionMappingSelectQuery + ", null as attr_value from attr_names " +
+							"where namespace=?",
+					new AttributeRowMapper(sess, this, member, group), AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
+		} catch(EmptyResultDataAccessException ex) {
+			log.debug("No virtual attribute for member-group combination exists.");
 			return new ArrayList<Attribute>();
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
@@ -1133,6 +1187,22 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	@Override
+	public Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws InternalErrorException, AttributeNotExistsException {
+		try {
+			//member-group attributes, member core attributes
+			return jdbc.queryForObject("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
+							"left join member_group_attr_values mem on id=mem.attr_id and mem.group_id=? and member_id=? " +
+							"where attr_name=?",
+					new AttributeRowMapper(sess, this, null), group.getId(), member.getId(), attributeName);
+
+		} catch(EmptyResultDataAccessException ex) {
+			throw new AttributeNotExistsException("Attribute name: \"" + attributeName +"\"", ex);
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public Attribute getAttribute(PerunSession sess, Member member, String attributeName) throws InternalErrorException, AttributeNotExistsException {
 		//member and member core attributes
 		try {
@@ -1328,6 +1398,21 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					"left join   member_resource_attr_values mem    on id=mem.attr_id and mem.resource_id=? and member_id=? " +
 					"where id=?",
 					new AttributeRowMapper(sess, this, member), resource.getId(), member.getId(), id);
+		} catch(EmptyResultDataAccessException ex) {
+			throw new AttributeNotExistsException("Attribute id= \"" + id +"\"", ex);
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws InternalErrorException, AttributeNotExistsException {
+		try {
+			//member-group attributes, member core attributes
+			return jdbc.queryForObject("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
+					"left join member_group_attr_values mem on id=mem.attr_id and mem.group_id=? and member_id=? " +
+					"where id=?",
+					new AttributeRowMapper(sess, this, member), group.getId(), member.getId(), id);
 		} catch(EmptyResultDataAccessException ex) {
 			throw new AttributeNotExistsException("Attribute id= \"" + id +"\"", ex);
 		} catch(RuntimeException ex) {
@@ -2047,6 +2132,118 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 							//Exception wasn't thrown -> update
 							return 0 < jdbc.update("update member_resource_attr_values set attr_value=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where attr_id=? and resource_id=? and member_id=?",
 									BeansUtils.attributeValueToString(attribute), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), attribute.getId(), resource.getId(), member.getId());
+						}
+					} catch(DataIntegrityViolationException ex) {
+						if(++repetatCounter > MERGE_TRY_CNT) throw new InternalErrorException("SQL merger (or other UPSERT command) failed more than " + MERGE_TRY_CNT + " times.", ex);
+						try {
+							Thread.sleep(Math.round(MERGE_RAND_SLEEP_MAX * Math.random())); //randomized sleep
+						} catch(InterruptedException IGNORE) { }
+					}
+				}
+			}
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public boolean setAttribute(final PerunSession sess, final Member member, final Group group, final Attribute attribute) throws InternalErrorException {
+		try {
+			if(isLargeAttribute(sess, attribute)) {
+				if(attribute.getValue() == null) {
+					int numAffected = jdbc.update("delete from member_group_attr_values where attr_id=? and member_id=? and group_id=?", attribute.getId(), member.getId(), group.getId());
+					if(numAffected > 1) throw new ConsistencyErrorException("Too much rows to delete (" + numAffected + " rows). SQL: delete from member_group_attr_values where attr_id="+ attribute.getId() +" and member_id=" + member.getId() + " and group_id=" + group.getId());
+					return numAffected == 1;
+				}
+				int repetatCounter = 0;
+				while(true) {
+					try {
+						if(Compatibility.isMergeSupported()) {
+							return 0 < jdbc.execute("merge into member_group_attr_values using dual on (attr_id=? and group_id=? and member_id=?) " +
+											"when not matched then insert (attr_id, group_id, member_id, attr_value_text, created_by, modified_by, created_at, modified_at, created_by_uid, modified_by_uid) " +
+											"values (?,?,?,?,?,?," + Compatibility.getSysdate() + "," + Compatibility.getSysdate() + ",?,?)" +
+											"when matched then update set attr_value_text=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate(),
+									new AbstractLobCreatingPreparedStatementCallback(lobHandler) {
+										public void setValues(PreparedStatement ps, LobCreator lobCreator) throws SQLException {
+											ps.setInt(1, attribute.getId());
+											ps.setInt(2, group.getId());
+											ps.setInt(3, member.getId());
+											ps.setInt(4, attribute.getId());
+											ps.setInt(5, group.getId());
+											ps.setInt(6, member.getId());
+											try {
+												lobCreator.setClobAsString(ps, 7, BeansUtils.attributeValueToString(attribute));
+												ps.setString(8, sess.getPerunPrincipal().getActor());
+												ps.setString(9, sess.getPerunPrincipal().getActor());
+												ps.setInt(10, sess.getPerunPrincipal().getUserId());
+												ps.setInt(11, sess.getPerunPrincipal().getUserId());
+												lobCreator.setClobAsString(ps, 11, BeansUtils.attributeValueToString(attribute));
+												ps.setString(12, sess.getPerunPrincipal().getActor());
+												ps.setInt(13, sess.getPerunPrincipal().getUserId());
+											} catch(InternalErrorException ex) {
+												throw new InternalErrorRuntimeException(ex);
+											}
+										}
+									}
+							);
+						} else {
+							try {
+								jdbc.queryForInt("select attr_id from member_group_attr_values where attr_id=? and group_id=? and member_id=? for update", attribute.getId(), group.getId(), member.getId());
+							} catch(EmptyResultDataAccessException ex) {
+								//Value doesn't exist -> insert (and return from this method
+								return 0 < jdbc.update("insert into member_group_attr_values (attr_id, group_id, member_id, attr_value_text, created_by, modified_by, created_at, modified_at, created_by_uid, modified_by_uid) " +
+												"values (?,?,?,?,?,?," + Compatibility.getSysdate() + "," + Compatibility.getSysdate() + ",?,?)", attribute.getId(), group.getId(),
+										member.getId(), BeansUtils.attributeValueToString(attribute), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
+							}
+							//Exception wasn't thrown -> update
+							return 0 < jdbc.update("update member_group_attr_values set attr_value_text=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where attr_id=? and group_id=? and member_id=?",
+									BeansUtils.attributeValueToString(attribute), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), attribute.getId(), group.getId(), member.getId());
+							//throw new InternalErrorException("Set large attribute isn't supported yet for databases without merge statement supported.");
+						}
+					} catch(DataIntegrityViolationException ex) {
+						if(++repetatCounter > MERGE_TRY_CNT) throw new InternalErrorException("SQL merger (or other UPSERT command) failed more than " + MERGE_TRY_CNT + " times.", ex);
+						try {
+							Thread.sleep(Math.round(MERGE_RAND_SLEEP_MAX * Math.random())); //randomized sleep
+						} catch(InterruptedException IGNORE) { }
+					}
+				}
+			} else {
+				if(attribute.getValue() == null) {
+					int numAffected = jdbc.update("delete from member_group_attr_values where attr_id=? and member_id=? and group_id=?", attribute.getId(), member.getId(), group.getId());
+					if(numAffected > 1) throw new ConsistencyErrorException("Too much rows to delete (" + numAffected + " rows). SQL: delete from member_group_attr_values where attr_id="+ attribute.getId() +" and member_id=" + member.getId() + " and group_id=" + group.getId());
+					return numAffected == 1;
+				}
+				try {
+					Object value = BeansUtils.stringToAttributeValue(jdbc.queryForObject("select attr_value from member_group_attr_values where attr_id=? and member_id=? and group_id=?", String.class, attribute.getId(), member.getId(), group.getId()), attribute.getType());
+					if(attribute.getValue().equals(value)) return false;
+				} catch(EmptyResultDataAccessException ex) {
+					//This is ok. Attribute will be stored later.
+				}
+				int repetatCounter = 0;
+				while(true) {
+					try {
+						if(Compatibility.isMergeSupported()) {
+							return 0 < jdbc.update("merge into member_group_attr_values using dual on (attr_id=? and group_id=? and member_id=?) " +
+											"when not matched then insert (attr_id, group_id, member_id, attr_value, created_by, modified_by, created_at, modified_at, created_by_uid, modified_by_uid) " +
+											"values (?,?,?,?,?,?," + Compatibility.getSysdate() + "," + Compatibility.getSysdate() + ",?,?)" +
+											"when matched then update set attr_value=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate(),
+									attribute.getId(), group.getId(), member.getId(), attribute.getId(), group.getId(), member.getId(),
+									BeansUtils.attributeValueToString(attribute), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(),
+									sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId(),
+									BeansUtils.attributeValueToString(attribute), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId()
+							);
+						} else {
+							try {
+								jdbc.queryForInt("select attr_id from member_group_attr_values where attr_id=? and group_id=? and member_id=? for update", attribute.getId(), group.getId(), member.getId());
+							} catch(EmptyResultDataAccessException ex) {
+								//Value doesn't exist -> insert (and return from this metod)
+								return 0 < jdbc.update("insert into member_group_attr_values (attr_id, group_id, member_id, attr_value, created_by, modified_by, created_at, modified_at, created_by_uid, modified_by_uid) " +
+												"values (?,?,?,?,?,?," + Compatibility.getSysdate() + "," + Compatibility.getSysdate() + ",?,?)", attribute.getId(), group.getId(),
+										member.getId(), BeansUtils.attributeValueToString(attribute), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
+							}
+							//Exception wasn't thrown -> update
+							return 0 < jdbc.update("update member_group_attr_values set attr_value=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + " where attr_id=? and group_id=? and member_id=?",
+									BeansUtils.attributeValueToString(attribute), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), attribute.getId(), group.getId(), member.getId());
 						}
 					} catch(DataIntegrityViolationException ex) {
 						if(++repetatCounter > MERGE_TRY_CNT) throw new InternalErrorException("SQL merger (or other UPSERT command) failed more than " + MERGE_TRY_CNT + " times.", ex);
@@ -3019,6 +3216,35 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	@Override
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
+							"join service_required_attrs on id=service_required_attrs.attr_id and service_required_attrs.service_id=? " +
+							"left join member_group_attr_values mem on id=mem.attr_id and mem.group_id=? and member_id=? " +
+							"where namespace in (?,?,?)",
+					new AttributeRowMapper(sess, this, member), service.getId(), group.getId(), member.getId(), AttributesManager.NS_MEMBER_GROUP_ATTR_DEF, AttributesManager.NS_MEMBER_GROUP_ATTR_OPT, AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
+							"left join member_group_attr_values mem on id=mem.attr_id and mem.group_id=? and member_id=? " +
+							"where namespace in (?,?,?) " +
+							"and attr_names.id in (select distinct service_required_attrs.attr_id from service_required_attrs " +
+							"join resource_services on service_required_attrs.service_id=resource_services.service_id and resource_services.resource_id=?)",
+					new AttributeRowMapper(sess, this, null), group.getId(), member.getId(), AttributesManager.NS_MEMBER_GROUP_ATTR_DEF, AttributesManager.NS_MEMBER_GROUP_ATTR_OPT, AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT, resourceToGetServicesFrom.getId());
+		} catch(EmptyResultDataAccessException ex) {
+			return new ArrayList<Attribute>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member) throws InternalErrorException {
 		//member and member core attributes
 		try {
@@ -3141,6 +3367,22 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 		log.debug("fillAttribute - There's no rule for this attribute. Attribute wasn't filled. Attribute={}", attribute);
 		return attribute;
+	}
+
+	@Override
+	public Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException {
+		//Use attributes module
+		MemberGroupAttributesModuleImplApi attributeModule = getMemberGroupAttributeModule(sess, attribute);
+		if(attributeModule == null) {
+			log.debug("fillAttribute - There's no attribute module for this attribute. Attribute wasn't filled. Attribute={}", attribute);
+			return attribute;
+		}
+
+		try {
+			return attributeModule.fillAttribute((PerunSessionImpl) sess, member, group, attribute);
+		} catch(WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
 	}
 
 	public Attribute fillAttribute(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException {
@@ -3319,6 +3561,18 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	@Override
+	public void changedAttributeHook(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		//Call attribute module
+		MemberGroupAttributesModuleImplApi memberGroupAttributesModule = getMemberGroupAttributeModule(sess, attribute);
+		if(memberGroupAttributesModule == null) return; //memberGroupAttributesModule module doesn't exists
+		try {
+			memberGroupAttributesModule.changedAttributeHook((PerunSessionImpl) sess, member, group, attribute);
+		} catch(WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public void changedAttributeHook(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//Call attribute module
 		FacilityUserAttributesModuleImplApi facilityUserModule = getFacilityUserAttributeModule(sess, attribute);
@@ -3335,7 +3589,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		FacilityAttributesModuleImplApi facilityModule = getFacilityAttributeModule(sess, attribute);
 		if(facilityModule == null) return; //facility module doesn't exists
 		try {
-			facilityModule.checkAttributeValue((PerunSessionImpl) sess,facility, attribute);
+			facilityModule.checkAttributeValue((PerunSessionImpl) sess, facility, attribute);
 		} catch(WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3386,6 +3640,18 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		if(resourceMemberGroupModule == null) return; //facility module doesn't exists
 		try {
 			resourceMemberGroupModule.checkAttributeValue((PerunSessionImpl) sess, resource, member, attribute);
+		} catch(WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public void checkAttributeValue(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		//Call attribute module
+		MemberGroupAttributesModuleImplApi memberGroupAttributeModule = getMemberGroupAttributeModule(sess, attribute);
+		if(memberGroupAttributeModule == null) return; //memberGroupAttributesModule module doesn't exists
+		try {
+			memberGroupAttributeModule.checkAttributeValue((PerunSessionImpl) sess, member, group, attribute);
 		} catch(WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3567,6 +3833,30 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			if(0 < jdbc.update("delete from member_resource_attr_values where resource_id=? and member_id=?", resource.getId(), member.getId())) {
 				log.info("All attributes (theirs values) were removed from member on resource. Member={}, resource={}.", member, resource);
+			}
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public boolean removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException {
+		try {
+			if(0 < jdbc.update("delete from member_group_attr_values where attr_id=? and member_id=? and group_id=?", attribute.getId(), member.getId(), group.getId())) {
+				log.info("Attribute (its value) was removed from member in group. Attribute={}, member={}, group=" + group, attribute, member);
+				return true;
+			}
+			return false;
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException {
+		try {
+			if(0 < jdbc.update("delete from member_group_attr_values where group_id=? and member_id=?", group.getId(), member.getId())) {
+				log.info("All attributes (theirs values) were removed from member in group. Member={}, group={}.", member, group);
 			}
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
@@ -3991,6 +4281,27 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			return (ResourceMemberAttributesModuleImplApi) attributeModule;
 		} else {
 			throw new WrongModuleTypeException("Required attribute module isn't FacilityAttributesModule");
+		}
+	}
+
+	/**
+	 * Get member-group attribute module for the attribute.
+	 *
+	 * @param attribute attribute for which you get the module
+	 * @return instance member group attribute module
+	 *         null if the module doesn't exists
+	 *
+	 * @throws WrongModuleTypeException
+	 * @throws InternalErrorException
+	 */
+	private MemberGroupAttributesModuleImplApi getMemberGroupAttributeModule(PerunSession sess, AttributeDefinition attribute) throws WrongModuleTypeException, InternalErrorException {
+		Object attributeModule = getAttributesModule(sess, attribute);
+		if(attributeModule == null) return null;
+
+		if(attributeModule instanceof MemberGroupAttributesModuleImplApi) {
+			return (MemberGroupAttributesModuleImplApi) attributeModule;
+		} else {
+			throw new WrongModuleTypeException("Required attribute module isn't MemberGroupAttributesModule");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -171,7 +171,7 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException;
 
 	/**
-	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
+	 * Get all attributes (empty and virtual too) associated with the member in the group which have name in list attrNames.
 	 *
 	 * @param sess perun session
 	 * @param member to get the attributes from

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -159,6 +159,31 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
 
 	/**
+	 * Get all <b>non-empty</b> attributes associated with the member in the group.
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group group to get the attributes from
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException;
+
+	/**
+	 * Get all attributes associated with the member in the group which have name in list attrNames (empty too).
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group group to get the attributes from
+	 * @param attrNames list of attributes' names
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException;
+
+	/**
 	 * Get all <b>non-empty</b> attributes associated with the member.
 	 *
 	 * @param sess perun session
@@ -327,6 +352,18 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getVirtualAttributes(PerunSession sess, Facility facility, User user) throws InternalErrorException;
 
 	/**
+	 * Get all virtual attributes associated with the member in the group.
+	 *
+	 * @param sess perun session
+	 * @param member to get the attributes from
+	 * @param group to get the attributes from
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getVirtualAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException;
+
+	/**
 	 * Get all <b>non-empty</b> attributes associated with the user.
 	 *
 	 * @param sess perun session
@@ -435,6 +472,20 @@ public interface AttributesManagerImplApi {
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlaying data source
 	 */
 	Attribute getAttribute(PerunSession sess, Resource resource, Member member, String attributeName) throws InternalErrorException, AttributeNotExistsException;
+
+	/**
+	 * Get particular attribute for the member in this group.
+	 *
+	 * @param sess perun session
+	 * @param member to get attribute from
+	 * @param group to get attribute from
+	 * @param attributeName attribute name defined in the particular manager
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 */
+	Attribute getAttribute(PerunSession sess, Member member, Group group, String attributeName) throws InternalErrorException, AttributeNotExistsException;
 
 	/**
 	 * Get particular attribute for the member.
@@ -579,6 +630,20 @@ public interface AttributesManagerImplApi {
 	Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws InternalErrorException, AttributeNotExistsException;
 
 	/**
+	 * Get particular attribute for the member in this group.
+	 *
+	 * @param sess perun session
+	 * @param member to get attribute from
+	 * @param group to get attribute from
+	 * @param id attribute id
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 */
+	Attribute getAttributeById(PerunSession sess, Member member, Group group, int id) throws InternalErrorException, AttributeNotExistsException;
+
+	/**
 	 * Get particular attribute for the member.
 	 *
 	 * @param sess
@@ -688,6 +753,18 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	boolean setAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException;
+
+	/**
+	 * Store the particular attribute associated with the group and member combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param group group to set on
+	 * @param attribute attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	boolean setAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException;
 
 	/**
 	 * Store the particular attribute associated with the facility and user combination. If an attribute is core attribute then the attribute isn't stored (It's skkiped whithout any notification).
@@ -1057,6 +1134,32 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws InternalErrorException;
 
 	/**
+	 * Get member-group attributes which are required by the service.
+	 *
+	 * @param sess perun session
+	 * @param member you get attributes for this member and the group
+	 * @param group you get attributes for this group in which member is associated
+	 * @param service attribute required by this service you'll get
+	 * @return list of attributes which are required by the service.
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException;
+
+	/**
+	 * Get member-group attributes which are required by services. Services are known from the resourceToGetServicesFrom.
+	 *
+	 * @param sess perun session
+	 * @param resourceToGetServicesFrom resource from which the services are taken
+	 * @param group you get attributes for this group and the member
+	 * @param member you get attributes for this member and the group
+	 * @return list of member-group attributes which are required by services which are assigned to another resource.
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Group group) throws InternalErrorException;
+
+	/**
 	 * Get member attributes which are required by the service.
 	 *
 	 * @param sess perun session
@@ -1122,6 +1225,19 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	Attribute fillAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException;
+
+	/**
+	 * This method tries to fill value of the member-group attribute. This value is automatically generated, but not all attributes can be filled this way.
+	 *
+	 * @param sess perun session
+	 * @param member attribute of this member (and group) you want to fill
+	 * @param group attribute of this group you want to fill
+	 * @param attribute attribute to fill. If attributes already have set value, this value won't be overwritten. This means the attribute value must be empty otherwise this method won't fill it.
+	 * @return attribute which MAY have filled value
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	Attribute fillAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException;
 
 	/**
 	 * This method try to fill value of the user-facility attribute. This value is automatically generated, but not all atrributes can be filled this way.
@@ -1292,6 +1408,19 @@ public interface AttributesManagerImplApi {
 	 * If you need to do some further work with other modules, this method do that
 	 *
 	 * @param sess
+	 * @param member
+	 * @param group
+	 * @param attribute
+	 * @throws InternalErrorException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 */
+	void changedAttributeHook(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * If you need to do some further work with other modules, this method do that
+	 *
+	 * @param sess
 	 * @param facility
 	 * @param user
 	 * @param attribute
@@ -1365,6 +1494,20 @@ public interface AttributesManagerImplApi {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	void checkAttributeValue(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Check if value of this member-group attribute is valid.
+	 *
+	 * @param sess perun session
+	 * @param group group for which (and for specified member) you want to check validity of attribute
+	 * @param member member for which (and for specified group) you want to check validity of attribute
+	 * @param attribute attribute to check
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void checkAttributeValue(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this user-facility attribute is valid.
@@ -1552,6 +1695,28 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	void removeAllAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
+
+	/**
+	 * Unset particular attribute for the member in the group. Core attributes can't be removed this way.
+	 *
+	 * @param sess perun session
+	 * @param group remove attributes for this group
+	 * @param member remove attribute from this member
+	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	boolean removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException;
+
+	/**
+	 * Unset all attributes for the member in the group.
+	 *
+	 * @param sess perun session
+	 * @param group remove attributes for this group
+	 * @param member remove attributes from this member
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException;
 
 	/**
 	 * Unset particular member attribute

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -159,7 +159,7 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
 
 	/**
-	 * Get all <b>non-empty</b> attributes associated with the member in the group.
+	 * Get all <b>non-empty, non-virtual</b> attributes associated with the member in the group.
 	 *
 	 * @param sess perun session
 	 * @param member to get the attributes from
@@ -898,6 +898,21 @@ public interface AttributesManagerImplApi {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	boolean setVirtualAttribute(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongModuleTypeException, ModuleNotExistsException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Store the particular virtual attribute associated with the member and group combination.
+	 *
+	 * @param sess perun session
+	 * @param member
+	 * @param group
+	 * @param attribute attribute to set
+	 * @return true if attribute was really changed
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ModuleNotExistsException
+	 * @throws WrongModuleTypeException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	boolean setVirtualAttribute(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongModuleTypeException, ModuleNotExistsException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Store the particular virtual attribute associated with the member.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupAttributesModuleAbstract.java
@@ -1,0 +1,35 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * Abstract class for Member Group Attributes modules.
+ * -----------------------------------------------------------------------------
+ * Implements methods for modules to perform default function.
+ * In the function that the method in the module does nothing, it is not necessary to implement it, simply extend this abstract class.
+ *
+ * author: Oliver Mrázik
+ * version: 2015-03-22
+ */
+public class MemberGroupAttributesModuleAbstract extends AttributesModuleAbstract implements MemberGroupAttributesModuleImplApi {
+
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+
+	}
+
+	public Attribute fillAttribute(PerunSessionImpl session, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+		return new Attribute(attribute);
+	}
+
+	public void changedAttributeHook(PerunSessionImpl session, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupAttributesModuleImplApi.java
@@ -1,0 +1,64 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * This interface serves as a template for checking and filling in attribute
+ * for a member in a specified group.
+ *
+ * author: Oliver Mrázik
+ * version: 2015-03-22
+ */
+public interface MemberGroupAttributesModuleImplApi extends AttributesModuleImplApi {
+	/**
+	 * This method checks Member's attributes in a specified group.
+	 *
+	 * @param perunSession Perun session
+	 * @param member Member
+	 * @param group Group
+	 * @param attribute Attribute to be checked.
+	 *
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongReferenceAttributeValueException if an referenced attribute against
+	 *         the parameter is to be compared is not available
+	 * @throws WrongAttributeAssignmentException
+	 */
+	void checkAttributeValue(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+
+	/**
+	 * This method MAY fill Member's attributes in a specified group.
+	 *
+	 * @param perunSession Perun session
+	 * @param member Member
+	 * @param group Group
+	 * @param attribute Attribute to be filled in
+	 *
+	 * @return Attribute which MAY be filled in.
+	 *
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	Attribute fillAttribute(PerunSessionImpl perunSession, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * If you need to do some further work with other modules, this method do that
+	 *
+	 * @param session session
+	 * @param member Member
+	 * @param group Group
+	 * @param attribute the attribute
+	 */
+	void changedAttributeHook(PerunSessionImpl session, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupVirtualAttributesModuleAbstract.java
@@ -1,0 +1,46 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract class for Member Group Virtual Attributes modules.
+ * Implements methods for modules to perform default function.
+ * In the function that the method in the module does nothing, it is not necessary to implement it, simply extend this abstract class.
+ *
+ * author: Oliver Mrazik
+ * version: 2015-04-16
+ */
+public abstract class MemberGroupVirtualAttributesModuleAbstract extends MemberGroupAttributesModuleAbstract implements MemberGroupVirtualAttributesModuleImplApi {
+
+	@Override
+	public Attribute getAttributeValue(PerunSessionImpl sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException {
+		return new Attribute(attribute);
+	}
+
+	@Override
+	public boolean setAttributeValue(PerunSessionImpl sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		return false;
+	}
+
+	@Override
+	public boolean removeAttributeValue(PerunSessionImpl sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return false;
+	}
+
+	@Override
+	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		return new ArrayList<>();
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupVirtualAttributesModuleImplApi.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * This interface serves as a template for checking and filling in virtual attribute
+ * for a member in a specified group.
+ *
+ * author: Oliver Mrazik
+ * version: 2015-04-16
+ */
+public interface MemberGroupVirtualAttributesModuleImplApi extends MemberGroupAttributesModuleImplApi, VirtualAttributesModuleImplApi {
+
+	/**
+	 * This method will return computed value.
+	 *
+	 * @param sess perun session
+	 * @param member member which is needed for computing the value
+	 * @param group group which is needed for computing the value
+	 * @param attribute attribute to operate on
+	 * @return attribute value
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 */
+	Attribute getAttributeValue(PerunSessionImpl sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException;
+
+	/**
+	 * Method sets attributes' values which are dependent on this virtual attribute.
+	 *
+	 * @param sess perun session
+	 * @param member member which is needed for computing the value
+	 * @param group group which is needed for computing the value
+	 * @param attribute attribute to operate on
+	 * @return true if attribute was really changed
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 */
+	boolean setAttributeValue(PerunSessionImpl sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Method remove attributes' value which are dependent on this virtual attribute.
+	 *
+	 * @param sess perun session
+	 * @param member member which is needed for computing the value
+	 * @param group group which is needed for computing the value
+	 * @param attribute attribute to operate on
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 */
+	boolean removeAttributeValue(PerunSessionImpl sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -5244,17 +5244,6 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, group);
 		assertNotNull("unable to get required member group attributes for its services", reqAttr);
 		assertTrue("Shouldn't return attribute, when there is no service on resource", reqAttr.size() == 0);
-
-		// FIXME vytvorit nejake fakeGrupy?
-		/*
-		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, member);
-		assertNotNull("unable to get required member group attributes for its services", reqAttr);
-		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set", reqAttr.size() == 0);
-
-		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member);
-		assertNotNull("unable to get required member group attributes for its services", reqAttr);
-		assertTrue("Should return 1 attribute (but with no value)", reqAttr.size() == 1);
-		*/
 	}
 
 
@@ -5338,17 +5327,6 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, group, true);
 		assertNotNull("unable to get required member group attributes for its services", reqAttr);
 		assertTrue("Shouldn't return attribute, when there is no service on resource", reqAttr.size() == 0);
-
-		//FIXME vytvorit nejake fakeGrupy???
-		/*
-		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, group, true);
-		assertNotNull("unable to get required member group attributes for its services", reqAttr);
-		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set", reqAttr.size() == 0);
-
-		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member, true);
-		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
-		assertTrue("Should return 4 attributes (but with no value)",reqAttr.size() == 4);
-		*/
 	}
 
 	@Test (expected=MemberNotExistsException.class)

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -1025,7 +1025,7 @@ public void getResourceMemberAttributesForUser() throws Exception {
 	// return members and users attributes from resources members
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member, true);
 	assertNotNull("unable to get member-resource(work with user) attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1055,6 +1055,127 @@ public void getResourceMemberAttributesForUser() throws Exception {
 	}
 
 @Test
+public void getMemberGroupAttributes() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributes");
+
+	vo = setUpVo();
+	member = setUpMember();
+	group = setUpGroup();
+	attributes = setUpMemberGroupAttribute();
+	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+
+	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
+	assertNotNull("unable to get member-group attributes", retAttr);
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+}
+
+@Test
+public void getMemberGroupAttributesForUser() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributesForUser");
+
+	vo = setUpVo();
+	member = setUpMember();
+	group = setUpGroup();
+	attributes = setUpUserAttribute();
+	User user = perun.getUsersManager().getUserByMember(sess, member);
+	attributesManager.setAttribute(sess, user, attributes.get(0));
+
+	Attribute attr = new Attribute();
+	attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+	attr.setFriendlyName("member_group_test_for_list_of_names_attribute");
+	attr.setType(String.class.getName());
+	attr.setValue("MemberGroupAttributeForList");
+	attributesManager.createAttribute(sess, attr);
+	attributesManager.setAttribute(sess, member, group, attr);
+
+	List<String> attrNames = new ArrayList<>();
+	attrNames.add(attributes.get(0).getName());
+	attrNames.add(attr.getName());
+
+	// return members and users attributes from groups members
+	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames, true);
+	assertNotNull("unable to get member-group(work with user) attributes", retAttr);
+	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+}
+
+@Test (expected=GroupNotExistsException.class)
+public void getMemberGroupAttributesForUserWhenGroupNotExists() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributesForUserWhenGroupNotExists");
+
+	vo = setUpVo();
+	member = setUpMember();
+
+	attributesManager.getAttributes(sess, member, new Group(), new ArrayList<String>(), true);
+	// shouldn't find group
+}
+
+@Test (expected=MemberNotExistsException.class)
+public void getMemberGroupAttributesForUserWhenMemberNotExists() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributesForUserWhenMemberNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+
+	attributesManager.getAttributes(sess, new Member(), group, new ArrayList<String>(), true);
+	// shouldn't find member
+}
+
+@Test
+public void getMemberGroupAttributesByListOfNames1() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributesByListOfNames");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+
+	Attribute attr = new Attribute();
+	attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+	attr.setFriendlyName("member_group_test_for_list_of_names_attribute");
+	attr.setType(String.class.getName());
+	attr.setValue("MemberGroupAttributeForList");
+	attributesManager.createAttribute(sess, attr);
+	attributesManager.setAttribute(sess, member, group, attr);
+
+	List<String> attrNames = new ArrayList<String>();
+	attrNames.add(attributes.get(0).getName());
+	attrNames.add(attr.getName());
+
+	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames);
+	assertNotNull("unable to get member-group attributes", retAttr);
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attr));
+}
+
+@Test
+public void getMemberGroupAttributesByListOfNames2() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributesByListOfNames");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+
+	Attribute attr = new Attribute();
+	attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+	attr.setFriendlyName("member_group_test_for_list_of_names_attribute");
+	attr.setType(String.class.getName());
+	attr.setValue("MemberGroupAttributeForList");
+	attributesManager.createAttribute(sess, attr);
+	attributesManager.setAttribute(sess, member, group, attr);
+
+	List<String> attrNames = new ArrayList<String>();
+	attrNames.add(attr.getName());
+
+	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames);
+	assertNotNull("unable to get member attributes", retAttr);
+	assertFalse("our attribute was not returned", retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attr));
+}
+
+@Test
 public void getMemberAttributes() throws Exception {
 	System.out.println("attributesManager.getMemberAttributes");
 
@@ -1065,7 +1186,7 @@ public void getMemberAttributes() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
 	assertNotNull("unable to get member attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1101,7 +1222,7 @@ public void getMemberAttributesByListOfNames1() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, attrNames);
 	assertNotNull("unable to get member attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 	assertTrue("our attribute was not returned",retAttr.contains(attr));
 }
 
@@ -1127,8 +1248,8 @@ public void getMemberAttributesByListOfNames2() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, attrNames);
 	assertNotNull("unable to get member attributes", retAttr);
-	assertFalse("our attribute was not returned",retAttr.contains(attributes.get(0)));
-	assertTrue("our attribute was not returned",retAttr.contains(attr));
+	assertFalse("our attribute was not returned", retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attr));
 }
 
 @Test
@@ -1147,7 +1268,7 @@ public void getFacilityUserAttributes() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
 	assertNotNull("unable to get facility-user attributes",retAttr);
-	assertTrue("returned incorrect facility-user",retAttr.contains(attributes.get(0)));
+	assertTrue("returned incorrect facility-user", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1187,8 +1308,8 @@ public void getUserAttributes() throws Exception {
 	attributesManager.setAttribute(sess, user, attributes.get(0));
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
-	assertNotNull("unable to get user attributes",retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertNotNull("unable to get user attributes", retAttr);
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1212,8 +1333,8 @@ public void getUserLargeAttributes() throws Exception {
 	attributesManager.setAttribute(sess, user, attributes.get(0));
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
-	assertNotNull("unable to get user attributes",retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertNotNull("unable to get user attributes", retAttr);
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 }
 
 @Test
@@ -1227,7 +1348,7 @@ public void getGroupAttributes() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
 	assertNotNull("unable to get group attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1253,7 +1374,7 @@ public void getGroupResourceAttributes() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
 	assertNotNull("unable to get group-resource attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1292,7 +1413,7 @@ public void getHostAttributes() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
 	assertNotNull("unable to get host attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1315,7 +1436,7 @@ public void getAttributesByAttributeDefinition() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributesByAttributeDefinition(sess, attributes.get(0));
 	assertNotNull("unable to get attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1340,7 +1461,7 @@ public void setFacilityAttributes() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
 
-	assertTrue("unable to set/or return facility attribute we created",retAttr.contains(attributes.get(0)));
+	assertTrue("unable to set/or return facility attribute we created", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1403,7 +1524,7 @@ public void setVoAttributes() throws Exception {
 	attributesManager.setAttributes(sess, vo, attributes);
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
-	assertTrue("unable to set/or return vo attribute we created",retAttr.contains(attributes.get(0)));
+	assertTrue("unable to set/or return vo attribute we created", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1468,7 +1589,7 @@ public void setResourceAttributes() throws Exception {
 	attributesManager.setAttributes(sess, resource, attributes);
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
-	assertTrue("unable to set/or return resource attribute we created",retAttr.contains(attributes.get(0)));
+	assertTrue("unable to set/or return resource attribute we created", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1541,7 +1662,7 @@ public void setMemberResourceAttributes() throws Exception {
 
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
 	assertNotNull("unable to get member-resource attributes", retAttr);
-	assertTrue("unable to set/or return our member-resource attribute",retAttr.contains(attributes.get(0)));
+	assertTrue("unable to set/or return our member-resource attribute", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1638,7 +1759,7 @@ public void setUserAttributesForMemberResource() throws Exception {
 	// return users attributes from resource member
 	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member, true);
 	assertNotNull("unable to set or get member-resource(work with user) attributes", attributes);
-	assertTrue("our attribute was not set/returned",retAttr.contains(attributes.get(0)));
+	assertTrue("our attribute was not set/returned", retAttr.contains(attributes.get(0)));
 
 }
 
@@ -1701,6 +1822,173 @@ public void setUserAttributesForMemberResource() throws Exception {
 		// shouldn't set wrong attribute
 
 	}
+
+@Test
+public void setMemberGroupAttributes() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributes");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttributes(sess, member, group, attributes);
+
+	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
+	assertNotNull("unable to get member-group attributes", retAttr);
+	assertTrue("unable to set/or return our member-group attribute", retAttr.contains(attributes.get(0)));
+}
+
+@Test (expected=GroupNotExistsException.class)
+public void setMemberGroupAttributesWhenGroupNotExists() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributesWhenResourceNotExists");
+
+	vo = setUpVo();
+	member = setUpMember();
+
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttributes(sess, member, new Group(), attributes);
+	// shouldn't find group
+}
+
+@Test (expected=MemberNotExistsException.class)
+public void setMemberGroupAttributesWhenMemberNotExists() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributesWhenMemberNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttributes(sess, new Member(), group, attributes);
+	// shouldn't find member
+}
+
+@Test (expected=AttributeNotExistsException.class)
+public void setMemberGroupAttributesWhenAttributeNotExists() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributesWhenAttributeNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+
+	attributes = setUpMemberGroupAttribute();
+	attributes.get(0).setId(0);
+	// make valid attribute not existing in DB by setting ID=0
+	attributesManager.setAttributes(sess, member, group, attributes);
+	// shouldn't find attribute
+}
+
+@Test (expected=WrongAttributeAssignmentException.class)
+public void setMemberGroupAttributesWhenWrongAttrAssigment() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributesWhenAttributeNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+
+	attributes = setUpVoAttribute();
+	// set up wrong attribute - vo instead of member-group
+	attributesManager.setAttributes(sess, member, group, attributes);
+	// shouldn't set attribute
+}
+
+@Test (expected=InternalErrorException.class)
+public void setMemberGroupAttributesWhenTypeMismatch() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributesWhenTypeMismatch");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+	attributes.get(0).setValue(1);
+	// set wrong value - integer into string
+	attributesManager.setAttributes(sess, member, group, attributes);
+	// shouldn't set wrong attribute
+}
+
+@Test
+public void setUserAttributesForMemberGroup() throws Exception {
+	System.out.println("attributesManager.setUserAttributesForMemberGroup");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpUserAttribute();
+
+	Attribute attr = new Attribute();
+	attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+	attr.setFriendlyName("member_group_test_for_list_of_names_attribute");
+	attr.setType(String.class.getName());
+	attr.setValue("MemberGroupAttributeForList");
+	attributesManager.createAttribute(sess, attr);
+	attributesManager.setAttribute(sess, member, group, attr);
+
+	List<String> attrNames = new ArrayList<String>();
+	attrNames.add(attributes.get(0).getName());
+	attrNames.add(attr.getName());
+
+	attributesManager.setAttributes(sess, member, group, attributes, true);
+
+	// return users attributes from member group
+	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames, true);
+	assertNotNull("unable to set or get member-group(work with user) attributes", attributes);
+	assertTrue("our attribute was not set/returned", retAttr.contains(attributes.get(0)));
+}
+
+@Test (expected=MemberNotExistsException.class)
+public void setUserAttributesForMemberGroupWhenMemberNotExists() throws Exception {
+	System.out.println("attributesManager.setUserAttributesForMemberGroupWhenMemberNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	attributes = setUpUserAttribute();
+
+	attributesManager.setAttributes(sess, new Member(), group, attributes, true);
+	// shouldn't find member
+}
+
+@Test (expected=GroupNotExistsException.class)
+public void setUserAttributesForMemberGroupWhenGroupNotExists() throws Exception {
+	System.out.println("attributesManager.setUserAttributesForMemberGroupWhenGroupNotExists");
+
+	vo = setUpVo();
+	member = setUpMember();
+	attributes = setUpUserAttribute();
+
+	attributesManager.setAttributes(sess, member, new Group(), attributes, true);
+	// shouldn't find group
+}
+
+@Test (expected=AttributeNotExistsException.class)
+public void setUserAttributesForMemberGroupWhenAttributeNotExists() throws Exception {
+	System.out.println("attributesManager.setUserAttributesForMemberGroupWhenAttributeNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpUserAttribute();
+	attributes.get(0).setId(0);
+	// make valid attribute object not existing in DB
+
+	attributesManager.setAttributes(sess, member, group, attributes, true);
+	// shouldn't find attribute
+}
+
+@Test (expected=InternalErrorException.class)
+public void setUserAttributesForMemberGroupWhenTypeMismatch() throws Exception {
+	System.out.println("attributesManager.setUserAttributesForMemberGroupWhenTypeMismatch");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpUserAttribute();
+	attributes.get(0).setValue(1);
+	// set wrong value - integer into string
+	attributesManager.setAttributes(sess, member, group, attributes, true);
+	// shouldn't set wrong attribute
+}
 
 @Test
 public void setMemberAttributes() throws Exception {
@@ -2216,7 +2504,7 @@ public void getResourceAttribute() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:id");
 	assertNotNull("unable to get core attribute resource id", retAttr);
-	assertEquals("returned core attr value is not correct",retAttr.getValue(),resource.getId());
+	assertEquals("returned core attr value is not correct", retAttr.getValue(), resource.getId());
 
 }
 
@@ -2269,7 +2557,7 @@ public void getMemberResourceAttribute() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttribute(sess, resource, member,"urn:perun:member_resource:attribute-def:opt:member_resource_test_attribute");
 	assertNotNull("unable to get opt member resource attribute ", retAttr);
-	assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
+	assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
 
 }
 
@@ -2336,6 +2624,79 @@ public void getMemberResourceAttribute() throws Exception {
 	}
 
 @Test
+public void getMemberGroupAttribute() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttribute");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttributes(sess, member, group, attributes);
+
+	Attribute retAttr = attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:member_group_test_attribute");
+	assertNotNull("unable to get opt member group attribute ", retAttr);
+	assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
+
+}
+
+@Test (expected=GroupNotExistsException.class)
+public void getMemberGroupAttributeWhenGroupNotExists() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeWhenGroupNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttributes(sess, member, group, attributes);
+
+	attributesManager.getAttribute(sess, member, new Group(), "urn:perun:member_group:attribute-def:opt:member_group_test_attribute");
+	// shouldn't find group
+}
+
+@Test (expected=MemberNotExistsException.class)
+public void getMemberGroupAttributeWhenMemberNotExists() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeWhenMemberNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttributes(sess, member, group, attributes);
+
+	attributesManager.getAttribute(sess, new Member(), group, "urn:perun:member_group:attribute-def:opt:member_group_test_attribute");
+	// shouldn't find member
+}
+
+@Test (expected=AttributeNotExistsException.class)
+public void getMemberGroupAttributeWhenAttributeNotExists() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeWhenAttributeNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+
+	attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:nesmysl");
+	// shouldn't find member group attribute "nesmysl"
+
+}
+
+@Test (expected=WrongAttributeAssignmentException.class)
+public void getMemberGroupAttributeWhenWrongAttrAssignment() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeWhenWrongAttrAssignment");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+
+	attributesManager.getAttribute(sess, member, group, "urn:perun:group:attribute-def:opt:member_groupe_test_attribute");
+	// shouldn't find group attribute instead of member-group
+
+}
+
+@Test
 public void getMemberAttribute() throws Exception {
 	System.out.println("attributesManager.getMemberAttribute");
 
@@ -2395,7 +2756,7 @@ public void getFacilityUserAttribute() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttribute(sess, facility, user, "urn:perun:user_facility:attribute-def:opt:user_facility_test_attribute");
 	assertNotNull("unable to get opt user_facility attribute ", retAttr);
-	assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
+	assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
 
 }
 
@@ -2532,7 +2893,7 @@ public void getGroupAttribute() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttribute(sess, group, "urn:perun:group:attribute-def:opt:group_test_attribute");
 	assertNotNull("unable to get opt group attribute", retAttr);
-	assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
+	assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
 
 }
 
@@ -2736,7 +3097,7 @@ public void getAttributeDefinition() throws Exception {
 
 	AttributeDefinition attrDef = attributesManager.getAttributeDefinition(sess, "urn:perun:vo:attribute-def:core:id");
 	assertNotNull("unable to get attribute definition by name",attrDef);
-	assertTrue("returned wrong attr def by name",attrDef.getName().equals("urn:perun:vo:attribute-def:core:id"));
+	assertTrue("returned wrong attr def by name", attrDef.getName().equals("urn:perun:vo:attribute-def:core:id"));
 
 }
 
@@ -2791,7 +3152,7 @@ public void getAttributesDefinition() throws Exception {
 
 	List<AttributeDefinition> attrDef = attributesManager.getAttributesDefinition(sess);
 	assertNotNull("unable to get attributes definition",attrDef);
-	assertTrue("there should be some attributes definition",attrDef.size() > 0);
+	assertTrue("there should be some attributes definition", attrDef.size() > 0);
 
 }
 
@@ -2810,7 +3171,7 @@ public void getAttributeDefinitionById() throws Exception {
 
 	AttributeDefinition retAttrDef = attributesManager.getAttributeDefinitionById(sess, attrDef.getId());
 	assertNotNull("unable to get attribute definition",retAttrDef);
-	assertTrue("returned wrong attr definition",retAttrDef.getName().equals(attrDef.getName()));
+	assertTrue("returned wrong attr definition", retAttrDef.getName().equals(attrDef.getName()));
 
 }
 
@@ -2858,8 +3219,8 @@ public void getFacilityAttributeById() throws Exception {
 	int id = attributes.get(0).getId();
 
 	Attribute retAttr = attributesManager.getAttributeById(sess, facility, id);
-	assertNotNull("unable to get facility attribute by id",retAttr);
-	assertEquals("returned attribute is not same as we stored",retAttr,attributes.get(0));
+	assertNotNull("unable to get facility attribute by id", retAttr);
+	assertEquals("returned attribute is not same as we stored", retAttr, attributes.get(0));
 
 }
 
@@ -2911,7 +3272,7 @@ public void getVoAttributeById() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttributeById(sess, vo, id);
 	assertNotNull("unable to get vo attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
+	assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
 
 }
 
@@ -2965,7 +3326,7 @@ public void getResourceAttributeById() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttributeById(sess, resource, id);
 	assertNotNull("unable to get resource attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
+	assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
 
 }
 
@@ -3024,7 +3385,7 @@ public void getMemberResourceAttributeById() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttributeById(sess, resource, member, id);
 	assertNotNull("unable to get resource member attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
+	assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
 
 }
 
@@ -3086,6 +3447,75 @@ public void getMemberResourceAttributeById() throws Exception {
 		// shouldn't return member resource attribute when ID belong to different type of attribute
 
 	}
+
+@Test
+public void getMemberGroupAttributeById() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeById");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+	attributesManager.setAttributes(sess, member, group, attributes);
+
+	int id = attributes.get(0).getId();
+
+	Attribute retAttr = attributesManager.getAttributeById(sess, member, group, id);
+	assertNotNull("unable to get group member attribute by id", retAttr);
+	assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
+}
+
+@Test (expected=GroupNotExistsException.class)
+public void getMemberGroupAttributeByIdWhenGroupNotExists() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeByIdWhenGroupNotExists");
+
+	vo = setUpVo();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+	int id = attributes.get(0).getId();
+
+	attributesManager.getAttributeById(sess, member, new Group(), id);
+	// shouldn't find group
+}
+
+@Test (expected=MemberNotExistsException.class)
+public void getMemberGroupAttributeByIdWhenMemberNotExists() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeByIdWhenMemberNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	attributes = setUpMemberGroupAttribute();
+	int id = attributes.get(0).getId();
+
+	attributesManager.getAttributeById(sess, new Member(), group, id);
+	// shouldn't find member
+}
+
+@Test (expected=AttributeNotExistsException.class)
+public void getMemberGroupAttributeByIdWhenAttributeNotExists() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeByIdWhenAttributeNotExists");
+
+	vo = setUpVo();
+	member = setUpMember();
+	group = setUpGroup();
+
+	attributesManager.getAttributeById(sess, member, group, 0);
+	// shouldn't find attribute
+}
+
+@Test (expected=WrongAttributeAssignmentException.class)
+public void getMemberGroupAttributeByIdWhenWrongAttrAssignment() throws Exception {
+	System.out.println("attributesManager.getMemberGroupAttributeByIdWhenWrongAttrAssignment");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpVoAttribute();
+	int id = attributes.get(0).getId();
+
+	attributesManager.getAttributeById(sess, member, group, id);
+	// shouldn't return member group attribute when ID belong to different type of attribute
+}
 
 @Test
 public void getMemberAttributeById() throws Exception {
@@ -3425,7 +3855,7 @@ public void setFacilityAttribute() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:opt:facility_test_attribute");
 	assertNotNull("unable to get facility attribute by name",retAttr);
-	assertEquals("returned facility attribute is not same as stored",retAttr,attributes.get(0));
+	assertEquals("returned facility attribute is not same as stored", retAttr, attributes.get(0));
 
 }
 
@@ -3493,7 +3923,7 @@ public void setFacilityUserAttribute() throws Exception {
 
 	Attribute retAttr = attributesManager.getAttribute(sess, facility, user, "urn:perun:user_facility:attribute-def:opt:user_facility_test_attribute");
 	assertNotNull("unable to get facility-user attribute by name",retAttr);
-	assertEquals("returned facility-user attribute is not same as stored",retAttr,attributes.get(0));
+	assertEquals("returned facility-user attribute is not same as stored", retAttr, attributes.get(0));
 
 }
 
@@ -3648,8 +4078,8 @@ public void setResourceAttribute() throws Exception {
 	attributesManager.setAttribute(sess, resource, attributes.get(0));
 
 	Attribute retAttr = attributesManager.getAttribute(sess, resource, "urn:perun:resource:attribute-def:opt:resource_test_attribute");
-	assertNotNull("unable to get resource attribute by name",retAttr);
-	assertEquals("returned resource attribute is not same as stored",retAttr,attributes.get(0));
+	assertNotNull("unable to get resource attribute by name", retAttr);
+	assertEquals("returned resource attribute is not same as stored", retAttr, attributes.get(0));
 
 }
 
@@ -3722,8 +4152,8 @@ public void setMemberResourceAttribute() throws Exception {
 	attributesManager.setAttribute(sess, resource, member, attributes.get(0));
 
 	Attribute retAttr = attributesManager.getAttribute(sess, resource, member, "urn:perun:member_resource:attribute-def:opt:member_resource_test_attribute");
-	assertNotNull("unable to get member-resource attribute by name",retAttr);
-	assertEquals("returned member-resource attribute is not same as stored",retAttr,attributes.get(0));
+	assertNotNull("unable to get member-resource attribute by name", retAttr);
+	assertEquals("returned member-resource attribute is not same as stored", retAttr, attributes.get(0));
 
 }
 
@@ -3801,6 +4231,89 @@ public void setMemberResourceAttribute() throws Exception {
 		// shouldn't add attribute with String type and Integer value
 
 	}
+
+@Test
+public void setMemberGroupAttribute() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttribute");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+
+	Attribute retAttr = attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:member_group_test_attribute");
+	assertNotNull("unable to get member-group attribute by name", retAttr);
+	assertEquals("returned member-group attribute is not same as stored", retAttr, attributes.get(0));
+}
+
+@Test (expected=GroupNotExistsException.class)
+public void setMemberGroupAttributeWhenGroupNotExists() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributeWhenResourceNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttribute(sess, member, new Group(), attributes.get(0));
+	// shouldn't find group
+}
+
+@Test (expected=MemberNotExistsException.class)
+public void setMemberGroupAttributeWhenMemberNotExists() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributeWhenMemberNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	attributes = setUpMemberGroupAttribute();
+
+	attributesManager.setAttribute(sess, new Member(), group, attributes.get(0));
+	// shouldn't find member
+}
+
+@Test (expected=AttributeNotExistsException.class)
+public void setMemberGroupAttributeWhenAttributeNotExists() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributeWhenAttributeNotExists");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+	attributes.get(0).setId(0);
+	// make valid attribute not existing in DB by setting ID = 0
+
+	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+	// shouldn't find attribute
+}
+
+@Test (expected=WrongAttributeAssignmentException.class)
+public void setMemberGroupAttributeWhenWrongAttrAssignment() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributeWhenWrongAttrAssignment");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpVoAttribute();
+
+	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+	// shouldn't add vo attribute into member-group
+}
+
+@Test (expected=InternalErrorException.class)
+public void setMemberGroupAttributeWhenTypeMismatch() throws Exception {
+	System.out.println("attributesManager.setMemberGroupAttributeWhenTypeMismatch");
+
+	vo = setUpVo();
+	group = setUpGroup();
+	member = setUpMember();
+	attributes = setUpMemberGroupAttribute();
+	attributes.get(0).setValue(1);
+
+	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+	// shouldn't add attribute with String type and Integer value
+}
 
 @Test
 public void setMemberAttribute() throws Exception {
@@ -4661,6 +5174,193 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 		resource = setUpResource();
 
 		attributesManager.getResourceRequiredAttributes(sess, resource, resource, new Member(), true);
+		// shouldn't find member
+	}
+
+	@Test
+	public void getResourceRequiredMemberGroupAttributes() throws Exception {
+		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributes");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, member, group);
+		assertNotNull("unable to get required member group attributes for its services", reqAttr);
+		assertTrue("should have only 1 req member group attribute", reqAttr.size() == 1);
+	}
+
+	@Test (expected=ResourceNotExistsException.class)
+	public void getResourceRequiredMemberGroupAttributesWhenResourceNotExists() throws Exception {
+		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWhenResourceNotExists");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		attributesManager.getResourceRequiredAttributes(sess, new Resource(), member, group);
+		// shouldn't find resource
+	}
+
+	@Test (expected=GroupNotExistsException.class)
+	public void getResourceRequiredMemberGroupAttributesWhenGroupNotExists() throws Exception {
+		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWhenGroupNotExists");
+
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		attributesManager.getResourceRequiredAttributes(sess, resource, member, new Group());
+		// shouldn't find group
+	}
+
+	@Test
+	public void getResourceRequiredMemberGroupAttributesWhenFakeResource() throws Exception {
+		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWhenFakeResource");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		Resource fakeResource = new Resource();
+		fakeResource.setName("AttrManTestResource2");
+		fakeResource.setDescription("fake resource");
+
+		perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
+
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, group);
+		assertNotNull("unable to get required member group attributes for its services", reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource", reqAttr.size() == 0);
+
+		// FIXME vytvorit nejake fakeGrupy?
+		/*
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, member);
+		assertNotNull("unable to get required member group attributes for its services", reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set", reqAttr.size() == 0);
+
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member);
+		assertNotNull("unable to get required member group attributes for its services", reqAttr);
+		assertTrue("Should return 1 attribute (but with no value)", reqAttr.size() == 1);
+		*/
+	}
+
+
+	@Test (expected=MemberNotExistsException.class)
+	public void getResourceRequiredMemberGroupAttributesWhenMemberNotExists() throws Exception {
+		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWhenMemberNotExists");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		attributesManager.getResourceRequiredAttributes(sess, resource, new Member(), group);
+		// shouldn't find member
+	}
+
+	@Test
+	public void getResourceRequiredMemberGroupAttributesWorkWithUserAttributes() throws Exception {
+		System.out.println("attributesManager.getRequiredMemberGroupAttributesWorkWithUserAttributes");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, member, group, true);
+		assertNotNull("unable to get required member group (work with user) attributes for its services", reqAttr);
+		assertTrue("should have more than 1 req attribute", reqAttr.size() >= 1);
+	}
+
+	@Test (expected=ResourceNotExistsException.class)
+	public void getResourceRequiredMemberGroupAttributesWorkWithUserWhenResourceNotExists() throws Exception {
+		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWorkWithUserWhenResourceNotExists");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		attributesManager.getResourceRequiredAttributes(sess, new Resource(), member, group, true);
+		// shouldn't find resource
+	}
+
+	@Test (expected=GroupNotExistsException.class)
+	public void getResourceRequiredMemberGroupAttributesWorkWithUserWhenGroupNotExists() throws Exception {
+		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWorkWithUserWhenGroupNotExists");
+
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		attributesManager.getResourceRequiredAttributes(sess, resource, member, new Group(), true);
+		// shouldn't find group
+	}
+
+	@Test
+	public void getResourceRequiredMemberGroupAttributesWorkWithUserWhenFakeResource() throws Exception {
+		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWorkWithUserWhenFakeResource");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		Resource fakeResource = new Resource();
+		fakeResource.setName("AttrManTestResource2");
+		fakeResource.setDescription("fake resource");
+
+		perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
+
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, group, true);
+		assertNotNull("unable to get required member group attributes for its services", reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource", reqAttr.size() == 0);
+
+		//FIXME vytvorit nejake fakeGrupy???
+		/*
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, group, true);
+		assertNotNull("unable to get required member group attributes for its services", reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set", reqAttr.size() == 0);
+
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member, true);
+		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
+		assertTrue("Should return 4 attributes (but with no value)",reqAttr.size() == 4);
+		*/
+	}
+
+	@Test (expected=MemberNotExistsException.class)
+	public void getResourceRequiredMemberGroupAttributesWorkWithUserWhenMemberNotExists() throws Exception {
+		System.out.println("attributesManager.getRequiredMemberGroupAttributesWorkWithUserWhenMemberNotExists");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+
+		attributesManager.getResourceRequiredAttributes(sess, resource, new Member(), group, true);
 		// shouldn't find member
 	}
 
@@ -6254,6 +6954,170 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	}
 
+	@Test
+	public void removeMemberGroupAttribute() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttribute");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		// create member-group and set attribute with value
+		attributesManager.removeAttribute(sess, member, group, attributes.get(0));
+		// remove attribute from member-group (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
+		assertFalse("our member-group shouldn't have set our attribute", retAttr.contains(attributes.get(0)));
+	}
+
+	@Test (expected=GroupNotExistsException.class)
+	public void removeMemberGroupAttributeWhenGroupNotExists() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributeWhenGroupNotExists");
+
+		attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		attributesManager.removeAttribute(sess, member, new Group(), attributes.get(0));
+		// shouldn't find group
+	}
+
+	@Test (expected=MemberNotExistsException.class)
+	public void removeMemberGroupAttributeWhenMemberNotExists() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributeWhenMemberNotExists");
+
+		attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		attributesManager.removeAttribute(sess, new Member(), group, attributes.get(0));
+		// shouldn't find member
+	}
+
+	@Test (expected=AttributeNotExistsException.class)
+	public void removeMemberGroupAttributeWhenAttributeNotExists() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributeWhenAttributeNotExists");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributes.get(0).setId(0);
+		attributesManager.removeAttribute(sess, member, group, attributes.get(0));
+		// shouldn't find attribute
+	}
+
+	@Test (expected=WrongAttributeAssignmentException.class)
+	public void removeMemberGroupAttributeWhenWrongAttrAssignment() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributeWhenWrongAttrAssignment");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpFacilityAttribute();
+		attributesManager.removeAttribute(sess, member, group, attributes.get(0));
+		// shouldn't find facility attribute on member-group
+	}
+
+	@Test
+	public void removeMemberGroupAttributes() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributes");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		// create member-group and set attribute with value
+		attributesManager.removeAttributes(sess, member, group, attributes);
+		// remove attributes from member-group (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
+		assertFalse("our member-group shouldn't have set our attribute", retAttr.contains(attributes.get(0)));
+	}
+
+	@Test (expected=GroupNotExistsException.class)
+	public void removeMemberGroupAttributesWhenGroupNotExists() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributesWhenGroupNotExists");
+
+		attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		attributesManager.removeAttributes(sess, member, new Group(), attributes);
+		// shouldn't find group
+	}
+
+	@Test (expected=MemberNotExistsException.class)
+	public void removeMemberGroupAttributesWhenMemberNotExists() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributesWhenMemberNotExists");
+
+		attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		attributesManager.removeAttributes(sess, new Member(), group, attributes);
+		// shouldn't find member
+	}
+
+	@Test (expected=AttributeNotExistsException.class)
+	public void removeMemberGroupAttributesWhenAttributeNotExists() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributesWhenAttributeNotExists");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpResourceAttribute();
+		attributes.get(0).setId(0);
+		attributesManager.removeAttributes(sess, member, group, attributes);
+		// shouldn't find attribute
+	}
+
+	@Test (expected=WrongAttributeAssignmentException.class)
+	public void removeMemberGroupAttributesWhenWrongAttrAssignment() throws Exception {
+		System.out.println("attributesManager.removeMemberGroupAttributesWhenWrongAttrAssignment");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpFacilityAttribute();
+		attributesManager.removeAttributes(sess, member, group, attributes);
+		// shouldn't find facility attribute on member-group
+	}
+
+	@Test
+	public void removeAllMemberGroupAttributes() throws Exception {
+		System.out.println("attributesManager.removeAllMemberGroupAttributes");
+
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		// create member-group and set attribute with value
+		attributesManager.removeAllAttributes(sess, member, group);
+		// remove all attributes from member-group (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
+		assertFalse("our member-group shouldn't have set our attribute", retAttr.contains(attributes.get(0)));
+	}
+
+	@Test (expected=GroupNotExistsException.class)
+	public void removeAllMemberGroupAttributesWhenGroupNotExists() throws Exception {
+		System.out.println("attributesManager.removeAllMemberGroupAttributesWhenGroupNotExists");
+
+		vo = setUpVo();
+		member = setUpMember();
+
+		attributesManager.removeAllAttributes(sess, member, new Group());
+		// shouldn't find group
+	}
+
+	@Test (expected=MemberNotExistsException.class)
+	public void removeAllMemberGroupAttributesWhenMemberNotExists() throws Exception {
+		System.out.println("attributesManager.removeAllMemberGroupAttributesWhenMemberNotExists");
+
+		vo = setUpVo();
+		group = setUpGroup();
+
+		attributesManager.removeAllAttributes(sess, new Member(), group);
+		// shouldn't find member
+	}
+
 @Test
 public void removeMemberAttribute() throws Exception {
 	System.out.println("attributesManager.removeMemberAttribute");
@@ -7514,7 +8378,7 @@ private Service setUpService2() throws Exception {
 private Group setUpGroup() throws Exception {
 
 	Group group = perun.getGroupsManager().createGroup(sess, vo, new Group("AttrTestGroup","AttrTestGroupDescription"));
-	assertNotNull("unable to create a group",group);
+	assertNotNull("unable to create a group", group);
 	return group;
 
 }
@@ -7555,6 +8419,7 @@ private List<Attribute> setUpRequiredAttributes() throws Exception {
 	attrList.add(setUpResourceAttribute().get(0));
 	attrList.add(setUpMemberAttribute().get(0));
 	attrList.add(setUpMemberResourceAttribute().get(0));
+	attrList.add(setUpMemberGroupAttribute().get(0));
 	attrList.add(setUpUserAttribute().get(0));
 	attrList.add(setUpHostAttribute().get(0));
 	attrList.add(setUpGroupResourceAttribute().get(0));
@@ -7575,7 +8440,7 @@ private Attribute setUpResourceRequiredAttributeForService(Service service) thro
 	attribute.setFriendlyName("resource_test_attribute_2");
 	attribute.setType(String.class.getName());
 	attribute.setValue("ResourceAttribute");
-	assertNotNull("unable to create resource attribute",attributesManager.createAttribute(sess, attribute));
+	assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attribute));
 	
 	listOfAttrs.add(attribute);
 	
@@ -7690,6 +8555,23 @@ private List<Attribute> setUpMemberResourceAttribute() throws Exception {
 	return attributes;
 
 }
+
+	private List<Attribute> setUpMemberGroupAttribute() throws Exception {
+
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+		attr.setFriendlyName("member_group_test_attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberGroupAttribute");
+		assertNotNull("unable to create member-group attribute",attributesManager.createAttribute(sess, attr));
+		// create new member-group attribute
+
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+
+		return attributes;
+	}
 
 private List<Attribute> setUpUserAttribute() throws Exception {
 

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -744,6 +744,22 @@ create table "member_resource_attr_values" (
 	modified_by_uid integer
 );
 
+-- MEMBER_GROUP_ATTR_VALUES - values of attributes assigned to members in groups
+create table "member_group_attr_values" (
+	member_id integer not null,   --identifier of member (members.id)
+	group_id integer not null, --identifier of group (groups.id)
+	attr_id integer not null,     --identifier of attribute (attr_names.id)
+	attr_value varchar(4000),     --attribute value
+	created_at timestamp default now() not null,
+	created_by varchar(1024) default user not null,
+	modified_at timestamp default now() not null,
+	modified_by varchar(1024) default user not null,
+	status char(1) default '0' not null,
+	attr_value_text text,         --attribute value in case it is very long text
+	created_by_uid integer,
+	modified_by_uid integer
+);
+
 -- USER_ATTR_VALUES - values of attributes assigned to users
 create table "user_attr_values" (
 	user_id integer not null,  --identifier of user (users.id)
@@ -1182,6 +1198,9 @@ create index idx_fk_grp_grp on groups(parent_group_id);
 create index idx_fk_memrav_mem on member_resource_attr_values(member_id);
 create index idx_fk_memrav_rsrc on member_resource_attr_values(resource_id);
 create index idx_fk_memrav_accattnam on member_resource_attr_values(attr_id);
+create index idx_fk_memgav_mem on member_group_attr_values(member_id);
+create index idx_fk_memgav_grp on member_group_attr_values(group_id);
+create index idx_fk_memgav_accattnam on member_group_attr_values(attr_id);
 create index idx_fk_usrfacav_mem on user_facility_attr_values(user_id);
 create index idx_fk_usrfacav_fac on user_facility_attr_values(facility_id);
 create index idx_fk_usrfacav_accattnam on user_facility_attr_values(attr_id);
@@ -1367,6 +1386,11 @@ alter table member_resource_attr_values add constraint memrav_mem_fk foreign key
 alter table member_resource_attr_values add constraint memrav_rsrc_fk foreign key (resource_id) references resources(id);
 alter table member_resource_attr_values add constraint memrav_accattnam_fk foreign key (attr_id) references attr_names(id);
 alter table member_resource_attr_values add constraint memrav_u unique(member_id,resource_id,attr_id);
+
+alter table member_group_attr_values add constraint memgav_mem_fk foreign key (member_id) references members(id);
+alter table member_group_attr_values add constraint memgav_grp_fk foreign key (group_id) references groups(id);
+alter table member_group_attr_values add constraint memgav_accattnam_fk foreign key (attr_id) references attr_names(id);
+alter table member_group_attr_values add constraint memgav_u unique(member_id,group_id,attr_id);
 
 alter table user_facility_attr_values add constraint usrfacav_mem_fk foreign key (user_id) references users(id);
 alter table user_facility_attr_values add constraint usrfacav_fac_fk foreign key (facility_id) references facilities(id);
@@ -1592,6 +1616,7 @@ grant all on service_packages to perun;
 grant all on service_service_packages to perun;
 grant all on groups to perun;
 grant all on member_resource_attr_values to perun;
+grant all on member_group_attr_values to perun;
 grant all on user_facility_attr_values to perun;
 grant all on tasks to perun;
 grant all on tasks_results to perun;


### PR DESCRIPTION
- added SQL commands for Postgres. Required tables, constraints, keys, indexes...
- added interface for memberGroupAttributesModule and MemberGroupAttributesModuleImplApi
- added constants for working with member-group attributes
- added methods associated with member-group attributes into entry, bl and impl layers
- added rights for member-group attributes inside isAuthorizedForAttribute method in AthzResolverBlImpl
- added dependencies for other attributes on member-group attributes and created all dependancies for member-group attributes
- added tests for member-group attributes