### PR TITLE
SERVICES: Fixed packaging of perun-slave

### DIFF
--- a/perun-services/slave/debian/changelog
+++ b/perun-services/slave/debian/changelog
@@ -1,3 +1,10 @@
+perun-slave (3.0.0-0.0.90) stable; urgency=low
+
+  * Added ldap folder with shared scripts for all ldap services.
+  * Removed build help file prepare_rpm_spec_file.sh from the package.
+
+ -- Pavel Zlamal <zlamal@cesnet.cz>  Wed, 05 May 2015 11:32:00 +0100
+
 perun-slave (3.0.0-0.0.89) stable; urgency=low
 
   * Add new service ldap_vsb_vi

--- a/perun-services/slave/debian/rules
+++ b/perun-services/slave/debian/rules
@@ -16,7 +16,6 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
-
 build: build-stamp
 
 build-stamp:
@@ -24,7 +23,7 @@ build-stamp:
 
 	touch $@
 
-clean: 
+clean:
 	dh_testdir
 	dh_testroot
 	rm -f build-stamp
@@ -32,21 +31,21 @@ clean:
 	# Add here commands to clean up after the build process.
 	#$(MAKE) clean
 
-	dh_clean 
+	dh_clean
 
-install: build-stamp 
+install: build-stamp
 	dh_testdir
 	dh_testroot
-	dh_clean 
-	dh_prep 
+	dh_clean
+	dh_prep
 	dh_installdirs -i
 
 	# Add here commands to install the indep part of the package into
 	# debian/<package>-doc.
 	#INSTALLDOC#
 
-	dh_install -i -X .svn
-	dh_install -i -X .svn *.d opt/perun/bin
+	# install listed folders and files only
+	dh_install -i -X .svn -X prepare_rpm_spec_file ldap *.d opt/perun/bin
 
 binary-arch: build install
 
@@ -54,12 +53,12 @@ binary-indep: build install
 
 	dh_testdir
 	dh_testroot
-	dh_installchangelogs 
+	dh_installchangelogs
 	dh_installdocs
 	dh_installexamples
 #	dh_installmenu
-	dh_installdebconf	
-#	dh_installlogrotate	
+	dh_installdebconf
+#	dh_installlogrotate
 #	dh_installemacsen
 #	dh_installpam
 #	dh_installmime
@@ -70,7 +69,7 @@ binary-indep: build install
 	dh_installman
 	dh_link
 	dh_strip
-	dh_compress 
+	dh_compress
 	dh_fixperms
 #	dh_perl
 	dh_makeshlibs

--- a/perun-services/slave/prepare_rpm_spec_file.sh
+++ b/perun-services/slave/prepare_rpm_spec_file.sh
@@ -36,10 +36,14 @@ rm -rf %{buildroot}
 
 %install
 mkdir -p %{buildroot}%{perun_home}
+mkdir -p %{buildroot}%{perun_home}/ldap
 install perun *.sh %{buildroot}%{perun_home}
+install ldap/* %{buildroot}%{perun_home}/ldap
+
 rsync -arvz *.d %{buildroot}%{perun_home} --exclude=".svn"
 
 %files
+%exclude %{perun_home}/prepare_rpm_spec_file.sh
 %defattr(-,root,root)
 %config(noreplace) %{perun_home}/*.d/*
 %{perun_home}


### PR DESCRIPTION
- Added missing "ldap" folder to the package sources.
  It contains shared scripts for all ldap/ad services.

- Exclude script for building rpms from package sources.

- Removed some trailing whitespace.