### PR TITLE
login namespace module works also for elixir-persistent attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import java.lang.String;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -19,10 +18,11 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
 
 /**
- * Class for checking logins uniqueness in the namespace
+ * Class for checking logins uniqueness in the namespace and filling namespaces
  *
  * @author Michal Prochazka  &lt;michalp@ics.muni.cz&gt;
  * @author Slavek Licehammer &lt;glory@ics.muni.cz&gt;
+ * 
  * @date 3.6.2011 11:02:22
  */
 public class urn_perun_user_attribute_def_def_login_namespace extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
@@ -30,9 +30,16 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace.class);
 
 	/**
-	 * Checks if the user's login is unique in the namespace
-	 * organization
+	 * Checks if the user's login is unique in the namespace organization
+	 * 
+	 * @param sess PerunSession
+	 * @param user User to check attribute for
+	 * @param attribute Attribute to check value to
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
+	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException
+	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException
 	 */
+        @Override
 	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
 
 		String userLogin = (String) attribute.getValue();
@@ -44,6 +51,7 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 
 		// Get all users who have set attribute urn:perun:member:attribute-def:def:login-namespace:[login-namespace], with the value.
 		List<User> usersWithSameLogin = sess.getPerunBl().getUsersManagerBl().getUsersByAttribute(sess, attribute);
+
 		usersWithSameLogin.remove(user); //remove self
 		if (!usersWithSameLogin.isEmpty()) {
 			if(usersWithSameLogin.size() > 1) throw new ConsistencyErrorException("FATAL ERROR: Duplicated Login detected." +  attribute + " " + usersWithSameLogin);
@@ -58,8 +66,15 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 	}
 
 	/**
-	 * Filling implemented only for namespaces configured in /etc/perun/perun.properties
-	 * as property: "perun.loginNamespace.generated"
+	 * Filling implemented for:
+	 * - namespaces configured in /etc/perun/perun.properties as property: "perun.loginNamespace.generated"
+	 * 
+	 * @param perunSession PerunSession
+	 * @param user User to fill attribute for
+	 * @param attribute Attribute to fill value to
+	 * @return Filled attribute
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
 	 */
 	@Override
 	public Attribute fillAttribute(PerunSessionImpl perunSession, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
@@ -90,11 +105,10 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 			// without value
 			return filledAttribute;
 		}
-
 	}
 
 	/**
-	 *  Fill login-namespace attribute with generated value.
+	 * Fill login-namespace attribute with generated value.
 	 * 	Format is: "firstName.lastName[number]" where number is opt and start with 1 when same login is already present.
 	 * 	All accented chars are unaccented and all non (a-z,A-Z) chars are removed from name and value is lowercased.
 	 *
@@ -161,5 +175,4 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 		attr.setDescription("Login namespace.");
 		return attr;
 	}*/
-
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_elixir_persistent.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_elixir_persistent.java
@@ -1,0 +1,130 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.exceptions.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Class for checking logins uniqueness in the namespace and filling elixir-persistent namespace
+ *
+ * @author Sona Mastrakova <sona.mastrakova@gmail.com>
+ * 
+ * @date 06.07.2015
+ */
+public class urn_perun_user_attribute_def_def_login_namespace_elixir_persistent extends urn_perun_user_attribute_def_def_login_namespace {
+
+	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace_elixir_persistent.class);
+        private final String extSourceNameElixir = "https://engine.elixir-idp.ics.muni.cz/authentication/idp/metadata";
+        private final String domainNameElixir = "@elixir-europe.org";
+        private final String attrNameElixir = "login-namespace:elixir-persistent";
+
+	/**
+	 * Filling implemented for login:namespace:elixir-persistent attribute
+	 * 
+	 * @param perunSession PerunSession
+	 * @param user User to fill attribute for
+	 * @param attribute Attribute to fill value to
+	 * @return Filled attribute
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	@Override
+	public Attribute fillAttribute(PerunSessionImpl perunSession, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+
+		Attribute filledAttribute = new Attribute(attribute);
+
+		if (attribute.getFriendlyName().equals(this.attrNameElixir)) {
+			return generateLoginValueElixir(perunSession, user, filledAttribute);
+		} else {
+			// without value
+			return filledAttribute;
+		}
+	}
+
+	/**
+	 * GenerateLoginValueElixir() fills login-namespace:elixir-persistent attribute with generated value.
+	 * 	Format is: "[hash]@elixir-europe.org" where [hash] represents sha1hash counted from user's id.
+	 *
+	 * @param sess PerunSession
+	 * @param user User to fill attribute for
+	 * @param attribute Attribute to fill value with
+	 * @return Filled attribute
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	private Attribute generateLoginValueElixir(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+            try {
+		attribute.setValue(sha1HashCount(user).toString() + this.domainNameElixir);
+		checkAttributeValue(sess, user, attribute);
+
+		return attribute;
+            } catch (WrongAttributeValueException ex) {
+		return attribute;
+            }
+	}
+
+	/**
+	 * Sha1HashCount() counts sha1hash for elixir-persistent namespace from user's id
+	 *
+	 * @param sess PerunSession
+	 * @param attribute Attribute to generate hash to
+	 * @return counted hash
+	 */
+	private StringBuilder sha1HashCount(User user) throws InternalErrorException {
+            try {
+		MessageDigest mDigest = MessageDigest.getInstance("SHA1");
+		// counts sha1hash and converts output to hex
+		byte[] result = mDigest.digest(ByteBuffer.allocate(4).putInt(user.getId()).array());
+		StringBuilder sb = new StringBuilder();
+ 		for (int i = 0; i < result.length; i++) {
+                    sb.append(Integer.toString((result[i] & 0xff) + 0x100, 16).substring(1));
+		}
+
+		return sb;
+            } catch (NoSuchAlgorithmException ex) {
+		throw new InternalErrorException("Algorithm for sha1hash was not found.", ex);
+            }
+	}
+
+	/**
+	 * ChangedAttributeHook() sets UserExtSource with following properties:
+	 *  - extSourceType is IdP
+	 *  - extSourceName is https://engine.elixir-idp.ics.muni.cz/authentication/idp/metadata
+	 *  - user's extSource login is the same as his elixir-persistent attribute
+	 *
+	 * @param session PerunSession
+	 * @param user User to set UserExtSource for
+	 * @param attribute Attribute containing elixirID
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
+	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException
+	 */
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+            try {
+                String userNamespace = attribute.getFriendlyNameParameter();
+
+		if(userNamespace.equals("elixir-persistent") && attribute.getValue() != null){
+                    ExtSource extSource = session.getPerunBl().getExtSourcesManagerBl().getExtSourceByName(session, ExtSourcesManager.EXTSOURCE_IDP);
+                    extSource.setName(this.extSourceNameElixir);
+                    UserExtSource userExtSource = new UserExtSource(extSource, 0, attribute.getValue().toString());
+
+                    session.getPerunBl().getUsersManagerBl().addUserExtSource(session, user, userExtSource);
+		}
+            } catch (UserExtSourceExistsException ex) {
+                log.warn("Elixir IdP external source already exists for the user.", ex);
+            } catch (ExtSourceNotExistsException ex) {
+                throw new InternalErrorException("IdP external source for elixir doesn't exist.", ex);
+            }
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_elixir_persistentTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_elixir_persistentTest.java
@@ -1,0 +1,87 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Testing class for login-namespace attribute
+ *
+ * @author Sona Mastrakova <sona.mastrakova@gmail.com>
+ * @date 03.07.2015
+ */
+public class urn_perun_user_attribute_def_def_login_namespace_elixir_persistentTest {
+
+    private static urn_perun_user_attribute_def_def_login_namespace_elixir_persistent classInstance;
+    private static PerunSessionImpl session;
+    private static User user;
+
+    @Before
+    public void SetUp() throws AttributeNotExistsException, InternalErrorException, WrongAttributeAssignmentException {
+        classInstance = new urn_perun_user_attribute_def_def_login_namespace_elixir_persistent();
+        session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+        user = new User();
+        user.setId(123456);
+    }
+
+    @Test
+    public void testCheckAttributeValueElixirNamespace() throws Exception {
+        System.out.println("testCheckAttributeValue()");
+        Attribute attribute = new Attribute();
+        attribute.setFriendlyName("login-namespace:elixir-persistent");
+        attribute.setValue("28c5353b8bb34984a8bd4169ba94c606@elixir-europe.org");
+
+        when(session.getPerunBl().getUsersManagerBl().getUsersByAttribute(any(PerunSession.class), any(Attribute.class))).thenReturn(new ArrayList<User>() {
+            {
+                add(user);
+            }
+        });
+
+        when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(User.class), anyString())).thenReturn(new Attribute() {
+            {
+                setValue("28c5353b8bb34984a8bd4169ba94c606@elixir-europe.org");
+            }
+        });
+
+        assertEquals(attribute.getValue().toString(), "28c5353b8bb34984a8bd4169ba94c606@elixir-europe.org");
+        classInstance.checkAttributeValue(session, user, attribute);
+    }
+
+    @Test
+    public void testFillAttributeValueElixirNamespace() throws Exception {
+        System.out.println("testFillAttributeValue()");
+
+        Attribute attribute = new Attribute();
+        attribute.setFriendlyName("login-namespace:elixir-persistent");
+        attribute.setValue("879a224546cf11fe53863737de037d2d39640258@elixir-europe.org");
+
+        when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(User.class), anyString())).thenReturn(new Attribute() {
+            {
+                setValue("879a224546cf11fe53863737de037d2d39640258@elixir-europe.org");
+            }
+        });
+
+        Attribute output = classInstance.fillAttribute(session, user, attribute);
+        assertEquals("879a224546cf11fe53863737de037d2d39640258@elixir-europe.org", output.getValue());
+    }
+
+    @Ignore
+    @Test
+    public void testChangedAttributeHookElixirNamespace() throws Exception {
+        System.out.println("testChangedAttributeHook()");
+    }
+}


### PR DESCRIPTION
- checkAttributeValue() and fillAttribute() now work with elixir-persistent attr.
- changedAttributeHook() has been implemented for setting UserExtSource after elixirID is generated by fillAttribute() method
- new testing class has been created for login namespace module