### PR TITLE
Fix failed task resubmission

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/impl/EventProcessorImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/impl/EventProcessorImpl.java
@@ -198,7 +198,7 @@ public class EventProcessorImpl implements EventProcessor {
 						task.setFacility(facility);
 						task.setExecService(execService);
 						task.setStatus(TaskStatus.NONE);
-						task.setRecurrence(execService.getDefaultRecurrence());
+						task.setRecurrence(0);
 						task.setSchedule(new Date(System.currentTimeMillis()));
 						task.setSourceUpdated(false);
 						schedulingPool.addToPool(task, dispatcherQueue);

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
@@ -121,7 +121,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 			int howManyMinutesAgo = (int) (System.currentTimeMillis() - task
 					.getEndTime().getTime()) / 1000 / 60;
 			if(howManyMinutesAgo < 0) {
-				log.error("RECOVERY FROM INCOSISNTENT STATE: ERROR task appears to have ended in future.");
+				log.error("RECOVERY FROM INCONSISTENT STATE: ERROR task appears to have ended in future.");
 				Date endTime = new Date(System.currentTimeMillis()
 						- ((task.getDelay() + 1) * 60000));
 				task.setEndTime(endTime);
@@ -154,7 +154,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 					if (assignedServices.contains(task.getExecService().getService())) {
 						ExecService execService = task.getExecService();
 						Facility facility = task.getFacility();
-						if(recurrence > task.getExecService().getDefaultRecurrence()) {
+						if(recurrence > execService.getDefaultRecurrence()) {
 							// this ERROR task is rescheduled for being here too long
 							task.setRecurrence(0);
 							task.setDestinations(null);

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
@@ -120,6 +120,13 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 			}
 			int howManyMinutesAgo = (int) (System.currentTimeMillis() - task
 					.getEndTime().getTime()) / 1000 / 60;
+			if(howManyMinutesAgo < 0) {
+				log.error("RECOVERY FROM INCOSISNTENT STATE: ERROR task appears to have ended in future.");
+				Date endTime = new Date(System.currentTimeMillis()
+						- ((task.getDelay() + 1) * 60000));
+				task.setEndTime(endTime);
+				howManyMinutesAgo = task.getDelay() + 1;
+			}
 			log.info("TASK [" + task + "] in ERROR state completed "
 					+ howManyMinutesAgo + " minutes ago.");
 			// XXX - apparently this is not what the authors had in mind,

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
@@ -134,13 +134,26 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 			// }
 			// task.setRecurrence(recurrence);
 			// If DELAY time has passed, we reschedule...
-			if (howManyMinutesAgo >= task.getDelay()) {
+			int recurrence = task.getRecurrence() + 1;
+			if(recurrence > task.getExecService().getDefaultRecurrence() &&
+					howManyMinutesAgo < 60 * 12 &&
+					!task.isSourceUpdated()) {
+				log.info("TASK [ " + task + "] in ERROR state has no more retries, bailing out.");
+			} else if (howManyMinutesAgo >= recurrence * task.getDelay() ||
+					task.isSourceUpdated()) {
 				// check if service is still assigned on facility
 				try {
 					List<Service> assignedServices = perun.getServicesManager().getAssignedServices(perunSession, task.getFacility());
 					if (assignedServices.contains(task.getExecService().getService())) {
 						ExecService execService = task.getExecService();
 						Facility facility = task.getFacility();
+						if(recurrence > task.getExecService().getDefaultRecurrence()) {
+							// this ERROR task is rescheduled for being here too long
+							task.setRecurrence(0);
+							task.setDestinations(null);
+							log.info("TASK id " + task.getId() + " is in ERROR state long enough, ");
+						}
+						task.setRecurrence(recurrence);
 						log.info("TASK ["
 								+ task
 								+ "] in ERROR state is going to be rescheduled: taskScheduler.propagateService(execService:ID "
@@ -474,6 +487,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 			// set destination list to null to refetch them later
 			completedTask.setDestinations(null);
 			schedulingPool.setTaskStatus(completedTask, TaskStatus.DONE);
+			completedTask.setRecurrence(0);
 			log.debug("TASK {} reported as DONE", completedTask.toString());
 			// for GEN tasks, signal SENDs that source data are updated
 			if(completedTask.getExecService().getExecServiceType().equals(ExecServiceType.GENERATE)) {
@@ -484,7 +498,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 						dependantTask.setSourceUpdated(false);
 					}
 				}
-			}
+			} 
 			
 		} else {
 			if (string.isEmpty()) {


### PR DESCRIPTION
Contains fixes to error task resubmisions in perun-dispatcher:
  - failing tasks are not resubmitted indefinitely, but only for defined number of retries (set in db) with increasing delays between resubmissions
  - failed tasks are restarted completely (properly) after defined period of time (12 hours) or when new event arrives