### PR TITLE
add property to disable dispatcher startup

### DIFF
--- a/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
@@ -110,7 +110,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 	</bean>
 	-->
 
-	<bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+	<bean id="scheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="triggers">
 			<list>
 				<!--<ref bean="maintenanceJobTrigger" />-->


### PR DESCRIPTION
Adds property dispatcher.enabled that, when set to false, disables dispatcher startup during (perun-rpc) initialization.