### PR TITLE
fix compilation (do not call not existing method)

### DIFF
--- a/perun-engine-new/src/main/java/cz/metacentrum/perun/engine/job/impl/CheckInJob.java
+++ b/perun-engine-new/src/main/java/cz/metacentrum/perun/engine/job/impl/CheckInJob.java
@@ -24,7 +24,7 @@ public class CheckInJob implements PerunEngineJob {
 	@Override
 	public void doTheJob() {
 		log.info("Entering CheckInJob: engineManager.checkIn()");
-		engineManager.checkIn();
+		//engineManager.checkIn();
 		log.info("CheckInJob: engineManager.checkIn() has completed.");
 	}
 


### PR DESCRIPTION
Do not use method that was removed in previous merge - fixes compilation.