### PR TITLE
GUI: Do not cache web page of GUI and fix session timeout

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
@@ -311,7 +311,9 @@ public class UiElements {
 
 		final ClickHandler okClickHandler = new ClickHandler() {
 			public void onClick(ClickEvent arg0) {
-				// do nothing
+				if (error != null && "0".equals(error.getErrorId())) {
+					Window.Location.reload();
+				}
 			}
 		};
 
@@ -332,10 +334,15 @@ public class UiElements {
 		layout.getFlexCellFormatter().setStyleName(0, 0, "alert-box-image");
 
 		// build confirm
-		Confirm conf = new Confirm(header + ((!error.getErrorId().equals("")) ? " (" + error.getErrorId() + ")" : ""), layout, okClickHandler, reportClickHandler, okLabel, reportLabel, true);
+		Confirm conf;
+		if (error != null && "0".equals(error.getErrorId())) {
+			conf = new Confirm(header + ((!error.getErrorId().equals("")) ? " (" + error.getErrorId() + ")" : ""), layout, okClickHandler, true);
+		} else {
+			conf = new Confirm(header + ((!error.getErrorId().equals("")) ? " (" + error.getErrorId() + ")" : ""), layout, okClickHandler, reportClickHandler, okLabel, reportLabel, true);
+			conf.setCancelIcon(SmallIcons.INSTANCE.emailIcon());
+		}
 		conf.setNonScrollable(true);
 		conf.setAutoHide(false);
-		conf.setCancelIcon(SmallIcons.INSTANCE.emailIcon());
 
 		conf.show();
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
@@ -244,6 +244,14 @@ public class WebGui implements EntryPoint, ValueChangeHandler<String> {
 												c.show();
 											}
 											layout.setVisible(true);
+											c.getOkButton().setText("Reload");
+											c.getOkButton().addClickHandler(new ClickHandler() {
+												@Override
+												public void onClick(ClickEvent event) {
+													Window.Location.reload();
+												}
+											});
+
 										}
 									}
 								}));
@@ -311,7 +319,9 @@ public class WebGui implements EntryPoint, ValueChangeHandler<String> {
 								loadingFailedBox = session.getUiElements().perunLoadingFailedBox(error.getErrorInfo());
 							}
 						}
-						loadingFailedBox.show();
+						if (!error.getErrorId().equals("0")) {
+							loadingFailedBox.show();
+						}
 
 					}
 				});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonClient.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonClient.java
@@ -5,6 +5,7 @@ import com.google.gwt.http.client.*;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
+import com.google.gwt.user.client.Window;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.localization.WidgetTranslation;
 import cz.metacentrum.perun.webgui.model.PerunError;
@@ -219,8 +220,14 @@ public class JsonClient {
 
 						} else if (resp.getStatusCode() == 0) {
 
-							error.setName("Aborted");
-							error.setErrorInfo("Can't contact remote server, connection was lost.");
+							error.setName("Can't contact remote server.");
+							error.setErrorInfo("You are either without network connection or your session has expired. Click \"OK\" to reload the page (all unsaved changes will be lost).");
+
+							// force reload page if it's first GUI call, otherwise keep it to alert box
+							if (!hidden && runningRequests.get(requestUrl).getManager().equals("authzResolver") &&
+									runningRequests.get(requestUrl).getMethod().equals("getPerunPrincipal")) {
+								Window.Location.reload();
+							}
 
 						}
 
@@ -251,12 +258,13 @@ public class JsonClient {
 	}
 
 	/**
-	 * Parses the responce to an object.
+	 * Parses the response to an object.
 	 *
 	 * @param resp JSON string
 	 * @return
 	 */
 	protected JavaScriptObject parseResponse(String callbackName, String resp) {
+
 		// trims the whitespace
 		resp = resp.trim();
 
@@ -300,7 +308,7 @@ public class JsonClient {
 	}
 
 	/**
-	 * Called when error occured.
+	 * Called when error occur.
 	 *
 	 * @param jso
 	 */

--- a/perun-web-gui/src/main/webapp/ApplicationForm.html
+++ b/perun-web-gui/src/main/webapp/ApplicationForm.html
@@ -11,6 +11,11 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+    <!-- No cache -->
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 
@@ -72,12 +77,12 @@
 
         // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+            // Is IE < 8
+            alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
         var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
         if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+            alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>
@@ -108,12 +113,12 @@
 </body>
 
 <script>
-	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-	ga('create', 'UA-40001256-2', 'auto');
-	ga('send', 'pageview');
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-40001256-2', 'auto');
+    ga('send', 'pageview');
 </script>
 
 </html>

--- a/perun-web-gui/src/main/webapp/ApplicationFormCert.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormCert.html
@@ -11,6 +11,11 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+    <!-- No cache -->
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 
@@ -72,12 +77,12 @@
 
         // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+            // Is IE < 8
+            alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
         var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
         if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+            alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>
@@ -108,12 +113,12 @@
 </body>
 
 <script>
-	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-	ga('create', 'UA-40001256-2', 'auto');
-	ga('send', 'pageview');
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-40001256-2', 'auto');
+    ga('send', 'pageview');
 </script>
 
 </html>

--- a/perun-web-gui/src/main/webapp/ApplicationFormFed.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormFed.html
@@ -11,6 +11,11 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+    <!-- No cache -->
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/ApplicationFormKrb.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormKrb.html
@@ -11,6 +11,11 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+    <!-- No cache -->
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 
@@ -72,12 +77,12 @@
 
         // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+            // Is IE < 8
+            alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
         var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
         if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+            alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>
@@ -108,12 +113,12 @@
 </body>
 
 <script>
-	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-	ga('create', 'UA-40001256-2', 'auto');
-	ga('send', 'pageview');
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-40001256-2', 'auto');
+    ga('send', 'pageview');
 </script>
 
 </html>

--- a/perun-web-gui/src/main/webapp/ApplicationFormKrbEinfra.html
+++ b/perun-web-gui/src/main/webapp/ApplicationFormKrbEinfra.html
@@ -11,6 +11,11 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+    <!-- No cache -->
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 
@@ -72,12 +77,12 @@
 
         // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
         if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+            // Is IE < 8
+            alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
         var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
         if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+            alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
         }
 
     </script>
@@ -108,12 +113,12 @@
 </body>
 
 <script>
-	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-	ga('create', 'UA-40001256-2', 'auto');
-	ga('send', 'pageview');
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-40001256-2', 'auto');
+    ga('send', 'pageview');
 </script>
 
 </html>

--- a/perun-web-gui/src/main/webapp/PasswordReset.html
+++ b/perun-web-gui/src/main/webapp/PasswordReset.html
@@ -11,6 +11,11 @@
     <!-- Charset -->
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+    <!-- No cache -->
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+
     <!-- Default GWT locale -->
     <meta name="gwt:property" content="locale=en">
 

--- a/perun-web-gui/src/main/webapp/PasswordResetCert.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetCert.html
@@ -8,82 +8,87 @@
 <html>
 <head>
 
-    <!-- Charset -->
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<!-- Charset -->
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Default GWT locale -->
-    <meta name="gwt:property" content="locale=en">
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
 
-    <!-- FavIcons -->
-    <link rel="icon" href="img/perun.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
+	<!-- Default GWT locale -->
+	<meta name="gwt:property" content="locale=en">
 
-    <!-- Styles -->
-    <link type="text/css" rel="stylesheet" href="./PerunWeb.css">
+	<!-- FavIcons -->
+	<link rel="icon" href="img/perun.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
 
-    <!-- Title -->
-    <title>Password Reset</title>
+	<!-- Styles -->
+	<link type="text/css" rel="stylesheet" href="./PerunWeb.css">
 
-    <!--  RPC definition -->
-    <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "cert";
-    </script>
+	<!-- Title -->
+	<title>Password Reset</title>
 
-    <!--  jQuery -->
-    <script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
+	<!--  RPC definition -->
+	<script type="text/javascript" language="javascript" >
+		RPC_SERVER = "cert";
+	</script>
 
-    <!--  Set language -->
-    <script type="text/javascript" language="javascript" >
+	<!--  jQuery -->
+	<script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
 
-        // get URL param function
-        function getURLParameter(name) {
-            return decodeURI(
-                    (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
-            );
-        }
+	<!--  Set language -->
+	<script type="text/javascript" language="javascript" >
 
-        var l_lang;
-        l_lang = getURLParameter('locale');
+		// get URL param function
+		function getURLParameter(name) {
+			return decodeURI(
+					(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
+			);
+		}
 
-        // if no locale set in URL
-        if (l_lang == 'default') {
+		var l_lang;
+		l_lang = getURLParameter('locale');
 
-            if (typeof(Storage) != "undefined") {
+		// if no locale set in URL
+		if (l_lang == 'default') {
 
-                l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
+			if (typeof(Storage) != "undefined") {
 
-            }
+				l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
 
-            // if not set, set from browser settings
-            if (l_lang == null) {
+			}
 
-                if (navigator.userLanguage) // Explorer
-                    l_lang = navigator.userLanguage;
-                else if (navigator.language) // FF
-                    l_lang = navigator.language;
-                else
-                    l_lang = "en";
+			// if not set, set from browser settings
+			if (l_lang == null) {
 
-            }
+				if (navigator.userLanguage) // Explorer
+					l_lang = navigator.userLanguage;
+				else if (navigator.language) // FF
+					l_lang = navigator.language;
+				else
+					l_lang = "en";
 
-        }
+			}
 
-        $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
+		}
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-        if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
-        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
-        if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
+		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-    </script>
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
+		if (document.all && !document.querySelector) {
+			// Is IE < 8
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
 
-    <!-- Load GWT GUI -->
-    <script type="text/javascript" language="javascript" src="./PasswordReset/PasswordReset.nocache.js"></script>
+	</script>
+
+	<!-- Load GWT GUI -->
+	<script type="text/javascript" language="javascript" src="./PasswordReset/PasswordReset.nocache.js"></script>
 
 </head>
 
@@ -100,16 +105,16 @@
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>
-    <div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-        Your web browser must have JavaScript enabled in order for this
-        application to display correctly.</div>
+	<div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
+		Your web browser must have JavaScript enabled in order for this
+		application to display correctly.</div>
 </noscript>
 
 </body>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');

--- a/perun-web-gui/src/main/webapp/PasswordResetFed.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetFed.html
@@ -8,82 +8,87 @@
 <html>
 <head>
 
-    <!-- Charset -->
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<!-- Charset -->
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Default GWT locale -->
-    <meta name="gwt:property" content="locale=en">
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
 
-    <!-- FavIcons -->
-    <link rel="icon" href="img/perun.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
+	<!-- Default GWT locale -->
+	<meta name="gwt:property" content="locale=en">
 
-    <!-- Styles -->
-    <link type="text/css" rel="stylesheet" href="./PerunWeb.css">
+	<!-- FavIcons -->
+	<link rel="icon" href="img/perun.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
 
-    <!-- Title -->
-    <title>Password Reset</title>
+	<!-- Styles -->
+	<link type="text/css" rel="stylesheet" href="./PerunWeb.css">
 
-    <!--  RPC definition -->
-    <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "fed";
-    </script>
+	<!-- Title -->
+	<title>Password Reset</title>
 
-    <!--  jQuery -->
-    <script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
+	<!--  RPC definition -->
+	<script type="text/javascript" language="javascript" >
+		RPC_SERVER = "fed";
+	</script>
 
-    <!--  Set language -->
-    <script type="text/javascript" language="javascript" >
+	<!--  jQuery -->
+	<script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
 
-        // get URL param function
-        function getURLParameter(name) {
-            return decodeURI(
-                    (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
-            );
-        }
+	<!--  Set language -->
+	<script type="text/javascript" language="javascript" >
 
-        var l_lang;
-        l_lang = getURLParameter('locale');
+		// get URL param function
+		function getURLParameter(name) {
+			return decodeURI(
+					(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
+			);
+		}
 
-        // if no locale set in URL
-        if (l_lang == 'default') {
+		var l_lang;
+		l_lang = getURLParameter('locale');
 
-            if (typeof(Storage) != "undefined") {
+		// if no locale set in URL
+		if (l_lang == 'default') {
 
-                l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
+			if (typeof(Storage) != "undefined") {
 
-            }
+				l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
 
-            // if not set, set from browser settings
-            if (l_lang == null) {
+			}
 
-                if (navigator.userLanguage) // Explorer
-                    l_lang = navigator.userLanguage;
-                else if (navigator.language) // FF
-                    l_lang = navigator.language;
-                else
-                    l_lang = "en";
+			// if not set, set from browser settings
+			if (l_lang == null) {
 
-            }
+				if (navigator.userLanguage) // Explorer
+					l_lang = navigator.userLanguage;
+				else if (navigator.language) // FF
+					l_lang = navigator.language;
+				else
+					l_lang = "en";
 
-        }
+			}
 
-        $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
+		}
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-        if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
-        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
-        if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
+		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-    </script>
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
+		if (document.all && !document.querySelector) {
+			// Is IE < 8
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
 
-    <!-- Load GWT GUI -->
-    <script type="text/javascript" language="javascript" src="./PasswordReset/PasswordReset.nocache.js"></script>
+	</script>
+
+	<!-- Load GWT GUI -->
+	<script type="text/javascript" language="javascript" src="./PasswordReset/PasswordReset.nocache.js"></script>
 
 </head>
 
@@ -100,16 +105,16 @@
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>
-    <div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-        Your web browser must have JavaScript enabled in order for this
-        application to display correctly.</div>
+	<div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
+		Your web browser must have JavaScript enabled in order for this
+		application to display correctly.</div>
 </noscript>
 
 </body>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');

--- a/perun-web-gui/src/main/webapp/PasswordResetKrb.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetKrb.html
@@ -8,82 +8,87 @@
 <html>
 <head>
 
-    <!-- Charset -->
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<!-- Charset -->
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Default GWT locale -->
-    <meta name="gwt:property" content="locale=en">
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
 
-    <!-- FavIcons -->
-    <link rel="icon" href="img/perun.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
+	<!-- Default GWT locale -->
+	<meta name="gwt:property" content="locale=en">
 
-    <!-- Styles -->
-    <link type="text/css" rel="stylesheet" href="./PerunWeb.css">
+	<!-- FavIcons -->
+	<link rel="icon" href="img/perun.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
 
-    <!-- Title -->
-    <title>Password Reset</title>
+	<!-- Styles -->
+	<link type="text/css" rel="stylesheet" href="./PerunWeb.css">
 
-    <!--  RPC definition -->
-    <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "krb";
-    </script>
+	<!-- Title -->
+	<title>Password Reset</title>
 
-    <!--  jQuery -->
-    <script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
+	<!--  RPC definition -->
+	<script type="text/javascript" language="javascript" >
+		RPC_SERVER = "krb";
+	</script>
 
-    <!--  Set language -->
-    <script type="text/javascript" language="javascript" >
+	<!--  jQuery -->
+	<script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
 
-        // get URL param function
-        function getURLParameter(name) {
-            return decodeURI(
-                    (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
-            );
-        }
+	<!--  Set language -->
+	<script type="text/javascript" language="javascript" >
 
-        var l_lang;
-        l_lang = getURLParameter('locale');
+		// get URL param function
+		function getURLParameter(name) {
+			return decodeURI(
+					(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
+			);
+		}
 
-        // if no locale set in URL
-        if (l_lang == 'default') {
+		var l_lang;
+		l_lang = getURLParameter('locale');
 
-            if (typeof(Storage) != "undefined") {
+		// if no locale set in URL
+		if (l_lang == 'default') {
 
-                l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
+			if (typeof(Storage) != "undefined") {
 
-            }
+				l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
 
-            // if not set, set from browser settings
-            if (l_lang == null) {
+			}
 
-                if (navigator.userLanguage) // Explorer
-                    l_lang = navigator.userLanguage;
-                else if (navigator.language) // FF
-                    l_lang = navigator.language;
-                else
-                    l_lang = "en";
+			// if not set, set from browser settings
+			if (l_lang == null) {
 
-            }
+				if (navigator.userLanguage) // Explorer
+					l_lang = navigator.userLanguage;
+				else if (navigator.language) // FF
+					l_lang = navigator.language;
+				else
+					l_lang = "en";
 
-        }
+			}
 
-        $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
+		}
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-        if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
-        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
-        if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
+		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-    </script>
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
+		if (document.all && !document.querySelector) {
+			// Is IE < 8
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
 
-    <!-- Load GWT GUI -->
-    <script type="text/javascript" language="javascript" src="./PasswordReset/PasswordReset.nocache.js"></script>
+	</script>
+
+	<!-- Load GWT GUI -->
+	<script type="text/javascript" language="javascript" src="./PasswordReset/PasswordReset.nocache.js"></script>
 
 </head>
 
@@ -100,16 +105,16 @@
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>
-    <div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-        Your web browser must have JavaScript enabled in order for this
-        application to display correctly.</div>
+	<div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
+		Your web browser must have JavaScript enabled in order for this
+		application to display correctly.</div>
 </noscript>
 
 </body>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');

--- a/perun-web-gui/src/main/webapp/PasswordResetKrbEinfra.html
+++ b/perun-web-gui/src/main/webapp/PasswordResetKrbEinfra.html
@@ -8,82 +8,87 @@
 <html>
 <head>
 
-    <!-- Charset -->
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<!-- Charset -->
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Default GWT locale -->
-    <meta name="gwt:property" content="locale=en">
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
 
-    <!-- FavIcons -->
-    <link rel="icon" href="img/perun.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
+	<!-- Default GWT locale -->
+	<meta name="gwt:property" content="locale=en">
 
-    <!-- Styles -->
-    <link type="text/css" rel="stylesheet" href="./PerunWeb.css">
+	<!-- FavIcons -->
+	<link rel="icon" href="img/perun.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
 
-    <!-- Title -->
-    <title>Password Reset</title>
+	<!-- Styles -->
+	<link type="text/css" rel="stylesheet" href="./PerunWeb.css">
 
-    <!--  RPC definition -->
-    <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "einfra";
-    </script>
+	<!-- Title -->
+	<title>Password Reset</title>
 
-    <!--  jQuery -->
-    <script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
+	<!--  RPC definition -->
+	<script type="text/javascript" language="javascript" >
+		RPC_SERVER = "einfra";
+	</script>
 
-    <!--  Set language -->
-    <script type="text/javascript" language="javascript" >
+	<!--  jQuery -->
+	<script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
 
-        // get URL param function
-        function getURLParameter(name) {
-            return decodeURI(
-                    (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
-            );
-        }
+	<!--  Set language -->
+	<script type="text/javascript" language="javascript" >
 
-        var l_lang;
-        l_lang = getURLParameter('locale');
+		// get URL param function
+		function getURLParameter(name) {
+			return decodeURI(
+					(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
+			);
+		}
 
-        // if no locale set in URL
-        if (l_lang == 'default') {
+		var l_lang;
+		l_lang = getURLParameter('locale');
 
-            if (typeof(Storage) != "undefined") {
+		// if no locale set in URL
+		if (l_lang == 'default') {
 
-                l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
+			if (typeof(Storage) != "undefined") {
 
-            }
+				l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
 
-            // if not set, set from browser settings
-            if (l_lang == null) {
+			}
 
-                if (navigator.userLanguage) // Explorer
-                    l_lang = navigator.userLanguage;
-                else if (navigator.language) // FF
-                    l_lang = navigator.language;
-                else
-                    l_lang = "en";
+			// if not set, set from browser settings
+			if (l_lang == null) {
 
-            }
+				if (navigator.userLanguage) // Explorer
+					l_lang = navigator.userLanguage;
+				else if (navigator.language) // FF
+					l_lang = navigator.language;
+				else
+					l_lang = "en";
 
-        }
+			}
 
-        $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
+		}
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-        if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
-        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
-        if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
+		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-    </script>
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
+		if (document.all && !document.querySelector) {
+			// Is IE < 8
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
 
-    <!-- Load GWT GUI -->
-    <script type="text/javascript" language="javascript" src="./PasswordReset/PasswordReset.nocache.js"></script>
+	</script>
+
+	<!-- Load GWT GUI -->
+	<script type="text/javascript" language="javascript" src="./PasswordReset/PasswordReset.nocache.js"></script>
 
 </head>
 
@@ -100,16 +105,16 @@
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>
-    <div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-        Your web browser must have JavaScript enabled in order for this
-        application to display correctly.</div>
+	<div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
+		Your web browser must have JavaScript enabled in order for this
+		application to display correctly.</div>
 </noscript>
 
 </body>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');

--- a/perun-web-gui/src/main/webapp/PerunWeb.html
+++ b/perun-web-gui/src/main/webapp/PerunWeb.html
@@ -6,6 +6,11 @@
 	<!-- Charset -->
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+
 	<!-- Default GWT locale -->
 	<meta name="gwt:property" content="locale=en">
 
@@ -104,7 +109,7 @@
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');

--- a/perun-web-gui/src/main/webapp/PerunWebCert.html
+++ b/perun-web-gui/src/main/webapp/PerunWebCert.html
@@ -3,87 +3,92 @@
 <html>
 <head>
 
-    <!-- Charset -->
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<!-- Charset -->
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Default GWT locale -->
-    <meta name="gwt:property" content="locale=en">
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
 
-    <!-- FavIcons -->
-    <link rel="icon" href="img/perun.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
+	<!-- Default GWT locale -->
+	<meta name="gwt:property" content="locale=en">
 
-    <!-- Styles -->
-    <link type="text/css" rel="stylesheet" href="./PerunWeb.css">
+	<!-- FavIcons -->
+	<link rel="icon" href="img/perun.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
 
-    <!-- Title -->
-    <title>Perun web gui</title>
+	<!-- Styles -->
+	<link type="text/css" rel="stylesheet" href="./PerunWeb.css">
 
-    <!--  jQuery -->
-    <script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
+	<!-- Title -->
+	<title>Perun web gui</title>
 
-    <!--  RPC definition -->
-    <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "cert";
-    </script>
+	<!--  jQuery -->
+	<script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
 
-    <!--  Set language -->
-    <script type="text/javascript" language="javascript" >
+	<!--  RPC definition -->
+	<script type="text/javascript" language="javascript" >
+		RPC_SERVER = "cert";
+	</script>
 
-        // get URL param function
-        function getURLParameter(name) {
-            return decodeURI(
-                    (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
-            );
-        }
+	<!--  Set language -->
+	<script type="text/javascript" language="javascript" >
 
-        var l_lang;
-        l_lang = getURLParameter('locale');
+		// get URL param function
+		function getURLParameter(name) {
+			return decodeURI(
+					(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
+			);
+		}
 
-        /*
-        // if no locale set in URL
-        if (l_lang == 'default') {
+		var l_lang;
+		l_lang = getURLParameter('locale');
 
-            if (typeof(Storage) != "undefined") {
+		/*
+		 // if no locale set in URL
+		 if (l_lang == 'default') {
 
-                l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
+		 if (typeof(Storage) != "undefined") {
 
-            }
+		 l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
 
-            // if not set, set from browser settings
-            if (l_lang == null) {
+		 }
 
-                if (navigator.userLanguage) // Explorer
-                    l_lang = navigator.userLanguage;
-                else if (navigator.language) // FF
-                    l_lang = navigator.language;
-                else
-                    l_lang = "en";
+		 // if not set, set from browser settings
+		 if (l_lang == null) {
 
-            }
+		 if (navigator.userLanguage) // Explorer
+		 l_lang = navigator.userLanguage;
+		 else if (navigator.language) // FF
+		 l_lang = navigator.language;
+		 else
+		 l_lang = "en";
 
-        }
-        */
-        if (l_lang == 'default') {
-            l_lang = 'en';
-        }
+		 }
 
-        $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
+		 }
+		 */
+		if (l_lang == 'default') {
+			l_lang = 'en';
+		}
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-        if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
-        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
-        if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
+		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-    </script>
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
+		if (document.all && !document.querySelector) {
+			// Is IE < 8
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
 
-    <!-- Load GWT GUI -->
-    <script type="text/javascript" language="javascript" src="./PerunWeb/PerunWeb.nocache.js"></script>
+	</script>
+
+	<!-- Load GWT GUI -->
+	<script type="text/javascript" language="javascript" src="./PerunWeb/PerunWeb.nocache.js"></script>
 
 </head>
 
@@ -95,16 +100,16 @@
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>
-    <div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-        Your web browser must have JavaScript enabled in order for this
-        application to display correctly.</div>
+	<div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
+		Your web browser must have JavaScript enabled in order for this
+		application to display correctly.</div>
 </noscript>
 
 </body>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');

--- a/perun-web-gui/src/main/webapp/PerunWebFed.html
+++ b/perun-web-gui/src/main/webapp/PerunWebFed.html
@@ -3,87 +3,92 @@
 <html>
 <head>
 
-    <!-- Charset -->
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<!-- Charset -->
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Default GWT locale -->
-    <meta name="gwt:property" content="locale=en">
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
 
-    <!-- FavIcons -->
-    <link rel="icon" href="img/perun.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
+	<!-- Default GWT locale -->
+	<meta name="gwt:property" content="locale=en">
 
-    <!-- Styles -->
-    <link type="text/css" rel="stylesheet" href="./PerunWeb.css">
+	<!-- FavIcons -->
+	<link rel="icon" href="img/perun.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
 
-    <!-- Title -->
-    <title>Perun web gui</title>
+	<!-- Styles -->
+	<link type="text/css" rel="stylesheet" href="./PerunWeb.css">
 
-    <!--  jQuery -->
-    <script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
+	<!-- Title -->
+	<title>Perun web gui</title>
 
-    <!--  RPC definition -->
-    <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "fed";
-    </script>
+	<!--  jQuery -->
+	<script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
 
-    <!--  Set language -->
-    <script type="text/javascript" language="javascript" >
+	<!--  RPC definition -->
+	<script type="text/javascript" language="javascript" >
+		RPC_SERVER = "fed";
+	</script>
 
-        // get URL param function
-        function getURLParameter(name) {
-            return decodeURI(
-                    (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
-            );
-        }
+	<!--  Set language -->
+	<script type="text/javascript" language="javascript" >
 
-        var l_lang;
-        l_lang = getURLParameter('locale');
+		// get URL param function
+		function getURLParameter(name) {
+			return decodeURI(
+					(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
+			);
+		}
 
-        /*
-        // if no locale set in URL
-        if (l_lang == 'default') {
+		var l_lang;
+		l_lang = getURLParameter('locale');
 
-            if (typeof(Storage) != "undefined") {
+		/*
+		 // if no locale set in URL
+		 if (l_lang == 'default') {
 
-                l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
+		 if (typeof(Storage) != "undefined") {
 
-            }
+		 l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
 
-            // if not set, set from browser settings
-            if (l_lang == null) {
+		 }
 
-                if (navigator.userLanguage) // Explorer
-                    l_lang = navigator.userLanguage;
-                else if (navigator.language) // FF
-                    l_lang = navigator.language;
-                else
-                    l_lang = "en";
+		 // if not set, set from browser settings
+		 if (l_lang == null) {
 
-            }
+		 if (navigator.userLanguage) // Explorer
+		 l_lang = navigator.userLanguage;
+		 else if (navigator.language) // FF
+		 l_lang = navigator.language;
+		 else
+		 l_lang = "en";
 
-        }
-        */
-        if (l_lang == 'default') {
-            l_lang = 'en';
-        }
+		 }
 
-        $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
+		 }
+		 */
+		if (l_lang == 'default') {
+			l_lang = 'en';
+		}
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-        if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
-        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
-        if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
+		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-    </script>
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
+		if (document.all && !document.querySelector) {
+			// Is IE < 8
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
 
-    <!-- Load GWT GUI -->
-    <script type="text/javascript" language="javascript" src="./PerunWeb/PerunWeb.nocache.js"></script>
+	</script>
+
+	<!-- Load GWT GUI -->
+	<script type="text/javascript" language="javascript" src="./PerunWeb/PerunWeb.nocache.js"></script>
 
 </head>
 
@@ -95,16 +100,16 @@
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>
-    <div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-        Your web browser must have JavaScript enabled in order for this
-        application to display correctly.</div>
+	<div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
+		Your web browser must have JavaScript enabled in order for this
+		application to display correctly.</div>
 </noscript>
 
 </body>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');

--- a/perun-web-gui/src/main/webapp/PerunWebKrb.html
+++ b/perun-web-gui/src/main/webapp/PerunWebKrb.html
@@ -3,87 +3,92 @@
 <html>
 <head>
 
-    <!-- Charset -->
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<!-- Charset -->
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Default GWT locale -->
-    <meta name="gwt:property" content="locale=en">
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
 
-    <!-- FavIcons -->
-    <link rel="icon" href="img/perun.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
+	<!-- Default GWT locale -->
+	<meta name="gwt:property" content="locale=en">
 
-    <!-- Styles -->
-    <link type="text/css" rel="stylesheet" href="./PerunWeb.css">
+	<!-- FavIcons -->
+	<link rel="icon" href="img/perun.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
 
-    <!-- Title -->
-    <title>Perun web gui</title>
+	<!-- Styles -->
+	<link type="text/css" rel="stylesheet" href="./PerunWeb.css">
 
-    <!--  jQuery -->
-    <script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
+	<!-- Title -->
+	<title>Perun web gui</title>
 
-    <!--  RPC definition -->
-    <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "krb";
-    </script>
+	<!--  jQuery -->
+	<script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
 
-    <!--  Set language -->
-    <script type="text/javascript" language="javascript" >
+	<!--  RPC definition -->
+	<script type="text/javascript" language="javascript" >
+		RPC_SERVER = "krb";
+	</script>
 
-        // get URL param function
-        function getURLParameter(name) {
-            return decodeURI(
-                    (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
-            );
-        }
+	<!--  Set language -->
+	<script type="text/javascript" language="javascript" >
 
-        var l_lang;
-        l_lang = getURLParameter('locale');
+		// get URL param function
+		function getURLParameter(name) {
+			return decodeURI(
+					(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
+			);
+		}
 
-        /*
-        // if no locale set in URL
-        if (l_lang == 'default') {
+		var l_lang;
+		l_lang = getURLParameter('locale');
 
-            if (typeof(Storage) != "undefined") {
+		/*
+		 // if no locale set in URL
+		 if (l_lang == 'default') {
 
-                l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
+		 if (typeof(Storage) != "undefined") {
 
-            }
+		 l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
 
-            // if not set, set from browser settings
-            if (l_lang == null) {
+		 }
 
-                if (navigator.userLanguage) // Explorer
-                    l_lang = navigator.userLanguage;
-                else if (navigator.language) // FF
-                    l_lang = navigator.language;
-                else
-                    l_lang = "en";
+		 // if not set, set from browser settings
+		 if (l_lang == null) {
 
-            }
+		 if (navigator.userLanguage) // Explorer
+		 l_lang = navigator.userLanguage;
+		 else if (navigator.language) // FF
+		 l_lang = navigator.language;
+		 else
+		 l_lang = "en";
 
-        }
-        */
+		 }
 
-        if (l_lang == 'default') {
-            l_lang = 'en';
-        }
-        $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
+		 }
+		 */
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-        if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
-        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
-        if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
+		if (l_lang == 'default') {
+			l_lang = 'en';
+		}
+		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-    </script>
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
+		if (document.all && !document.querySelector) {
+			// Is IE < 8
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
 
-    <!-- Load GWT GUI -->
-    <script type="text/javascript" language="javascript" src="./PerunWeb/PerunWeb.nocache.js"></script>
+	</script>
+
+	<!-- Load GWT GUI -->
+	<script type="text/javascript" language="javascript" src="./PerunWeb/PerunWeb.nocache.js"></script>
 
 </head>
 
@@ -95,16 +100,16 @@
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>
-    <div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-        Your web browser must have JavaScript enabled in order for this
-        application to display correctly.</div>
+	<div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
+		Your web browser must have JavaScript enabled in order for this
+		application to display correctly.</div>
 </noscript>
 
 </body>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');

--- a/perun-web-gui/src/main/webapp/PerunWebKrbEinfra.html
+++ b/perun-web-gui/src/main/webapp/PerunWebKrbEinfra.html
@@ -3,87 +3,92 @@
 <html>
 <head>
 
-    <!-- Charset -->
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<!-- Charset -->
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-    <!-- Default GWT locale -->
-    <meta name="gwt:property" content="locale=en">
+	<!-- No cache -->
+	<meta http-equiv="pragma" content="no-cache" />
+	<meta http-equiv="cache-control" content="no-cache" />
+	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
 
-    <!-- FavIcons -->
-    <link rel="icon" href="img/perun.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
+	<!-- Default GWT locale -->
+	<meta name="gwt:property" content="locale=en">
 
-    <!-- Styles -->
-    <link type="text/css" rel="stylesheet" href="./PerunWeb.css">
+	<!-- FavIcons -->
+	<link rel="icon" href="img/perun.ico" type="image/x-icon">
+	<link rel="shortcut icon" href="img/perun.ico" type="image/x-icon">
 
-    <!-- Title -->
-    <title>Perun web gui</title>
+	<!-- Styles -->
+	<link type="text/css" rel="stylesheet" href="./PerunWeb.css">
 
-    <!--  jQuery -->
-    <script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
+	<!-- Title -->
+	<title>Perun web gui</title>
 
-    <!--  RPC definition -->
-    <script type="text/javascript" language="javascript" >
-        RPC_SERVER = "einfra";
-    </script>
+	<!--  jQuery -->
+	<script type="text/javascript" language="javascript" src="./js/jquery-1.7.1.min.js"></script>
 
-    <!--  Set language -->
-    <script type="text/javascript" language="javascript" >
+	<!--  RPC definition -->
+	<script type="text/javascript" language="javascript" >
+		RPC_SERVER = "einfra";
+	</script>
 
-        // get URL param function
-        function getURLParameter(name) {
-            return decodeURI(
-                    (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
-            );
-        }
+	<!--  Set language -->
+	<script type="text/javascript" language="javascript" >
 
-        var l_lang;
-        l_lang = getURLParameter('locale');
+		// get URL param function
+		function getURLParameter(name) {
+			return decodeURI(
+					(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,'default'])[1]
+			);
+		}
 
-        /*
-        // if no locale set in URL
-        if (l_lang == 'default') {
+		var l_lang;
+		l_lang = getURLParameter('locale');
 
-            if (typeof(Storage) != "undefined") {
+		/*
+		 // if no locale set in URL
+		 if (l_lang == 'default') {
 
-                l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
+		 if (typeof(Storage) != "undefined") {
 
-            }
+		 l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
 
-            // if not set, set from browser settings
-            if (l_lang == null) {
+		 }
 
-                if (navigator.userLanguage) // Explorer
-                    l_lang = navigator.userLanguage;
-                else if (navigator.language) // FF
-                    l_lang = navigator.language;
-                else
-                    l_lang = "en";
+		 // if not set, set from browser settings
+		 if (l_lang == null) {
 
-            }
+		 if (navigator.userLanguage) // Explorer
+		 l_lang = navigator.userLanguage;
+		 else if (navigator.language) // FF
+		 l_lang = navigator.language;
+		 else
+		 l_lang = "en";
 
-        }
-        */
+		 }
 
-        if (l_lang == 'default') {
-            l_lang = 'en';
-        }
-        $("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
+		 }
+		 */
 
-        // Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-        if (document.all && !document.querySelector) {
-	        // Is IE < 8
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
-        var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
-        if (isOperaBefore15) {
-	        alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
-        }
+		if (l_lang == 'default') {
+			l_lang = 'en';
+		}
+		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
-    </script>
+		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
+		if (document.all && !document.querySelector) {
+			// Is IE < 8
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		if (isOperaBefore15) {
+			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		}
 
-    <!-- Load GWT GUI -->
-    <script type="text/javascript" language="javascript" src="./PerunWeb/PerunWeb.nocache.js"></script>
+	</script>
+
+	<!-- Load GWT GUI -->
+	<script type="text/javascript" language="javascript" src="./PerunWeb/PerunWeb.nocache.js"></script>
 
 </head>
 
@@ -95,16 +100,16 @@
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>
-    <div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
-        Your web browser must have JavaScript enabled in order for this
-        application to display correctly.</div>
+	<div style="width: 22em; position: absolute; left: 50%; margin-left: -11em; color: red; background-color: white; border: 1px solid red; padding: 4px; font-family: sans-serif">
+		Your web browser must have JavaScript enabled in order for this
+		application to display correctly.</div>
 </noscript>
 
 </body>
 
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 	ga('create', 'UA-40001256-2', 'auto');


### PR DESCRIPTION
- Tell browsers to force reload web page when visiting page
  with expired session.

- Aborted requests (no connection or session expired) now
  inform user about situation and allows to reload the webpage,
  forcing user to log-in.

- When aborted request is authzResolver/getPerunPrincipal then
  force reload page (since fed session is probably expired).

- Source formatting in html pages.