### PR TITLE
CORE: Implemented fillAttribute() for login-namespace

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
@@ -2,26 +2,23 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import java.lang.String;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.exceptions.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
-import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
-import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
 
 /**
- * Class for checking login's uniqueness in the namespace
+ * Class for checking logins uniqueness in the namespace
  *
  * @author Michal Prochazka  &lt;michalp@ics.muni.cz&gt;
  * @author Slavek Licehammer &lt;glory@ics.muni.cz&gt;
@@ -41,7 +38,7 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 		if (userLogin == null) throw new WrongAttributeValueException(attribute, user, "Value can't be null");
 		if(!userLogin.matches("^[a-zA-Z0-9][-A-z0-9_.@/]*$")) throw new WrongAttributeValueException(attribute, user, "Wrong format. ^[A-z0-9][-A-z0-9_.@/]*$ expected.");
 
-		//Check if user login is permitted or unpermitted
+		//Check if user login is permitted or not permitted
 		sess.getPerunBl().getModulesUtilsBl().checkUnpermittedUserLogins(attribute);
 
 		// Get all users who have set attribute urn:perun:member:attribute-def:def:login-namespace:[login-namespace], with the value.
@@ -59,12 +56,96 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 		}
 	}
 
-	@Override
 	/**
-	 * Not implemented yet
+	 * Filling implemented only for namespaces configured in /etc/perun/perun.properties
+	 * as property: "perun.loginNamespace.generated"
 	 */
+	@Override
 	public Attribute fillAttribute(PerunSessionImpl perunSession, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
-		return new Attribute(attribute);
+
+		Attribute filledAttribute = new Attribute(attribute);
+
+		// load namespaces to generate login for
+		List<String> namespaces = new ArrayList<String>();
+		try {
+			String nmspc = BeansUtils.getPropertyFromConfiguration("perun.loginNamespace.generated");
+			namespaces = Arrays.asList(nmspc.split(","));
+			for (String namespace : namespaces) {
+				namespace = namespace.trim();
+			}
+		} catch (InternalErrorException ex) {
+			// without value
+			return filledAttribute;
+		}
+
+		if (namespaces.contains(attribute.getFriendlyNameParameter())) {
+			// with value
+			return generateLoginValue(perunSession, user, filledAttribute);
+		} else {
+			// without value
+			return filledAttribute;
+		}
+
+	}
+
+	/**
+	 *  Fill login-namespace attribute with generated value.
+	 * 	Format is: "firstName.lastName[number]" where number is opt and start with 1 when same login is already present.
+	 * 	All accented chars are unaccented and all non (a-z,A-Z) chars are removed from name and value is lowercased.
+	 *
+	 * @param sess PerunSession
+	 * @param user User to fill attribute for
+	 * @param attribute Attribute to fill value with
+	 * @return Filled attribute
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	private Attribute generateLoginValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+
+		String firstName = user.getFirstName();
+		String lastName = user.getLastName();
+
+		// get only first part of first name and remove spec. chars
+		if (firstName != null && !firstName.isEmpty()) {
+			firstName = firstName.split(" ")[0];
+			firstName = firstName.toLowerCase();
+			firstName = java.text.Normalizer.normalize(firstName, java.text.Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+","");
+			firstName = firstName.replaceAll("[^a-zA-Z]+", "");
+		}
+
+		// get only last part of last name and remove spec. chars
+		if (lastName != null && !lastName.isEmpty()) {
+			List<String> names = Arrays.asList(lastName.split(" "));
+			lastName = names.get(names.size() - 1);
+			lastName = lastName.toLowerCase();
+			lastName = java.text.Normalizer.normalize(lastName, java.text.Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+			lastName = lastName.replaceAll("[^a-zA-Z]+", "");
+		}
+
+		// unable to fill login for users without name or with partial name
+		if (firstName == null || firstName.isEmpty() || lastName == null || lastName.isEmpty()) {
+			return attribute;
+		}
+
+		// fill value
+		int iterator = 0;
+		while (iterator >= 0) {
+			if (iterator > 0) {
+				attribute.setValue(firstName+ "." + lastName + iterator);
+			} else {
+				attribute.setValue(firstName + "." + lastName);
+			}
+			try {
+				checkAttributeValue(sess, user, attribute);
+				return attribute;
+			} catch (WrongAttributeValueException ex) {
+				// continue in a WHILE cycle
+				iterator++;
+			}
+		}
+
+		return attribute;
+
 	}
 
 	/*public AttributeDefinition getAttributeDefinition() {
@@ -75,4 +156,5 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 		attr.setDescription("Login namespace.");
 		return attr;
 	}*/
+
 }


### PR DESCRIPTION
- Allow to generate login for configured namespaces.
  Generated namespaces are noted in perun.properties config as
  a property "perun.loginNamespace.generated".

  Before deploy, this property must be added to perun.properties

- Generate login from name in format "firstName.lastName[number]" where
  - firstName is first of all names
  - lastName is last of all names
  - number is optional and present only when same login is already taken and
  counter starts with 1.
  - names are unaccented, stripped of all characters outside A-Z,a-z and lowercased.