### PR TITLE
DB: Removed double definition of member_group attrs table

### DIFF
--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -712,21 +712,6 @@ create table member_resource_attr_values (
 	modified_by_uid integer
 );
 
-create table member_group_attr_values (
-	member_id integer not null,
-	group_id integer not null,
-	attr_id integer not null,
-	attr_value nvarchar2(4000),
-	created_at date default sysdate not null,
-	created_by nvarchar2(1024) default user not null,
-	modified_at date default sysdate not null,
-	modified_by nvarchar2(1024) default user not null,
-	status char(1) default '0' not null,
-	attr_value_text clob,
-	created_by_uid integer,
-	modified_by_uid integer
-);
-
 create table user_attr_values (
 	user_id integer not null,
 	attr_id integer not null,
@@ -1220,9 +1205,6 @@ create index IDX_FK_TAGS_RES_TAGS on tags_resources(tag_id);
 create index IDX_FK_TAGS_RES_RES on tags_resources(resource_id);
 create index IDX_FK_MAILCHANGE_USER_ID on mailchange(user_id);
 create index IDX_FK_PWDRESET_USER_ID on pwdreset(user_id);
-create index IDX_FK_MEMGAV_MEM on member_group_attr_values(member_id);
-create index IDX_FK_MEMGAV_GRP on member_group_attr_values(group_id);
-create index IDX_FK_MEMGAV_ACCATTNAM on member_group_attr_values(attr_id);
 
 alter table auditer_log add (constraint AUDLOG_PK primary key (id));
 alter table auditer_consumers add (constraint AUDCON_PK primary key (id),
@@ -1414,12 +1396,6 @@ alter table group_attr_values add (
 constraint GRPATTVAL_PK primary key (group_id,attr_id),
 constraint GRPATTVAL_GRP_FK foreign key (group_id) references groups(id),
 constraint GRPATTVAL_ATTR_FK foreign key (attr_id) references attr_names(id)
-);
-alter table member_group_attr_values add (
-constraint MEMGAV_MEM_FK foreign key (member_id) references members(id),
-constraint MEMGAV_GRP_FK foreign key (group_id) references groups(id),
-constraint MEMGAV_ACCATTNAM_FK foreign key (attr_id) references attr_names(id),
-constraint MEMGAV_U unique(member_id,group_id,attr_id)
 );
 alter table group_resource_attr_values add (
 constraint GRPRESAV_PK primary key (group_id,resource_id,attr_id),

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -761,22 +761,6 @@ create table "member_resource_attr_values" (
 	modified_by_uid integer
 );
 
--- MEMBER_GROUP_ATTR_VALUES - values of attributes assigned to members in groups
-create table "member_group_attr_values" (
-	member_id integer not null,   --identifier of member (members.id)
-	group_id integer not null, --identifier of group (groups.id)
-	attr_id integer not null,     --identifier of attribute (attr_names.id)
-	attr_value varchar(4000),     --attribute value
-	created_at timestamp default now() not null,
-	created_by varchar(1024) default user not null,
-	modified_at timestamp default now() not null,
-	modified_by varchar(1024) default user not null,
-	status char(1) default '0' not null,
-	attr_value_text text,         --attribute value in case it is very long text
-	created_by_uid integer,
-	modified_by_uid integer
-);
-
 -- USER_ATTR_VALUES - values of attributes assigned to users
 create table "user_attr_values" (
 	user_id integer not null,  --identifier of user (users.id)
@@ -1304,9 +1288,6 @@ create index idx_fk_tags_res_tags on tags_resources(tag_id);
 create index idx_fk_tags_res_res on tags_resources(resource_id);
 create index idx_fk_mailchange_user_id on mailchange(user_id);
 create index idx_fk_pwdreset_user_id on pwdreset(user_id);
-create index idx_fk_memgav_mem on member_group_attr_values(member_id);
-create index idx_fk_memgav_grp on member_group_attr_values(group_id);
-create index idx_fk_memgav_accattnam on member_group_attr_values(attr_id);
 
 alter table auditer_log add constraint audlog_pk primary key (id);
 
@@ -1612,10 +1593,6 @@ alter table mailchange add constraint mailchange_pk primary key (id);
 alter table mailchange add constraint mailchange_u_fk foreign key (user_id) references users(id);
 alter table pwdreset add constraint pwdreset_pk primary key (id);
 alter table pwdreset add constraint pwdreset_u_fk foreign key (user_id) references users(id);
-alter table member_group_attr_values add constraint memgav_mem_fk foreign key (member_id) references members(id);
-alter table member_group_attr_values add constraint memgav_grp_fk foreign key (group_id) references groups(id);
-alter table member_group_attr_values add constraint memgav_accattnam_fk foreign key (attr_id) references attr_names(id);
-alter table member_group_attr_values add constraint memgav_u unique(member_id,group_id,attr_id);
 
 grant all on users to perun;
 grant all on vos to perun;
@@ -1701,7 +1678,6 @@ grant all on tags_resources to perun;
 grant all on configurations to perun;
 grant all on mailchange to perun;
 grant all on pwdreset to perun;
-grant all on member_group_attr_values to perun;
 
 -- set initial Perun DB version
 insert into configurations values ('DATABASE VERSION','3.1.25');


### PR DESCRIPTION
- There was doubled definition of table member_group_attr_values
  including all constraints and sequences.