### PR TITLE
Able to set lastProcessedId at start of LDAPc

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuditMessagesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuditMessagesManager.java
@@ -129,4 +129,15 @@ public interface AuditMessagesManager {
 	 * @throws PrivilegeException
 	 */
 	int getLastMessageId(PerunSession perunSession) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Set last processed ID of message in consumer with consumerName.
+	 *
+	 * @param perunSession 
+	 * @param consumerName name of consumer
+	 * @param lastProcessedId id of last processed message in consumer
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	void setLastProcessedId(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AuditMessagesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AuditMessagesManagerBl.java
@@ -106,4 +106,13 @@ public interface AuditMessagesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	int getLastMessageId() throws InternalErrorException;
+
+	/**
+	 * Set last processed ID of message in consumer with consumerName.
+	 *
+	 * @param consumerName name of consumer
+	 * @param lastProcessedId id of last processed message in consumer
+	 * @throws InternalErrorException
+	 */
+	void setLastProcessedId(String consumerName, int lastProcessedId) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuditMessagesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuditMessagesManagerBlImpl.java
@@ -86,4 +86,9 @@ public class AuditMessagesManagerBlImpl implements AuditMessagesManagerBl {
 
 		return perunBl.getAuditer().getLastMessageId();
 	}
+
+	public void setLastProcessedId(String consumerName, int lastProcessedId) throws InternalErrorException {
+
+		perunBl.getAuditer().setLastProcessedId(consumerName, lastProcessedId);
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
@@ -110,6 +110,15 @@ public class AuditMessagesManagerEntry implements AuditMessagesManager {
 		return getAuditMessagesManagerBl().getLastMessageId();
 	}
 
+	public void setLastProcessedId(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException {
+		// Authorization
+		if (!AuthzResolver.isAuthorized(perunSession, Role.PERUNADMIN)) {
+			throw new PrivilegeException(perunSession, "setLastProcessedId");
+		}
+
+		getAuditMessagesManagerBl().setLastProcessedId(consumerName, lastProcessedId);
+	}
+
 	/**
 	 * Gets the AuditMessagesManagerBl for this instance.
 	 *

--- a/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/Rpc.java
+++ b/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/Rpc.java
@@ -113,6 +113,20 @@ public class Rpc {
 				throw new ConsistencyErrorException(e);
 			}
 		}
+
+		public static void setLastProcessedId(RpcCaller rpcCaller, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException {
+			Map<String, Object> params = new HashMap<>();
+			params.put("consumerName", consumerName);
+			params.put("lastProcessedId", new Integer(lastProcessedId));
+
+			try {
+				rpcCaller.call("auditMessagesManager", "setLastProcessedId", params);
+			} catch (PrivilegeException | InternalErrorException e) {
+				throw e;
+			} catch (PerunException e) {
+				throw new ConsistencyErrorException(e);
+			}
+		}
 	}
 
 	// FacilitiesManager

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuditMessagesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuditMessagesManagerMethod.java
@@ -103,6 +103,23 @@ public enum AuditMessagesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Set last processed ID of message in consumer with consumerName.
+	 *
+	 * @param consumerName String name of consumer
+	 * @param lastProcessedId int id of message to what consumer will be set
+	 * @throws InternalErrorException
+	 */
+	setLastProcessedId {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			ac.getAuditMessagesManager().setLastProcessedId(ac.getSession(), parms.readString("consumerName"),
+			  parms.readInt("lastProcessedId"));
+			return null;
+		}
+	},
+
+	/*#
 	 * Creates new auditer consumer with last processed id which equals auditer log max id.
 	 *
 	 * @param consumerName String New name for consumer


### PR DESCRIPTION
 - now there can be 1 number argument to set consumer lastProcessed Id
   to this specific number (easy without direct access to DB)