### PR TITLE
DISPATCHER: Fixed Dispatcher disabling on startup

### DIFF
--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -239,15 +239,6 @@
 			<version>1.5.2</version>
 		</dependency>
 
-
-		<!--
-				<dependency>
-					<groupId>opensymphony</groupId>
-					<artifactId>quartz</artifactId>
-					<version>1.6.3</version>
-				</dependency>
-			-->
-
 		<!-- HORNET-Q  -->
 
 		<dependency>

--- a/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
@@ -71,46 +71,8 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 	</bean>
 
 	<!-- BEGIN Quartz tasks -->
-	<bean id="maintenanceJob" class="org.springframework.scheduling.quartz.JobDetailBean">
-		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.MaintenanceJob" />
-		<property name="jobDataAsMap">
-			<map>
-				<entry key="dispatcherManager" value-ref="dispatcherManager" />
-			</map>
-		</property>
-	</bean>
 
-	<!-- 
-	<bean id="checkInJob" class="org.springframework.scheduling.quartz.JobDetailBean">
-		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.CheckInJob" />
-		<property name="jobDataAsMap">
-			<map>
-				<entry key="dispatcherManager" value-ref="dispatcherManager" />
-			</map>
-		</property>
-	</bean>
-	 -->
-
-	<bean id="maintenanceJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
-		<property name="jobDetail" ref="maintenanceJob" />
-		<!-- Every 20 minutes -->
-		<!--<property name="cronExpression" value="0 0/20 * * * ?" /> -->
-		<!-- Every 5 seconds -->
-		<property name="cronExpression" value="0/5 * * * * ?" />
-	</bean>
-
-	<!--  
-	<bean id="checkInJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
-		<property name="jobDetail" ref="checkInJob" /> -->
-	<!-- Every 3 minutes -->
-	<!-- <property name="cronExpression" value="0 0/5 * * * ?" />-->
-	<!-- Every 10 seconds -->
-	<!-- property name="cronExpression" value="0/10 * * * * ?" /-->
-	<!--
-	</bean>
-	-->
-
-	<bean id="scheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+	<bean id="perunScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="triggers">
 			<list>
 				<!--<ref bean="maintenanceJobTrigger" />-->
@@ -120,6 +82,23 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 				<ref bean="cleanTaskResultsJobTrigger" />
 			</list>
 		</property>
+	</bean>
+
+	<bean id="maintenanceJob" class="org.springframework.scheduling.quartz.JobDetailBean">
+		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.MaintenanceJob" />
+		<property name="jobDataAsMap">
+			<map>
+				<entry key="dispatcherManager" value-ref="dispatcherManager" />
+			</map>
+		</property>
+	</bean>
+
+	<bean id="maintenanceJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+		<property name="jobDetail" ref="maintenanceJob" />
+		<!-- Every 20 minutes -->
+		<!--<property name="cronExpression" value="0 0/20 * * * ?" /> -->
+		<!-- Every 5 seconds -->
+		<property name="cronExpression" value="0/5 * * * * ?" />
 	</bean>
 
 	<bean id="propagationMaintainerJob" class="org.springframework.scheduling.quartz.JobDetailBean">
@@ -149,7 +128,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<property name="jobDetail" ref="processPoolJob" />
 		<property name="cronExpression" value="0 0/2 * * * ?" />
 	</bean>
-	
+
 	<bean id="cleanTaskResultsJob" class="org.springframework.scheduling.quartz.JobDetailBean">
 		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.CleanTaskResultsJob" />
 		<property name="jobDataAsMap">
@@ -158,11 +137,34 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 			</map>
 		</property>
 	</bean>
-	
+
 	<bean id="cleanTaskResultsJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
 		<property name="jobDetail" ref="cleanTaskResultsJob" />
 		<property name="cronExpression" value="0 0 1 * * ?" />
 	</bean>
-	<!-- END Quartz tasks -->	
-           
+
+	<!--
+	<bean id="checkInJob" class="org.springframework.scheduling.quartz.JobDetailBean">
+		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.CheckInJob" />
+		<property name="jobDataAsMap">
+			<map>
+				<entry key="dispatcherManager" value-ref="dispatcherManager" />
+			</map>
+		</property>
+	</bean>
+    -->
+
+	<!--
+	<bean id="checkInJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+		<property name="jobDetail" ref="checkInJob" /> -->
+	<!-- Every 3 minutes -->
+	<!-- <property name="cronExpression" value="0 0/5 * * * ?" />-->
+	<!-- Every 10 seconds -->
+	<!-- property name="cronExpression" value="0/10 * * * * ?" /-->
+	<!--
+	</bean>
+	-->
+
+	<!-- END Quartz tasks -->
+
 </beans>

--- a/perun-notification/src/main/resources/perun-notification-applicationcontext-scheduling.xml
+++ b/perun-notification/src/main/resources/perun-notification-applicationcontext-scheduling.xml
@@ -4,7 +4,7 @@
 <beans>
     <!-- Quartz timer -->
 
-    <bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+    <bean id="notifScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
         <property name="quartzProperties">
             <props>
                 <prop key="org.quartz.threadPool.threadPriority">1</prop>


### PR DESCRIPTION
- When we autowire FactorySchedulerBean we must use also
  qualifier, because in perun-rpc same bean from perun-notifications
  module is already present (loaded in config before).

- We must also pauseAll() triggers for Scheduler, when dispatcher is
  disabled, otherwise jobs are still triggered.

- Added names (qualifiers) to both FactorySchedulerBeans in appcontext.
- Reordered entries in appcontext for dispatcher to makes more sense.
- Removed old and commented dependency (org.symphony) from pom.xml.
- Source format.