### PR TITLE
Core: fix AuditerMessages behaviour to handle top-level transactions

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -188,8 +188,15 @@ public class Auditer {
 	public void log(PerunSession sess, String message) throws InternalErrorException {
 		if(TransactionSynchronizationManager.isActualTransactionActive()) {
 			log.trace("Auditer stores audit message to current transaction. Message: {}.", message);
-			List<List<AuditerMessage>> savepoints = getSavepoints();
-			List<AuditerMessage> messages = savepoints.get(savepoints.size() - 1);
+			List<List<List<AuditerMessage>>> topLevelTransactions = (List<List<List<AuditerMessage>>>) TransactionSynchronizationManager.getResource(this);
+			if (topLevelTransactions == null) {
+				newTopLevelTransaction();
+				topLevelTransactions = (List<List<List<AuditerMessage>>>) TransactionSynchronizationManager.getResource(this);
+			}
+			// pick last top-level messages chain
+			List<List<AuditerMessage>> transactionChain = topLevelTransactions.get(topLevelTransactions.size() - 1);
+			// pick last messages in that chain
+			List<AuditerMessage> messages = transactionChain.get(transactionChain.size() - 1);
 			messages.add(new AuditerMessage(sess, message));
 		} else {
 			this.storeMessageToDb(sess, message);
@@ -209,7 +216,7 @@ public class Auditer {
 
 	/**
 	 * Log mesage. Substitute first {} with arg1.toString().
-	 *
+	 * 
 	 * IMPORTANT: This method stores the message aside from DB transaction.
 	 *
 	 * @param message
@@ -222,7 +229,7 @@ public class Auditer {
 
 	/**
 	 * Log mesage. Substitute first two {} with arg1.toString() and arg2.toString().
-	 *
+	 * 
 	 * IMPORTANT: This method stores the message aside from DB transaction.
 	 *
 	 * @param message
@@ -308,75 +315,95 @@ public class Auditer {
 	}
 
 	/**
-	 * Initialize lists for sotring Audit messages.
+	 * Initialize new lists for sotring Audit messages.
 	 *
 	 */
-	public void transactionBegin() {
-		List<List<AuditerMessage>> savepoints = new ArrayList<>();
+	public void newTopLevelTransaction() {
+		List<List<List<AuditerMessage>>> topLevelTransactions = (List<List<List<AuditerMessage>>>) TransactionSynchronizationManager.getResource(this);
+		
+		// prepare new messages chain
+		List<List<AuditerMessage>> transactionChain = new ArrayList<>();
 		List<AuditerMessage> messages = new ArrayList<>();
-		savepoints.add(messages);
-		TransactionSynchronizationManager.bindResource(this, savepoints);
+		transactionChain.add(messages);
+		if (topLevelTransactions == null) {
+			// there is no other top-level messages
+			topLevelTransactions = new ArrayList<>();
+			topLevelTransactions.add(transactionChain);
+			TransactionSynchronizationManager.bindResource(this, topLevelTransactions);
+		} else {
+			topLevelTransactions.add(transactionChain);
+		}
 	}
 		
 	/**
-	 * Creates new list for saving auditer messages of a new transaction.
+	 * Creates new list for saving auditer messages of a new nested transactions.
 	 * 
 	 */
-	public void newTransaction() {
-		List<List<AuditerMessage>> savepoints = getSavepoints();
+	public void newNestedTransaction() {
+		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
+		List<List<AuditerMessage>> transactionChain = topLevelTransactions.get(topLevelTransactions.size() - 1);
 		List<AuditerMessage> messages = new ArrayList<>();
-		savepoints.add(messages);
+		transactionChain.add(messages);
 	}
 	
 	/**
-	 * Flush auditer messages of the last transaction to the store of the outer transaction.
+	 * Flush auditer messages of the last messages to the store of the outer transaction.
 	 * There should be at least one nested transaction.
 	 * 
 	 */
-	public void flushTransaction() {
-		List<List<AuditerMessage>> savepoints = getSavepoints();
-		if (savepoints.size() < 2) {
+	public void flushNestedTransaction() {
+		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
+		List<List<AuditerMessage>> transactionChain = topLevelTransactions.get(topLevelTransactions.size() - 1);
+		if (transactionChain.size() < 2) {
 			log.trace("No messages to flush");
 			return;
 		}
-		List<AuditerMessage> messagesToFlush = savepoints.get(savepoints.size() - 1);
+		List<AuditerMessage> messagesToFlush = transactionChain.get(transactionChain.size() - 1);
 		
-		savepoints.get(savepoints.size() - 2).addAll(messagesToFlush);
-		List<AuditerMessage> messages = savepoints.remove(savepoints.size() - 1);
-		log.trace("Flushed auditer messages of the last transaction: " + messages);
+		transactionChain.get(transactionChain.size() - 2).addAll(messagesToFlush);
+		List<AuditerMessage> messages = transactionChain.remove(transactionChain.size() - 1);
 	}
 	
 	/**
 	 * Erases the auditer messages for the last transaction.
 	 * 
 	 */
-	public void cleanTransation() {
-		List<List<AuditerMessage>> savepoints = getSavepoints();
-		if (savepoints.isEmpty()) {
+	public void cleanNestedTransation() {
+		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
+		List<List<AuditerMessage>> transactionChain = topLevelTransactions.get(topLevelTransactions.size() - 1);
+		if (transactionChain.isEmpty()) {
 			log.trace("No messages to clean");
 			return;
 		}
-		List<AuditerMessage> messages = savepoints.remove(savepoints.size() - 1);
-		log.trace("Erased auditer messages for the last transaction: " + messages);
+		List<AuditerMessage> messages = transactionChain.remove(transactionChain.size() - 1);
 	}
 	
 	/**
-	 * Imidiately flushes stored message for specified transaction into the log
+	 * Imidiately flushes stored message for last top-level transaction into the log
 	 *
 	 */
 	public void flush() {
-		List<List<AuditerMessage>> savepoints = getSavepoints();
-		if (savepoints.isEmpty()) {
+		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
+		if (topLevelTransactions.isEmpty()) {
 			log.trace("No messages to flush");
 			return;
 		}
+		List<List<AuditerMessage>> transactionChain = topLevelTransactions.get(topLevelTransactions.size() - 1);
+		if (transactionChain.isEmpty()) {
+			log.trace("No messages to flush");
+			topLevelTransactions.remove(topLevelTransactions.size() - 1);
+			return;
+		}
 		
-		if (savepoints.size() != 1) {
+		if (transactionChain.size() != 1) {
 			log.error("There should be only one list of messages while flushing representing the most outer transaction.");
 		}
 
-		List<AuditerMessage> messages = savepoints.get(0);
-		TransactionSynchronizationManager.unbindResourceIfPossible(this);
+		List<AuditerMessage> messages = transactionChain.get(0);
+		topLevelTransactions.remove(topLevelTransactions.size() - 1);
+		if (topLevelTransactions.isEmpty()) {
+			TransactionSynchronizationManager.unbindResourceIfPossible(this);
+		}
 		log.trace("Audit messages was flushed for current transaction.");
 		synchronized (LOCK_DB_TABLE_AUDITER_LOG) {
 			for(AuditerMessage auditerMessage : messages) {
@@ -411,36 +438,43 @@ public class Auditer {
 	}
 
 	/**
-	 * All prepared auditer messages in transaction are erased without storing into db.
+	 * All prepared auditer messages in the last top-level transaction are erased without storing into db.
 	 * Mostly wanted while rollbacking.
 	 * 
 	 */
 	public void clean() {
-		List<List<AuditerMessage>> savepoints = getSavepoints();
-		if (savepoints.isEmpty()) {
-			log.trace("No messages to flush");
+		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
+		if (topLevelTransactions.isEmpty()) {
+			log.trace("No messages to clean");
 			return;
 		}
 		
-		if (savepoints.size() != 1) {
+		List<List<AuditerMessage>> transactionChain = topLevelTransactions.get(topLevelTransactions.size() - 1);
+		if (transactionChain.isEmpty()) {
+			log.trace("No messages to clean");
+		}
+		
+		if (transactionChain.size() != 1) {
 			log.error("There should be only one list of messages while cleaning.");
 		}
 
-		List<AuditerMessage> messages = savepoints.get(0);
-		TransactionSynchronizationManager.unbindResourceIfPossible(this);
-		log.trace("Audit messages erased for current transaction. {}", messages);
+		topLevelTransactions.remove(topLevelTransactions.size() - 1);
+		
+		if (topLevelTransactions.isEmpty()) {
+			TransactionSynchronizationManager.unbindResourceIfPossible(this);
+		}
 	}
 
 	/**
-	 * Get stored (not flushed) messages for current transaction. Messages remains stored.
+	 * Get stored (not flushed) messages for current transaction. Messages remain stored.
 	 *
 	 * @return list of messages
 	 */
 	public List<AuditerMessage> getMessages() {
-		List<List<AuditerMessage>> savepoints = getSavepoints();
-		if (savepoints.isEmpty()) return new ArrayList<AuditerMessage>();
-		List<AuditerMessage> messages = savepoints.get(savepoints.size() - 1);
-		if(messages == null) return new ArrayList<AuditerMessage>();
+		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
+		List<List<AuditerMessage>> transactionChain = topLevelTransactions.get(topLevelTransactions.size() - 1);
+		if (transactionChain.isEmpty()) return new ArrayList<>();
+		List<AuditerMessage> messages = transactionChain.get(transactionChain.size() - 1);
 		return messages;
 	}
 
@@ -493,13 +527,13 @@ public class Auditer {
 		}
 	}
 	
-	private List<List<AuditerMessage>> getSavepoints() {
-		List<List<AuditerMessage>> savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
-		if (savepoints == null) {
-			transactionBegin();
-			savepoints = (List<List<AuditerMessage>>) TransactionSynchronizationManager.getResource(this);
+	private List<List<List<AuditerMessage>>> getTopLevelTransactions() {
+		List<List<List<AuditerMessage>>> topLevelTransactions = (List<List<List<AuditerMessage>>>) TransactionSynchronizationManager.getResource(this);
+		if (topLevelTransactions == null) {
+			newTopLevelTransaction();
+			topLevelTransactions = (List<List<List<AuditerMessage>>>) TransactionSynchronizationManager.getResource(this);
 		}
-		return savepoints;
+		return topLevelTransactions;
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunConnection.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunConnection.java
@@ -43,26 +43,26 @@ public class PerunConnection implements Connection {
 		
 	@Override
 	public Savepoint setSavepoint() throws SQLException {
-		auditer.newTransaction();
+		auditer.newNestedTransaction();
 		return connectionImpl.setSavepoint();
 	}
 
 	@Override
 	public Savepoint setSavepoint(String string) throws SQLException {
-		auditer.newTransaction();
+		auditer.newNestedTransaction();
 		return connectionImpl.setSavepoint(string);
 	}
 		
 	@Override
 	public void rollback(Savepoint svpnt) throws SQLException {
-		auditer.cleanTransation();
+		auditer.cleanNestedTransation();
 		connectionImpl.rollback(svpnt);
 		
 	}
 		
 	@Override
 	public void releaseSavepoint(Savepoint svpnt) throws SQLException {
-		auditer.flushTransaction();
+		auditer.flushNestedTransaction();
 		connectionImpl.releaseSavepoint(svpnt);
 	}
 	

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunTransactionManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunTransactionManager.java
@@ -16,7 +16,7 @@ public class PerunTransactionManager extends DataSourceTransactionManager implem
 	
 	@Override
 	protected void doBegin(Object transaction, TransactionDefinition definition) {
-		this.getAuditer().transactionBegin();
+		this.getAuditer().newTopLevelTransaction();
 		super.doBegin(transaction, definition);
 	}
 


### PR DESCRIPTION
- fixed problem with more top-level transactions when synchronizing groups in perun