### PR TITLE
CORE, RPC: Allow to delete ExtSource from RPC call

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
@@ -75,7 +75,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
-			throw new PrivilegeException(sess, "createExtSource");
+			throw new PrivilegeException(sess, "deleteExtSource");
 		}
 
 		getExtSourcesManagerBl().checkExtSourceExists(sess, extSource);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ExtSourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ExtSourcesManagerMethod.java
@@ -18,7 +18,21 @@ public enum ExtSourcesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ExtSource call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
 			return ac.getExtSourcesManager().createExtSource(ac.getSession(), parms.read("extSource", ExtSource.class));
+		}
+	},
+	/*#
+	 * Delete an external source.
+	 * @param id int ExtSource <code>id</code>
+	 */
+	deleteExtSource {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+			ac.getExtSourcesManager().deleteExtSource(ac.getSession(), ac.getExtSourceById(parms.readInt("id")));
+			return null;
 		}
 	},
 	/*#


### PR DESCRIPTION
- Fixed copy/paste typo in not authorized message for deleteExtSource().
- Add deleteExtSource() method to RPC.
- Make create/delete method requiring POST call.