### PR TITLE
VOOT: Make tests to run in memory above HSQLDB

### DIFF
--- a/perun-voot/src/main/resources/perun-voot-applicationcontext-test.xml
+++ b/perun-voot/src/main/resources/perun-voot-applicationcontext-test.xml
@@ -11,8 +11,8 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 ">
 
-	<import resource="classpath:perun-datasources.xml"/>
-	<import resource="classpath:perun-beans.xml"/>
+	<import resource="classpath:perun-datasources-test.xml"/>
+	<import resource="classpath:perun-beans-test.xml"/>
 	<import resource="classpath:perun-transaction-manager.xml"/>
 
 	<!-- Enable @Transactional support -->

--- a/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTBaseTest.java
+++ b/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTBaseTest.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.voot;
+
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Main test class defining context and common variables.
+ * Any VOOT test class should extend this one.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:perun-voot-applicationcontext-test.xml"})
+@TransactionConfiguration(defaultRollback=true)
+@Transactional
+public abstract class VOOTBaseTest {
+
+	@Autowired
+	PerunBl perun;
+	// session
+	PerunSession session;
+	// user in session
+	User user1;
+
+	/**
+	 * Setup session for tests, it's called before each class
+	 * @throws Exception
+	 */
+	@Before
+	public void setUpSession() throws Exception {
+		session = perun.getPerunSession(new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
+		user1 = setUpUser1();
+		session.getPerunPrincipal().setUser(user1);
+		setUpBackground();
+	}
+
+	/**
+	 * Each test can setup own background (environment)
+	 * by implementing this method
+	 * @throws PerunException
+	 */
+	abstract void setUpBackground() throws PerunException;
+
+	User setUpUser1() throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		User user = new User();
+		user.setFirstName("James");
+		user.setMiddleName("");
+		user.setLastName("Bond");
+		user.setTitleBefore("");
+		user.setTitleAfter("");
+		return perun.getUsersManagerBl().createUser(session, user);
+	}
+
+}

--- a/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTLimitResultIntegrationTest.java
+++ b/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTLimitResultIntegrationTest.java
@@ -19,34 +19,13 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Martin Malik <374128@mail.muni.cz>
  */
-
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:perun-voot-applicationcontext.xml","classpath:perun-beans.xml"})
-@TransactionConfiguration(defaultRollback=true)
-@Transactional
-
-public class VOOTLimitResultIntegrationTest {
-	@Autowired
-	private PerunBl perun;
-
-	private PerunSession session;
-	private VOOT voot;
+public class VOOTLimitResultIntegrationTest extends VOOTBaseTest {
 
 	private Vo vo1;
 	private Group group1;
 	private Group group2; //group 2 is subgroup of group1
 
-	private User user1;
-
 	private Member member1;
-
-	@Before
-	public void setUpSession() throws Exception{
-		session = perun.getPerunSession(new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
-		user1 = setUpUser1();
-		setUpBackground();
-		session.getPerunPrincipal().setUser(user1);
-	}
 
 	@Test
 	public void isMemberOfTestStartIndex() throws InternalErrorException, AlreadyMemberException, WrongAttributeValueException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, VOOTException, GroupNotExistsException {
@@ -87,7 +66,8 @@ public class VOOTLimitResultIntegrationTest {
 		System.out.println(response);
 	}
 
-	private void setUpBackground() throws VoExistsException, InternalErrorException, GroupExistsException, AlreadyMemberException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, AlreadyAdminException, AttributeNotExistsException, ExtendMembershipException {
+	@Override
+	public void setUpBackground() throws VoExistsException, InternalErrorException, GroupExistsException, AlreadyMemberException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, AlreadyAdminException, AttributeNotExistsException, ExtendMembershipException {
 		vo1 = perun.getVosManagerBl().createVo(session, new Vo(1, "vo1", "vo1"));
 
 		group1 = perun.getGroupsManagerBl().createGroup(session, vo1, new Group("group1", "group1 in vo1"));
@@ -96,17 +76,6 @@ public class VOOTLimitResultIntegrationTest {
 		member1 = perun.getMembersManagerBl().createMember(session, vo1, user1);
 
 		perun.getGroupsManagerBl().addMember(session, group2, member1);
-	}
-
-	private User setUpUser1() throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		User user = new User();
-		user.setFirstName("James");
-		user.setMiddleName("");
-		user.setLastName("Bond");
-		user.setTitleBefore("");
-		user.setTitleAfter("");
-
-		return perun.getUsersManagerBl().createUser(session, user);
 	}
 
 }

--- a/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTMainAndFilterIntegrationTest.java
+++ b/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTMainAndFilterIntegrationTest.java
@@ -20,51 +20,25 @@ import static org.junit.Assert.assertNotNull;
  *
  * @author Martin Malik <374128@mail.muni.cz>
  */
+public class VOOTMainAndFilterIntegrationTest extends VOOTBaseTest {
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:perun-voot-applicationcontext.xml","classpath:perun-beans.xml"})
-@TransactionConfiguration(defaultRollback=true)
-@Transactional
-
-public class VOOTMainAndFilterIntegrationTest{
-	@Autowired
-	private PerunBl perun;
-
-	private PerunSession session;
 	private VOOT voot;
 
 	Vo vo1;
 	Vo vo2;
-	Vo vo3;
 
 	Group group1OfVo1;
 	Group group2OfVo1;
 
 	Group group1OfVo2;
-	Group group2OfVo2;
 
-	Group group1OfVo3;
-
-	User user1;
 	User user2;
-	User user3;
 
 	Member member1OfUser1;
 	Member member2OfUser1;
 
 	Member member1OfUser2;
 	Member member2OfUser2;
-
-	Member member1OfUser3;
-
-	@Before
-	public void setUpSession() throws Exception{
-		session = perun.getPerunSession(new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
-		user1 = setUpUser1();
-		setMail(user1,"james.bond@mi6.co.uk");
-		setUpBackground();
-		session.getPerunPrincipal().setUser(user1);
-	}
 
 	@Test
 	public void getPersonTest() throws VOOTException {
@@ -238,7 +212,11 @@ public class VOOTMainAndFilterIntegrationTest{
 		System.out.println(response);
 	}
 
-	private void setUpBackground() throws VoExistsException, InternalErrorException, GroupExistsException, AlreadyMemberException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, AlreadyAdminException, AttributeNotExistsException, ExtendMembershipException {
+	@Override
+	public void setUpBackground() throws VoExistsException, InternalErrorException, GroupExistsException, AlreadyMemberException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, AlreadyAdminException, AttributeNotExistsException, ExtendMembershipException {
+
+		setMail(user1,"james.bond@mi6.co.uk");
+
 		vo1 = perun.getVosManagerBl().createVo(session, new Vo(1, "vo1", "vo1"));
 		vo2 = perun.getVosManagerBl().createVo(session, new Vo(2, "vo2", "vo2"));
 
@@ -265,17 +243,6 @@ public class VOOTMainAndFilterIntegrationTest{
 		perun.getGroupsManagerBl().addMember(session, group2OfVo1, member1OfUser2);
 		member2OfUser2 = perun.getMembersManagerBl().createMember(session, vo2, user2);
 		perun.getGroupsManagerBl().addMember(session, group1OfVo2, member2OfUser2);
-	}
-
-	private User setUpUser1() throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		User user = new User();
-		user.setFirstName("James");
-		user.setMiddleName("");
-		user.setLastName("Bond");
-		user.setTitleBefore("");
-		user.setTitleAfter("");
-
-		return perun.getUsersManagerBl().createUser(session, user);
 	}
 
 	private void setMail(User user, String mailValue) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, AttributeNotExistsException {

--- a/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTSortIntegrationTest.java
+++ b/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTSortIntegrationTest.java
@@ -21,38 +21,16 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Martin Malik <374128@mail.muni.cz>
  */
-
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:perun-voot-applicationcontext.xml","classpath:perun-beans.xml"})
-@TransactionConfiguration(defaultRollback=true)
-@Transactional
-
-public class VOOTSortIntegrationTest {
-
-	@Autowired
-	private PerunBl perun;
-
-	private PerunSession session;
-	private VOOT voot;
+public class VOOTSortIntegrationTest extends VOOTBaseTest {
 
 	private Vo vo1;
 	private Group group1;
 	private Group group2; //group 2 is subgroup of group1
 	private Group group3;
 
-	private User user1;
-
 	private Member member1;
 	private Member member2;
 	private Member member3;
-
-	@Before
-	public void setUpSession() throws Exception{
-		session = perun.getPerunSession(new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
-		user1 = setUpUser1();
-		setUpBackground();
-		session.getPerunPrincipal().setUser(user1);
-	}
 
 	@Test
 	public void isMemberOfSortIdTest() throws InternalErrorException, AlreadyMemberException, WrongAttributeValueException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, VOOTException, GroupNotExistsException {
@@ -68,7 +46,7 @@ public class VOOTSortIntegrationTest {
 		assertArrayEquals(vootGroupsOfResponse, vootGroupsOfResponse2);
 
 		Response response3 = (Response) voot.process(session, "groups/@me", "sortBy=id,sortOrder=descending");
-		VOOTGroup[] vootGroupsOfResponse3 = (VOOTGroup[])response3.getEntry();
+		VOOTGroup[] vootGroupsOfResponse3 = (VOOTGroup[]) response3.getEntry();
 		ArrayUtils.reverse(vootGroupsOfResponse);
 		assertArrayEquals(vootGroupsOfResponse, vootGroupsOfResponse3);
 	}
@@ -133,7 +111,7 @@ public class VOOTSortIntegrationTest {
 		assertEquals("member", vootGroupsOfResponse[3].getVoot_membership_role());
 
 		Response response2 = (Response) voot.process(session, "groups/@me", "sortBy=voot_membership_role,sortOrder=descending");
-		VOOTGroup[] vootGroupsOfResponse2 = (VOOTGroup[])response2.getEntry();
+		VOOTGroup[] vootGroupsOfResponse2 = (VOOTGroup[]) response2.getEntry();
 
 		assertEquals("admin", vootGroupsOfResponse2[3].getVoot_membership_role());
 		assertEquals("admin", vootGroupsOfResponse2[2].getVoot_membership_role());
@@ -155,7 +133,7 @@ public class VOOTSortIntegrationTest {
 		assertArrayEquals(vootMembersOfResponse, vootMembersOfResponse2);
 
 		Response response3 = (Response) voot.process(session, "people/@me/vo1:group1", "sortBy=id,sortOrder=descending");
-		VOOTMember[] vootMembersOfResponse3 = (VOOTMember[])response3.getEntry();
+		VOOTMember[] vootMembersOfResponse3 = (VOOTMember[]) response3.getEntry();
 		ArrayUtils.reverse(vootMembersOfResponse);
 		assertArrayEquals(vootMembersOfResponse, vootMembersOfResponse3);
 	}
@@ -195,12 +173,13 @@ public class VOOTSortIntegrationTest {
 		assertEquals("member", vootMembersOfResponse[2].getVoot_membership_role());
 
 		Response response2 = (Response) voot.process(session, "people/@me/vo1:group1", "sortBy=voot_membership_role,sortOrder=descending");
-		VOOTMember[] vootMembersOfResponse2 = (VOOTMember[])response2.getEntry();
+		VOOTMember[] vootMembersOfResponse2 = (VOOTMember[]) response2.getEntry();
 		ArrayUtils.reverse(vootMembersOfResponse);
 		assertArrayEquals(vootMembersOfResponse, vootMembersOfResponse2);
 	}
 
-	private void setUpBackground() throws VoExistsException, InternalErrorException, GroupExistsException, AlreadyMemberException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, AlreadyAdminException, AttributeNotExistsException, ExtendMembershipException {
+	@Override
+	public void setUpBackground() throws VoExistsException, InternalErrorException, GroupExistsException, AlreadyMemberException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, AlreadyAdminException, AttributeNotExistsException, ExtendMembershipException {
 		vo1 = perun.getVosManagerBl().createVo(session, new Vo(1, "vo1", "vo1"));
 
 		group1 = perun.getGroupsManagerBl().createGroup(session, vo1, new Group("group1", "B group1 in vo1"));
@@ -233,14 +212,4 @@ public class VOOTSortIntegrationTest {
 
 	}
 
-	private User setUpUser1() throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		User user = new User();
-		user.setFirstName("James");
-		user.setMiddleName("");
-		user.setLastName("Bond");
-		user.setTitleBefore("");
-		user.setTitleAfter("");
-
-		return perun.getUsersManagerBl().createUser(session, user);
-	}
 }

--- a/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTSubGroupsIntegrationTest.java
+++ b/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTSubGroupsIntegrationTest.java
@@ -19,36 +19,14 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Martin Malik <374128@mail.muni.cz>
  */
-
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:perun-voot-applicationcontext.xml","classpath:perun-beans.xml"})
-@TransactionConfiguration(defaultRollback=true)
-@Transactional
-
-public class VOOTSubGroupsIntegrationTest {
-	@Autowired
-	private PerunBl perun;
-
-	private PerunSession session;
-	private VOOT voot;
+public class VOOTSubGroupsIntegrationTest extends VOOTBaseTest {
 
 	private Vo vo1;
 	private Group group1;
 	private Group group2; //group 2 is subgroup of group1
-	private Group group3;
-
-	private User user1;
 
 	private Member member1;
 	private Member member2;
-
-	@Before
-	public void setUpSession() throws Exception{
-		session = perun.getPerunSession(new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));
-		user1 = setUpUser1();
-		setUpBackground();
-		session.getPerunPrincipal().setUser(user1);
-	}
 
 	@Test
 	public void isMemberOfSubGroupTest() throws InternalErrorException, AlreadyMemberException, WrongAttributeValueException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, VOOTException, GroupNotExistsException {
@@ -68,7 +46,8 @@ public class VOOTSubGroupsIntegrationTest {
 		System.out.println(response);
 	}
 
-	private void setUpBackground() throws VoExistsException, InternalErrorException, GroupExistsException, AlreadyMemberException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, AlreadyAdminException, AttributeNotExistsException, ExtendMembershipException {
+	@Override
+	public void setUpBackground() throws VoExistsException, InternalErrorException, GroupExistsException, AlreadyMemberException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, AlreadyAdminException, AttributeNotExistsException, ExtendMembershipException {
 		vo1 = perun.getVosManagerBl().createVo(session, new Vo(1, "vo1", "vo1"));
 
 		group1 = perun.getGroupsManagerBl().createGroup(session, vo1, new Group("group1", "group1 in vo1"));
@@ -86,14 +65,4 @@ public class VOOTSubGroupsIntegrationTest {
 		perun.getGroupsManagerBl().addMember(session, group2, member2);
 	}
 
-	private User setUpUser1() throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		User user = new User();
-		user.setFirstName("James");
-		user.setMiddleName("");
-		user.setLastName("Bond");
-		user.setTitleBefore("");
-		user.setTitleAfter("");
-
-		return perun.getUsersManagerBl().createUser(session, user);
-	}
 }


### PR DESCRIPTION
- Added test context for running on HSQL.
- Removed repeating code, moved to abstract
  class which is extended by each test class