### PR TITLE
Fix disabled service propagation

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/DenialsResolver.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/DenialsResolver.java
@@ -16,8 +16,8 @@ import cz.metacentrum.perun.taskslib.model.ExecService;
 public interface DenialsResolver {
 
 	boolean isExecServiceDeniedOnFacility(ExecService execService,
-			Facility facility) throws InternalErrorException;
+			Facility facility);
 
 	boolean isExecServiceDeniedOnDestination(ExecService execService,
-			int destination) throws InternalErrorException;
+			int destination);
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/DenialsResolverImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/DenialsResolverImpl.java
@@ -1,0 +1,35 @@
+package cz.metacentrum.perun.engine.scheduling.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.engine.scheduling.DenialsResolver;
+import cz.metacentrum.perun.taskslib.dao.ExecServiceDenialDao;
+import cz.metacentrum.perun.taskslib.model.ExecService;
+
+/**
+ * 
+ * 
+ */
+@org.springframework.stereotype.Service(value = "denialsResolver")
+public class DenialsResolverImpl implements DenialsResolver {
+
+	@Autowired
+	private ExecServiceDenialDao execServiceDenialDao;
+
+	@Override
+	public boolean isExecServiceDeniedOnFacility(ExecService execService,
+			Facility facility)  {
+		return execServiceDenialDao.isExecServiceDeniedOnFacility(
+				execService.getId(), facility.getId());
+	}
+
+	@Override
+	public boolean isExecServiceDeniedOnDestination(ExecService execService,
+			int destination)  {
+		return execServiceDenialDao.isExecServiceDeniedOnDestination(
+				execService.getId(), destination);
+	}
+
+}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskExecutorEngineImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskExecutorEngineImpl.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.engine.scheduling.DenialsResolver;
 import cz.metacentrum.perun.engine.scheduling.DependenciesResolver;
 import cz.metacentrum.perun.engine.scheduling.ExecutorEngineWorker;
 import cz.metacentrum.perun.engine.scheduling.PropagationMaintainer;
@@ -62,7 +63,7 @@ public class TaskExecutorEngineImpl implements TaskExecutorEngine {
 	@Autowired
 	private SchedulingPool schedulingPool;
 	@Autowired
-	private ExecServiceDenialDao execServiceDenialDao;
+	private DenialsResolver denialsResolver;
 	
 	final int MAX_RUNNING_GEN = 20;
 	final int MAX_RUNNING = 1000;
@@ -169,7 +170,7 @@ public class TaskExecutorEngineImpl implements TaskExecutorEngine {
 		for (Destination destination : taskStatusManager.getTaskStatus(task)
 				.getWaitingDestinations()) {
 			// check if exec service is enabled for the destination
-			if(execServiceDenialDao.isExecServiceDeniedOnDestination(task.getExecServiceId(), destination.getId())) {
+			if(denialsResolver.isExecServiceDeniedOnDestination(task.getExecService(), destination.getId())) {
 				log.info("Not starting worker for disabled destination " + destination.toString());
 				continue;
 			}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskSchedulerImpl.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.engine.model.Pair;
+import cz.metacentrum.perun.engine.scheduling.DenialsResolver;
 import cz.metacentrum.perun.engine.scheduling.DependenciesResolver;
 import cz.metacentrum.perun.engine.scheduling.PropagationMaintainer;
 import cz.metacentrum.perun.engine.scheduling.SchedulingPool;
@@ -55,7 +56,7 @@ public class TaskSchedulerImpl implements TaskScheduler {
 	private Perun perun;
 	private PerunSession perunSession;
 	@Autowired
-	private ExecServiceDenialDao execServiceDenialDao;
+	private DenialsResolver denialsResolver;
 	/*
 	 * @Autowired private TaskManager taskManager;
 	 * 
@@ -80,7 +81,7 @@ public class TaskSchedulerImpl implements TaskScheduler {
 		 // Is the ExecService denied on this Facility? 
 		 // If it is, we drop it and do nothing. 
 		 log.debug("   Is the execService ID:" + task.getExecServiceId() + " denied on facility ID:" + task.getFacilityId() + "?"); 
-		 if(execServiceDenialDao.isExecServiceDeniedOnFacility(task.getExecServiceId(), task.getFacilityId())) { 
+		 if(denialsResolver.isExecServiceDeniedOnFacility(task.getExecService(), task.getFacility())) { 
 			 schedulingPool.setTaskStatus(task, TaskStatus.DONE);
 			 log.info("Exec service " + task.getExecServiceId() + " for task " + task.getId() + 
 					 " is denied for facility " + task.getFacilityId() + 


### PR DESCRIPTION
Check if the service is not disabled globally, for the facility or for the particular destination, add checks both to dispatcher and engine before the propagation is sent out/executed. 