### PR TITLE
Transactions - new Auditer Messages behaviour

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -392,6 +392,7 @@ public class PerunBlImpl implements PerunBl {
 	 */
 	public void initialize() throws InternalErrorException {
 		this.extSourcesManagerBl.initialize(this.getPerunSession());
+		this.auditer.initialize();
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -177,6 +177,7 @@ public class Auditer {
 		}
 	}
 
+	
 	/**
 	 * Log message.
 	 * Message is stored in actual transaction. If no transaction is active message will be immediatelly flushed out.
@@ -187,11 +188,12 @@ public class Auditer {
 	public void log(PerunSession sess, String message) throws InternalErrorException {
 		if(TransactionSynchronizationManager.isActualTransactionActive()) {
 			log.trace("Auditer stores audit message to current transaction. Message: {}.", message);
-			List<AuditerMessage> messages = (List<AuditerMessage>) TransactionSynchronizationManager.getResource(this);
-			if(messages == null) {
-				messages = new ArrayList<AuditerMessage>();
-				TransactionSynchronizationManager.bindResource(this, messages);
+			List<List<AuditerMessage>> savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
+			if (savepoints == null) {
+				transactionBegin();
+				savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
 			}
+			List<AuditerMessage> messages = savepoints.get(savepoints.size() - 1);
 			messages.add(new AuditerMessage(sess, message));
 		} else {
 			this.storeMessageToDb(sess, message);
@@ -310,17 +312,71 @@ public class Auditer {
 	}
 
 	/**
-	 * Imidiately flushes stored message for specified transaction into the log
+	 * Initialize lists for sotring Audit messages.
 	 *
-	 * @param transaction
 	 */
-	public void flush() {
-		List<AuditerMessage> messages = (List<AuditerMessage>) TransactionSynchronizationManager.unbindResourceIfPossible(this);
-		if(messages == null) {
-			log.trace("No message to flush");
+	public void transactionBegin() {
+		List<List<AuditerMessage>> savepoints = new ArrayList<>();
+		List<AuditerMessage> messages = new ArrayList<>();
+		savepoints.add(messages);
+		TransactionSynchronizationManager.bindResource(this, savepoints);
+	}
+		
+	/**
+	 * Creates new list for saving auditer messages of a new transaction.
+	 * 
+	 */
+	public void newTransaction() {
+		List<List<AuditerMessage>> savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
+		List<AuditerMessage> messages = new ArrayList<>();
+		savepoints.add(messages);
+	}
+	
+	/**
+	 * Flush auditer messages of the last transaction to the store of the outer transaction.
+	 * There should be at least one nested transaction.
+	 * 
+	 */
+	public void flushTransaction() {
+		List<List<AuditerMessage>> savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
+		if (savepoints.size() < 2) {
+			log.trace("No messages to flush");
 			return;
 		}
+		List<AuditerMessage> messagesToFlush = savepoints.get(savepoints.size() - 1);
+		
+		savepoints.get(savepoints.size() - 2).addAll(messagesToFlush);
+		List<AuditerMessage> messages = savepoints.remove(savepoints.size() - 1);
+		log.trace("Flushed auditer messages of the last transaction: " + messages);
+	}
+	
+	/**
+	 * Erases the auditer messages for the last transaction.
+	 * 
+	 */
+	public void cleanTransation() {
+		List<List<AuditerMessage>> savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
+		List<AuditerMessage> messages = savepoints.remove(savepoints.size() - 1);
+		log.trace("Erased auditer messages for the last transaction: " + messages);
+	}
+	
+	/**
+	 * Imidiately flushes stored message for specified transaction into the log
+	 *
+	 */
+	public void flush() {
+		List<List<AuditerMessage>> savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
+		if ((savepoints == null) || (savepoints.isEmpty())) {
+			log.trace("No messages to flush");
+			return;
+		}
+		
+		if (savepoints.size() != 1) {
+			log.error("There should be only one list of messages while flushing representing the most outer transaction.");
+		}
 
+		List<AuditerMessage> messages = savepoints.get(0);
+		TransactionSynchronizationManager.unbindResourceIfPossible(this);
 		log.trace("Audit messages was flushed for current transaction.");
 		synchronized (LOCK_DB_TABLE_AUDITER_LOG) {
 			for(AuditerMessage auditerMessage : messages) {
@@ -355,8 +411,24 @@ public class Auditer {
 		}
 	}
 
+	/**
+	 * All prepared auditer messages in transaction are erased without storing into db.
+	 * Mostly wanted while rollbacking.
+	 * 
+	 */
 	public void clean() {
-		List<AuditerMessage> messages = (List<AuditerMessage>) TransactionSynchronizationManager.unbindResourceIfPossible(this);
+		List<List<AuditerMessage>> savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
+		if ((savepoints == null) || (savepoints.isEmpty())) {
+			log.trace("No messages to flush");
+			return;
+		}
+		
+		if (savepoints.size() != 1) {
+			log.error("There should be only one list of messages while cleaning.");
+		}
+
+		List<AuditerMessage> messages = savepoints.get(0);
+		TransactionSynchronizationManager.unbindResourceIfPossible(this);
 		log.trace("Audit messages erased for current transaction. {}", messages);
 	}
 
@@ -366,7 +438,9 @@ public class Auditer {
 	 * @return list of messages
 	 */
 	public List<AuditerMessage> getMessages() {
-		List<AuditerMessage> messages = (List<AuditerMessage>) TransactionSynchronizationManager.getResource(this);
+		List<List<AuditerMessage>> savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
+		if ((savepoints == null) || (savepoints.isEmpty())) return new ArrayList<AuditerMessage>();
+		List<AuditerMessage> messages = savepoints.get(savepoints.size() - 1);
 		if(messages == null) return new ArrayList<AuditerMessage>();
 		return messages;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunBasicDataSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunBasicDataSource.java
@@ -1,0 +1,19 @@
+package cz.metacentrum.perun.core.impl;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.apache.tomcat.dbcp.dbcp.BasicDataSource;
+
+/**
+ * BasicDataSource used instead of BasicDataSource in Perun to override getConnection.
+ * 
+ * @author Jiri Mauritz <jirmauritz at gmail dot com>
+ */
+public class PerunBasicDataSource extends BasicDataSource {
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		return new PerunConnection(super.getConnection());
+	}
+	
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunBasicDataSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunBasicDataSource.java
@@ -11,9 +11,18 @@ import org.apache.tomcat.dbcp.dbcp.BasicDataSource;
  */
 public class PerunBasicDataSource extends BasicDataSource {
 
+	private Auditer auditer;
+	
 	@Override
 	public Connection getConnection() throws SQLException {
-		return new PerunConnection(super.getConnection());
+		return new PerunConnection(super.getConnection(), auditer);
 	}
-	
+
+	public Auditer getAuditer() {
+		return auditer;
+	}
+
+	public void setAuditer(Auditer auditer) {
+		this.auditer = auditer;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunConnection.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunConnection.java
@@ -1,0 +1,316 @@
+package cz.metacentrum.perun.core.impl;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * Implementation of connection used in Perun to catch connection events.
+ * A connection from constructor is fully used. Some features are added.
+ * 
+ * @author Jiri Mauritz <jirmauritz at gmail dot com>
+ */
+public class PerunConnection implements Connection {
+	
+	private final Connection connectionImpl;
+	
+	// Constructor
+	public PerunConnection(Connection connectionImpl) {
+		this.connectionImpl = connectionImpl;
+	}
+	
+	
+	// Methods with added features
+		
+	@Override
+	public Savepoint setSavepoint() throws SQLException {
+		return connectionImpl.setSavepoint();
+	}
+
+	@Override
+	public Savepoint setSavepoint(String string) throws SQLException {
+		return connectionImpl.setSavepoint(string);
+	}
+		
+	@Override
+	public void rollback(Savepoint svpnt) throws SQLException {
+		connectionImpl.rollback(svpnt);
+	}
+		
+	@Override
+	public void releaseSavepoint(Savepoint svpnt) throws SQLException {
+		connectionImpl.releaseSavepoint(svpnt);
+	}
+	
+	
+	// Other methods uses connectionImpl
+	
+	@Override
+	public Statement createStatement() throws SQLException {
+		return connectionImpl.createStatement();
+	}
+	
+	@Override
+	public PreparedStatement prepareStatement(String string) throws SQLException {
+		return connectionImpl.prepareStatement(string);
+	}
+	
+	@Override
+	public CallableStatement prepareCall(String string) throws SQLException {
+		return connectionImpl.prepareCall(string);
+	}
+	
+	@Override
+	public String nativeSQL(String string) throws SQLException {
+		return connectionImpl.nativeSQL(string);
+	}
+	
+	@Override
+	public void setAutoCommit(boolean bln) throws SQLException {
+		connectionImpl.setAutoCommit(bln);
+	}
+	
+	@Override
+	public boolean getAutoCommit() throws SQLException {
+		return connectionImpl.getAutoCommit();
+	}
+	
+	@Override
+	public void commit() throws SQLException {
+		connectionImpl.commit();
+	}
+	
+	@Override
+	public void rollback() throws SQLException {
+		connectionImpl.rollback();
+	}
+	
+	@Override
+	public void close() throws SQLException {
+		connectionImpl.close();
+	}
+	
+	@Override
+	public boolean isClosed() throws SQLException {
+		return connectionImpl.isClosed();
+	}
+	
+	@Override
+	public DatabaseMetaData getMetaData() throws SQLException {
+		return connectionImpl.getMetaData();
+	}
+	
+	@Override
+	public void setReadOnly(boolean bln) throws SQLException {
+		connectionImpl.setReadOnly(bln);
+	}
+	
+	@Override
+	public boolean isReadOnly() throws SQLException {
+		return connectionImpl.isReadOnly();
+	}
+	
+	@Override
+	public void setCatalog(String string) throws SQLException {
+		connectionImpl.setCatalog(string);
+	}
+	
+	@Override
+	public String getCatalog() throws SQLException {
+		return connectionImpl.getCatalog();
+	}
+	
+	@Override
+	public void setTransactionIsolation(int i) throws SQLException {
+		connectionImpl.setTransactionIsolation(i);
+	}
+	
+	@Override
+	public int getTransactionIsolation() throws SQLException {
+		return connectionImpl.getTransactionIsolation();
+	}
+	
+	@Override
+	public SQLWarning getWarnings() throws SQLException {
+		return connectionImpl.getWarnings();
+	}
+	
+	@Override
+	public void clearWarnings() throws SQLException {
+		connectionImpl.clearWarnings();
+	}
+	
+	@Override
+	public Statement createStatement(int i, int i1) throws SQLException {
+		return connectionImpl.createStatement(i,i1);
+	}
+	
+	@Override
+	public PreparedStatement prepareStatement(String string, int i, int i1) throws SQLException {
+		return connectionImpl.prepareStatement(string, i, i1);
+	}
+	
+	@Override
+	public CallableStatement prepareCall(String string, int i, int i1) throws SQLException {
+		return connectionImpl.prepareCall(string, i, i1);
+	}
+	
+	@Override
+	public Map<String, Class<?>> getTypeMap() throws SQLException {
+		return connectionImpl.getTypeMap();
+	}
+	
+	@Override
+	public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+		connectionImpl.setTypeMap(map);
+	}
+	
+	@Override
+	
+	public void setHoldability(int i) throws SQLException {
+		connectionImpl.setHoldability(i);
+	}
+
+	@Override
+	public int getHoldability() throws SQLException {
+		return connectionImpl.getHoldability();
+	}
+	
+	@Override
+	public Statement createStatement(int i, int i1, int i2) throws SQLException {
+		return connectionImpl.createStatement(i, i1, i2);
+	}
+		
+	@Override
+	public PreparedStatement prepareStatement(String string, int i, int i1, int i2) throws SQLException {
+		return connectionImpl.prepareStatement(string, i, i1, i2);
+	}
+	
+	@Override
+	public CallableStatement prepareCall(String string, int i, int i1, int i2) throws SQLException {
+		
+		return connectionImpl.prepareCall(string, i, i1, i2);
+	}
+
+	@Override
+	public PreparedStatement prepareStatement(String string, int i) throws SQLException {
+		return connectionImpl.prepareStatement(string, i);
+	}
+	
+	@Override
+	public PreparedStatement prepareStatement(String string, int[] ints) throws SQLException {
+		return connectionImpl.prepareStatement(string, ints);
+	}
+		
+	@Override
+	
+	public PreparedStatement prepareStatement(String string, String[] strings) throws SQLException {
+		return connectionImpl.prepareStatement(string, strings);
+	}
+	
+	@Override
+	public Clob createClob() throws SQLException {
+		return connectionImpl.createClob();
+	}
+	
+	@Override
+	public Blob createBlob() throws SQLException {
+		return connectionImpl.createBlob();
+	}
+	
+	@Override
+	public NClob createNClob() throws SQLException {
+		return connectionImpl.createNClob();
+	}
+	
+	@Override
+	public SQLXML createSQLXML() throws SQLException {
+		return connectionImpl.createSQLXML();
+	}
+	
+	@Override
+	public boolean isValid(int i) throws SQLException {
+		return connectionImpl.isValid(i);
+	}
+	
+	@Override
+	public void setClientInfo(String string, String string1) throws SQLClientInfoException {
+		connectionImpl.setClientInfo(string, string1);
+	}
+	
+	@Override
+	public void setClientInfo(Properties prprts) throws SQLClientInfoException {
+		connectionImpl.setClientInfo(prprts);
+	}
+	
+	@Override
+	public String getClientInfo(String string) throws SQLException {
+		return connectionImpl.getClientInfo(string);
+	}
+	
+	@Override
+	public Properties getClientInfo() throws SQLException {
+		return connectionImpl.getClientInfo();
+	}
+	
+	@Override
+	public Array createArrayOf(String string, Object[] os) throws SQLException {
+		return connectionImpl.createArrayOf(string, os);
+	}	
+	
+	@Override
+	public Struct createStruct(String string, Object[] os) throws SQLException {
+		return connectionImpl.createStruct(string, os);
+	}
+	
+	@Override
+	public void setSchema(String string) throws SQLException {
+		connectionImpl.setSchema(string);
+	}
+	
+	@Override
+	public String getSchema() throws SQLException {
+		return connectionImpl.getSchema();
+	}
+	
+	@Override
+	public void abort(Executor exctr) throws SQLException {
+		connectionImpl.abort(exctr);
+	}
+	
+	@Override
+	public void setNetworkTimeout(Executor exctr, int i) throws SQLException {
+		connectionImpl.setNetworkTimeout(exctr, i);
+	}
+	
+	@Override
+	public int getNetworkTimeout() throws SQLException {
+		return connectionImpl.getNetworkTimeout();
+	}
+	
+	@Override
+	public <T> T unwrap(Class<T> type) throws SQLException {
+		return connectionImpl.unwrap(type);
+	}
+	
+	@Override
+	public boolean isWrapperFor(Class<?> type) throws SQLException {
+		return connectionImpl.isWrapperFor(type);
+	}	
+}
+

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunTransactionManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunTransactionManager.java
@@ -1,40 +1,23 @@
 package cz.metacentrum.perun.core.impl;
 
-import java.util.List;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.ResourceTransactionManager;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import cz.metacentrum.perun.core.impl.Auditer;
-import cz.metacentrum.perun.core.impl.AuditerMessage;
 
 public class PerunTransactionManager extends DataSourceTransactionManager implements ResourceTransactionManager, InitializingBean {
 
 	private static final long serialVersionUID = 1L;
 
 	private Auditer auditer;
-
+	
 	@Override
-	protected Object doSuspend(Object transaction) {
-		if(TransactionSynchronizationManager.hasResource(this.getAuditer())) {
-			List<AuditerMessage> messages = (List<AuditerMessage>) TransactionSynchronizationManager.getResource(getAuditer());
-			logger.trace("Storing audit messages while suspending transaction. Number of messages " + messages.size());
-		}
-
-		return super.doSuspend(transaction);
-	}
-
-	@Override
-	protected void doResume(Object transaction, Object suspendedResources) {
-		if(TransactionSynchronizationManager.hasResource(this.getAuditer())) {
-			List<AuditerMessage> messages = (List<AuditerMessage>) TransactionSynchronizationManager.getResource(transaction);
-			logger.trace("Retrieving audit messages while rusuming transaction. Number of messages " + messages.size());
-		}
-
-		super.doResume(transaction, suspendedResources);
+	protected void doBegin(Object transaction, TransactionDefinition definition) {
+		this.getAuditer().transactionBegin();
+		super.doBegin(transaction, definition);
 	}
 
 	@Override

--- a/perun-core/src/main/resources/perun-core-jdbc.xml
+++ b/perun-core/src/main/resources/perun-core-jdbc.xml
@@ -45,6 +45,7 @@
             <property name="logAbandoned" value="true" />
             <property name="removeAbandonedTimeout" value="300" />
             <property name="testOnBorrow" value="true" />
+            <property name="auditer" ref="auditer"/>
         </bean>
     </beans>
 

--- a/perun-core/src/main/resources/perun-core-jdbc.xml
+++ b/perun-core/src/main/resources/perun-core-jdbc.xml
@@ -31,7 +31,7 @@
         </bean>
 
         <!-- DataSource implementation -->
-        <bean id="dataSource" class="org.apache.tomcat.dbcp.dbcp.BasicDataSource" destroy-method="close">
+        <bean id="dataSource" class="cz.metacentrum.perun.core.impl.PerunBasicDataSource" destroy-method="close">
             <property name="driverClassName" value="${jdbc.driver}"/>
             <property name="url" value="${jdbc.url}"/>
             <property name="username" value="${jdbc.username}"/>

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -262,7 +262,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		<constructor-arg ref="dataSource" />
 	</bean>
 
-	<bean id="auditer" class="cz.metacentrum.perun.core.impl.Auditer" scope="singleton" init-method="initialize" depends-on="utilsProperties">
+	<bean id="auditer" class="cz.metacentrum.perun.core.impl.Auditer" scope="singleton" depends-on="utilsProperties">
 		<property name="perunPool" ref="dataSource"/>
 	</bean>
 


### PR DESCRIPTION
- PerunConnection created to catch important events such as setSavepoint, releaseSavepoint, rolback
- Auditer Messages are stored in list of lists where inner lists represent one nested transaction
 - when a transaction is successful, all the Auditer Messages from last list are copied to the previous list
 - when a transaction is not successful, the last list is deleted