### PR TITLE
make some scheduling parameters configurable by properties

### DIFF
--- a/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher-applicationcontext.xml
@@ -66,8 +66,16 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 				<prop key="perun.principal.name">perunDispatcher</prop>
 				<prop key="perun.principal.extSourceName">INTERNAL</prop>
 				<prop key="perun.principal.extSourceType">cz.metacentrum.perun.core.impl.ExtSourceInternal</prop>
+				<prop key="dispatcher.cron.propagation">45 0/4 * * * ?</prop>
+				<prop key="dispatcher.cron.processpool">0 0/2 * * * ?</prop>
+				<prop key="dispatcher.cron.cleantaskresults">0 0 1 * * ?</prop>
 			</props>
 		</property>
+	</bean>
+
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+		<property name="properties" ref="dispatcherPropertiesBean" />
 	</bean>
 
 	<!-- BEGIN Quartz tasks -->
@@ -112,7 +120,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 
 	<bean id="propagationMaintainerJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
 		<property name="jobDetail" ref="propagationMaintainerJob" />
-		<property name="cronExpression" value="45 0/4 * * * ?" />
+		<property name="cronExpression" value="${dispatcher.cron.propagation}" />
 	</bean>
 
 	<bean id="processPoolJob" class="org.springframework.scheduling.quartz.JobDetailBean">
@@ -126,7 +134,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 
 	<bean id="processPoolJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
 		<property name="jobDetail" ref="processPoolJob" />
-		<property name="cronExpression" value="0 0/2 * * * ?" />
+		<property name="cronExpression" value="${dispatcher.cron.processpool}" />
 	</bean>
 
 	<bean id="cleanTaskResultsJob" class="org.springframework.scheduling.quartz.JobDetailBean">
@@ -140,7 +148,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 
 	<bean id="cleanTaskResultsJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
 		<property name="jobDetail" ref="cleanTaskResultsJob" />
-		<property name="cronExpression" value="0 0 1 * * ?" />
+		<property name="cronExpression" value="${dispatcher.cron.cleantaskresults}" />
 	</bean>
 
 	<!--

--- a/perun-dispatcher/src/test/resources/schema.sql
+++ b/perun-dispatcher/src/test/resources/schema.sql
@@ -216,6 +216,8 @@ create table attr_names (
 create table facilities (
     id integer not null,
     name varchar(128) not null,
+    dsc varchar(1024),
+    type varchar(32),
     created_at date  default now not null,
     created_by varchar(1024) default user not null,
     modified_at date default now not null,

--- a/perun-dispatcher/src/test/resources/schema.sql
+++ b/perun-dispatcher/src/test/resources/schema.sql
@@ -217,7 +217,6 @@ create table facilities (
     id integer not null,
     name varchar(128) not null,
     dsc varchar(1024),
-    type varchar(32),
     created_at date  default now not null,
     created_by varchar(1024) default user not null,
     modified_at date default now not null,

--- a/perun-engine/src/main/resources/devel/perun-engine-applicationcontext.xml
+++ b/perun-engine/src/main/resources/devel/perun-engine-applicationcontext.xml
@@ -37,9 +37,9 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
     <task:scheduled-tasks scheduler="scheduler">
         <!-- 30 seconds: 0/30 * * * * ? -->
         <!--  3 minutes: 0 0/3 * * * ?  -->
-        <task:scheduled ref="propagationMaintainerJob" method="doTheJob" cron="45 0/4 * * * ?"/>
-        <task:scheduled ref="processPoolJob" method="doTheJob" cron="0 0/2 * * * ?"/>
-        <task:scheduled ref="taskExecutorEngineJob" method="doTheJob" cron="0 0/4 * * * ?"/>
+        <task:scheduled ref="propagationMaintainerJob" method="doTheJob" cron="${engine.cron.propagation}" />
+        <task:scheduled ref="processPoolJob" method="doTheJob" cron="${engine.cron.processpool}" />
+        <task:scheduled ref="taskExecutorEngineJob" method="doTheJob" cron="${engine.cron.taskexecutor}" />
         <!-- <task:scheduled ref="checkInJob" method="doTheJob" cron="0 0/4 * * * ?"/>  -->
     </task:scheduled-tasks>
 
@@ -87,13 +87,13 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 
     <bean id="taskExecutorGenWorkers" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
           <property name="corePoolSize" value="10" />
-          <property name="maxPoolSize" value="10" />
+          <property name="maxPoolSize" value="${engine.thread.gentasks.max}" />
           <property name="queueCapacity" value="2000" />
     </bean>
 
     <bean id="taskExecutorSendWorkers" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
           <property name="corePoolSize" value="10" />
-          <property name="maxPoolSize" value="1000" />
+          <property name="maxPoolSize" value="${engine.thread.sendtasks.max}" />
           <property name="queueCapacity" value="200" />
     </bean>
 
@@ -106,9 +106,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
                 <value>file:${perun.conf.custom}perun-engine.properties</value>
             </list>
         </property>
-        <property name="ignoreResourceNotFound">
-            <value>true</value>
-        </property>
+        <property name="ignoreResourceNotFound" value="true"/>
         <property name="properties">
         	<props>
         		<prop key="engine.unique.id">0</prop>
@@ -117,7 +115,18 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		    	<prop key="perun.principal.name">perunTests</prop>
     	    	<prop key="perun.principal.extSourceName">cz.metacentrum.perun.core.impl.ExtSourceInternal</prop>
     	    	<prop key="perun.principal.extSourceType">cz.metacentrum.perun.core.impl.ExtSourceInternal</prop>
+    	    	<prop key="engine.cron.propagation">45 0/4 * * * ?</prop>
+    	    	<prop key="engine.cron.processpool">0 0/2 * * * ?</prop>
+    	    	<prop key="engine.cron.taskexecutor">0 0/4 * * * ?</prop>
+    	    	<prop key="engine.thread.gentasks.max">10</prop>
+    	    	<prop key="engine.thread.sendtasks.max">1000</prop>
         	</props>
         </property>
     </bean>
+    
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+		<property name="properties" ref="propertiesBean" />
+	</bean>
+    
 </beans>

--- a/perun-engine/src/main/resources/devel/schema.sql
+++ b/perun-engine/src/main/resources/devel/schema.sql
@@ -73,7 +73,6 @@ create table facilities (
     id integer not null,
     name varchar(128) not null,
     dsc varchar(1024),
-    type varchar(32) not null,
     created_at date  default now not null,
     created_by varchar(1024) default user not null,
     modified_at date default now not null,

--- a/perun-engine/src/main/resources/production/perun-engine-applicationcontext.xml
+++ b/perun-engine/src/main/resources/production/perun-engine-applicationcontext.xml
@@ -38,9 +38,9 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
     <task:scheduled-tasks scheduler="scheduler">
         <!-- 30 seconds: 0/30 * * * * ? -->
         <!--  3 minutes: 0 0/3 * * * ?  -->
-        <task:scheduled ref="propagationMaintainerJob" method="doTheJob" cron="45 0/4 * * * ?"/>
-        <task:scheduled ref="processPoolJob" method="doTheJob" cron="0 0/2 * * * ?"/>
-        <task:scheduled ref="taskExecutorEngineJob" method="doTheJob" cron="0 0/2 * * * ?"/>
+        <task:scheduled ref="propagationMaintainerJob" method="doTheJob" cron="${engine.cron.propagation}" />
+        <task:scheduled ref="processPoolJob" method="doTheJob" cron=${engine.cron.processpool}" />
+        <task:scheduled ref="taskExecutorEngineJob" method="doTheJob" cron="${engine.cron.taskexecutor}" />
         <!--<task:scheduled ref="checkInJob" method="doTheJob" cron="0 0/4 * * * ?"/>-->
     </task:scheduled-tasks>
 
@@ -88,13 +88,13 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 
     <bean id="taskExecutorGenWorkers" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
           <property name="corePoolSize" value="5" />
-          <property name="maxPoolSize" value="5" />
+          <property name="maxPoolSize" value="${engine.thread.gentasks.max}" />
           <property name="queueCapacity" value="2000" />
     </bean>
 
     <bean id="taskExecutorSendWorkers" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
           <property name="corePoolSize" value="200" />
-          <property name="maxPoolSize" value="1000" />
+          <property name="maxPoolSize" value="${engine.thread.sendtasks.max}" />
           <property name="queueCapacity" value="200000" />
     </bean>
 
@@ -107,9 +107,21 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
                 <value>file:${perun.conf.custom}perun-engine.properties</value>
             </list>
         </property>
-        <property name="ignoreResourceNotFound">
-            <value>true</value>
+        <property name="ignoreResourceNotFound" value="true"/>
+        <property name="properties">
+        	<props>
+    	    	<prop key="engine.cron.propagation">45 0/4 * * * ?</prop>
+    	    	<prop key="engine.cron.processpool">0 0/2 * * * ?</prop>
+    	    	<prop key="engine.cron.taskexecutor">0 0/2 * * * ?</prop>
+    	    	<prop key="engine.thread.gentasks.max">5</prop>
+    	    	<prop key="engine.thread.sendtasks.max">1000</prop>
+        	</props>
         </property>
     </bean>
 
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+		<property name="properties" ref="propertiesBean" />
+	</bean>
+	
 </beans>

--- a/perun-engine/src/main/resources/production/schema.sql
+++ b/perun-engine/src/main/resources/production/schema.sql
@@ -73,7 +73,6 @@ create table facilities (
     id integer not null,
     name varchar(128) not null,
     dsc varchar(1024),
-    type varchar(32) not null,
     created_at date  default now not null,
     created_by varchar(1024) default user not null,
     modified_at date default now not null,


### PR DESCRIPTION
Make some scheduling parameters (cron expressions, thread pool size) configurable by properties instead of hardcoded. Proper defaults are set in spring context, no change to configuration files is required.