### PR TITLE
Add periodic cleaning of old entries in tasks_results table

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/hornetq/PerunHornetQServer.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/hornetq/PerunHornetQServer.java
@@ -59,6 +59,9 @@ public class PerunHornetQServer {
 		if (serverRunning && jmsServerManager != null) {
 			try {
 				jmsServerManager.stop();
+				server.stop();
+				configuration.stop();
+				serverRunning = false;
 			} catch (Exception e) {
 				log.error(e.toString(), e);
 			}

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueReceiver.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueReceiver.java
@@ -92,6 +92,12 @@ public class SystemQueueReceiver implements Runnable {
 			}
 			// TODO: Close connection and restart SystemQueueProcessor?
 		}
+		try {
+			messageConsumer.close();
+		} catch (JMSException e) {
+			log.error(e.toString(), e);
+		}
+		messageConsumer = null;
 	}
 
 	public void stop() {

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/job/CleanTaskResultsJob.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/job/CleanTaskResultsJob.java
@@ -1,0 +1,29 @@
+package cz.metacentrum.perun.dispatcher.job;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+import cz.metacentrum.perun.dispatcher.service.DispatcherManager;
+
+public class CleanTaskResultsJob  extends QuartzJobBean {
+
+	private final static Logger log = LoggerFactory.getLogger(CleanTaskResultsJob.class);
+
+	private DispatcherManager dispatcherManager;
+
+	protected void executeInternal(JobExecutionContext arg0) throws JobExecutionException {
+		log.debug("Entering CleanTaskResults job...");
+		dispatcherManager.cleanOldTaskResults();
+	}
+
+	public DispatcherManager getDispatcherManager() {
+		return dispatcherManager;
+	}
+
+	public void setDispatcherManager(DispatcherManager dispatcherManager) {
+		this.dispatcherManager = dispatcherManager;
+	}
+}

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/job/CleanTaskResultsJob.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/job/CleanTaskResultsJob.java
@@ -17,6 +17,7 @@ public class CleanTaskResultsJob  extends QuartzJobBean {
 	protected void executeInternal(JobExecutionContext arg0) throws JobExecutionException {
 		log.debug("Entering CleanTaskResults job...");
 		dispatcherManager.cleanOldTaskResults();
+		log.debug("CleanTaskResults done.");
 	}
 
 	public DispatcherManager getDispatcherManager() {

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/DispatcherManager.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/DispatcherManager.java
@@ -28,9 +28,9 @@ public interface DispatcherManager {
 	void stopParsingData();
 
 	// /Event Processor///
-	void startPocessingEvents();
+	void startProcessingEvents();
 
-	void stopPocessingEvents();
+	void stopProcessingEvents();
 
 	// /Task database///
 	void loadSchedulingPool();

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/DispatcherManager.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/DispatcherManager.java
@@ -34,4 +34,6 @@ public interface DispatcherManager {
 
 	// /Task database///
 	void loadSchedulingPool();
+	
+	void cleanOldTaskResults();
 }

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/impl/DispatcherManagerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/impl/DispatcherManagerImpl.java
@@ -89,12 +89,12 @@ public class DispatcherManagerImpl implements DispatcherManager {
 	}
 
 	@Override
-	public void startPocessingEvents() {
+	public void startProcessingEvents() {
 		eventProcessor.startProcessingEvents();
 	}
 
 	@Override
-	public void stopPocessingEvents() {
+	public void stopProcessingEvents() {
 		eventProcessor.stopProcessingEvents();
 	}
 

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/impl/DispatcherManagerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/impl/DispatcherManagerImpl.java
@@ -13,12 +13,15 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.dispatcher.dao.DispatcherDao;
 import cz.metacentrum.perun.dispatcher.exceptions.PerunHornetQServerException;
 import cz.metacentrum.perun.dispatcher.hornetq.PerunHornetQServer;
+import cz.metacentrum.perun.dispatcher.jms.DispatcherQueue;
 import cz.metacentrum.perun.dispatcher.jms.SystemQueueProcessor;
+import cz.metacentrum.perun.dispatcher.jms.DispatcherQueuePool;
 import cz.metacentrum.perun.dispatcher.parser.ParserManager;
 import cz.metacentrum.perun.dispatcher.processing.EventProcessor;
 import cz.metacentrum.perun.dispatcher.processing.SmartMatcher;
 import cz.metacentrum.perun.dispatcher.scheduling.SchedulingPool;
 import cz.metacentrum.perun.dispatcher.service.DispatcherManager;
+import cz.metacentrum.perun.taskslib.service.ResultManager;
 
 /**
  * 
@@ -41,6 +44,10 @@ public class DispatcherManagerImpl implements DispatcherManager {
 	private SmartMatcher smartMatcher;
 	@Autowired
 	private SchedulingPool schedulingPool;
+	@Autowired
+	private DispatcherQueuePool dispatcherQueuePool;
+	@Autowired
+	private ResultManager resultManager;
 	@Autowired
 	private Properties dispatcherPropertiesBean;
 
@@ -129,5 +136,18 @@ public class DispatcherManagerImpl implements DispatcherManager {
 	 * catch (InternalErrorException e) { log.error(e.toString()); } } return
 	 * this.dispatcherSession; }
 	 */
+	
+	@Override
+	public void cleanOldTaskResults() {
+		for(DispatcherQueue queue: dispatcherQueuePool.getPool()) {
+			try {
+				int numRows = resultManager.clearOld(queue.getClientID(), 3);
+				log.debug("Cleaned {} old task results for engine {}", numRows, queue.getClientID());
+			} catch (InternalErrorException e) {
+				log.warn("Error cleaning old task results for engine {} : {}", 
+						queue.getClientID(), e.toString());
+			}
+		}
+	}
 
 }

--- a/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
@@ -148,6 +148,20 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<property name="jobDetail" ref="processPoolJob" />
 		<property name="cronExpression" value="0 0/2 * * * ?" />
 	</bean>
-	<!-- END Quartz tasks -->
-
+	
+	<bean id="cleanTaskResultsJob" class="org.springframework.scheduling.quartz.JobDetailBean">
+		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.CleanTaskResultsJob" />
+		<property name="jobDataAsMap">
+			<map>
+				<entry key="dispatcherManager" value-ref="dispatcherManager" />
+			</map>
+		</property>
+	</bean>
+	
+	<bean id="cleanTaskResultsJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+		<property name="jobDetail" ref="cleanTaskResultsJob" />
+		<property name="cronExpression" value="0 1 * * * ?" />
+	</bean>
+	<!-- END Quartz tasks -->	
+           
 </beans>

--- a/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
@@ -117,6 +117,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 				<!-- <ref bean="checkInJobTrigger" /> -->
 				<ref bean="processPoolJobTrigger" />
 				<ref bean="propagationMaintainerJobTrigger" />
+				<ref bean="cleanTaskResultsJobTrigger" />
 			</list>
 		</property>
 	</bean>
@@ -160,7 +161,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 	
 	<bean id="cleanTaskResultsJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
 		<property name="jobDetail" ref="cleanTaskResultsJob" />
-		<property name="cronExpression" value="0 1 * * * ?" />
+		<property name="cronExpression" value="0 0 1 * * ?" />
 	</bean>
 	<!-- END Quartz tasks -->	
            

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/TaskResultDao.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/TaskResultDao.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.taskslib.dao;
 
 import java.util.List;
 
+import org.springframework.dao.DataAccessException;
+
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
 
@@ -60,6 +62,8 @@ public interface TaskResultDao {
 	int clearByTask(int taskId, int engineID);
 
 	int clearAll(int engineID);
+
+	int clearOld(int engineID, int numDays) throws InternalErrorException;
 
 	List<TaskResult> getTaskResultsByTask(int taskId, int engineID);
 

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskResultDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskResultDaoJdbc.java
@@ -191,16 +191,16 @@ public class TaskResultDaoJdbc extends JdbcDaoSupport implements TaskResultDao {
 	public int clearOld(int engineID, int numDays) throws InternalErrorException {
 		return this.getJdbcTemplate().update("delete from tasks_results where engine_id = ? and " +
 				"id in (" +
-				"select otr.id from perunv3.tasks_results otr " +
+				"select otr.id from tasks_results otr " +
 				"         left join ( " +
 				"	select tr.destination_id, tr.task_id, max(tr.timestamp) as maxtimestamp " +
-				"	from perunv3.tasks_results tr " + 
-				"		inner join perunv3.tasks t on tr.task_id = t.id " +
+				"	from tasks_results tr " + 
+				"		inner join tasks t on tr.task_id = t.id " +
 				"		group by tr.destination_id,tr.task_id " +
 				"   )  tmp on otr.task_id = tmp.task_id and otr.destination_id = tmp.destination_id " +
 				"where otr.timestamp < maxtimestamp and otr.timestamp < ( " +
-				Compatibility.getSysdate() + " - ?) ", 
-				engineID, numDays);
+				Compatibility.getSysdate() + " - ?) ) ", 
+				new Object[] { engineID, numDays });
 	}
 
 	@Override

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskResultDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskResultDaoJdbc.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -187,6 +188,22 @@ public class TaskResultDaoJdbc extends JdbcDaoSupport implements TaskResultDao {
 	}
 
 	@Override
+	public int clearOld(int engineID, int numDays) throws InternalErrorException {
+		return this.getJdbcTemplate().update("delete from tasks_results where engine_id = ? and " +
+				"id in (" +
+				"select otr.id from perunv3.tasks_results otr " +
+				"         left join ( " +
+				"	select tr.destination_id, tr.task_id, max(tr.timestamp) as maxtimestamp " +
+				"	from perunv3.tasks_results tr " + 
+				"		inner join perunv3.tasks t on tr.task_id = t.id " +
+				"		group by tr.destination_id,tr.task_id " +
+				"   )  tmp on otr.task_id = tmp.task_id and otr.destination_id = tmp.destination_id " +
+				"where otr.timestamp < maxtimestamp and otr.timestamp < ( " +
+				Compatibility.getSysdate() + " - ?) ", 
+				engineID, numDays);
+	}
+
+	@Override
 	public List<TaskResult> getTaskResultsByTask(int taskId, int engineID) {
 		List<TaskResult> taskResults = this.getJdbcTemplate().query(
 				"select " + taskResultMappingSelectQuery + ", " + ServicesManagerImpl.destinationMappingSelectQuery + ", " +
@@ -236,4 +253,5 @@ public class TaskResultDaoJdbc extends JdbcDaoSupport implements TaskResultDao {
 			throw new InternalErrorException(e);
 		}
 	}
+
 }

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/ResultManager.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/ResultManager.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.taskslib.service;
 
 import java.util.List;
 
+import org.springframework.dao.DataAccessException;
+
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
 
@@ -32,6 +34,8 @@ public interface ResultManager {
 	int clearByTask(int taskId, int engineID);
 
 	int clearAll(int engineID);
+
+	int clearOld(int engineID, int numDays) throws InternalErrorException;
 
 	List<TaskResult> getTaskResultsByTask(int taskId, int engineID);
 

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/impl/ResultManagerImpl.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/impl/ResultManagerImpl.java
@@ -5,7 +5,9 @@ import java.util.List;
 import cz.metacentrum.perun.taskslib.dao.TaskResultDao;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
 import cz.metacentrum.perun.taskslib.service.ResultManager;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,6 +80,11 @@ public class ResultManagerImpl implements ResultManager {
 	}
 
 	@Override
+	public int clearOld(int engineID, int numDays) throws InternalErrorException {
+		return taskResultDao.clearOld(engineID, numDays);
+	}
+
+	@Override
 	public List<TaskResult> getTaskResultsByTask(int taskId, int engineID) {
 		return taskResultDao.getTaskResultsByTask(taskId, engineID);
 	}
@@ -93,4 +100,5 @@ public class ResultManagerImpl implements ResultManager {
 	public TaskResultDao getTaskResultDao() {
 		return taskResultDao;
 	}
+
 }


### PR DESCRIPTION
Add periodic (once a day) cleaning of old entries in tasks_results table:
  - deletes entries older than three days
  - always leaves the last entry per task/destination

Shutdown all dispatcher (HornetQ) spawned threads when unloading perun-rpc from container:
  - stop and close server
  - stop and close client connection and connection factory
  - do not use global thread pool (global pool does not stop threads)
This is necessary to avoid memory leaks during rpc/dispatcher (re)deploy in Tomcat.