### PR TITLE
New Perun ExtSource

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -73,6 +73,19 @@ public abstract class Deserializer {
 	}
 
 	/**
+	 * Reads value from root Json node.
+	 *
+	 * @param valueType type of the value to read
+	 * @return the value as {@code valueType}
+	 *
+	 * @throws UnsupportedOperationException if this deserializer does not implement this method
+	 * @throws RpcException if the specified value cannot be parsed as {@code valueType} or if it is not supplied
+	 */
+	public <T> T read(Class<T> valueType) throws RpcException {
+		throw new UnsupportedOperationException("read(Class<T> valueType)");
+	}
+
+	/**
 	 * Reads array with the specified name as {@code List<valueType>}.
 	 *
 	 * @param name name of the array to read
@@ -84,6 +97,19 @@ public abstract class Deserializer {
 	 */
 	public <T> List<T> readList(String name, Class<T> valueType) throws RpcException {
 		throw new UnsupportedOperationException("readList(String name, Class<T> valueType)");
+	}
+
+	/**
+	 * Reads array from root Json node.
+	 *
+	 * @param valueType type of the value to read
+	 * @return the value as {@code List<valueType>}
+	 *
+	 * @throws UnsupportedOperationException if this deserializer does not implement this method
+	 * @throws RpcException if the specified value cannot be parsed as {@code valueType} or if it is not supplied
+	 */
+	public <T> List<T> readList(Class<T> valueType) throws RpcException {
+		throw new UnsupportedOperationException("readList(Class<T> valueType)");
 	}
 
 	/**

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -345,6 +345,13 @@
 			<version>1.0.2</version>
 		</dependency>
 
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<version>2.5</version>
+			<scope>provided</scope>
+		</dependency>
+
 	</dependencies>
 
 	<profiles>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -203,6 +203,18 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 		candidate.setTitleAfter(subject.get("titleAfter"));
 		candidate.setTitleBefore(subject.get("titleBefore"));
 
+		//Set service user
+		if(subject.get("isServiceUser") == null) {
+			candidate.setServiceUser(false);
+		} else {
+			String isServiceUser = subject.get("isServiceUser");
+			if(isServiceUser.equals("true")) {
+				candidate.setServiceUser(true);
+			} else {
+				candidate.setServiceUser(false);
+			}
+		}
+
 		// Additional userExtSources
 		List<UserExtSource> additionalUserExtSources = new ArrayList<UserExtSource>();
 
@@ -295,6 +307,18 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 		candidate.setMiddleName(subjectData.get("middleName"));
 		candidate.setTitleAfter(subjectData.get("titleAfter"));
 		candidate.setTitleBefore(subjectData.get("titleBefore"));
+
+		//Set service user
+		if(subjectData.get("isServiceUser") == null) {
+			candidate.setServiceUser(false);
+		} else {
+			String isServiceUser = subjectData.get("isServiceUser");
+			if(isServiceUser.equals("true")) {
+				candidate.setServiceUser(true);
+			} else {
+				candidate.setServiceUser(false);
+			}
+		}
 
 		// Additional userExtSources
 		List<UserExtSource> additionalUserExtSources = new ArrayList<UserExtSource>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -329,7 +329,14 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				try {
 					method = attributeHolder.getClass().getMethod(methodName);
 				} catch(NoSuchMethodException ex) {
-					throw new InternalErrorRuntimeException("Bad core attribute definition. " + attribute , ex);
+					//try also "is"
+					log.debug("Bad core attribute definition for methodname " + methodName);
+					try {
+						methodName = "is" + Character.toUpperCase(attribute.getFriendlyName().charAt(0)) + attribute.getFriendlyName().substring(1);
+						method = attributeHolder.getClass().getMethod(methodName);
+					} catch (NoSuchMethodException e) {
+						throw new InternalErrorRuntimeException("Bad core attribute definition. " + attribute , e);
+					}
 				}
 				try {
 					Object value = method.invoke(attributeHolder);
@@ -4921,6 +4928,14 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		attr.setType(String.class.getName());
 		attr.setFriendlyName("titleAfter");
 		attr.setDisplayName("User title after");
+		attributes.add(attr);
+
+		//User.titleAfter
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_CORE);
+		attr.setType(Boolean.class.getName());
+		attr.setFriendlyName("serviceUser");
+		attr.setDisplayName("If user is service user or not.");
 		attributes.add(attr);
 
 		//Group.id

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -1,0 +1,318 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import java.util.List;
+
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
+import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
+import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cz.metacentrum.perun.core.api.RichMember;
+import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.RpcException;
+import cz.metacentrum.perun.rpc.deserializer.Deserializer;
+import cz.metacentrum.perun.rpc.deserializer.JsonDeserializer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.DefaultHttpClient;
+
+/**
+ * ExtSource for synchronization from another Perun instance
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
+
+	private final static Logger log = LoggerFactory.getLogger(ExtSourcePerun.class);
+
+	private static String format = "json";
+	private String perunUrl;
+	private String username;
+	private String password;
+
+	private String extSourceNameForLogin = null;
+
+
+	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjectsLogins(searchString, 0);
+	}
+
+	public List<Map<String,String>> findSubjectsLogins(String searchString, int maxResulsts) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("For Perun ExtSource is not supported to use this method. Use findSubjects instead.");
+	}
+
+	public List<Map<String,String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjects(searchString, 0);
+	}
+
+	public List<Map<String,String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		setEnviroment();
+		List<RichUser> richUsers = findRichUsers(searchString);
+		if(maxResults != 0) {
+			if(richUsers.size() > maxResults) {
+				richUsers = richUsers.subList(0, maxResults);
+			}
+		}
+
+		List<Map<String,String>> subjects = convertRichUsersToListOfSubjects(richUsers);
+		return subjects;
+	}
+
+	public Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException {
+		setEnviroment();
+		Map<String,String> subject = covertRichUserToSubject(findRichUser(login));
+		return subject;
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		setEnviroment();
+		// Get the query for the group subjects
+		String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+
+		//If there is no query for group, throw exception
+		if(queryForGroup == null) throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSEXTSOURCE_ATTRNAME + " can't be null.");
+
+		Integer groupId = Integer.valueOf(queryForGroup);
+
+		List<Map<String,String>> subjectsFromGroup = convertRichUsersToListOfSubjects(findRichUsers(groupId));
+
+		return subjectsFromGroup;
+	}
+
+	private List<Map<String, String>> convertRichUsersToListOfSubjects(List<RichUser> richUsers) throws InternalErrorException {
+		List<Map<String, String>> listOfSubjects = new ArrayList<>();
+		for(RichUser ru: richUsers) {
+			listOfSubjects.add(covertRichUserToSubject(ru));
+		}
+		return listOfSubjects;
+	}
+
+	private Map<String, String> covertRichUserToSubject(RichUser richUser) throws InternalErrorException {
+		Map<String,String> richUserInMap = new HashMap<String,String>();
+		String mapping = getAttributes().get("xmlMapping");
+		String[] mappingArray = mapping.split(",\n");
+
+		//Get user login
+		String login = "";
+		for(UserExtSource ues: richUser.getUserExtSources()) {
+			if(ues.getExtSource() != null && ues.getExtSource().getName().equals(extSourceNameForLogin)) {
+				login = ues.getLogin();
+				break;
+			}
+		}
+
+		for(int i=0; i<mappingArray.length; i++) {
+			String attr = mappingArray[i].trim();
+			int index = attr.indexOf("=");
+
+			if(index <= 0) throw new InternalErrorException("There is no text in xmlMapping attribute or there is no '=' character.");
+			String name = attr.substring(0, index);
+			String value = attr.substring(index +1);
+
+			//Value == attr.name
+			if(value.matches("^.*[{]login[}].*$")) {
+				value = value.replaceFirst("[{]login[}]", login);
+			} else {
+				value = lookingForValueInRichUserAttributes(value, richUser);
+			}
+
+			richUserInMap.put(name.trim(), value);
+		}
+
+		return richUserInMap;
+	}
+
+	private String lookingForValueInRichUserAttributes(String value, RichUser richUser) throws InternalErrorException {
+		String returnedValue = null;
+		List<Attribute> attributes = richUser.getUserAttributes();
+		for(Attribute attr: attributes) {
+			if(attr.getName().equals(value)) {
+				returnedValue = BeansUtils.attributeValueToString(attr);
+				break;
+			}
+		}
+		return returnedValue;
+	}
+
+	private RichUser findRichUser(String login) throws InternalErrorException, SubjectNotExistsException {
+		Map<String, Object> params = new HashMap<String, Object>();
+
+		List<RichUser> richUsers = this.findRichUsers(login);
+
+		List<RichUser> matchesRichUsers = new ArrayList<>();
+		for(RichUser richUser: richUsers) {
+			List<UserExtSource> userExtSources = richUser.getUserExtSources();
+			for(UserExtSource userExtSource: userExtSources) {
+				if(extSourceNameForLogin.equals(userExtSource.getExtSource().getName())) {
+					if(login.equals(userExtSource.getLogin())) matchesRichUsers.add(richUser);
+				}
+			}
+		}
+
+		if(matchesRichUsers.isEmpty()) throw new SubjectNotExistsException("There is no subject with login " + login + " in extSource " + extSourceNameForLogin + " in System perun with RPC url: " + perunUrl);
+		if(matchesRichUsers.size() > 1) throw new InternalErrorException("There are more then one subject with login " + login + " in extSource " + extSourceNameForLogin + " in System perun with RPC url: " + perunUrl);
+		
+		return richUsers.get(0);
+	}
+
+	private List<RichUser> findRichUsers(String substring) throws InternalErrorException {
+		String query = "searchString=" + substring;
+
+		List<RichUser> richUsers;
+		try {
+			richUsers = this.call("usersManager", "findRichUsers", query).readList(RichUser.class);
+		} catch (PerunException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+		Iterator<RichUser> iterator = richUsers.iterator();
+		while(iterator.hasNext()) {
+			RichUser richUser = iterator.next();
+			boolean hasLogin = false;
+			for(UserExtSource ues: richUser.getUserExtSources()) {
+				if(ues.getExtSource() != null && ues.getExtSource().getName().equals(extSourceNameForLogin)) {
+					hasLogin = true;
+					continue;
+				}
+			}
+			if(!hasLogin) iterator.remove();
+		}
+
+		return richUsers;
+	}
+
+	private List<RichUser> findRichUsers(Integer groupId) throws InternalErrorException {
+		String query = "group=" + groupId + "&" + "allowedStatuses[]=" + "VALID";
+		
+		List<RichMember> richMembers;
+		try {
+			richMembers = this.call("membersManager", "getRichMembersWithAttributes", query).readList(RichMember.class);
+		} catch (PerunException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+		return convertListOfRichMembersToListOfRichUsers(richMembers);
+	}
+
+	private void setEnviroment() throws InternalErrorException {
+		perunUrl = getAttributes().get("perunUrl");
+		username = getAttributes().get("username");
+		password = getAttributes().get("password");
+		extSourceNameForLogin = getAttributes().get("extSourceNameForLogin");
+		BeansUtils.notNull(perunUrl, "perunUrl");
+		BeansUtils.notNull(username, "username");
+		BeansUtils.notNull(password, "password");
+		BeansUtils.notNull(extSourceNameForLogin, "extSourceNameForLogin");
+	}
+
+	private List<RichUser> convertListOfRichMembersToListOfRichUsers(List<RichMember> richMembers) throws InternalErrorException {
+		List<RichUser> richUsers = new ArrayList<>();
+		if(richMembers == null || richMembers.isEmpty()) return richUsers;
+
+		for(RichMember rm: richMembers) {
+			RichUser ru = new RichUser(rm.getUser(), rm.getUserExtSources(), rm.getUserAttributes());
+			richUsers.add(ru);
+		}
+
+		return richUsers;
+	}
+
+	private Deserializer call(String managerName, String methodName) throws PerunException {
+		return this.call(managerName, methodName, null);
+	}
+
+	private Deserializer call(String managerName, String methodName, String query) throws PerunException {
+		//Prepare sending message
+		HttpResponse response;
+		HttpClient httpClient = new DefaultHttpClient();
+		httpClient.getParams().setParameter(ClientPNames.COOKIE_POLICY, org.apache.http.client.params.CookiePolicy.IGNORE_COOKIES);
+
+		String commandUrl = perunUrl + format + "/" + managerName + "/" + methodName;
+		if(query != null) commandUrl+= "?" + query;
+
+		HttpGet get = new HttpGet(commandUrl);
+		get.setHeader("content-Type", "application/json");
+		get.setHeader("charset", "utf-8");
+		get.setHeader("Connection", "Close");
+		UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password);
+
+		get.addHeader(BasicScheme.authenticate(credentials, "utf-8", false));
+		//post.setParams(params);
+
+		InputStream rpcServerAnswer = null;
+
+		try {
+			 response = httpClient.execute(get);
+			 rpcServerAnswer = response.getEntity().getContent();
+		} catch(IOException ex) {
+			this.processIOException(ex);
+		}
+
+		JsonDeserializer des = null;
+		try {
+			des = new JsonDeserializer(rpcServerAnswer);
+		} catch (IOException ex) {
+			this.processIOException(ex);
+		}
+		
+		return des;
+	}
+
+	private void processIOException(Throwable e) throws RpcException {
+		this.processIOException(null, e);
+	}
+
+	private void processIOException(HttpURLConnection con, Throwable e) throws RpcException {
+		// Process known IOExceptions
+		if (e instanceof ProtocolException) {
+			throw new RpcException(RpcException.Type.COMMUNICATION_ERROR_WITH_PERUN_RPC_SERVER, "Communication problem with Perun server on URL: " + perunUrl, e);
+		} else if (e instanceof UnknownHostException) {
+			throw new RpcException(RpcException.Type.UNKNOWN_PERUN_RPC_SERVER, "Perun server cannot be contacted on URL: " + perunUrl, e);
+		}
+
+		// If the connection has been provided, check the responseCode
+		if (con != null) {
+			// Check return code
+			int responseCode;
+			try {
+				responseCode = con.getResponseCode();
+
+				if (responseCode != HttpURLConnection.HTTP_OK) {
+					throw new RpcException(RpcException.Type.PERUN_RPC_SERVER_ERROR_HTTP_CODE, "Perun server on URL: " + perunUrl + " returned HTTP code: " + responseCode, e);
+				}
+			} catch (IOException e1) {
+				throw new RpcException(RpcException.Type.UNKNOWN_EXCEPTION, "Failed to contact Perun server on URL: " + perunUrl, e1);
+			}
+		}
+
+		throw new RpcException(RpcException.Type.UNKNOWN_EXCEPTION, "Failed to contact Perun server on URL: " + perunUrl, e);
+	}
+
+	public void close() throws InternalErrorException {
+		//not needed there
+	}
+}


### PR DESCRIPTION
 - extSource for synchronization with another perun system
 - some changes in rpc-Deserializer and rpc-JsonDeserializer to be able
   create objects from root node (not only named node)
 - add javax.servlet to pom.xml in perun-core
 - add isServiceUser attr definition to initialization of core
   attributes
 - add setting serviceUser settings in getCandidate methods
 - fix AttributeMapper to try also "is" methods, not only "get" by java
   reflection api for getting core attributes
 - add specific json deserialization of object Member method
   getMembershipType to JsonDeserializer