### PR TITLE
Character '.' can be also used in name of attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -4408,7 +4408,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 * @return name of attribute module
 	 */
 	private String attributeNameToModuleName(String attributeName) {
-		return ATTRIBUTES_MODULES_PACKAGE + "." + attributeName.replaceAll(":|-", "_");
+		return ATTRIBUTES_MODULES_PACKAGE + "." + attributeName.replaceAll(":|-|[.]", "_");
 	}
 
 	/**


### PR DESCRIPTION
 - especially in the name of parameter like (:einfra.cesnet.cz) when
   concrete modules are created