### PR TITLE
REGISTRAR: Allow simple consolidation of user identities

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -4,7 +4,6 @@ import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 /**
@@ -159,16 +158,6 @@ public abstract class Deserializer {
 	 */
 	public HttpServletRequest getServletRequest() throws UnsupportedOperationException {
 		throw new UnsupportedOperationException("getServletRequest()");
-	}
-
-	/**
-	 * Return HttpServletResponse related to concrete call this deserializer is used to process.
-	 *
-	 * @return HttpServletResponse related to concrete call
-	 * @throws UnsupportedOperationException if this deserializer does not implement this method
-	 */
-	public HttpServletResponse getServletResponse() throws UnsupportedOperationException {
-		throw new UnsupportedOperationException("getServletResponse()");
 	}
 
 }

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/Deserializer.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 /**
@@ -157,7 +158,17 @@ public abstract class Deserializer {
 	 * @throws UnsupportedOperationException if this deserializer does not implement this method
 	 */
 	public HttpServletRequest getServletRequest() throws UnsupportedOperationException {
-		throw new UnsupportedOperationException("readList(String name, Class<T> valueType)");
+		throw new UnsupportedOperationException("getServletRequest()");
+	}
+
+	/**
+	 * Return HttpServletResponse related to concrete call this deserializer is used to process.
+	 *
+	 * @return HttpServletResponse related to concrete call
+	 * @throws UnsupportedOperationException if this deserializer does not implement this method
+	 */
+	public HttpServletResponse getServletResponse() throws UnsupportedOperationException {
+		throw new UnsupportedOperationException("getServletResponse()");
 	}
 
 }

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -31,6 +31,7 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import java.io.InputStream;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Deserializer for JSON / JSONP data format.
@@ -120,18 +121,21 @@ public class JsonDeserializer extends Deserializer {
 
 	private JsonNode root;
 	private HttpServletRequest req;
+	private HttpServletResponse resp;
 
 	/**
 	 * Create deserializer for JSON/JSONP data format.
 	 *
 	 * @param request HttpServletRequest this deserializer is about to process
+	 * @param response HttpServletResponse this deserializer is about to process
 	 *
 	 * @throws IOException if an IO error occurs
 	 * @throws RpcException if content of {@code in} is wrongly formatted
 	 */
-	public JsonDeserializer(HttpServletRequest request) throws IOException, RpcException {
+	public JsonDeserializer(HttpServletRequest request, HttpServletResponse response) throws IOException, RpcException {
 
 		this.req = request;
+		this.resp = response;
 
 		try {
 			root = mapper.readTree(req.getInputStream());
@@ -391,6 +395,11 @@ public class JsonDeserializer extends Deserializer {
 	@Override
 	public HttpServletRequest getServletRequest() {
 		return this.req;
+	}
+
+	@Override
+	public HttpServletResponse getServletResponse() {
+		return this.resp;
 	}
 
 }

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -26,12 +26,10 @@ import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.MembershipType;
-import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import java.io.InputStream;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * Deserializer for JSON / JSONP data format.
@@ -121,21 +119,18 @@ public class JsonDeserializer extends Deserializer {
 
 	private JsonNode root;
 	private HttpServletRequest req;
-	private HttpServletResponse resp;
 
 	/**
 	 * Create deserializer for JSON/JSONP data format.
 	 *
 	 * @param request HttpServletRequest this deserializer is about to process
-	 * @param response HttpServletResponse this deserializer is about to process
 	 *
 	 * @throws IOException if an IO error occurs
 	 * @throws RpcException if content of {@code in} is wrongly formatted
 	 */
-	public JsonDeserializer(HttpServletRequest request, HttpServletResponse response) throws IOException, RpcException {
+	public JsonDeserializer(HttpServletRequest request) throws IOException, RpcException {
 
 		this.req = request;
-		this.resp = response;
 
 		try {
 			root = mapper.readTree(req.getInputStream());
@@ -395,11 +390,6 @@ public class JsonDeserializer extends Deserializer {
 	@Override
 	public HttpServletRequest getServletRequest() {
 		return this.req;
-	}
-
-	@Override
-	public HttpServletResponse getServletResponse() {
-		return this.resp;
 	}
 
 }

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
@@ -5,6 +5,7 @@ import java.util.Enumeration;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 
@@ -20,14 +21,17 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 public class UrlDeserializer extends Deserializer {
 
 	private HttpServletRequest req;
+	private HttpServletResponse resp;
 
 	/**
 	 * Create deserializer for URL data format.
 	 *
-	 * @param req HttpServletRequest this deserializer is about to process
+	 * @param request HttpServletRequest this deserializer is about to process
+	 * @param response HttpServletResponse this deserializer is about to process
 	 */
-	public UrlDeserializer(HttpServletRequest req) {
-		this.req = req;
+	public UrlDeserializer(HttpServletRequest request, HttpServletResponse response) {
+		this.req = request;
+		this.resp = response;
 	}
 
 	/**
@@ -118,6 +122,11 @@ public class UrlDeserializer extends Deserializer {
 	@Override
 	public HttpServletRequest getServletRequest() {
 		return this.req;
+	}
+
+	@Override
+	public HttpServletResponse getServletResponse() {
+		return this.resp;
 	}
 
 }

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
@@ -5,7 +5,6 @@ import java.util.Enumeration;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 
@@ -21,17 +20,14 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 public class UrlDeserializer extends Deserializer {
 
 	private HttpServletRequest req;
-	private HttpServletResponse resp;
 
 	/**
 	 * Create deserializer for URL data format.
 	 *
 	 * @param request HttpServletRequest this deserializer is about to process
-	 * @param response HttpServletResponse this deserializer is about to process
 	 */
-	public UrlDeserializer(HttpServletRequest request, HttpServletResponse response) {
+	public UrlDeserializer(HttpServletRequest request) {
 		this.req = request;
-		this.resp = response;
 	}
 
 	/**
@@ -122,11 +118,6 @@ public class UrlDeserializer extends Deserializer {
 	@Override
 	public HttpServletRequest getServletRequest() {
 		return this.req;
-	}
-
-	@Override
-	public HttpServletResponse getServletResponse() {
-		return this.resp;
 	}
 
 }

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerGWT.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerGWT.java
@@ -37,8 +37,8 @@ public final class JsonSerializerGWT implements Serializer {
 	}
 
 	@JsonIgnoreProperties({"commonName", "displayName"})
-		private interface UserMixIn {
-		}
+	private interface UserMixIn {
+	}
 
 	@JsonIgnoreProperties({"userExtSources"})
 	private interface CandidateMixIn {

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpclib/api/Deserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpclib/api/Deserializer.java
@@ -35,7 +35,6 @@ public abstract class Deserializer {
 	/**
 	 * Reads value as {@code String}.
 	 *
-	 * @param name name of the value to read
 	 * @return the value as {@code String}
 	 *
 	 * @throws RpcException If the specified value cannot be parsed as {@code String} or if it is not supplied
@@ -56,7 +55,6 @@ public abstract class Deserializer {
 	/**
 	 * Reads value as {@code int}.
 	 *
-	 * @param name name of the value to read
 	 * @return the value as {@code int}
 	 *
 	 * @throws RpcException if the specified value cannot be parsed as {@code int} or if it is not supplied
@@ -88,7 +86,6 @@ public abstract class Deserializer {
 	/**
 	 * Reads value as {@code valueType}.
 	 *
-	 * @param name name of the value to read
 	 * @param valueType type of the value to read
 	 * @return the value as {@code valueType}
 	 *

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
@@ -35,13 +35,13 @@ import cz.metacentrum.perun.taskslib.model.ExecService;
 public class JsonDeserializer extends Deserializer {
 
 	@JsonIgnoreProperties({"name", "baseFriendlyName", "friendlyNameParameter", "entity", "beanName"})
-		private interface AttributeMixIn {}
+	private interface AttributeMixIn {}
 
 	@JsonIgnoreProperties({"name", "value", "baseFriendlyName", "friendlyNameParameter", "entity", "beanName"})
-		private interface AttributeDefinitionMixIn {}
+	private interface AttributeDefinitionMixIn {}
 
 	@JsonIgnoreProperties({"commonName", "displayName", "beanName"})
-		private interface UserMixIn {}
+	private interface UserMixIn {}
 
 	@JsonIgnoreProperties({"fullMessage"})
 	private interface AuditMessageMixIn {}
@@ -59,10 +59,10 @@ public class JsonDeserializer extends Deserializer {
 	private interface PerunExceptionMixIn {}
 
 	@JsonIgnoreProperties({"hostNameFromDestination", "beanName"})
-		private interface DestinationMixIn {}
+	private interface DestinationMixIn {}
 
 	@JsonIgnoreProperties({"shortName", "beanName"})
-		private interface GroupMixIn {}
+	private interface GroupMixIn {}
 
 	private interface MemberMixIn {
 		@JsonIgnore

--- a/perun-beans/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonSerializer.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonSerializer.java
@@ -32,8 +32,8 @@ public final class JsonSerializer implements Serializer {
 	private interface AttributeDefinitionMixIn {}
 
 	@JsonIgnoreProperties({"commonName", "displayName"})
-		private interface UserMixIn {
-		}
+	private interface UserMixIn {
+	}
 
 	private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/perun-registrar-lib/pom.xml
+++ b/perun-registrar-lib/pom.xml
@@ -158,6 +158,11 @@
 		</dependency>
 
 		<!-- OTHERS -->
+		<dependency>
+			<groupId>net.jodah</groupId>
+			<artifactId>expiringmap</artifactId>
+			<version>0.4.3</version>
+		</dependency>
 
 	</dependencies>
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/ConsolidatorManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/ConsolidatorManager.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.registrar;
 
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.registrar.model.Application;
@@ -60,6 +61,29 @@ public interface ConsolidatorManager {
 	 * @return List of found similar Identities
 	 * @throws PerunException
 	 */
-	public List<Identity> checkForSimilarUsers(PerunSession sess, Vo vo, Group group, Application.AppType type) throws PerunException;
+	List<Identity> checkForSimilarUsers(PerunSession sess, Vo vo, Group group, Application.AppType type) throws PerunException;
+
+	/**
+	 * Return unique token with information about current authz. It can be used to join this identity
+	 * with another, when user calls opposite method with different credentials.
+	 *
+	 * @param sess PerunSession for authz (identity)
+	 * @return Unique token for identity consolidation
+	 * @throws PerunException When error occurs.
+	 * @see #consolidateIdentityUsingToken(PerunSession, String)
+	 */
+	String getConsolidatorToken(PerunSession sess) throws PerunException;
+
+	/**
+	 * Join current user identity with another referenced by the passed token.
+	 * To get token for your authz see opposite method.
+	 *
+	 * @param sess PerunSession for authz (identity)
+	 * @param token Reference to identity to join with.
+	 * @return List of User identities (UserExtSources) known to Perun.
+	 * @throws PerunException When error occurs.
+	 * @see #getConsolidatorToken(PerunSession)
+	 */
+	List<UserExtSource> consolidateIdentityUsingToken(PerunSession sess, String token) throws PerunException;
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/IdentitiesAlreadyJoinedException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/IdentitiesAlreadyJoinedException.java
@@ -1,0 +1,22 @@
+package cz.metacentrum.perun.registrar.exceptions;
+
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+
+/**
+ * Exception thrown when user tries to join two identities, which already belongs to him.
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class IdentitiesAlreadyJoinedException extends PerunException {
+
+	private static final long serialVersionUID = 1L;
+
+	public IdentitiesAlreadyJoinedException(String message) {
+		super(message);
+	}
+
+	public IdentitiesAlreadyJoinedException(String message, Throwable ex) {
+		super(message, ex);
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/IdentityAlreadyInUseException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/IdentityAlreadyInUseException.java
@@ -1,0 +1,53 @@
+package cz.metacentrum.perun.registrar.exceptions;
+
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+
+/**
+ * Exception thrown when user tries to join two identities, but both are assigned to different users.
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class IdentityAlreadyInUseException extends PerunException {
+
+	private static final long serialVersionUID = 1L;
+
+	private User user;
+	private User secondUser;
+
+	public IdentityAlreadyInUseException(String message) {
+		super(message);
+	}
+
+	public IdentityAlreadyInUseException(String message, User user, User secondUser) {
+		super(message);
+		this.user = user;
+		this.secondUser = secondUser;
+	}
+
+	public IdentityAlreadyInUseException(String message, Throwable ex) {
+		super(message, ex);
+	}
+
+	public IdentityAlreadyInUseException(String message, Throwable ex, User user, User secondUser) {
+		super(message, ex);
+		this.user = user;
+		this.secondUser = secondUser;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public void setUser(User user) {
+		this.user = user;
+	}
+
+	public User getSecondUser() {
+		return secondUser;
+	}
+
+	public void setSecondUser(User secondUser) {
+		this.secondUser = secondUser;
+	}
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/IdentityIsSameException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/IdentityIsSameException.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.registrar.exceptions;
+
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+
+/**
+ * Exception thrown when user tries to join one identity with itself.
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class IdentityIsSameException extends PerunException {
+
+	private static final long serialVersionUID = 1L;
+
+	private String login = "";
+	private String source = "";
+	private String sourceType = "";
+
+	public IdentityIsSameException(String message) {
+		super(message);
+	}
+
+	public IdentityIsSameException(String message, Throwable ex) {
+		super(message, ex);
+	}
+
+	public String getLogin() {
+		return login;
+	}
+
+	public void setLogin(String login) {
+		this.login = login;
+	}
+
+	public String getSource() {
+		return source;
+	}
+
+	public void setSource(String source) {
+		this.source = source;
+	}
+
+	public String getSourceType() {
+		return sourceType;
+	}
+
+	public void setSourceType(String sourceType) {
+		this.sourceType = sourceType;
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/IdentityUnknownException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/IdentityUnknownException.java
@@ -1,0 +1,77 @@
+package cz.metacentrum.perun.registrar.exceptions;
+
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+
+/**
+ * Exception thrown when user tries to join two identities, by neither is known to Perun
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class IdentityUnknownException extends PerunException {
+
+	private static final long serialVersionUID = 1L;
+
+	private String login = "";
+	private String source = "";
+	private String sourceType = "";
+	private String login2 = "";
+	private String source2 = "";
+	private String sourceType2 = "";
+
+	public IdentityUnknownException(String message) {
+		super(message);
+	}
+
+	public IdentityUnknownException(String message, Throwable ex) {
+		super(message, ex);
+	}
+
+	public String getLogin() {
+		return login;
+	}
+
+	public void setLogin(String login) {
+		this.login = login;
+	}
+
+	public String getSource() {
+		return source;
+	}
+
+	public void setSource(String source) {
+		this.source = source;
+	}
+
+	public String getSourceType() {
+		return sourceType;
+	}
+
+	public void setSourceType(String sourceType) {
+		this.sourceType = sourceType;
+	}
+
+	public String getLogin2() {
+		return login2;
+	}
+
+	public void setLogin2(String login2) {
+		this.login2 = login2;
+	}
+
+	public String getSource2() {
+		return source2;
+	}
+
+	public void setSource2(String source2) {
+		this.source2 = source2;
+	}
+
+	public String getSourceType2() {
+		return sourceType2;
+	}
+
+	public void setSourceType2(String sourceType2) {
+		this.sourceType2 = sourceType2;
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/InvalidTokenException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/InvalidTokenException.java
@@ -1,0 +1,22 @@
+package cz.metacentrum.perun.registrar.exceptions;
+
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+
+/**
+ * Exception thrown when user uses invalid token (expired or totally wrong)
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class InvalidTokenException extends PerunException {
+
+	private static final long serialVersionUID = 1L;
+
+	public InvalidTokenException(String message) {
+		super(message);
+	}
+
+	public InvalidTokenException(String message, Throwable ex) {
+		super(message, ex);
+	}
+
+}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -346,9 +346,9 @@ public class Api extends HttpServlet {
 			// Initialize deserializer
 			Deserializer des;
 			if (isGet) {
-				des = new UrlDeserializer(req);
+				des = new UrlDeserializer(req, resp);
 			} else {
-				des = selectDeserializer(fcm[0], req);
+				des = selectDeserializer(fcm[0], req, resp);
 			}
 
 			// We have new request, so do the whole auth/authz stuff
@@ -538,14 +538,14 @@ public class Api extends HttpServlet {
 		}
 	}
 
-	private Deserializer selectDeserializer(String format, HttpServletRequest req) throws IOException, RpcException {
+	private Deserializer selectDeserializer(String format, HttpServletRequest req, HttpServletResponse resp) throws IOException, RpcException {
 		switch (Formats.match(format)) {
 			case json:
 			case jsonp:
-				return new JsonDeserializer(req);
+				return new JsonDeserializer(req, resp);
 			case urlinjsonout:
 			case voot:
-				return new UrlDeserializer(req);
+				return new UrlDeserializer(req, resp);
 			default:
 				throw new RpcException(RpcException.Type.UNKNOWN_DESERIALIZER_FORMAT, format);
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -31,7 +31,6 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
 import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
-import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import cz.metacentrum.perun.rpc.deserializer.JsonDeserializer;
 import cz.metacentrum.perun.rpc.deserializer.UrlDeserializer;
@@ -346,9 +345,9 @@ public class Api extends HttpServlet {
 			// Initialize deserializer
 			Deserializer des;
 			if (isGet) {
-				des = new UrlDeserializer(req, resp);
+				des = new UrlDeserializer(req);
 			} else {
-				des = selectDeserializer(fcm[0], req, resp);
+				des = selectDeserializer(fcm[0], req);
 			}
 
 			// We have new request, so do the whole auth/authz stuff
@@ -538,14 +537,14 @@ public class Api extends HttpServlet {
 		}
 	}
 
-	private Deserializer selectDeserializer(String format, HttpServletRequest req, HttpServletResponse resp) throws IOException, RpcException {
+	private Deserializer selectDeserializer(String format, HttpServletRequest req) throws IOException, RpcException {
 		switch (Formats.match(format)) {
 			case json:
 			case jsonp:
-				return new JsonDeserializer(req, resp);
+				return new JsonDeserializer(req);
 			case urlinjsonout:
 			case voot:
-				return new UrlDeserializer(req, resp);
+				return new UrlDeserializer(req);
 			default:
 				throw new RpcException(RpcException.Type.UNKNOWN_DESERIALIZER_FORMAT, format);
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -2,11 +2,7 @@ package cz.metacentrum.perun.rpc.methods;
 
 import java.util.*;
 
-import cz.metacentrum.perun.core.api.Attribute;
-import cz.metacentrum.perun.core.api.BeansUtils;
-import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.RichUser;
-import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.registrar.model.*;
@@ -17,6 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import net.tanesha.recaptcha.ReCaptchaImpl;
 import net.tanesha.recaptcha.ReCaptchaResponse;
+
+import javax.servlet.http.Cookie;
 
 public enum RegistrarManagerMethod implements ManagerMethod {
 
@@ -1134,6 +1132,28 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 			} else {
 				return ac.getRegistrarManager().getConsolidatorManager().checkForSimilarUsers(ac.getSession());
 			}
+
+		}
+
+	},
+
+	getConsolidatorToken {
+
+		@Override
+		public String call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getRegistrarManager().getConsolidatorManager().getConsolidatorToken(ac.getSession());
+
+		}
+
+	},
+
+	consolidateIdentityUsingToken {
+
+		@Override
+		public List<UserExtSource> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getRegistrarManager().getConsolidatorManager().consolidateIdentityUsingToken(ac.getSession(), parms.readString("token"));
 
 		}
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.registrar.model.*;
 import cz.metacentrum.perun.registrar.model.Application.AppType;
 import cz.metacentrum.perun.rpc.ApiCaller;
@@ -13,8 +12,6 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import net.tanesha.recaptcha.ReCaptchaImpl;
 import net.tanesha.recaptcha.ReCaptchaResponse;
-
-import javax.servlet.http.Cookie;
 
 public enum RegistrarManagerMethod implements ManagerMethod {
 


### PR DESCRIPTION
- Registrar can create unique token from current authz and store it
  in a time expiring cache.
  Token can be then used to join original and current identity.
  Error cases throws exception, when joined, session is refreshed and
  list of known identities is returned.

- Added dependency on small library with expiring cache implementation.
- Added methods to RPC.
- Code cleanup, fixed typos, indentation.