### PR TITLE
CORE, GUI: Allow admins to see associated/service users

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -83,8 +83,19 @@ public class UsersManagerEntry implements UsersManager {
 		Utils.checkPerunSession(sess);
 		getUsersManagerBl().checkUserExists(sess, user);
 		if(user.isServiceUser()) throw new NotServiceUserExpectedException(user);
+
 		if(!AuthzResolver.isAuthorized(sess, Role.SELF, user)) {
-			throw new PrivilegeException(sess, "getServiceUsersByUser");
+			List<Vo> vos = getUsersManagerBl().getVosWhereUserIsMember(sess, user);
+			boolean found = false;
+			for (Vo vo : vos) {
+				if (found = AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo)) break;
+				if (found = AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo)) break;
+				if (found = AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, vo)) break;
+			}
+			// if not self or vo/group admin of any of users VOs
+			if (!found) {
+				throw new PrivilegeException(sess, "getServiceUsersByUser");
+			}
 		}
 		return getUsersManagerBl().getServiceUsersByUser(sess, user);
 	}
@@ -94,7 +105,17 @@ public class UsersManagerEntry implements UsersManager {
 		getUsersManagerBl().checkUserExists(sess, serviceUser);
 		if(!serviceUser.isServiceUser()) throw new ServiceUserExpectedException(serviceUser);
 		if(!AuthzResolver.isAuthorized(sess, Role.SELF, serviceUser)) {
-			throw new PrivilegeException(sess, "getUsersByServiceUser");
+			List<Vo> vos = getUsersManagerBl().getVosWhereUserIsMember(sess, serviceUser);
+			boolean found = false;
+			for (Vo vo : vos) {
+				if (found = AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo)) break;
+				if (found = AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo)) break;
+				if (found = AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, vo)) break;
+			}
+			// if not self or vo/group admin of any of users VOs
+			if (!found) {
+				throw new PrivilegeException(sess, "getUsersByServiceUser");
+			}
 		}
 		return getUsersManagerBl().getUsersByServiceUser(sess, serviceUser);
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/GetServiceUsersByUser.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/GetServiceUsersByUser.java
@@ -46,6 +46,7 @@ public class GetServiceUsersByUser implements JsonCallback, JsonCallbackTable<Us
 	private FieldUpdater<User, String> tableFieldUpdater;
 	// loader image
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
+	private boolean checkable = true;
 
 	/**
 	 * Creates a new request
@@ -104,7 +105,9 @@ public class GetServiceUsersByUser implements JsonCallback, JsonCallbackTable<Us
 		loaderImage.setEmptyResultMessage("You have no service identities assigned.");
 
 		// columns
-		table.addCheckBoxColumn();
+		if (checkable) {
+			table.addCheckBoxColumn();
+		}
 		table.addIdColumn("User ID", tableFieldUpdater);
 
 		// NAME COLUMN
@@ -233,7 +236,7 @@ public class GetServiceUsersByUser implements JsonCallback, JsonCallbackTable<Us
 	}
 
 	public void setCheckable(boolean checkable) {
-		// TODO Auto-generated method stub
+		this.checkable = checkable;
 	}
 
 	public void setList(ArrayList<User> list) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/GetUsersByServiceUser.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/GetUsersByServiceUser.java
@@ -46,6 +46,7 @@ public class GetUsersByServiceUser implements JsonCallback, JsonCallbackTable<Us
 	private FieldUpdater<User, String> tableFieldUpdater;
 	// loader image
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
+	private boolean checkable = true;
 
 	/**
 	 * Creates a new request
@@ -104,7 +105,9 @@ public class GetUsersByServiceUser implements JsonCallback, JsonCallbackTable<Us
 		loaderImage.setEmptyResultMessage("Service identity has no owners (users) assigned.");
 
 		// columns
-		table.addCheckBoxColumn();
+		if (checkable) {
+			table.addCheckBoxColumn();
+		}
 		table.addIdColumn("User ID", tableFieldUpdater);
 
 		// NAME COLUMN
@@ -233,7 +236,7 @@ public class GetUsersByServiceUser implements JsonCallback, JsonCallbackTable<Us
 	}
 
 	public void setCheckable(boolean checkable) {
-		// TODO Auto-generated method stub
+		this.checkable = checkable;
 	}
 
 	public void setList(ArrayList<User> list) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberDetailTabItem.java
@@ -161,6 +161,11 @@ public class MemberDetailTabItem implements TabItem, TabItemWithUrl {
 		tabPanel.add(new MemberResourcesTabItem(member, groupId), "Resources");
 		tabPanel.add(new MemberApplicationsTabItem(member, groupId), "Applications");
 		tabPanel.add(new MemberSettingsTabItem(member, groupId), "Settings");
+		if (member.getUser().isServiceUser()) {
+			tabPanel.add(new MemberServiceUsersTabItem(member, groupId), "Associated users");
+		} else {
+			tabPanel.add(new MemberServiceUsersTabItem(member, groupId), "Service identities");
+		}
 
 		// Resize must be called after page fully displays
 		Scheduler.get().scheduleDeferred(new Command() {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberServiceUsersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberServiceUsersTabItem.java
@@ -1,0 +1,165 @@
+package cz.metacentrum.perun.webgui.tabs.memberstabs;
+
+import com.google.gwt.cell.client.FieldUpdater;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.client.ui.*;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.resources.*;
+import cz.metacentrum.perun.webgui.json.usersManager.GetServiceUsersByUser;
+import cz.metacentrum.perun.webgui.json.usersManager.GetUsersByServiceUser;
+import cz.metacentrum.perun.webgui.model.RichMember;
+import cz.metacentrum.perun.webgui.model.User;
+import cz.metacentrum.perun.webgui.tabs.TabItem;
+import cz.metacentrum.perun.webgui.tabs.userstabs.UserDetailTabItem;
+
+/**
+ * Displays members service identities or associated users for service members.
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class MemberServiceUsersTabItem implements TabItem {
+
+	private RichMember member;
+	private int memberId;
+	private PerunWebSession session = PerunWebSession.getInstance();
+	private SimplePanel contentWidget = new SimplePanel();
+	private Label titleWidget = new Label("Loading member details");
+	private int groupId = 0;
+
+	/**
+	 * Constructor
+	 *
+	 * @param member RichMember object, typically from table
+	 */
+	public MemberServiceUsersTabItem(RichMember member, int groupId){
+		this.member = member;
+		this.memberId = member.getId();
+		this.groupId = groupId;
+	}
+
+	public boolean isPrepared(){
+		return !(member == null);
+	}
+
+	public Widget draw() {
+
+		if (member.getUser().isServiceUser()) {
+			this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(member.getUser().getFullNameWithTitles().trim()) + ": associated users");
+		} else {
+			this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(member.getUser().getFullNameWithTitles().trim()) + ": service identities");
+		}
+
+		VerticalPanel vp = new VerticalPanel();
+		vp.setSize("100%", "100%");
+
+		if (member.getUser().isServiceUser()) {
+
+			// request
+			final GetUsersByServiceUser request = new GetUsersByServiceUser(member.getUserId());
+			request.setCheckable(false);
+
+			// table
+			CellTable<User> table;
+			if (session.isPerunAdmin()) {
+				table = request.getTable(new FieldUpdater<User, String>() {
+					public void update(int i, User user, String s) {
+						session.getTabManager().addTab(new UserDetailTabItem(user));
+					}
+				});
+			} else {
+				table = request.getTable();
+			}
+
+			table.addStyleName("perun-table");
+			table.setWidth("100%");
+			ScrollPanel sp = new ScrollPanel(table);
+			sp.addStyleName("perun-tableScrollPanel");
+
+			vp.add(sp);
+
+		} else {
+
+			final GetServiceUsersByUser request = new GetServiceUsersByUser(member.getUserId());
+			request.setCheckable(false);
+
+			// table
+			CellTable<User> table;
+			if (session.isPerunAdmin()) {
+				table = request.getTable(new FieldUpdater<User, String>() {
+					public void update(int i, User user, String s) {
+						session.getTabManager().addTab(new UserDetailTabItem(user));
+					}
+				});
+			} else {
+				table = request.getTable();
+			}
+
+			table.addStyleName("perun-table");
+			table.setWidth("100%");
+			ScrollPanel sp = new ScrollPanel(table);
+			sp.addStyleName("perun-tableScrollPanel");
+
+			vp.add(sp);
+
+		}
+
+		contentWidget.setWidget(vp);
+
+		return getWidget();
+
+	}
+
+	public Widget getWidget() {
+		return this.contentWidget;
+	}
+
+	public Widget getTitle() {
+		return this.titleWidget;
+	}
+
+	public ImageResource getIcon() {
+		return SmallIcons.INSTANCE.userGreenIcon();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 17389;
+		int result = 1;
+		result = prime * result + memberId;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MemberServiceUsersTabItem other = (MemberServiceUsersTabItem) obj;
+		if (memberId != other.memberId)
+			return false;
+		return true;
+	}
+
+	public boolean multipleInstancesEnabled() {
+		return false;
+	}
+
+	public void open() {
+
+	}
+
+	public boolean isAuthorized() {
+
+		if (session.isVoAdmin(member.getVoId()) || session.isVoObserver(member.getVoId()) || session.isGroupAdmin(groupId)) {
+			return true;
+		} else {
+			return false;
+		}
+
+	}
+
+}


### PR DESCRIPTION
- Allow to list service users or service user owners for
  vo/group admin and vo observer when selected user is member
  at least one of their vo/group.
- Show service identities or associated users tab on members detail.
- Perun admin can click through to user detail, others just see list
  of names.