### PR TITLE
Updated .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.war
 *.ear
 
+# Ignore data folder of running perun-rpc | perun-dispatcher
+perun-rpc/data/
+
 # Ignore Maven target #
 
 **/target


### PR DESCRIPTION
- When running perun-rpc locally with integrated dispatcher,
  data subfolder is created inside perun-rpc and we don't want
  it to be part of the sources.