### PR TITLE
Fix zero escaping in auditparser

### DIFF
--- a/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
+++ b/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
@@ -498,13 +498,16 @@ public class AuditParserTest {
 		assertEquals(richMember.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(richMember.serializeToString())));
 		assertEquals(richUser.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(richUser.serializeToString())));
 		assertEquals(richGroup.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(richGroup.serializeToString())));
-		//assertEquals(richFacility.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(richFacility.serializeToString())));
+		assertEquals(richFacility.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(richFacility.serializeToString())));
 		assertEquals(richResource.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(richResource.serializeToString())));
 		assertEquals(service.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(service.serializeToString())));
 		assertEquals(vo.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(vo.serializeToString())));
 		assertEquals(userExtSource1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(userExtSource1.serializeToString())));
 		assertEquals(resourceTag1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(resourceTag1.serializeToString())));
 		assertEquals(exService1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(exService1.serializeToString())));
+		//test also some null serializing
+		Resource newResource = new Resource(20, null, null, 5);
+		assertEquals(newResource.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(newResource.serializeToString())));
 	}
 
 	@Test

--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -62,6 +62,8 @@ public class BeansUtils {
 
 	/**
 	 * This method take text and for every chars in "<>\" erase escaping
+	 * also change '\0' to 'null' if it is escaped zero symbol.
+	 *
 	 * Escaping char is \.
 	 * Expecting: Before using this method, text must be escaped by using method createEscaping.
 	 *            So in text will never be string like "\\>", "\" or "\\\".
@@ -73,6 +75,8 @@ public class BeansUtils {
 	 */
 	public static String eraseEscaping(String text) {
 		if(text == null || text.equals("\\0")) return null;
+		//change \0 to null if zero is escaped
+		text = text.replaceAll("((^|[^\\\\])(\\\\\\\\)*)(\\\\0)", "$1null");
 		text = text.replace("\\>", ">");
 		text = text.replace("\\<", "<");
 		text = text.replace("\\\\", "\\");


### PR DESCRIPTION
 - when removing escaping from audit log message, replace also \0 for
   null if this zero is escaped