### PR TITLE
CORE: Fixed tests dependency on DB data

### DIFF
--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -8,16 +8,10 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.List;
 
+import cz.metacentrum.perun.core.api.exceptions.*;
 import org.junit.Test;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
-import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
-import cz.metacentrum.perun.core.api.exceptions.ExtSourceAlreadyAssignedException;
-import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
-import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.AuthzRoles;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
@@ -33,7 +27,7 @@ import java.util.Set;
 public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	private static final String CLASS_NAME = "AuthzResolver.";
-	final ExtSource extSource = new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal");
+	final ExtSource extSource = new ExtSource(0, "AuthzResolverExtSource", ExtSourcesManager.EXTSOURCE_LDAP);
 
 	@Test
 	public void isAuthorizedInvalidPrincipal() throws Exception {
@@ -292,15 +286,10 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	}
 
-
-	private Member createSomeMember(final Vo createdVo)
-		throws InternalErrorException, ExtSourceNotExistsException,
-										PrivilegeException, VoNotExistsException,
-										ExtSourceAlreadyAssignedException, Exception,
-										AlreadyMemberException {
-						 final Candidate candidateKouril = setUpCandidate();
-						 final Member createdMemberKouril = perun.getMembersManagerBl().createMemberSync(sess, createdVo, candidateKouril);
-						 return createdMemberKouril;
+	private Member createSomeMember(final Vo createdVo) throws ExtendMembershipException, AlreadyMemberException, WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException {
+		final Candidate candidate = setUpCandidate();
+		final Member createdMember = perun.getMembersManagerBl().createMemberSync(sess, createdVo, candidate);
+		return createdMember;
 	}
 
 	private PerunSession getHisSession(final Member createdMember) throws InternalErrorException {
@@ -311,7 +300,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		}
 		UserExtSource ue = new UserExtSource();
 		for (UserExtSource u : ues) {
-			if (u.getExtSource().getType().equals(ExtSourcesManager.EXTSOURCE_SQL)) {
+			if (u.getExtSource().getType().equals(ExtSourcesManager.EXTSOURCE_LDAP)) {
 				ue = u;
 				break;
 			}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntryIntegrationTest.java
@@ -224,88 +224,88 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=ExtSourceNotExistsException.class)
-		public void getExtSourceByNameWhenExtSourceNotExist() throws Exception {
-			System.out.println(CLASS_NAME + "getExtSourceByNameWhenExtSourceNotExists()");
+	public void getExtSourceByNameWhenExtSourceNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getExtSourceByNameWhenExtSourceNotExists()");
 
-			extSourcesManagerEntry.getExtSourceByName(sess, "nonsense");
-			// shouldn't find ext source
+		extSourcesManagerEntry.getExtSourceByName(sess, "nonsense");
+		// shouldn't find ext source
 
-		}
+	}
 
 	@Test (expected=ExtSourceNotExistsException.class)
-		public void getExtSourceByIdWhenExtSourceNotExist() throws Exception {
-			System.out.println(CLASS_NAME + "getExtSourceByIdWhenExtSourceNotExists()");
+	public void getExtSourceByIdWhenExtSourceNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getExtSourceByIdWhenExtSourceNotExists()");
 
-			extSourcesManagerEntry.getExtSourceById(sess, 0);
-			// shouldn't find ext source
+		extSourcesManagerEntry.getExtSourceById(sess, 0);
+		// shouldn't find ext source
 
-		}
+	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void addExtSourceWhenVoNotExists() throws Exception {
-			System.out.println(CLASS_NAME + "addExtSourceWhenVoNotExists()");
+	public void addExtSourceWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addExtSourceWhenVoNotExists()");
 
-			extSourcesManagerEntry.addExtSource(sess, new Vo(), extSource);
-			// shouldn't find VO
+		extSourcesManagerEntry.addExtSource(sess, new Vo(), extSource);
+		// shouldn't find VO
 
-		}
+	}
 
 	@Test (expected=ExtSourceNotExistsException.class)
-		public void addExtSourceWhenExtSourceNotExists() throws Exception {
-			System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceNotExists()");
+	public void addExtSourceWhenExtSourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceNotExists()");
 
-			ExtSource source = new ExtSource(0, "Fake", ExtSourcesManager.EXTSOURCE_INTERNAL);
-			Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0, "sjk", "kljlk"));
-			extSourcesManagerEntry.addExtSource(sess, createdVo, source);
-			// shouldn't find Ext Source
+		ExtSource source = new ExtSource(0, "Fake", ExtSourcesManager.EXTSOURCE_INTERNAL);
+		Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0, "sjk", "kljlk"));
+		extSourcesManagerEntry.addExtSource(sess, createdVo, source);
+		// shouldn't find Ext Source
 
-		}
+	}
 
 	@Test (expected=ExtSourceAlreadyAssignedException.class)
-		public void addExtSourceWhenExtSourceAlreadyAssigned() throws Exception {
-			System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceAlreadyAssigned()");
+	public void addExtSourceWhenExtSourceAlreadyAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceAlreadyAssigned()");
 
-			VosManager vosManager = perun.getVosManager();
-			Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
+		VosManager vosManager = perun.getVosManager();
+		Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
 
-			extSourcesManagerEntry.addExtSource(sess, createdVo, extSource);
-			extSourcesManagerEntry.addExtSource(sess, createdVo, extSource);
-			// shouldn't add same ext source twice
+		extSourcesManagerEntry.addExtSource(sess, createdVo, extSource);
+		extSourcesManagerEntry.addExtSource(sess, createdVo, extSource);
+		// shouldn't add same ext source twice
 
-		}
+	}
 
 	@Test (expected=ExtSourceNotAssignedException.class)
-		public void removeExtSourceWhenExtSourceNotAssigned() throws Exception {
-			System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotAssigned()");
+	public void removeExtSourceWhenExtSourceNotAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotAssigned()");
 
-			VosManager vosManager = perun.getVosManager();
-			Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
+		VosManager vosManager = perun.getVosManager();
+		Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
 
-			extSourcesManagerEntry.removeExtSource(sess, createdVo, extSource);
-			// shouldn't find not assigned ext source
+		extSourcesManagerEntry.removeExtSource(sess, createdVo, extSource);
+		// shouldn't find not assigned ext source
 
-		}
+	}
 
 	@Test (expected=ExtSourceNotExistsException.class)
-		public void removeExtSourceWhenExtSourceNotExist() throws Exception {
-			System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotExist()");
+	public void removeExtSourceWhenExtSourceNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotExist()");
 
-			VosManager vosManager = perun.getVosManager();
-			Vo createdVo = vosManager.createVo(sess, new Vo(0, "sjk", "kljlk"));
+		VosManager vosManager = perun.getVosManager();
+		Vo createdVo = vosManager.createVo(sess, new Vo(0, "sjk", "kljlk"));
 
-			ExtSource source = new ExtSource(0, "Fake", ExtSourcesManager.EXTSOURCE_INTERNAL);
-			extSourcesManagerEntry.removeExtSource(sess, createdVo, source);
-			// shouldn't find invalid ext source
+		ExtSource source = new ExtSource(0, "Fake", ExtSourcesManager.EXTSOURCE_INTERNAL);
+		extSourcesManagerEntry.removeExtSource(sess, createdVo, source);
+		// shouldn't find invalid ext source
 
-		}
+	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getVoExtSourcesWhenVoNotExists() throws Exception {
-			System.out.println(CLASS_NAME + "getVoExtSourcesWhenVoNotExists()");
+	public void getVoExtSourcesWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getVoExtSourcesWhenVoNotExists()");
 
-			extSourcesManagerEntry.getVoExtSources(sess, new Vo());
+		extSourcesManagerEntry.getVoExtSources(sess, new Vo());
 
-		}
+	}
 
 
 	// private methods --------------------------------------------------------

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntryIntegrationTest.java
@@ -31,15 +31,16 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
  */
 
 public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
-	private static final String EXT_SOURCE_NAME = "SearcherEntryIntegrationTest";
+
+	private static final String EXT_SOURCE_NAME = "ExtSourcesManagerEntryIntegrationTest";
 	private static final String CLASS_NAME = "ExtSourcesManagerEntry.";
 	private ExtSourcesManager extSourcesManagerEntry;
+	private static ExtSource extSource;
 
 	@Before
 	public void setUp() throws Exception {
-		//System.out.println(CLASS_NAME + "setUp()");
 		ExtSource newExtSource = new ExtSource(EXT_SOURCE_NAME, ExtSourcesManager.EXTSOURCE_INTERNAL);
-		perun.getExtSourcesManager().createExtSource(sess, newExtSource);
+		extSource = perun.getExtSourcesManager().createExtSource(sess, newExtSource);
 		this.extSourcesManagerEntry = perun.getExtSourcesManager();
 	}
 
@@ -205,20 +206,9 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	public void getCandidate() throws Exception {
 		System.out.println(CLASS_NAME + "getCandidate");
 
-		ExtSource source = extSourcesManagerEntry.getExtSourceByName(sess, "LDAPMU");
-
-		try {
-
-			Candidate candid = extSourcesManagerEntry.getCandidate(sess, source, "256627");
-			assertNotNull("User has to have additional userExtSource", candid.getAdditionalUserExtSources());
-			assertEquals("User has to have IdP MU userExtSource", candid.getAdditionalUserExtSources().get(0).getExtSource().getName(), "https://idp2.ics.muni.cz/idp/shibboleth");
-			assertEquals("User has to have login 256627@muni.cz in IdP MU userExtSource", candid.getAdditionalUserExtSources().get(0).getLogin(), "256627@muni.cz");
-			assertNotNull("Unable to return candidate",candid);
-			assertEquals("Ext source returned wrong user","Pavel Zlámal",candid.getCommonName());
-
-		} catch (InternalErrorException e) {
-			System.out.println(CLASS_NAME + "getCandidate FAILED - LDAPMU unavailable");
-		}
+		// TODO create searchable ext source (mock ?)
+		// search for specific Candidate
+		fail("not implemented");
 
 	}
 
@@ -227,15 +217,9 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	public void getCandidateWhenCandidateNotExist() throws Exception {
 		System.out.println(CLASS_NAME + "getCandidateWhenCandidateNotExists()");
 
-		ExtSource source = extSourcesManagerEntry.getExtSourceByName(sess, "LDAPMU");
-
-		try {
-			extSourcesManagerEntry.getCandidate(sess, source, "nonsense");
-			// shouldn't find candidate nonsense
-		} catch (InternalErrorException e) {
-			System.out.println(CLASS_NAME + "getCandidateWhenCandidateNotExists FAILED - LDAPMU unavailable");
-			throw new CandidateNotExistsException(CLASS_NAME + "getCandidateWhenCandidateNotExists FAILED - LDAPMU unavailable");
-		}
+		// TODO create searchable ExtSource (mock ?)
+		// search for specific Candidate which doesn't exists in ExtSource.
+		fail("not implemented");
 
 	}
 
@@ -261,9 +245,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		public void addExtSourceWhenVoNotExists() throws Exception {
 			System.out.println(CLASS_NAME + "addExtSourceWhenVoNotExists()");
 
-			ExtSource source = extSourcesManagerEntry.getExtSourceByName(sess, "LDAPMU");
-
-			extSourcesManagerEntry.addExtSource(sess, new Vo(), source);
+			extSourcesManagerEntry.addExtSource(sess, new Vo(), extSource);
 			// shouldn't find VO
 
 		}
@@ -272,12 +254,8 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		public void addExtSourceWhenExtSourceNotExists() throws Exception {
 			System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceNotExists()");
 
-			ExtSource source = extSourcesManagerEntry.getExtSourceByName(sess, "LDAPMU");
-			source.setId(0);
-
-			VosManager vosManager = perun.getVosManager();
-			Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
-
+			ExtSource source = new ExtSource(0, "Fake", ExtSourcesManager.EXTSOURCE_INTERNAL);
+			Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0, "sjk", "kljlk"));
 			extSourcesManagerEntry.addExtSource(sess, createdVo, source);
 			// shouldn't find Ext Source
 
@@ -287,13 +265,11 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		public void addExtSourceWhenExtSourceAlreadyAssigned() throws Exception {
 			System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceAlreadyAssigned()");
 
-			ExtSource source = extSourcesManagerEntry.getExtSourceByName(sess, "LDAPMU");
-
 			VosManager vosManager = perun.getVosManager();
 			Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
 
-			extSourcesManagerEntry.addExtSource(sess, createdVo, source);
-			extSourcesManagerEntry.addExtSource(sess, createdVo, source);
+			extSourcesManagerEntry.addExtSource(sess, createdVo, extSource);
+			extSourcesManagerEntry.addExtSource(sess, createdVo, extSource);
 			// shouldn't add same ext source twice
 
 		}
@@ -302,12 +278,10 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		public void removeExtSourceWhenExtSourceNotAssigned() throws Exception {
 			System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotAssigned()");
 
-			ExtSource source = extSourcesManagerEntry.getExtSourceByName(sess, "LDAPMU");
-
 			VosManager vosManager = perun.getVosManager();
 			Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
 
-			extSourcesManagerEntry.removeExtSource(sess, createdVo, source);
+			extSourcesManagerEntry.removeExtSource(sess, createdVo, extSource);
 			// shouldn't find not assigned ext source
 
 		}
@@ -316,13 +290,10 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		public void removeExtSourceWhenExtSourceNotExist() throws Exception {
 			System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotExist()");
 
-			ExtSource source = extSourcesManagerEntry.getExtSourceByName(sess, "LDAPMU");
-
 			VosManager vosManager = perun.getVosManager();
-			Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
+			Vo createdVo = vosManager.createVo(sess, new Vo(0, "sjk", "kljlk"));
 
-			source.setId(0);
-
+			ExtSource source = new ExtSource(0, "Fake", ExtSourcesManager.EXTSOURCE_INTERNAL);
 			extSourcesManagerEntry.removeExtSource(sess, createdVo, source);
 			// shouldn't find invalid ext source
 
@@ -342,9 +313,10 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	private ExtSource newInstanceExtSource() {
 		final ExtSource es;
 		es = new ExtSource();
-		es.setName("nejakyExtSource396");
-		es.setType("cz.metacentrum.perun.core.impl.ExtSourceSql");
+		es.setName("SomeExtSource");
+		es.setType(ExtSourcesManager.EXTSOURCE_SQL);
 		es.setAttributes(new HashMap<String,String>());
 		return es;
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -32,8 +32,9 @@ import java.util.Arrays;
 public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	private static final String MEMBERS_MANAGER_ENTRY = "MembersManagerEntry";
+	private static final String EXT_SOURCE_NAME = "MembersManagerEntryExtSource";
 	private Vo createdVo = null;
-	final ExtSource extSource = new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal");
+	private ExtSource extSource = new ExtSource(0, EXT_SOURCE_NAME, ExtSourcesManager.EXTSOURCE_INTERNAL);
 	private Group createdGroup;
 	private Group g1;
 	private Group g2;
@@ -49,11 +50,13 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	@Before
 	public void setUp() throws Exception {
 
+		extSource = perun.getExtSourcesManager().createExtSource(sess, extSource);
+
 		usersManagerEntry = perun.getUsersManager();
 		attributesManagerEntry = perun.getAttributesManager();
 		membersManagerEntry = perun.getMembersManager();
 		final Vo vo = new Vo(0, "m3mb3r r00m", "m3mber-room");
-		VosManager vosManagerEntry = perun.getVosManager();//new VosManagerEntry(perun);
+		VosManager vosManagerEntry = perun.getVosManager();
 		createdVo = vosManagerEntry.createVo(sess, vo);
 		assertNotNull(createdVo);
 
@@ -72,7 +75,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		candidate.setLastName(userLastName);
 		candidate.setTitleBefore("");
 		candidate.setTitleAfter("");
-		ues = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), extLogin);
+		ues = new UserExtSource(extSource, extLogin);
 		candidate.setUserExtSource(ues);
 		candidate.setAttributes(new HashMap<String,String>());
 
@@ -122,7 +125,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		candidate.setLastName(userLastName);
 		candidate.setTitleBefore("");
 		candidate.setTitleAfter("");
-		UserExtSource ues = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), extLogin);
+		UserExtSource ues = new UserExtSource(new ExtSource(0, "testExtSource", ExtSourcesManager.EXTSOURCE_INTERNAL), extLogin);
 		candidate.setUserExtSource(ues);
 		candidate.setAttributes(new HashMap<String,String>());
 
@@ -675,7 +678,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		attributesManagerEntry.setAttribute(sess, createdVo, extendMembershipRulesAttribute);
 
 		// Set LOA 2 for member
-		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, "INTERNAL");
+		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, EXT_SOURCE_NAME);
 		ues = new UserExtSource(es, "abc");
 		ues.setLoa(2);
 
@@ -724,7 +727,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		attributesManagerEntry.setAttribute(sess, createdMember, membershipExpirationAttribute);
 
 		// Set LOA 1 for member
-		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, "INTERNAL");
+		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, EXT_SOURCE_NAME);
 		ues = new UserExtSource(es, "abc");
 		ues.setLoa(1);
 
@@ -761,7 +764,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		attributesManagerEntry.setAttribute(sess, createdVo, extendMembershipRulesAttribute);
 
 		// Set LOA 1 for member
-		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, "INTERNAL");
+		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, EXT_SOURCE_NAME);
 		ues = new UserExtSource(es, "abc");
 		ues.setLoa(1);
 
@@ -811,7 +814,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		attributesManagerEntry.setAttribute(sess, createdVo, extendMembershipRulesAttribute);
 
 		// Set LOA 1 for member
-		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, "INTERNAL");
+		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, EXT_SOURCE_NAME);
 		ues = new UserExtSource(es, "abc");
 		ues.setLoa(0);
 
@@ -847,7 +850,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		attributesManagerEntry.setAttribute(sess, createdVo, extendMembershipRulesAttribute);
 
 		// Set LOA 1 for member
-		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, "INTERNAL");
+		ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, EXT_SOURCE_NAME);
 		ues = new UserExtSource(es, "abc");
 		ues.setLoa(1);
 


### PR DESCRIPTION
- Some test still expected that there are ExtSources in DB
  created by xml definition in /etc/perun/perun-extSources.xml.

  From now on, tests creates own ExtSources when necessary.

- Fixed indentation in ExtSourcesManagerEntryIntegrationTest.