### PR TITLE
CONTROLLER: Fixed resolving of service state on facility

### DIFF
--- a/perun-controller/src/main/java/cz/metacentrum/perun/controller/service/impl/PropagationStatsReaderImpl.java
+++ b/perun-controller/src/main/java/cz/metacentrum/perun/controller/service/impl/PropagationStatsReaderImpl.java
@@ -325,6 +325,11 @@ public class PropagationStatsReaderImpl implements PropagationStatsReader {
 				serviceState.setSendTask(task);
 			}
 
+			if (!task.getExecService().isEnabled()) {
+				serviceStates.get(taskService).setBlockedGlobally(true);
+			}
+			if (getGeneralServiceManager().isExecServiceDeniedOnFacility(task.getExecService(), facility)) serviceStates.get(taskService).setBlockedOnFacility(true);
+
 		}
 
 		return new ArrayList<ServiceState>(serviceStates.values());


### PR DESCRIPTION
- When service is not assigned to facility, but state is calculated from
  task, fill correctly "blocked on facility" and "blocked globally".