### PR TITLE
CORE: Select facility owners all at once instead of iterating over ids

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -128,18 +128,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	public List<Owner> getOwners(PerunSession sess, Facility facility) throws InternalErrorException {
-		List<Integer> ownersIds = getFacilitiesManagerImpl().getOwnersIds(sess, facility);
-		List<Owner> owners = new ArrayList<Owner>();
-
-		for (Integer ownerId: ownersIds) {
-			try {
-				owners.add(getPerunBl().getOwnersManagerBl().getOwnerById(sess, ownerId));
-			} catch (OwnerNotExistsException e) {
-				throw new ConsistencyErrorException("Non-existent owner is assigned to the facility", e);
-			}
-		}
-
-		return owners;
+		return getFacilitiesManagerImpl().getOwners(sess, facility);
 	}
 
 	public void setOwners(PerunSession sess, Facility facility, List<Owner> owners) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -338,9 +338,9 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 		}
 	}
 
-	public List<Integer> getOwnersIds(PerunSession sess, Facility facility) throws InternalErrorException {
+	public List<Owner> getOwners(PerunSession sess, Facility facility) throws InternalErrorException {
 		try {
-			return jdbc.query("select id from owners, facility_owners where owners.id=owner_id and facility_id=?", Utils.ID_MAPPER, facility.getId());
+			return jdbc.query("select "+OwnersManagerImpl.ownerMappingSelectQuery+" from owners left join facility_owners on owners.id = facility_owners.owner_id where facility_id=?", OwnersManagerImpl.OWNER_MAPPER, facility.getId());
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/OwnersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/OwnersManagerImpl.java
@@ -45,7 +45,7 @@ public class OwnersManagerImpl implements OwnersManagerImplApi {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
 	}
 
-	private static final RowMapper<Owner> OWNER_MAPPER = new RowMapper<Owner>() {
+	protected static final RowMapper<Owner> OWNER_MAPPER = new RowMapper<Owner>() {
 		public Owner mapRow(ResultSet rs, int i) throws SQLException {
 			Owner owner = new Owner();
 			owner.setId(rs.getInt("owners_id"));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -103,16 +103,16 @@ public interface FacilitiesManagerImplApi {
 
 
 	/**
-	 * Returns owners' id of the facility.
+	 * Returns owners of the facility.
 	 *
 	 * @param perunSession
 	 * @param facility
 	 *
-	 * @return owners' id of specified facility
+	 * @return owners of specified facility
 	 *
 	 * @throws InternalErrorException
 	 */
-	List<Integer> getOwnersIds(PerunSession perunSession, Facility facility) throws InternalErrorException;
+	List<Owner> getOwners(PerunSession perunSession, Facility facility) throws InternalErrorException;
 
 	/**
 	 * Updates owners of facility

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -136,7 +136,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		System.out.println("FacilitiesManager.getFacilityByName");
 
 		Facility returnedFacility = perun.getFacilitiesManager().getFacilityByName(sess, facility.getName());
-		assertNotNull("unable to get Facility by Name",returnedFacility);
+		assertNotNull("unable to get Facility by Name", returnedFacility);
 		assertEquals("created and returned facility should be the same", returnedFacility, facility);
 
 	}
@@ -165,7 +165,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		perun.getServicesManager().addDestination(sess, serv, facility, dest);
 
 		List<Facility> facilities = perun.getFacilitiesManager().getFacilitiesByDestination(sess,"TestovaciDestinace");
-		assertTrue("At least one facility with destinatnion " + dest.getDestination() + " should exists",facilities.size() > 0);
+		assertTrue("At least one facility with destinatnion " + dest.getDestination() + " should exists", facilities.size() > 0);
 		assertTrue("Created facility with destinantion " + dest.getDestination() + " should exist between others", facilities.contains(facility));
 	}
 
@@ -193,6 +193,10 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Owner> owners = perun.getFacilitiesManager().getOwners(sess, facility);
 		assertTrue("there should be 1 owner",owners.size() == 1);
 		assertTrue("facility should be owned by our owner", owners.contains(owner));
+
+		perun.getFacilitiesManager().removeOwner(sess, facility, owner);
+		List<Owner> empty_owners = perun.getFacilitiesManager().getOwners(sess, facility);
+		assertTrue("there shouldn't be any owner", empty_owners.isEmpty());
 
 	}
 


### PR DESCRIPTION
- Use single select when retrieving facility owners.
- Removed getOwnersIds(sess, facility) from FacilitiesManagerImpl,
- Replaced with getOwners(sess, facility) in same manager.
- Bl layer uses new impl method with single select.
- Make owners_mapper protected, to be available to other managers.