### PR TITLE
CORE: Fixed test of getAdmins() for security teams

### DIFF
--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -273,7 +273,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpUsers();
 		List<User> expected = setUpAdmins(u0, u1, setUpGroup(u1, u2));
 		List<User> actual = securityTeamsManagerEntry.getAdmins(sess, st0);
-
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
 	@Test


### PR DESCRIPTION
- We must sort both lists when asserting equals on them,
  otherwise test is dependant on current db select order.