### PR TITLE
BEANS: Added filtering on resource on build

### DIFF
--- a/perun-beans/pom.xml
+++ b/perun-beans/pom.xml
@@ -59,6 +59,14 @@
 
 		</plugins>
 
+		<!-- set filtering on resources -->
+		<resources>
+			<resource>
+				<directory>src/main/resources/</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
+
 	</build>
 
 
@@ -140,6 +148,14 @@
 				<plugins>
 					<!-- profile build specific plugins -->
 				</plugins>
+
+				<!-- set filtering on resources -->
+				<resources>
+					<resource>
+						<directory>src/main/resources/</directory>
+						<filtering>true</filtering>
+					</resource>
+				</resources>
 
 			</build>
 

--- a/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -523,7 +523,7 @@ public class BeansUtils {
 	 * @return value of the property
 	 */
 	public static String getPropertyFromConfiguration(String propertyName) throws InternalErrorException {
-		log.trace("Entering getPropertyFromConfiguration: propertyName='" +  propertyName + "'");
+		log.trace("Entering getPropertyFromConfiguration: propertyName='" + propertyName + "'");
 		notNull(propertyName, "propertyName");
 
 		if(BeansUtils.properties == null) {

--- a/perun-beans/src/main/resources/perun-beans-appcontext-tests.xml
+++ b/perun-beans/src/main/resources/perun-beans-appcontext-tests.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xsi:schemaLocation="
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+">
+
+	<!-- FIXME  hack, hackiti hack - inject properties bean into static class Utils
+             	(creates another bean, that is never used)
+             	The point is to stop Utils from complaining about non-existent /etc/perun/perun.properties.
+	-->
+	<bean id="utilsProperties" class="cz.metacentrum.perun.core.api.BeansUtils" factory-method="setProperties" scope="singleton">
+		<constructor-arg ref="coreProperties" />
+	</bean>
+
+	<!-- Properties Bean for perun-core -->
+	<bean id="coreProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+		<property name="ignoreResourceNotFound" value="true" />
+		<property name="properties">
+			<props>
+				<prop key="perun.admins">perunTests, perunController, perunEngine, perunDispatcher, perunRegistrar, perunSynchronizer, perunCabinet</prop>
+				<prop key="perun.engine.principals">perunEngine</prop>
+				<prop key="perun.registrar.principals"></prop>
+				<prop key="perun.notification.principals">perunNotifications</prop>
+				<prop key="perun.rpc.principal">perunRpc</prop>
+				<prop key="perun.db.type">hsqldb</prop>
+				<prop key="perun.group.synchronization.interval">1</prop>
+				<prop key="perun.group.synchronization.timeout">10</prop>
+				<prop key="perun.rpc.powerusers"></prop>
+				<prop key="perun.perun.db.name">perun</prop>
+				<prop key="perun.rt.url">https://rt3.cesnet.cz/rt/REST/1.0/ticket/new</prop>
+				<prop key="perun.rt.serviceuser.username">perunv3-rt</prop>
+				<prop key="perun.rt.serviceuser.password">password</prop>
+				<prop key="perun.passwordManager.program">/usr/local/bin/perun.passwordManager</prop>
+				<prop key="perun.alternativePasswordManager.program">/usr/local/bin/perun.altPasswordManager</prop>
+				<prop key="perun.recaptcha.privatekey"></prop>
+				<prop key="perun.mailchange.secretKey"></prop>
+				<prop key="perun.mailchange.backupFrom"></prop>
+				<prop key="perun.mailchange.validationWindow">6</prop>
+				<prop key="perun.pwdreset.secretKey">jda3ufK92DKs2335af</prop>
+				<prop key="perun.pwdreset.initVector">2Akd14k3o9s1d2G5</prop>
+				<prop key="perun.pwdreset.validationWindow">6</prop>
+				<prop key="perun.native.language">cs,Česky,Czech</prop>
+			</props>
+		</property>
+	</bean>
+
+</beans>

--- a/perun-core/src/main/resources/perun-beans-test.xml
+++ b/perun-core/src/main/resources/perun-beans-test.xml
@@ -7,7 +7,7 @@
 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
-	<import resource="classpath:perun-beans-appcontext.xml"/>
+	<import resource="classpath:perun-beans-appcontext-tests.xml"/>
     <import resource="classpath:perun-transaction-manager.xml"/>
     <import resource="perun-datasources-test.xml"/>
 	

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -1321,7 +1321,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void convertGroupToRichGroupWithAttributesTest() throws Exception {
-		System.out.println("groupsManagerBl.convertGroupToRichGroupWithAttributes");
+		System.out.println("GroupsManagerBl.convertGroupToRichGroupWithAttributes");
 
 		vo = setUpVo();
 		attributesList = setUpGroupAttributes();
@@ -1334,7 +1334,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void convertGroupToRichGroupWithAttributesByNameTest() throws Exception {
-		System.out.println("groupsManagerBl.convertGroupToRichGroupWithAttributesByName");
+		System.out.println("GroupsManagerBl.convertGroupToRichGroupWithAttributesByName");
 
 		vo = setUpVo();
 		attributesList = setUpGroupAttributes();
@@ -1372,7 +1372,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void convertGroupsToRichGroupsWithAttributesWithListOfNamesTest() throws Exception {
-		System.out.println("groupsManagerBl.convertGroupsToRichGroupsWithAttributesWithListOfNamesTest");
+		System.out.println("GroupsManagerBl.convertGroupsToRichGroupsWithAttributesWithListOfNamesTest");
 
 		vo = setUpVo();
 		attributesList = setUpGroupAttributes();


### PR DESCRIPTION
- We must let maven to "filter" resources since we have
  moved replaceable variables from core to beans (appcontext).

  Otherwise backup env properties are used on production runtime,
  which is not good.