### PR TITLE
REGISTRAR: Fixed case when approving group application

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1129,6 +1129,10 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			throw new RegistrarException("To approve application user must already be member of VO.", ex);
 		} catch (UserNotExistsException ex) {
 			throw new RegistrarException("To approve application user must already be member of VO.", ex);
+		} catch (UserExtSourceNotExistsException ex) {
+			throw new RegistrarException("To approve application user must already be member of VO.", ex);
+		} catch (ExtSourceNotExistsException ex) {
+			throw new RegistrarException("To approve application user must already be member of VO.", ex);
 		}
 
 		Member member = perun.getMembersManager().getMemberByUser(registrarSession, app.getVo(), app.getUser());


### PR DESCRIPTION
- When admin tries to approve group application, but user is not yet
  member of VO or user object doesn't exists at all, let him know, that
  he needs to approve VO application first.