### PR TITLE
getMemberGroups() in GroupsManager fix

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -4075,7 +4075,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("There is unrecognized object in primaryHolder of aidingAttr.");
 			}
 		} else {
-			throw new InternalErrorException("Aiding attribtue must have primaryHolder which is not null.");
+			throw new InternalErrorException("Aiding attribute must have primaryHolder which is not null.");
 		}
 
 		//Get object for secondaryHolder of aidingAttr
@@ -4196,7 +4196,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				List<Group> groupsFromMembers = new ArrayList<Group>();
 				for(Member memberElement: members) {
 					if(!getPerunBl().getMembersManagerBl().haveStatus(sess, memberElement, Status.INVALID)) {
-						groupsFromMembers.addAll(getPerunBl().getGroupsManagerBl().getMemberGroups(sess, memberElement));
+						groupsFromMembers.addAll(getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement));
 					}
 				}
 				List<Resource> resources = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
@@ -4803,7 +4803,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				List<Resource> resourcesFromFacility = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 				//Retain of Resources
 				resourcesFromFacility.retainAll(resourcesFromUser);
-				//All posibilities
+				//All possibilities
 				resourcesFromFacility = new ArrayList<Resource>(new HashSet<Resource>(resourcesFromFacility));
 				for(Resource resourceElement: resourcesFromFacility) {
 					List<Group> groupsForResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
@@ -5175,7 +5175,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				}
 			}
 		} else {
-			throw new InternalErrorException("There are unrecognized namespace in attribute " + attrDef);
+			throw new InternalErrorException("There is unrecognized namespace in attribute " + attrDef);
 		}
 
 		return listOfRichAttributes;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -765,6 +765,15 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<Integer> groupsIds = new ArrayList<Integer>(new HashSet<Integer>(this.groupsManagerImpl.getMemberGroupsIds(sess, member, vo)));
 		List<Group> groups = getPerunBl().getGroupsManagerBl().getGroupsByIds(sess, groupsIds);
 
+		//Remove members and administrators groups
+		if(!groups.isEmpty()) {
+			Iterator<Group> iterator = groups.iterator();
+			while(iterator.hasNext()) {
+				Group g = iterator.next();
+				if(g.getName().equals(VosManager.MEMBERS_GROUP)) iterator.remove();
+			}
+		}
+
 		// Sort
 		Collections.sort(groups);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -869,17 +869,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "getMemberGroups for " + member);
 				}
 
-		//Remove members and administrators groups
-		List<Group> groups = getGroupsManagerBl().getMemberGroups(sess, member);
-		if(!groups.isEmpty()) {
-			Iterator<Group> iterator = groups.iterator();
-			while(iterator.hasNext()) {
-				Group g = iterator.next();
-				if(g.getName().equals(VosManager.MEMBERS_GROUP)) iterator.remove();
-			}
-		}
-
-		return groups;
+		return getGroupsManagerBl().getMemberGroups(sess, member);
 	}
 
 		

--- a/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOT.java
+++ b/perun-voot/src/main/java/cz/metacentrum/perun/voot/VOOT.java
@@ -117,8 +117,8 @@ public class VOOT {
 	 * Allowed parameters request:
 	 * @see http://opensocial-resources.googlecode.com/svn/spec/2.0.1/Core-API-Server.xml#rfc.section.6
 	 *
-	 * In section 6.2 Collection request parameters are all avaible and is possible to use paramter SortBy.
-	 * Value of SortBy is singular attribute of oject, e.g. for group 'title' or for member 'displayName'.
+	 * In section 6.2 Collection request parameters are all available and it is possible to use parameter SortBy.
+	 * Value of SortBy is singular attribute of object, e.g. for group 'title' or for member 'displayName'.
 	 * This value is used to sort by this. If value is invalid items are sorting by default value.
 	 *
 	 * @param session           session of Perun
@@ -412,7 +412,7 @@ public class VOOT {
 		try{
 			for (Vo vo : vos) {
 				Member member = perun.getMembersManagerBl().getMemberByUser(session, vo, user);
-				groups.addAll(perun.getGroupsManagerBl().getMemberGroups(session, member));
+				groups.addAll(perun.getGroupsManagerBl().getAllMemberGroups(session, member));
 			}
 		}catch(InternalErrorException ex){
 			throw new VOOTException("internal_server_error");


### PR DESCRIPTION
- removing of members group in getMemberGroups() moved from GroupsManagerEntry to GroupsManagerBlImpl, javadoc not changed, because by javadoc the blimpl method should have returned the groups without the members group
- checked usages of getMemberGroups() in GroupsManagerBlImpl - those usages that needed the members group now use getAllMemberGroups() method that returns all groups (including members group)