### PR TITLE
Minor fix

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -101,6 +101,17 @@ public interface AttributesManagerBl {
 	void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Get all virtual attributes associated with the member-resource attributes.
+	 *
+	 * @param sess perun session
+	 * @param resource to get the attributes from
+	 * @param member to get the attributes from
+	 * @return list of attributes
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getVirtualAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
+
+	/**
 	 * Get all <b>non-empty</b> attributes associated with the member on the resource.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -161,6 +161,18 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
 
 	/**
+	 * Get all virtual attributes associated with the member on the resource.
+	 *
+	 * @param sess perun session
+	 * @param resource to get the attributes from
+	 * @param member to get the attributes from
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getVirtualAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
+
+	/**
 	 * Get all <b>non-empty</b> attributes associated with the member.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -2032,7 +2032,7 @@ public void setGroupResourceAttributes() throws Exception {
 
 @Test (expected=InternalErrorException.class)
 	public void setGroupResourceAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributesWhenTypeMismatch");
+		System.out.println("attributesManager.setGroupResourceAttributesWhenTypeMismatch");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -2041,7 +2041,7 @@ public void setGroupResourceAttributes() throws Exception {
 		attributes = setUpGroupResourceAttribute();
 		attributes.get(0).setValue(1);
 		// set wrong value - integer into string
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, resource, group, attributes);
 		// shouldn't set wrong attribute
 
 	}


### PR DESCRIPTION
- setGroupResourceAttributesWhenTypeMismatch() fixed to actually test
  group-resource instead of resource-member
- getAttributes methods for resource-member attributes in
  AttributesManagerBlImpl now return virtual attributes too
- fillAttribute for resource-member attributes in AttributesManagerImpl
  now implemented. Before it only returns log message sais that there is
  no module for this attribute
- removeAll command changed to retainAll in
  getRichAttributesWithoutHoldersForAttributeDefinition for
  NS_GROUP_RESOURCE_ATTR as it should be