### PR TITLE
CORE,REGISTRAR: Allow method calls to TOPGROUPCREATOR

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -217,6 +217,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo)
 				&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo)
+				&& !AuthzResolver.isAuthorized(sess, Role.TOPGROUPCREATOR, vo)
 				&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
 			throw new PrivilegeException(sess, "getGroupByName");
 				}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -323,8 +323,11 @@ public class MailManagerImpl implements MailManager {
 	@Override
 	public void copyMailsFromGroupToGroup(PerunSession sess, Group fromGroup, Group toGroup) throws PerunException {
 
+		Vo fromVO = perun.getVosManagerBl().getVoById(registrarSession, fromGroup.getVoId());
+
 		if (!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, fromGroup) &&
-				!AuthzResolver.isAuthorized(sess, Role.VOADMIN, fromGroup)) {
+				!AuthzResolver.isAuthorized(sess, Role.VOADMIN, fromGroup) &&
+				!AuthzResolver.isAuthorized(sess, Role.TOPGROUPCREATOR, fromVO)) {
 			throw new PrivilegeException(sess, "copyMailsFromGroupToGroup");
 		}
 		if (!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, toGroup) &&

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1630,6 +1630,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		} else {
 			if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, form.getVo())
 					&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, form.getVo())
+					&& !AuthzResolver.isAuthorized(sess, Role.TOPGROUPCREATOR, form.getVo())
 					&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, form.getGroup())) {
 				throw new PrivilegeException("getFormItems");
 			}
@@ -2058,7 +2059,10 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	@Override
 	public void copyFormFromGroupToGroup(PerunSession sess, Group fromGroup, Group toGroup) throws PerunException {
 
-		if ((!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, fromGroup) && !AuthzResolver.isAuthorized(sess, Role.VOADMIN, fromGroup)) ||
+		Vo fromVO = perun.getVosManagerBl().getVoById(registrarSession, fromGroup.getVoId());
+
+		if ((!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, fromGroup) && !AuthzResolver.isAuthorized(sess, Role.VOADMIN, fromGroup)
+				&& !AuthzResolver.isAuthorized(sess, Role.TOPGROUPCREATOR, fromVO)) ||
 				(!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, toGroup) && !AuthzResolver.isAuthorized(sess, Role.VOADMIN, toGroup))) {
 			throw new PrivilegeException(sess, "copyFormFromGroupToGroup");
 		}


### PR DESCRIPTION
- For new eduGAIN group manager demo we need to allow access
  to group, form and mails also to TOPGROUPCREATOR role, since
  after creating 1st group they need to copy settings from default group.