### PR TITLE
DISPATCHER,ENGINE: Removed unused checkInJob

### DIFF
--- a/perun-dispatcher-new/src/main/resources/perun-dispatcher-applicationcontext.xml
+++ b/perun-dispatcher-new/src/main/resources/perun-dispatcher-applicationcontext.xml
@@ -100,13 +100,13 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 	</bean>
 
 	<!--  
-	<bean id="checkInJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
-		<property name="jobDetail" ref="checkInJob" />
+	<bean id="checkInJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean"> -->
+	<!--<property name="jobDetail" ref="checkInJob" /> -->
 		<!-- Every 3 minutes -->
-		<property name="cronExpression" value="0 0/5 * * * ?" />
+	<!--<property name="cronExpression" value="0 0/5 * * * ?" /> -->
 		<!-- Every 10 seconds -->
 		<!-- property name="cronExpression" value="0/10 * * * * ?" /-->
-	</bean>
+	<!--</bean>
 	-->
 	
 	<bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">

--- a/perun-engine-new/src/main/java/cz/metacentrum/perun/engine/job/impl/CheckInJob.java
+++ b/perun-engine-new/src/main/java/cz/metacentrum/perun/engine/job/impl/CheckInJob.java
@@ -24,7 +24,7 @@ public class CheckInJob implements PerunEngineJob {
 	@Override
 	public void doTheJob() {
 		log.info("Entering CheckInJob: engineManager.checkIn()");
-		engineManager.checkIn();
+		//engineManager.checkIn();
 		log.info("CheckInJob: engineManager.checkIn() has completed.");
 	}
 

--- a/perun-engine-new/src/main/resources/production/perun-engine-applicationcontext.xml
+++ b/perun-engine-new/src/main/resources/production/perun-engine-applicationcontext.xml
@@ -41,7 +41,8 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
         <task:scheduled ref="propagationMaintainerJob" method="doTheJob" cron="45 0/4 * * * ?"/>
         <task:scheduled ref="processPoolJob" method="doTheJob" cron="0 0/2 * * * ?"/>
         <task:scheduled ref="taskExecutorEngineJob" method="doTheJob" cron="0 0/2 * * * ?"/>
-        <task:scheduled ref="checkInJob" method="doTheJob" cron="0 0/4 * * * ?"/>
+        <!-- disabled engine checkIn
+        <task:scheduled ref="checkInJob" method="doTheJob" cron="0 0/4 * * * ?"/>-->
     </task:scheduled-tasks>
 
     <bean id="callerRuns" class="java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy"/>


### PR DESCRIPTION
- We do not register engine/dispatcher using checkInJob anymore.
- Fixed wrong application context due to wrong comments.