### PR TITLE
Find complete richMembers in perun

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -566,6 +566,27 @@ public interface MembersManager {
 	List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, List<String> allowedStatuses, String searchString) throws InternalErrorException, PrivilegeException, VoNotExistsException, AttributeNotExistsException;
 
 	/**
+	 * Return list of richMembers from Perun by searchString with attrs specific for list of attrsNames
+	 * and who have only status which is contain in list of statuses.
+	 * If attrsNames is empty or null return all attributes for specific richMembers.
+	 * If listOfStatuses is empty or null, return all possible statuses.
+	 *
+	 * @param sess
+	 * @param attrsNames
+	 * @param allowedStatuses
+	 * @param searchString
+	 *
+	 * @return list of founded richMembers with specific attributes by searchString with allowed statuses
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws VoNotExistsException
+	 * @throws AttributeNotExistsException
+	 * @throws MemberNotExistsException
+	 */
+	List<RichMember> findCompleteRichMembers(PerunSession sess, List<String> attrsNames, List<String> allowedStatuses, String searchString) throws InternalErrorException, MemberNotExistsException, PrivilegeException, VoNotExistsException, AttributeNotExistsException;
+
+	/**
 	 * Return list of richMembers for specific group by the searchString with attrs specific for list of attrsNames.
 	 * If attrsNames is empty or null return all attributes for specific richMembers.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -577,6 +577,19 @@ public interface MembersManagerBl {
 	List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, String searchString) throws InternalErrorException, AttributeNotExistsException;
 
 	/**
+	 * Return list of richMembers by the searchString with attributes specific for list of attrsNames.
+	 * If attrsNames is empty or null return all attributes for specific richMembers.
+	 *
+	 * @param sess
+	 * @param attrsNames
+	 * @param searchString
+	 * @return list of founded richMembers with specific attributes from Vo for searchString
+	 * @throws InternalErrorException
+	 * @throws AttributeNotExistsException
+	 */
+	List<RichMember> findCompleteRichMembers(PerunSession sess, List<String> attrsNames, String searchString) throws InternalErrorException, AttributeNotExistsException;
+
+	/**
 	 * Return list of richMembers for specific vo by the searchString with attributes specific for list of attrsNames
 	 * and who have only status which is contain in list of statuses.
 	 * If attrsNames is empty or null return all attributes for specific richMembers.
@@ -592,6 +605,22 @@ public interface MembersManagerBl {
 	 * @throws AttributeNotExistsException
 	 */
 	List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, List<String> allowedStatuses, String searchString) throws InternalErrorException, AttributeNotExistsException;
+
+	/**
+	 * Return list of richMembers by the searchString with attributes specific for list of attrsNames
+	 * and who have only status which is contain in list of statuses.
+	 * If attrsNames is empty or null return all attributes for specific richMembers.
+	 * If listOfStatuses is empty or null, return all possible statuses.
+	 *
+	 * @param sess
+	 * @param attrsNames
+	 * @param allowedStatuses
+	 * @param searchString
+	 * @return list of founded richMembers with specific attributes by searchString with allowed statuses
+	 * @throws InternalErrorException
+	 * @throws AttributeNotExistsException
+	 */
+	List<RichMember> findCompleteRichMembers(PerunSession sess, List<String> attrsNames, List<String> allowedStatuses, String searchString) throws InternalErrorException, AttributeNotExistsException;
 
 	/**
 	 * Return list of richMembers for specific group by the searchString with attributes specific for list of attrsNames.
@@ -870,6 +899,15 @@ public interface MembersManagerBl {
 	List<RichMember> findRichMembersInVo(PerunSession sess, Vo vo, String searchString) throws InternalErrorException;
 
 	/**
+	 * Return list of rich members by theirs name or login or email
+	 * @param sess
+	 * @param searchString
+	 * @return list of rich members
+	 * @throws InternalErrorException
+	 */
+	List<RichMember> findRichMembers(PerunSession sess, String searchString) throws InternalErrorException;
+
+	/**
 	 * Return list of rich members with attributes by theirs name or login or email under defined VO.
 	 * @param sess
 	 * @param searchString
@@ -878,6 +916,15 @@ public interface MembersManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<RichMember> findRichMembersWithAttributesInVo(PerunSession sess, Vo vo, String searchString) throws InternalErrorException;
+
+	/**
+	 * Return list of rich members with attributes by theirs name or login or email
+	 * @param sess
+	 * @param searchString
+	 * @return list of rich members with attributes
+	 * @throws InternalErrorException
+	 */
+	List<RichMember> findRichMembersWithAttributes(PerunSession sess, String searchString) throws InternalErrorException;
 
 	void checkMemberExists(PerunSession sess, Member member) throws InternalErrorException, MemberNotExistsException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -619,8 +619,19 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return this.getRichMembersOnlyWithSpecificAttrNames(sess, richMembersWithAttributesFromVo, attrsNames);
 	}
 
+
+	public List<RichMember> findCompleteRichMembers(PerunSession sess, List<String> attrsNames, String searchString) throws InternalErrorException, AttributeNotExistsException {
+		List<RichMember> richMembersWithAttributes = this.findRichMembersWithAttributes(sess, searchString);
+		return this.getRichMembersOnlyWithSpecificAttrNames(sess, richMembersWithAttributes, attrsNames);
+	}
+
 	public List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, List<String> allowedStatuses, String searchString) throws InternalErrorException, AttributeNotExistsException {
 		return getOnlyRichMembersWithAllowedStatuses(sess, this.findCompleteRichMembers(sess, vo, attrsNames, searchString), allowedStatuses);
+	}
+
+	@Override
+	public List<RichMember> findCompleteRichMembers(PerunSession sess, List<String> attrsNames, List<String> allowedStatuses, String searchString) throws InternalErrorException, AttributeNotExistsException {
+		return getOnlyRichMembersWithAllowedStatuses(sess, this.findCompleteRichMembers(sess, attrsNames, searchString), allowedStatuses);
 	}
 
 	public List<RichMember> findCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, String searchString, boolean lookingInParentGroup) throws InternalErrorException, AttributeNotExistsException, ParentGroupNotExistsException {
@@ -925,11 +936,30 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return this.convertMembersToRichMembers(sess, this.setAllMembersSameType(members, MembershipType.DIRECT));
 	}
 
+	@Override
+	public List<RichMember> findRichMembers(PerunSession sess, String searchString) throws InternalErrorException {
+
+		List<User> users = getPerunBl().getUsersManagerBl().findUsers(sess, searchString);
+
+		List<Member> members = new ArrayList<Member>();
+		for (User user: users) {
+			members.addAll(getMembersByUser(sess, user));
+		}
+
+		return this.convertMembersToRichMembers(sess, this.setAllMembersSameType(members, MembershipType.DIRECT));
+	}
+
 	public List<RichMember> findRichMembersWithAttributesInVo(PerunSession sess, Vo vo, String searchString) throws InternalErrorException {
 
 		List<RichMember> list = findRichMembersInVo(sess, vo, searchString);
 		return convertMembersToRichMembersWithAttributes(sess, list);
 
+	}
+
+	@Override
+	public List<RichMember> findRichMembersWithAttributes(PerunSession sess, String searchString) throws InternalErrorException {
+		List<RichMember> list = findRichMembers(sess, searchString);
+		return convertMembersToRichMembersWithAttributes(sess, list);
 	}
 
 	public void checkMemberExists(PerunSession sess, Member member) throws InternalErrorException, MemberNotExistsException {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -144,6 +144,22 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test
+	public void findCompleteRichMembers() throws Exception {
+		System.out.println(MEMBERS_MANAGER_ENTRY + ".findCompleteRichMembers()");
+
+		User user = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+
+		List<RichMember> richMembers = perun.getMembersManager().findCompleteRichMembers(sess, new ArrayList<String>(), new ArrayList<String>(), user.getFirstName());
+
+		List<Integer> ids = new ArrayList<>();
+		for(RichMember rm: richMembers) {
+			ids.add(rm.getId());
+		}
+
+		assertTrue(ids.contains(createdMember.getId()));
+	}
+
+	@Test
 	public void createMemberFromUserInGroup() throws Exception {
 		System.out.println(MEMBERS_MANAGER_ENTRY + ".createMember()");
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -730,6 +730,18 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 * @return List<RichMember> List of founded richMembers with specific attributes from Group for searchString
  	 */
 	/*#
+ 	 * Return list of richMembers from perun by the searchString with attributes specific for list of attrsNames
+ 	 * and who have only status which is contain in list of statuses.
+ 	 * If attrsNames is empty or null return all attributes for specific richMembers.
+ 	 * If listOfStatuses is empty or null, return all possible statuses.
+ 	 *
+ 	 * @param attrsNames List<String> Attribute names
+ 	 * @param allowedStatuses List<String> Allowed statuses
+ 	 * @param searchString String String to search by
+ 	 * @param lookingInParentGroup boolean If true, look up in a parent group
+ 	 * @return List<RichMember> List of founded richMembers with specific attributes from perun for searchString
+ 	 */
+	/*#
  	 * Return list of richMembers for specific group by the searchString with attrs specific for list of attrsNames.
  	 * If attrsNames is empty or null return all attributes for specific richMembers.
  	 *
@@ -760,12 +772,19 @@ public enum MembersManagerMethod implements ManagerMethod {
 				}
 			} else {
 				if(parms.contains("allowedStatuses")) {
-					return ac.getMembersManager().findCompleteRichMembers(ac.getSession(),
-							ac.getGroupById(parms.readInt("group")),
-							parms.readList("attrsNames", String.class),
-							parms.readList("allowedStatuses", String.class),
-							parms.readString("searchString"),
-							parms.readBoolean("lookingInParentGroup"));
+					if(parms.contains("group")) {
+						return ac.getMembersManager().findCompleteRichMembers(ac.getSession(),
+								ac.getGroupById(parms.readInt("group")),
+								parms.readList("attrsNames", String.class),
+								parms.readList("allowedStatuses", String.class),
+								parms.readString("searchString"),
+								parms.readBoolean("lookingInParentGroup"));
+					} else {
+						return ac.getMembersManager().findCompleteRichMembers(ac.getSession(),
+								parms.readList("attrsNames", String.class),
+								parms.readList("allowedStatuses", String.class),
+								parms.readString("searchString"));
+					}
 				} else {
 					return ac.getMembersManager().findCompleteRichMembers(ac.getSession(),
 							ac.getGroupById(parms.readInt("group")),


### PR DESCRIPTION
 - method which can find all complete rich members in perun
 - rights to member can actor get by authorization to vo or to resource
   where member is assigned
 - can apply list of allowed statuses and list of attributes
 - add method to RPC
 - add test of basic funcionality of this method