### PR TITLE
REGISTRAR, GUI: Make native language optional

### DIFF
--- a/perun-beans/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItem.java
@@ -3,7 +3,6 @@ package cz.metacentrum.perun.registrar.model;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import java.util.*;
 
-//import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.registrar.model.Application.AppType;
 
 /**
@@ -12,7 +11,6 @@ import cz.metacentrum.perun.registrar.model.Application.AppType;
  * @author Martin Kuba makub@ics.muni.cz
  */
 public class ApplicationFormItem {
-	private static Object BeanUtils;
 
 	//data fields
 	private int id;
@@ -36,19 +34,23 @@ public class ApplicationFormItem {
 	private boolean forDelete = false;
 
 	public static final Locale EN = new Locale("en");
-	public static final Locale CS = new Locale(getNativeLanguage());
+	public static final Locale CS = getNativeLanguage();
 
 	/**
 	 * Return code of native language defined in config file.
-	 * Return "cs" for Czech language if no native language set.
+	 * Return NULL if no native language set.
 	 *
 	 * @return String representation of native language
 	 */
-	public static String getNativeLanguage() {
+	public static Locale getNativeLanguage() {
 		try {
-			return BeansUtils.getPropertyFromConfiguration("perun.native.language").split(",")[0];
+			String loc = BeansUtils.getPropertyFromConfiguration("perun.native.language").split(",")[0];
+			if (loc != null && loc.trim().isEmpty()) {
+				return null;
+			}
+			return new Locale(loc);
 		} catch (Exception ex) {
-			return "cs";
+			return null;
 		}
 	}
 
@@ -69,7 +71,6 @@ public class ApplicationFormItem {
 	                           String perunDestinationAttribute, String regex,
 	                           List<AppType> applicationTypes, Integer ordnum, boolean forDelete,
 	                           Map<Locale, ItemTexts> i18n) {
-		super();
 		this.id = id;
 		this.shortname = shortname;
 		this.required = required;
@@ -81,7 +82,6 @@ public class ApplicationFormItem {
 		this.ordnum = ordnum;
 		this.forDelete = forDelete;
 		this.i18n = i18n;
-
 	}
 
 	public String getPerunDestinationAttribute() {
@@ -272,10 +272,12 @@ public class ApplicationFormItem {
 		}
 	}
 
-	private Map<Locale,ItemTexts> i18n = new HashMap<Locale, ItemTexts>(3); {
+	private Map<Locale,ItemTexts> i18n = new HashMap<Locale, ItemTexts>(); {
 		// create with locale property set
-		i18n.put(CS,new ItemTexts(CS));
 		i18n.put(EN,new ItemTexts(EN));
+		if (CS != null) {
+			i18n.put(CS,new ItemTexts(CS));
+		}
 	}
 
 	public ApplicationFormItem() {
@@ -331,7 +333,6 @@ public class ApplicationFormItem {
 
 	public Map<Locale, ItemTexts> getI18n() {
 		return i18n;
-
 	}
 
 	public ItemTexts getTexts(Locale locale) {

--- a/perun-beans/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationMail.java
+++ b/perun-beans/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationMail.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.registrar.model.Application.AppType;
 
 /**
@@ -16,7 +17,25 @@ public class ApplicationMail {
 
 	// locale const
 	public static final Locale EN = new Locale("en");
-	public static final Locale CS = new Locale("cs");
+	public static final Locale CS = getNativeLanguage();
+
+	/**
+	 * Return code of native language defined in config file.
+	 * Return NULL if no native language set.
+	 *
+	 * @return String representation of native language
+	 */
+	public static Locale getNativeLanguage() {
+		try {
+			String loc = BeansUtils.getPropertyFromConfiguration("perun.native.language").split(",")[0];
+			if (loc != null && loc.trim().isEmpty()) {
+				return null;
+			}
+			return new Locale(loc);
+		} catch (Exception ex) {
+			return null;
+		}
+	}
 
 	/**
 	 * Available mail types
@@ -69,8 +88,10 @@ public class ApplicationMail {
 	private MailType mailType;     // to what "action" is notification related
 	private boolean send = true; // if sending email is enabled or disabled (enabled by default)
 	// localized mail text (EN and CS by default)
-	private Map<Locale, MailText> message = new HashMap<Locale, MailText>(3); {
-		message.put(CS,new MailText(CS));
+	private Map<Locale, MailText> message = new HashMap<Locale, MailText>(); {
+		if (CS != null) {
+			message.put(CS, new MailText(CS));
+		}
 		message.put(EN,new MailText(EN));
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/MailManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/MailManager.java
@@ -153,7 +153,7 @@ public interface MailManager {
 	 * @param group Group to link form to
 	 * @param name Name of invited User
 	 * @param email Email to send invitation to.
-	 * @param language "cs" or "en" as language used in notification (if not specified, VO settings is used, if not set, "en" is used).
+	 * @param language Language used in notification (if not specified, VO settings is used, if not set, "en" is used).
 	 *
 	 * @throws PerunException
 	 */

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -800,7 +800,6 @@ public class MailManagerImpl implements MailManager {
 		}
 
 		if (email == null || email.isEmpty()) throw new RegistrarException("You must provide non-empty email of person you are inviting.");
-		if (language != null && !language.equals("en") && !language.equals("cs")) throw new RegistrarException("You must specify language like: \"en\" or \"cs\".");
 
 		// get form
 		ApplicationForm form;
@@ -818,7 +817,6 @@ public class MailManagerImpl implements MailManager {
 			throw new RegistrarException("Sending of invitations is disabled.");
 		}
 
-		// if not null, valid input is checked at start of method
 		if (language == null) {
 
 			language = "en";
@@ -1142,7 +1140,7 @@ public class MailManagerImpl implements MailManager {
 					language = BeansUtils.attributeValueToString(a);
 				}
 			} catch (Exception ex) {
-				log.error("[MAIL MANAGER] Exception thrown when getting preferred language for User={}: {}", app.getUser(), ex);
+				log.error("[MAIL MANAGER] Exception thrown when getting preferred language for {}: {}", app.getUser(), ex);
 			}
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
@@ -1061,7 +1061,12 @@ public class UiElements {
 		// en = english strings
 		// cs = czech strings
 
-		// english is fallback in all cases
+		// translation not supported
+		if (Utils.getNativeLanguage().isEmpty()) {
+			languageButton.setVisible(false);
+			languageButton.setEnabled(false);
+			return languageButton;
+		}
 
 		languageButton.setVisible(true); // display for perun admin only in WebGui.class
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
@@ -155,7 +155,7 @@ public class RegistrarFormItemGenerator {
 		this.strValue = strValue.trim();
 		this.prefilledValue = strValue.trim();  // store original value
 		this.item = item;
-		if (locale.equalsIgnoreCase("en") || locale.equalsIgnoreCase(Utils.getNativeLanguage().get(0))) {
+		if ((!Utils.getNativeLanguage().isEmpty() && locale.equalsIgnoreCase(Utils.getNativeLanguage().get(0))) || locale.equalsIgnoreCase("en")) {
 			// set locale if correct
 			this.locale = locale;
 		}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
@@ -106,6 +106,13 @@ public class ApplicationFormPage extends ApplicationPage {
 
 		languageButton = new PushButton(new Image(SmallIcons.INSTANCE.locateIcon()));
 
+		// translation not supported
+		if (Utils.getNativeLanguage().isEmpty()) {
+			languageButton.setEnabled(false);
+			languageButton.setVisible(false);
+			return;
+		}
+
 		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0))) {
 			languageButton.setTitle(WidgetTranslation.INSTANCE.changeLanguageToCzech(Utils.getNativeLanguage().get(2)));
 		} else {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.webgui.client.resources;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.URL;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
@@ -149,10 +149,10 @@ public class GetApplicationDataById implements JsonCallback{
 		ft.setWidth("100%");
 		ft.setCellPadding(10);
 		FlexCellFormatter fcf = ft.getFlexCellFormatter();
-		String locale;
-		if (LocaleInfo.getCurrentLocale().getLocaleName().equals("default") || LocaleInfo.getCurrentLocale().getLocaleName().equals("en")) {
-			locale = "en";
-		} else {
+		String locale = "en";
+		if (!Utils.getNativeLanguage().isEmpty() &&
+				!LocaleInfo.getCurrentLocale().getLocaleName().equals("default") &&
+				!LocaleInfo.getCurrentLocale().getLocaleName().equals("en")) {
 			locale = Utils.getNativeLanguage().get(0);
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
@@ -233,9 +233,9 @@ public class GetFormItems implements JsonCallback {
 
 		String locale = "en";
 
-		if (LocaleInfo.getCurrentLocale().getLocaleName().equals("default") || LocaleInfo.getCurrentLocale().getLocaleName().equals("en")) {
-			locale = "en";
-		} else {
+		if (!Utils.getNativeLanguage().isEmpty() &&
+				!LocaleInfo.getCurrentLocale().getLocaleName().equals("default") &&
+				!LocaleInfo.getCurrentLocale().getLocaleName().equals("en")) {
 			locale = Utils.getNativeLanguage().get(0);
 		}
 
@@ -543,11 +543,11 @@ public class GetFormItems implements JsonCallback {
 
 		FlexTable ft = new FlexTable();
 		FlexCellFormatter fcf = ft.getFlexCellFormatter();
-		String locale;
+		String locale = "en";
 
-		if (LocaleInfo.getCurrentLocale().getLocaleName().equals("default")) {
-			locale = "en";
-		} else {
+		if (!Utils.getNativeLanguage().isEmpty() &&
+				!LocaleInfo.getCurrentLocale().getLocaleName().equals("default") &&
+				!LocaleInfo.getCurrentLocale().getLocaleName().equals("en")) {
 			locale = Utils.getNativeLanguage().get(0);
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
@@ -290,10 +290,10 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 		FlexCellFormatter fcf = ft.getFlexCellFormatter();
 		String locale;
 
-		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0))) {
-			locale = "en";
-		} else {
+		if (!Utils.getNativeLanguage().isEmpty() && LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0))) {
 			locale = Utils.getNativeLanguage().get(0);
+		} else {
+			locale = "en";
 		}
 
 		int i = 0;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/SetSendingEnabled.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/SetSendingEnabled.java
@@ -109,12 +109,14 @@ public class SetSendingEnabled {
 			JSONObject mailTexts = new JSONObject();
 
 			// update texts
-			String locales[] = {Utils.getNativeLanguage().get(0), "en"};
-			for(String locale : locales){
+			MailText mt = appMail.getMessage("en");
+			mailTexts.put("en", new JSONObject(mt));
 
-				MailText mt = appMail.getMessage(locale);
-				mailTexts.put(locale, new JSONObject(mt));
+			if (!Utils.getNativeLanguage().isEmpty()) {
+				MailText mt2 = appMail.getMessage(Utils.getNativeLanguage().get(0));
+				mailTexts.put(Utils.getNativeLanguage().get(0), new JSONObject(mt2));
 			}
+
 			mail.put("message", mailTexts);
 
 			// sending other values just for sure

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateApplicationMail.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateApplicationMail.java
@@ -104,12 +104,14 @@ public class UpdateApplicationMail {
 		JSONObject mailTexts = new JSONObject();
 
 		// update texts
-		String locales[] = {Utils.getNativeLanguage().get(0), "en"};
-		for(String locale : locales){
+		MailText mt = appMail.getMessage("en");
+		mailTexts.put("en", new JSONObject(mt));
 
-			MailText mt = appMail.getMessage(locale);
-			mailTexts.put(locale, new JSONObject(mt));
+		if (!Utils.getNativeLanguage().isEmpty()) {
+			MailText mt2 = appMail.getMessage(Utils.getNativeLanguage().get(0));
+			mailTexts.put(Utils.getNativeLanguage().get(0), new JSONObject(mt2));
 		}
+
 		mail.put("message", mailTexts);
 
 		// sending other values just for sure

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItems.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItems.java
@@ -135,7 +135,9 @@ public class UpdateFormItems {
 			// recreate i18n
 			JSONObject i18n = new JSONObject();
 			i18n.put("en", new JSONObject(formItems.get(i).getItemTexts("en")));
-			i18n.put(Utils.getNativeLanguage().get(0), new JSONObject(formItems.get(i).getItemTexts(Utils.getNativeLanguage().get(0))));
+			if (!Utils.getNativeLanguage().isEmpty()) {
+				i18n.put(Utils.getNativeLanguage().get(0), new JSONObject(formItems.get(i).getItemTexts(Utils.getNativeLanguage().get(0))));
+			}
 			newItem.put("i18n", i18n);
 
 			data.set(i, newItem);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
@@ -393,7 +393,9 @@ public class CreateMailTabItem implements TabItem {
 
 		// languages
 		ArrayList<String> languages = new ArrayList<String>();
-		languages.add(Utils.getNativeLanguage().get(0));
+		if (!Utils.getNativeLanguage().isEmpty()) {
+			languages.add(Utils.getNativeLanguage().get(0));
+		}
 		languages.add("en");
 
 		// vertical panel

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
@@ -556,7 +556,9 @@ public class EditFormItemTabItem implements TabItem {
 
 		// languages
 		ArrayList<String> languages = item.getLocales();
-		if (!languages.contains(Utils.getNativeLanguage().get(0))) languages.add(Utils.getNativeLanguage().get(0));
+		if (!Utils.getNativeLanguage().isEmpty()) {
+			if (!languages.contains(Utils.getNativeLanguage().get(0))) languages.add(Utils.getNativeLanguage().get(0));
+		}
 		if (!languages.contains("en")) languages.add("en");
 
 		// vertical panel

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.webgui.tabs.registrartabs;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -336,8 +337,11 @@ public class EditMailTabItem implements TabItem, TabItemWithUrl {
 
 		// languages
 		ArrayList<String> languages = appMail.getLocales();
-		if (!languages.contains(Utils.getNativeLanguage().get(0))) languages.add(Utils.getNativeLanguage().get(0));
+		if (!Utils.getNativeLanguage().isEmpty() && !languages.contains(Utils.getNativeLanguage().get(0))) {
+			languages.add(Utils.getNativeLanguage().get(0));
+		}
 		if (!languages.contains("en")) languages.add("en");
+
 
 		// vertical panel
 		VerticalPanel vp = new VerticalPanel();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/PreviewFormTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/PreviewFormTabItem.java
@@ -79,7 +79,7 @@ public class PreviewFormTabItem implements TabItem, TabItemWithUrl {
 		final ScrollPanel sp = new ScrollPanel();
 
 		final CustomButton switchType = new CustomButton(ButtonTranslation.INSTANCE.switchToExtensionButton(), ButtonTranslation.INSTANCE.switchBetweenInitialAndExtension(), SmallIcons.INSTANCE.applicationFormIcon());
-		switchType.addClickHandler(new ClickHandler(){
+		switchType.addClickHandler(new ClickHandler() {
 			public void onClick(ClickEvent event) {
 				// switch type
 				if (appType.equalsIgnoreCase("EXTENSION")) {
@@ -95,22 +95,24 @@ public class PreviewFormTabItem implements TabItem, TabItemWithUrl {
 		});
 		menu.addWidget(switchType);
 
-		final CustomButton switchLocale = new CustomButton(ButtonTranslation.INSTANCE.switchToCzechButton(Utils.getNativeLanguage().get(1)), ButtonTranslation.INSTANCE.switchBetweenCzechAndEnglish(), SmallIcons.INSTANCE.locateIcon());
-		menu.addWidget(switchLocale);
-		switchLocale.addClickHandler(new ClickHandler(){
-			public void onClick(ClickEvent event) {
-				// switch type
-				if (locale.equalsIgnoreCase("en")) {
-					locale = Utils.getNativeLanguage().get(0);
-					switchLocale.setText(ButtonTranslation.INSTANCE.switchToEnglishButton());
-				} else {
-					locale = "en";
-					switchLocale.setText(ButtonTranslation.INSTANCE.switchToCzechButton(Utils.getNativeLanguage().get(1)));
+		if (!Utils.getNativeLanguage().isEmpty()) {
+			final CustomButton switchLocale = new CustomButton(ButtonTranslation.INSTANCE.switchToCzechButton(Utils.getNativeLanguage().get(1)), ButtonTranslation.INSTANCE.switchBetweenCzechAndEnglish(), SmallIcons.INSTANCE.locateIcon());
+			menu.addWidget(switchLocale);
+			switchLocale.addClickHandler(new ClickHandler() {
+				public void onClick(ClickEvent event) {
+					// switch type
+					if (locale.equalsIgnoreCase("en")) {
+						locale = Utils.getNativeLanguage().get(0);
+						switchLocale.setText(ButtonTranslation.INSTANCE.switchToEnglishButton());
+					} else {
+						locale = "en";
+						switchLocale.setText(ButtonTranslation.INSTANCE.switchToCzechButton(Utils.getNativeLanguage().get(1)));
+					}
+					// prepare new
+					prepareApplicationForm(sp);
 				}
-				// prepare new
-				prepareApplicationForm(sp);
-			}
-		});
+			});
+		}
 
 		vp.add(menu);
 		vp.setCellHeight(menu, "30px");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/InviteUserTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/InviteUserTabItem.java
@@ -92,9 +92,11 @@ public class InviteUserTabItem implements TabItem {
 		final ListBox languages = new ListBox();
 		languages.setWidth("200px");
 		//languages.addItem("Czech", "cs");
-		languages.addItem(Utils.getNativeLanguage().get(2), Utils.getNativeLanguage().get(0));
 		languages.addItem("English", "en");
 		languages.setSelectedIndex(1);
+		if (!Utils.getNativeLanguage().isEmpty()) {
+			languages.addItem(Utils.getNativeLanguage().get(2), Utils.getNativeLanguage().get(0));
+		}
 
 		final ExtendedTextBox name = new ExtendedTextBox();
 		final ExtendedTextBox email = new ExtendedTextBox();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPersonalTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPersonalTabItem.java
@@ -120,7 +120,9 @@ public class SelfPersonalTabItem implements TabItem {
 		final ListBox preferredLanguage = new ListBox();
 
 		preferredLanguage.addItem("Not selected", "");
-		preferredLanguage.addItem(Utils.getNativeLanguage().get(2), Utils.getNativeLanguage().get(0));
+		if (!Utils.getNativeLanguage().isEmpty()) {
+			preferredLanguage.addItem(Utils.getNativeLanguage().get(2), Utils.getNativeLanguage().get(0));
+		}
 		preferredLanguage.addItem("English", "en");
 
 		final ListBox timezone = new ListBox();
@@ -283,7 +285,7 @@ public class SelfPersonalTabItem implements TabItem {
 						// don't skip this null attribute
 						preferredUnixGroupNameWidget.setAttribute((Attribute)JsonUtils.clone(a).cast());
 					} else if (a.getFriendlyName().equalsIgnoreCase("preferredLanguage")) {
-						if (a.getValue().equals(Utils.getNativeLanguage().get(0))) {
+						if (!Utils.getNativeLanguage().isEmpty() && a.getValue().equals(Utils.getNativeLanguage().get(0))) {
 							preferredLanguage.setSelectedIndex(1);
 						} else if (a.getValue().equals("en")) {
 							preferredLanguage.setSelectedIndex(2);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/NotUserOfPerunWidget.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/NotUserOfPerunWidget.java
@@ -23,7 +23,7 @@ public class NotUserOfPerunWidget extends Composite {
 
 		String text = "";
 
-		if (!LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0))) {
+		if (Utils.getNativeLanguage().isEmpty() || (!Utils.getNativeLanguage().isEmpty() && !LocaleInfo.getCurrentLocale().getLocaleName().equals(Utils.getNativeLanguage().get(0)))) {
 			// english for all
 			text = "<h3>You are not user of Perun or you don't have registered identity you used to log in.</h3><h3>For joining your identities please go to:</h3>";
 


### PR DESCRIPTION
- We can omit native language in registration component
  (mails, forms) and GUI if no native language is set in
  perun-web-gui.properties and perun.properties.

  English version is offered instead.