### PR TITLE
CORE: Improved selecting members groups

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -801,7 +801,7 @@ public interface GroupsManagerBl {
 	void synchronizeGroups(PerunSession sess) throws InternalErrorException;
 
 	/**
-	 * Returns all member's groups. Except members and administrators groups.
+	 * Returns all members groups. Except 'members' group.
 	 *
 	 * @param sess
 	 * @param member
@@ -844,16 +844,6 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getAllMemberGroups(PerunSession sess, Member member) throws InternalErrorException;
-
-	/**
-	 * Returns all member's groups which are assigned to at least one resource. Except members and administrators groups.
-	 *
-	 * @param sess
-	 * @param member
-	 * @return
-	 * @throws InternalErrorException
-	 */
-	List<Group> getMemberGroupsForResources(PerunSession sess, Member member) throws InternalErrorException;
 
 	/**
 	 * Returns all groups which have set the attribute with the value. Searching only def and opt attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -782,11 +782,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	public List<Group> getMemberGroups(PerunSession sess, Member member) throws InternalErrorException {
-		Vo vo = getPerunBl().getMembersManagerBl().getMemberVo(sess, member);
-
-		List<Integer> groupsIds = new ArrayList<Integer>(new HashSet<Integer>(this.groupsManagerImpl.getMemberGroupsIds(sess, member, vo)));
-		List<Group> groups = getPerunBl().getGroupsManagerBl().getGroupsByIds(sess, groupsIds);
-
+		List<Group> groups = this.getAllMemberGroups(sess, member);
 		//Remove members group
 		if(!groups.isEmpty()) {
 			Iterator<Group> iterator = groups.iterator();
@@ -795,10 +791,8 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				if(g.getName().equals(VosManager.MEMBERS_GROUP)) iterator.remove();
 			}
 		}
-
 		// Sort
 		Collections.sort(groups);
-
 		return groups;
 	}
 
@@ -822,19 +816,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 		
 	public List<Group> getAllMemberGroups(PerunSession sess, Member member) throws InternalErrorException {
-		return new ArrayList<Group>(new HashSet<Group>(getGroupsManagerImpl().getAllMemberGroups(sess, member)));
-	}
-
-	public List<Group> getMemberGroupsForResources(PerunSession sess, Member member) throws InternalErrorException {
-		Vo vo = getPerunBl().getMembersManagerBl().getMemberVo(sess, member);
-		List<Integer> groupsIds = this.groupsManagerImpl.getMemberGroupsIdsForResources(sess, member, vo);
-
-		List<Group> groups = getPerunBl().getGroupsManagerBl().getGroupsByIds(sess, groupsIds);
-
-		// Sort
-		Collections.sort(groups);
-
-		return groups;
+		return getGroupsManagerImpl().getAllMemberGroups(sess, member);
 	}
 
 	public List<Member> getParentGroupMembers(PerunSession sess, Group group) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -262,7 +262,7 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	public List<User> getGroupUsers(PerunSession sess, Group group) throws InternalErrorException {
 		try {
 			return jdbc.query("select " + UsersManagerImpl.userMappingSelectQuery + " from groups_members join members on members.id=member_id join " +
-					"users on members.user_id=users.id where group_id=? order by "+Compatibility.orderByBinary("users.last_name")+", " +
+					"users on members.user_id=users.id where group_id=? order by " + Compatibility.orderByBinary("users.last_name") + ", " +
 					Compatibility.orderByBinary("users.first_name"), UsersManagerImpl.USER_MAPPER, group.getId());
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
@@ -422,20 +422,9 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 		}
 	}
 
-
-	public List<Integer> getMemberGroupsIds(PerunSession sess, Member member, Vo vo) throws InternalErrorException {
-		try {
-			return jdbc.query("select groups.id as id from groups_members join groups on groups_members.group_id = groups.id " +
-					"where groups.vo_id=? and groups_members.member_id=?",
-					Utils.ID_MAPPER, vo.getId(), member.getId());
-		} catch(RuntimeException ex) {
-			throw new InternalErrorException(ex);
-		}
-	}
-
 	public List<Group> getAllMemberGroups(PerunSession sess, Member member) throws InternalErrorException {
 		try {
-			return jdbc.query("select " + groupMappingSelectQuery + " from groups_members join groups on groups_members.group_id = groups.id " +
+			return jdbc.query("select distinct " + groupMappingSelectQuery + " from groups_members join groups on groups_members.group_id = groups.id " +
 					" where groups_members.member_id=?",
 					GROUP_MAPPER, member.getId());
 		} catch (EmptyResultDataAccessException e) {
@@ -443,21 +432,6 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
-	}
-
-	public List<Integer> getMemberGroupsIdsForResources(PerunSession sess, Member member, Vo vo) throws InternalErrorException {
-		/*XXX New DB implementation ...
-		//FIXME Where can I get the resource?
-		try {
-		jdbc.query("select groups_members.group_id as id from groups_members join groups_resources on groups_members.group_id = groups_resources.group_id " +
-		"where groups_members.member_id=? and groups_resources.resource_id=?",
-		Utils.ID_MAPPER, member.getId(), resource.getId());
-		} catch(RuntimeException ex) {
-		throw new InternalErrorException(ex);
-		}
-		*/
-		//FIXME delete this method after removing grouper
-		throw new InternalErrorException("Unsupported method");
 	}
 
 	public List<Group> getGroupsByAttribute(PerunSession sess, Attribute attribute) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -217,7 +217,7 @@ public interface GroupsManagerImplApi {
 	boolean isUserMemberOfGroup(PerunSession sess, User user, Group group) throws InternalErrorException;
 
 	/**
-	 * Return all member's groups. Included members and administrators groups.
+	 * Return all members groups. Included 'members' group.
 	 *
 	 * @param sess
 	 * @param member
@@ -406,32 +406,6 @@ public interface GroupsManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getGroupsToSynchronize(PerunSession sess) throws InternalErrorException;
-
-	/**
-	 * Returns list of groups' id where the member is member.
-	 *
-	 * @param sess
-	 * @param member
-	 * @param vo
-	 *
-	 * @return list of groups' id
-	 *
-	 * @throws InternalErrorException
-	 */
-	List<Integer> getMemberGroupsIds(PerunSession sess, Member member, Vo vo) throws InternalErrorException;
-
-	/**
-	 * Returns list of groups' id where the member is member and the groups are under the defined resource.
-	 *
-	 * @param sess
-	 * @param member
-	 * @param vo
-	 *
-	 * @return list of groups' id
-	 *
-	 * @throws InternalErrorException
-	 */
-	List<Integer> getMemberGroupsIdsForResources(PerunSession sess, Member member, Vo vo) throws InternalErrorException;
 
 	/**
 	 * Returns all groups which have set the attribute with the value. Searching only def and opt attributes.


### PR DESCRIPTION
- Removed getMemberGroupsForResources() from Bl and Impl,
  since it was not implemented in impl and was marked for deletion
  after removing grouper (that was a long ago).
- Removed unused getMemberGroupsIds() from Impl we now select
  groups directly from Bl.
- Updated getAllMemberGroups() and getMemberGroups() where we select
  groups directly by member_id and added "distinct" to make sure, that we get
  single group if member is direct/indirect member of a group.
  With this change, making unique list using Set, was removed from Bl layer of this method.
  Also removed retrieving members VO it was not used anyway but selected from DB.
- Fixed misleading javadoc.