### PR TITLE
Notifications: prevent from stopping on exception EmailSendException

### DIFF
--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifEmailManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifEmailManagerImpl.java
@@ -150,7 +150,7 @@ public class PerunNotifEmailManagerImpl implements PerunNotifEmailManager {
 					}
 				}
 			}
-			throw ex;
+			logger.error("Sending of the email failed.", ex);
 		} catch (Exception ex) {
 			throw new EmailPreparationException(ex);
 		}


### PR DESCRIPTION
- the exception EmailSendException is cought and written to log and
  the notification module is not stopped