### PR TITLE
DISPATCHER: Log exception when deleting TaskResults

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/impl/DispatcherManagerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/service/impl/DispatcherManagerImpl.java
@@ -143,9 +143,8 @@ public class DispatcherManagerImpl implements DispatcherManager {
 			try {
 				int numRows = resultManager.clearOld(queue.getClientID(), 3);
 				log.debug("Cleaned {} old task results for engine {}", numRows, queue.getClientID());
-			} catch (InternalErrorException e) {
-				log.warn("Error cleaning old task results for engine {} : {}", 
-						queue.getClientID(), e.toString());
+			} catch (Exception e) {
+				log.error("Error cleaning old task results for engine {} : {}", queue.getClientID(), e);
 			}
 		}
 	}


### PR DESCRIPTION
- We were catching InternalErrorException while it was never
  thrown from impl layer. It didn't catch DataAccessException
  which is thrown.
- Now we should properly log what exception is thrown.