### PR TITLE
Safe IN sql clause usage in notifications

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -433,13 +433,28 @@ public class BeansUtils {
 	 * @param beans list of perun beans
 	 * @return string with some sql IN clause
 	 */
-	public static String prepareInSQLCaluse(String identifier, List<? extends PerunBean> beans) {
+	public static String prepareInSQLClause(String identifier, List<? extends PerunBean> beans) {
 		//get Ids
 		List<Integer> beansIds = new ArrayList<>();
 		for(PerunBean pb: beans) {
 			beansIds.add(pb.getId());
 		}
+		return BeansUtils.prepareInSQLClause(beansIds, identifier);
+	}
 
+
+	/**
+	 * Create a string with set of IN clause. Every in clause has maximum 1000 ids.
+	 * Identifier means for what IN clause is calling (Like 'table.id')
+	 *
+	 * Reason for using is compatibility with oracle and other dbs.
+	 *
+	 * Example: " ( in (10,15,...) or in (...) or ... ) "
+	 *
+	 * @param beansIds list of perun bean ids
+	 * @return string with some sql IN clause
+	 */
+	public static String prepareInSQLClause(List<Integer> beansIds, String identifier) {
 		StringBuilder sb = new StringBuilder();
 		//use or in sql clause
 		boolean useOr = false;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3191,7 +3191,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("SELECT " + getAttributeMappingSelectQuery("mem") + ", members.id FROM attr_names " +
 							"JOIN service_required_attrs ON attr_names.id=service_required_attrs.attr_id AND service_required_attrs.service_id=? " +
-							"JOIN members ON " + BeansUtils.prepareInSQLCaluse("members.id", members) +
+							"JOIN members ON " + BeansUtils.prepareInSQLClause("members.id", members) +
 							"LEFT JOIN member_resource_attr_values mem ON attr_names.id=mem.attr_id AND mem.resource_id=? " +
 							"AND mem.member_id=members.id WHERE namespace IN (?,?,?)",
 					new MemberAttributeExtractor(sess, this, members), service.getId(), resource.getId(),
@@ -3205,7 +3205,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("SELECT " + getAttributeMappingSelectQuery("mem") + ", members.id FROM attr_names " +
 							"JOIN service_required_attrs ON attr_names.id=service_required_attrs.attr_id AND service_required_attrs.service_id=? " +
-							"JOIN members ON " + BeansUtils.prepareInSQLCaluse("members.id", members) +
+							"JOIN members ON " + BeansUtils.prepareInSQLClause("members.id", members) +
 							"LEFT JOIN member_attr_values mem ON attr_names.id=mem.attr_id " +
 							"AND mem.member_id=members.id WHERE namespace IN (?,?,?,?)",
 					new MemberAttributeExtractor(sess, this, members), service.getId(),
@@ -3221,7 +3221,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("SELECT " + getAttributeMappingSelectQuery("usr_fac") + ", users.id FROM attr_names " +
 							"JOIN service_required_attrs ON attr_names.id=service_required_attrs.attr_id AND service_required_attrs.service_id=? " +
-							"JOIN users ON " + BeansUtils.prepareInSQLCaluse("users.id", users) +
+							"JOIN users ON " + BeansUtils.prepareInSQLClause("users.id", users) +
 							"LEFT JOIN user_facility_attr_values usr_fac ON attr_names.id=usr_fac.attr_id AND facility_id=? AND user_id=users.id " +
 							"WHERE namespace IN (?,?,?)",
 					new UserAttributeExtractor(sess, this, users, facility), service.getId(), facility.getId(), AttributesManager.NS_USER_FACILITY_ATTR_DEF, AttributesManager.NS_USER_FACILITY_ATTR_OPT, AttributesManager.NS_USER_FACILITY_ATTR_VIRT);
@@ -3237,7 +3237,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("SELECT " + getAttributeMappingSelectQuery("usr") + ", users.id FROM attr_names " +
 							"JOIN service_required_attrs on attr_names.id=service_required_attrs.attr_id AND service_required_attrs.service_id=? " +
-							"JOIN users ON " + BeansUtils.prepareInSQLCaluse("users.id", users) +
+							"JOIN users ON " + BeansUtils.prepareInSQLClause("users.id", users) +
 							"LEFT JOIN user_attr_values usr ON attr_names.id=usr.attr_id AND user_id=users.id " +
 							"WHERE namespace IN (?,?,?,?)",
 					new UserAttributeExtractor(sess, this, users), service.getId(), AttributesManager.NS_USER_ATTR_CORE, AttributesManager.NS_USER_ATTR_DEF, AttributesManager.NS_USER_ATTR_OPT, AttributesManager.NS_USER_ATTR_VIRT);

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/jdbc/PerunNotifPoolMessageDaoImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/jdbc/PerunNotifPoolMessageDaoImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.notif.dao.jdbc;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.notif.dao.PerunNotifPoolMessageDao;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -87,15 +89,7 @@ public class PerunNotifPoolMessageDaoImpl extends JdbcDaoSupport implements Peru
 
 		logger.debug("Removing poolMessages from db with ids: {}", proccessedIds);
 		StringBuffer buffer = new StringBuffer();
-		buffer.append("delete from pn_pool_message where id in (");
-		for (Iterator<Integer> iter = proccessedIds.iterator(); iter.hasNext();) {
-			Integer id = iter.next();
-			buffer.append(id);
-			if (iter.hasNext()) {
-				buffer.append(",");
-			}
-		}
-		buffer.append(")");
+		buffer.append("delete from pn_pool_message where " + BeansUtils.prepareInSQLClause(new ArrayList<Integer>(proccessedIds), "id"));
 		this.getJdbcTemplate().update(buffer.toString());
 		logger.debug("PoolMessages with id: {}, removed.", proccessedIds);
 	}

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifTemplateManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifTemplateManagerImpl.java
@@ -923,7 +923,7 @@ public class PerunNotifTemplateManagerImpl implements PerunNotifTemplateManager 
 		}
 		return loc;
 	}
-	
+
 	private String resolveSender(String input, Map<String,Object> container) throws IOException {
 		Matcher emailMatcher = Utils.emailPattern.matcher(input);
 		String method = null;
@@ -945,9 +945,12 @@ public class PerunNotifTemplateManagerImpl implements PerunNotifTemplateManager 
 			Template freeMarkerTemplate = this.configuration.getTemplate(EVALUATION_TEMPLATE);
 			StringWriter stringWriter = new StringWriter(4096);
 			try {
+				// because for template messages the nulls are ignored, now we want to fail when null
+				this.configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
 				freeMarkerTemplate.process(container, stringWriter);
 			} catch (TemplateException ex) {
 				stringWriter = null;
+				logger.info("Resolving sender for method " + method + " failed because of exception: ", ex);
 			}
 			if (stringWriter != null) {
 				if (stringWriter.toString().trim().isEmpty()) {


### PR DESCRIPTION
- method removeAllPoolMessages now uses BeansUtil to carefully build sql
  query where IN clause with big number of argument is used
- new method in BeansUtil, takes List\<Integer> instead of List\<PerunBean>
- logging sender resolution