### PR TITLE
UTILS: Allow to use JAVA_OPTS in dispatcher/engine init.d script

### DIFF
--- a/perun-utils/init.d-scripts/perun-dispatcher.debian
+++ b/perun-utils/init.d-scripts/perun-dispatcher.debian
@@ -23,7 +23,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid
 LOG4J_CONF=/etc/perun/log4j.xml
 PERUN_DISPATCHER_CONF_DIR=/etc/perun/
-DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_DISPATCHER_CONF_DIR -jar $JAR"
+DAEMON_OPTS='-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_DISPATCHER_CONF_DIR $JAVA_OPTS -jar $JAR'
 DAEMON_USER=perun
 JAVA=`which java`
 EXEC_DIR=/home/perun/perun-dispatcher/
@@ -55,6 +55,8 @@ do_start () {
 	# Create empty pidfile
 	touch $PIDFILE;
 	chown $DAEMON_USER $PIDFILE;
+	# Eval all options for daemon
+	DAEMON_OPTS=eval echo ${DAEMON_OPTS};
 	start-stop-daemon --make-pidfile --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
         --pidfile $PIDFILE --chdir $EXEC_DIR --background --exec $DAEMON -- $DAEMON_OPTS \
         || return 2

--- a/perun-utils/init.d-scripts/perun-engine.debian
+++ b/perun-utils/init.d-scripts/perun-engine.debian
@@ -24,7 +24,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid
 LOG4J_CONF=/etc/perun/log4j.xml
 PERUN_ENGINE_CONF_DIR=/etc/perun/
-DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR -jar $JAR"
+DAEMON_OPTS='-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR $JAVA_OPTS -jar $JAR'
 DAEMON_USER=perun
 JAVA=`which java`
 EXEC_DIR=/home/perun/perun-engine/
@@ -60,6 +60,8 @@ do_start () {
 	# Create empty pidfile
 	touch $PIDFILE;
 	chown $DAEMON_USER $PIDFILE;
+	# Eval all options for daemon
+	DAEMON_OPTS=eval echo ${DAEMON_OPTS};
 	start-stop-daemon --make-pidfile --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
         --pidfile $PIDFILE --chdir $EXEC_DIR --background --exec $DAEMON -- $DAEMON_OPTS \
         || return 2


### PR DESCRIPTION
- Allow later evaluation of DAEMON_OPTS since we include configuration
  from file sourced later than property is defined.
- Added support for passing JAVA_OPTS to the start command, for e.g.
  setting a truststore etc.