### PR TITLE
CORE, REGISTRAR: Allow to serach for users by exact match

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -860,6 +860,21 @@ public interface UsersManager {
 		throws InternalErrorException, UserNotExistsException, PrivilegeException;
 
 	/**
+	 * Returns list of RichUsers with attributes who matches the searchString, searching name, email, logins.
+	 * Name part is searched for exact match.
+	 *
+	 * @param sess
+	 * @param searchString
+	 * @param attrNames
+	 * @return list of RichUsers with selected attributes
+	 * @throws InternalErrorException
+	 * @throws UserNotExistsException
+	 * @throws PrivilegeException
+	 */
+	List<RichUser> findRichUsersWithAttributesByExactMatch(PerunSession sess, String searchString, List<String> attrNames)
+		throws InternalErrorException, UserNotExistsException, PrivilegeException;
+
+	/**
 	 * Returns list of RichUsers which are not members of any VO and with selected attributes
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.api.exceptions.*;
  * @author Michal Prochazka
  * @author Slavek Licehammer
  * @author Zora Sebestianova
+ * @author Sona Mastrakova
  */
 public interface UsersManager {
 
@@ -521,6 +522,16 @@ public interface UsersManager {
 	 */
 	List<User> findUsersByName(PerunSession sess, String titleBefore, String firstName, String middleName, String lastName, String titleAfter) throws InternalErrorException, PrivilegeException;
 
+        /**
+	 * Returns list of users who exactly matches the searchString
+	 *
+	 * @param sess
+	 * @param searchString
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException, PrivilegeException;
+        
 	/**
 	 * Checks if the login is available in the namespace.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -542,6 +542,18 @@ public interface UsersManagerBl {
 	List<RichUser> findRichUsers(PerunSession sess, String searchString) throws InternalErrorException, UserNotExistsException;
 
 	/**
+	 * Returns list of richusers with attributes who matches the searchString, searching name, email, logins.
+	 * Name part is searched for exact match.
+	 *
+	 * @param sess
+	 * @param searchString
+	 * @return list of richusers
+	 * @throws InternalErrorException
+	 * @throws UserNotExistsException
+	 */
+	List<RichUser> findRichUsersByExactMatch(PerunSession sess, String searchString) throws InternalErrorException, UserNotExistsException;
+
+	/**
 	 * Return list of users who matches the searchString, searching name, email and logins
 	 * and are not member in specific VO.
 	 *
@@ -577,7 +589,7 @@ public interface UsersManagerBl {
 	 */
 	List<User> findUsersByName(PerunSession sess, String titleBefore, String firstName, String middleName, String lastName, String titleAfter) throws InternalErrorException;
         
-        /**
+	/**
 	 * Returns list of users who exactly matches the searchString
 	 *
 	 * @param sess
@@ -932,6 +944,19 @@ public interface UsersManagerBl {
 	 * @throws UserNotExistsException
 	 */
 	List<RichUser> findRichUsersWithAttributes(PerunSession sess, String searchString, List<String> attrNames) throws InternalErrorException, UserNotExistsException;
+
+	/**
+	 * Returns list of RichUsers with selected attributes who matches the searchString, searching name, email, logins.
+	 * Name part is searched for exact match.
+	 *
+	 * @param sess
+	 * @param searchString
+	 * @param attrNames
+	 * @return list of RichUsers
+	 * @throws InternalErrorException
+	 * @throws UserNotExistsException
+	 */
+	List<RichUser> findRichUsersWithAttributesByExactMatch(PerunSession sess, String searchString, List<String> attrNames) throws InternalErrorException, UserNotExistsException;
 
 	/**
 	 * Get User to RichUser with attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.core.api.exceptions.*;
  * @author Michal Prochazka
  * @author Slavek Licehammer
  * @author Zora Sebestianova
+ * @author Sona Mastrakova
  */
 public interface UsersManagerBl {
 
@@ -553,7 +554,7 @@ public interface UsersManagerBl {
 	List<User> getUsersWithoutSpecificVo(PerunSession sess, Vo vo, String searchString) throws InternalErrorException;
 
 	/**
-	 * Returns list of users' who matches the searchString
+	 * Returns list of users who matches the searchString
 	 *
 	 * @param sess
 	 * @param searchString
@@ -575,6 +576,16 @@ public interface UsersManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<User> findUsersByName(PerunSession sess, String titleBefore, String firstName, String middleName, String lastName, String titleAfter) throws InternalErrorException;
+        
+        /**
+	 * Returns list of users who exactly matches the searchString
+	 *
+	 * @param sess
+	 * @param searchString
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException;
 
 	/**
 	 * Checks if the login is available in the namespace.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -32,6 +32,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttribute
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  * @author Slavek Licehammer glory@ics.muni.cz
+ * @author Sona Mastrakova
  */
 public class UsersManagerBlImpl implements UsersManagerBl {
 
@@ -624,6 +625,10 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		titleAfter = titleAfter.toLowerCase();
 
 		return this.getUsersManagerImpl().findUsersByName(sess, titleBefore, firstName, middleName, lastName, titleAfter);
+	}
+        
+        public List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException {
+		return this.getUsersManagerImpl().findUsersByExactName(sess, searchString);
 	}
 
 	public List<User> getUsersByIds(PerunSession sess, List<Integer> usersIds) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -612,6 +612,11 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		return this.convertRichUsersToRichUsersWithAttributes(sess, this.convertUsersToRichUsers(sess, users));
 	}
 
+	public List<RichUser> findRichUsersByExactMatch(PerunSession sess, String searchString) throws InternalErrorException, UserNotExistsException {
+		List<User> users = this.getUsersManagerImpl().findUsersByExactMatch(sess, searchString);
+		return this.convertRichUsersToRichUsersWithAttributes(sess, this.convertUsersToRichUsers(sess, users));
+	}
+
 	public List<User> findUsersByName(PerunSession sess, String searchString) throws InternalErrorException {
 		return this.getUsersManagerImpl().findUsersByName(sess, searchString);
 	}
@@ -626,9 +631,13 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 		return this.getUsersManagerImpl().findUsersByName(sess, titleBefore, firstName, middleName, lastName, titleAfter);
 	}
-        
-        public List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException {
+
+	public List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException {
 		return this.getUsersManagerImpl().findUsersByExactName(sess, searchString);
+	}
+
+	public List<User> findUsersByExactMatch(PerunSession sess, String searchString) throws InternalErrorException {
+		return this.getUsersManagerImpl().findUsersByExactMatch(sess, searchString);
 	}
 
 	public List<User> getUsersByIds(PerunSession sess, List<Integer> usersIds) throws InternalErrorException {
@@ -1464,6 +1473,16 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			return convertRichUsersToRichUsersWithAttributes(sess, findRichUsers(sess, searchString));
 		} else {
 			return convertUsersToRichUsersWithAttributesByNames(sess, findUsers(sess, searchString), attrsName);
+		}
+
+	}
+
+	public List<RichUser> findRichUsersWithAttributesByExactMatch(PerunSession sess, String searchString, List<String> attrsName) throws InternalErrorException, UserNotExistsException {
+
+		if(attrsName == null || attrsName.isEmpty()) {
+			return convertRichUsersToRichUsersWithAttributes(sess, findRichUsersByExactMatch(sess, searchString));
+		} else {
+			return convertUsersToRichUsersWithAttributesByNames(sess, findUsersByExactMatch(sess, searchString), attrsName);
 		}
 
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -15,6 +15,7 @@ import cz.metacentrum.perun.core.implApi.UsersManagerImplApi;
  * UsersManager entry logic
  *
  * @author Slavek Licehammer glory@ics.muni.cz
+ * @author Sona Mastrakova
  */
 public class UsersManagerEntry implements UsersManager {
 
@@ -540,6 +541,13 @@ public class UsersManagerEntry implements UsersManager {
 
 		// Probably without authorization
 		return getUsersManagerBl().findUsersByName(sess, titleBefore, firstName, middleName, lastName, titleAfter);
+	}
+        
+        public List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		// Probably without authorization
+		return getUsersManagerBl().findUsersByExactName(sess, searchString);
 	}
 
 	public List<User> getUsersByAttribute(PerunSession sess, Attribute attribute) throws InternalErrorException, PrivilegeException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -542,8 +542,8 @@ public class UsersManagerEntry implements UsersManager {
 		// Probably without authorization
 		return getUsersManagerBl().findUsersByName(sess, titleBefore, firstName, middleName, lastName, titleAfter);
 	}
-        
-        public List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException, PrivilegeException {
+
+	public List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Probably without authorization
@@ -924,6 +924,22 @@ public class UsersManagerEntry implements UsersManager {
 		}
 
 		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getUsersManagerBl().findRichUsersWithAttributes(sess, searchString, attrNames));
+
+	}
+
+	public List<RichUser> findRichUsersWithAttributesByExactMatch(PerunSession sess, String searchString, List<String> attrNames) throws InternalErrorException, UserNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN) &&
+				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER) &&
+				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN) &&
+				!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN) &&
+				!AuthzResolver.isAuthorized(sess, Role.SELF)) {
+			throw new PrivilegeException(sess, "findRichUsersWithAttributesByExactMatch");
+		}
+
+		return getPerunBl().getUsersManagerBl().filterOnlyAllowedAttributes(sess, getUsersManagerBl().findRichUsersWithAttributesByExactMatch(sess, searchString, attrNames));
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -27,6 +27,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
  * @author Michal Prochazka
  * @author Slavek Licehammer
  * @author Zora Sebestianova
+ * @author Sona Mastrakova
  */
 public interface UsersManagerImplApi {
 	/**
@@ -463,6 +464,16 @@ public interface UsersManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<User> findUsersByName(PerunSession sess, String titleBefore, String firstName, String middleName, String lastName, String titleAfter) throws InternalErrorException;
+        
+        /**
+	 * Returns list of users who exactly matches the searchString
+	 *
+	 * @param sess
+	 * @param searchString
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> findUsersByExactName(PerunSession sess, String searchString) throws InternalErrorException;
 
 	/**
 	 * Returns all users who have set the attribute with the value. Searching only def and opt attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -442,6 +442,16 @@ public interface UsersManagerImplApi {
 	List<User> findUsers(PerunSession sess, String searchString) throws InternalErrorException;
 
 	/**
+	 * Returns list of users who matches the searchString, searching name, email and logins.
+	 *
+	 * @param sess
+	 * @param searchString
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> findUsersByExactMatch(PerunSession sess, String searchString) throws InternalErrorException;
+
+	/**
 	 * Returns list of users who matches the searchString
 	 *
 	 * @param sess

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -517,9 +518,9 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		Member member = setUpMember(vo);
 
 		User firstUser = usersManager.getUserByMember(sess, member);
-		assertNotNull("unable to get user by member from DB",firstUser);
+		assertNotNull("unable to get user by member from DB", firstUser);
 		User secondUser = usersManager.getUserById(sess,firstUser.getId());
-		assertEquals("both users should be the same",firstUser,secondUser);
+		assertEquals("both users should be the same", firstUser, secondUser);
 
 	}
 
@@ -563,7 +564,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 			List<Group> groups = usersManager.getGroupsWhereUserIsAdmin(sess, returnedUser);
 			assertTrue("our user should be admin in one group", groups.size() >= 1);
-			assertTrue("created group is not between them",groups.contains(group));
+			assertTrue("created group is not between them", groups.contains(group));
 
 		}
 
@@ -628,13 +629,9 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	}
 
-	//FIXME az bude odstranen Grouper
-	@Ignore
 	@Test
 	public void findUsers() throws Exception {
 		System.out.println("UsersManager.findUsers");
-
-		// TODO otestovat hledani podle loginu i emailu
 
 		// Create second user
 		User user2 = new User();
@@ -660,8 +657,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		assertTrue("results must contain user and user2", users.contains(user) && users.contains(user2));
 	}
 
-	//FIXME az bude odstranen Grouper
-	@Ignore
 	@Test
 	public void findUsersByNameFullText() throws Exception {
 		System.out.println("UsersManager.findUsersByNameFullText");
@@ -678,7 +673,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		usersForDeletion.add(user2);
 		// save user for deletion after testing
 
-		List<User> users = usersManager.findUsersByName(sess, userFirstName +" "+ userLastName);
+		List<User> users = usersManager.findUsersByName(sess, userFirstName + " " + userLastName);
 		// This search must contain at least one result
 		assertTrue("results must contain at least one user", users.size() >= 1);
 		// And must contain the user
@@ -744,6 +739,36 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		perun.getAttributesManagerBl().setAttribute(sess, user, attr);
 
 		assertTrue("results must contain user", usersManager.getUsersByAttribute(sess, attr).contains(user));
+	}
+
+	@Test
+	public void findUsersByExactName() throws Exception {
+		System.out.println("UsersManager.findUsersByExactName");
+
+		String searchString = user.getFirstName()+user.getLastName();
+		List<User> users = perun.getUsersManager().findUsersByExactName(sess, searchString);
+		assertTrue("No users found for exact match!", !users.isEmpty());
+		assertTrue("Test user not found in results!", users.contains(user));
+
+		// we shouldn't find anybody using substring
+		searchString = searchString.substring(0, searchString.length()-3);
+		users = perun.getUsersManager().findUsersByExactName(sess, searchString);
+		assertTrue("Some user found using substring when we shouldn't find anybody!", users.isEmpty());
+		assertTrue("Test user found in results when shouldn't!", !users.contains(user));
+
+	}
+
+	@Test
+	public void findRichUsersWithAttributesByExactMatch() throws Exception {
+		System.out.println("UsersManager.findRichUsersWithAttributesByExactMatch");
+
+		ArrayList<String> attrNames = new ArrayList<>();
+		attrNames.add("urn:perun:user:attribute-def:def:preferredMail");
+
+		String searchString = user.getFirstName()+user.getLastName();
+		List<RichUser> users = perun.getUsersManager().findRichUsersWithAttributesByExactMatch(sess, searchString, attrNames);
+		assertTrue("No users found for exact match!", !users.isEmpty());
+
 	}
 
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
@@ -85,23 +85,23 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 				String mailSearch[] = mail.split(";");
 				for (String m : mailSearch) {
 					if (m != null && !m.isEmpty())
-						res.addAll(perun.getUsersManager().findRichUsersWithAttributes(registrarSession, m, attrNames));
+						res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, m, attrNames));
 				}
 			} else {
-				res.addAll(perun.getUsersManager().findRichUsersWithAttributes(registrarSession, mail, attrNames));
+				res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, mail, attrNames));
 			}
 		}
 
 		// check by mail is more precise, so check by name only if nothing is found.
-		if (res == null || res.isEmpty()) {
+		if (res.isEmpty()) {
 
 			name = sess.getPerunPrincipal().getAdditionalInformations().get("cn");
 
-			if (name != null && !name.isEmpty()) res.addAll(perun.getUsersManager().findRichUsersWithAttributes(registrarSession, name, attrNames));
+			if (name != null && !name.isEmpty()) res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames));
 
 			name = sess.getPerunPrincipal().getAdditionalInformations().get("displayName");
 
-			if (name != null && !name.isEmpty()) res.addAll(perun.getUsersManager().findRichUsersWithAttributes(registrarSession, name, attrNames));
+			if (name != null && !name.isEmpty()) res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames));
 
 		}
 
@@ -180,7 +180,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 				if (email != null && !email.isEmpty()) break;
 			}
 
-			List<RichUser> users = (email != null && !email.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributes(registrarSession, email, attrNames) : new ArrayList<RichUser>();
+			List<RichUser> users = (email != null && !email.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, email, attrNames) : new ArrayList<RichUser>();
 
 			if (users != null && !users.isEmpty()) {
 				// found by preferredMail
@@ -197,7 +197,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 				if (email != null && !email.isEmpty()) break;
 			}
 
-			users = (email != null && !email.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributes(registrarSession, email, attrNames) : new ArrayList<RichUser>();
+			users = (email != null && !email.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, email, attrNames) : new ArrayList<RichUser>();
 			if (users != null && !users.isEmpty()) {
 				// found by member mail
 				return convertToIdentities(users);
@@ -234,7 +234,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 				}
 			}
 
-			users = (name != null && !name.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributes(registrarSession, name, attrNames) : new ArrayList<RichUser>();
+			users = (name != null && !name.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames) : new ArrayList<RichUser>();
 			if (users != null && !users.isEmpty()) {
 				// found by member display name
 				return convertToIdentities(users);
@@ -252,7 +252,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 
 			if (name != null && !name.isEmpty()) {
 				// what was found by name
-				return convertToIdentities(perun.getUsersManager().findRichUsersWithAttributes(registrarSession, name, attrNames));
+				return convertToIdentities(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames));
 			} else {
 				// not found by name
 				return convertToIdentities(result);


### PR DESCRIPTION
- When searching for users, use exact match for name part
  of the search to prevent offering consolidation with wrong users.

- Implemented findRichUsersWithAttributesByExactMatch().

- Removed @Ignore from tests on searching users. Added
  some more tests.

- Fixed sources formating.