### PR TITLE
Notifications: methods now use only bl layer

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1036,7 +1036,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * @param role to get object for
 	 * @param perunBeanClass particular class ( Vo | Group | ... )
 	 * @return list of complementary objects
-	 * 
+	 *
 	 * @throws InternalErrorException
 	 */
 	public static List<PerunBean> getComplementaryObjectsForRole(PerunSession sess, Role role, Class perunBeanClass) throws InternalErrorException {
@@ -1355,16 +1355,6 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		if (perunEngineAdmins.contains(sess.getPerunPrincipal().getActor())) {
 			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.ENGINE);
 			log.trace("AuthzResolver.init: Perun Engine {} loaded", perunEngineAdmins);
-		}
-
-		List<String> perunNotifications = new ArrayList<String>(Arrays.asList(BeansUtils.getPropertyFromConfiguration("perun.notification.principals").split("[ \t]*,[ \t]*")));
-		if (perunNotifications.contains(sess.getPerunPrincipal().getActor())) {
-			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.NOTIFICATIONS);
-
-			//FIXME ted pridame i roli plneho admina
-			sess.getPerunPrincipal().getRoles().putAuthzRole(Role.PERUNADMIN);
-
-			log.trace("AuthzResolver.init: Perun Notifications {} loaded", perunNotifications);
 		}
 
 		List<String> perunRegistrars = new ArrayList<String>(Arrays.asList(BeansUtils.getPropertyFromConfiguration("perun.registrar.principals").split("[ \t]*,[ \t]*")));

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManagerImpl.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.notif.utils.NotifUtils;
 import cz.metacentrum.perun.notif.dao.PerunNotifPoolMessageDao;
 import cz.metacentrum.perun.notif.dto.PoolMessage;
 import cz.metacentrum.perun.notif.entities.PerunNotifAuditMessage;
@@ -56,7 +57,7 @@ public class PerunNotifPoolMessageManagerImpl implements PerunNotifPoolMessageMa
 	private void init() throws Exception {
 
 		perunNotifPoolMessageDao.setAllCreatedToNow();
-		this.session = perun.getPerunSession(new PerunPrincipal("perunNotifications", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
+		session = NotifUtils.getPerunSession(perun);
 	}
 
 	public void savePerunNotifPoolMessages(List<PerunNotifPoolMessage> poolMessages) throws InternalErrorException {

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifTemplateManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifTemplateManagerImpl.java
@@ -22,6 +22,7 @@ import cz.metacentrum.perun.notif.exceptions.NotifReceiverAlreadyExistsException
 import cz.metacentrum.perun.notif.exceptions.NotifTemplateMessageAlreadyExistsException;
 import cz.metacentrum.perun.notif.exceptions.TemplateMessageSyntaxErrorException;
 import cz.metacentrum.perun.notif.senders.PerunNotifSender;
+import cz.metacentrum.perun.notif.utils.NotifUtils;
 import freemarker.cache.MruCacheStorage;
 import freemarker.core.Environment;
 import freemarker.core.InvalidReferenceException;
@@ -113,7 +114,7 @@ public class PerunNotifTemplateManagerImpl implements PerunNotifTemplateManager 
 
 
 
-		this.session = perun.getPerunSession(new PerunPrincipal("perunNotifications", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
+		session = NotifUtils.getPerunSession(perun);
 	}
 
 	private Configuration createFreemarkerConfiguration(StringTemplateLoader stringTemplateLoader) {

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/SchedulingManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/SchedulingManagerImpl.java
@@ -126,7 +126,7 @@ public class SchedulingManagerImpl {
 	public void processPerunAuditMessages() throws Exception {
 		List<PerunNotifAuditMessage> perunNotifAuditMessages = new ArrayList<PerunNotifAuditMessage>();
 		try {
-			List<AuditMessage> messages = perun.getAuditMessagesManager().pollConsumerMessagesForParser(session, consumerName);
+			List<AuditMessage> messages = perun.getAuditMessagesManagerBl().pollConsumerMessagesForParser(session, consumerName);
 
 			for (AuditMessage message : messages) {
 				try {

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/SchedulingManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/SchedulingManagerImpl.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.AuditerConsumer;
 import cz.metacentrum.perun.notif.entities.PerunNotifAuditMessage;
 import cz.metacentrum.perun.notif.entities.PerunNotifPoolMessage;
+import cz.metacentrum.perun.notif.utils.NotifUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -63,7 +64,7 @@ public class SchedulingManagerImpl {
 
 	@PostConstruct
 	public void init() throws InternalErrorException {
-		this.session = perun.getPerunSession(new PerunPrincipal("perunNotifications", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
+		session = NotifUtils.getPerunSession(perun);
 	}
 
 	/**
@@ -126,7 +127,7 @@ public class SchedulingManagerImpl {
 	public void processPerunAuditMessages() throws Exception {
 		List<PerunNotifAuditMessage> perunNotifAuditMessages = new ArrayList<PerunNotifAuditMessage>();
 		try {
-			List<AuditMessage> messages = perun.getAuditMessagesManagerBl().pollConsumerMessagesForParser(session, consumerName);
+			List<AuditMessage> messages = perun.getAuditMessagesManagerBl().pollConsumerMessagesForParser(consumerName);
 
 			for (AuditMessage message : messages) {
 				try {

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailGroupSender.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailGroupSender.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.notif.entities.PerunNotifReceiver;
 import cz.metacentrum.perun.notif.entities.PerunNotifTemplate;
 import cz.metacentrum.perun.notif.enums.PerunNotifTypeOfReceiver;
 import cz.metacentrum.perun.notif.managers.PerunNotifEmailManager;
+import cz.metacentrum.perun.notif.utils.NotifUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +41,7 @@ public class PerunNotifEmailGroupSender implements PerunNotifSender {
 
 	@PostConstruct
 	public void init() throws Exception {
-		this.session = perun.getPerunSession(new PerunPrincipal("perunNotifications", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
+		session = NotifUtils.getPerunSession(perun);
 	}
 
 	@Override

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailGroupSender.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailGroupSender.java
@@ -80,7 +80,7 @@ public class PerunNotifEmailGroupSender implements PerunNotifSender {
 							PerunNotifEmailMessageToSendDto memberEmailDto = new PerunNotifEmailMessageToSendDto();
 							memberEmailDto.setMessage(messageDto.getMessageToSend());
 							memberEmailDto.setSubject(messageDto.getSubject());
-							memberEmailDto.setReceiver((String) perun.getAttributesManager().getAttribute(session, perun.getUsersManager().getUserByMember(session, member), "urn:perun:user:attribute-def:def:preferredMail").getValue());
+							memberEmailDto.setReceiver((String) perun.getAttributesManagerBl().getAttribute(session, perun.getUsersManager().getUserByMember(session, member), "urn:perun:user:attribute-def:def:preferredMail").getValue());
 							memberEmailDto.setSender(groupSender);
 
 							messagesToSend.add(memberEmailDto);

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailUserSender.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailUserSender.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.notif.dto.PoolMessage;
 import cz.metacentrum.perun.notif.entities.PerunNotifReceiver;
 import cz.metacentrum.perun.notif.enums.PerunNotifTypeOfReceiver;
 import cz.metacentrum.perun.notif.managers.PerunNotifEmailManager;
+import cz.metacentrum.perun.notif.utils.NotifUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,7 @@ public class PerunNotifEmailUserSender implements PerunNotifSender {
 
 	@PostConstruct
 	public void init() throws Exception {
-		this.session = perun.getPerunSession(new PerunPrincipal("perunNotifications", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
+		session = NotifUtils.getPerunSession(perun);
 	}
 
 	@Override

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailUserSender.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailUserSender.java
@@ -86,7 +86,7 @@ public class PerunNotifEmailUserSender implements PerunNotifSender {
 				if (id != null) {
 					try {
 						User user = perun.getUsersManagerBl().getUserById(session, id);
-						Attribute emailAttribute = perun.getAttributesManager().getAttribute(session, user, "urn:perun:user:attribute-def:def:preferredMail");
+						Attribute emailAttribute = perun.getAttributesManagerBl().getAttribute(session, user, "urn:perun:user:attribute-def:def:preferredMail");
 						if (emailAttribute != null && StringUtils.hasText(emailAttribute.toString())) {
 							emailDto.setReceiver((String) emailAttribute.getValue());
 						}

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifJabberSender.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifJabberSender.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.notif.dto.PerunNotifMessageDto;
 import cz.metacentrum.perun.notif.dto.PoolMessage;
 import cz.metacentrum.perun.notif.entities.PerunNotifReceiver;
 import cz.metacentrum.perun.notif.enums.PerunNotifTypeOfReceiver;
+import cz.metacentrum.perun.notif.utils.NotifUtils;
 import org.jivesoftware.smack.ConnectionConfiguration;
 import org.jivesoftware.smack.SASLAuthentication;
 import org.jivesoftware.smack.XMPPConnection;
@@ -45,7 +46,7 @@ public class PerunNotifJabberSender implements PerunNotifSender {
 
 	@PostConstruct
 	public void init() throws Exception {
-		this.session = perun.getPerunSession(new PerunPrincipal("perunNotifications", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
+		session = NotifUtils.getPerunSession(perun);
 		this.jabberServer = (String) propertiesBean.get("notif.jabber.jabberServer");
 		this.port = Integer.valueOf((String) propertiesBean.get("notif.jabber.port"));
 		this.serviceName = (String) propertiesBean.get("notif.jabber.serviceName");

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifJabberSender.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifJabberSender.java
@@ -101,7 +101,7 @@ public class PerunNotifJabberSender implements PerunNotifSender {
 					if (id != null) {
 						try {
 							User user = perun.getUsersManagerBl().getUserById(session, id);
-							Attribute emailAttribute = perun.getAttributesManager().getAttribute(session, user, "urn:perun:user:attribute-def:def:jabber");
+							Attribute emailAttribute = perun.getAttributesManagerBl().getAttribute(session, user, "urn:perun:user:attribute-def:def:jabber");
 							if (emailAttribute != null && StringUtils.hasText(emailAttribute.toString())) {
 								message.setTo((String) emailAttribute.getValue());
 							}

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/utils/NotifUtils.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/utils/NotifUtils.java
@@ -1,14 +1,19 @@
 package cz.metacentrum.perun.notif.utils;
 
 import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.notif.dao.jdbc.PerunNotifTemplateDaoImpl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 
-public class ParseUtils {
+public class NotifUtils {
+
+	public static PerunSession session = null;
 
 	public static Map<String, String> parseMap(String row) {
 
@@ -76,5 +81,12 @@ public class ParseUtils {
 		result.add(member);
 
 		return result;
+	}
+
+	public static PerunSession getPerunSession(PerunBl perun) throws InternalErrorException {
+		if (session == null) {
+			session = perun.getPerunSession(new PerunPrincipal("perunNotifications", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
+		}
+		return session;
 	}
 }


### PR DESCRIPTION
- all core methods use bl layer
- Role.NOTIFICATION no more has PERUNADMIN rights
- optimalization of perun session initialization