### PR TITLE
GUI: Better filtering above some tables

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/extSourcesManager/GetExtSources.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/extSourcesManager/GetExtSources.java
@@ -46,7 +46,7 @@ public class GetExtSources implements JsonCallback, JsonCallbackTable<ExtSource>
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
 	// display checkboxes
 	private boolean checkable = true;
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" ./-");
 	private ArrayList<ExtSource> fullBackup = new ArrayList<ExtSource>();
 
 	/**

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/extSourcesManager/GetVoExtSources.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/extSourcesManager/GetVoExtSources.java
@@ -47,7 +47,7 @@ public class GetVoExtSources implements JsonCallback, JsonCallbackTable<ExtSourc
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
 	private boolean checkable = true;
 	private ArrayList<ExtSource> fullBackup = new ArrayList<ExtSource>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" ./-");
 
 	/**
 	 * Creates a new callback
@@ -291,8 +291,8 @@ public class GetVoExtSources implements JsonCallback, JsonCallbackTable<ExtSourc
 		} else {
 			for (ExtSource src : fullBackup){
 				// store ext source if name or type matches
-				if ((src.getName().toLowerCase().startsWith(filter.toLowerCase())) ||
-						renameContent(src.getType()).toLowerCase().startsWith(filter.toLowerCase())) {
+				if ((src.getName().toLowerCase().contains(filter.toLowerCase())) ||
+						renameContent(src.getType()).toLowerCase().contains(filter.toLowerCase())) {
 					list.add(src);
 						}
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/facilitiesManager/GetAssignedRichResources.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/facilitiesManager/GetAssignedRichResources.java
@@ -42,7 +42,7 @@ public class GetAssignedRichResources implements JsonCallback, JsonCallbackTable
 	private ArrayList<RichResource> list = new ArrayList<RichResource>();
 	private FieldUpdater<RichResource, String> tableFieldUpdater;
 	final MultiSelectionModel<RichResource> selectionModel = new MultiSelectionModel<RichResource>(new GeneralKeyProvider<RichResource>());
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 	private ArrayList<RichResource> backupList = new ArrayList<RichResource>();
 	private boolean checkable = true;
 
@@ -319,9 +319,9 @@ public class GetAssignedRichResources implements JsonCallback, JsonCallbackTable
 			list.addAll(backupList);
 		} else {
 			for (RichResource r : backupList){
-				if ((r.getName().toLowerCase().startsWith(text.toLowerCase())) ||
-						(r.getVo().getName().toLowerCase().startsWith(text.toLowerCase())) ||
-						(r.getVo().getShortName().toLowerCase().startsWith(text.toLowerCase()))) {
+				if ((r.getName().toLowerCase().contains(text.toLowerCase())) ||
+						(r.getVo().getName().toLowerCase().contains(text.toLowerCase())) ||
+						(r.getVo().getShortName().toLowerCase().contains(text.toLowerCase()))) {
 					list.add(r);
 						}
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/facilitiesManager/GetFacilities.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/facilitiesManager/GetFacilities.java
@@ -53,7 +53,7 @@ public class GetFacilities implements JsonCallback, JsonCallbackTable<Facility>,
 	private boolean checkable = true;
 	// oracle support
 	private ArrayList<Facility> fullBackup = new ArrayList<Facility>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 	// get Rich or Normal facilities (default normal)
 	private boolean provideRich = false;
 
@@ -327,7 +327,7 @@ public class GetFacilities implements JsonCallback, JsonCallbackTable<Facility>,
 		} else {
 			for (Facility fac : fullBackup){
 				// store facility by filter
-				if (fac.getName().toLowerCase().startsWith(text.toLowerCase())) {
+				if (fac.getName().toLowerCase().contains(text.toLowerCase())) {
 					list.add(fac);
 				} else if (provideRich) {
 					// if name doesn't match, try to match owners

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/facilitiesManager/GetFacilityOwners.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/facilitiesManager/GetFacilityOwners.java
@@ -47,7 +47,7 @@ public class GetFacilityOwners implements JsonCallback, JsonCallbackTable<Owner>
 	// checkable
 	private boolean checkable = true;
 	private ArrayList<Owner> backupList = new ArrayList<Owner>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .@");
 
 	/**
 	 * New instance of get facility owners
@@ -303,8 +303,8 @@ public class GetFacilityOwners implements JsonCallback, JsonCallbackTable<Owner>
 		} else {
 			for (Owner o: backupList){
 				// store owner by filter
-				if (o.getName().toLowerCase().startsWith(filter.toLowerCase()) ||
-						o.getContact().toLowerCase().startsWith(filter.toLowerCase()) ||
+				if (o.getName().toLowerCase().contains(filter.toLowerCase()) ||
+						o.getContact().toLowerCase().contains(filter.toLowerCase()) ||
 						Owner.getTranslatedType(o.getType()).toLowerCase().startsWith(Owner.getTranslatedType(filter).toLowerCase())) {
 					list.add(o);
 						}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/facilitiesManager/GetHosts.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/facilitiesManager/GetHosts.java
@@ -48,7 +48,7 @@ public class GetHosts implements JsonCallback, JsonCallbackTable<Host>, JsonCall
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
 	// oracle
 	private ArrayList<Host> backupList = new ArrayList<Host>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 	private boolean checkable = true; // default is checkable
 
 	/**
@@ -284,7 +284,7 @@ public class GetHosts implements JsonCallback, JsonCallbackTable<Host>, JsonCall
 		} else {
 			for (Host o: backupList){
 				// store owner by filter
-				if (o.getName().toLowerCase().startsWith(filter.toLowerCase())) {
+				if (o.getName().toLowerCase().contains(filter.toLowerCase())) {
 					list.add(o);
 				}
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/ownersManager/GetOwners.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/ownersManager/GetOwners.java
@@ -45,7 +45,7 @@ public class GetOwners implements JsonCallback, JsonCallbackTable<Owner>, JsonCa
 
 	private boolean checkable = true;
 	private ArrayList<Owner> backupList = new ArrayList<Owner>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .@");
 
 	/**
 	 * New instance of get owners
@@ -308,8 +308,8 @@ public class GetOwners implements JsonCallback, JsonCallbackTable<Owner>, JsonCa
 		} else {
 			for (Owner o: backupList){
 				// store owner by filter
-				if (o.getName().toLowerCase().startsWith(filter.toLowerCase()) ||
-						o.getContact().toLowerCase().startsWith(filter.toLowerCase()) ||
+				if (o.getName().toLowerCase().contains(filter.toLowerCase()) ||
+						o.getContact().toLowerCase().contains(filter.toLowerCase()) ||
 						Owner.getTranslatedType(o.getType()).toLowerCase().startsWith(Owner.getTranslatedType(filter).toLowerCase())) {
 					list.add(o);
 						}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/resourcesManager/GetAssignedRichResources.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/resourcesManager/GetAssignedRichResources.java
@@ -53,7 +53,7 @@ public class GetAssignedRichResources implements JsonCallback, JsonCallbackTable
 	private PerunEntity entity;
 	// oracle support
 	private ArrayList<RichResource> fullBackup = new ArrayList<RichResource>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 
 	/**
 	 * Creates a new getResources method instance
@@ -338,12 +338,12 @@ public class GetAssignedRichResources implements JsonCallback, JsonCallbackTable
 		} else {
 			for (RichResource res : fullBackup){
 				// store resource by filter
-				if (res.getName().toLowerCase().startsWith(filter.toLowerCase())) {
+				if (res.getName().toLowerCase().contains(filter.toLowerCase())) {
 					list.add(res);
 				}
 				for (ResourceTag r : res.getResourceTags()) {
 					// remove " (tag)" after tag name
-					if (r.getName().startsWith(filter.substring(0, (filter.length() > 6) ? filter.length()-6 : filter.length()).trim())) {
+					if (r.getName().contains(filter.substring(0, (filter.length() > 6) ? filter.length()-6 : filter.length()).trim())) {
 						list.add(res);
 						break;
 					}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/resourcesManager/GetRichResources.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/resourcesManager/GetRichResources.java
@@ -51,7 +51,7 @@ public class GetRichResources implements JsonCallback, JsonCallbackTable<RichRes
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
 	// oracle support
 	private ArrayList<RichResource> fullBackup = new ArrayList<RichResource>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 
 	private boolean checkable = true;
 
@@ -320,12 +320,12 @@ public class GetRichResources implements JsonCallback, JsonCallbackTable<RichRes
 		} else {
 			for (RichResource res : fullBackup){
 				// store facility by filter
-				if (res.getName().toLowerCase().startsWith(filter.toLowerCase())) {
+				if (res.getName().toLowerCase().contains(filter.toLowerCase())) {
 					list.add(res);
 				}
 				for (ResourceTag r : res.getResourceTags()) {
 					// remove " (tag)" from tag name
-					if (r.getName().startsWith(filter.substring(0, (filter.length() > 6) ? filter.length()-6 : filter.length()).trim())) {
+					if (r.getName().contains(filter.substring(0, (filter.length() > 6) ? filter.length()-6 : filter.length()).trim())) {
 						list.add(res);
 						break;
 					}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/servicesManager/GetAllRichDestinations.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/servicesManager/GetAllRichDestinations.java
@@ -49,7 +49,7 @@ public class GetAllRichDestinations implements JsonCallback, JsonCallbackTable<D
 	private boolean showServ = true; // display service column by default
 	private boolean checkable = true;
 	// oracle support
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 	private ArrayList<Destination> fullBackup = new ArrayList<Destination>();
 
 	/**
@@ -414,11 +414,11 @@ public class GetAllRichDestinations implements JsonCallback, JsonCallbackTable<D
 			for (Destination dst : fullBackup){
 				// store facility by filter
 				if (service == null) {
-					if (dst.getDestination().toLowerCase().startsWith(text.toLowerCase()) || dst.getService().getName().toLowerCase().startsWith(text.toLowerCase())) {
+					if (dst.getDestination().toLowerCase().contains(text.toLowerCase()) || dst.getService().getName().toLowerCase().contains(text.toLowerCase())) {
 						list.add(dst);
 					}
 				} else {
-					if (dst.getDestination().toLowerCase().startsWith(text.toLowerCase()) || dst.getFacility().getName().toLowerCase().startsWith(text.toLowerCase())) {
+					if (dst.getDestination().toLowerCase().contains(text.toLowerCase()) || dst.getFacility().getName().toLowerCase().contains(text.toLowerCase())) {
 						list.add(dst);
 					}
 				}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/servicesManager/GetDestinations.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/servicesManager/GetDestinations.java
@@ -52,7 +52,7 @@ public class GetDestinations implements JsonCallback, JsonCallbackTable<Destinat
 	private boolean showFac = false;
 	private boolean checkable = true;
 	// oracle support
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 	private ArrayList<Destination> fullBackup = new ArrayList<Destination>();
 
 	/**
@@ -408,11 +408,11 @@ public class GetDestinations implements JsonCallback, JsonCallbackTable<Destinat
 			for (Destination dst : fullBackup){
 				// store facility by filter
 				if (dst.getService() != null) {
-					if (dst.getDestination().toLowerCase().startsWith(text.toLowerCase()) || dst.getService().getName().toLowerCase().startsWith(text.toLowerCase())) {
+					if (dst.getDestination().toLowerCase().contains(text.toLowerCase()) || dst.getService().getName().toLowerCase().contains(text.toLowerCase())) {
 						list.add(dst);
 					}
 				} else {
-					if (dst.getDestination().toLowerCase().startsWith(text.toLowerCase())) {
+					if (dst.getDestination().toLowerCase().contains(text.toLowerCase())) {
 						list.add(dst);
 					}
 				}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/GetAssignedRichResources.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/GetAssignedRichResources.java
@@ -53,7 +53,7 @@ public class GetAssignedRichResources implements JsonCallback, JsonCallbackTable
 	private PerunEntity entity;
 	// oracle support
 	private ArrayList<RichResource> fullBackup = new ArrayList<RichResource>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 
 	/**
 	 * Creates a new getResources method instance
@@ -317,12 +317,12 @@ public class GetAssignedRichResources implements JsonCallback, JsonCallbackTable
 		} else {
 			for (RichResource res : fullBackup){
 				// store resource by filter
-				if (res.getName().toLowerCase().startsWith(filter.toLowerCase())) {
+				if (res.getName().toLowerCase().contains(filter.toLowerCase())) {
 					list.add(res);
 				}
 				for (ResourceTag r : res.getResourceTags()) {
 					// remove " (tag)" after tag name
-					if (r.getName().startsWith(filter.substring(0, (filter.length() > 6) ? filter.length()-6 : filter.length()).trim())) {
+					if (r.getName().contains(filter.substring(0, (filter.length() > 6) ? filter.length()-6 : filter.length()).trim())) {
 						list.add(res);
 						break;
 					}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/vosManager/GetVos.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/vosManager/GetVos.java
@@ -51,7 +51,7 @@ public class GetVos implements JsonCallback, JsonCallbackTable<VirtualOrganizati
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
 	// oracle
 	private ArrayList<VirtualOrganization> fullBackup = new ArrayList<VirtualOrganization>();
-	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" .-");
 	private boolean forceAll = false;
 	private boolean checkable = true;
 
@@ -286,7 +286,7 @@ public class GetVos implements JsonCallback, JsonCallbackTable<VirtualOrganizati
 		} else {
 			for (VirtualOrganization vo : fullBackup){
 				// store facility by filter
-				if (vo.getName().toLowerCase().startsWith(filter.toLowerCase()) || vo.getShortName().toLowerCase().startsWith(filter.toLowerCase())) {
+				if (vo.getName().toLowerCase().contains(filter.toLowerCase()) || vo.getShortName().toLowerCase().contains(filter.toLowerCase())) {
 					list.add(vo);
 				}
 			}


### PR DESCRIPTION
- When filtering VOs, Facilities, Resources, Hosts, Owners,
  Destinations and ExtSources, use also other characters as
  a whitespace (like: .@/-).

  Then more relevant entries can be filtered, eg. all facilities
  in "muni.cz" namespace etc.