### PR TITLE
CORE: Security teams feature

### DIFF
--- a/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
+++ b/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
@@ -66,6 +66,7 @@ public class AuditParser {
 				else if(p.getLeft().equals("Authorship")) perunBean = createAuthorship(p.getRight());
 				else if(p.getLeft().equals("ResourceTag")) perunBean = createResourceTag(p.getRight());
 				else if(p.getLeft().equals("ExecService")) perunBean = createExecService(p.getRight());
+				else if(p.getLeft().equals("SecurityTeam")) perunBean = createSecurityTeam(p.getRight());
 				else loger.debug("Object of this type can't be parsed cause there is no such object in parser's branches. ObjectName:" + p.getLeft());
 				if(perunBean != null) listPerunBeans.add(perunBean);
 			} catch (RuntimeException e) {
@@ -493,6 +494,15 @@ public class AuditParser {
 		}
 		execService.setExecServiceType(exType);
 		return execService;
+	}
+
+	private static SecurityTeam createSecurityTeam(Map<String, String> beanAttr) {
+		if(beanAttr==null) return null;
+		SecurityTeam securityTeam = new SecurityTeam();
+		securityTeam.setId(Integer.valueOf(beanAttr.get("id")).intValue());
+		securityTeam.setName(BeansUtils.eraseEscaping(beanAttr.get("name")));
+		securityTeam.setDescription(BeansUtils.eraseEscaping(beanAttr.get("description")));
+		return securityTeam;
 	}
 
 	//--------------------------------------------------------------------------

--- a/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
+++ b/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
@@ -57,7 +57,8 @@ public class AuditParserTest {
 	private RichFacility richFacility;
 	private ResourceTag resourceTag1 = new ResourceTag(5, "cosi" , 2);
 	private ResourceTag resourceTag2 = new ResourceTag(8, null, 5);
-
+	private SecurityTeam securityTeam1 = new SecurityTeam(1, "jmeno", "popis");
+	private SecurityTeam securityTeam2 = new SecurityTeam(2, null, null);
 	private ExecService exService1 = new ExecService();
 	private ExecService exService2 = new ExecService();
 
@@ -367,6 +368,13 @@ public class AuditParserTest {
 		assertEquals(candidate1.getAttributes(), ((Candidate) candidate1InList.get(0)).getAttributes());
 		assertEquals(candidate2.getAttributes(), ((Candidate) candidate2InList.get(0)).getAttributes());
 
+		//FOR SECURITY TEAM
+		SecurityTeam securityTeam = new SecurityTeam(18, textMismatch, textMismatch);
+		List<PerunBean> scsInList = AuditParser.parseLog(securityTeam.serializeToString());
+		assertEquals(securityTeam.toString(), ((SecurityTeam) scsInList.get(0)).toString());
+		assertEquals(securityTeam.getName(), ((SecurityTeam) scsInList.get(0)).getName());
+		assertEquals(securityTeam.getDescription(), ((SecurityTeam) scsInList.get(0)).getDescription());
+
 		//FOR RICHMEMBER
 		RichMember richMember1 = new RichMember(null, member, null);
 		//List<UserExtSource> userExtSources = new ArrayList<UserExtSource>();
@@ -499,6 +507,8 @@ public class AuditParserTest {
 		assertEquals(userExtSource1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(userExtSource1.serializeToString())));
 		assertEquals(resourceTag1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(resourceTag1.serializeToString())));
 		assertEquals(exService1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(exService1.serializeToString())));
+		assertEquals(securityTeam1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(securityTeam1.serializeToString())));
+		assertEquals(securityTeam2.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(securityTeam2.serializeToString())));
 		//test also some null serializing
 		Resource newResource = new Resource(20, null, null, 5);
 		assertEquals(newResource.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(newResource.serializeToString())));
@@ -515,11 +525,12 @@ public class AuditParserTest {
 			owner.serializeToString() + service.serializeToString() + attributeDefinition1.serializeToString() +
 			attribute1.serializeToString() + richMember.serializeToString() + richDestination.serializeToString() +
 			richResource.serializeToString() + richUser.serializeToString() + richGroup.serializeToString() +
-			richFacility.serializeToString() + resourceTag1.serializeToString() + exService1.serializeToString();
+			richFacility.serializeToString() + resourceTag1.serializeToString() + exService1.serializeToString() +
+			securityTeam1.serializeToString();
 
 		List<PerunBean> perunBeans = new ArrayList<PerunBean>();
 		perunBeans = AuditParser.parseLog(bigLog);
-		assertEquals(23, perunBeans.size());
+		assertEquals(24, perunBeans.size());
 		assertTrue(perunBeans.contains(user));
 		assertTrue(perunBeans.contains(attribute1));
 		assertTrue(perunBeans.contains(attributeDefinition1));
@@ -543,6 +554,7 @@ public class AuditParserTest {
 		assertTrue(perunBeans.contains(richFacility));
 		assertTrue(perunBeans.contains(resourceTag1));
 		assertTrue(perunBeans.contains(exService1));
+		assertTrue(perunBeans.contains(securityTeam1));
 	}
 
 	private AttributeDefinition getAttributeDefinition1() {

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Role.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Role.java
@@ -14,6 +14,7 @@ public enum Role {
 	SERVICEUSER ("serviceuser"),
 	VOOBSERVER ("voobserver"),
 	TOPGROUPCREATOR ("topgroupcreator"),
+	SECURITYADMIN ("securityadmin"),
 	UNKNOWNROLENAME ("unknown");
 
 	private final String roleName;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/SecurityTeam.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/SecurityTeam.java
@@ -1,0 +1,113 @@
+package cz.metacentrum.perun.core.api;
+
+/**
+ * Security team entity
+ *
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+public class SecurityTeam extends Auditable implements Comparable<SecurityTeam> {
+	private String name;
+	private String description;
+
+	public SecurityTeam() {
+	}
+
+	public SecurityTeam(String name) {
+		super();
+		this.name = name;
+	}
+
+	public SecurityTeam(String name, String description) {
+		super();
+		this.name = name;
+		this.description = description;
+	}
+
+	public SecurityTeam(int id, String name, String description) {
+		super(id);
+		this.name = name;
+		this.description = description;
+	}
+
+	public SecurityTeam(int id, String name, String description, String createdAt, String createdBy, String modifiedAt,
+	                    String modifiedBy, Integer createdByUid, Integer modifiedByUid) {
+		super(id, createdAt, createdBy, modifiedAt, modifiedBy, createdByUid, modifiedByUid);
+		this.name = name;
+		this.description = description;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@Override
+	public String serializeToString() {
+		StringBuilder str = new StringBuilder();
+
+		return str.append(this.getClass().getSimpleName()).append(":[").append(
+				"id=<").append(getId()).append(">").append(
+				", name=<").append(getName() == null ? "\\0" : BeansUtils.createEscaping(getName())).append(">").append(
+				", description=<").append(getDescription() == null ? "\\0" : BeansUtils.createEscaping(getDescription())).append(">").append(
+				']').toString();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+
+		return str.append(this.getClass().getSimpleName()).append(":[").append(
+				"id='").append(this.getId()).append('\'').append(
+				", name='").append(name).append('\'').append(
+				", description='").append(description).append('\'').append(
+				']').toString();
+	}
+
+	public int compareTo(SecurityTeam securityTeam) {
+		if (securityTeam == null) {
+			throw new NullPointerException();
+		}
+		return this.getName().compareTo(securityTeam.getName());
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 7;
+		hash = 53 * hash + this.getId();
+		hash = 53 * hash + (this.name != null ? this.name.hashCode() : 0);
+		hash = 53 * hash + (this.description != null ? this.description.hashCode() : 0);
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final SecurityTeam other = (SecurityTeam) obj;
+		if (this.getId() != other.getId()) {
+			return false;
+		}
+		if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
+			return false;
+		}
+		if ((this.description == null) ? (other.description != null) : !this.description.equals(other.description)) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AlreadyAdminException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AlreadyAdminException.java
@@ -18,6 +18,7 @@ public class AlreadyAdminException extends PerunException {
 	private Vo vo;
 	private Group group;
 	private Group authorizedGroup;
+	private SecurityTeam securityTeam;
 
 	public AlreadyAdminException(AlreadyAdminRuntimeException rt) {
 		super(rt.getMessage(),rt);
@@ -100,6 +101,30 @@ public class AlreadyAdminException extends PerunException {
 		this.vo = vo;
 	}
 
+	public AlreadyAdminException(String message, Throwable cause, User user, SecurityTeam securityTeam) {
+		super(message, cause);
+		this.user = user;
+		this.securityTeam = securityTeam;
+	}
+
+	public AlreadyAdminException(String message, User user, SecurityTeam securityTeam) {
+		super(message);
+		this.user = user;
+		this.securityTeam = securityTeam;
+	}
+
+	public AlreadyAdminException(String message, Throwable cause, Group group, SecurityTeam securityTeam) {
+		super(message, cause);
+		this.authorizedGroup = group;
+		this.securityTeam = securityTeam;
+	}
+
+	public AlreadyAdminException(String message, Group group, SecurityTeam securityTeam) {
+		super(message);
+		this.authorizedGroup = group;
+		this.securityTeam = securityTeam;
+	}
+
 	// getters
 
 	public Member getMember() {
@@ -126,4 +151,7 @@ public class AlreadyAdminException extends PerunException {
 		return authorizedGroup;
 	}
 
+	public SecurityTeam getSecurityTeam() {
+		return securityTeam;
+	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SecurityTeamAlreadyAssignedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SecurityTeamAlreadyAssignedException.java
@@ -1,0 +1,37 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.SecurityTeam;
+
+/**
+ * Security team is already assigned to facility
+ *
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+public class SecurityTeamAlreadyAssignedException extends EntityAlreadyAssignedException {
+
+	private final SecurityTeam securityTeam;
+
+	public SecurityTeamAlreadyAssignedException(String message, SecurityTeam securityTeam) {
+		super(message);
+		this.securityTeam = securityTeam;
+	}
+
+	public SecurityTeamAlreadyAssignedException(String message, Throwable cause, SecurityTeam securityTeam) {
+		super(message, cause);
+		this.securityTeam = securityTeam;
+	}
+
+	public SecurityTeamAlreadyAssignedException(Throwable cause, SecurityTeam securityTeam) {
+		super(cause);
+		this.securityTeam = securityTeam;
+	}
+
+	public SecurityTeamAlreadyAssignedException(SecurityTeam securityTeam) {
+		super(securityTeam.toString());
+		this.securityTeam = securityTeam;
+	}
+
+	public SecurityTeam getSecurityTeam() {
+		return securityTeam;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SecurityTeamExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SecurityTeamExistsException.java
@@ -1,0 +1,21 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * Security team already exists in perun system
+ *
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+public class SecurityTeamExistsException extends EntityExistsException {
+
+	public SecurityTeamExistsException(String message) {
+		super(message);
+	}
+
+	public SecurityTeamExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SecurityTeamExistsException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SecurityTeamNotAssignedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SecurityTeamNotAssignedException.java
@@ -1,0 +1,37 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.SecurityTeam;
+
+/**
+ * Security team is not assigned to facility
+ *
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+public class SecurityTeamNotAssignedException extends EntityNotAssignedException {
+
+	private final SecurityTeam securityTeam;
+
+	public SecurityTeamNotAssignedException(String message, SecurityTeam securityTeam) {
+		super(message);
+		this.securityTeam = securityTeam;
+	}
+
+	public SecurityTeamNotAssignedException(String message, Throwable cause, SecurityTeam securityTeam) {
+		super(message, cause);
+		this.securityTeam = securityTeam;
+	}
+
+	public SecurityTeamNotAssignedException(Throwable cause, SecurityTeam securityTeam) {
+		super(cause);
+		this.securityTeam = securityTeam;
+	}
+
+	public SecurityTeamNotAssignedException(SecurityTeam securityTeam) {
+		super(securityTeam.toString());
+		this.securityTeam = securityTeam;
+	}
+
+	public SecurityTeam getSecurityTeam() {
+		return securityTeam;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SecurityTeamNotExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/SecurityTeamNotExistsException.java
@@ -1,0 +1,21 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * Security team not exists in perun system yet
+ *
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+public class SecurityTeamNotExistsException extends EntityNotExistsException {
+
+	public SecurityTeamNotExistsException(String message) {
+		super(message);
+	}
+
+	public SecurityTeamNotExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SecurityTeamNotExistsException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/UserAlreadyBlacklistedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/UserAlreadyBlacklistedException.java
@@ -1,0 +1,22 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * User is already blacklisted by security team
+ *
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+public class UserAlreadyBlacklistedException extends PerunException {
+
+	public UserAlreadyBlacklistedException(String message) {
+		super(message);
+	}
+
+	public UserAlreadyBlacklistedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public UserAlreadyBlacklistedException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -115,6 +115,16 @@ public class AuthzResolver {
 	}
 
 	/**
+	 * Returns true if the perun principal inside the perun session is security admin.
+	 *
+	 * @param sess perun session
+	 * @return true if the perun principal is security admin.
+	 */
+	public static boolean isSecurityAdmin(PerunSession sess) {
+		return cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.isSecurityAdmin(sess);
+	}
+
+	/**
 	 * Returns true if the perun principal inside the perun session is vo observer.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -20,6 +20,9 @@ import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.HostExistsException;
@@ -951,4 +954,45 @@ public interface FacilitiesManager {
 	 * @throws GroupNotExistsException 
 	 */
 	void removeFacilityContact(PerunSession sess, ContactGroup contactGroupToRemove) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, OwnerNotExistsException, UserNotExistsException, GroupNotExistsException;
+
+	/**
+	 * return assigned security teams for specific facility
+	 *
+	 * @param sess
+	 * @param facility
+	 * @return assigned security teams fot given facility
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException can do only PerunAdmin or FacilityAdmin of the facility
+	 * @throws FacilityNotExistsException
+	 */
+	List<SecurityTeam> getAssignedSecurityTeams(PerunSession sess, Facility facility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
+
+	/**
+	 * Assign given security team to given facility (means the facility trusts the security team)
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException can do only PerunAdmin or FacilityAdmin of the facility
+	 * @throws FacilityNotExistsException
+	 * @throws SecurityTeamNotExistsException
+	 * @throws SecurityTeamAlreadyAssignedException
+	 */
+	void assignSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, SecurityTeamNotExistsException, SecurityTeamAlreadyAssignedException;
+
+	/**
+	 * Remove (Unassign) given security team from given facility
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException can do only PerunAdmin or FacilityAdmin of the facility
+	 * @throws FacilityNotExistsException
+	 * @throws SecurityTeamNotExistsException
+	 * @throws SecurityTeamNotAssignedException
+	 */
+	void removeSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, SecurityTeamNotExistsException, SecurityTeamNotAssignedException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/Perun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/Perun.java
@@ -106,6 +106,12 @@ public interface Perun {
 	public RTMessagesManager getRTMessagesManager();
 
 	/**
+	 * Gets a Security teams manager.
+	 * @return Security teams manager
+	 */
+	public SecurityTeamsManager getSecurityTeamsManager();
+
+	/**
 	 * Gets a Searcher.
 	 * @return Searcher
 	 */

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/SecurityTeamsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/SecurityTeamsManager.java
@@ -1,0 +1,228 @@
+package cz.metacentrum.perun.core.api;
+
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
+import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyBlacklistedException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+
+import java.util.List;
+
+/**
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+public interface SecurityTeamsManager {
+
+	/**
+	 * Get list of SecurityTeams by access rights
+	 *  - PERUNADMIN : all teams
+	 *  - SECURITYADMIN : teams where user is admin
+	 *
+	 * @param perunSession
+	 * @return List of SecurityTeams or empty ArrayList<SecurityTeam>
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	List<SecurityTeam> getSecurityTeams(PerunSession perunSession) throws PrivilegeException, InternalErrorException;
+
+	/**
+	 * get all security teams in perun system
+	 *
+	 * @param perunSession
+	 * @return List of SecurityTeams or empty List<SecurityTeam>
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	List<SecurityTeam> getAllSecurityTeams(PerunSession perunSession) throws PrivilegeException, InternalErrorException;
+
+	/**
+	 * Create new SecurityTeam.
+	 *
+	 * @param perunSession
+	 * @param securityTeam SecurityTeam object with prefilled name
+	 * @return Newly created Security team with new id
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin.
+	 * @throws SecurityTeamExistsException
+	 */
+	SecurityTeam createSecurityTeam(PerunSession perunSession, SecurityTeam securityTeam) throws PrivilegeException, InternalErrorException, SecurityTeamExistsException;
+
+	/**
+	 * Updates SecurityTeam.
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @return returns updated SecurityTeam
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam updateSecurityTeam(PerunSession perunSession, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, SecurityTeamExistsException;
+
+	/**
+	 * Delete SecurityTeam.
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	void deleteSecurityTeam(PerunSession perunSession, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
+
+	/**
+	 * Find existing SecurityTeam by ID.
+	 *
+	 * @param perunSession
+	 * @param id
+	 * @return security team with given id
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam getSecurityTeamById(PerunSession perunSession, int id) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
+
+	/**
+	 * Find existing SecurityTeam by name.
+	 *
+	 * @param perunSession
+	 * @param name
+	 * @return security team with given name
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam getSecurityTeamByName(PerunSession perunSession, String name) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
+
+	/**
+	 * get all security admins of given security team
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @return list of users which are admis of given security team
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws SecurityTeamNotExistsException
+	 */
+	List<User> getAdmins(PerunSession perunSession, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
+
+	/**
+	 * create security admin from given user and add him as security admin of given security team
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param user user who will became a security administrator
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws SecurityTeamNotExistsException
+	 * @throws UserNotExistsException
+	 * @throws AlreadyAdminException
+	 */
+	void addAdmin(PerunSession perunSession, SecurityTeam securityTeam, User user) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, UserNotExistsException, AlreadyAdminException;
+
+	/**
+	 * Create group as security admins group of given security team (all users in group will have security admin rights)
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param group group which members will became a security administrators
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws SecurityTeamNotExistsException
+	 * @throws GroupNotExistsException
+	 * @throws AlreadyAdminException
+	 */
+	void addAdmin(PerunSession perunSession, SecurityTeam securityTeam, Group group) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, GroupNotExistsException, AlreadyAdminException;
+
+	/**
+	 * Remove security admin role for given security team from user
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param user
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws SecurityTeamNotExistsException
+	 * @throws UserNotExistsException
+	 * @throws UserNotAdminException
+	 */
+	void removeAdmin(PerunSession perunSession, SecurityTeam securityTeam, User user) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, UserNotExistsException, UserNotAdminException;
+
+	/**
+	 * Remove security admin role for given security team from group
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param group
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws SecurityTeamNotExistsException
+	 * @throws GroupNotExistsException
+	 * @throws GroupNotAdminException
+	 */
+	void removeAdmin(PerunSession perunSession, SecurityTeam securityTeam, Group group) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, GroupNotExistsException, GroupNotAdminException;
+
+	/**
+	 * Add User to black list of security team to filter him out.
+	 *
+	 * Description of adding can be null.
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param user
+	 * @param description
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws SecurityTeamNotExistsException
+	 * @throws UserNotExistsException
+	 * @throws AlreadyMemberException
+	 * @throws UserAlreadyBlacklistedException
+	 */
+	void addUserToBlacklist(PerunSession perunSession, SecurityTeam securityTeam, User user, String description) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, UserNotExistsException, AlreadyMemberException, UserAlreadyBlacklistedException;
+
+	/**
+	 * remove user from blacklist of given security team
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param user user who will became a security administrator
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 */
+	void removeUserFromBlacklist(PerunSession perunSession, SecurityTeam securityTeam, User user) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, UserNotExistsException, MemberNotExistsException, UserAlreadyRemovedException;
+
+	/**
+	 * get list of blacklisted users by security team
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @return lis of blacklisted users by security team
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws SecurityTeamNotExistsException
+	 */
+	List<User> getBlacklist(PerunSession perunSession, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
+
+	/**
+	 * get union of blacklists of all security teams assigned to facility
+	 *
+	 * @param perunSession
+	 * @param facility
+	 * @return list of blacklisted users for facility
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws SecurityTeamNotExistsException
+	 * @throws FacilityNotExistsException
+	 */
+	List<User> getBlacklist(PerunSession perunSession, Facility facility) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, FacilityNotExistsException;
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -15,6 +15,7 @@ import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichFacility;
 import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -36,6 +37,8 @@ import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -918,6 +921,36 @@ public interface FacilitiesManagerBl {
 	void removeFacilityContact(PerunSession sess, ContactGroup contactGroupToRemove) throws InternalErrorException;
 
 	/**
+	 * Return all security teams which specific facility trusts
+	 *
+	 * @param sess
+	 * @param facility specific facility
+	 * @return list of assigned security teams
+	 * @throws InternalErrorException
+	 */
+	List<SecurityTeam> getAssignedSecurityTeams(PerunSession sess, Facility facility) throws InternalErrorException;
+
+	/**
+	 * Assign given security team to given facility (means the facility trusts the security team)
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 */
+	void assignSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException;
+
+	/**
+	 * Remove (Unassign) given security team from given facility
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 */
+	void removeSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException;
+
+	/**
 	 * Check if facility contact for the user already exists.
 	 * Throw exception info not.
 	 *
@@ -955,4 +988,29 @@ public interface FacilitiesManagerBl {
 	 * @throws FacilityContactNotExistsException
 	 */
 	void checkFacilityContactExists(PerunSession sess, Facility facility, String name, Owner owner) throws InternalErrorException, FacilityContactNotExistsException;
+
+	/**
+	 * Check if security team is <b>not</b> assigned to facility.
+	 * Throw exception info is.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamAlreadyAssignedException
+	 */
+	void checkSecurityTeamNotAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws SecurityTeamAlreadyAssignedException, InternalErrorException;
+
+	/**
+	 * Check if security team is assigned to facility.
+	 * Throw exception info not.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotAssignedException
+	 */
+	void checkSecurityTeamAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws SecurityTeamNotAssignedException, InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/PerunBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/PerunBl.java
@@ -14,6 +14,7 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.RTMessagesManager;
 import cz.metacentrum.perun.core.api.ResourcesManager;
 import cz.metacentrum.perun.core.api.Searcher;
+import cz.metacentrum.perun.core.api.SecurityTeamsManager;
 import cz.metacentrum.perun.core.api.ServicesManager;
 import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.VosManager;
@@ -126,6 +127,12 @@ public interface PerunBl extends Perun {
 	public RTMessagesManager getRTMessagesManager();
 
 	/**
+	 * Gets a Security Teams manager.
+	 * @return Security Teams manager
+	 */
+	public SecurityTeamsManager getSecurityTeamsManager();
+
+	/**
 	 * Gets a Searcher.
 	 * @return Searcher
 	 */
@@ -208,6 +215,12 @@ public interface PerunBl extends Perun {
 	 * @return Messages manager
 	 */
 	public RTMessagesManagerBl getRTMessagesManagerBl();
+
+	/**
+	 * Gets a Security Teams manager.
+	 * @return Security Teams manager
+	 */
+	public SecurityTeamsManagerBl getSecurityTeamsManagerBl();
 
 	/**
 	 * Gets a AuthzResolver.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SecurityTeamsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SecurityTeamsManagerBl.java
@@ -1,0 +1,312 @@
+package cz.metacentrum.perun.core.bl;
+
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.SecurityTeam;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyBlacklistedException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+
+import java.util.List;
+
+/**
+ * Created by ondrej on 12.8.15.
+ */
+public interface SecurityTeamsManagerBl {
+
+	/**
+	 * Get list of SecurityTeams by access rights
+	 *  - PERUNADMIN : all teams
+	 *  - SECURITYADMIN : teams where user is admin
+	 *
+	 * @param sess
+	 * @return list of security teams by access rights
+	 * @throws InternalErrorException
+	 */
+	List<SecurityTeam> getSecurityTeams(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * get all security teams in perun system
+	 *
+	 * @param sess
+	 * @return list of all security teams
+	 * @throws InternalErrorException
+	 */
+	List<SecurityTeam> getAllSecurityTeams(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * Create security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return Newly created Security team with new id
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamExistsException
+	 */
+	SecurityTeam createSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException;
+
+	/**
+	 * Update security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return updated security team
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam updateSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException;
+
+	/**
+	 * Delete security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException;
+
+	/**
+	 * get security team by its id
+	 *
+	 * @param sess
+	 * @param id
+	 * @return security team with given id
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam getSecurityTeamById(PerunSession sess, int id) throws InternalErrorException, SecurityTeamNotExistsException;
+
+	/**
+	 * get security team by its name
+	 *
+	 * @param sess
+	 * @param name
+	 * @return security team with given name
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam getSecurityTeamByName(PerunSession sess, String name) throws InternalErrorException, SecurityTeamNotExistsException;
+
+	/**
+	 * get all security admins of given security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return list of users which are security admins in security team
+	 * @throws InternalErrorException
+	 */
+	List<User> getAdmins(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
+
+	/**
+	 * create security admin from given user and add him as security admin of given security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws InternalErrorException
+	 * @throws AlreadyAdminException
+	 */
+	void addAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, AlreadyAdminException;
+
+	/**
+	 * Create group as security admins group of given security team (all users in group will have security admin rights)
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param group
+	 * @throws InternalErrorException
+	 * @throws AlreadyAdminException
+	 */
+	void addAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, AlreadyAdminException;
+
+	/**
+	 * Remove security admin role for given security team from user
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws InternalErrorException
+	 * @throws UserNotAdminException
+	 */
+	void removeAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, UserNotAdminException;
+
+	/**
+	 * Remove security admin role for given security team from group
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param group
+	 * @throws InternalErrorException
+	 * @throws GroupNotAdminException
+	 */
+	void removeAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException;
+
+	/**
+	 * Blacklist user by given security team with description.
+	 *
+	 * Description can be null.
+	 * 
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @param description
+	 * @throws InternalErrorException
+	 */
+	void addUserToBlacklist(PerunSession sess, SecurityTeam securityTeam, User user, String description) throws InternalErrorException;
+
+	/**
+	 * remove user from blacklist of given security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws InternalErrorException
+	 */
+	void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException;
+
+	/**
+	 * get blacklist of security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return lis of blacklisted users by security team
+	 * @throws InternalErrorException
+	 */
+	List<User> getBlacklist(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
+
+	/**
+	 * get union of blacklists of all security teams assigned to facility
+	 *
+	 * @param sess
+	 * @param facility
+	 * @return list of blacklisted users for facility
+	 * @throws InternalErrorException
+	 */
+	List<User> getBlacklist(PerunSession sess, Facility facility) throws InternalErrorException;
+
+
+	/**
+	 * check if security team exists
+	 * throw exception if doesn't
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws SecurityTeamNotExistsException
+	 * @throws InternalErrorException
+	 */
+	void checkSecurityTeamExists(PerunSession sess, SecurityTeam securityTeam) throws SecurityTeamNotExistsException, InternalErrorException;
+
+	/**
+	 * check if security team does <b>not</b> exist
+	 * throw exception if do
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws SecurityTeamExistsException
+	 * @throws InternalErrorException
+	 */
+	void checkSecurityTeamNotExists(PerunSession sess, SecurityTeam securityTeam) throws SecurityTeamExistsException, InternalErrorException;
+
+	/**
+	 * check if name is unique
+	 * throw exception if it is not
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 */
+	void checkSecurityTeamUniqueName(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException;
+
+	/**
+	 * check if user is not security admin of given security team
+	 * throw exception if it is
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws AlreadyAdminException
+	 * @throws InternalErrorException
+	 */
+	void checkUserIsNotSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws AlreadyAdminException, InternalErrorException;
+
+	/**
+	 * check if user is security admin of given security team
+	 * throw exception if is not
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws UserNotAdminException
+	 * @throws InternalErrorException
+	 */
+	void checkUserIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws UserNotAdminException, InternalErrorException;
+
+	/**
+	 * check if group is not security admin of given security team
+	 * throw exception if it is
+	 *
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param group
+	 * @throws AlreadyAdminException
+	 * @throws InternalErrorException
+	 */
+	void checkGroupIsNotSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws AlreadyAdminException, InternalErrorException;
+
+	/**
+	 * check if group is security admin of given security team
+	 * throw exception if is not
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param group
+	 * @throws GroupNotAdminException
+	 * @throws InternalErrorException
+	 */
+	void checkGroupIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws GroupNotAdminException, InternalErrorException;
+
+	/**
+	 * check if user is not blacklisted by given security team
+	 * throw exception if is
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws UserAlreadyBlacklistedException
+	 * @throws InternalErrorException
+	 */
+	void checkUserIsNotInBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws UserAlreadyBlacklistedException, InternalErrorException;
+
+	/**
+	 * check if user is blacklisted by given security team
+	 * throw exception if is not
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws UserAlreadyRemovedException
+	 * @throws InternalErrorException
+	 */
+	void checkUserIsInBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws UserAlreadyRemovedException, InternalErrorException;
+
+	/**
+	 * control if user is blacklisted by given security team
+	 *
+	 * @param sess
+	 * @param st
+	 * @param user
+	 * @return true if given user is blacklisted
+	 * @throws InternalErrorException
+	 */
+	boolean isUserBlacklisted(PerunSession sess, SecurityTeam st, User user) throws InternalErrorException;
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -33,6 +34,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -161,6 +163,11 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				// Facility admin and resource, get facility id from resource and check if the user is facility admin
 				if (beanName.equals(Resource.class.getSimpleName())) {
 					return sess.getPerunPrincipal().getRoles().hasRole(role, Facility.class.getSimpleName(), ((Resource) complementaryObject).getFacilityId());
+				}
+			} else if (role.equals(Role.SECURITYADMIN)) {
+				// Security admin, check if security admin is admin of the SecurityTeam
+				if (beanName.equals(SecurityTeam.class.getSimpleName())) {
+					return sess.getPerunPrincipal().getRoles().hasRole(role, SecurityTeam.class.getSimpleName(), ((SecurityTeam) complementaryObject).getId());
 				}
 			} else if (role.equals(Role.GROUPADMIN) || role.equals(Role.TOPGROUPCREATOR)) {
 				// Group admin can see some of the date of the VO
@@ -529,7 +536,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess perun session
 	 * @param user the user for setting role
-	 * @param role role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator )
+	 * @param role role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | securityadmin  )
 	 * @param complementaryObjects objects for which role will be set
 	 *
 	 * @throws InternalErrorException
@@ -567,7 +574,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess perun session
 	 * @param user the user for setting role
-	 * @param role role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator )
+	 * @param role role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | securityadmin )
 	 * @param complementaryObject object for which role will be set
 	 *
 	 * @throws InternalErrorException
@@ -825,6 +832,15 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				} else {
 					throw new InternalErrorException("Not supported complementary object for FacilityAdmin: " + complementaryObject);
 				}
+			} else if(role.equals(Role.SECURITYADMIN)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't set SecurityAdmin rights without SecurityTeam.");
+				} else if(complementaryObject instanceof SecurityTeam) {
+					if(user != null) addAdmin(sess, (SecurityTeam) complementaryObject, user);
+					else addAdmin(sess, (SecurityTeam) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for FacilityAdmin: " + complementaryObject);
+				}
 			} else {
 				throw new InternalErrorException("Not supported role: " + role);
 			}
@@ -879,6 +895,15 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				} else {
 					throw new InternalErrorException("Not supported complementary object for FacilityAdmin: " + complementaryObject);
 				}
+			} else if(role.equals(Role.SECURITYADMIN)) {
+				if(complementaryObject == null) {
+					throw new InternalErrorException("Not supported operation, can't unset SecurityAdmin rights without Security this way.");
+				} else if(complementaryObject instanceof SecurityTeam) {
+					if(user != null) removeAdmin(sess, (SecurityTeam) complementaryObject, user);
+					else removeAdmin(sess, (SecurityTeam) complementaryObject, authorizedGroup);
+				} else {
+					throw new InternalErrorException("Not supported complementary object for VoObserver: " + complementaryObject);
+				}
 			} else {
 				throw new InternalErrorException("Not supported role: " + role);
 			}
@@ -932,6 +957,16 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 */
 	public static boolean isFacilityAdmin(PerunSession sess) {
 		return sess.getPerunPrincipal().getRoles().hasRole(Role.FACILITYADMIN);
+	}
+
+	/**
+	 * Returns true if the perun principal inside the perun session is security admin.
+	 *
+	 * @param sess perun session
+	 * @return true if the perun principal is security admin.
+	 */
+	public static boolean isSecurityAdmin(PerunSession sess) {
+		return sess.getPerunPrincipal().getRoles().hasRole(Role.SECURITYADMIN);
 	}
 
 	/**
@@ -1103,6 +1138,18 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 							}
 						}
 					}
+
+					if (beanName.equals(SecurityTeam.class.getSimpleName())) {
+						for (Integer beanId : sess.getPerunPrincipal().getRoles().get(role).get(beanName)) {
+							try {
+								complementaryObjects.add(perunBlImpl.getSecurityTeamsManagerBl().getSecurityTeamById(sess, beanId));
+							} catch (SecurityTeamNotExistsException e) {
+								//this is ok, securityTeam was probably deleted but still exists in user session, only log it
+								log.debug("SecurityTeam not find by id {} but still exists in user session when getComplementaryObjectsForRole method was called.", beanId);
+							}
+						}
+					}
+
 				}
 			}
 		}
@@ -1222,6 +1269,10 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		authzResolverImpl.removeAllAuthzForService(sess, service);
 	}
 
+	public static void removeAllAuthzForSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException {
+		authzResolverImpl.removeAllAuthzForSecurityTeam(sess, securityTeam);
+	}
+
 	public static void addAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, AlreadyAdminException {
 		authzResolverImpl.addAdmin(sess, facility, user);
 	}
@@ -1262,12 +1313,28 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		authzResolverImpl.addAdmin(sess, vo, group);
 	}
 
+	public static void addAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, AlreadyAdminException {
+		authzResolverImpl.addAdmin(sess, securityTeam, user);
+	}
+
+	public static void addAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, AlreadyAdminException {
+		authzResolverImpl.addAdmin(sess, securityTeam, group);
+	}
+
 	public static void removeAdmin(PerunSession sess, Vo vo, User user) throws InternalErrorException, UserNotAdminException {
 		authzResolverImpl.removeAdmin(sess, vo, user);
 	}
 
 	public static void removeAdmin(PerunSession sess, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException {
 		authzResolverImpl.removeAdmin(sess, vo, group);
+	}
+
+	public static void removeAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, UserNotAdminException {
+		authzResolverImpl.removeAdmin(sess, securityTeam, user);
+	}
+
+	public static void removeAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException {
+		authzResolverImpl.removeAdmin(sess, securityTeam, group);
 	}
 
 	public static void addObserver(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyAdminException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -27,6 +27,7 @@ import cz.metacentrum.perun.core.api.RichFacility;
 import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
@@ -50,6 +51,8 @@ import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
@@ -838,6 +841,22 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 		this.getFacilitiesManagerImpl().checkFacilityContactExists(sess, facility, name, user);
 	}
 
+	public List<SecurityTeam> getAssignedSecurityTeams(PerunSession sess, Facility facility) throws InternalErrorException {
+		return facilitiesManagerImpl.getAssignedSecurityTeams(sess, facility);
+	}
+
+	@Override
+	public void assignSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException {
+		facilitiesManagerImpl.assignSecurityTeam(sess, facility, securityTeam);
+		getPerunBl().getAuditer().log(sess, "{} was assigned to {}.", securityTeam, facility);
+	}
+
+	@Override
+	public void removeSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException {
+		facilitiesManagerImpl.removeSecurityTeam(sess, facility, securityTeam);
+		getPerunBl().getAuditer().log(sess, "{} was removed from {}.", securityTeam, facility);
+	}
+
 	@Override
 	public void checkFacilityContactExists(PerunSession sess, Facility facility, String name, Group group) throws InternalErrorException, FacilityContactNotExistsException {
 		this.getFacilitiesManagerImpl().checkFacilityContactExists(sess, facility, name, group);
@@ -846,6 +865,16 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	@Override
 	public void checkFacilityContactExists(PerunSession sess, Facility facility, String name, Owner owner) throws InternalErrorException, FacilityContactNotExistsException {
 		this.getFacilitiesManagerImpl().checkFacilityContactExists(sess, facility, name, owner);
+	}
+
+	@Override
+	public void checkSecurityTeamNotAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws SecurityTeamAlreadyAssignedException, InternalErrorException {
+		getFacilitiesManagerImpl().checkSecurityTeamNotAssigned(sess, facility, securityTeam);
+	}
+
+	@Override
+	public void checkSecurityTeamAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws SecurityTeamNotAssignedException, InternalErrorException {
+		getFacilitiesManagerImpl().checkSecurityTeamAssigned(sess, facility, securityTeam);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -20,6 +20,7 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.RTMessagesManager;
 import cz.metacentrum.perun.core.api.ResourcesManager;
 import cz.metacentrum.perun.core.api.Searcher;
+import cz.metacentrum.perun.core.api.SecurityTeamsManager;
 import cz.metacentrum.perun.core.api.ServicesManager;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.UsersManager;
@@ -42,6 +43,7 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.RTMessagesManagerBl;
 import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
 import cz.metacentrum.perun.core.bl.SearcherBl;
+import cz.metacentrum.perun.core.bl.SecurityTeamsManagerBl;
 import cz.metacentrum.perun.core.bl.ServicesManagerBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.bl.VosManagerBl;
@@ -67,6 +69,7 @@ public class PerunBlImpl implements PerunBl {
 	private OwnersManager ownersManager = null;
 	private AuditMessagesManager auditMessagesManager = null;
 	private RTMessagesManager rtMessagesManager = null;
+	private SecurityTeamsManager securityTeamsManager = null;
 	private Searcher searcher = null;
 
 	private ModulesUtilsBl modulesUtilsBl = null;
@@ -83,6 +86,7 @@ public class PerunBlImpl implements PerunBl {
 	private OwnersManagerBl ownersManagerBl = null;
 	private AuditMessagesManagerBl auditMessagesManagerBl = null;
 	private RTMessagesManagerBl rtMessagesManagerBl = null;
+	private SecurityTeamsManagerBl securityTeamsManagerBl = null;
 	private AuthzResolverBl authzResolverBl = null;
 	private SearcherBl searcherBl = null;
 
@@ -173,6 +177,14 @@ public class PerunBlImpl implements PerunBl {
 
 	public void setRTMessagesManager(RTMessagesManager rtMessagesManager) {
 		this.rtMessagesManager = rtMessagesManager;
+	}
+
+	public SecurityTeamsManager getSecurityTeamsManager() {
+		return securityTeamsManager;
+	}
+
+	public void setSecurityTeamsManager(SecurityTeamsManager securityTeamsManager) {
+		this.securityTeamsManager = securityTeamsManager;
 	}
 
 	public void setVosManager(VosManager vosManager) {
@@ -363,6 +375,14 @@ public class PerunBlImpl implements PerunBl {
 		this.ownersManagerBl = ownersManagerBl;
 	}
 
+	public SecurityTeamsManagerBl getSecurityTeamsManagerBl() {
+		return securityTeamsManagerBl;
+	}
+
+	public void setSecurityTeamsManagerBl(SecurityTeamsManagerBl securityTeamsManagerBl) {
+		this.securityTeamsManagerBl = securityTeamsManagerBl;
+	}
+
 	public Auditer getAuditer() {
 		return this.auditer;
 	}
@@ -455,6 +475,7 @@ public class PerunBlImpl implements PerunBl {
 			"extSourcesManager='" + extSourcesManager + "', " +
 			"attributesManager='" + attributesManager + "', " +
 			"rtMessagesManager='" + rtMessagesManager + "', " +
+			"securityTeamsManager='" + securityTeamsManager + "', " +
 			"searcher='" + searcher + "', " +
 			"servicesManager='" + servicesManager + "']";
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
@@ -1,0 +1,233 @@
+package cz.metacentrum.perun.core.blImpl;
+
+import cz.metacentrum.perun.core.api.AuthzResolver;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.SecurityTeam;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyBlacklistedException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.SecurityTeamsManagerBl;
+import cz.metacentrum.perun.core.implApi.SecurityTeamsManagerImplApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by ondrej on 12.8.15.
+ */
+public class SecurityTeamsManagerBlImpl implements SecurityTeamsManagerBl {
+
+	private final static Logger log = LoggerFactory.getLogger(SecurityTeamsManagerBlImpl.class);
+
+	private final SecurityTeamsManagerImplApi securityTeamsManagerImpl;
+	private PerunBl perunBl;
+
+	public SecurityTeamsManagerBlImpl(SecurityTeamsManagerImplApi securityTeamsManagerImpl) {
+		this.securityTeamsManagerImpl = securityTeamsManagerImpl;
+	}
+
+	@Override
+	public List<SecurityTeam> getSecurityTeams(PerunSession sess) throws InternalErrorException {
+		if (AuthzResolverBlImpl.hasRole(sess.getPerunPrincipal(), Role.PERUNADMIN)) {
+			return getSecurityTeamsManagerImpl().getAllSecurityTeams(sess);
+		} else if (AuthzResolverBlImpl.hasRole(sess.getPerunPrincipal(), Role.SECURITYADMIN)) {
+
+			List<SecurityTeam> securityTeams = new ArrayList<>();
+
+			// Get SecurityTeams where user is Admin
+			for (PerunBean st: AuthzResolver.getComplementaryObjectsForRole(sess, Role.SECURITYADMIN, SecurityTeam.class)) {
+				securityTeams.add((SecurityTeam) st);
+			}
+
+			return securityTeams;
+		} else {
+			throw new InternalErrorException("Wrong Entry. Should throw PrivilegeException");
+		}
+	}
+
+	@Override
+	public List<SecurityTeam> getAllSecurityTeams(PerunSession sess) throws InternalErrorException {
+		return getSecurityTeamsManagerImpl().getAllSecurityTeams(sess);
+	}
+
+	@Override
+	public SecurityTeam createSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws SecurityTeamExistsException, InternalErrorException {
+		securityTeam = getSecurityTeamsManagerImpl().createSecurityTeam(sess, securityTeam);
+		getPerunBl().getAuditer().log(sess, "{} was created.", securityTeam);
+		return securityTeam;
+	}
+
+	@Override
+	public SecurityTeam updateSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException {
+		securityTeam = getSecurityTeamsManagerImpl().updateSecurityTeam(sess, securityTeam);
+		getPerunBl().getAuditer().log(sess, "{} was updated.", securityTeam);
+		return securityTeam;
+	}
+
+	@Override
+	public void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws SecurityTeamNotExistsException, InternalErrorException {
+		getSecurityTeamsManagerImpl().deleteSecurityTeam(sess, securityTeam);
+		getPerunBl().getAuditer().log(sess, "{} was deleted.", securityTeam);
+
+	}
+
+	@Override
+	public SecurityTeam getSecurityTeamById(PerunSession sess, int id) throws SecurityTeamNotExistsException, InternalErrorException {
+		return getSecurityTeamsManagerImpl().getSecurityTeamById(sess, id);
+	}
+
+	@Override
+	public SecurityTeam getSecurityTeamByName(PerunSession sess, String name) throws SecurityTeamNotExistsException, InternalErrorException {
+		return getSecurityTeamsManagerImpl().getSecurityTeamByName(sess, name);
+	}
+
+	@Override
+	public List<User> getAdmins(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException {
+		return getSecurityTeamsManagerImpl().getAdmins(sess, securityTeam);
+	}
+
+	@Override
+	public void addAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws AlreadyAdminException, InternalErrorException {
+		AuthzResolverBlImpl.addAdmin(sess, securityTeam, user);
+		getPerunBl().getAuditer().log(sess, "{} was added as security admin of {}.", user, securityTeam);
+	}
+
+	@Override
+	public void addAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, AlreadyAdminException {
+		AuthzResolverBlImpl.addAdmin(sess, securityTeam, group);
+		getPerunBl().getAuditer().log(sess, "{} was added as security admins of {}.", group, securityTeam);
+	}
+
+	@Override
+	public void removeAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws UserNotAdminException, InternalErrorException {
+		AuthzResolverBlImpl.removeAdmin(sess, securityTeam, user);
+		getPerunBl().getAuditer().log(sess, "{} was removed from security admins of {}.", user, securityTeam);
+	}
+
+	@Override
+	public void removeAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException {
+		AuthzResolverBlImpl.removeAdmin(sess, securityTeam, group);
+		getPerunBl().getAuditer().log(sess, "{} was removed from security admins of {}.", group, securityTeam);
+	}
+
+	@Override
+	public void addUserToBlacklist(PerunSession sess, SecurityTeam securityTeam, User user, String description) throws InternalErrorException {
+		getSecurityTeamsManagerImpl().addUserToBlacklist(sess, securityTeam, user, description);
+		getPerunBl().getAuditer().log(sess, "{} add to blaclist of {} with description '{}'.", user, securityTeam, description);
+	}
+
+	@Override
+	public void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException {
+		getSecurityTeamsManagerImpl().removeUserFromBlacklist(sess, securityTeam, user);
+		getPerunBl().getAuditer().log(sess, "{} remove from blaclist of {}.", user, securityTeam);
+	}
+
+	@Override
+	public List<User> getBlacklist(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException {
+		List<SecurityTeam> wrapper = new ArrayList<>();
+		wrapper.add(securityTeam);
+		return getSecurityTeamsManagerImpl().getBlacklist(sess, wrapper);
+	}
+
+	@Override
+	public List<User> getBlacklist(PerunSession sess, Facility facility) throws InternalErrorException {
+		List<SecurityTeam> securityTeams = perunBl.getFacilitiesManagerBl().getAssignedSecurityTeams(sess, facility);
+		return getSecurityTeamsManagerImpl().getBlacklist(sess, securityTeams);
+	}
+
+
+	@Override
+	public void checkSecurityTeamExists(PerunSession sess, SecurityTeam securityTeam) throws SecurityTeamNotExistsException, InternalErrorException {
+		getSecurityTeamsManagerImpl().checkSecurityTeamExists(sess, securityTeam);
+	}
+
+	@Override
+	public void checkSecurityTeamNotExists(PerunSession sess, SecurityTeam securityTeam) throws SecurityTeamExistsException, InternalErrorException {
+		getSecurityTeamsManagerImpl().checkSecurityTeamNotExists(sess, securityTeam);
+	}
+
+	@Override
+	public void checkSecurityTeamUniqueName(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException {
+		getSecurityTeamsManagerImpl().checkSecurityTeamUniqueName(sess, securityTeam);
+	}
+
+	@Override
+	public void checkUserIsNotSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws AlreadyAdminException, InternalErrorException {
+		getSecurityTeamsManagerImpl().checkUserIsNotSecurityAdmin(sess, securityTeam, user);
+	}
+
+	@Override
+	public void checkUserIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws UserNotAdminException, InternalErrorException {
+		getSecurityTeamsManagerImpl().checkUserIsSecurityAdmin(sess, securityTeam, user);
+	}
+
+	@Override
+	public void checkGroupIsNotSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws AlreadyAdminException, InternalErrorException {
+		getSecurityTeamsManagerImpl().checkGroupIsNotSecurityAdmin(sess, securityTeam, group);
+	}
+
+	@Override
+	public void checkGroupIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws GroupNotAdminException, InternalErrorException {
+		getSecurityTeamsManagerImpl().checkGroupIsSecurityAdmin(sess, securityTeam, group);
+	}
+
+	@Override
+	public void checkUserIsNotInBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws UserAlreadyBlacklistedException, InternalErrorException {
+		if (isUserBlacklisted(sess, securityTeam, user)) {
+			throw new UserAlreadyBlacklistedException("User "+user+" is already in blacklist of security team "+securityTeam);
+		}
+	}
+
+	@Override
+	public void checkUserIsInBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws UserAlreadyRemovedException, InternalErrorException {
+		if (!isUserBlacklisted(sess, securityTeam, user)) {
+			throw new UserAlreadyRemovedException("User "+user+" is not in blacklist of security team "+securityTeam);
+		}
+	}
+
+	@Override
+	public boolean isUserBlacklisted(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException {
+		return getSecurityTeamsManagerImpl().isUserBlacklisted(sess, securityTeam, user);
+	}
+
+
+	/**
+	 * Gets the securityTeamsManagerImpl.
+	 *
+	 * @return The securityTeamsManagerImpl.
+	 */
+	public SecurityTeamsManagerImplApi getSecurityTeamsManagerImpl() {
+		return this.securityTeamsManagerImpl;
+	}
+
+	/**
+	 * Sets the perunBl for this instance.
+	 *
+	 * @param perunBl The perunBl.
+	 */
+	public void setPerunBl(PerunBl perunBl) {
+		this.perunBl = perunBl;
+	}
+
+	/**
+	 * Gets the perunBl.
+	 *
+	 * @return The perunBl.
+	 */
+	public PerunBl getPerunBl() {
+		return this.perunBl;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -22,6 +22,7 @@ import cz.metacentrum.perun.core.api.RichFacility;
 import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -45,6 +46,9 @@ import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -619,7 +623,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		getFacilitiesManagerBl().addAdmin(sess, facility, group);
 	}
 
-	public void removeAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, FacilityNotExistsException, UserNotExistsException, PrivilegeException, UserNotAdminException{
+	public void removeAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, FacilityNotExistsException, UserNotExistsException, PrivilegeException, UserNotAdminException {
 		Utils.checkPerunSession(sess);
 
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
@@ -634,7 +638,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 	}
 
 	@Override
-	public void removeAdmin(PerunSession sess, Facility facility, Group group) throws InternalErrorException, FacilityNotExistsException, GroupNotExistsException, PrivilegeException, GroupNotAdminException{
+	public void removeAdmin(PerunSession sess, Facility facility, Group group) throws InternalErrorException, FacilityNotExistsException, GroupNotExistsException, PrivilegeException, GroupNotAdminException {
 		Utils.checkPerunSession(sess);
 
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
@@ -1118,6 +1122,46 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		}
 
 		this.getFacilitiesManagerBl().removeFacilityContact(sess, contactGroupToRemove);
+	}
+
+	@Override
+	public List<SecurityTeam> getAssignedSecurityTeams(PerunSession sess, Facility facility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException {
+		Utils.checkPerunSession(sess);
+		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+
+		if(!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "getAssignedSecurityTeams");
+		}
+
+		return this.getFacilitiesManagerBl().getAssignedSecurityTeams(sess, facility);
+	}
+
+	@Override
+	public void assignSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, FacilityNotExistsException, SecurityTeamAlreadyAssignedException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+		getFacilitiesManagerBl().checkSecurityTeamNotAssigned(sess, facility, securityTeam);
+
+		if(!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "assignSecurityTeam");
+		}
+
+		this.getFacilitiesManagerBl().assignSecurityTeam(sess, facility, securityTeam);
+	}
+
+	@Override
+	public void removeSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, SecurityTeamNotExistsException, SecurityTeamNotAssignedException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+		getFacilitiesManagerBl().checkSecurityTeamAssigned(sess, facility, securityTeam);
+
+		if(!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "removeSecurityTeam");
+		}
+
+		this.getFacilitiesManagerBl().removeSecurityTeam(sess, facility, securityTeam);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
@@ -1,0 +1,292 @@
+package cz.metacentrum.perun.core.entry;
+
+import cz.metacentrum.perun.core.api.AuthzResolver;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.SecurityTeam;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyBlacklistedException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.SecurityTeamsManagerBl;
+import cz.metacentrum.perun.core.impl.Utils;
+
+import java.util.List;
+
+/**
+ * Created by ondrej on 5.8.15.
+ */
+public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.SecurityTeamsManager {
+
+	private SecurityTeamsManagerBl securityTeamsManagerBl;
+	private PerunBl perunBl;
+
+	public SecurityTeamsManagerEntry(PerunBl perunBl) {
+		this.perunBl = perunBl;
+		this.securityTeamsManagerBl = perunBl.getSecurityTeamsManagerBl();
+	}
+
+	public SecurityTeamsManagerEntry() {
+	}
+
+	public SecurityTeamsManagerBl getSecurityTeamsManagerBl() {
+		return this.securityTeamsManagerBl;
+	}
+	public PerunBl getPerunBl() {
+		return this.perunBl;
+	}
+	public void setPerunBl(PerunBl perunBl) {
+		this.perunBl = perunBl;
+	}
+	public void setSecurityTeamsManagerBl(SecurityTeamsManagerBl securityTeamsManagerBl) {
+		this.securityTeamsManagerBl = securityTeamsManagerBl;
+	}
+
+	@Override
+	public List<SecurityTeam> getSecurityTeams(PerunSession sess) throws PrivilegeException, InternalErrorException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN)) {
+			throw new PrivilegeException(sess, "getSecurityTeams");
+		}
+
+		return getSecurityTeamsManagerBl().getSecurityTeams(sess);
+	}
+
+	@Override
+	public List<SecurityTeam> getAllSecurityTeams(PerunSession sess) throws PrivilegeException, InternalErrorException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN)
+				&& !AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN)) {
+			throw new PrivilegeException(sess, "getAllSecurityTeams");
+		}
+
+		return getSecurityTeamsManagerBl().getAllSecurityTeams(sess);
+	}
+
+	@Override
+	public SecurityTeam createSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws PrivilegeException, InternalErrorException, SecurityTeamExistsException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamNotExists(sess, securityTeam);
+		getSecurityTeamsManagerBl().checkSecurityTeamUniqueName(sess, securityTeam);
+		Utils.notNull(securityTeam, "securityTeam");
+		Utils.notNull(securityTeam.getName(), "securityTeam.name");
+
+		if (securityTeam.getName().length() > 128) {
+			throw new InternalErrorException("Security Team name is too long, >128 characters");
+		}
+
+		if (!securityTeam.getName().matches("^[-_a-zA-z0-9.]{1,128}$")) {
+			throw new InternalErrorException("Wrong Security name - must matches [-_a-zA-z0-9.]+ and not be longer than 128 characters.");
+		}
+
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+			throw new PrivilegeException(sess, "createSecurityTeam");
+		}
+
+		return getSecurityTeamsManagerBl().createSecurityTeam(sess, securityTeam);
+	}
+
+	@Override
+	public SecurityTeam updateSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, SecurityTeamExistsException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getSecurityTeamsManagerBl().checkSecurityTeamUniqueName(sess, securityTeam);
+		Utils.notNull(securityTeam, "securityTeam");
+		Utils.notNull(securityTeam.getName(), "securityTeam.name");
+
+		if (securityTeam.getName().length() > 128) {
+			throw new InternalErrorException("Security Team name is too long, >128 characters");
+		}
+
+		if (!securityTeam.getName().matches("^[-_a-zA-z0-9.]{1,128}$")) {
+			throw new InternalErrorException("Wrong Security name - must matches [-_a-zA-z0-9.]+ and not be longer than 128 characters.");
+		}
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "updateSecurityTeam");
+		}
+
+		return getSecurityTeamsManagerBl().updateSecurityTeam(sess, securityTeam);
+	}
+
+	@Override
+	public void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "deleteSecurityTeam");
+		}
+
+		getSecurityTeamsManagerBl().deleteSecurityTeam(sess, securityTeam);
+	}
+
+	@Override
+	public SecurityTeam getSecurityTeamById(PerunSession sess, int id) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN)
+				&& !AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN)
+				&& !(AuthzResolver.isAuthorized(sess, Role.RPC))) {
+			throw new PrivilegeException(sess, "getSecurityTeamById");
+		}
+
+		return getSecurityTeamsManagerBl().getSecurityTeamById(sess, id);
+	}
+
+	@Override
+	public SecurityTeam getSecurityTeamByName(PerunSession sess, String name) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(name, "name");
+
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN)
+				&& !AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN)
+				&& !(AuthzResolver.isAuthorized(sess, Role.RPC))) {
+			throw new PrivilegeException(sess, "getSecurityTeamByName");
+		}
+
+		return getSecurityTeamsManagerBl().getSecurityTeamByName(sess, name);
+	}
+
+	@Override
+	public List<User> getAdmins(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "getAdmins");
+		}
+
+		return getSecurityTeamsManagerBl().getAdmins(sess, securityTeam);
+	}
+
+	@Override
+	public void addAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, UserNotExistsException, AlreadyAdminException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
+
+		getSecurityTeamsManagerBl().checkUserIsNotSecurityAdmin(sess, securityTeam, user);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "addAdmin");
+		}
+
+		getSecurityTeamsManagerBl().addAdmin(sess, securityTeam, user);
+	}
+
+	@Override
+	public void addAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, GroupNotExistsException, AlreadyAdminException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		getSecurityTeamsManagerBl().checkGroupIsNotSecurityAdmin(sess, securityTeam, group);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "addAdmin");
+		}
+
+		getSecurityTeamsManagerBl().addAdmin(sess, securityTeam, group);
+
+	}
+
+	@Override
+	public void removeAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, UserNotExistsException, UserNotAdminException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
+
+		getSecurityTeamsManagerBl().checkUserIsSecurityAdmin(sess, securityTeam, user);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "removeAdmin");
+		}
+
+
+		getSecurityTeamsManagerBl().removeAdmin(sess, securityTeam, user);
+	}
+
+	@Override
+	public void removeAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, GroupNotExistsException, GroupNotAdminException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		getSecurityTeamsManagerBl().checkGroupIsSecurityAdmin(sess, securityTeam, group);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "removeAdmin");
+		}
+
+		getSecurityTeamsManagerBl().removeAdmin(sess, securityTeam, group);
+	}
+
+	@Override
+	public void addUserToBlacklist(PerunSession sess, SecurityTeam securityTeam, User user, String description) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, UserNotExistsException, UserAlreadyBlacklistedException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
+		getSecurityTeamsManagerBl().checkUserIsNotInBlacklist(sess, securityTeam, user);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "addUserToBlacklist");
+		}
+
+		getSecurityTeamsManagerBl().addUserToBlacklist(sess, securityTeam, user, description);
+	}
+
+	@Override
+	public void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, UserNotExistsException, UserAlreadyRemovedException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
+		getSecurityTeamsManagerBl().checkUserIsInBlacklist(sess, securityTeam, user);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "removeUserFromBlacklist");
+		}
+
+
+		getSecurityTeamsManagerBl().removeUserFromBlacklist(sess, securityTeam, user);
+	}
+
+	@Override
+	public List<User> getBlacklist(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException {
+		Utils.checkPerunSession(sess);
+		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "getBlacklist");
+		}
+
+		return getSecurityTeamsManagerBl().getBlacklist(sess, securityTeam);
+	}
+
+	@Override
+	public List<User> getBlacklist(PerunSession sess, Facility facility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "getBlacklist");
+		}
+
+		return getSecurityTeamsManagerBl().getBlacklist(sess, facility);
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
@@ -1,0 +1,361 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.SecurityTeam;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
+import cz.metacentrum.perun.core.implApi.SecurityTeamsManagerImplApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcPerunTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created by ondrej on 13.8.15.
+ */
+public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
+
+	private final static Logger log = LoggerFactory.getLogger(SecurityTeamsManagerImpl.class);
+
+	protected final static String securityTeamMappingSelectQuery = "security_teams.id as security_teams_id,security_teams.name as security_teams_name, " +
+			"security_teams.description as security_teams_description, " +
+			"security_teams.created_at as security_teams_created_at, security_teams.created_by as security_teams_created_by, " +
+			"security_teams.modified_by as security_teams_modified_by, security_teams.modified_at as security_teams_modified_at, " +
+			"security_teams.created_by_uid as security_teams_created_by_uid, security_teams.modified_by_uid as security_teams_modified_by_uid";
+
+	private JdbcPerunTemplate jdbc;
+
+	/**
+	 * Create new instance of this class.
+	 */
+	public SecurityTeamsManagerImpl(DataSource perunPool) {
+		this.jdbc = new JdbcPerunTemplate(perunPool);
+	}
+
+	/**
+	 * Converts s ResultSet's row to a SecurityTeam instance.
+	 */
+	protected static final RowMapper<SecurityTeam> SECURITY_TEAM_MAPPER = new RowMapper<SecurityTeam>() {
+
+		public SecurityTeam mapRow(ResultSet rs, int i) throws SQLException {
+			return new SecurityTeam(rs.getInt("security_teams_id"), rs.getString("security_teams_name"), rs.getString("security_teams_description"),
+					rs.getString("security_teams_created_at"),
+					rs.getString("security_teams_created_by"), rs.getString("security_teams_modified_at"), rs.getString("security_teams_modified_by"),
+					rs.getInt("security_teams_created_by_uid") == 0 ? null : rs.getInt("security_teams_created_by_uid"),
+					rs.getInt("security_teams_modified_by_uid") == 0 ? null : rs.getInt("security_teams_modified_by_uid"));
+		}
+	};
+
+	@Override
+	public List<SecurityTeam> getAllSecurityTeams(PerunSession sess) throws InternalErrorException {
+		try {
+			List<SecurityTeam> list = jdbc.query("select " + securityTeamMappingSelectQuery + " from security_teams", SECURITY_TEAM_MAPPER);
+
+			return list;
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public SecurityTeam createSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException {
+
+		// Get SecurityTeam ID
+		int securityTeamId;
+		try {
+			securityTeamId = Utils.getNewId(jdbc, "security_teams_id_seq");
+			jdbc.update("insert into security_teams(id, name, description, created_by, modified_by, created_by_uid, modified_by_uid) values (?,?,?,?,?,?,?)",
+					securityTeamId, securityTeam.getName(), securityTeam.getDescription(),
+					sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+
+		// set assigned id
+		securityTeam.setId(securityTeamId);
+
+		return securityTeam;
+	}
+
+	@Override
+	public SecurityTeam updateSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException {
+		try {
+			Map<String, Object> map = jdbc.queryForMap("select name, description from security_teams where id=?", securityTeam.getId());
+
+			if (!securityTeam.getName().equals(map.get("name"))) {
+				jdbc.update("update security_teams set name=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + "  where id=?",
+						securityTeam.getName(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), securityTeam.getId());
+			}
+			if (!securityTeam.getDescription().equals(map.get("description"))) {
+				jdbc.update("update security_teams set description=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + "  where id=?",
+						securityTeam.getDescription(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), securityTeam.getId());
+			}
+
+			return securityTeam;
+		} catch (EmptyResultDataAccessException ex) {
+			throw new SecurityTeamNotExistsException("Updating non existing SecurityTeam", ex);
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException {
+		try {
+			// Delete authz entries for this Security team
+			AuthzResolverBlImpl.removeAllAuthzForSecurityTeam(sess, securityTeam);
+
+			if (jdbc.update("delete from security_teams where id=?", securityTeam.getId()) == 0) {
+				throw new ConsistencyErrorException("no record was deleted from the DB.");
+			}
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		} catch (ConsistencyErrorException e) {
+			throw new SecurityTeamNotExistsException(e);
+		}
+
+		log.debug("SecurityTeam {} deleted", securityTeam);
+	}
+
+	@Override
+	public SecurityTeam getSecurityTeamById(PerunSession sess, int id) throws SecurityTeamNotExistsException, InternalErrorException {
+		try {
+			return jdbc.queryForObject("select " + securityTeamMappingSelectQuery + " from security_teams where id=?", SECURITY_TEAM_MAPPER, id);
+		} catch(EmptyResultDataAccessException ex) {
+			throw new SecurityTeamNotExistsException(ex);
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public SecurityTeam getSecurityTeamByName(PerunSession sess, String name) throws SecurityTeamNotExistsException, InternalErrorException {
+		try {
+			return jdbc.queryForObject("select " + securityTeamMappingSelectQuery + " from security_teams where name=?", SECURITY_TEAM_MAPPER, name);
+		} catch(EmptyResultDataAccessException ex) {
+			throw new SecurityTeamNotExistsException(ex);
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public List<User> getAdmins(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException {
+		try {
+			List<User> list = jdbc.query("select " + UsersManagerImpl.userMappingSelectQuery +
+							" from users inner join (" +
+							"select user_id from authz where security_team_id=? " +
+							"UNION (" +
+							"select user_id from members inner join (" +
+							"select gm.member_id, gm.group_id from groups_members " + Compatibility.getAsAlias("gm") +
+							" inner join " +
+							"authz on authz.authorized_group_id=gm.group_id where authz.security_team_id=? " +
+							") as member_group_ids on members.id=member_group_ids.member_id)" +
+							") as user_ids ON users.id=user_ids.user_id",
+					UsersManagerImpl.USER_MAPPER, securityTeam.getId(), securityTeam.getId());
+
+			return list;
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public void addUserToBlacklist(PerunSession sess, SecurityTeam securityTeam, User user, String description) throws InternalErrorException {
+		try {
+			jdbc.update("insert into blacklists(security_team_id, user_id, description, created_by, created_at, modified_by, modified_at, created_by_uid, modified_by_uid) " +
+					"values (?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)",
+					securityTeam.getId(), user.getId(), description, sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(),
+					sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException {
+		try {
+			jdbc.update("delete from blacklists where security_team_id=? and user_id=?",
+					securityTeam.getId(), user.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<User> getBlacklist(PerunSession sess, List<SecurityTeam> securityTeams) throws InternalErrorException {
+		try {
+			Set<User> blacklisted = new HashSet<>();
+			List<User> list;
+			for (SecurityTeam st : securityTeams) {
+
+				list = jdbc.query("select " + UsersManagerImpl.userMappingSelectQuery +
+								" from users inner join (" +
+								"select blacklists.user_id from blacklists where security_team_id=?" +
+								") as blacklisted_ids ON users.id=blacklisted_ids.user_id",
+						UsersManagerImpl.USER_MAPPER, st.getId());
+
+				blacklisted.addAll(list);
+
+			}
+			return new ArrayList<>(blacklisted);
+
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
+	public void checkSecurityTeamExists(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException {
+		if (!securityTeamExists(securityTeam)) {
+			throw new SecurityTeamNotExistsException("Security Team " + securityTeam + " doesn't exist in DB");
+		}
+	}
+
+	@Override
+	public void checkSecurityTeamNotExists(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException {
+		if (securityTeamExists(securityTeam)) {
+			throw new SecurityTeamExistsException("Security Team " + securityTeam + " already exists in DB");
+		}
+	}
+
+	@Override
+	public void checkSecurityTeamUniqueName(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException {
+		try {
+			int number = jdbc.queryForInt("select 1 from security_teams where name=?", securityTeam.getName());
+			if (number == 1) {
+				throw new SecurityTeamExistsException("Name of security team " +securityTeam+ " is not unique. It already exists.");
+			} else if (number > 1) {
+				throw new ConsistencyErrorException("Security teams with the same name as security team" + securityTeam + " exist multiple times.");
+			}
+		} catch(EmptyResultDataAccessException ex) {
+			// is ok. No row with same name was founded
+		} catch(RuntimeException e) {
+			throw new InternalErrorException(e);
+		} catch (ConsistencyErrorException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public void checkUserIsNotSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, AlreadyAdminException {
+		if (isUserSecurityAdmin(user, securityTeam)) {
+			throw new AlreadyAdminException("User " + user + " is already admin of " + securityTeam);
+		}
+	}
+
+	@Override
+	public void checkUserIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, UserNotAdminException {
+		if (!isUserSecurityAdmin(user, securityTeam)) {
+			throw new UserNotAdminException("User " + user + " is not admin of " + securityTeam);
+		}
+	}
+
+	@Override
+	public void checkGroupIsNotSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, AlreadyAdminException {
+		if (isGroupSecurityAdmin(group, securityTeam)) {
+			throw new AlreadyAdminException("Group " + group + " is already admin of " + securityTeam);
+		}
+	}
+
+	@Override
+	public void checkGroupIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException {
+		if (!isGroupSecurityAdmin(group, securityTeam)) {
+			throw new GroupNotAdminException("Group " + group + " is not admin of " + securityTeam);
+		}
+	}
+
+	@Override
+	public boolean isUserBlacklisted(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException {
+		try {
+			int number = jdbc.queryForInt("select 1 from blacklists where security_team_id=? and user_id=?", securityTeam.getId(), user.getId());
+			if (number == 1) {
+				return true;
+			} else if (number > 1) {
+				throw new ConsistencyErrorException("User " + user + " is blacklisted multiple in security team " + securityTeam);
+			}
+			return false;
+		} catch(EmptyResultDataAccessException ex) {
+			return false;
+		} catch(RuntimeException e) {
+			throw new InternalErrorException(e);
+		} catch (ConsistencyErrorException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+
+	private boolean securityTeamExists(SecurityTeam securityTeam) throws InternalErrorException {
+		try {
+			int number = jdbc.queryForInt("select 1 from security_teams where id=?", securityTeam.getId());
+			if (number == 1) {
+				return true;
+			} else if (number > 1) {
+				throw new ConsistencyErrorException("Security Team " + securityTeam + " exists multiple in DB");
+			}
+			return false;
+		} catch(EmptyResultDataAccessException ex) {
+			return false;
+		} catch(RuntimeException e) {
+			throw new InternalErrorException(e);
+		} catch (ConsistencyErrorException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	private boolean isUserSecurityAdmin(User user, SecurityTeam securityTeam) throws InternalErrorException {
+		try {
+			int number = jdbc.queryForInt("select 1 from authz where user_id=? and security_team_id=?", user.getId(), securityTeam.getId());
+			if (number == 1) {
+				return true;
+			} else if (number > 1) {
+				throw new ConsistencyErrorException("User " + user + " is security admin more times of one security team " + securityTeam);
+			}
+			return false;
+		} catch(EmptyResultDataAccessException ex) {
+			return false;
+		} catch(RuntimeException e) {
+			throw new InternalErrorException(e);
+		} catch (ConsistencyErrorException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	private boolean isGroupSecurityAdmin(Group group, SecurityTeam securityTeam) throws InternalErrorException {
+		try {
+			int number = jdbc.queryForInt("select 1 from authz where authorized_group_id=? and security_team_id=?", group.getId(), securityTeam.getId());
+			if (number == 1) {
+				return true;
+			} else if (number > 1) {
+				throw new ConsistencyErrorException("Group " + group + " is security admin more times of one security team " + securityTeam);
+			}
+			return false;
+		} catch(EmptyResultDataAccessException ex) {
+			return false;
+		} catch(RuntimeException e) {
+			throw new InternalErrorException(e);
+		} catch (ConsistencyErrorException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_blacklisted.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_blacklisted.java
@@ -1,0 +1,42 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
+
+import java.util.List;
+
+/**
+ * Get and set specified user krb Principal Name in arrayList included all userExtSources which are type of KERBEROS
+ *
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+public class urn_perun_user_facility_attribute_def_virt_blacklisted extends FacilityUserVirtualAttributesModuleAbstract {
+	@Override
+	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+		Attribute attribute = new Attribute(attributeDefinition);
+
+		List<SecurityTeam> securityTeams = sess.getPerunBl().getFacilitiesManagerBl().getAssignedSecurityTeams(sess, facility);
+
+		for (SecurityTeam st : securityTeams) {
+			if (sess.getPerunBl().getSecurityTeamsManagerBl().isUserBlacklisted(sess, st, user)) {
+				attribute.setValue(true);
+				return attribute;
+			}
+		}
+
+		attribute.setValue(null);
+		return attribute;
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_VIRT);
+		attr.setFriendlyName("blacklisted");
+		attr.setDisplayName("Blacklisted");
+		attr.setType(Boolean.class.getName());
+		attr.setDescription("Flag which means if user is banned by Security team");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -82,6 +83,15 @@ public interface AuthzResolverImplApi {
 	 * @throws InternalErrorException
 	 */
 	void removeAllAuthzForService(PerunSession sess, Service service) throws InternalErrorException;
+
+	/**
+	 * Removes all authz entries for the securityTeam
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 */
+	void removeAllAuthzForSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
 
 	/**
 	 * Add user role admin for the facility
@@ -193,6 +203,10 @@ public interface AuthzResolverImplApi {
 	 */
 	void addAdmin(PerunSession sess, Vo vo, Group group) throws InternalErrorException, AlreadyAdminException;
 
+	void addAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws AlreadyAdminException, InternalErrorException;
+
+	void addAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws AlreadyAdminException, InternalErrorException;
+
 	/**
 	 * Remove user role admin for the vo
 	 *
@@ -214,6 +228,10 @@ public interface AuthzResolverImplApi {
 	 * @throws GroupNotAdminException
 	 */
 	void removeAdmin(PerunSession sess, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException;
+
+	void removeAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws UserNotAdminException, InternalErrorException;
+
+	void removeAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException;
 
 	/**
 	 * Add user role vo observer for the vo
@@ -321,4 +339,5 @@ public interface AuthzResolverImplApi {
 	 * @throws InternalErrorException
 	 */
 	void removePerunAdmin(PerunSession sess, User user) throws InternalErrorException, UserNotAdminException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichResource;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
@@ -23,6 +24,8 @@ import cz.metacentrum.perun.core.api.exceptions.HostNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 
 /**
@@ -622,4 +625,60 @@ public interface FacilitiesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	void removeFacilityContact(PerunSession sess, Facility facility, String contactGroupName, Group group) throws InternalErrorException;
+
+
+	/**
+	 * Return all security teams which specific facility trusts
+	 *
+	 * @param sess
+	 * @param facility specific facility
+	 * @return list of assigned security teams
+	 * @throws InternalErrorException
+	 */
+	List<SecurityTeam> getAssignedSecurityTeams(PerunSession sess, Facility facility) throws InternalErrorException;
+
+	/**
+	 * Assign given security team to given facility (means the facility trusts the security team)
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 */
+	void assignSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException;
+
+	/**
+	 * Remove (Unassign) given security team from given facility
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 */
+	void removeSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException;
+
+	/**
+	 * Check if security team is <b>not</b> assigned to facility.
+	 * Throw exception info is.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamAlreadyAssignedException
+	 */
+	void checkSecurityTeamNotAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamAlreadyAssignedException;
+
+	/**
+	 * Check if security team is assigned to facility.
+	 * Throw exception info not.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotAssignedException
+	 */
+	void checkSecurityTeamAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotAssignedException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SecurityTeamsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SecurityTeamsManagerImplApi.java
@@ -1,0 +1,221 @@
+package cz.metacentrum.perun.core.implApi;
+
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.SecurityTeam;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+
+import java.util.List;
+
+/**
+ * Created by ondrej on 12.8.15.
+ */
+public interface SecurityTeamsManagerImplApi {
+
+	/**
+	 * get all security teams in perun system
+	 *
+	 * @param sess
+	 * @return list of all security teams
+	 * @throws InternalErrorException
+	 */
+	List<SecurityTeam> getAllSecurityTeams(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * Create security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return Newly created Security team with new id
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamExistsException
+	 */
+	SecurityTeam createSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException;
+
+	/**
+	 * Update security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return updated security team
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam updateSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException;
+
+	/**
+	 * Delete security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException;
+
+	/**
+	 * get security team by its id
+	 *
+	 * @param sess
+	 * @param id
+	 * @return security team with given id
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam getSecurityTeamById(PerunSession sess, int id) throws SecurityTeamNotExistsException, InternalErrorException;
+
+	/**
+	 * get security team by its name
+	 *
+	 * @param sess
+	 * @param name
+	 * @return security team with given name
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	SecurityTeam getSecurityTeamByName(PerunSession sess, String name) throws SecurityTeamNotExistsException, InternalErrorException;
+
+	/**
+	 * get all security admins of given security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return list of users which are security admins in security team
+	 * @throws InternalErrorException
+	 */
+	List<User> getAdmins(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
+
+	/**
+	 * Blacklist user by given security team with optional reason in description.
+	 *
+	 * Description can be null.
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @param description
+	 * @throws InternalErrorException
+	 */
+	void addUserToBlacklist(PerunSession sess, SecurityTeam securityTeam, User user, String description) throws InternalErrorException;
+
+	/**
+	 * remove user from blacklist of given security team
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws InternalErrorException
+	 */
+	void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException;
+
+	/**
+	 * get union of blacklists of security teams
+	 *
+	 * @param sess
+	 * @param securityTeams
+	 * @return list of blacklisted users for list of given security teams
+	 * @throws InternalErrorException
+	 */
+	List<User> getBlacklist(PerunSession sess, List<SecurityTeam> securityTeams) throws InternalErrorException;
+
+
+
+	/**
+	 * check if security team exists
+	 * throw exception if doesn't
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws SecurityTeamNotExistsException
+	 * @throws InternalErrorException
+	 */
+	void checkSecurityTeamExists(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException;
+
+	/**
+	 * check if security team does <b>not</b> exist
+	 * throw exception if do
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws SecurityTeamExistsException
+	 * @throws InternalErrorException
+	 */
+	void checkSecurityTeamNotExists(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException;
+
+	/**
+	 * check if name is unique
+	 * throw exception if it is not
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @throws InternalErrorException
+	 */
+	void checkSecurityTeamUniqueName(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException;
+
+	/**
+	 * check if user is not security admin of given security team
+	 * throw exception if it is
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws AlreadyAdminException
+	 * @throws InternalErrorException
+	 */
+	void checkUserIsNotSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, AlreadyAdminException;
+
+	/**
+	 * check if user is security admin of given security team
+	 * throw exception if is not
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws UserNotAdminException
+	 * @throws InternalErrorException
+	 */
+	void checkUserIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, UserNotAdminException;
+
+	/**
+	 * check if group is not security admin of given security team
+	 * throw exception if it is
+	 *
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param group
+	 * @throws AlreadyAdminException
+	 * @throws InternalErrorException
+	 */
+	void checkGroupIsNotSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, AlreadyAdminException;
+
+	/**
+	 * check if group is security admin of given security team
+	 * throw exception if is not
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param group
+	 * @throws GroupNotAdminException
+	 * @throws InternalErrorException
+	 */
+	void checkGroupIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException;
+
+	/**
+	 * check if user is not blacklisted by given security team
+	 * throw exception if is
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @param user
+	 * @throws InternalErrorException
+	 */
+	boolean isUserBlacklisted(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException;
+
+}

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -82,6 +82,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		<property name="ownersManagerBl" ref="ownersManagerBl"/>
 		<property name="auditMessagesManagerBl" ref="auditMessagesManagerBl"/>
 		<property name="RTMessagesManagerBl" ref="RTMessagesManagerBl"/>
+		<property name="securityTeamsManagerBl" ref="securityTeamsManagerBl"/>
 		<property name="searcherBl" ref="searcherBl"/>
 		<property name="modulesUtilsBl" ref="modulesUtilsBl"/>
 		<property name="databaseManagerBl" ref="databaseManagerBl"/>
@@ -98,6 +99,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		<property name="ownersManager" ref="ownersManager"/>
 		<property name="auditMessagesManager" ref="auditMessagesManager"/>
 		<property name="RTMessagesManager" ref="RTMessagesManager"/>
+		<property name="securityTeamsManager" ref="securityTeamsManager"/>
 		<property name="searcher" ref="searcher"/>
 		<property name="auditer" ref="auditer"/>
 		<property name="databaseManager" ref="databaseManager"/>
@@ -154,6 +156,10 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	<bean id="RTMessagesManager" class="cz.metacentrum.perun.core.entry.RTMessagesManagerEntry" scope="singleton">
 		<property name="perunBl" ref="perun"/>
 		<property name="RTMessagesManagerBl" ref="RTMessagesManagerBl"/>
+	</bean>
+	<bean id="securityTeamsManager" class="cz.metacentrum.perun.core.entry.SecurityTeamsManagerEntry" scope="singleton">
+		<property name="perunBl" ref="perun"/>
+		<property name="securityTeamsManagerBl" ref="securityTeamsManagerBl"/>
 	</bean>
 	<bean id="searcher" class="cz.metacentrum.perun.core.entry.SearcherEntry" scope="singleton">
 		<property name="perunBl" ref="perun"/>
@@ -214,6 +220,10 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	<bean id="RTMessagesManagerBl" class="cz.metacentrum.perun.core.blImpl.RTMessagesManagerBlImpl" scope="singleton">
 		<property name="perunBl" ref="perun"/>
 	</bean>
+	<bean id="securityTeamsManagerBl" class="cz.metacentrum.perun.core.blImpl.SecurityTeamsManagerBlImpl" scope="singleton">
+		<property name="perunBl" ref="perun"/>
+		<constructor-arg ref="securityTeamsManagerImpl" />
+	</bean>
 	<bean id="authzResolverBl" class="cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl" scope="singleton">
 	</bean>
 	<bean id="searcherBl" class="cz.metacentrum.perun.core.blImpl.SearcherBlImpl" scope="singleton">
@@ -253,6 +263,9 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		<constructor-arg ref="dataSource" />
 	</bean>
 	<bean id="ownersManagerImpl" class="cz.metacentrum.perun.core.impl.OwnersManagerImpl" scope="singleton">
+		<constructor-arg ref="dataSource" />
+	</bean>
+	<bean id="securityTeamsManagerImpl" class="cz.metacentrum.perun.core.impl.SecurityTeamsManagerImpl" scope="singleton">
 		<constructor-arg ref="dataSource" />
 	</bean>
 	<bean id="authzResolverImpl" class="cz.metacentrum.perun.core.impl.AuthzResolverImpl" scope="singleton" init-method="initialize">

--- a/perun-core/src/main/resources/test-data.sql
+++ b/perun-core/src/main/resources/test-data.sql
@@ -12,6 +12,7 @@ insert into roles (created_by_uid,modified_by_uid,id,name) values (null,null,81,
 insert into roles (created_by_uid,modified_by_uid,id,name) values (null,null,101,'topgroupcreator');
 insert into roles (created_by_uid,modified_by_uid,id,name) values (null,null,41,'notifications');
 insert into roles (created_by_uid,modified_by_uid,id,name) values (null,null,61,'serviceuser');
+insert into roles (created_by_uid,modified_by_uid,id,name) values (null,null,121,'securityadmin');
 insert into action_types (id,action_type,description) values (1,'read','Can read value.');
 insert into action_types (id,action_type,description) values (2,'write','Can write, rewrite and remove value.');
 insert into membership_types (id,membership_type,description) values (1,'DIRECT','Member is directly added into group');
@@ -2143,7 +2144,7 @@ insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routin
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,2,timestamp '2011-11-15 14:43:13.3','PERUNV3',timestamp '2011-11-15 14:43:13.3','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6071,timestamp '2015-01-21 13:05:00.4',timestamp '2015-01-16 14:29:29.6','PERUNV3',timestamp '2015-01-16 14:29:29.6','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6060,timestamp '2015-01-16 14:25:00.6',timestamp '2015-01-16 09:39:07.6','PERUNV3',timestamp '2015-01-16 09:39:07.6','PERUNV3','0');
-insert into configurations (property,value) values ('DATABASE VERSION','3.1.28');
+insert into configurations (property,value) values ('DATABASE VERSION','3.1.29');
 
 drop sequence service_principals_id_seq;
 create sequence service_principals_id_seq start with 1;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import cz.metacentrum.perun.core.api.OwnerType;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.RichUser;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
@@ -48,6 +50,9 @@ import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import java.util.Arrays;
@@ -164,7 +169,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		dest.setDestination("TestovaciDestinace");
 		perun.getServicesManager().addDestination(sess, serv, facility, dest);
 
-		List<Facility> facilities = perun.getFacilitiesManager().getFacilitiesByDestination(sess,"TestovaciDestinace");
+		List<Facility> facilities = perun.getFacilitiesManager().getFacilitiesByDestination(sess, "TestovaciDestinace");
 		assertTrue("At least one facility with destinatnion " + dest.getDestination() + " should exists", facilities.size() > 0);
 		assertTrue("Created facility with destinantion " + dest.getDestination() + " should exist between others", facilities.contains(facility));
 	}
@@ -173,7 +178,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	public void getFacilitiesByDestinationWhenFacilityNotExist() throws Exception {
 		System.out.println("FacilitiesManager.getFacilitiesByDestinationWhenFacilityNotExist");
 		List<Facility> facilities = perun.getFacilitiesManager().getFacilitiesByDestination(sess,"TestovaciDestinace neexistujici.");
-		assertTrue("No facility with such destination exist.",facilities.isEmpty());
+		assertTrue("No facility with such destination exist.", facilities.isEmpty());
 	}
 
 	@Test
@@ -191,7 +196,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		System.out.println("FacilitiesManager.getOwners");
 
 		List<Owner> owners = perun.getFacilitiesManager().getOwners(sess, facility);
-		assertTrue("there should be 1 owner",owners.size() == 1);
+		assertTrue("there should be 1 owner", owners.size() == 1);
 		assertTrue("facility should be owned by our owner", owners.contains(owner));
 
 		perun.getFacilitiesManager().removeOwner(sess, facility, owner);
@@ -322,8 +327,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
 
 		List<User> users = perun.getFacilitiesManager().getAllowedUsers(sess, facility);
-		assertTrue("our facility should have 1 allowed user",users.size() == 1);
-		assertTrue("our user should be between allowed on facility",users.contains(user));
+		assertTrue("our facility should have 1 allowed user", users.size() == 1);
+		assertTrue("our user should be between allowed on facility", users.contains(user));
 
 	}
 
@@ -420,7 +425,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 			assertTrue("RichResource must have VO value filled",rr.getVo() != null);
 			vos.add(rr.getVo());
 		}
-		assertTrue("Our VO must be between RichResources VOs",vos.contains(vo));
+		assertTrue("Our VO must be between RichResources VOs", vos.contains(vo));
 
 		assertTrue("our facility should have 1 assigned Resource", assignedResources.size() == 1);
 		assertTrue("our facility should have our Resource assigned", assignedResources.contains(rresource));
@@ -444,8 +449,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		facility.setName("FacilitiesManagerTestSecondFacility");
 		facility.setDescription("TestSecondFacilityDescriptionText");
 		Facility returnedFacility = perun.getFacilitiesManager().createFacility(sess, facility);
-		assertNotNull("unable to create Facility",returnedFacility);
-		assertEquals("created and returned facility should be the same",returnedFacility,facility);
+		assertNotNull("unable to create Facility", returnedFacility);
+		assertEquals("created and returned facility should be the same", returnedFacility, facility);
 
 	}
 
@@ -612,7 +617,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		hostsForDeletion.add(hosts.get(0));
 		final List<Host> expectedHosts = facilitiesManagerEntry.getHosts(sess, facility);
 		final Host expectedHost = expectedHosts.get(0);
-		assertEquals("Created and returned host should be the same",expectedHost, createdHost);
+		assertEquals("Created and returned host should be the same", expectedHost, createdHost);
 
 	}
 
@@ -633,7 +638,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		host3 = perun.getFacilitiesManagerBl().addHost(sess, host3, secondFacility);
 
 		List<Host> expectedHosts = facilitiesManagerEntry.getHostsByHostname(sess, hostname);
-		assertEquals("There should be 3 hosts",3, expectedHosts.size());
+		assertEquals("There should be 3 hosts", 3, expectedHosts.size());
 		assertTrue(expectedHosts.contains(host1));
 		assertTrue(expectedHosts.contains(host2));
 		assertTrue(expectedHosts.contains(host3));
@@ -659,7 +664,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		// set this host for deletion - host is created after adding to facility !!
 		hostsForDeletion.add(hosts.get(0));
 		facilitiesManagerEntry.removeHosts(sess, hosts, facility);
-		assertEquals("Unable to remove host from facility",facilitiesManagerEntry.getHostsCount(sess, facility), 0);
+		assertEquals("Unable to remove host from facility", facilitiesManagerEntry.getHostsCount(sess, facility), 0);
 
 	}
 
@@ -676,7 +681,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		System.out.println(FACILITIES_MANAGER + ".getFacilitiesCount()");
 
 		int count = facilitiesManagerEntry.getFacilitiesCount(sess);
-		assertTrue(count>0);
+		assertTrue(count > 0);
 	}
 
 	@Test
@@ -1127,7 +1132,123 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		assertTrue(cgnames.isEmpty());
 	}
 
-	// PRIVATE METHODS -------------------------------------------------------
+	@Test
+	public void getAssignedSecurityTeams() throws Exception {
+		List<SecurityTeam> expected = new ArrayList<>();
+		expected.add(setUpSecurityTeam0());
+		expected.add(setUpSecurityTeam1());
+		setUpAssignSecurityTeams(facility, expected);
+		setUpSecurityTeam2();
+		List<SecurityTeam> actual = facilitiesManagerEntry.getAssignedSecurityTeams(sess, facility);
+
+		assertEquals(expected, actual);
+	}
+	@Test
+	public void getAssignedSecurityTeamsEmpty() throws Exception {
+		List<SecurityTeam> expected = new ArrayList<>();
+		setUpAssignSecurityTeams(facility, expected);
+		setUpSecurityTeam0();
+		setUpSecurityTeam1();
+		setUpSecurityTeam2();
+		List<SecurityTeam> actual = facilitiesManagerEntry.getAssignedSecurityTeams(sess, facility);
+
+		assertEquals(expected, actual);
+	}
+	@Test(expected = FacilityNotExistsException.class)
+	public void getAssignedSecurityTeamsFacilityNotExists() throws Exception {
+		setUpSecurityTeam0();
+		setUpSecurityTeam1();
+		facilitiesManagerEntry.getAssignedSecurityTeams(sess, new Facility(11, "Name"));
+	}
+
+	@Test
+	public void assignSecurityTeam() throws Exception {
+		SecurityTeam st0 = setUpSecurityTeam0();
+		setUpSecurityTeam1();
+		facilitiesManagerEntry.assignSecurityTeam(sess, facility, st0);
+
+		List<SecurityTeam> actual = facilitiesManagerEntry.getAssignedSecurityTeams(sess, facility);
+
+		if (actual.size() != 1) {
+			fail();
+		}
+		if (!actual.contains(st0)) {
+			fail();
+		}
+	}
+	@Test(expected = FacilityNotExistsException.class)
+	public void assignSecurityTeamFacilityNotExists() throws Exception {
+		SecurityTeam st0 = setUpSecurityTeam0();
+		setUpSecurityTeam1();
+		facilitiesManagerEntry.assignSecurityTeam(sess, new Facility(11, "Name"), st0);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void assignSecurityTeamSecurityTeamNotExists() throws Exception {
+		facilitiesManagerEntry.assignSecurityTeam(sess, facility, new SecurityTeam(11, "name", "dsc"));
+	}
+	@Test(expected = SecurityTeamAlreadyAssignedException.class)
+	public void assignSecurityTeamAlreadyAssigned() throws Exception {
+		SecurityTeam st0 = setUpSecurityTeam0();
+		List<SecurityTeam> expected = new ArrayList<>();
+		expected.add(st0);
+		expected.add(setUpSecurityTeam1());
+		setUpAssignSecurityTeams(facility, expected);
+		setUpSecurityTeam2();
+
+		facilitiesManagerEntry.assignSecurityTeam(sess, facility, st0);
+	}
+
+	@Test
+	public void removeSecurityTeam() throws Exception {
+		SecurityTeam st0 = setUpSecurityTeam0();
+		SecurityTeam st1 = setUpSecurityTeam1();
+		List<SecurityTeam> expected = new ArrayList<>();
+		expected.add(st0);
+		expected.add(st1);
+		setUpAssignSecurityTeams(facility, expected);
+		setUpSecurityTeam2();
+		facilitiesManagerEntry.removeSecurityTeam(sess, facility, st0);
+		expected.remove(st0);
+
+		List<SecurityTeam> actual = facilitiesManagerEntry.getAssignedSecurityTeams(sess, facility);
+
+		if (actual.size() != 1) {
+			fail();
+		}
+		if (actual.contains(st0)) {
+			fail();
+		}
+		if (!actual.contains(st1)) {
+			fail();
+		}
+	}
+	@Test(expected = FacilityNotExistsException.class)
+	public void removeSecurityTeamFacilityNotExists() throws Exception {
+		SecurityTeam st0 = setUpSecurityTeam0();
+		setUpSecurityTeam1();
+		facilitiesManagerEntry.removeSecurityTeam(sess, new Facility(11, "Name"), st0);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void removeSecurityTeamSecurityTeamNotExists() throws Exception {
+		List<SecurityTeam> expected = new ArrayList<>();
+		expected.add(setUpSecurityTeam0());
+		expected.add(setUpSecurityTeam1());
+		setUpAssignSecurityTeams(facility, expected);
+		setUpSecurityTeam2();
+		facilitiesManagerEntry.removeSecurityTeam(sess, facility, new SecurityTeam(11, "name", "dsc"));
+	}
+	@Test(expected = SecurityTeamNotAssignedException.class)
+	public void removeSecurityTeamNotAssigned() throws Exception {
+		List<SecurityTeam> expected = new ArrayList<>();
+		expected.add(setUpSecurityTeam0());
+		expected.add(setUpSecurityTeam1());
+		setUpAssignSecurityTeams(facility, expected);
+
+		facilitiesManagerEntry.removeSecurityTeam(sess, facility, setUpSecurityTeam2());
+	}
+
+
+// PRIVATE METHODS -------------------------------------------------------
 
 	private Vo setUpVo() throws Exception {
 
@@ -1191,7 +1312,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		ExtSource extSource = new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal");
 		UserExtSource userExtSource = new UserExtSource(extSource, extLogin);
 		candidate.setUserExtSource(userExtSource);
-		candidate.setAttributes(new HashMap<String,String>());
+		candidate.setAttributes(new HashMap<String, String>());
 		return candidate;
 
 	}
@@ -1250,4 +1371,25 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		return attribute;
 	}
 
+	private SecurityTeam setUpSecurityTeam0() throws Exception {
+		SecurityTeam st = new SecurityTeam("Security0", "Description test 0");
+		perun.getSecurityTeamsManagerBl().createSecurityTeam(sess, st);
+		return st;
+	}
+	private SecurityTeam setUpSecurityTeam1() throws Exception {
+		SecurityTeam st = new SecurityTeam("Security1", "Description test 1");
+		perun.getSecurityTeamsManagerBl().createSecurityTeam(sess, st);
+		return st;
+	}
+	private SecurityTeam setUpSecurityTeam2() throws Exception {
+		SecurityTeam st = new SecurityTeam("Security2", "Description test 2");
+		perun.getSecurityTeamsManagerBl().createSecurityTeam(sess, st);
+		return st;
+	}
+
+	private void setUpAssignSecurityTeams(Facility facility, List<SecurityTeam> securityTeams) throws Exception {
+		for (SecurityTeam st : securityTeams) {
+			facilitiesManagerEntry.assignSecurityTeam(sess, facility, st);
+		}
+	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -1,0 +1,745 @@
+package cz.metacentrum.perun.core.entry;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.SecurityTeam;
+import cz.metacentrum.perun.core.api.SecurityTeamsManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
+import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
+import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
+import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupExistsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.NotMemberOfParentGroupException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
+import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyBlacklistedException;
+import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
+import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.AuthzRoles;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
+ */
+
+public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
+
+	private SecurityTeamsManager securityTeamsManagerEntry;
+
+	private SecurityTeam st0;
+	private SecurityTeam st1;
+	private SecurityTeam st2;
+	private Facility f0;
+	private Facility f1;
+	private Facility f2;
+	private User u0;
+	private User u1;
+	private User u2;
+	private User u3;
+	private User u4;
+
+	@Before
+	public void setUp() throws Exception {
+		securityTeamsManagerEntry = perun.getSecurityTeamsManager();
+	}
+
+
+	@Test
+	public void testGetSecurityTeamsPerunAdmin() throws Exception {
+		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
+		try {
+			List<SecurityTeam> expected = setUpSecurityTeams();
+			sess.getPerunPrincipal().setRoles(new AuthzRoles(Role.PERUNADMIN));
+
+			List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
+			assertEquals(expected, actual);
+		} finally {
+			sess.getPerunPrincipal().setRoles(roles);
+		}
+	}
+	@Test
+	public void testGetSecurityTeamsSecurityAdmin() throws Exception {
+		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
+		try {
+			setUpSecurityTeams();
+			setUpUsers();
+
+			List<SecurityTeam> expected = new ArrayList<>();
+			expected.add(st0);
+			sess.getPerunPrincipal().setRoles(new AuthzRoles(Role.SECURITYADMIN, st0));
+
+			List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
+
+			assertEquals(expected, actual);
+		} finally {
+			sess.getPerunPrincipal().setRoles(roles);
+		}
+	}
+	@Test
+	public void testGetSecurityTeamsSecurityAdmin1() throws Exception {
+		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
+		try {
+			setUpSecurityTeams();
+			setUpUsers();
+
+			List<SecurityTeam> expected = new ArrayList<>();
+			expected.add(st0);
+			expected.add(st1);
+			sess.getPerunPrincipal().setRoles(new AuthzRoles(Role.SECURITYADMIN, expected));
+
+			List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
+
+			Collections.sort(expected);
+			Collections.sort(actual);
+			assertEquals(expected, actual);
+		} finally {
+			sess.getPerunPrincipal().setRoles(roles);
+		}
+	}
+	@Test
+	public void testGetSecurityTeamsEmpty() throws Exception {
+		List<SecurityTeam> expected = new ArrayList<>();
+		List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
+		assertEquals(expected, actual);
+	}
+
+
+	@Test
+	public void testGetAllSecurityTeams() throws Exception {
+		List<SecurityTeam> expected = setUpSecurityTeams();
+		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
+		assertEquals(expected, actual);
+	}
+	@Test
+	public void testGetAllSecurityTeamsEmpty() throws Exception {
+		List<SecurityTeam> expected = new ArrayList<>();
+		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
+		assertEquals(expected, actual);
+	}
+
+
+	@Test
+	public void testCreateSecurityTeam() throws Exception {
+		SecurityTeam expected = new SecurityTeam("Name", "Desc");
+		SecurityTeam actual = securityTeamsManagerEntry.createSecurityTeam(sess, expected);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
+
+		actual = securityTeamsManagerEntry.getSecurityTeamById(sess, actual.getId());
+		assertNotNull(actual);
+		assertEquals(expected, actual);
+	}
+	@Test
+	public void testCreateSecurityTeamWithoutDsc() throws Exception {
+		SecurityTeam expected = new SecurityTeam("Name", null);
+		SecurityTeam actual = securityTeamsManagerEntry.createSecurityTeam(sess, expected);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testCreateSecurityTeamWithoutName() throws Exception {
+		SecurityTeam expected = new SecurityTeam(null, "Desc");
+		securityTeamsManagerEntry.createSecurityTeam(sess, expected);
+	}
+	@Test(expected = SecurityTeamExistsException.class)
+	public void testCreateSecurityTeamAlreadyExists() throws Exception {
+		SecurityTeam expected = new SecurityTeam("Name", "Desc");
+		securityTeamsManagerEntry.createSecurityTeam(sess, expected);
+		SecurityTeam actual = securityTeamsManagerEntry.createSecurityTeam(sess, expected);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
+		securityTeamsManagerEntry.createSecurityTeam(sess, actual);
+	}
+	@Test(expected = SecurityTeamExistsException.class)
+	public void testCreateSecurityTeamUniqueName() throws Exception {
+		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam("UniqueName", "Desc 1"));
+		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam("UniqueName", "Desc 2"));
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testCreateSecurityTeamNameLength() throws Exception {
+		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam(
+				"1---------2---------3---------4---------5---------6---------7---------8---------9---------10--------11--------12--------13--------",
+				"Desc 1"));
+	}
+
+
+	@Test
+	public void testUpdateSecurityTeam() throws Exception {
+		List<SecurityTeam> teams = setUpSecurityTeams();
+		SecurityTeam expected = teams.get(0);
+		expected.setName("Updated");
+		SecurityTeam middle = securityTeamsManagerEntry.updateSecurityTeam(sess, expected);
+
+		assertNotNull(middle);
+		assertEquals(expected, middle);
+
+		SecurityTeam actual = securityTeamsManagerEntry.getSecurityTeamById(sess, expected.getId());
+		assertNotNull(actual);
+		assertEquals(expected, actual);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testUpdateSecurityTeamWithNoName() throws Exception {
+		SecurityTeam expected = new SecurityTeam("ToUpdate", "Desc");
+		securityTeamsManagerEntry.updateSecurityTeam(sess, expected);
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testUpdateSecurityTeamWithoutName() throws Exception {
+		List<SecurityTeam> teams = setUpSecurityTeams();
+		SecurityTeam expected = teams.get(0);
+		expected.setName(null);
+		securityTeamsManagerEntry.updateSecurityTeam(sess, expected);
+	}
+
+
+	@Test
+	public void testDeleteSecurityTeam() throws Exception {
+		List<SecurityTeam> expected = setUpSecurityTeams();
+		expected.remove(st0);
+		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
+
+		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
+		assertEquals(expected, actual);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testDeleteSecurityTeamShouldNotExists() throws Exception {
+		setUpSecurityTeams();
+		SecurityTeam actual = securityTeamsManagerEntry.getSecurityTeamById(sess, st0.getId());
+		assertNotNull(actual);
+		assertEquals(st0, actual);
+		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
+		securityTeamsManagerEntry.getSecurityTeamById(sess, st0.getId());
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testDeleteSecurityTeamBeanNotExists() throws Exception {
+		st0 = new SecurityTeam("Name", "Desc");
+		st0.setId(10);
+		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testDeleteSecurityTeamAlreadyDeleted() throws Exception {
+		setUpSecurityTeams();
+		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
+		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testDeleteSecurityTeamWithNullSecurityTeam() throws Exception {
+		securityTeamsManagerEntry.deleteSecurityTeam(sess, null);
+	}
+
+
+	@Test
+	public void testGetSecurityTeamById() throws Exception {
+		SecurityTeam expected = setUpSecurityTeams().get(0);
+		SecurityTeam actual = securityTeamsManagerEntry.getSecurityTeamById(sess, expected.getId());
+		assertEquals(expected, actual);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testGetSecurityTeamByIdNotExists() throws Exception {
+		securityTeamsManagerEntry.getSecurityTeamById(sess, 10);
+	}
+
+
+	@Test
+	public void testGetAdmins() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		List<User> expected = setUpAdmins(u0, u1, setUpGroup(u1, u2));
+		List<User> actual = securityTeamsManagerEntry.getAdmins(sess, st0);
+
+		assertEquals(expected, actual);
+	}
+	@Test
+	public void testGetAdminsEmpty() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+
+		List<User> expected = new ArrayList<>();
+		List<User> actual = securityTeamsManagerEntry.getAdmins(sess, st0);
+
+		assertEquals(expected, actual);
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testGetAdminsWithNullSecurityTeam() throws Exception {
+		securityTeamsManagerEntry.getAdmins(sess, null);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testGetAdminsWithoutSecurityTeam() throws Exception {
+		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		securityTeamsManagerEntry.getAdmins(sess, st);
+	}
+
+
+	@Test
+	public void testAddAdmin() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+
+		List<User> admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (admins.size() > 0) fail();
+		if (admins.contains(u0)) fail();
+
+		securityTeamsManagerEntry.addAdmin(sess, st0, u0);
+
+		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (admins.size() != 1) fail();
+		if (!admins.contains(u0)) fail();
+	}
+	@Test(expected = AlreadyAdminException.class)
+	public void testAddAdminAlreadyAdmin() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpAdmins(u0, u1, setUpGroup(u1, u2));
+
+		securityTeamsManagerEntry.addAdmin(sess, st0, u0);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testAddAdminSecurityTeamNotExists() throws Exception {
+		setUpUsers();
+		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		securityTeamsManagerEntry.addAdmin(sess, st, u0);
+	}
+	@Test(expected = UserNotExistsException.class)
+	public void testAddAdminUserNotExists() throws Exception {
+		setUpSecurityTeams();
+		User user = new User(11, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
+		securityTeamsManagerEntry.addAdmin(sess, st0, user);
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testAddAdminNullSecurityTeam() throws Exception {
+		setUpUsers();
+		securityTeamsManagerEntry.addAdmin(sess, null, u0);
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testAddAdminNullUser() throws Exception {
+		setUpSecurityTeams();
+		securityTeamsManagerEntry.addAdmin(sess, st0, (User) null);
+	}
+
+
+	@Test
+	public void testAddGroupAsAdmin() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		Group group = setUpGroup(u0, u1);
+
+		List<User> admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (admins.size() > 0) fail();
+
+		securityTeamsManagerEntry.addAdmin(sess, st0, group);
+
+		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (admins.size() != 2) fail();
+		if (!admins.contains(u0)) fail();
+		if (!admins.contains(u1)) fail();
+		if (admins.contains(u2)) fail();
+		if (admins.contains(u3)) fail();
+		if (admins.contains(u4)) fail();
+	}
+	@Test(expected = AlreadyAdminException.class)
+	public void testAddGroupAsAdminAlreadyAdmin() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		Group group = setUpGroup(u1, u2);
+		setUpAdmins(u0, u1, group);
+
+		securityTeamsManagerEntry.addAdmin(sess, st0, group);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testAddGroupAsAdminSecurityTeamNotExists() throws Exception {
+		setUpUsers();
+		Group group = setUpGroup(u0, u1);
+		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		securityTeamsManagerEntry.addAdmin(sess, st, group);
+	}
+	@Test(expected = GroupNotExistsException.class)
+	public void testAddGroupAsAdminGroupNotExists() throws Exception {
+		setUpSecurityTeams();
+		Group group = new Group(11, "firstName", "lastName");
+		securityTeamsManagerEntry.addAdmin(sess, st0, group);
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testAddGroupAsAdminNullSecurityTeam() throws Exception {
+		setUpUsers();
+		securityTeamsManagerEntry.addAdmin(sess, null, u0);
+	}
+	@Test(expected = InternalErrorException.class)
+	public void testAddGroupAsAdminNullGroup() throws Exception {
+		setUpSecurityTeams();
+		securityTeamsManagerEntry.addAdmin(sess, st0, (Group) null);
+	}
+
+
+	@Test
+	public void testRemoveAdmin() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpAdmins(u0, u1, setUpGroup(u1, u2));
+
+		List<User> admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (!admins.contains(u0)) fail();
+
+		securityTeamsManagerEntry.removeAdmin(sess, st0, u0);
+
+		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (admins.contains(u0)) fail();
+	}
+	@Test
+	public void testRemoveAdminAlsoInGroup() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpAdmins(u0, u1, setUpGroup(u1, u2));
+
+		List<User> admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (!admins.contains(u1)) fail();
+
+		//Shouldnt remove from admins because he is also in group as admin
+		securityTeamsManagerEntry.removeAdmin(sess, st0, u1);
+
+		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (!admins.contains(u1)) fail();
+	}
+	@Test(expected = UserNotAdminException.class)
+	public void testRemoveAdminAlreadyRemoved() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpAdmins(u0, u1, setUpGroup(u1, u2));
+
+		securityTeamsManagerEntry.removeAdmin(sess, st0, u3);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testRemoveAdminSecurityTeamNotExists() throws Exception {
+		setUpUsers();
+		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		securityTeamsManagerEntry.removeAdmin(sess, st, u1);
+	}
+	@Test(expected = UserNotExistsException.class)
+	public void testRemoveAdminUserNotExists() throws Exception {
+		setUpSecurityTeams();
+		User user = new User(11, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
+		securityTeamsManagerEntry.removeAdmin(sess, st0, user);
+	}
+
+
+	@Test
+	public void testRemoveGroupAsAdmin() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		Group group = setUpGroup(u1, u2);
+		setUpAdmins(u0, u1, group);
+
+		List<User> admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (!admins.contains(u1)) fail();
+		if (!admins.contains(u2)) fail();
+
+		securityTeamsManagerEntry.removeAdmin(sess, st0, group);
+
+		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
+		if (!admins.contains(u1)) fail(); // Shouldnt be removed because is also admin as user
+		if (admins.contains(u2)) fail();
+	}
+	@Test(expected = GroupNotAdminException.class)
+	public void testRemoveGroupAsAdminAlreadyRemoved() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		Group group = setUpGroup(u1, u2);
+		securityTeamsManagerEntry.removeAdmin(sess, st0, group);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testRemoveGroupAsAdminSecurityTeamNotExists() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		Group group = setUpGroup(u1, u2);
+		setUpAdmins(u0, u1, group);
+		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		securityTeamsManagerEntry.removeAdmin(sess, st, group);
+	}
+	@Test(expected = GroupNotExistsException.class)
+	public void testRemoveGroupAsAdminGroupNotExists() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpAdmins(u0, u1, setUpGroup(u1, u2));
+		Group group = new Group(11, "Name", "name");
+		securityTeamsManagerEntry.removeAdmin(sess, st0, group);
+	}
+
+
+	@Test
+	public void testAddUserToBlacklist() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+
+		List<User> expected = new ArrayList<>();
+		expected.add(u0);
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st0, u0, "reason");
+
+		List<User> actual = securityTeamsManagerEntry.getBlacklist(sess, st0);
+		assertEquals(expected, actual);
+
+		if (!perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u0)) {
+			fail();
+		}
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testAddUserToBlacklistSecurityTeamNotExists() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		SecurityTeam st = new SecurityTeam(11, "Security0", "Description test 0");
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st, u0,"reason");
+	}
+	@Test(expected = UserNotExistsException.class)
+	public void testAddUserToBlacklistUserNotExists() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		User user = new User(11, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st0, user, null);
+	}
+	@Test(expected = UserAlreadyBlacklistedException.class)
+	public void testAddUserToBlacklistAlreadyBlacklisted() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st0, u1, null);
+	}
+
+
+	@Test
+	public void testRemoveUserFromBlacklist() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+
+		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st0, u1);
+
+		if (perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u1)) {
+			fail();
+		}
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testRemoveUserFromBlacklistSecurityTeamNotExists() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+		SecurityTeam st = new SecurityTeam(11, "Security0", "Description test 0");
+		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st, u1);
+	}
+	@Test(expected = UserNotExistsException.class)
+	public void testRemoveUserFromBlacklistUserNotExists() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+		User user = new User(11, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
+		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st0, user);
+	}
+	@Test(expected = UserAlreadyRemovedException.class)
+	public void testRemoveUserFromBlacklistUserNotInBlacklist() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st0, u0);
+	}
+
+
+	@Test
+	public void testGetBlacklistBySecurityTeam() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+
+		List<User> expected = new ArrayList<>();
+		expected.add(u1);
+		expected.add(u2);
+
+		List<User> actual = securityTeamsManagerEntry.getBlacklist(sess, st0);
+		Collections.sort(expected);
+		Collections.sort(actual);
+		assertEquals(expected, actual);
+	}
+	@Test(expected = SecurityTeamNotExistsException.class)
+	public void testGetBlacklistBySecurityTeamSecurityTeamNotExists() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+		SecurityTeam st = new SecurityTeam(11, "Security0", "Description test 0");
+
+		securityTeamsManagerEntry.getBlacklist(sess, st);
+	}
+
+
+	@Test
+	public void testGetBlacklistByFacility() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+
+		List<User> expected = new ArrayList<>();
+		expected.add(u1);
+		expected.add(u2);
+		expected.add(u3);
+		expected.add(u4);
+
+		List<User> actual = securityTeamsManagerEntry.getBlacklist(sess, f0);
+
+		Collections.sort(expected);
+		Collections.sort(actual);
+		assertEquals(expected, actual);
+	}
+	@Test(expected = FacilityNotExistsException.class)
+	public void testGetBlacklistByFacilityNotExists() throws Exception {
+		setUpSecurityTeams();
+		setUpUsers();
+		setUpFacilities();
+		setUpBlacklists();
+
+		Facility facility = new Facility(11, "facility");
+
+		securityTeamsManagerEntry.getBlacklist(sess, facility);
+	}
+
+
+
+
+
+
+	private List<SecurityTeam> setUpSecurityTeams() throws PrivilegeException, InternalErrorException, SecurityTeamExistsException {
+		st0 = new SecurityTeam("Security0", "Description test 0");
+		st1 = new SecurityTeam("Security1", "");
+		st2 = new SecurityTeam("Security2", null);
+
+		securityTeamsManagerEntry.createSecurityTeam(sess, st0);
+		securityTeamsManagerEntry.createSecurityTeam(sess, st1);
+		securityTeamsManagerEntry.createSecurityTeam(sess, st2);
+
+		List<SecurityTeam> result = new ArrayList<>();
+		result.add(st0);
+		result.add(st1);
+		result.add(st2);
+		return result;
+	}
+
+	private List<Facility> setUpFacilities() throws PrivilegeException, FacilityExistsException, InternalErrorException, SecurityTeamAlreadyAssignedException, FacilityNotExistsException, SecurityTeamNotExistsException {
+		f0 = new Facility();
+		f1 = new Facility();
+		f2 = new Facility();
+
+		f0.setName("Facility 0");
+		f1.setName("Facility 1");
+		f2.setName("Facility 2");
+
+		perun.getFacilitiesManager().createFacility(sess, f0);
+		perun.getFacilitiesManager().createFacility(sess, f1);
+		perun.getFacilitiesManager().createFacility(sess, f2);
+
+		perun.getFacilitiesManager().assignSecurityTeam(sess, f0, st0);
+		perun.getFacilitiesManager().assignSecurityTeam(sess, f0, st1);
+		perun.getFacilitiesManager().assignSecurityTeam(sess, f1, st0);
+
+		List<Facility> result = new ArrayList<>();
+		result.add(f0);
+		result.add(f1);
+		result.add(f2);
+		return result;
+	}
+
+	private void setUpUsers() throws PrivilegeException, InternalErrorException, UserAlreadyBlacklistedException, UserNotExistsException, SecurityTeamNotExistsException, AlreadyMemberException {
+		u0 = new User();
+		u1 = new User();
+		u2 = new User();
+		u3 = new User();
+		u4 = new User();
+
+		u0.setFirstName("User 0");
+		u1.setFirstName("User 1");
+		u2.setFirstName("User 2");
+		u3.setFirstName("User 3");
+		u4.setFirstName("User 4");
+
+		perun.getUsersManager().createUser(sess, u0);
+		perun.getUsersManager().createUser(sess, u1);
+		perun.getUsersManager().createUser(sess, u2);
+		perun.getUsersManager().createUser(sess, u3);
+		perun.getUsersManager().createUser(sess, u4);
+	}
+
+	private void setUpBlacklists() throws PrivilegeException, InternalErrorException, UserAlreadyBlacklistedException, UserNotExistsException, SecurityTeamNotExistsException, AlreadyMemberException {
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st0, u1, "reason");
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st0, u2, null);
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st1, u2, "reason");
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st1, u3, null);
+		securityTeamsManagerEntry.addUserToBlacklist(sess, st1, u4, "reason");
+	}
+
+	private Group setUpGroup(User u0, User u1) throws PrivilegeException, InternalErrorException, UserNotExistsException, AlreadyAdminException, SecurityTeamNotExistsException, VoExistsException, GroupExistsException, VoNotExistsException, GroupNotExistsException, AlreadyMemberException, MemberNotExistsException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, WrongAttributeValueException, ExtendMembershipException, NotMemberOfParentGroupException {
+		Vo vo = new Vo();
+		vo.setShortName("testVo");
+		vo.setName("Test VO");
+		perun.getVosManager().createVo(sess, vo);
+
+		Group authGroup = new Group();
+		authGroup.setShortName("testGroup");
+		authGroup.setName("Test Group");
+		Member m0 = perun.getMembersManager().createMember(sess, vo, u0);
+		Member m1 = perun.getMembersManager().createMember(sess, vo, u1);
+		perun.getGroupsManager().createGroup(sess, vo, authGroup);
+		perun.getGroupsManager().addMember(sess, authGroup, m0);
+		perun.getGroupsManager().addMember(sess, authGroup, m1);
+
+		return authGroup;
+	}
+
+	private List<User> setUpAdmins(User u0, User u1, Group group) throws PrivilegeException, InternalErrorException, UserNotExistsException, AlreadyAdminException, SecurityTeamNotExistsException, VoExistsException, GroupExistsException, VoNotExistsException, GroupNotExistsException, AlreadyMemberException, MemberNotExistsException, WrongReferenceAttributeValueException, NotMemberOfParentGroupException, WrongAttributeValueException, ExtendMembershipException {
+		securityTeamsManagerEntry.addAdmin(sess, st0, u0);
+		securityTeamsManagerEntry.addAdmin(sess, st0, u1);
+
+		securityTeamsManagerEntry.addAdmin(sess, st0, group);
+
+		Set<User> set = new HashSet<>();
+		set.add(u0);
+		set.add(u1);
+		for (Member member : perun.getGroupsManager().getGroupMembers(sess, group)) {
+			set.add(perun.getUsersManager().getUserByMember(sess, member));
+		}
+
+		List<User> expected = new ArrayList<>(set);
+		Collections.sort(expected);
+		return expected;
+	}
+}

--- a/perun-db/table_order
+++ b/perun-db/table_order
@@ -27,6 +27,9 @@ authz
 hosts
 host_attr_values
 auditer_consumers
+security_teams
+security_teams_facilities
+blacklists
 services
 service_processing_rule
 service_required_attrs

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -37,6 +37,8 @@ import cz.metacentrum.perun.core.api.RTMessagesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.ResourcesManager;
 import cz.metacentrum.perun.core.api.Searcher;
+import cz.metacentrum.perun.core.api.SecurityTeam;
+import cz.metacentrum.perun.core.api.SecurityTeamsManager;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.ServicesManager;
 import cz.metacentrum.perun.core.api.ServicesPackage;
@@ -80,6 +82,7 @@ public class ApiCaller {
 	private OwnersManager ownersManager = null;
 	private GeneralServiceManager generalServiceManager;
 	private RTMessagesManager rtMessagesManager = null;
+	private SecurityTeamsManager securityTeamsManager = null;
 	private PropagationStatsReader propagationStatsReader;
 	private Searcher searcher = null;
 	private ICabinetApi cabinetManager;
@@ -104,6 +107,13 @@ public class ApiCaller {
 			rtMessagesManager = rpcSession.getPerun().getRTMessagesManager();
 		}
 		return rtMessagesManager;
+	}
+
+	public SecurityTeamsManager getSecurityTeamsManager() {
+		if (securityTeamsManager == null) {
+			securityTeamsManager = rpcSession.getPerun().getSecurityTeamsManager();
+		}
+		return securityTeamsManager;
 	}
 
 	public Searcher getSearcher() {
@@ -267,6 +277,10 @@ public class ApiCaller {
 
 	public Application getApplicationById(int id) throws PerunException {
 		return getRegistrarManager().getApplicationById(rpcSession, id);
+	}
+
+	public SecurityTeam getSecurityTeamById(int id) throws PerunException {
+		return getSecurityTeamsManager().getSecurityTeamById(rpcSession, id);
 	}
 
 	public AttributeDefinition getAttributeDefinitionById(int id) throws PerunException {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/PerunManager.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/PerunManager.java
@@ -1,138 +1,163 @@
 package cz.metacentrum.perun.rpc;
 
-import cz.metacentrum.perun.rpc.methods.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
+import cz.metacentrum.perun.rpc.deserializer.Deserializer;
+import cz.metacentrum.perun.rpc.methods.AttributesManagerMethod;
+import cz.metacentrum.perun.rpc.methods.AuditMessagesManagerMethod;
+import cz.metacentrum.perun.rpc.methods.AuthzResolverMethod;
+import cz.metacentrum.perun.rpc.methods.CabinetManagerMethod;
+import cz.metacentrum.perun.rpc.methods.DatabaseManagerMethod;
+import cz.metacentrum.perun.rpc.methods.ExtSourcesManagerMethod;
+import cz.metacentrum.perun.rpc.methods.FacilitiesManagerMethod;
+import cz.metacentrum.perun.rpc.methods.GeneralServiceManagerMethod;
+import cz.metacentrum.perun.rpc.methods.GroupsManagerMethod;
+import cz.metacentrum.perun.rpc.methods.MembersManagerMethod;
+import cz.metacentrum.perun.rpc.methods.NotificationManagerMethod;
+import cz.metacentrum.perun.rpc.methods.OwnersManagerMethod;
+import cz.metacentrum.perun.rpc.methods.PropagationStatsReaderMethod;
+import cz.metacentrum.perun.rpc.methods.RTMessagesManagerMethod;
+import cz.metacentrum.perun.rpc.methods.RegistrarManagerMethod;
+import cz.metacentrum.perun.rpc.methods.ResourcesManagerMethod;
+import cz.metacentrum.perun.rpc.methods.SearcherMethod;
+import cz.metacentrum.perun.rpc.methods.SecurityTeamsManagerMethod;
+import cz.metacentrum.perun.rpc.methods.ServicesManagerMethod;
+import cz.metacentrum.perun.rpc.methods.UsersManagerMethod;
+import cz.metacentrum.perun.rpc.methods.VosManagerMethod;
 
 public enum PerunManager {
 
 	vosManager {
-
 		@Override
 		public ManagerMethod getMethod(String methodName) {
 			return VosManagerMethod.valueOf(methodName);
 		}
 	},
-						 rtMessagesManager {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return RTMessagesManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 searcher {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return SearcherMethod.valueOf(methodName);
-							 }
-						 },
-						 membersManager {
+	rtMessagesManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return RTMessagesManagerMethod.valueOf(methodName);
+		}
+	},
+	searcher {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return SearcherMethod.valueOf(methodName);
+		}
+	},
+	membersManager {
 
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return MembersManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 groupsManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return MembersManagerMethod.valueOf(methodName);
+		}
+	},
+	groupsManager {
 
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return GroupsManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 usersManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return GroupsManagerMethod.valueOf(methodName);
+		}
+	},
+	usersManager {
 
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return UsersManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 attributesManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return UsersManagerMethod.valueOf(methodName);
+		}
+	},
+	attributesManager {
 
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return AttributesManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 extSourcesManager {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return ExtSourcesManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 facilitiesManager {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return FacilitiesManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 databaseManager {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return DatabaseManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 resourcesManager {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return ResourcesManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 servicesManager {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return ServicesManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 ownersManager {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return OwnersManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 authzResolver {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return AuthzResolverMethod.valueOf(methodName);
-							 }
-						 },
-						 generalServiceManager {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return GeneralServiceManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 propagationStatsReader {
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return PropagationStatsReaderMethod.valueOf(methodName);
-							 }
-						 },
-						 cabinetManager{
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return CabinetManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 auditMessagesManager{
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return AuditMessagesManagerMethod.valueOf(methodName);
-							 }
-						 },
-						 registrarManager{
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return RegistrarManagerMethod.valueOf(methodName);
-							 }
-						 },
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return AttributesManagerMethod.valueOf(methodName);
+		}
+	},
+	extSourcesManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return ExtSourcesManagerMethod.valueOf(methodName);
+		}
+	},
+	facilitiesManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return FacilitiesManagerMethod.valueOf(methodName);
+		}
+	},
+	databaseManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return DatabaseManagerMethod.valueOf(methodName);
+		}
+	},
+	resourcesManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return ResourcesManagerMethod.valueOf(methodName);
+		}
+	},
+	servicesManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return ServicesManagerMethod.valueOf(methodName);
+		}
+	},
+	ownersManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return OwnersManagerMethod.valueOf(methodName);
+		}
+	},
+	authzResolver {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return AuthzResolverMethod.valueOf(methodName);
+		}
+	},
+	generalServiceManager {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return GeneralServiceManagerMethod.valueOf(methodName);
+		}
+	},
+	propagationStatsReader {
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return PropagationStatsReaderMethod.valueOf(methodName);
+		}
+	},
+	cabinetManager{
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return CabinetManagerMethod.valueOf(methodName);
+		}
+	},
+	auditMessagesManager{
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return AuditMessagesManagerMethod.valueOf(methodName);
+		}
+	},
+	registrarManager{
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return RegistrarManagerMethod.valueOf(methodName);
+		}
+	},
+	securityTeamsManager{
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return SecurityTeamsManagerMethod.valueOf(methodName);
+		}
+	},
 
-						 notificationManager{
-							 @Override
-							 public ManagerMethod getMethod(String methodName) {
-								 return NotificationManagerMethod.valueOf(methodName);
-							 }
-						 };
+	notificationManager{
+		@Override
+		public ManagerMethod getMethod(String methodName) {
+			return NotificationManagerMethod.valueOf(methodName);
+		}
+	};
 
 	protected abstract ManagerMethod getMethod(String methodName) throws IllegalArgumentException;
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.rpc.methods;
 
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.*;
 
 import java.util.ArrayList;
@@ -221,7 +222,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 			if (parms.contains("service")) {
 				service = ac.getServiceById(parms.readInt("service"));
 			}
-			return ac.getFacilitiesManager().getAllowedGroups(ac.getSession(),facility, vo, service);
+			return ac.getFacilitiesManager().getAllowedGroups(ac.getSession(), facility, vo, service);
 		}
 	},
 
@@ -916,7 +917,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 		public ContactGroup call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if(parms.contains("facility") && parms.contains("name")) {
 				return ac.getFacilitiesManager().getFacilityContactGroup(ac.getSession(),
-				  ac.getFacilityById(parms.readInt("facility")), parms.readString("name"));
+					ac.getFacilityById(parms.readInt("facility")), parms.readString("name"));
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility and name");
 			}
@@ -999,6 +1000,49 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 			ac.getFacilitiesManager().removeFacilityContact(ac.getSession(),
 					parms.read("contactGroupToRemove", ContactGroup.class));
 
+			return null;
+		}
+	},
+
+	/*#
+	 * return assigned security teams for specific facility
+	 *
+	 * @param facility
+	 * @return assigned security teams fot given facility
+	 */
+	getAssignedSecurityTeams {
+		@Override
+		public List<SecurityTeam> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getFacilitiesManager().getAssignedSecurityTeams(ac.getSession(), ac.getFacilityById(parms.readInt("facility")));
+		}
+	},
+
+	/*#
+	 * Assign given security team to given facility (means the facility trusts the security team)
+	 *
+	 * @param facility
+	 * @param securityTeam
+	 */
+	assignSecurityTeam {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getFacilitiesManager().assignSecurityTeam(ac.getSession(), ac.getFacilityById(parms.readInt("facility")),
+					ac.getSecurityTeamById(parms.readInt("securityTeam")));
+			return null;
+		}
+	},
+
+	/*#
+	 * Remove (Unassign) given security team from given facility
+	 *
+	 * @param facility
+	 * @param securityTeam
+	 */
+	removeSecurityTeam {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getFacilitiesManager().removeSecurityTeam(ac.getSession(), ac.getFacilityById(parms.readInt("facility")),
+					ac.getSecurityTeamById(parms.readInt("securityTeam")));
 			return null;
 		}
 	};

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SecurityTeamsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SecurityTeamsManagerMethod.java
@@ -1,0 +1,239 @@
+package cz.metacentrum.perun.rpc.methods;
+
+import cz.metacentrum.perun.core.api.SecurityTeam;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.rpc.ApiCaller;
+import cz.metacentrum.perun.rpc.ManagerMethod;
+import cz.metacentrum.perun.rpc.deserializer.Deserializer;
+
+import java.util.List;
+
+public enum SecurityTeamsManagerMethod implements ManagerMethod {
+
+	/*#
+	 * Get list of SecurityTeams by access rights
+	 *  - PERUNADMIN : all teams
+	 *  - SECURITYADMIN : teams where user is admin
+	 *
+	 * @param perunSession
+	 * @return List of SecurityTeams or empty ArrayList<SecurityTeam>
+	 */
+	getSecurityTeams {
+		@Override
+		public List<SecurityTeam> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getSecurityTeamsManager().getSecurityTeams(ac.getSession());
+		}
+	},
+
+	/*#
+	 * get all security teams in perun system
+	 *
+	 * @param perunSession
+	 * @return List of SecurityTeams or empty List
+	 */
+	getAllSecurityTeams {
+		@Override
+		public List<SecurityTeam> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getSecurityTeamsManager().getAllSecurityTeams(ac.getSession());
+		}
+	},
+
+	/*#
+	 * Create new SecurityTeam.
+	 *
+	 * @param perunSession
+	 * @param securityTeam SecurityTeam object with prefilled name
+	 * @return Newly created Security team with new id
+	 */
+	createSecurityTeam {
+		@Override
+		public SecurityTeam call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			return ac.getSecurityTeamsManager().createSecurityTeam(ac.getSession(), parms.read("securityTeam", SecurityTeam.class));
+		}
+	},
+
+	/*#
+	 * Updates SecurityTeam.
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @return returns updated SecurityTeam
+	 */
+	updateSecurityTeam {
+		@Override
+		public SecurityTeam call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			return ac.getSecurityTeamsManager().updateSecurityTeam(ac.getSession(), parms.read("securityTeam", SecurityTeam.class));
+		}
+	},
+
+	/*#
+	 * Delete SecurityTeam.
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 */
+	deleteSecurityTeam {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			ac.getSecurityTeamsManager().deleteSecurityTeam(ac.getSession(),  ac.getSecurityTeamById(parms.readInt("securityTeam")));
+			return null;
+		}
+	},
+
+	/*#
+	 * Find existing SecurityTeam by ID.
+	 *
+	 * @param perunSession
+	 * @param id
+	 * @return security team with given id
+	 */
+	getSecurityTeamById {
+		@Override
+		public SecurityTeam call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getSecurityTeamsManager().getSecurityTeamById(ac.getSession(), parms.readInt("id"));
+		}
+	},
+
+	/*#
+	 * get all security admins of given security team
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @return list of users which are admis of given security team
+	 */
+	getAdmins {
+		@Override
+		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getSecurityTeamsManager().getAdmins(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")));
+		}
+	},
+
+	/*#
+	 * Create group as security admins group of given security team (all users in group will have security admin rights)
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param group group which members will became a security administrators
+	 */
+	/*#
+	 * create security admin from given user and add him as security admin of given security team
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param user user who will became a security administrator
+	 */
+	addAdmin {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			if (parms.contains("group")) {
+				ac.getSecurityTeamsManager().addAdmin(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
+						ac.getGroupById(parms.readInt("group")));
+			} else {
+				ac.getSecurityTeamsManager().addAdmin(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
+						ac.getUserById(parms.readInt("user")));
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Remove security admin role for given security team from group
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param group
+	 */
+	/*#
+	 * Remove security admin role for given security team from user
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param user
+	 */
+	removeAdmin {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			if (parms.contains("group")) {
+				ac.getSecurityTeamsManager().removeAdmin(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
+						ac.getGroupById(parms.readInt("group")));
+			} else {
+				ac.getSecurityTeamsManager().removeAdmin(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
+						ac.getUserById(parms.readInt("user")));
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Add User to black list of security team to filter him out.
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param user
+	 */
+	addUserToBlacklist {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			ac.getSecurityTeamsManager().addUserToBlacklist(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
+					ac.getUserById(parms.readInt("user")),
+					parms.readString("description"));
+			return null;
+		}
+	},
+
+	/*#
+	 * remove user from blacklist of given security team
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param user user who will became a security administrator
+	 */
+	removeUserFromBlacklist {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			ac.getSecurityTeamsManager().removeUserFromBlacklist(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")),
+					ac.getUserById(parms.readInt("user")));
+			return null;
+		}
+	},
+
+	/*#
+	 * get union of blacklists of all security teams assigned to facility
+	 *
+	 * @param perunSession
+	 * @param facility
+	 * @return list of blacklisted users for facility
+	 */
+	/*#
+	 * get list of blacklisted users by security team
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @return lis of blacklisted users by security team
+	 */
+	getBlacklist {
+		@Override
+		public List<User> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if (parms.contains("facility")) {
+				return ac.getSecurityTeamsManager().getBlacklist(ac.getSession(), ac.getFacilityById(parms.readInt("facility")));
+			} else {
+				return ac.getSecurityTeamsManager().getBlacklist(ac.getSession(), ac.getSecurityTeamById(parms.readInt("securityTeam")));
+			}
+		}
+	};
+}


### PR DESCRIPTION
CORE: Security teams feature
    
     - change postgres.sql, oracle.sql, schema and tableOrder
     - add SecurityTeam class
     - create new Managers for SecurityTeams (api,bl,impl)
     - add methods for work with SecurityTeams
     - add new exceptions for work with security teams
     - add new attribute user_fac virt blacklisted for info about users
       blacklisted on facility by some security teams
     - new Role securityadmin for work with security teams plus all changes
       to authzResolver
     - add new managers also to perun-core.xml for spring
     - tests all new methods
     - add new methods also to RPC
     - add new object also to AuditParser and add tests to it
