### PR TITLE
Fix of using groupOfUniqueNames object class in perun LDAP

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Main.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Main.java
@@ -46,7 +46,16 @@ public class Main {
 
 	private static BufferedWriter writer;
 
-	public Main(String fileName) throws Exception{
+	/**
+	 * Main method for generating LDIF
+	 *
+	 * GroupOfUniqueNames object class is not supported in new instances of perun LDAP
+	 *
+	 * @param fileName if not null, use file for generating. if null use stdout
+	 * @param newLDAPversion if true, then do not use GroupOfUniqueNames object class
+	 * @throws Exception
+	 */
+	public Main(String fileName, boolean newLDAPversion) throws Exception{
 		try {
 			this.springCtx = new ClassPathXmlApplicationContext("perun-beans.xml", "perun-datasources.xml", "perun-transaction-manager.xml");
 			this.perun = springCtx.getBean("perun", PerunBl.class);
@@ -60,8 +69,8 @@ public class Main {
 		int LastMessageBeforeInitializingData = perun.getAuditer().getLastMessageId();
 		System.err.println("Last message id before starting initializing: " + LastMessageBeforeInitializingData + '\n');
 		vosLdifToWriter();
-		groupsLdifToWriter();
-		resourcesLdifToWriter();
+		groupsLdifToWriter(newLDAPversion);
+		resourcesLdifToWriter(newLDAPversion);
 		usersLdifToWriter();
 		int LastMessageAfterInitializingData = perun.getAuditer().getLastMessageId();
 		System.err.println("Last message id after initializing: " + LastMessageAfterInitializingData + '\n');
@@ -79,9 +88,17 @@ public class Main {
 		} else if(args[0].equals("-g")) {
 			Main main;
 			if(args[1] != null && args[1].length() != 0) {
-				main = new Main(args[1]);
+				main = new Main(args[1], false);
 			} else {
-				main = new Main(null);
+				main = new Main(null, false);
+			}
+			writer.close();
+		} else if(args[0].equals("-gnew")) {
+			Main main;
+			if(args[1] != null && args[1].length() != 0) {
+				main = new Main(args[1], true);
+			} else {
+				main = new Main(null, true);
 			}
 			writer.close();
 		} else {
@@ -174,7 +191,7 @@ public class Main {
 		}
 	}
 
-	private void resourcesLdifToWriter() throws Exception {
+	private void resourcesLdifToWriter(boolean newLDAPversion) throws Exception {
 		List<Vo> vos = perun.getVosManagerBl().getVos(perunSession);
 
 		for(Vo v: vos) {
@@ -202,7 +219,10 @@ public class Main {
 				}
 				writer.write(dn + '\n');
 				writer.write(oc1 + '\n');
-				writer.write(oc2 + '\n');
+				//Use only if old version of ldap with groupOfUniqueNames is used
+				if(!newLDAPversion) {
+					writer.write(oc2 + '\n');
+				}
 				writer.write(oc3 + '\n');
 				writer.write(cn + '\n');
 				writer.write(perunResourceId + '\n');
@@ -220,7 +240,7 @@ public class Main {
 		}
 	}
 
-	private void groupsLdifToWriter() throws Exception {
+	private void groupsLdifToWriter(boolean newLDAPversion) throws Exception {
 		List<Vo> vos = perun.getVosManagerBl().getVos(perunSession);
 
 		for(Vo v: vos) {
@@ -254,7 +274,10 @@ public class Main {
 				List<Member> admins = new ArrayList<Member>();
 				writer.write(dn + '\n');
 				writer.write(oc1 + '\n');
-				writer.write(oc2 + '\n');
+				//Use only if old version of ldap with groupOfUniqueNames is used
+				if(!newLDAPversion) {
+					writer.write(oc2 + '\n');
+				}
 				writer.write(oc3 + '\n');
 				writer.write(cn + '\n');
 				writer.write(perunUniqueGroupName + '\n');

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/LdapProperties.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/LdapProperties.java
@@ -36,6 +36,19 @@ public class LdapProperties {
 		return this.getLdapcProperties().getProperty("ldap.loginNamespace");
 	}
 
+	/**
+	 * This means that object class groupOfUniqueNames is not supported yet!
+	 *
+	 * @return true if not supported, false if still needed
+	 */
+	public boolean isThisNewVersionOfLdap() {
+		String newVersionOfLdap = this.getLdapcProperties().getProperty("ldap.newVersionOfLdap");
+		if("true".equals(newVersionOfLdap)) {
+			return true;
+		}
+		return false;
+	}
+
 	public void setLdapcProperties(Properties ldapcProperties) {
 		this.ldapcProperties = ldapcProperties;
 	}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/LdapConnectorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/LdapConnectorImpl.java
@@ -52,7 +52,10 @@ public class LdapConnectorImpl implements LdapConnector {
 		// Create the objectclass to add
 		Attribute objClasses = new BasicAttribute("objectClass");
 		objClasses.add("top");
-		objClasses.add("groupOfUniqueNames");
+		//use this object class only in old version of perun ldap
+		if(!ldapProperties.isThisNewVersionOfLdap()) {
+			objClasses.add("groupOfUniqueNames");
+		}
 		objClasses.add("perunResource");
 
 		// Add attributes
@@ -95,7 +98,10 @@ public class LdapConnectorImpl implements LdapConnector {
 		// Create the objectclass to add
 		Attribute objClasses = new BasicAttribute("objectClass");
 		objClasses.add("top");
-		objClasses.add("groupOfUniqueNames");
+		//use this object class only in old version of perun ldap
+		if(!ldapProperties.isThisNewVersionOfLdap()) {
+			objClasses.add("groupOfUniqueNames");
+		}
 		objClasses.add("perunGroup");
 
 		// Add attributes


### PR DESCRIPTION
 - in Main.java (for generating ldif purpose)
 - we don't want to use obejct class GroupOfUniqueNames for new
   instances of Perun LDAP (do not support them)
 - for new instances use -gnew instead of -g
 - in the future, -g will be deprycated and replaced by -gnew
 - in LDAPc (for adding new object Group or Resource purpose)