### PR TITLE
SERVICES: Updated ldifsort function to respect DN hierarchy tree

### DIFF
--- a/perun-services/slave/ldap/ldifsort.pl
+++ b/perun-services/slave/ldap/ldifsort.pl
@@ -95,7 +95,27 @@ my %canonicaldns;
 sub cmpdn {
 	my $cadn = ($canonicaldns{$a->[0]} ||= lc(canonical_dn($a->[0])));
 	my $cbdn = ($canonicaldns{$b->[0]} ||= lc(canonical_dn($b->[0])));
-	$cadn cmp $cbdn;
+
+	# sort by DN hierarchy
+	my @cadns = split(/(^|[^\\])(\\\\)*,/, $cadn);
+	my @cbdns = split(/(^|[^\\])(\\\\)*,/, $cbdn);
+
+	while (@cadns || @cbdns) {
+
+		# read from the top of the tree
+		my $cmpa = pop(@cadns);
+		my $cmpb = pop(@cbdns);
+
+		# if differs return cmp if not, continue with checking
+		if ($cmpa cmp $cmpb) {
+			return $cmpa cmp $cmpb;
+		}
+
+	}
+
+	# both entries match
+	return 0;
+
 }
 
 my $cmpfunc;


### PR DESCRIPTION
- ldifsort.pl can now sort DN attribute in a hierarchical way, where
  shorter entries (higher in a tree) are before longer (lower in a tree).
  Each level of a tree is sorted alphabetically.

- This allows us to update whole subtree using single ldif file and
  prevent cases, where parent entry was alphabetically sorted after child entry,
  hence adding of entry failed.