### PR TITLE
Change logging in Attributes Row Mapper

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -329,13 +329,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				try {
 					method = attributeHolder.getClass().getMethod(methodName);
 				} catch(NoSuchMethodException ex) {
-					//try also "is"
-					log.debug("Bad core attribute definition for methodname " + methodName);
+					//if not "get", try "is"
+					String methodGet = methodName;
 					try {
 						methodName = "is" + Character.toUpperCase(attribute.getFriendlyName().charAt(0)) + attribute.getFriendlyName().substring(1);
 						method = attributeHolder.getClass().getMethod(methodName);
 					} catch (NoSuchMethodException e) {
-						throw new InternalErrorRuntimeException("Bad core attribute definition. " + attribute , e);
+						throw new InternalErrorRuntimeException("There is no method '" + methodGet + "' or '" + methodName + "'  for core attribute definition. " + attribute , e);
 					}
 				}
 				try {


### PR DESCRIPTION
 - logging for core attributes
 - when 'get' method for core attribute not exists, try also 'is' method
   and if this one not exists too then throw an exception with all info
 - do not log if 'get' method not exists, but 'is' method exists

Example:
 - there is method isServiceUser for attribute serviceUser so first try
   to find getServiceUser and then isServiceUser if the first one not
   exists