### PR TITLE
CORE: Exclude maven and test dependencies from shaded jar

### DIFF
--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -98,6 +98,13 @@
 									<resource>META-INF/spring.schemas</resource>
 								</transformer>
 							</transformers>
+							<artifactSet>
+								<excludes>
+									<!-- test artifacts are excluded by default -->
+									<!-- we don't need maven build plugins in our application -->
+									<exclude>org.apache.maven*</exclude>
+								</excludes>
+							</artifactSet>
 						</configuration>
 					</execution>
 				</executions>
@@ -269,6 +276,7 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>1.8.5</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceVirtualAttributesModuleImplApi.java
@@ -7,7 +7,6 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import org.mockito.stubbing.VoidMethodStubbable;
 
 /**
  * This interface serves as a template for virtual attributes.


### PR DESCRIPTION
- We don't need Maven build plugins and test dependencies
  in final shaded jar of perun-core.