### PR TITLE
CABINET: Added Mockito dependency

### DIFF
--- a/perun-cabinet/pom.xml
+++ b/perun-cabinet/pom.xml
@@ -161,6 +161,13 @@
 			<scope>compile</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.8.5</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- LOGGING -->
 
 		<dependency>


### PR DESCRIPTION
- Since we moved Mockito dependency in perun-core to test
  scope, we must declare same dependency in perun-cabinet.
  Including original perun-core is not enough.