### PR TITLE
UTILS: Allow to use JAVA_OPTS in dispatcher/engine init.d script

### DIFF
--- a/perun-utils/init.d-scripts/perun-dispatcher.debian
+++ b/perun-utils/init.d-scripts/perun-dispatcher.debian
@@ -23,7 +23,6 @@ SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid
 LOG4J_CONF=/etc/perun/log4j.xml
 PERUN_DISPATCHER_CONF_DIR=/etc/perun/
-DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_DISPATCHER_CONF_DIR -jar $JAR"
 DAEMON_USER=perun
 JAVA=`which java`
 EXEC_DIR=/home/perun/perun-dispatcher/
@@ -36,6 +35,8 @@ EXEC_DIR=/home/perun/perun-dispatcher/
 
 # Read configuration if it is present.
 [ -r /etc/perun/$NAME ] && . /etc/perun/$NAME
+
+DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_DISPATCHER_CONF_DIR $JAVA_OPTS -jar $JAR"
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh

--- a/perun-utils/init.d-scripts/perun-engine.debian
+++ b/perun-utils/init.d-scripts/perun-engine.debian
@@ -24,7 +24,6 @@ SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid
 LOG4J_CONF=/etc/perun/log4j.xml
 PERUN_ENGINE_CONF_DIR=/etc/perun/
-DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR -jar $JAR"
 DAEMON_USER=perun
 JAVA=`which java`
 EXEC_DIR=/home/perun/perun-engine/
@@ -41,6 +40,8 @@ EXEC_DIR=/home/perun/perun-engine/
 
 # Read configuration if it is present.
 [ -r /etc/perun/$NAME ] && . /etc/perun/$NAME
+
+DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR $JAVA_OPTS -jar $JAR"
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh


### PR DESCRIPTION
- Added support for passing JAVA_OPTS to the start command, for e.g.
  setting a truststore etc. It must be set in /etc/perun/perun-[engine|dispatcher]
  file accordingly.