### PR TITLE
UTILS: Added debian init scripts for engine and dispatcher

### DIFF
--- a/perun-utils/init.d-scripts/perun-dispatcher.debian
+++ b/perun-utils/init.d-scripts/perun-dispatcher.debian
@@ -25,6 +25,7 @@ PERUN_DISPATCHER_CONF_DIR=/etc/perun/
 DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_DISPATCHER_CONF_DIR -jar $JAR"
 DAEMON_USER=perun
 JAVA=`which java`
+EXEC_DIR=/home/perun/perun-dispatcher/
 
 # Exit if the package is not installed.
 [ -x "$DAEMON" ] || exit 0
@@ -48,10 +49,10 @@ do_start () {
     #   1 if daemon was already running
     #   2 if daemon could not be started
     start-stop-daemon --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
-        --pidfile $PIDFILE --exec $DAEMON --test --background > /dev/null \
+        --pidfile $PIDFILE --chdir $EXEC_DIR --exec $DAEMON --test --background > /dev/null \
         || return 1
     start-stop-daemon --make-pidfile --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
-        --pidfile $PIDFILE --background --exec $DAEMON -- $DAEMON_OPTS \
+        --pidfile $PIDFILE --chdir $EXEC_DIR --background --exec $DAEMON -- $DAEMON_OPTS \
         || return 2
 }
 

--- a/perun-utils/init.d-scripts/perun-dispatcher.debian
+++ b/perun-utils/init.d-scripts/perun-dispatcher.debian
@@ -1,28 +1,28 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides:             perun-engine
+# Provides:             perun-dispatcher
 # Required-Start:       $local_fs $remote_fs $network
 # Required-Stop:        $local_fs $remote_fs
 # Default-Start:        2 3 4 5
 # Default-Stop:         0 1 6
-# Short-Description:    Perun Engine
-# Description:          Starts Perun Engine component.
+# Short-Description:    Perun Dispatcher
+# Description:          Starts Perun Dispatcher component.
 ### END INIT INFO
 #
 # Written by Michal Prochazka <michalp@ics.muni.cz>
 #
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
-DESC="Perun Engine"
+DESC="Perun Dispatcher"
 DAEMON="/usr/bin/java"
-JAR=/home/perun/perun-engine/perun-engine-new-3.0.1-SNAPSHOT-production.jar
-LOG_FILE=/var/log/perun/perun-engine-out.log
-NAME=perun-engine
+JAR=/home/perun/perun-dispatcher/perun-dispatcher-new-3.0.1-SNAPSHOT-production.jar
+LOG_FILE=/var/log/perun/perun-dispatcher-out.log
+NAME=perun-dispatcher
 SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid
 LOG4J_CONF=/etc/perun/log4j.xml
-PERUN_ENGINE_CONF_DIR=/etc/perun/
-DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR -jar $JAR"
+PERUN_DISPATCHER_CONF_DIR=/etc/perun/
+DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_DISPATCHER_CONF_DIR -jar $JAR"
 DAEMON_USER=perun
 JAVA=`which java`
 
@@ -41,7 +41,7 @@ JAVA=`which java`
 # Define LSB log_* functions.
 . /lib/lsb/init-functions
 
-# Start Perun Engine.
+# Start Perun Dispatcher.
 do_start () {
     # Return
     #   0 if daemon has been started
@@ -55,7 +55,7 @@ do_start () {
         || return 2
 }
 
-# Stop Perun Engine.
+# Stop Perun Dispatcher.
 do_stop () {
     # Return
     #   0 if daemon has been stopped
@@ -70,7 +70,7 @@ do_stop () {
 
 case "$1" in
 start)
-    # Don't start Perun Engine if NO_START is set.
+    # Don't start Perun Dispatcher if NO_START is set.
     if [ "$NO_START" = 1 ] ; then
         if [ "$VERBOSE" != no ] ; then
             echo "Not starting $DESC (see /etc/default/$NAME)"

--- a/perun-utils/init.d-scripts/perun-engine.debian
+++ b/perun-utils/init.d-scripts/perun-engine.debian
@@ -11,7 +11,8 @@
 #
 # Written by Michal Prochazka <michalp@ics.muni.cz>
 #
-
+# 14.04.2015 Moddified path to perun.conf.custom and log4j to /etc/perun
+#
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Perun Engine"
 DAEMON="/usr/bin/java"
@@ -25,6 +26,11 @@ PERUN_ENGINE_CONF_DIR=/etc/perun/
 DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR -jar $JAR"
 DAEMON_USER=perun
 JAVA=`which java`
+EXEC_DIR=/home/perun/perun-engine/
+
+# Uncomment to support Kerberos authentication to Perun
+#export KRB5CCNAME=/path/krb5cc_perun-engine
+#export PERUN_URL=https://hostname.domain/krb/rpc/
 
 # Exit if the package is not installed.
 [ -x "$DAEMON" ] || exit 0
@@ -48,10 +54,10 @@ do_start () {
     #   1 if daemon was already running
     #   2 if daemon could not be started
     start-stop-daemon --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
-        --pidfile $PIDFILE --exec $DAEMON --test --background > /dev/null \
+        --pidfile $PIDFILE --chdir $EXEC_DIR --exec $DAEMON --test --background > /dev/null \
         || return 1
     start-stop-daemon --make-pidfile --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
-        --pidfile $PIDFILE --background --exec $DAEMON -- $DAEMON_OPTS \
+        --pidfile $PIDFILE --chdir $EXEC_DIR --background --exec $DAEMON -- $DAEMON_OPTS \
         || return 2
 }
 
@@ -67,56 +73,55 @@ do_stop () {
     RETVAL="$?"
     return "$RETVAL"
 }
-
 case "$1" in
-start)
+    start)
     # Don't start Perun Engine if NO_START is set.
-    if [ "$NO_START" = 1 ] ; then
-        if [ "$VERBOSE" != no ] ; then
-            echo "Not starting $DESC (see /etc/default/$NAME)"
+        if [ "$NO_START" = 1 ] ; then
+            if [ "$VERBOSE" != no ] ; then
+                echo "Not starting $DESC (see /etc/default/$NAME)"
+            fi
+            exit 0
         fi
-        exit 0
-    fi
-    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
-    do_start
-    case "$?" in
-        0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-        2)   [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
+        [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+        do_start
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+            2)   [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
     ;;
-stop)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
-    do_stop
-    case "$?" in
-        0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-        2)   [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
+    stop)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+        do_stop
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+            2)   [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
     ;;
-restart|force-reload)
+    restart|force-reload)
 
-    log_daemon_msg "Restarting $DESC" "$NAME"
-    do_stop
-    case "$?" in
-        0|1)
-            do_start
-            case "$?" in
-                0) log_end_msg 0 ;;
-                1) log_end_msg 1 ;; # Old process is still running
-                *) log_end_msg 1 ;; # Failed to start
-            esac
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        case "$?" in
+            0|1)
+                do_start
+                case "$?" in
+                    0) log_end_msg 0 ;;
+                    1) log_end_msg 1 ;; # Old process is still running
+                    *) log_end_msg 1 ;; # Failed to start
+                esac
             ;;
-        *)
+            *)
             # Failed to stop
-            log_end_msg 1
+                log_end_msg 1
             ;;
-    esac
+        esac
     ;;
-status)
-    status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
+    status)
+        status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
     ;;
-*)
-    echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload|status}" >&2
-    exit 1
+    *)
+        echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload|status}" >&2
+        exit 1
     ;;
 esac
 

--- a/perun-utils/init.d-scripts/perun-engine.debian
+++ b/perun-utils/init.d-scripts/perun-engine.debian
@@ -1,0 +1,123 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:             perun-engine
+# Required-Start:       $local_fs $remote_fs $network
+# Required-Stop:        $local_fs $remote_fs
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    Perun Engine
+# Description:          Starts Perun Engine component.
+### END INIT INFO
+#
+# Written by Michal Prochazka <michalp@ics.muni.cz>
+#
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+DESC="Perun Engine"
+DAEMON="/usr/bin/java"
+JAR=/home/perun/perun-engine/perun-engine-new-3.0.1-SNAPSHOT-production.jar
+LOG_FILE=/var/log/perun/perun-engine-out.log
+NAME=perun-engine
+SCRIPTNAME=/etc/init.d/$NAME
+PIDFILE=/var/run/perun/$NAME.pid
+LOG4J_CONF=/home/perun/perun-engine/log4j.properties
+PERUN_ENGINE_CONF_DIR=/home/perun/perun-engine/
+DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR -jar $JAR"
+DAEMON_USER=perun
+JAVA=`which java`
+
+# Exit if the package is not installed.
+[ -x "$DAEMON" ] || exit 0
+
+# Exit if Java isn't present
+[ -x "$JAVA" ] || exit 0
+
+# Read configuration if it is present.
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+# Start Perun Engine.
+do_start () {
+    # Return
+    #   0 if daemon has been started
+    #   1 if daemon was already running
+    #   2 if daemon could not be started
+    start-stop-daemon --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
+        --pidfile $PIDFILE --exec $DAEMON --test --background > /dev/null \
+        || return 1
+    start-stop-daemon --make-pidfile --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
+        --pidfile $PIDFILE --background --exec $DAEMON -- $DAEMON_OPTS \
+        || return 2
+}
+
+# Stop Perun Engine.
+do_stop () {
+    # Return
+    #   0 if daemon has been stopped
+    #   1 if daemon was already stopped
+    #   2 if daemon could not be stopped
+    #   other if a failure occurred
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 \
+        --pidfile $PIDFILE
+    RETVAL="$?"
+    return "$RETVAL"
+}
+
+case "$1" in
+start)
+    # Don't start Perun Engine if NO_START is set.
+    if [ "$NO_START" = 1 ] ; then
+        if [ "$VERBOSE" != no ] ; then
+            echo "Not starting $DESC (see /etc/default/$NAME)"
+        fi
+        exit 0
+    fi
+    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+    do_start
+    case "$?" in
+        0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+        2)   [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
+    ;;
+stop)
+    [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+    do_stop
+    case "$?" in
+        0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+        2)   [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
+    ;;
+restart|force-reload)
+
+    log_daemon_msg "Restarting $DESC" "$NAME"
+    do_stop
+    case "$?" in
+        0|1)
+            do_start
+            case "$?" in
+                0) log_end_msg 0 ;;
+                1) log_end_msg 1 ;; # Old process is still running
+                *) log_end_msg 1 ;; # Failed to start
+            esac
+            ;;
+        *)
+            # Failed to stop
+            log_end_msg 1
+            ;;
+    esac
+    ;;
+status)
+    status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
+    ;;
+*)
+    echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload|status}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
- Added init.d scripts for managing perun-engine and perun-dispatcher
  as system service for Debian. They must be located in /etc/init.d/.
  You can start them using command "service perun-[engine|dispatcher] start".