### PR TITLE
CORE: Fixed user and security team and facility deletion and SQL

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/ContactGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/ContactGroup.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- *
  * Represents group of contacts for Facility (users, owners and groups)
  *
  * @author Michal Stava <stavamichal@gmail.com>
@@ -106,6 +105,14 @@ public class ContactGroup {
 		return true;
 	}
 
+	/**
+	 * Check if ContactGroup is equals in base params like name and facility.
+	 * It is used when merging ContactGroups selected from DB together
+	 * and filling connected owners, groups and users.
+	 *
+	 * @param other Other ContactGroup to compare with
+	 * @return TRUE if both equals in name and facility
+	 */
 	public boolean equalsGroup(ContactGroup other) {
 		if (other == null) {
 			return false;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Facility.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Facility.java
@@ -1,7 +1,5 @@
 package cz.metacentrum.perun.core.api;
 
-import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
-
 /**
  * Class represents facility.
  *
@@ -104,7 +102,10 @@ public class Facility extends Auditable implements Comparable<Facility> {
 
 	@Override
 	public int compareTo(Facility facility) {
-		if (facility == null || this.name == null) throw new InternalErrorRuntimeException(new NullPointerException("Facility facility or name"));
+		if (facility == null) new NullPointerException("Facility to compare with is null.");
+		if (this.name == null && facility.getName() != null) return -1;
+		if (facility.getName() == null && this.name != null) return 1;
+		if (this.name == null && facility.getName() == null) return 0;
 		return this.name.compareTo(facility.getName());
 	}
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Facility.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Facility.java
@@ -102,7 +102,7 @@ public class Facility extends Auditable implements Comparable<Facility> {
 
 	@Override
 	public int compareTo(Facility facility) {
-		if (facility == null) new NullPointerException("Facility to compare with is null.");
+		if (facility == null) throw new NullPointerException("Facility to compare with is null.");
 		if (this.name == null && facility.getName() != null) return -1;
 		if (facility.getName() == null && this.name != null) return 1;
 		if (this.name == null && facility.getName() == null) return 0;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/SecurityTeam.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/SecurityTeam.java
@@ -74,10 +74,12 @@ public class SecurityTeam extends Auditable implements Comparable<SecurityTeam> 
 				']').toString();
 	}
 
+	@Override
 	public int compareTo(SecurityTeam securityTeam) {
-		if (securityTeam == null) {
-			throw new NullPointerException();
-		}
+		if (securityTeam == null) throw new NullPointerException();
+		if (this.name == null && securityTeam.getName() != null) return -1;
+		if (securityTeam.getName() == null && this.name != null) return 1;
+		if (this.name == null && securityTeam.getName() == null) return 0;
 		return this.getName().compareTo(securityTeam.getName());
 	}
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/SecurityTeam.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/SecurityTeam.java
@@ -76,7 +76,7 @@ public class SecurityTeam extends Auditable implements Comparable<SecurityTeam> 
 
 	@Override
 	public int compareTo(SecurityTeam securityTeam) {
-		if (securityTeam == null) throw new NullPointerException();
+		if (securityTeam == null) throw new NullPointerException("SecurityTeam to compare with is null.");
 		if (this.name == null && securityTeam.getName() != null) return -1;
 		if (securityTeam.getName() == null && this.name != null) return 1;
 		if (this.name == null && securityTeam.getName() == null) return 0;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -410,6 +410,19 @@ public interface FacilitiesManager {
 	List<Facility> getAssignedFacilities(PerunSession sess, Service service) throws InternalErrorException, PrivilegeException, ServiceNotExistsException;
 
 	/**
+	 * Get facilities where security team is assigned.
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws SecurityTeamNotExistsException
+	 */
+	List<Facility> getAssignedFacilities(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
+
+	/**
 	 * List hosts of Facility.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/SecurityTeamsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/SecurityTeamsManager.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserAlreadyBlacklistedException;
@@ -76,8 +77,23 @@ public interface SecurityTeamsManager {
 	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
 	 * @throws InternalErrorException
 	 * @throws SecurityTeamNotExistsException
+	 * @throws RelationExistsException if team is assigned to any facility or has blacklisted users.
 	 */
-	void deleteSecurityTeam(PerunSession perunSession, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
+	void deleteSecurityTeam(PerunSession perunSession, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, RelationExistsException;
+
+	/**
+	 * Delete SecurityTeam.
+	 *
+	 * @param perunSession
+	 * @param securityTeam
+	 * @param forceDelete TRUE if Team should be forcefully deleted.
+	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
+	 * @throws InternalErrorException
+	 * @throws SecurityTeamNotExistsException
+	 * @throws RelationExistsException if forceDelete == FALSE and team is assigned to any facility or has blacklisted users.
+	 */
+	void deleteSecurityTeam(PerunSession perunSession, SecurityTeam securityTeam, boolean forceDelete) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, RelationExistsException;
+
 
 	/**
 	 * Find existing SecurityTeam by ID.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -376,6 +376,17 @@ public interface FacilitiesManagerBl {
 	List<Facility> getAssignedFacilities(PerunSession sess, Service service) throws InternalErrorException;
 
 	/**
+	 * Get facilities where the security team is assigned
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Facility> getAssignedFacilities(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
+
+	/**
 	 * Returns all facilities which have set the attribute with the value. Searching only def and opt attributes.
 	 *
 	 * @param sess
@@ -832,9 +843,8 @@ public interface FacilitiesManagerBl {
 	 * @param facility
 	 * @return list of ContactGroups for the facility
 	 * @throws InternalErrorException
-	 * @throws FacilityContactNotExistsException
 	 */
-	List<ContactGroup> getFacilityContactGroups(PerunSession sess, Facility facility) throws InternalErrorException, FacilityContactNotExistsException;
+	List<ContactGroup> getFacilityContactGroups(PerunSession sess, Facility facility) throws InternalErrorException;
 
 	/**
 	 * Get contact group for the facility and the contact group name

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SecurityTeamsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SecurityTeamsManagerBl.java
@@ -5,19 +5,12 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
-import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
-import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.UserAlreadyBlacklistedException;
-import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
-import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.*;
 
 import java.util.List;
 
 /**
- * Created by ondrej on 12.8.15.
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
  */
 public interface SecurityTeamsManagerBl {
 
@@ -68,10 +61,12 @@ public interface SecurityTeamsManagerBl {
 	 *
 	 * @param sess
 	 * @param securityTeam
+	 * @param forceDelete TRUE if Team should be forcefully deleted.
 	 * @throws InternalErrorException
 	 * @throws SecurityTeamNotExistsException
+	 * @throws RelationExistsException if forceDelete == FALSE and team is assigned to any facility or has blacklisted users.
 	 */
-	void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotExistsException;
+	void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam, boolean forceDelete) throws InternalErrorException, SecurityTeamNotExistsException, RelationExistsException;
 
 	/**
 	 * get security team by its id
@@ -171,6 +166,15 @@ public interface SecurityTeamsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException;
+
+	/**
+	 * Remove user from all blacklists
+	 *
+	 * @param sess
+	 * @param user
+	 * @throws InternalErrorException
+	 */
+	void removeUserFromAllBlacklists(PerunSession sess, User user) throws InternalErrorException;
 
 	/**
 	 * get blacklist of security team
@@ -308,5 +312,15 @@ public interface SecurityTeamsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	boolean isUserBlacklisted(PerunSession sess, SecurityTeam st, User user) throws InternalErrorException;
+
+	/**
+	 * Check if user is blacklisted by any security team
+	 *
+	 * @param sess
+	 * @param user
+	 * @return true if given user is blacklisted by any security team
+	 * @throws InternalErrorException
+	 */
+	boolean isUserBlacklisted(PerunSession sess, User user) throws InternalErrorException;
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1154,7 +1154,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			}
 		}
 
-			return complementaryObjects;
+		return complementaryObjects;
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Created by ondrej on 12.8.15.
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
  */
 public class SecurityTeamsManagerBlImpl implements SecurityTeamsManagerBl {
 
@@ -126,13 +126,13 @@ public class SecurityTeamsManagerBlImpl implements SecurityTeamsManagerBl {
 	@Override
 	public void addUserToBlacklist(PerunSession sess, SecurityTeam securityTeam, User user, String description) throws InternalErrorException {
 		getSecurityTeamsManagerImpl().addUserToBlacklist(sess, securityTeam, user, description);
-		getPerunBl().getAuditer().log(sess, "{} add to blaclist of {} with description '{}'.", user, securityTeam, description);
+		getPerunBl().getAuditer().log(sess, "{} add to blacklist of {} with description '{}'.", user, securityTeam, description);
 	}
 
 	@Override
 	public void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException {
 		getSecurityTeamsManagerImpl().removeUserFromBlacklist(sess, securityTeam, user);
-		getPerunBl().getAuditer().log(sess, "{} remove from blaclist of {}.", user, securityTeam);
+		getPerunBl().getAuditer().log(sess, "{} remove from blacklist of {}.", user, securityTeam);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserAlreadyBlacklistedException;
@@ -23,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -78,10 +80,30 @@ public class SecurityTeamsManagerBlImpl implements SecurityTeamsManagerBl {
 	}
 
 	@Override
-	public void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam) throws SecurityTeamNotExistsException, InternalErrorException {
+	public void deleteSecurityTeam(PerunSession sess, SecurityTeam securityTeam, boolean forceDelete) throws SecurityTeamNotExistsException, InternalErrorException, RelationExistsException {
+
+		// remove all users from blacklist, which were blacklisted by this security team.
+		List<User> blacklist = getSecurityTeamsManagerImpl().getBlacklist(sess, Arrays.asList(securityTeam));
+		if (blacklist != null && !blacklist.isEmpty() && !forceDelete) {
+			throw new RelationExistsException("SecurityTeam has blacklisted users.");
+		}
+		for (User blacklistedUser : blacklist) {
+			// calling BL will make auditer message about user to appear.
+			getPerunBl().getSecurityTeamsManagerBl().removeUserFromBlacklist(sess, securityTeam, blacklistedUser);
+		}
+
+		// remove security team from all facilities
+		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getAssignedFacilities(sess, securityTeam);
+		if (facilities != null && !facilities.isEmpty() && !forceDelete) {
+			throw new RelationExistsException("SecurityTeam is assigned to some facilities.");
+		}
+		for (Facility facility : facilities) {
+			// calling BL will make auditer message about facility to appear.
+			getPerunBl().getFacilitiesManagerBl().removeSecurityTeam(sess, facility, securityTeam);
+		}
+
 		getSecurityTeamsManagerImpl().deleteSecurityTeam(sess, securityTeam);
 		getPerunBl().getAuditer().log(sess, "{} was deleted.", securityTeam);
-
 	}
 
 	@Override
@@ -133,6 +155,12 @@ public class SecurityTeamsManagerBlImpl implements SecurityTeamsManagerBl {
 	public void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException {
 		getSecurityTeamsManagerImpl().removeUserFromBlacklist(sess, securityTeam, user);
 		getPerunBl().getAuditer().log(sess, "{} remove from blacklist of {}.", user, securityTeam);
+	}
+
+	@Override
+	public void removeUserFromAllBlacklists(PerunSession sess, User user) throws InternalErrorException {
+		getSecurityTeamsManagerImpl().removeUserFromAllBlacklists(sess, user);
+		getPerunBl().getAuditer().log(sess, "{} remove from all blacklists.", user);
 	}
 
 	@Override
@@ -203,6 +231,10 @@ public class SecurityTeamsManagerBlImpl implements SecurityTeamsManagerBl {
 		return getSecurityTeamsManagerImpl().isUserBlacklisted(sess, securityTeam, user);
 	}
 
+	@Override
+	public boolean isUserBlacklisted(PerunSession sess, User user) throws InternalErrorException {
+		return getSecurityTeamsManagerImpl().isUserBlacklisted(sess, user);
+	}
 
 	/**
 	 * Gets the securityTeamsManagerImpl.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -303,6 +303,12 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			}
 		}
 
+		if (getPerunBl().getSecurityTeamsManagerBl().isUserBlacklisted(sess, user) && forceDelete) {
+			getPerunBl().getSecurityTeamsManagerBl().removeUserFromAllBlacklists(sess, user);
+		} else if (getPerunBl().getSecurityTeamsManagerBl().isUserBlacklisted(sess, user) && !forceDelete) {
+			throw new RelationExistsException("User is blacklisted by some security team. Deletion would cause loss of this information.");
+		}
+
 		// First delete all associated external sources to the user
 		getUsersManagerImpl().removeAllUserExtSources(sess, user);
 		getPerunBl().getAuditer().log(sess, "All user ext sources removed for {}.", user);
@@ -661,8 +667,8 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 		// Create Attribute
 		try {
-			AttributeDefinition attributeDefinitition = getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:" + loginNamespace);
-			Attribute attribute = new Attribute(attributeDefinitition);
+			AttributeDefinition attributeDefinition = getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:" + loginNamespace);
+			Attribute attribute = new Attribute(attributeDefinition);
 
 			attribute.setValue(login);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -447,6 +447,18 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		return getFacilitiesManagerBl().getAssignedFacilities(sess, service);
 	}
 
+	public List<Facility> getAssignedFacilities(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN, securityTeam)) {
+			throw new PrivilegeException(sess, "getAssignedFacilities");
+		}
+
+		return getFacilitiesManagerBl().getAssignedFacilities(sess, securityTeam);
+	}
+
 	/**
 	 * Gets the facilitiesManagerBl for this instance.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -933,7 +933,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 			return jdbc.query("select " + SecurityTeamsManagerImpl.securityTeamMappingSelectQuery +
 							" from security_teams inner join (" +
 							"select security_teams_facilities.security_team_id from security_teams_facilities where facility_id=?" +
-							") " + Compatibility.getAsAlias("assigned_ids") + " ON security_teams.id=assigned_ids.security_team_id",
+							") " + Compatibility.getAsAlias("assigned_ids")+ " ON security_teams.id=assigned_ids.security_team_id",
 					SecurityTeamsManagerImpl.SECURITY_TEAM_MAPPER, facility.getId());
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
@@ -975,6 +975,17 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 		}
 	}
 
+	public List<Facility> getAssignedFacilities(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + facilityMappingSelectQuery +
+							" from facilities inner join (" +
+							"select security_teams_facilities.facility_id from security_teams_facilities where security_team_id=?" +
+							") " + Compatibility.getAsAlias("assigned_ids")+ " ON facilities.id=assigned_ids.facility_id",
+					FACILITY_MAPPER, securityTeam.getId());
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
 
 	private boolean isSecurityTeamAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException {
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -933,7 +933,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 			return jdbc.query("select " + SecurityTeamsManagerImpl.securityTeamMappingSelectQuery +
 							" from security_teams inner join (" +
 							"select security_teams_facilities.security_team_id from security_teams_facilities where facility_id=?" +
-							") as assigned_ids ON security_teams.id=assigned_ids.security_team_id",
+							") " + Compatibility.getAsAlias("assigned_ids") + " ON security_teams.id=assigned_ids.security_team_id",
 					SecurityTeamsManagerImpl.SECURITY_TEAM_MAPPER, facility.getId());
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Created by ondrej on 13.8.15.
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
  */
 public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 
@@ -168,8 +168,8 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 							"select gm.member_id, gm.group_id from groups_members " + Compatibility.getAsAlias("gm") +
 							" inner join " +
 							"authz on authz.authorized_group_id=gm.group_id where authz.security_team_id=? " +
-							") as member_group_ids on members.id=member_group_ids.member_id)" +
-							") as user_ids ON users.id=user_ids.user_id",
+							") " + Compatibility.getAsAlias("member_group_ids") + " on members.id=member_group_ids.member_id)" +
+							") " + Compatibility.getAsAlias("user_ids") + " on users.id=user_ids.user_id",
 					UsersManagerImpl.USER_MAPPER, securityTeam.getId(), securityTeam.getId());
 
 			return list;
@@ -180,6 +180,9 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 
 	@Override
 	public void addUserToBlacklist(PerunSession sess, SecurityTeam securityTeam, User user, String description) throws InternalErrorException {
+		if (description != null && description.trim().isEmpty()) {
+			description = null;
+		}
 		try {
 			jdbc.update("insert into blacklists(security_team_id, user_id, description, created_by, created_at, modified_by, modified_at, created_by_uid, modified_by_uid) " +
 					"values (?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)",
@@ -210,7 +213,7 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 				list = jdbc.query("select " + UsersManagerImpl.userMappingSelectQuery +
 								" from users inner join (" +
 								"select blacklists.user_id from blacklists where security_team_id=?" +
-								") as blacklisted_ids ON users.id=blacklisted_ids.user_id",
+								") " + Compatibility.getAsAlias("blacklisted_ids") + " ON users.id=blacklisted_ids.user_id",
 						UsersManagerImpl.USER_MAPPER, st.getId());
 
 				blacklisted.addAll(list);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -681,4 +681,15 @@ public interface FacilitiesManagerImplApi {
 	 */
 	void checkSecurityTeamAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamNotAssignedException;
 
+	/**
+	 * Get facilities where security team is assigned.
+	 *
+	 * @param sess
+	 * @param securityTeam
+	 * @return
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Facility> getAssignedFacilities(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SecurityTeamsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SecurityTeamsManagerImplApi.java
@@ -14,7 +14,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import java.util.List;
 
 /**
- * Created by ondrej on 12.8.15.
+ * @author Ondrej Velisek <ondrejvelisek@gmail.com>
  */
 public interface SecurityTeamsManagerImplApi {
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SecurityTeamsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SecurityTeamsManagerImplApi.java
@@ -115,6 +115,15 @@ public interface SecurityTeamsManagerImplApi {
 	void removeUserFromBlacklist(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException;
 
 	/**
+	 * Remove user from all blacklists
+	 *
+	 * @param sess
+	 * @param user
+	 * @throws InternalErrorException
+	 */
+	void removeUserFromAllBlacklists(PerunSession sess, User user) throws InternalErrorException;
+
+	/**
 	 * get union of blacklists of security teams
 	 *
 	 * @param sess
@@ -208,8 +217,7 @@ public interface SecurityTeamsManagerImplApi {
 	void checkGroupIsSecurityAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException;
 
 	/**
-	 * check if user is not blacklisted by given security team
-	 * throw exception if is
+	 * Check if user is blacklisted by given security team
 	 *
 	 * @param sess
 	 * @param securityTeam
@@ -217,5 +225,14 @@ public interface SecurityTeamsManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	boolean isUserBlacklisted(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException;
+
+	/**
+	 * Check if user is blacklisted by any security team
+	 *
+	 * @param sess
+	 * @param user
+	 * @throws InternalErrorException
+	 */
+	boolean isUserBlacklisted(PerunSession sess, User user) throws InternalErrorException;
 
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/AbstractPerunIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/AbstractPerunIntegrationTest.java
@@ -50,7 +50,7 @@ import cz.metacentrum.perun.core.bl.PerunBl;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "classpath:/perun-core.xml", "/perun-core-jdbc.xml" })
+@ContextConfiguration(locations = { "classpath:perun-core.xml", "classpath:perun-core-jdbc.xml" })
 @TransactionConfiguration(transactionManager = "springTransactionManager", defaultRollback = true)
 @Transactional
 public abstract class AbstractPerunIntegrationTest {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -15,15 +15,14 @@ import org.junit.Test;
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**
+ * Integration tests of AuthzResolver
+ *
  * @author Jiri Harazim <harazim@mail.muni.cz>
  */
-
 public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	private static final String CLASS_NAME = "AuthzResolver.";
@@ -31,14 +30,14 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isAuthorizedInvalidPrincipal() throws Exception {
-		System.out.println(CLASS_NAME + "isAuthorizedInvalidPrincipal()");
+		System.out.println(CLASS_NAME + "isAuthorizedInvalidPrincipal");
 
 		assertTrue(! AuthzResolver.isAuthorized(new PerunSessionImpl(perun, new PerunPrincipal("pepa", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL)), Role.PERUNADMIN));
 	}
 
 	@Test
 	public void setRoleVoAdmin() throws Exception {
-		System.out.println(CLASS_NAME + "setRole()");
+		System.out.println(CLASS_NAME + "setRole");
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
 		final Member createdMember = createSomeMember(createdVo);
 		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
@@ -53,7 +52,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void setRoleVoObserver() throws Exception {
-		System.out.println(CLASS_NAME + "setRole()");
+		System.out.println(CLASS_NAME + "setRole");
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
 		final Member createdMember = createSomeMember(createdVo);
 		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
@@ -68,7 +67,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void unsetRoleVoAdmin() throws Exception {
-		System.out.println(CLASS_NAME + "unsetRole()");
+		System.out.println(CLASS_NAME + "unsetRole");
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
 		final Member createdMember = createSomeMember(createdVo);
 		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
@@ -88,7 +87,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test (expected = UserNotAdminException.class)
 	public void unsetRoleWhichNotExists() throws Exception {
-		System.out.println(CLASS_NAME + "unsetRole()");
+		System.out.println(CLASS_NAME + "unsetRole");
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
 		final Member createdMember = createSomeMember(createdVo);
 		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
@@ -98,7 +97,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test (expected = UserNotAdminException.class)
 	public void setUnsuportedRole() throws Exception {
-		System.out.println(CLASS_NAME + "setRole()");
+		System.out.println(CLASS_NAME + "setRole");
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
 		final Member createdMember = createSomeMember(createdVo);
 		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
@@ -108,7 +107,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isVoAdmin() throws Exception {
-		System.out.println(CLASS_NAME + "isVoAdmin()");
+		System.out.println(CLASS_NAME + "isVoAdmin");
 
 		assertTrue(! AuthzResolver.isVoAdmin(sess));
 
@@ -127,7 +126,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isGroupAdmin() throws Exception {
-		System.out.println(CLASS_NAME + "isGroupAdmin()");
+		System.out.println(CLASS_NAME + "isGroupAdmin");
 
 		sess = mock(PerunSession.class, RETURNS_DEEP_STUBS);
 		when(sess.getPerunPrincipal().getRoles().hasRole(Role.GROUPADMIN)).thenReturn(true);
@@ -137,7 +136,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isFacilityAdmin() {
-		System.out.println(CLASS_NAME + "isFacilityAdmin()");
+		System.out.println(CLASS_NAME + "isFacilityAdmin");
 
 		sess = mock(PerunSession.class, RETURNS_DEEP_STUBS);
 		when(sess.getPerunPrincipal().getRoles().hasRole(Role.FACILITYADMIN)).thenReturn(true);
@@ -147,7 +146,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isVoAdminUnit() {
-		System.out.println(CLASS_NAME + "isVoAdminUnit()");
+		System.out.println(CLASS_NAME + "isVoAdminUnit");
 
 		sess = mock(PerunSession.class, RETURNS_DEEP_STUBS);
 		when(sess.getPerunPrincipal().getRoles().hasRole(Role.VOADMIN)).thenReturn(true);
@@ -157,7 +156,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isPerunAdmin() {
-		System.out.println(CLASS_NAME + "isPerunAdmin()");
+		System.out.println(CLASS_NAME + "isPerunAdmin");
 
 		sess = mock(PerunSession.class, RETURNS_DEEP_STUBS);
 		when(sess.getPerunPrincipal().getRoles().hasRole(Role.PERUNADMIN)).thenReturn(true);
@@ -167,7 +166,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isAuthorized() throws Exception {
-		System.out.println(CLASS_NAME + "isAuthorized()");
+		System.out.println(CLASS_NAME + "isAuthorized");
 
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"sdf","sdfh"));
 		final Member createdMember = createSomeMember(createdVo);
@@ -182,7 +181,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void addAllSubgroupsToAuthzRoles() throws Exception {
-		System.out.println(CLASS_NAME + "addAllSubgroupsToAuthzRoles()");
+		System.out.println(CLASS_NAME + "addAllSubgroupsToAuthzRoles");
 
 		Vo testVo = new Vo(1000, "AuthzResolver-testVo", "AuthzResolver-testVo");
 		testVo = perun.getVosManagerBl().createVo(sess, testVo);
@@ -217,7 +216,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isAuthorizedInOtherVo() throws Exception {
-		System.out.println(CLASS_NAME + "isAuthorizedInOtherVo()");
+		System.out.println(CLASS_NAME + "isAuthorizedInOtherVo");
 
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"som3Vo","VoSom3Nam3"));
 		final Member createdMemberKouril = createSomeMember(createdVo);
@@ -235,7 +234,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void isAuthorizedWrongRole() throws Exception {
-		System.out.println(CLASS_NAME + "isAuthorizedWrongRole()");
+		System.out.println(CLASS_NAME + "isAuthorizedWrongRole");
 
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"sdf","sdfh"));
 		final Member createdMember = createSomeMember(createdVo);
@@ -253,7 +252,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getPrincipalRoleNames() throws Exception {
-		System.out.println(CLASS_NAME + "getPrincipalRoleNames()");
+		System.out.println(CLASS_NAME + "getPrincipalRoleNames");
 
 		// Principal perunTests is PERUNADMIN
 		PerunPrincipal pp =  new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -1,12 +1,5 @@
 package cz.metacentrum.perun.core.entry;
 
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.spy;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -17,16 +10,12 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.PrintWriter;
 
 import cz.metacentrum.perun.core.api.ResourcesManager;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
@@ -39,15 +28,11 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Owner;
-import cz.metacentrum.perun.core.api.OwnerType;
 import cz.metacentrum.perun.core.api.PerunBean;
-import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichAttribute;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.Service;
-import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
@@ -65,17 +50,16 @@ import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import java.util.LinkedList;
 import java.util.Set;
-import javax.print.attribute.SetOfIntegerSyntax;
-import org.mockito.internal.matchers.Any;
 
 /**
+ * Integration tests of AttributesManager
+ *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-
 public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
+
+	private final static String CLASS_NAME = "AttributesManager.";
 
 	/*
 	 * Test is divided into groups by the type of methods
@@ -92,7 +76,6 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 * 10. ==checkAttributeValue==
 	 * 11. removeAttribute/s / removeAllAttributes
 	 * 12. rest check methods
-	 *
 	 */
 
 	// these are in DB only when setUp"Type"() and must be used in correct (this) order
@@ -272,7 +255,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void setGroupNameWillProduceSettingMoreThanOneGIDAtOnce() throws Exception {
-		System.out.println("attributesManager.setGroupNameWillProduceSettingMoreThanOneGIDAtOnce");
+		System.out.println(CLASS_NAME + "setGroupNameWillProduceSettingMoreThanOneGIDAtOnce");
 
 		//special variables
 		String namespaceAAA = "AAA";
@@ -422,7 +405,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResourceAndMember() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResourceAndMember");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResourceAndMember");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo1, attribute);
@@ -440,7 +423,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResourceAndGroup() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResourceAndGroup");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResourceAndGroup");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo1, attribute);
@@ -458,7 +441,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromUserAndFacility() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromUserAndFacility");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromUserAndFacility");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo1, attribute);
@@ -478,7 +461,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromGroup() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromGroup");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromGroup");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo2, attribute);
@@ -498,7 +481,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromMember() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromMember");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromMember");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo1, attribute);
@@ -514,7 +497,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResource() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResource");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromResource");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo2, attribute);
@@ -534,7 +517,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromUser() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromUser");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromUser");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo1, attribute);
@@ -554,7 +537,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromHost() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromHost");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromHost");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo2, attribute);
@@ -581,7 +564,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromFacility() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromFacility");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromFacility");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo2, attribute);
@@ -607,7 +590,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromVo() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromVo");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromVo");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo2, attribute);
@@ -628,7 +611,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetVosFromKey() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetVosFromKey");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetVosFromKey");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_VO_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, vo2, attribute);
@@ -653,7 +636,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromResourceAndMember() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromResourceAndMember");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromResourceAndMember");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_GROUP_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, group1InVo2, attribute);
@@ -671,7 +654,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromResourceAndGroup() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromResourceAndGroup");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromResourceAndGroup");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_GROUP_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, group2InVo2, attribute);
@@ -693,7 +676,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromUserAndFacility() throws Exception {
-		System.out.println("attributesManager.getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromUserAndFacility");
+		System.out.println(CLASS_NAME + "getRichAttributesWithHoldersForAttributeDefinitionGetGroupFromUserAndFacility");
 		//Prepare attribute, create it and set it with testing value
 		Attribute attribute = setAttributeInNamespace(AttributesManager.NS_GROUP_ATTR);
 		perun.getAttributesManagerBl().setAttribute(sess, group1InVo2, attribute);
@@ -722,7 +705,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAllSimilarAttributeNames() throws Exception {
-		System.out.println("attributesManager.getAllSimilarAttributeNames");
+		System.out.println(CLASS_NAME + "getAllSimilarAttributeNames");
 
 		List<String> similarAttrNames = new ArrayList<String>();
 		String name = "urn:perun:user:attribute-def:def:login-namespace";
@@ -732,7 +715,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getFacilityAttributes() throws Exception {
-		System.out.println("attributesManager.getFacilityAttributes");
+		System.out.println(CLASS_NAME + "getFacilityAttributes");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -748,17 +731,17 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getFacilityAttributesWhenFacilityNotExists() throws Exception {
-			System.out.println("attributesManager.getFacilityAttributesWhenFacilityNotExists");
+	public void getFacilityAttributesWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesWhenFacilityNotExists");
 
-			attributesManager.getAttributes(sess, new Facility());
-			// shouldn't find facility
+		attributesManager.getAttributes(sess, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void getAllGroupAttributesStartWithNameWithoutNullValue() throws Exception {
-		System.out.println("attributesManager.getAllAttributesStartWithNameWithoutNullValue");
+		System.out.println(CLASS_NAME + "getAllAttributesStartWithNameWithoutNullValue");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -779,7 +762,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAllResourceAttributesStartWithNameWithoutNullValue() throws Exception {
-		System.out.println("attributesManager.getAllAttributesStartWithNameWithoutNullValue");
+		System.out.println(CLASS_NAME + "getAllAttributesStartWithNameWithoutNullValue");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -799,7 +782,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getVoAttributes() throws Exception {
-		System.out.println("attributesManager.getVoAttributes");
+		System.out.println(CLASS_NAME + "getVoAttributes");
 
 		vo = setUpVo();
 		attributes = setUpVoAttribute();
@@ -868,7 +851,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getEntitylessAttributes() throws Exception {
-		System.out.println("attributesManager.getEntitylessAttributes");
+		System.out.println(CLASS_NAME + "getEntitylessAttributes");
 
 		attributes = setUpEntitylessAttribute();
 		String key = "Test Attributu Michal";
@@ -881,56 +864,56 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		assertEquals("We expected 1 and we get "+retAttr.size(), 1, retAttr.size());
 
 	}
-	
+
 	@Test
 	public void getEntitylessAttributeForUpdateWithListValue() throws Exception {
-		System.out.println("attributesManager.getEntitylessAttributeForUpdate");
+		System.out.println(CLASS_NAME + "getEntitylessAttributeForUpdate");
 
 		List<Attribute> attributes = setUpEntitylessAttributeWithListValue();
 		perun.getAttributesManagerBl().setAttribute(sess, "test1", attributes.get(0));
 		perun.getAttributesManagerBl().setAttribute(sess, "test2", attributes.get(0));
-		
+
 		Attribute attr1 = perun.getAttributesManagerBl().getEntitylessAttributeForUpdate(sess, "test1", attributes.get(0).getName());
 		Attribute attr2 = perun.getAttributesManagerBl().getEntitylessAttributeForUpdate(sess, "test2", attributes.get(0).getName());
-		
+
 		List<String> attr1Value = (List<String>) attr1.getValue();
 		List<String> attr2Value = (List<String>) attr2.getValue();
-		
+
 		assertTrue("Values must be equals", attr1Value.equals(attributes.get(0).getValue()));
 		assertTrue("Values must be equals", attr2Value.equals(attributes.get(0).getValue()));
 		assertTrue("Attributes are the same", attr1.equals(attr2));
 		assertTrue("Attributes are the same", attr1.equals(attributes.get(0)));
 		assertTrue("Attributes are the same", attr2.equals(attributes.get(0)));
 	}
-	
+
 	@Test
 	public void getEntitylessAttributeForUpdateWithMapValue() throws Exception {
-		System.out.println("attributesManager.getEntitylessAttributeForUpdate");
+		System.out.println(CLASS_NAME + "getEntitylessAttributeForUpdate");
 
 		List<Attribute> attributes = setUpEntitylessAttributeWithMapValue();
-		
+
 		perun.getAttributesManagerBl().setAttribute(sess, "test1", attributes.get(0));
 		perun.getAttributesManagerBl().setAttribute(sess, "test2", attributes.get(0));
-		
+
 		Attribute testAttr1 = perun.getAttributesManagerBl().getAttribute(sess, "test1", attributes.get(0).getName());
 		Attribute testAttr2 = perun.getAttributesManagerBl().getAttribute(sess, "test2", attributes.get(0).getName());
-		
+
 		Attribute attr1 = perun.getAttributesManagerBl().getEntitylessAttributeForUpdate(sess, "test1", attributes.get(0).getName());
 		Attribute attr2 = perun.getAttributesManagerBl().getEntitylessAttributeForUpdate(sess, "test2", attributes.get(0).getName());
-		
+
 		Map<String, String> attr1Value = (Map<String, String>) attr1.getValue();
 		Map<String, String> attr2Value = (Map<String, String>) attr2.getValue();
-		
+
 		assertTrue("Values must be equals", attr1Value.equals(attributes.get(0).getValue()));
 		assertTrue("Values must be equals", attr2Value.equals(attributes.get(0).getValue()));
 		assertTrue("Attributes are the same", attr1.equals(attr2));
 		assertTrue("Attributes are the same", attr1.equals(attributes.get(0)));
 		assertTrue("Attributes are the same", attr2.equals(attributes.get(0)));
 	}
-	
+
 	@Test
 	public void getEntitylessKeys() throws Exception {
-		System.out.println("attributesManager.getEntitylessKeys");
+		System.out.println(CLASS_NAME + "getEntitylessKeys");
 
 		attributes = setUpEntitylessAttribute();
 		String key = "Test Attributu Michal2";
@@ -946,92 +929,92 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	/*@Test
 		public void checkAttributeDependenciesForAllAttributesInMap() throws Exception {
-		System.out.println("attributesManager.checkAttributeDependenciesForAllAttributesInMap");
+		System.out.println(CLASS_NAME + "checkAttributeDependenciesForAllAttributesInMap");
 		AttributesManagerBlImpl attributesManagerBlImpl = mock(AttributesManagerBlImpl.class, RETURNS_DEEP_STUBS); //RETURNS_DEEP_STUBS = budeme mockovat nekolik vnorenych volani metod
 //spy(attributesManagerBlImpl).checkAttributeValue(sess, resource, null);
 //when(attributesManagerBlImpl.checkAttributeValue(any(PerunSession.class), any(Resource.class), any(Attribute.class)))
 }*/
 
-@Test (expected=VoNotExistsException.class)
+	@Test (expected=VoNotExistsException.class)
 	public void getVoAttributesWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.getVoAttributesWhenVoNotExists");
+		System.out.println(CLASS_NAME + "getVoAttributesWhenVoNotExists");
 
 		attributesManager.getAttributes(sess, new Vo());
 		// shouldn't find VO
 
 	}
 
-@Test
-public void getResourceAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceAttributes");
+	@Test
+	public void getResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpResourceAttribute();
-	attributesManager.setAttribute(sess, resource, attributes.get(0));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpResourceAttribute();
+		attributesManager.setAttribute(sess, resource, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
-	assertNotNull("unable to get resource attributes", retAttr);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
+		assertNotNull("unable to get resource attributes", retAttr);
 
-	assertTrue("our atttribute not returned",retAttr.contains(attributes.get(0)));
-	assertTrue("returned less than 4 attributes",retAttr.size() >= 4);
-	// 3 core + 1 opt
+		assertTrue("our atttribute not returned",retAttr.contains(attributes.get(0)));
+		assertTrue("returned less than 4 attributes",retAttr.size() >= 4);
+		// 3 core + 1 opt
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceAttributesWhenResourceNotExists");
 
 		attributesManager.getAttributes(sess, new Resource());
 		// shouldn't find resource
 
 	}
 
-@Test
-public void getResourceMemberAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceMemberAttributes");
+	@Test
+	public void getResourceMemberAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceMemberAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpMemberResourceAttribute();
-	attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpMemberResourceAttribute();
+		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
-	assertNotNull("unable to get member-resource attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		assertNotNull("unable to get member-resource attributes", retAttr);
+		assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
 // výjímky pro Member a Resource Not Exists nenastanou,
 // protože si to bere data z předaných objektů a ne z databáze
 
 
-@Test
-public void getResourceMemberAttributesForUser() throws Exception {
-	System.out.println("attributesManager.getResourceMemberAttributesForUser");
+	@Test
+	public void getResourceMemberAttributesForUser() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceMemberAttributesForUser");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpUserAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributesManager.setAttribute(sess, user, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpUserAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributesManager.setAttribute(sess, user, attributes.get(0));
 
-	// return members and users attributes from resources members
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member, true);
-	assertNotNull("unable to get member-resource(work with user) attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		// return members and users attributes from resources members
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member, true);
+		assertNotNull("unable to get member-resource(work with user) attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceMemberAttributesForUserWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceMemberAttributesForUserWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceMemberAttributesForUserWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -1041,9 +1024,9 @@ public void getResourceMemberAttributesForUser() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getResourceMemberAttributesForUserWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceMemberAttributesForUserWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getResourceMemberAttributesForUserWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1054,227 +1037,227 @@ public void getResourceMemberAttributesForUser() throws Exception {
 
 	}
 
-@Test
-public void getMemberGroupAttributes() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributes");
+	@Test
+	public void getMemberGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	group = setUpGroup();
-	attributes = setUpMemberGroupAttribute();
-	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		group = setUpGroup();
+		attributes = setUpMemberGroupAttribute();
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
-	assertNotNull("unable to get member-group attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
+		assertNotNull("unable to get member-group attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+	}
 
-@Test
-public void getMemberGroupAttributesForUser() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributesForUser");
+	@Test
+	public void getMemberGroupAttributesForUser() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesForUser");
 
-	vo = setUpVo();
-	member = setUpMember();
-	group = setUpGroup();
-	attributes = setUpUserAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributesManager.setAttribute(sess, user, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		group = setUpGroup();
+		attributes = setUpUserAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributesManager.setAttribute(sess, user, attributes.get(0));
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member_group:attribute-def:opt");
-	attr.setFriendlyName("member-group-test-for-list-of-names-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("MemberGroupAttributeForList");
-	attributesManager.createAttribute(sess, attr);
-	attributesManager.setAttribute(sess, member, group, attr);
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+		attr.setFriendlyName("member-group-test-for-list-of-names-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberGroupAttributeForList");
+		attributesManager.createAttribute(sess, attr);
+		attributesManager.setAttribute(sess, member, group, attr);
 
-	List<String> attrNames = new ArrayList<>();
-	attrNames.add(attributes.get(0).getName());
-	attrNames.add(attr.getName());
+		List<String> attrNames = new ArrayList<>();
+		attrNames.add(attributes.get(0).getName());
+		attrNames.add(attr.getName());
 
-	// return members and users attributes from groups members
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames, true);
-	assertNotNull("unable to get member-group(work with user) attributes", retAttr);
-	assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
-}
+		// return members and users attributes from groups members
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames, true);
+		assertNotNull("unable to get member-group(work with user) attributes", retAttr);
+		assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
+	}
 
-@Test (expected=GroupNotExistsException.class)
-public void getMemberGroupAttributesForUserWhenGroupNotExists() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributesForUserWhenGroupNotExists");
+	@Test (expected=GroupNotExistsException.class)
+	public void getMemberGroupAttributesForUserWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesForUserWhenGroupNotExists");
 
-	vo = setUpVo();
-	member = setUpMember();
+		vo = setUpVo();
+		member = setUpMember();
 
-	attributesManager.getAttributes(sess, member, new Group(), new ArrayList<String>(), true);
-	// shouldn't find group
-}
+		attributesManager.getAttributes(sess, member, new Group(), new ArrayList<String>(), true);
+		// shouldn't find group
+	}
 
-@Test (expected=MemberNotExistsException.class)
-public void getMemberGroupAttributesForUserWhenMemberNotExists() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributesForUserWhenMemberNotExists");
+	@Test (expected=MemberNotExistsException.class)
+	public void getMemberGroupAttributesForUserWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesForUserWhenMemberNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
+		vo = setUpVo();
+		group = setUpGroup();
 
-	attributesManager.getAttributes(sess, new Member(), group, new ArrayList<String>(), true);
-	// shouldn't find member
-}
+		attributesManager.getAttributes(sess, new Member(), group, new ArrayList<String>(), true);
+		// shouldn't find member
+	}
 
-@Test
-public void getMemberGroupAttributesByListOfNames1() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributesByListOfNames");
+	@Test
+	public void getMemberGroupAttributesByListOfNames1() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByListOfNames");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
-	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member_group:attribute-def:opt");
-	attr.setFriendlyName("member-group-test-for-list-of-names-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("MemberGroupAttributeForList");
-	attributesManager.createAttribute(sess, attr);
-	attributesManager.setAttribute(sess, member, group, attr);
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+		attr.setFriendlyName("member-group-test-for-list-of-names-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberGroupAttributeForList");
+		attributesManager.createAttribute(sess, attr);
+		attributesManager.setAttribute(sess, member, group, attr);
 
-	List<String> attrNames = new ArrayList<String>();
-	attrNames.add(attributes.get(0).getName());
-	attrNames.add(attr.getName());
+		List<String> attrNames = new ArrayList<String>();
+		attrNames.add(attributes.get(0).getName());
+		attrNames.add(attr.getName());
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames);
-	assertNotNull("unable to get member-group attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
-	assertTrue("our attribute was not returned", retAttr.contains(attr));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames);
+		assertNotNull("unable to get member-group attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		assertTrue("our attribute was not returned", retAttr.contains(attr));
+	}
 
-@Test
-public void getMemberGroupAttributesByListOfNames2() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributesByListOfNames");
+	@Test
+	public void getMemberGroupAttributesByListOfNames2() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByListOfNames");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
-	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member_group:attribute-def:opt");
-	attr.setFriendlyName("member-group-test-for-list-of-names-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("MemberGroupAttributeForList");
-	attributesManager.createAttribute(sess, attr);
-	attributesManager.setAttribute(sess, member, group, attr);
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+		attr.setFriendlyName("member-group-test-for-list-of-names-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberGroupAttributeForList");
+		attributesManager.createAttribute(sess, attr);
+		attributesManager.setAttribute(sess, member, group, attr);
 
-	List<String> attrNames = new ArrayList<String>();
-	attrNames.add(attr.getName());
+		List<String> attrNames = new ArrayList<String>();
+		attrNames.add(attr.getName());
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames);
-	assertNotNull("unable to get member attributes", retAttr);
-	assertFalse("our attribute was not returned", retAttr.contains(attributes.get(0)));
-	assertTrue("our attribute was not returned", retAttr.contains(attr));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames);
+		assertNotNull("unable to get member attributes", retAttr);
+		assertFalse("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		assertTrue("our attribute was not returned", retAttr.contains(attr));
+	}
 
-@Test
-public void getMemberAttributes() throws Exception {
-	System.out.println("attributesManager.getMemberAttributes");
+	@Test
+	public void getMemberAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttribute(sess, member, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttribute(sess, member, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
-	assertNotNull("unable to get member attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
+		assertNotNull("unable to get member attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getMemberAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getMemberAttributesWhenMemberNotExists");
 
 		attributesManager.getAttributes(sess, new Member());
 		// shouldn't find member
 
 	}
 
-@Test
-public void getMemberAttributesByListOfNames1() throws Exception {
-	System.out.println("attributesManager.getMemberAttributesByListOfNames");
+	@Test
+	public void getMemberAttributesByListOfNames1() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByListOfNames");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttribute(sess, member, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttribute(sess, member, attributes.get(0));
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member:attribute-def:opt");
-	attr.setFriendlyName("member-test-for-list-of-names-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("MemberAttributeForList");
-	attributesManager.createAttribute(sess, attr);
-	attributesManager.setAttribute(sess, member, attr);
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member:attribute-def:opt");
+		attr.setFriendlyName("member-test-for-list-of-names-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberAttributeForList");
+		attributesManager.createAttribute(sess, attr);
+		attributesManager.setAttribute(sess, member, attr);
 
-	List<String> attrNames = new ArrayList<String>();
-	attrNames.add(attributes.get(0).getName());
-	attrNames.add(attr.getName());
+		List<String> attrNames = new ArrayList<String>();
+		attrNames.add(attributes.get(0).getName());
+		attrNames.add(attr.getName());
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, attrNames);
-	assertNotNull("unable to get member attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
-	assertTrue("our attribute was not returned",retAttr.contains(attr));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, attrNames);
+		assertNotNull("unable to get member attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		assertTrue("our attribute was not returned",retAttr.contains(attr));
+	}
 
-@Test
-public void getMemberAttributesByListOfNames2() throws Exception {
-	System.out.println("attributesManager.getMemberAttributesByListOfNames");
+	@Test
+	public void getMemberAttributesByListOfNames2() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByListOfNames");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttribute(sess, member, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttribute(sess, member, attributes.get(0));
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member:attribute-def:opt");
-	attr.setFriendlyName("member-test-for-list-of-names-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("MemberAttributeForList");
-	attributesManager.createAttribute(sess, attr);
-	attributesManager.setAttribute(sess, member, attr);
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member:attribute-def:opt");
+		attr.setFriendlyName("member-test-for-list-of-names-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberAttributeForList");
+		attributesManager.createAttribute(sess, attr);
+		attributesManager.setAttribute(sess, member, attr);
 
-	List<String> attrNames = new ArrayList<String>();
-	attrNames.add(attr.getName());
+		List<String> attrNames = new ArrayList<String>();
+		attrNames.add(attr.getName());
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, attrNames);
-	assertNotNull("unable to get member attributes", retAttr);
-	assertFalse("our attribute was not returned", retAttr.contains(attributes.get(0)));
-	assertTrue("our attribute was not returned", retAttr.contains(attr));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, attrNames);
+		assertNotNull("unable to get member attributes", retAttr);
+		assertFalse("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		assertTrue("our attribute was not returned", retAttr.contains(attr));
+	}
 
-@Test
-public void getFacilityUserAttributes() throws Exception {
-	System.out.println("attributesManager.getFacilityUserAttributes");
+	@Test
+	public void getFacilityUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityUserAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpFacilityUserAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpFacilityUserAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	attributesManager.setAttributes(sess, facility, user, attributes);
-	// set facility-user attribute
+		attributesManager.setAttributes(sess, facility, user, attributes);
+		// set facility-user attribute
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
-	assertNotNull("unable to get facility-user attributes",retAttr);
-	assertTrue("returned incorrect facility-user", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
+		assertNotNull("unable to get facility-user attributes",retAttr);
+		assertTrue("returned incorrect facility-user", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void getFacilityUserAttributesWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributesWhenFacilityNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -1286,9 +1269,9 @@ public void getFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getFacilityUserAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributesWhenUserNotExists");
 
 		facility = setUpFacility();
 
@@ -1297,90 +1280,90 @@ public void getFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test
-public void getUserAttributes() throws Exception {
-	System.out.println("attributesManager.getUserAttributes");
+	@Test
+	public void getUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpUserAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributesManager.setAttribute(sess, user, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpUserAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributesManager.setAttribute(sess, user, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
-	assertNotNull("unable to get user attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
+		assertNotNull("unable to get user attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getUserAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "getUserAttributesWhenUserNotExists");
 
 		attributesManager.getAttributes(sess, new User());
 		// souldn't find user
 
 	}
 
-@Test
-public void getUserLargeAttributes() throws Exception {
-	System.out.println("attributesManager.getUserAttributes - large attributes");
+	@Test
+	public void getUserLargeAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributes - large attributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpUserLargeAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributesManager.setAttribute(sess, user, attributes.get(0));
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpUserLargeAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributesManager.setAttribute(sess, user, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
-	assertNotNull("unable to get user attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
+		assertNotNull("unable to get user attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+	}
 
-@Test
-public void getGroupAttributes() throws Exception {
-	System.out.println("attributesManager.getGroupAttributes");
+	@Test
+	public void getGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpGroupAttribute();
-	attributesManager.setAttribute(sess, group, attributes.get(0));
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpGroupAttribute();
+		attributesManager.setAttribute(sess, group, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
-	assertNotNull("unable to get group attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
+		assertNotNull("unable to get group attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void getGroupAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getGroupAttributesWhenGroupNotExists");
 
 		attributesManager.getAttributes(sess, new Group());
 		// shouldn't find group
 
 	}
 
-@Test
-public void getGroupResourceAttributes() throws Exception {
-	System.out.println("attributesManager.getGroupResourceAttributes");
+	@Test
+	public void getGroupResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpGroupResourceAttribute();
-	attributesManager.setAttribute(sess, resource, group, attributes.get(0));
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpGroupResourceAttribute();
+		attributesManager.setAttribute(sess, resource, group, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
-	assertNotNull("unable to get group-resource attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
+		assertNotNull("unable to get group-resource attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getGroupResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -1390,9 +1373,9 @@ public void getGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void getGroupResourceAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesWhenGroupNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1403,42 +1386,42 @@ public void getGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void getHostAttributes() throws Exception {
-	System.out.println("attributesManager.getHostAttributes");
+	@Test
+	public void getHostAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributes");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
-	attributesManager.setAttribute(sess, host, attributes.get(0));
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
+		attributesManager.setAttribute(sess, host, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
-	assertNotNull("unable to get host attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
+		assertNotNull("unable to get host attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void getHostAttributesWhenHostNotExists() throws Exception {
-		System.out.println("attributesManager.getHostAttributesWhenHostNotExists");
+		System.out.println(CLASS_NAME + "getHostAttributesWhenHostNotExists");
 
 		attributesManager.getAttributes(sess, new Host());
 		// shouldn't find host
 
 	}
 
-@Test
-public void getAttributesByAttributeDefinition() throws Exception {
-	System.out.println("attributesManager.getAttributesByAttributeDefinition");
+	@Test
+	public void getAttributesByAttributeDefinition() throws Exception {
+		System.out.println(CLASS_NAME + "getAttributesByAttributeDefinition");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
-	attributesManager.setAttribute(sess, host, attributes.get(0));
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
+		attributesManager.setAttribute(sess, host, attributes.get(0));
 
-	List<Attribute> retAttr = attributesManager.getAttributesByAttributeDefinition(sess, attributes.get(0));
-	assertNotNull("unable to get attributes", retAttr);
-	assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributesByAttributeDefinition(sess, attributes.get(0));
+		assertNotNull("unable to get attributes", retAttr);
+		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
 
 
@@ -1450,24 +1433,24 @@ public void getAttributesByAttributeDefinition() throws Exception {
 
 
 
-@Test
-public void setFacilityAttributes() throws Exception {
-	System.out.println("attributesManager.setFacilityAttributes");
+	@Test
+	public void setFacilityAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setFacilityAttributes");
 
-	facility = setUpFacility();
-	attributes = setUpFacilityAttribute();
+		facility = setUpFacility();
+		attributes = setUpFacilityAttribute();
 
-	attributesManager.setAttributes(sess, facility, attributes);
+		attributesManager.setAttributes(sess, facility, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
 
-	assertTrue("unable to set/or return facility attribute we created", retAttr.contains(attributes.get(0)));
+		assertTrue("unable to set/or return facility attribute we created", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void setFacilityAttributesWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.setFacilityAttributesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "setFacilityAttributesWhenFacilityNotExists");
 
 		attributes = setUpFacilityAttribute();
 
@@ -1476,9 +1459,9 @@ public void setFacilityAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setFacilityAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setFacilityAttributesWhenAttrbuteNotExists");
+		System.out.println(CLASS_NAME + "setFacilityAttributesWhenAttrbuteNotExists");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -1489,9 +1472,9 @@ public void setFacilityAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setFacilityAttributesWhenWrongAttrAssigment() throws Exception {
-		System.out.println("attributesManager.setFacilityAttributesWhenWrongAttrAssigment");
+		System.out.println(CLASS_NAME + "setFacilityAttributesWhenWrongAttrAssigment");
 
 		facility = setUpFacility();
 		attributes = setUpVoAttribute();
@@ -1501,9 +1484,9 @@ public void setFacilityAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setFacilityAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setFacilityAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setFacilityAttributesWhenTypeMismatch");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -1514,23 +1497,23 @@ public void setFacilityAttributes() throws Exception {
 
 	}
 
-@Test
-public void setVoAttributes() throws Exception {
-	System.out.println("attributesManager.setVoAttributes");
+	@Test
+	public void setVoAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setVoAttributes");
 
-	vo = setUpVo();
-	attributes = setUpVoAttribute();
+		vo = setUpVo();
+		attributes = setUpVoAttribute();
 
-	attributesManager.setAttributes(sess, vo, attributes);
+		attributesManager.setAttributes(sess, vo, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
-	assertTrue("unable to set/or return vo attribute we created", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
+		assertTrue("unable to set/or return vo attribute we created", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=VoNotExistsException.class)
+	@Test (expected=VoNotExistsException.class)
 	public void setVoAttributesWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.setVoAttributesWhenVoNotExists");
+		System.out.println(CLASS_NAME + "setVoAttributesWhenVoNotExists");
 
 		attributes = setUpVoAttribute();
 
@@ -1539,9 +1522,9 @@ public void setVoAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setVoAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setVoAttributes");
+		System.out.println(CLASS_NAME + "setVoAttributes");
 
 		vo = setUpVo();
 		attributes = setUpVoAttribute();
@@ -1552,9 +1535,9 @@ public void setVoAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setVoAttributesWhenWrongAttrAssigment() throws Exception {
-		System.out.println("attributesManager.setVoAttributesWhenWrongAttrAssigment");
+		System.out.println(CLASS_NAME + "setVoAttributesWhenWrongAttrAssigment");
 
 		vo = setUpVo();
 		attributes = setUpFacilityAttribute();
@@ -1564,9 +1547,9 @@ public void setVoAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setVoAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setVoAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setVoAttributesWhenTypeMismatch");
 
 		vo = setUpVo();
 		attributes = setUpVoAttribute();
@@ -1577,25 +1560,25 @@ public void setVoAttributes() throws Exception {
 
 	}
 
-@Test
-public void setResourceAttributes() throws Exception {
-	System.out.println("attributesManager.setResourceAttributes");
+	@Test
+	public void setResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpResourceAttribute();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpResourceAttribute();
 
-	attributesManager.setAttributes(sess, resource, attributes);
+		attributesManager.setAttributes(sess, resource, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
-	assertTrue("unable to set/or return resource attribute we created", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
+		assertTrue("unable to set/or return resource attribute we created", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void setResourceAttributesWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.setResourceAttributesWhenVoNotExists");
+		System.out.println(CLASS_NAME + "setResourceAttributesWhenVoNotExists");
 
 		attributes = setUpResourceAttribute();
 
@@ -1604,9 +1587,9 @@ public void setResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setResourceAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setVoAttributes");
+		System.out.println(CLASS_NAME + "setVoAttributes");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1619,9 +1602,9 @@ public void setResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setResourceAttributesWhenWrongAttrAssigment() throws Exception {
-		System.out.println("attributesManager.setResourceAttributesWhenWrongAttrAssigment");
+		System.out.println(CLASS_NAME + "setResourceAttributesWhenWrongAttrAssigment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1633,9 +1616,9 @@ public void setResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setResourceAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setResourceAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setResourceAttributesWhenTypeMismatch");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1648,27 +1631,27 @@ public void setResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void setMemberResourceAttributes() throws Exception {
-	System.out.println("attributesManager.setMemberResourceAttributes");
+	@Test
+	public void setMemberResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberResourceAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpMemberResourceAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpMemberResourceAttribute();
 
-	attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, resource, member, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
-	assertNotNull("unable to get member-resource attributes", retAttr);
-	assertTrue("unable to set/or return our member-resource attribute", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		assertNotNull("unable to get member-resource attributes", retAttr);
+		assertTrue("unable to set/or return our member-resource attribute", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void setMemberResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.setResourceMemberAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "setResourceMemberAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -1680,9 +1663,9 @@ public void setMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void setMemberResourceAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributesWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1695,9 +1678,9 @@ public void setMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setMemberResourceAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1712,9 +1695,9 @@ public void setMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setMemberResourceAttributesWhenWrongAttrAssigment() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1728,9 +1711,9 @@ public void setMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setMemberResourceAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributesWhenTypeMismatch");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1744,28 +1727,28 @@ public void setMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void setUserAttributesForMemberResource() throws Exception {
-	System.out.println("attributesManager.setUserAttributesForMemberResource");
+	@Test
+	public void setUserAttributesForMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberResource");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpUserAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpUserAttribute();
 
-	attributesManager.setAttributes(sess, resource, member, attributes, true);
+		attributesManager.setAttributes(sess, resource, member, attributes, true);
 
-	// return users attributes from resource member
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member, true);
-	assertNotNull("unable to set or get member-resource(work with user) attributes", attributes);
-	assertTrue("our attribute was not set/returned", retAttr.contains(attributes.get(0)));
+		// return users attributes from resource member
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member, true);
+		assertNotNull("unable to set or get member-resource(work with user) attributes", attributes);
+		assertTrue("our attribute was not set/returned", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void setUserAttributesForMemberResourceWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.setUserAttributesForMemberResourceWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberResourceWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1777,9 +1760,9 @@ public void setUserAttributesForMemberResource() throws Exception {
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void setUserAttributesForMemberResourceWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.setUserAttributesForMemberResourceWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberResourceWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -1790,9 +1773,9 @@ public void setUserAttributesForMemberResource() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setUserAttributesForMemberResourceWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setUserAttributesForMemberResourceWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberResourceWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -1807,9 +1790,9 @@ public void setUserAttributesForMemberResource() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setUserAttributesForMemberResourceWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setUserAttributesForMemberResourceWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberResourceWhenTypeMismatch");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1823,192 +1806,192 @@ public void setUserAttributesForMemberResource() throws Exception {
 
 	}
 
-@Test
-public void setMemberGroupAttributes() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributes");
+	@Test
+	public void setMemberGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttributes(sess, member, group, attributes);
+		attributesManager.setAttributes(sess, member, group, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
-	assertNotNull("unable to get member-group attributes", retAttr);
-	assertTrue("unable to set/or return our member-group attribute", retAttr.contains(attributes.get(0)));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group);
+		assertNotNull("unable to get member-group attributes", retAttr);
+		assertTrue("unable to set/or return our member-group attribute", retAttr.contains(attributes.get(0)));
+	}
 
-@Test (expected=GroupNotExistsException.class)
-public void setMemberGroupAttributesWhenGroupNotExists() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributesWhenResourceNotExists");
+	@Test (expected=GroupNotExistsException.class)
+	public void setMemberGroupAttributesWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributesWhenResourceNotExists");
 
-	vo = setUpVo();
-	member = setUpMember();
+		vo = setUpVo();
+		member = setUpMember();
 
-	attributes = setUpMemberGroupAttribute();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttributes(sess, member, new Group(), attributes);
-	// shouldn't find group
-}
+		attributesManager.setAttributes(sess, member, new Group(), attributes);
+		// shouldn't find group
+	}
 
-@Test (expected=MemberNotExistsException.class)
-public void setMemberGroupAttributesWhenMemberNotExists() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributesWhenMemberNotExists");
+	@Test (expected=MemberNotExistsException.class)
+	public void setMemberGroupAttributesWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributesWhenMemberNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
+		vo = setUpVo();
+		group = setUpGroup();
 
-	attributes = setUpMemberGroupAttribute();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttributes(sess, new Member(), group, attributes);
-	// shouldn't find member
-}
+		attributesManager.setAttributes(sess, new Member(), group, attributes);
+		// shouldn't find member
+	}
 
-@Test (expected=AttributeNotExistsException.class)
-public void setMemberGroupAttributesWhenAttributeNotExists() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributesWhenAttributeNotExists");
+	@Test (expected=AttributeNotExistsException.class)
+	public void setMemberGroupAttributesWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributesWhenAttributeNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
 
-	attributes = setUpMemberGroupAttribute();
-	attributes.get(0).setId(0);
-	// make valid attribute not existing in DB by setting ID=0
-	attributesManager.setAttributes(sess, member, group, attributes);
-	// shouldn't find attribute
-}
+		attributes = setUpMemberGroupAttribute();
+		attributes.get(0).setId(0);
+		// make valid attribute not existing in DB by setting ID=0
+		attributesManager.setAttributes(sess, member, group, attributes);
+		// shouldn't find attribute
+	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
-public void setMemberGroupAttributesWhenWrongAttrAssigment() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributesWhenAttributeNotExists");
+	@Test (expected=WrongAttributeAssignmentException.class)
+	public void setMemberGroupAttributesWhenWrongAttrAssigment() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributesWhenAttributeNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
 
-	attributes = setUpVoAttribute();
-	// set up wrong attribute - vo instead of member-group
-	attributesManager.setAttributes(sess, member, group, attributes);
-	// shouldn't set attribute
-}
+		attributes = setUpVoAttribute();
+		// set up wrong attribute - vo instead of member-group
+		attributesManager.setAttributes(sess, member, group, attributes);
+		// shouldn't set attribute
+	}
 
-@Test (expected=InternalErrorException.class)
-public void setMemberGroupAttributesWhenTypeMismatch() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributesWhenTypeMismatch");
+	@Test (expected=InternalErrorException.class)
+	public void setMemberGroupAttributesWhenTypeMismatch() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributesWhenTypeMismatch");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
-	attributes.get(0).setValue(1);
-	// set wrong value - integer into string
-	attributesManager.setAttributes(sess, member, group, attributes);
-	// shouldn't set wrong attribute
-}
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributes.get(0).setValue(1);
+		// set wrong value - integer into string
+		attributesManager.setAttributes(sess, member, group, attributes);
+		// shouldn't set wrong attribute
+	}
 
-@Test
-public void setUserAttributesForMemberGroup() throws Exception {
-	System.out.println("attributesManager.setUserAttributesForMemberGroup");
+	@Test
+	public void setUserAttributesForMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberGroup");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpUserAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpUserAttribute();
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member_group:attribute-def:opt");
-	attr.setFriendlyName("member-group-test-for-list-of-names-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("MemberGroupAttributeForList");
-	attributesManager.createAttribute(sess, attr);
-	attributesManager.setAttribute(sess, member, group, attr);
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member_group:attribute-def:opt");
+		attr.setFriendlyName("member-group-test-for-list-of-names-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberGroupAttributeForList");
+		attributesManager.createAttribute(sess, attr);
+		attributesManager.setAttribute(sess, member, group, attr);
 
-	List<String> attrNames = new ArrayList<String>();
-	attrNames.add(attributes.get(0).getName());
-	attrNames.add(attr.getName());
+		List<String> attrNames = new ArrayList<String>();
+		attrNames.add(attributes.get(0).getName());
+		attrNames.add(attr.getName());
 
-	attributesManager.setAttributes(sess, member, group, attributes, true);
+		attributesManager.setAttributes(sess, member, group, attributes, true);
 
-	// return users attributes from member group
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames, true);
-	assertNotNull("unable to set or get member-group(work with user) attributes", attributes);
-	assertTrue("our attribute was not set/returned", retAttr.contains(attributes.get(0)));
-}
+		// return users attributes from member group
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, group, attrNames, true);
+		assertNotNull("unable to set or get member-group(work with user) attributes", attributes);
+		assertTrue("our attribute was not set/returned", retAttr.contains(attributes.get(0)));
+	}
 
-@Test (expected=MemberNotExistsException.class)
-public void setUserAttributesForMemberGroupWhenMemberNotExists() throws Exception {
-	System.out.println("attributesManager.setUserAttributesForMemberGroupWhenMemberNotExists");
+	@Test (expected=MemberNotExistsException.class)
+	public void setUserAttributesForMemberGroupWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberGroupWhenMemberNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpUserAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpUserAttribute();
 
-	attributesManager.setAttributes(sess, new Member(), group, attributes, true);
-	// shouldn't find member
-}
+		attributesManager.setAttributes(sess, new Member(), group, attributes, true);
+		// shouldn't find member
+	}
 
-@Test (expected=GroupNotExistsException.class)
-public void setUserAttributesForMemberGroupWhenGroupNotExists() throws Exception {
-	System.out.println("attributesManager.setUserAttributesForMemberGroupWhenGroupNotExists");
+	@Test (expected=GroupNotExistsException.class)
+	public void setUserAttributesForMemberGroupWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberGroupWhenGroupNotExists");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpUserAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpUserAttribute();
 
-	attributesManager.setAttributes(sess, member, new Group(), attributes, true);
-	// shouldn't find group
-}
+		attributesManager.setAttributes(sess, member, new Group(), attributes, true);
+		// shouldn't find group
+	}
 
-@Test (expected=AttributeNotExistsException.class)
-public void setUserAttributesForMemberGroupWhenAttributeNotExists() throws Exception {
-	System.out.println("attributesManager.setUserAttributesForMemberGroupWhenAttributeNotExists");
+	@Test (expected=AttributeNotExistsException.class)
+	public void setUserAttributesForMemberGroupWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberGroupWhenAttributeNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpUserAttribute();
-	attributes.get(0).setId(0);
-	// make valid attribute object not existing in DB
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpUserAttribute();
+		attributes.get(0).setId(0);
+		// make valid attribute object not existing in DB
 
-	attributesManager.setAttributes(sess, member, group, attributes, true);
-	// shouldn't find attribute
-}
+		attributesManager.setAttributes(sess, member, group, attributes, true);
+		// shouldn't find attribute
+	}
 
-@Test (expected=InternalErrorException.class)
-public void setUserAttributesForMemberGroupWhenTypeMismatch() throws Exception {
-	System.out.println("attributesManager.setUserAttributesForMemberGroupWhenTypeMismatch");
+	@Test (expected=InternalErrorException.class)
+	public void setUserAttributesForMemberGroupWhenTypeMismatch() throws Exception {
+		System.out.println(CLASS_NAME + "setUserAttributesForMemberGroupWhenTypeMismatch");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpUserAttribute();
-	attributes.get(0).setValue(1);
-	// set wrong value - integer into string
-	attributesManager.setAttributes(sess, member, group, attributes, true);
-	// shouldn't set wrong attribute
-}
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpUserAttribute();
+		attributes.get(0).setValue(1);
+		// set wrong value - integer into string
+		attributesManager.setAttributes(sess, member, group, attributes, true);
+		// shouldn't set wrong attribute
+	}
 
-@Test
-public void setMemberAttributes() throws Exception {
-	System.out.println("attributesManager.setMemberAttributes");
+	@Test
+	public void setMemberAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
 
-	attributesManager.setAttributes(sess, member, attributes);
+		attributesManager.setAttributes(sess, member, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
-	assertNotNull("unable to get members attributes", retAttr);
-	assertTrue("our attribute is not set or returned from member", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
+		assertNotNull("unable to get members attributes", retAttr);
+		assertTrue("our attribute is not set or returned from member", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void setMemberAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "setMemberAttributesWhenMemberNotExists");
 
 		attributes = setUpMemberAttribute();
 
@@ -2017,9 +2000,9 @@ public void setMemberAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setMemberAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setMemberAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2033,9 +2016,9 @@ public void setMemberAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setMemberAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setMemberAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setMemberAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2048,9 +2031,9 @@ public void setMemberAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setMemberAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setMemberAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setMemberAttributesWhenTypeMismatch");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2062,26 +2045,26 @@ public void setMemberAttributes() throws Exception {
 
 	}
 
-@Test
-public void setUserAttributes() throws Exception {
-	System.out.println("attributesManager.setUserAttributes");
+	@Test
+	public void setUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setUserAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpUserAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpUserAttribute();
 
-	attributesManager.setAttributes(sess, user, attributes);
+		attributesManager.setAttributes(sess, user, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
-	assertNotNull("unable to get user attributes", retAttr);
-	assertTrue("our attribute is not set or returned from user", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
+		assertNotNull("unable to get user attributes", retAttr);
+		assertTrue("our attribute is not set or returned from user", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void setUserAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.setUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "setUserAttributesWhenUserNotExists");
 
 		attributes = setUpUserAttribute();
 
@@ -2090,9 +2073,9 @@ public void setUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setUserAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setUserAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setUserAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2106,9 +2089,9 @@ public void setUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setUserAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setUserAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setUserAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2120,9 +2103,9 @@ public void setUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setUserAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setUserAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setUserAttributesWhenTypeMismatch");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2135,25 +2118,25 @@ public void setUserAttributes() throws Exception {
 
 	}
 
-@Test
-public void setGroupAttributes() throws Exception {
-	System.out.println("attributesManager.setGroupAttributes");
+	@Test
+	public void setGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setGroupAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpGroupAttribute();
 
-	attributesManager.setAttributes(sess, group, attributes);
+		attributesManager.setAttributes(sess, group, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
-	assertNotNull("unable to get group attributes", retAttr);
-	assertTrue("our attribute is not set or returned from group", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
+		assertNotNull("unable to get group attributes", retAttr);
+		assertTrue("our attribute is not set or returned from group", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void setGroupAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "setGroupAttributesWhenGroupNotExists");
 
 		attributes = setUpGroupAttribute();
 
@@ -2162,9 +2145,9 @@ public void setGroupAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setGroupAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setGroupAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -2177,9 +2160,9 @@ public void setGroupAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setGroupAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setGroupAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setGroupAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -2190,9 +2173,9 @@ public void setGroupAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setGroupAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setGroupAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setGroupAttributesWhenTypeMismatch");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -2204,61 +2187,61 @@ public void setGroupAttributes() throws Exception {
 
 	}
 
-@Test
-public void setMemberWorkWithUserAttributes() throws Exception {
-	System.out.println("attributesManager.setMemberWorkWithUserAttributes");
-	vo = setUpVo();
-	member = setUpMember();
-	List<Attribute> attributes_member = setUpMemberAttribute();
-	User user =sess.getPerun().getUsersManager().getUserByMember(sess, member);
-	List<Attribute> attributes_user = setUpUserAttribute();
-	attributes = new ArrayList<Attribute>();
-	attributes.addAll(attributes_member);
-	attributes.addAll(attributes_user);
+	@Test
+	public void setMemberWorkWithUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberWorkWithUserAttributes");
+		vo = setUpVo();
+		member = setUpMember();
+		List<Attribute> attributes_member = setUpMemberAttribute();
+		User user =sess.getPerun().getUsersManager().getUserByMember(sess, member);
+		List<Attribute> attributes_user = setUpUserAttribute();
+		attributes = new ArrayList<Attribute>();
+		attributes.addAll(attributes_member);
+		attributes.addAll(attributes_user);
 
-	attributesManager.setAttributes(sess, member, attributes, true);
+		attributesManager.setAttributes(sess, member, attributes, true);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, true);
-	assertNotNull("unable to get member attributes", retAttr);
-	assertTrue("unable to set/or return our member attribute",retAttr.contains(attributes.get(0)));
-	assertTrue("unable to set/or return our member attribute",retAttr.contains(attributes.get(1)));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, true);
+		assertNotNull("unable to get member attributes", retAttr);
+		assertTrue("unable to set/or return our member attribute",retAttr.contains(attributes.get(0)));
+		assertTrue("unable to set/or return our member attribute",retAttr.contains(attributes.get(1)));
+	}
 
-@Test
-public void setMemberWorkWithoutUserAttributes() throws Exception {
-	System.out.println("attributesManager.setMemberWorkWithoutUserAttributes");
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
+	@Test
+	public void setMemberWorkWithoutUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberWorkWithoutUserAttributes");
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
 
-	attributesManager.setAttributes(sess, member, attributes, false);
+		attributesManager.setAttributes(sess, member, attributes, false);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member, false);
-	assertNotNull("unable to get member attributes", retAttr);
-	assertTrue("unable to set/or return our member attribute",retAttr.contains(attributes.get(0)));
-}
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, false);
+		assertNotNull("unable to get member attributes", retAttr);
+		assertTrue("unable to set/or return our member attribute",retAttr.contains(attributes.get(0)));
+	}
 
-@Test
-public void setGroupResourceAttributes() throws Exception {
-	System.out.println("attributesManager.setGroupResourceAttributes");
+	@Test
+	public void setGroupResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setGroupResourceAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpGroupResourceAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpGroupResourceAttribute();
 
-	attributesManager.setAttributes(sess, resource, group, attributes);
+		attributesManager.setAttributes(sess, resource, group, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
-	assertNotNull("unable to get group-resource attributes", retAttr);
-	assertTrue("unable to set/or return our group-resource attribute",retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
+		assertNotNull("unable to get group-resource attributes", retAttr);
+		assertTrue("unable to set/or return our group-resource attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void setGroupResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -2269,9 +2252,9 @@ public void setGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void setGroupResourceAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributesWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -2283,9 +2266,9 @@ public void setGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setGroupResourceAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -2300,9 +2283,9 @@ public void setGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setGroupResourceAttributesWhenWrongAttrAssigment() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -2316,9 +2299,9 @@ public void setGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setGroupResourceAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributesWhenTypeMismatch");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -2332,24 +2315,24 @@ public void setGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void setHostAttributes() throws Exception {
-	System.out.println("attributesManager.setHostAttributes");
+	@Test
+	public void setHostAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "setHostAttributes");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
 
-	attributesManager.setAttributes(sess, host, attributes);
+		attributesManager.setAttributes(sess, host, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
-	assertNotNull("unable to get host attributes", retAttr);
-	assertTrue("our attribute is not set or returned from group", retAttr.contains(attributes.get(0)));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
+		assertNotNull("unable to get host attributes", retAttr);
+		assertTrue("our attribute is not set or returned from group", retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void setHostAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.setHostAttributesWhenHostNotExists");
+		System.out.println(CLASS_NAME + "setHostAttributesWhenHostNotExists");
 
 		attributes = setUpHostAttribute();
 
@@ -2358,9 +2341,9 @@ public void setHostAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setHostAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setHostAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setHostAttributesWhenAttributeNotExists");
 
 		host = setUpHost().get(0);
 		attributes = setUpHostAttribute();
@@ -2372,9 +2355,9 @@ public void setHostAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setHostAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setHostAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setHostAttributesWhenWrongAttrAssignment");
 
 		host = setUpHost().get(0);
 		attributes = setUpMemberAttribute();
@@ -2384,9 +2367,9 @@ public void setHostAttributes() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setHostAttributesWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setHostAttributesWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setHostAttributesWhenTypeMismatch");
 
 		host = setUpHost().get(0);
 		attributes = setUpHostAttribute();
@@ -2408,30 +2391,30 @@ public void setHostAttributes() throws Exception {
 
 
 
-@Test
-public void getFacilityAttribute() throws Exception {
-	System.out.println("attributesManager.getFacilityAttribute");
+	@Test
+	public void getFacilityAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttribute");
 
-	facility = setUpFacility();
+		facility = setUpFacility();
 
-	Attribute retAttr = attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:id");
-	assertNotNull("unable to get core attribute facility id", retAttr);
-	assertEquals("returned core attr value is not correct",retAttr.getValue(),facility.getId());
+		Attribute retAttr = attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:id");
+		assertNotNull("unable to get core attribute facility id", retAttr);
+		assertEquals("returned core attr value is not correct",retAttr.getValue(),facility.getId());
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void getFacilityAttributeWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityAttributeWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getFacilityAttributeWhenFacilityNotExists");
 
 		attributesManager.getAttribute(sess, new Facility(), "urn:perun:facility:attribute-def:core:id");
 		// shouldn't find facility
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getFacilityAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getFacilityAttributeWhenAttributeNotExists");
 
 		facility = setUpFacility();
 
@@ -2440,9 +2423,9 @@ public void getFacilityAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getFacilityAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getFacilityAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getFacilityAttributeWhenWrongAttrAssignment");
 
 		facility = setUpFacility();
 
@@ -2451,30 +2434,30 @@ public void getFacilityAttribute() throws Exception {
 
 	}
 
-@Test
-public void getVoAttribute() throws Exception {
-	System.out.println("attributesManager.getVoAttribute");
+	@Test
+	public void getVoAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttribute");
 
-	vo = setUpVo();
+		vo = setUpVo();
 
-	Attribute retAttr = attributesManager.getAttribute(sess, vo, "urn:perun:vo:attribute-def:core:id");
-	assertNotNull("unable to get core attribute vo id", retAttr);
-	assertEquals("returned core attr value is not correct",retAttr.getValue(),vo.getId());
+		Attribute retAttr = attributesManager.getAttribute(sess, vo, "urn:perun:vo:attribute-def:core:id");
+		assertNotNull("unable to get core attribute vo id", retAttr);
+		assertEquals("returned core attr value is not correct",retAttr.getValue(),vo.getId());
 
-}
+	}
 
-@Test (expected=VoNotExistsException.class)
+	@Test (expected=VoNotExistsException.class)
 	public void getVoAttributeWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.getVoAttributeWhenVoNotExists");
+		System.out.println(CLASS_NAME + "getVoAttributeWhenVoNotExists");
 
 		attributesManager.getAttribute(sess, new Vo(), "urn:perun:vo:attribute-def:core:id");
 		// shouldn't find vo
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getVoAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getVoAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getVoAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 
@@ -2483,9 +2466,9 @@ public void getVoAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getVoAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getVoAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getVoAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 
@@ -2494,32 +2477,32 @@ public void getVoAttribute() throws Exception {
 
 	}
 
-@Test
-public void getResourceAttribute() throws Exception {
-	System.out.println("attributesManager.getResourceAttribute");
+	@Test
+	public void getResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttribute");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
 
-	Attribute retAttr = attributesManager.getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:id");
-	assertNotNull("unable to get core attribute resource id", retAttr);
-	assertEquals("returned core attr value is not correct", retAttr.getValue(), resource.getId());
+		Attribute retAttr = attributesManager.getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:id");
+		assertNotNull("unable to get core attribute resource id", retAttr);
+		assertEquals("returned core attr value is not correct", retAttr.getValue(), resource.getId());
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceAttributeWhenResourceNotExists");
 
 		attributesManager.getAttribute(sess, new Resource(), "urn:perun:resource:attribute-def:core:id");
 		// shouldn't find resource
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -2530,9 +2513,9 @@ public void getResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -2543,27 +2526,27 @@ public void getResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void getMemberResourceAttribute() throws Exception {
-	System.out.println("attributesManager.getMemberResourceAttribute");
+	@Test
+	public void getMemberResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpMemberResourceAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpMemberResourceAttribute();
 
-	attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, resource, member, attributes);
 
-	Attribute retAttr = attributesManager.getAttribute(sess, resource, member,"urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
-	assertNotNull("unable to get opt member resource attribute ", retAttr);
-	assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
+		Attribute retAttr = attributesManager.getAttribute(sess, resource, member,"urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
+		assertNotNull("unable to get opt member resource attribute ", retAttr);
+		assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getMemberResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2578,9 +2561,9 @@ public void getMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getMemberResourceAttributeWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberResourceAttributeWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeWhenMemberNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2595,9 +2578,9 @@ public void getMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getMemberResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2609,9 +2592,9 @@ public void getMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getMemberResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getMemberResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2623,104 +2606,104 @@ public void getMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void getMemberGroupAttribute() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttribute");
+	@Test
+	public void getMemberGroupAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttribute");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttributes(sess, member, group, attributes);
+		attributesManager.setAttributes(sess, member, group, attributes);
 
-	Attribute retAttr = attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:member-group-test-attribute");
-	assertNotNull("unable to get opt member group attribute ", retAttr);
-	assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
+		Attribute retAttr = attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:member-group-test-attribute");
+		assertNotNull("unable to get opt member group attribute ", retAttr);
+		assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
-public void getMemberGroupAttributeWhenGroupNotExists() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeWhenGroupNotExists");
+	@Test (expected=GroupNotExistsException.class)
+	public void getMemberGroupAttributeWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeWhenGroupNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttributes(sess, member, group, attributes);
+		attributesManager.setAttributes(sess, member, group, attributes);
 
-	attributesManager.getAttribute(sess, member, new Group(), "urn:perun:member_group:attribute-def:opt:member-group-test-attribute");
-	// shouldn't find group
-}
+		attributesManager.getAttribute(sess, member, new Group(), "urn:perun:member_group:attribute-def:opt:member-group-test-attribute");
+		// shouldn't find group
+	}
 
-@Test (expected=MemberNotExistsException.class)
-public void getMemberGroupAttributeWhenMemberNotExists() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeWhenMemberNotExists");
+	@Test (expected=MemberNotExistsException.class)
+	public void getMemberGroupAttributeWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeWhenMemberNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttributes(sess, member, group, attributes);
+		attributesManager.setAttributes(sess, member, group, attributes);
 
-	attributesManager.getAttribute(sess, new Member(), group, "urn:perun:member_group:attribute-def:opt:member-group-test-attribute");
-	// shouldn't find member
-}
+		attributesManager.getAttribute(sess, new Member(), group, "urn:perun:member_group:attribute-def:opt:member-group-test-attribute");
+		// shouldn't find member
+	}
 
-@Test (expected=AttributeNotExistsException.class)
-public void getMemberGroupAttributeWhenAttributeNotExists() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeWhenAttributeNotExists");
+	@Test (expected=AttributeNotExistsException.class)
+	public void getMemberGroupAttributeWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeWhenAttributeNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
 
-	attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:nesmysl");
-	// shouldn't find member group attribute "nesmysl"
+		attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:nesmysl");
+		// shouldn't find member group attribute "nesmysl"
 
-}
+	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
-public void getMemberGroupAttributeWhenWrongAttrAssignment() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeWhenWrongAttrAssignment");
+	@Test (expected=WrongAttributeAssignmentException.class)
+	public void getMemberGroupAttributeWhenWrongAttrAssignment() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeWhenWrongAttrAssignment");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
 
-	attributesManager.getAttribute(sess, member, group, "urn:perun:group:attribute-def:opt:member-groupe-test-attribute");
-	// shouldn't find group attribute instead of member-group
+		attributesManager.getAttribute(sess, member, group, "urn:perun:group:attribute-def:opt:member-groupe-test-attribute");
+		// shouldn't find group attribute instead of member-group
 
-}
+	}
 
-@Test
-public void getMemberAttribute() throws Exception {
-	System.out.println("attributesManager.getMemberAttribute");
+	@Test
+	public void getMemberAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
+		vo = setUpVo();
+		member = setUpMember();
 
-	Attribute retAttr = attributesManager.getAttribute(sess, member, "urn:perun:member:attribute-def:core:id");
-	assertNotNull("unable to get core attribute member id", retAttr);
-	assertEquals("returned core attr value is not correct",retAttr.getValue(),member.getId());
+		Attribute retAttr = attributesManager.getAttribute(sess, member, "urn:perun:member:attribute-def:core:id");
+		assertNotNull("unable to get core attribute member id", retAttr);
+		assertEquals("returned core attr value is not correct",retAttr.getValue(),member.getId());
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getMemberAttributeWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getMemberAttributeWhenMemberNotExists");
 
 		attributesManager.getAttribute(sess, new Member(), "urn:perun:member:attribute-def:core:id");
 		// shouldn't find member
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getMemberAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getMemberAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2730,9 +2713,9 @@ public void getMemberAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getMemberAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getMemberAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2742,27 +2725,27 @@ public void getMemberAttribute() throws Exception {
 
 	}
 
-@Test
-public void getFacilityUserAttribute() throws Exception {
-	System.out.println("attributesManager.getFacilityUserAttribute");
+	@Test
+	public void getFacilityUserAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityUserAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	attributes = setUpFacilityUserAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		attributes = setUpFacilityUserAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	attributesManager.setAttributes(sess, facility, user, attributes);
+		attributesManager.setAttributes(sess, facility, user, attributes);
 
-	Attribute retAttr = attributesManager.getAttribute(sess, facility, user, "urn:perun:user_facility:attribute-def:opt:user-facility-test-attribute");
-	assertNotNull("unable to get opt user_facility attribute ", retAttr);
-	assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
+		Attribute retAttr = attributesManager.getAttribute(sess, facility, user, "urn:perun:user_facility:attribute-def:opt:user-facility-test-attribute");
+		assertNotNull("unable to get opt user_facility attribute ", retAttr);
+		assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void getFacilityUserAttributeWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributeWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeWhenFacilityNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2777,9 +2760,9 @@ public void getFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getFacilityUserAttributeWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributeWhenUserNotExists");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeWhenUserNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2794,9 +2777,9 @@ public void getFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getFacilityUserAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2808,9 +2791,9 @@ public void getFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getFacilityUserAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2822,26 +2805,26 @@ public void getFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test
-public void getUserAttribute() throws Exception {
-	System.out.println("attributesManager.getUserAttribute");
+	@Test
+	public void getUserAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpUserAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpUserAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	attributesManager.setAttributes(sess, user, attributes);
+		attributesManager.setAttributes(sess, user, attributes);
 
-	Attribute retAttr = attributesManager.getAttribute(sess, user, "urn:perun:user:attribute-def:core:id");
-	assertNotNull("unable to get core attribute user id", retAttr);
-	assertEquals("returned core attr value is not correct",retAttr.getValue(),user.getId());
+		Attribute retAttr = attributesManager.getAttribute(sess, user, "urn:perun:user:attribute-def:core:id");
+		assertNotNull("unable to get core attribute user id", retAttr);
+		assertEquals("returned core attr value is not correct",retAttr.getValue(),user.getId());
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getUserAttributeWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getUserAttributeWhenUserNotExists");
+		System.out.println(CLASS_NAME + "getUserAttributeWhenUserNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2855,9 +2838,9 @@ public void getUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getUserAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getUserAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getUserAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2868,9 +2851,9 @@ public void getUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getUserAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getUserAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getUserAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -2881,53 +2864,53 @@ public void getUserAttribute() throws Exception {
 
 	}
 
-@Test
-public void getGroupAttribute() throws Exception {
-	System.out.println("attributesManager.getGroupAttribute");
+	@Test
+	public void getGroupAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttribute");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpGroupAttribute();
 
-	attributesManager.setAttribute(sess, group, attributes.get(0));
+		attributesManager.setAttribute(sess, group, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, group, "urn:perun:group:attribute-def:opt:group-test-attribute");
-	assertNotNull("unable to get opt group attribute", retAttr);
-	assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
+		Attribute retAttr = attributesManager.getAttribute(sess, group, "urn:perun:group:attribute-def:opt:group-test-attribute");
+		assertNotNull("unable to get opt group attribute", retAttr);
+		assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
 
-}
-
-@Test
-public void getGroupAttributesFromList() throws Exception {
-	System.out.println("attributesManager.getAttributes");
-
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpGroupAttributes();
-	attributesManager.setAttributes(sess, group, attributes);
-
-	List<String> attNames = new ArrayList<>();
-	for (Attribute a : attributes) {
-		attNames.add(a.getName());
 	}
 
-	List<Attribute> retAttributes = attributesManager.getAttributes(sess, group, attNames);
-	assertNotNull("unable to get group attributes", retAttributes);
-	assertTrue("returned opt attributes are not correct", attributes.equals(retAttributes));
-}
+	@Test
+	public void getGroupAttributesFromList() throws Exception {
+		System.out.println(CLASS_NAME + "getAttributes");
 
-@Test (expected=GroupNotExistsException.class)
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpGroupAttributes();
+		attributesManager.setAttributes(sess, group, attributes);
+
+		List<String> attNames = new ArrayList<>();
+		for (Attribute a : attributes) {
+			attNames.add(a.getName());
+		}
+
+		List<Attribute> retAttributes = attributesManager.getAttributes(sess, group, attNames);
+		assertNotNull("unable to get group attributes", retAttributes);
+		assertTrue("returned opt attributes are not correct", attributes.equals(retAttributes));
+	}
+
+	@Test (expected=GroupNotExistsException.class)
 	public void getGroupAttributeWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupAttributeWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getGroupAttributeWhenGroupNotExists");
 
 		attributesManager.getAttribute(sess, new Group(), "urn:perun:group:attribute-def:opt:group-test-attribute");
 		// shouldn't find groups
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getGroupAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getGroupAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -2937,9 +2920,9 @@ public void getGroupAttributesFromList() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getGroupAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getGroupAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getGroupAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -2949,27 +2932,27 @@ public void getGroupAttributesFromList() throws Exception {
 
 	}
 
-@Test
-public void getGroupResourceAttribute() throws Exception {
-	System.out.println("attributesManager.getGroupResourceAttribute");
+	@Test
+	public void getGroupResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttribute");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpGroupResourceAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpGroupResourceAttribute();
 
-	attributesManager.setAttributes(sess, resource, group, attributes);
+		attributesManager.setAttributes(sess, resource, group, attributes);
 
-	Attribute retAttr = attributesManager.getAttribute(sess, resource, group,"urn:perun:group_resource:attribute-def:opt:group-resource-test-attribute");
-	assertNotNull("unable to get opt group resource attribute ", retAttr);
-	assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
+		Attribute retAttr = attributesManager.getAttribute(sess, resource, group,"urn:perun:group_resource:attribute-def:opt:group-resource-test-attribute");
+		assertNotNull("unable to get opt group resource attribute ", retAttr);
+		assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getGroupResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributeWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -2984,9 +2967,9 @@ public void getGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void getGroupResourceAttributeWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributeWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributeWhenGroupNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -3001,9 +2984,9 @@ public void getGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getGroupResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -3015,9 +2998,9 @@ public void getGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getGroupResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -3029,24 +3012,24 @@ public void getGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void getHostAttribute() throws Exception {
-	System.out.println("attributesManager.getHostAttribute");
+	@Test
+	public void getHostAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttribute");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
 
-	attributesManager.setAttributes(sess, host, attributes);
+		attributesManager.setAttributes(sess, host, attributes);
 
-	Attribute retAttr = attributesManager.getAttribute(sess, host,"urn:perun:host:attribute-def:opt:host-test-attribute");
-	assertNotNull("unable to get opt host attribute ", retAttr);
-	assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
+		Attribute retAttr = attributesManager.getAttribute(sess, host,"urn:perun:host:attribute-def:opt:host-test-attribute");
+		assertNotNull("unable to get opt host attribute ", retAttr);
+		assertEquals("returned opt attr value is not correct",retAttr.getValue(),attributes.get(0).getValue());
 
-}
+	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void getHostAttributeWhenHostNotExists() throws Exception {
-		System.out.println("attributesManager.getHostAttributeWhenHostNotExists");
+		System.out.println(CLASS_NAME + "getHostAttributeWhenHostNotExists");
 
 		host = setUpHost().get(0);
 		attributes = setUpHostAttribute();
@@ -3058,9 +3041,9 @@ public void getHostAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getHostAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getHostAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getHostAttributeWhenAttributeNotExists");
 
 		host = setUpHost().get(0);
 
@@ -3069,9 +3052,9 @@ public void getHostAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getHostAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getHostAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getHostAttributeWhenWrongAttrAssignment");
 
 		host = setUpHost().get(0);
 
@@ -3091,108 +3074,108 @@ public void getHostAttribute() throws Exception {
 // ==============  4.  GET ATTRIBUTE DEFINITION ================================
 
 
-@Test
-public void getAttributeDefinition() throws Exception {
-	System.out.println("attributesManager.getAttributeDefinition");
+	@Test
+	public void getAttributeDefinition() throws Exception {
+		System.out.println(CLASS_NAME + "getAttributeDefinition");
 
-	AttributeDefinition attrDef = attributesManager.getAttributeDefinition(sess, "urn:perun:vo:attribute-def:core:id");
-	assertNotNull("unable to get attribute definition by name",attrDef);
-	assertTrue("returned wrong attr def by name", attrDef.getName().equals("urn:perun:vo:attribute-def:core:id"));
+		AttributeDefinition attrDef = attributesManager.getAttributeDefinition(sess, "urn:perun:vo:attribute-def:core:id");
+		assertNotNull("unable to get attribute definition by name",attrDef);
+		assertTrue("returned wrong attr def by name", attrDef.getName().equals("urn:perun:vo:attribute-def:core:id"));
 
-}
-
-@Test
-public void getAttributeDefinitionWithRights() throws Exception {
-	System.out.println("attributesManager.getAttributeDefinitionWithRights");
-
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	group = setUpGroup();
-	member = setUpMember();
-
-	perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
-	perun.getGroupsManagerBl().addMember(sess, group, member);
-
-	Attribute attr = setUpSpecificMemberResourceAttribute(member, resource);
-
-	List<PerunBean> perunBeans = new ArrayList<PerunBean>();
-	perunBeans.add(member);
-	perunBeans.add(resource);
-
-	List<AttributeDefinition> attrDefs = attributesManager.getAttributesDefinitionWithRights(sess, perunBeans);
-	List<AttributeDefinition> allAttrDef = attributesManager.getAttributesDefinition(sess);
-
-	assertFalse(attrDefs.isEmpty());
-	assertFalse(attrDefs.containsAll(allAttrDef));
-	assertTrue(allAttrDef.containsAll(attrDefs));
-	assertTrue(attrDefs.contains(attr));
-
-	for(AttributeDefinition ad: attrDefs) {
-		assertTrue(attributesManager.isFromNamespace(sess, ad, AttributesManager.NS_MEMBER_ATTR) ||
-				attributesManager.isFromNamespace(sess, ad, AttributesManager.NS_RESOURCE_ATTR) ||
-				attributesManager.isFromNamespace(sess, ad, AttributesManager.NS_MEMBER_RESOURCE_ATTR));
-		assertTrue(ad.getWritable());
 	}
 
-}
+	@Test
+	public void getAttributeDefinitionWithRights() throws Exception {
+		System.out.println(CLASS_NAME + "getAttributeDefinitionWithRights");
 
-@Test (expected=AttributeNotExistsException.class)
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup();
+		member = setUpMember();
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+		perun.getGroupsManagerBl().addMember(sess, group, member);
+
+		Attribute attr = setUpSpecificMemberResourceAttribute(member, resource);
+
+		List<PerunBean> perunBeans = new ArrayList<PerunBean>();
+		perunBeans.add(member);
+		perunBeans.add(resource);
+
+		List<AttributeDefinition> attrDefs = attributesManager.getAttributesDefinitionWithRights(sess, perunBeans);
+		List<AttributeDefinition> allAttrDef = attributesManager.getAttributesDefinition(sess);
+
+		assertFalse(attrDefs.isEmpty());
+		assertFalse(attrDefs.containsAll(allAttrDef));
+		assertTrue(allAttrDef.containsAll(attrDefs));
+		assertTrue(attrDefs.contains(attr));
+
+		for(AttributeDefinition ad: attrDefs) {
+			assertTrue(attributesManager.isFromNamespace(sess, ad, AttributesManager.NS_MEMBER_ATTR) ||
+					attributesManager.isFromNamespace(sess, ad, AttributesManager.NS_RESOURCE_ATTR) ||
+					attributesManager.isFromNamespace(sess, ad, AttributesManager.NS_MEMBER_RESOURCE_ATTR));
+			assertTrue(ad.getWritable());
+		}
+
+	}
+
+	@Test (expected=AttributeNotExistsException.class)
 	public void getAttributeDefinitionWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getAttributeDefinitionWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getAttributeDefinitionWhenAttributeNotExists");
 
 		attributesManager.getAttributeDefinition(sess, "urn:perun:vo:attribute-def:core:nesmysl");
 		// shouldn't find vo attribute "nesmysl"
 
 	}
 
-@Test
-public void getAttributesDefinition() throws Exception {
-	System.out.println("attributesManager.getAttributesDefinition");
+	@Test
+	public void getAttributesDefinition() throws Exception {
+		System.out.println(CLASS_NAME + "getAttributesDefinition");
 
-	List<AttributeDefinition> attrDef = attributesManager.getAttributesDefinition(sess);
-	assertNotNull("unable to get attributes definition",attrDef);
-	assertTrue("there should be some attributes definition", attrDef.size() > 0);
+		List<AttributeDefinition> attrDef = attributesManager.getAttributesDefinition(sess);
+		assertNotNull("unable to get attributes definition",attrDef);
+		assertTrue("there should be some attributes definition", attrDef.size() > 0);
 
-}
+	}
 
-@Test
-public void getAttributeDefinitionById() throws Exception {
-	System.out.println("attributesManager.getAttributesDefinitionById");
+	@Test
+	public void getAttributeDefinitionById() throws Exception {
+		System.out.println(CLASS_NAME + "getAttributesDefinitionById");
 
-	AttributeDefinition attrDef = new AttributeDefinition();
-	attrDef.setDescription("attributesManagerTestAttrDef");
-	attrDef.setFriendlyName("attrDef");
-	attrDef.setNamespace("urn:perun:member:attribute-def:opt");
-	attrDef.setType(String.class.getName());
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setDescription("attributesManagerTestAttrDef");
+		attrDef.setFriendlyName("attrDef");
+		attrDef.setNamespace("urn:perun:member:attribute-def:opt");
+		attrDef.setType(String.class.getName());
 
-	attributesManager.createAttribute(sess, attrDef);
-	// store attr definition in DB
+		attributesManager.createAttribute(sess, attrDef);
+		// store attr definition in DB
 
-	AttributeDefinition retAttrDef = attributesManager.getAttributeDefinitionById(sess, attrDef.getId());
-	assertNotNull("unable to get attribute definition",retAttrDef);
-	assertTrue("returned wrong attr definition", retAttrDef.getName().equals(attrDef.getName()));
+		AttributeDefinition retAttrDef = attributesManager.getAttributeDefinitionById(sess, attrDef.getId());
+		assertNotNull("unable to get attribute definition",retAttrDef);
+		assertTrue("returned wrong attr definition", retAttrDef.getName().equals(attrDef.getName()));
 
-}
+	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getAttributeDefinitionByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getAttributesDefinitionByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getAttributesDefinitionByIdWhenAttributeNotExists");
 
 		attributesManager.getAttributeDefinitionById(sess, 0);
 		// shouldn't find attribute definition
 
 	}
 
-@Test
-public void getAttributesDefinitionByNamespace() throws Exception {
-	System.out.println("attributesManager.getAttributesDefinitionByNamespace");
+	@Test
+	public void getAttributesDefinitionByNamespace() throws Exception {
+		System.out.println(CLASS_NAME + "getAttributesDefinitionByNamespace");
 
-	List<AttributeDefinition> attrDef = attributesManager.getAttributesDefinitionByNamespace(sess, "urn:perun:member:attribute-def:core");
-	assertNotNull("unable to get attributes definition",attrDef);
-	assertTrue("there should be some attributes definition",attrDef.size() > 0);
+		List<AttributeDefinition> attrDef = attributesManager.getAttributesDefinitionByNamespace(sess, "urn:perun:member:attribute-def:core");
+		assertNotNull("unable to get attributes definition",attrDef);
+		assertTrue("there should be some attributes definition",attrDef.size() > 0);
 
-}
+	}
 
 
 
@@ -3208,25 +3191,25 @@ public void getAttributesDefinitionByNamespace() throws Exception {
 
 
 
-@Test
-public void getFacilityAttributeById() throws Exception {
-	System.out.println("attributesManager.getFacilityAttributeById");
+	@Test
+	public void getFacilityAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributeById");
 
-	facility = setUpFacility();
-	attributes = setUpFacilityAttribute();
-	attributesManager.setAttributes(sess, facility, attributes);
+		facility = setUpFacility();
+		attributes = setUpFacilityAttribute();
+		attributesManager.setAttributes(sess, facility, attributes);
 
-	int id = attributes.get(0).getId();
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, facility, id);
-	assertNotNull("unable to get facility attribute by id", retAttr);
-	assertEquals("returned attribute is not same as we stored", retAttr, attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, facility, id);
+		assertNotNull("unable to get facility attribute by id", retAttr);
+		assertEquals("returned attribute is not same as we stored", retAttr, attributes.get(0));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void getFacilityAttributeByIdWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityAttributeByIdWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getFacilityAttributeByIdWhenFacilityNotExists");
 
 		attributes = setUpFacilityAttribute();
 		int id = attributes.get(0).getId();
@@ -3236,9 +3219,9 @@ public void getFacilityAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getFacilityAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getFacilityAttributeByIdWhenAttributeNotExists");
 
 		facility = setUpFacility();
 
@@ -3247,9 +3230,9 @@ public void getFacilityAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getFacilityAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getFacilityAttributeByIdWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getFacilityAttributeByIdWhenWrongAttrAssignment");
 
 		facility = setUpFacility();
 		attributes = setUpMemberAttribute();
@@ -3260,25 +3243,25 @@ public void getFacilityAttributeById() throws Exception {
 
 	}
 
-@Test
-public void getVoAttributeById() throws Exception {
-	System.out.println("attributesManager.getVoAttributeById");
+	@Test
+	public void getVoAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributeById");
 
-	vo = setUpVo();
-	attributes = setUpVoAttribute();
-	attributesManager.setAttributes(sess, vo, attributes);
+		vo = setUpVo();
+		attributes = setUpVoAttribute();
+		attributesManager.setAttributes(sess, vo, attributes);
 
-	int id = attributes.get(0).getId();
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, vo, id);
-	assertNotNull("unable to get vo attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, vo, id);
+		assertNotNull("unable to get vo attribute by id",retAttr);
+		assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
 
-}
+	}
 
-@Test (expected=VoNotExistsException.class)
+	@Test (expected=VoNotExistsException.class)
 	public void getVoAttributeByIdWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.getVoAttributeByIdWhenVoNotExists");
+		System.out.println(CLASS_NAME + "getVoAttributeByIdWhenVoNotExists");
 
 		attributes = setUpVoAttribute();
 		int id = attributes.get(0).getId();
@@ -3288,9 +3271,9 @@ public void getVoAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getVoAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getVoAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getVoAttributeByIdWhenAttributeNotExists");
 
 		vo = setUpVo();
 
@@ -3299,9 +3282,9 @@ public void getVoAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getVoAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getVoAttributeByIdWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getVoAttributeByIdWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		attributes = setUpMemberAttribute();
@@ -3312,27 +3295,27 @@ public void getVoAttributeById() throws Exception {
 
 	}
 
-@Test
-public void getResourceAttributeById() throws Exception {
-	System.out.println("attributesManager.getResourceAttributeById");
+	@Test
+	public void getResourceAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributeById");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpResourceAttribute();
-	attributesManager.setAttributes(sess, resource, attributes);
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpResourceAttribute();
+		attributesManager.setAttributes(sess, resource, attributes);
 
-	int id = attributes.get(0).getId();
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, resource, id);
-	assertNotNull("unable to get resource attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, resource, id);
+		assertNotNull("unable to get resource attribute by id",retAttr);
+		assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceAttributeByIdWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceAttributeByIdWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceAttributeByIdWhenResourceNotExists");
 
 		attributes = setUpResourceAttribute();
 		int id = attributes.get(0).getId();
@@ -3342,9 +3325,9 @@ public void getResourceAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getResourceAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getResourceAttributeByIdWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -3355,9 +3338,9 @@ public void getResourceAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getResourceAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getResourceAttributeByIdWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getResourceAttributeByIdWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -3370,28 +3353,28 @@ public void getResourceAttributeById() throws Exception {
 
 	}
 
-@Test
-public void getMemberResourceAttributeById() throws Exception {
-	System.out.println("attributesManager.getMemberResourceAttributeById");
+	@Test
+	public void getMemberResourceAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeById");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpMemberResourceAttribute();
-	attributesManager.setAttributes(sess, resource, member, attributes);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpMemberResourceAttribute();
+		attributesManager.setAttributes(sess, resource, member, attributes);
 
-	int id = attributes.get(0).getId();
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, resource, member, id);
-	assertNotNull("unable to get resource member attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, resource, member, id);
+		assertNotNull("unable to get resource member attribute by id",retAttr);
+		assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getMemberResourceAttributeByIdWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberResourceAttributeByIdWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeByIdWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3403,9 +3386,9 @@ public void getMemberResourceAttributeById() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getMemberResourceAttributeByIdWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberResourceAttributeByIdWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeByIdWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility= setUpFacility();
@@ -3418,9 +3401,9 @@ public void getMemberResourceAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getMemberResourceAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberResourceAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeByIdWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3432,9 +3415,9 @@ public void getMemberResourceAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getMemberResourceAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getMemberResourceAttributeByIdWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getMemberResourceAttributeByIdWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3448,94 +3431,94 @@ public void getMemberResourceAttributeById() throws Exception {
 
 	}
 
-@Test
-public void getMemberGroupAttributeById() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeById");
+	@Test
+	public void getMemberGroupAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeById");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
-	attributesManager.setAttributes(sess, member, group, attributes);
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributesManager.setAttributes(sess, member, group, attributes);
 
-	int id = attributes.get(0).getId();
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, member, group, id);
-	assertNotNull("unable to get group member attribute by id", retAttr);
-	assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
-}
+		Attribute retAttr = attributesManager.getAttributeById(sess, member, group, id);
+		assertNotNull("unable to get group member attribute by id", retAttr);
+		assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
+	}
 
-@Test (expected=GroupNotExistsException.class)
-public void getMemberGroupAttributeByIdWhenGroupNotExists() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeByIdWhenGroupNotExists");
+	@Test (expected=GroupNotExistsException.class)
+	public void getMemberGroupAttributeByIdWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeByIdWhenGroupNotExists");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
-	int id = attributes.get(0).getId();
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		int id = attributes.get(0).getId();
 
-	attributesManager.getAttributeById(sess, member, new Group(), id);
-	// shouldn't find group
-}
+		attributesManager.getAttributeById(sess, member, new Group(), id);
+		// shouldn't find group
+	}
 
-@Test (expected=MemberNotExistsException.class)
-public void getMemberGroupAttributeByIdWhenMemberNotExists() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeByIdWhenMemberNotExists");
+	@Test (expected=MemberNotExistsException.class)
+	public void getMemberGroupAttributeByIdWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeByIdWhenMemberNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpMemberGroupAttribute();
-	int id = attributes.get(0).getId();
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpMemberGroupAttribute();
+		int id = attributes.get(0).getId();
 
-	attributesManager.getAttributeById(sess, new Member(), group, id);
-	// shouldn't find member
-}
+		attributesManager.getAttributeById(sess, new Member(), group, id);
+		// shouldn't find member
+	}
 
-@Test (expected=AttributeNotExistsException.class)
-public void getMemberGroupAttributeByIdWhenAttributeNotExists() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeByIdWhenAttributeNotExists");
+	@Test (expected=AttributeNotExistsException.class)
+	public void getMemberGroupAttributeByIdWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeByIdWhenAttributeNotExists");
 
-	vo = setUpVo();
-	member = setUpMember();
-	group = setUpGroup();
+		vo = setUpVo();
+		member = setUpMember();
+		group = setUpGroup();
 
-	attributesManager.getAttributeById(sess, member, group, 0);
-	// shouldn't find attribute
-}
+		attributesManager.getAttributeById(sess, member, group, 0);
+		// shouldn't find attribute
+	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
-public void getMemberGroupAttributeByIdWhenWrongAttrAssignment() throws Exception {
-	System.out.println("attributesManager.getMemberGroupAttributeByIdWhenWrongAttrAssignment");
+	@Test (expected=WrongAttributeAssignmentException.class)
+	public void getMemberGroupAttributeByIdWhenWrongAttrAssignment() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributeByIdWhenWrongAttrAssignment");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpVoAttribute();
-	int id = attributes.get(0).getId();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpVoAttribute();
+		int id = attributes.get(0).getId();
 
-	attributesManager.getAttributeById(sess, member, group, id);
-	// shouldn't return member group attribute when ID belong to different type of attribute
-}
+		attributesManager.getAttributeById(sess, member, group, id);
+		// shouldn't return member group attribute when ID belong to different type of attribute
+	}
 
-@Test
-public void getMemberAttributeById() throws Exception {
-	System.out.println("attributesManager.getMemberAttributeById");
+	@Test
+	public void getMemberAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributeById");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttributes(sess, member, attributes);
-	int id = attributes.get(0).getId();
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttributes(sess, member, attributes);
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, member, id);
-	assertNotNull("unable to get member attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, member, id);
+		assertNotNull("unable to get member attribute by id",retAttr);
+		assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getMemberAttributeByIdWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeByIdWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getMemberAttributeByIdWhenMemberNotExists");
 
 		attributes = setUpMemberAttribute();
 		int id = attributes.get(0).getId();
@@ -3545,9 +3528,9 @@ public void getMemberAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getMemberAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getMemberAttributeByIdWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3557,9 +3540,9 @@ public void getMemberAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getMemberAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeByIdWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getMemberAttributeByIdWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3571,27 +3554,27 @@ public void getMemberAttributeById() throws Exception {
 
 	}
 
-@Test
-public void getFacilityUserAttributeById() throws Exception {
-	System.out.println("attributesManager.getFacilityUserAttributeById");
+	@Test
+	public void getFacilityUserAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeById");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpFacilityUserAttribute();
-	attributesManager.setAttributes(sess, facility, user, attributes);
-	int id = attributes.get(0).getId();
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpFacilityUserAttribute();
+		attributesManager.setAttributes(sess, facility, user, attributes);
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, facility, user, id);
-	assertNotNull("unable to get facility-user attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, facility, user, id);
+		assertNotNull("unable to get facility-user attribute by id",retAttr);
+		assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void getFacilityUserAttributeByIdWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributeByIdWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeByIdWhenFacilityNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3603,9 +3586,9 @@ public void getFacilityUserAttributeById() throws Exception {
 		// shouldn't find facility
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getFacilityUserAttributeByIdWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributeByIdWhenUserNotExists");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeByIdWhenUserNotExists");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityUserAttribute();
@@ -3616,9 +3599,9 @@ public void getFacilityUserAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getFacilityUserAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeByIdWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3630,9 +3613,9 @@ public void getFacilityUserAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getFacilityUserAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getFacilityUserAttributeByIdWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getFacilityUserAttributeByIdWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3646,26 +3629,26 @@ public void getFacilityUserAttributeById() throws Exception {
 
 	}
 
-@Test
-public void getUserAttributeById() throws Exception {
-	System.out.println("attributesManager.getUserAttributeById");
+	@Test
+	public void getUserAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributeById");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpUserAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributesManager.setAttributes(sess, user, attributes);
-	int id = attributes.get(0).getId();
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpUserAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributesManager.setAttributes(sess, user, attributes);
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, user, id);
-	assertNotNull("unable to get user attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, user, id);
+		assertNotNull("unable to get user attribute by id",retAttr);
+		assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getUserAttributeByIdWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getUserAttributeByIdWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getUserAttributeByIdWhenMemberNotExists");
 
 		attributes = setUpUserAttribute();
 		int id = attributes.get(0).getId();
@@ -3675,9 +3658,9 @@ public void getUserAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getUserAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getMemberAttributeByIdWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3688,9 +3671,9 @@ public void getUserAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getUserAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeByIdWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getMemberAttributeByIdWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3706,27 +3689,27 @@ public void getUserAttributeById() throws Exception {
 // TODO - není implementace pro getAttributeById(sess, group, id)
 // až bude metoda potřeba doplní se i test
 
-@Test
-public void getGroupResourceAttributeById() throws Exception {
-	System.out.println("attributesManager.getGroupResourceAttributeById");
+	@Test
+	public void getGroupResourceAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributeById");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpGroupResourceAttribute();
-	attributesManager.setAttributes(sess, resource, group, attributes);
-	int id = attributes.get(0).getId();
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpGroupResourceAttribute();
+		attributesManager.setAttributes(sess, resource, group, attributes);
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, resource, group, id);
-	assertNotNull("unable to get user attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, resource, group, id);
+		assertNotNull("unable to get user attribute by id",retAttr);
+		assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void getGroupResourceAttributeByIdWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributeByIdWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributeByIdWhenGroupNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -3739,9 +3722,9 @@ public void getGroupResourceAttributeById() throws Exception {
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getGroupResourceAttributeByIdWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributeByIdWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributeByIdWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -3753,9 +3736,9 @@ public void getGroupResourceAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getGroupResourceAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getGroupResourceAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getGroupResourceAttributeByIdWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -3767,9 +3750,9 @@ public void getGroupResourceAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getGroupResourceAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getMemberAttributeByIdWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getMemberAttributeByIdWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -3783,24 +3766,24 @@ public void getGroupResourceAttributeById() throws Exception {
 
 	}
 
-@Test
-public void getHostAttributeById() throws Exception {
-	System.out.println("attributesManager.getHostAttributeById");
+	@Test
+	public void getHostAttributeById() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributeById");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
-	attributesManager.setAttributes(sess, host, attributes);
-	int id = attributes.get(0).getId();
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
+		attributesManager.setAttributes(sess, host, attributes);
+		int id = attributes.get(0).getId();
 
-	Attribute retAttr = attributesManager.getAttributeById(sess, host, id);
-	assertNotNull("unable to get host attribute by id",retAttr);
-	assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttributeById(sess, host, id);
+		assertNotNull("unable to get host attribute by id",retAttr);
+		assertEquals("returned attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void getHostAttributeByIdWhenHostNotExists() throws Exception {
-		System.out.println("attributesManager.getHostAttributeByIdWhenHostNotExists");
+		System.out.println(CLASS_NAME + "getHostAttributeByIdWhenHostNotExists");
 
 		attributes = setUpHostAttribute();
 		int id = attributes.get(0).getId();
@@ -3810,9 +3793,9 @@ public void getHostAttributeById() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void getHostAttributeByIdWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.getHostAttributeByIdWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "getHostAttributeByIdWhenAttributeNotExists");
 
 		host = setUpHost().get(0);
 
@@ -3821,9 +3804,9 @@ public void getHostAttributeById() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void getHostAttributeByIdWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.getHostAttributeByIdWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "getHostAttributeByIdWhenWrongAttrAssignment");
 
 		host = setUpHost().get(0);
 		attributes = setUpVoAttribute();
@@ -3844,24 +3827,24 @@ public void getHostAttributeById() throws Exception {
 // ==============  6. SET ATTRIBUTE ================================
 
 
-@Test
-public void setFacilityAttribute() throws Exception {
-	System.out.println("attributesManager.setFacilityAttribute");
+	@Test
+	public void setFacilityAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setFacilityAttribute");
 
-	facility = setUpFacility();
-	attributes = setUpFacilityAttribute();
+		facility = setUpFacility();
+		attributes = setUpFacilityAttribute();
 
-	attributesManager.setAttribute(sess, facility, attributes.get(0));
+		attributesManager.setAttribute(sess, facility, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:opt:facility-test-attribute");
-	assertNotNull("unable to get facility attribute by name",retAttr);
-	assertEquals("returned facility attribute is not same as stored", retAttr, attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:opt:facility-test-attribute");
+		assertNotNull("unable to get facility attribute by name",retAttr);
+		assertEquals("returned facility attribute is not same as stored", retAttr, attributes.get(0));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void setFacilityAttributeWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.setFacilityAttributeWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "setFacilityAttributeWhenFacilityNotExists");
 
 		attributes = setUpFacilityAttribute();
 
@@ -3870,9 +3853,9 @@ public void setFacilityAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setFacilityAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setFacilityAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setFacilityAttributeWhenAttributeNotExists");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -3884,9 +3867,9 @@ public void setFacilityAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setFacilityAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setFacilityAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setFacilityAttributeWhenWrongAttrAssignment");
 
 		facility = setUpFacility();
 		attributes = setUpVoAttribute();
@@ -3896,9 +3879,9 @@ public void setFacilityAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setFacilityAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setFacilityAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setFacilityAttributeWhenTypeMismatch");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -3909,27 +3892,27 @@ public void setFacilityAttribute() throws Exception {
 
 	}
 
-@Test
-public void setFacilityUserAttribute() throws Exception {
-	System.out.println("attributesManager.setFacilityUserAttribute");
+	@Test
+	public void setFacilityUserAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setFacilityUserAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	attributes = setUpFacilityUserAttribute();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		attributes = setUpFacilityUserAttribute();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	attributesManager.setAttribute(sess, facility, user, attributes.get(0));
+		attributesManager.setAttribute(sess, facility, user, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, facility, user, "urn:perun:user_facility:attribute-def:opt:user-facility-test-attribute");
-	assertNotNull("unable to get facility-user attribute by name",retAttr);
-	assertEquals("returned facility-user attribute is not same as stored", retAttr, attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, facility, user, "urn:perun:user_facility:attribute-def:opt:user-facility-test-attribute");
+		assertNotNull("unable to get facility-user attribute by name",retAttr);
+		assertEquals("returned facility-user attribute is not same as stored", retAttr, attributes.get(0));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void setFacilityUserAttributeWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.setFacilityUserAttributeWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "setFacilityUserAttributeWhenFacilityNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3941,9 +3924,9 @@ public void setFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void setFacilityUserAttributeWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.setFacilityUserAttributeWhenUserNotExists");
+		System.out.println(CLASS_NAME + "setFacilityUserAttributeWhenUserNotExists");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityUserAttribute();
@@ -3953,9 +3936,9 @@ public void setFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setFacilityUserAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setFacilityUserAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setFacilityUserAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3970,9 +3953,9 @@ public void setFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setFacilityUserAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setFacilityUserAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setFacilityUserAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -3985,9 +3968,9 @@ public void setFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setFacilityUserAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setFacilityUserAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setFacilityUserAttributeWhenTypeMismatch");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -4001,24 +3984,24 @@ public void setFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test
-public void setVoAttribute() throws Exception {
-	System.out.println("attributesManager.setVoAttribute");
+	@Test
+	public void setVoAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setVoAttribute");
 
-	vo = setUpVo();
-	attributes = setUpVoAttribute();
+		vo = setUpVo();
+		attributes = setUpVoAttribute();
 
-	attributesManager.setAttribute(sess, vo, attributes.get(0));
+		attributesManager.setAttribute(sess, vo, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, vo, "urn:perun:vo:attribute-def:opt:vo-test-attribute");
-	assertNotNull("unable to get vo attribute by name",retAttr);
-	assertEquals("returned vo attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, vo, "urn:perun:vo:attribute-def:opt:vo-test-attribute");
+		assertNotNull("unable to get vo attribute by name",retAttr);
+		assertEquals("returned vo attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=VoNotExistsException.class)
+	@Test (expected=VoNotExistsException.class)
 	public void setVoAttributeWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.setVoAttributeWhenVoNotExists");
+		System.out.println(CLASS_NAME + "setVoAttributeWhenVoNotExists");
 
 		attributes = setUpVoAttribute();
 
@@ -4027,9 +4010,9 @@ public void setVoAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setVoAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setVoAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setVoAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		attributes = setUpVoAttribute();
@@ -4041,9 +4024,9 @@ public void setVoAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setVoAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setVoAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setVoAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		attributes = setUpFacilityAttribute();
@@ -4053,9 +4036,9 @@ public void setVoAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setVoAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setVoAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setVoAttributeWhenTypeMismatch");
 
 		vo = setUpVo();
 		attributes = setUpVoAttribute();
@@ -4066,26 +4049,26 @@ public void setVoAttribute() throws Exception {
 
 	}
 
-@Test
-public void setResourceAttribute() throws Exception {
-	System.out.println("attributesManager.setResourceAttribute");
+	@Test
+	public void setResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setResourceAttribute");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpResourceAttribute();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpResourceAttribute();
 
-	attributesManager.setAttribute(sess, resource, attributes.get(0));
+		attributesManager.setAttribute(sess, resource, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, resource, "urn:perun:resource:attribute-def:opt:resource-test-attribute");
-	assertNotNull("unable to get resource attribute by name", retAttr);
-	assertEquals("returned resource attribute is not same as stored", retAttr, attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, resource, "urn:perun:resource:attribute-def:opt:resource-test-attribute");
+		assertNotNull("unable to get resource attribute by name", retAttr);
+		assertEquals("returned resource attribute is not same as stored", retAttr, attributes.get(0));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void setResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.setResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "setResourceAttributeWhenResourceNotExists");
 
 		attributes = setUpResourceAttribute();
 
@@ -4094,9 +4077,9 @@ public void setResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4110,9 +4093,9 @@ public void setResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4124,9 +4107,9 @@ public void setResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setResourceAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setResourceAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setResourceAttributeWhenTypeMismatch");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4139,27 +4122,27 @@ public void setResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void setMemberResourceAttribute() throws Exception {
-	System.out.println("attributesManager.setMemberResourceAttribute");
+	@Test
+	public void setMemberResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberResourceAttribute");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	member = setUpMember();
-	attributes = setUpMemberResourceAttribute();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember();
+		attributes = setUpMemberResourceAttribute();
 
-	attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, resource, member, "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
-	assertNotNull("unable to get member-resource attribute by name", retAttr);
-	assertEquals("returned member-resource attribute is not same as stored", retAttr, attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, resource, member, "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
+		assertNotNull("unable to get member-resource attribute by name", retAttr);
+		assertEquals("returned member-resource attribute is not same as stored", retAttr, attributes.get(0));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void setMemberResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributeWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -4170,9 +4153,9 @@ public void setMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void setMemberResourceAttributeWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributeWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributeWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4184,9 +4167,9 @@ public void setMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setMemberResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4201,9 +4184,9 @@ public void setMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setMemberResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4216,9 +4199,9 @@ public void setMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setMemberResourceAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setMemberResourceAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setMemberResourceAttributeWhenTypeMismatch");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4232,108 +4215,108 @@ public void setMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void setMemberGroupAttribute() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttribute");
+	@Test
+	public void setMemberGroupAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttribute");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:member-group-test-attribute");
-	assertNotNull("unable to get member-group attribute by name", retAttr);
-	assertEquals("returned member-group attribute is not same as stored", retAttr, attributes.get(0));
-}
+		Attribute retAttr = attributesManager.getAttribute(sess, member, group, "urn:perun:member_group:attribute-def:opt:member-group-test-attribute");
+		assertNotNull("unable to get member-group attribute by name", retAttr);
+		assertEquals("returned member-group attribute is not same as stored", retAttr, attributes.get(0));
+	}
 
-@Test (expected=GroupNotExistsException.class)
-public void setMemberGroupAttributeWhenGroupNotExists() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributeWhenResourceNotExists");
+	@Test (expected=GroupNotExistsException.class)
+	public void setMemberGroupAttributeWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributeWhenResourceNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttribute(sess, member, new Group(), attributes.get(0));
-	// shouldn't find group
-}
+		attributesManager.setAttribute(sess, member, new Group(), attributes.get(0));
+		// shouldn't find group
+	}
 
-@Test (expected=MemberNotExistsException.class)
-public void setMemberGroupAttributeWhenMemberNotExists() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributeWhenMemberNotExists");
+	@Test (expected=MemberNotExistsException.class)
+	public void setMemberGroupAttributeWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributeWhenMemberNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpMemberGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpMemberGroupAttribute();
 
-	attributesManager.setAttribute(sess, new Member(), group, attributes.get(0));
-	// shouldn't find member
-}
+		attributesManager.setAttribute(sess, new Member(), group, attributes.get(0));
+		// shouldn't find member
+	}
 
-@Test (expected=AttributeNotExistsException.class)
-public void setMemberGroupAttributeWhenAttributeNotExists() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributeWhenAttributeNotExists");
+	@Test (expected=AttributeNotExistsException.class)
+	public void setMemberGroupAttributeWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributeWhenAttributeNotExists");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
-	attributes.get(0).setId(0);
-	// make valid attribute not existing in DB by setting ID = 0
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributes.get(0).setId(0);
+		// make valid attribute not existing in DB by setting ID = 0
 
-	attributesManager.setAttribute(sess, member, group, attributes.get(0));
-	// shouldn't find attribute
-}
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		// shouldn't find attribute
+	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
-public void setMemberGroupAttributeWhenWrongAttrAssignment() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributeWhenWrongAttrAssignment");
+	@Test (expected=WrongAttributeAssignmentException.class)
+	public void setMemberGroupAttributeWhenWrongAttrAssignment() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributeWhenWrongAttrAssignment");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpVoAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpVoAttribute();
 
-	attributesManager.setAttribute(sess, member, group, attributes.get(0));
-	// shouldn't add vo attribute into member-group
-}
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		// shouldn't add vo attribute into member-group
+	}
 
-@Test (expected=InternalErrorException.class)
-public void setMemberGroupAttributeWhenTypeMismatch() throws Exception {
-	System.out.println("attributesManager.setMemberGroupAttributeWhenTypeMismatch");
+	@Test (expected=InternalErrorException.class)
+	public void setMemberGroupAttributeWhenTypeMismatch() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberGroupAttributeWhenTypeMismatch");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	member = setUpMember();
-	attributes = setUpMemberGroupAttribute();
-	attributes.get(0).setValue(1);
+		vo = setUpVo();
+		group = setUpGroup();
+		member = setUpMember();
+		attributes = setUpMemberGroupAttribute();
+		attributes.get(0).setValue(1);
 
-	attributesManager.setAttribute(sess, member, group, attributes.get(0));
-	// shouldn't add attribute with String type and Integer value
-}
+		attributesManager.setAttribute(sess, member, group, attributes.get(0));
+		// shouldn't add attribute with String type and Integer value
+	}
 
-@Test
-public void setMemberAttribute() throws Exception {
-	System.out.println("attributesManager.setMemberAttribute");
+	@Test
+	public void setMemberAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setMemberAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
 
-	attributesManager.setAttribute(sess, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, member, "urn:perun:member:attribute-def:opt:member-test-attribute");
-	assertNotNull("unable to get member attribute by name",retAttr);
-	assertEquals("returned member attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, member, "urn:perun:member:attribute-def:opt:member-test-attribute");
+		assertNotNull("unable to get member attribute by name",retAttr);
+		assertEquals("returned member attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void setMemberAttributeWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberAttributeWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "setMemberAttributeWhenMemberNotExists");
 
 		attributes = setUpMemberAttribute();
 
@@ -4342,9 +4325,9 @@ public void setMemberAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setMemberAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setMemberAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setMemberAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -4357,9 +4340,9 @@ public void setMemberAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setMemberAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setMemberAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setMemberAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -4370,9 +4353,9 @@ public void setMemberAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setMemberAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setMemberAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setMemberAttributeWhenTypeMismatch");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -4384,26 +4367,26 @@ public void setMemberAttribute() throws Exception {
 
 	}
 
-@Test
-public void setUserAttribute() throws Exception {
-	System.out.println("attributesManager.setUserAttribute");
+	@Test
+	public void setUserAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setUserAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpUserAttribute();
+		vo = setUpVo();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpUserAttribute();
 
-	attributesManager.setAttribute(sess, user, attributes.get(0));
+		attributesManager.setAttribute(sess, user, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, user, "urn:perun:user:attribute-def:opt:user-test-attribute");
-	assertNotNull("unable to get user attribute by name",retAttr);
-	assertEquals("returned user attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, user, "urn:perun:user:attribute-def:opt:user-test-attribute");
+		assertNotNull("unable to get user attribute by name",retAttr);
+		assertEquals("returned user attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void setUserAttributeWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.setUserAttributeWhenUserNotExists");
+		System.out.println(CLASS_NAME + "setUserAttributeWhenUserNotExists");
 
 		attributes = setUpUserAttribute();
 
@@ -4412,9 +4395,9 @@ public void setUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setUserAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setUserAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setUserAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -4428,9 +4411,9 @@ public void setUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setUserAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setUserAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setUserAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -4442,9 +4425,9 @@ public void setUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setUserAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setUserAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setUserAttributeWhenTypeMismatch");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -4457,25 +4440,25 @@ public void setUserAttribute() throws Exception {
 
 	}
 
-@Test
-public void setGroupAttribute() throws Exception {
-	System.out.println("attributesManager.setGroupAttribute");
+	@Test
+	public void setGroupAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setGroupAttribute");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpGroupAttribute();
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpGroupAttribute();
 
-	attributesManager.setAttribute(sess, group, attributes.get(0));
+		attributesManager.setAttribute(sess, group, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, group, "urn:perun:group:attribute-def:opt:group-test-attribute");
-	assertNotNull("unable to get group attribute by name",retAttr);
-	assertEquals("returned group attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, group, "urn:perun:group:attribute-def:opt:group-test-attribute");
+		assertNotNull("unable to get group attribute by name",retAttr);
+		assertEquals("returned group attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void setGroupAttributeWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupAttributeWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "setGroupAttributeWhenGroupNotExists");
 
 		attributes = setUpGroupAttribute();
 
@@ -4484,9 +4467,9 @@ public void setGroupAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setGroupAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setGroupAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -4499,9 +4482,9 @@ public void setGroupAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setGroupAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setGroupAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setGroupAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -4512,9 +4495,9 @@ public void setGroupAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setGroupAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setResourceAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setResourceAttributeWhenTypeMismatch");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -4526,27 +4509,27 @@ public void setGroupAttribute() throws Exception {
 
 	}
 
-@Test
-public void setGroupResourceAttribute() throws Exception {
-	System.out.println("attributesManager.setGroupResourceAttribute");
+	@Test
+	public void setGroupResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setGroupResourceAttribute");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	group = setUpGroup();
-	attributes = setUpGroupResourceAttribute();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup();
+		attributes = setUpGroupResourceAttribute();
 
-	attributesManager.setAttribute(sess, resource, group, attributes.get(0));
+		attributesManager.setAttribute(sess, resource, group, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, resource, group, "urn:perun:group_resource:attribute-def:opt:group-resource-test-attribute");
-	assertNotNull("unable to get group-resource attribute by name",retAttr);
-	assertEquals("returned group-resource attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, resource, group, "urn:perun:group_resource:attribute-def:opt:group-resource-test-attribute");
+		assertNotNull("unable to get group-resource attribute by name",retAttr);
+		assertEquals("returned group-resource attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void setGroupResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributeWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -4557,9 +4540,9 @@ public void setGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void setGroupResourceAttributeWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributeWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributeWhenGroupNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4571,9 +4554,9 @@ public void setGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setGroupResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4588,9 +4571,9 @@ public void setGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setGroupResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4603,9 +4586,9 @@ public void setGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setGroupResourceAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setGroupResourceAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setGroupResourceAttributeWhenTypeMismatch");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -4619,24 +4602,24 @@ public void setGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void setHostAttribute() throws Exception {
-	System.out.println("attributesManager.setHostAttribute");
+	@Test
+	public void setHostAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "setHostAttribute");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
 
-	attributesManager.setAttribute(sess, host, attributes.get(0));
+		attributesManager.setAttribute(sess, host, attributes.get(0));
 
-	Attribute retAttr = attributesManager.getAttribute(sess, host, "urn:perun:host:attribute-def:opt:host-test-attribute");
-	assertNotNull("unable to get host attribute by name",retAttr);
-	assertEquals("returned host attribute is not same as stored",retAttr,attributes.get(0));
+		Attribute retAttr = attributesManager.getAttribute(sess, host, "urn:perun:host:attribute-def:opt:host-test-attribute");
+		assertNotNull("unable to get host attribute by name",retAttr);
+		assertEquals("returned host attribute is not same as stored",retAttr,attributes.get(0));
 
-}
+	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void setHostAttributeWhenHostNotExists() throws Exception {
-		System.out.println("attributesManager.setHostAttributeWhenHostNotExists");
+		System.out.println(CLASS_NAME + "setHostAttributeWhenHostNotExists");
 
 		host = setUpHost().get(0);
 		attributes = setUpHostAttribute();
@@ -4646,9 +4629,9 @@ public void setHostAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void setHostAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.setHostAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "setHostAttributeWhenAttributeNotExists");
 
 		host = setUpHost().get(0);
 		attributes = setUpHostAttribute();
@@ -4660,9 +4643,9 @@ public void setHostAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void setHostAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.setHostAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "setHostAttributeWhenWrongAttrAssignment");
 
 		host = setUpHost().get(0);
 		attributes = setUpVoAttribute();
@@ -4672,9 +4655,9 @@ public void setHostAttribute() throws Exception {
 
 	}
 
-@Test (expected=InternalErrorException.class)
+	@Test (expected=InternalErrorException.class)
 	public void setHostAttributeWhenTypeMismatch() throws Exception {
-		System.out.println("attributesManager.setHostAttributeWhenTypeMismatch");
+		System.out.println(CLASS_NAME + "setHostAttributeWhenTypeMismatch");
 
 		host = setUpHost().get(0);
 		attributes = setUpHostAttribute();
@@ -4698,29 +4681,29 @@ public void setHostAttribute() throws Exception {
 
 
 
-@Test
-public void createAttribute() throws Exception {
-	System.out.println("attributesManager.createAttribute");
+	@Test
+	public void createAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "createAttribute");
 
-	AttributeDefinition attrDef = new AttributeDefinition();
-	attrDef.setFriendlyName("attr-def-facility-tests-attr");
-	attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
-	attrDef.setDescription("poznamka");
-	attrDef.setType(String.class.getName());
-	// create attr definition
-	attributesManager.createAttribute(sess, attrDef);
-	// store attr def in DB acording namespace
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setFriendlyName("attr-def-facility-tests-attr");
+		attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
+		attrDef.setDescription("poznamka");
+		attrDef.setType(String.class.getName());
+		// create attr definition
+		attributesManager.createAttribute(sess, attrDef);
+		// store attr def in DB acording namespace
 
-	AttributeDefinition retAttrDef = attributesManager.getAttributeDefinition(sess, "urn:perun:facility:attribute-def:opt:attr-def-facility-tests-attr");
+		AttributeDefinition retAttrDef = attributesManager.getAttributeDefinition(sess, "urn:perun:facility:attribute-def:opt:attr-def-facility-tests-attr");
 
-	assertNotNull("unable to get attr definition by name",retAttrDef);
-	assertEquals("returned attr definition is not same as stored",attrDef,retAttrDef);
+		assertNotNull("unable to get attr definition by name",retAttrDef);
+		assertEquals("returned attr definition is not same as stored",attrDef,retAttrDef);
 
-}
+	}
 
-@Test (expected=AttributeExistsException.class)
+	@Test (expected=AttributeExistsException.class)
 	public void createAttributeWhenAttributeExists() throws Exception {
-		System.out.println("attributesManager.createAttributeWhenAttributeExists");
+		System.out.println(CLASS_NAME + "createAttributeWhenAttributeExists");
 
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setFriendlyName("attr-def-facility-tests-attr");
@@ -4735,9 +4718,9 @@ public void createAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void deleteAttribute() throws Exception {
-		System.out.println("attributesManager.deleteAttribute");
+		System.out.println(CLASS_NAME + "deleteAttribute");
 
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setFriendlyName("attr-def-facility-tests-attr");
@@ -4753,9 +4736,9 @@ public void createAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void deleteAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.deleteAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "deleteAttributeWhenAttributeNotExists");
 
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setFriendlyName("attr-def-facility-tests-attr");
@@ -4771,7 +4754,7 @@ public void createAttribute() throws Exception {
 	@Ignore
 	@Test (expected=RelationExistsException.class)
 	public void deleteAttributeWhenRelationExists() throws Exception {
-		System.out.println("attributesManager.deleteAttributeWhenRelationExists");
+		System.out.println(CLASS_NAME + "deleteAttributeWhenRelationExists");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -4784,11 +4767,11 @@ public void createAttribute() throws Exception {
 
 	}
 
-// FIXME - deleteAttributeForce - not yet implemented
+	// FIXME - deleteAttributeForce - not yet implemented
 	@Ignore
 	@Test (expected=AttributeNotExistsException.class)
 	public void deleteAttributeForce() throws Exception {
-		System.out.println("attributesManager.deleteAttributeForce");
+		System.out.println(CLASS_NAME + "deleteAttributeForce");
 
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setFriendlyName("attr-def-facility-tests-attr");
@@ -4806,9 +4789,9 @@ public void createAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void deleteAttributeForceWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.deleteAttributeForceWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "deleteAttributeForceWhenAttributeNotExists");
 
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setFriendlyName("attr-def-facility-tests-attr");
@@ -4821,11 +4804,11 @@ public void createAttribute() throws Exception {
 
 	}
 
-// FIXME - deleteAttributeForce - not yet implemented
+	// FIXME - deleteAttributeForce - not yet implemented
 	@Ignore
 	@Test (expected=AttributeNotExistsException.class)
 	public void deleteAttributeForceWhenRelationExists() throws Exception {
-		System.out.println("attributesManager.deleteAttributeForceWhenRelationExists");
+		System.out.println(CLASS_NAME + "deleteAttributeForceWhenRelationExists");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -4865,156 +4848,156 @@ public void createAttribute() throws Exception {
 
 // ==============  8. GET REQUIRED ATTRIBUTES ================================
 
-@Test
-public void getRequiredFacilityAttributesForItsServices() throws Exception {
-	System.out.println("attributesManager.getRequiredFacilityAttributesForItsServices");
+	@Test
+	public void getRequiredFacilityAttributesForItsServices() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredFacilityAttributesForItsServices");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
-	attributesManager.setAttribute(sess, facility, attributes.get(0));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+		attributesManager.setAttribute(sess, facility, attributes.get(0));
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, facility);
-	assertNotNull("unable to get required facility attributes for its services",reqAttr);
-	assertTrue("should have only 1 req facility attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, facility);
+		assertNotNull("unable to get required facility attributes for its services",reqAttr);
+		assertTrue("should have only 1 req facility attribute",reqAttr.size() == 1);
 
-}
-
-@Test
-public void setRequiredAttributesForMemberResourceFacilityUser() throws Exception {
-	System.out.println("attributesManager.setRequiredAttributesForMemberResourceFacilityUser");
-
-	vo = setUpVo();
-	member = setUpMember();
-	User user = perun.getUsersManagerBl().getUserByMember(sess, member);
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.addAll(setUpMemberAttribute());
-	attributes.addAll(setUpUserAttribute());
-	attributes.addAll(setUpMemberResourceAttribute());
-	attributes.addAll(setUpFacilityUserAttribute());
-	perun.getResourcesManager().assignService(sess, resource, service);
-
-	perun.getAttributesManagerBl().setRequiredAttributes(sess, facility, resource, user, member);
-}
-
-@Test
-public void getResourceRequiredGroupResourceAndGroupAttributesForItsServices() throws Exception {
-	System.out.println("attributesManager.getRequiredFacilityAttributesForItsServices");
-
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	group = setUpGroup();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
-	for(Attribute a: attributes) {
-		if(attributesManager.isFromNamespace(sess, a, AttributesManager.NS_GROUP_ATTR)) {
-			attributesManager.setAttribute(sess, group, a);
-		} else if(attributesManager.isFromNamespace(sess, a, AttributesManager.NS_GROUP_RESOURCE_ATTR)) {
-			attributesManager.setAttribute(sess, resource, group, a);
-		}
 	}
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, group, true);
+	@Test
+	public void setRequiredAttributesForMemberResourceFacilityUser() throws Exception {
+		System.out.println(CLASS_NAME + "setRequiredAttributesForMemberResourceFacilityUser");
 
-	assertNotNull("unable to get required group_resource and group attributes for its services",reqAttr);
-	assertTrue("should have only 2 req group_resource and group attributes",reqAttr.size() == 2);
+		vo = setUpVo();
+		member = setUpMember();
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.addAll(setUpMemberAttribute());
+		attributes.addAll(setUpUserAttribute());
+		attributes.addAll(setUpMemberResourceAttribute());
+		attributes.addAll(setUpFacilityUserAttribute());
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-}
+		perun.getAttributesManagerBl().setRequiredAttributes(sess, facility, resource, user, member);
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test
+	public void getResourceRequiredGroupResourceAndGroupAttributesForItsServices() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredFacilityAttributesForItsServices");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+		for(Attribute a: attributes) {
+			if(attributesManager.isFromNamespace(sess, a, AttributesManager.NS_GROUP_ATTR)) {
+				attributesManager.setAttribute(sess, group, a);
+			} else if(attributesManager.isFromNamespace(sess, a, AttributesManager.NS_GROUP_RESOURCE_ATTR)) {
+				attributesManager.setAttribute(sess, resource, group, a);
+			}
+		}
+
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, group, true);
+
+		assertNotNull("unable to get required group_resource and group attributes for its services",reqAttr);
+		assertTrue("should have only 2 req group_resource and group attributes",reqAttr.size() == 2);
+
+	}
+
+	@Test (expected=FacilityNotExistsException.class)
 	public void getRequiredFacilityAttributesForItsServicesWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredFacilityAttributesForItsServicesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getRequiredFacilityAttributesForItsServicesWhenFacilityNotExists");
 
 		attributesManager.getRequiredAttributes(sess, new Facility());
 		// shouldn't find facility
 
 	}
 
-@Test
-public void getRequiredResourceAttributesForItsServices() throws Exception {
-	System.out.println("attributesManager.getRequiredResourceAttributesForItsServices");
+	@Test
+	public void getRequiredResourceAttributesForItsServices() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredResourceAttributesForItsServices");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
-	attributesManager.setAttribute(sess, resource, attributes.get(3));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+		attributesManager.setAttribute(sess, resource, attributes.get(3));
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, resource);
-	assertNotNull("unable to get required resource attributes for its services",reqAttr);
-	assertTrue("should have only 1 req resource attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, resource);
+		assertNotNull("unable to get required resource attributes for its services",reqAttr);
+		assertTrue("should have only 1 req resource attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getRequiredResourceAttributesForItsServicesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredResourceAttributesForItsServicesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredResourceAttributesForItsServicesWhenResourceNotExists");
 
 		attributesManager.getRequiredAttributes(sess, new Resource());
 		// shouldn't find Resource
 
 	}
 
-@Test
-public void getResourceRequiredMemberResourceAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredMemberResourceAttributes");
+	@Test
+	public void getResourceRequiredMemberResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberResourceAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, member);
-	assertNotNull("unable to get required member resource attributes for its services",reqAttr);
-	assertTrue("should have only 1 req member resource attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, member);
+		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
+		assertTrue("should have only 1 req member resource attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test
-public void getServiceRequiredResourceAttributes() throws Exception {
-	System.out.println("attributesManager.getServiceRequiredResourceAttributes");
+	@Test
+	public void getServiceRequiredResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getServiceRequiredResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
-	
-	Service service2 = setUpService2();
-	Attribute attr = setUpResourceRequiredAttributeForService(service2);
-	perun.getResourcesManager().assignService(sess, resource, service2);
-	
-	List<Service> serviceList = new ArrayList<>();
-	serviceList.add(service);
-	
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, serviceList, resource);
-	assertNotNull("unable to get required resource attributes for its services",reqAttr);
-	assertTrue("should have only 1 req resource attribute",reqAttr.size() == 1);
-	
-	serviceList.add(service2);
-	reqAttr = attributesManager.getRequiredAttributes(sess, serviceList, resource);
-	assertNotNull("unable to get required resource attributes for its services",reqAttr);
-	assertTrue("should have only 1 req resource attribute",reqAttr.size() == 2);
-}
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
 
-@Test (expected=ResourceNotExistsException.class)
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		Service service2 = setUpService2();
+		Attribute attr = setUpResourceRequiredAttributeForService(service2);
+		perun.getResourcesManager().assignService(sess, resource, service2);
+
+		List<Service> serviceList = new ArrayList<>();
+		serviceList.add(service);
+
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, serviceList, resource);
+		assertNotNull("unable to get required resource attributes for its services",reqAttr);
+		assertTrue("should have only 1 req resource attribute",reqAttr.size() == 1);
+
+		serviceList.add(service2);
+		reqAttr = attributesManager.getRequiredAttributes(sess, serviceList, resource);
+		assertNotNull("unable to get required resource attributes for its services",reqAttr);
+		assertTrue("should have only 1 req resource attribute",reqAttr.size() == 2);
+	}
+
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredMemberResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberResourceAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5026,9 +5009,9 @@ public void getServiceRequiredResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredMemberResourceAttributesWhenSecondResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberResourceAttributesWhenSecondResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberResourceAttributesWhenSecondResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5040,42 +5023,42 @@ public void getServiceRequiredResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void getResourceRequiredMemberResourceAttributesWhenFakeResource() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredMemberResourceAttributesWhenFakeResource");
+	@Test
+	public void getResourceRequiredMemberResourceAttributesWhenFakeResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberResourceAttributesWhenFakeResource");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	Resource fakeResource = new Resource();
-	fakeResource.setName("AttrManTestResource2");
-	fakeResource.setDescription("fake resource");
+		Resource fakeResource = new Resource();
+		fakeResource.setName("AttrManTestResource2");
+		fakeResource.setDescription("fake resource");
 
-	perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
+		perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, resource, member);
-	assertNotNull("unable to get required member resource attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, resource, member);
+		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-	reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, member);
-	assertNotNull("unable to get required member resource attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource and no value set",reqAttr.size() == 0);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, member);
+		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set",reqAttr.size() == 0);
 
-	reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member);
-	assertNotNull("unable to get required member resource attributes for its services",reqAttr);
-	assertTrue("Should return 1 attribute (but with no value)",reqAttr.size() == 1);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member);
+		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
+		assertTrue("Should return 1 attribute (but with no value)",reqAttr.size() == 1);
 
-}
+	}
 
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getResourceRequiredMemberResourceAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberResourceAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberResourceAttributesWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5086,27 +5069,27 @@ public void getResourceRequiredMemberResourceAttributesWhenFakeResource() throws
 
 	}
 
-@Test
-public void getResourceRequiredMemberResourceAttributesWorkWithUserAttributes() throws Exception {
-	System.out.println("attributesManager.getRequiredMemberResourceAttributesWorkWithUserAttributes");
+	@Test
+	public void getResourceRequiredMemberResourceAttributesWorkWithUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesWorkWithUserAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, member, true);
-	assertNotNull("unable to get required member resource (work with user) attributes for its services",reqAttr);
-	assertTrue("should have more than 1 req attribute",reqAttr.size() >= 1);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, member, true);
+		assertNotNull("unable to get required member resource (work with user) attributes for its services",reqAttr);
+		assertTrue("should have more than 1 req attribute",reqAttr.size() >= 1);
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberResourceAttributesWorkWithUserWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberResourceAttributesWorkWithUserWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5118,9 +5101,9 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserAttributes() 
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenSecondResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberResourceAttributesWorkWithUserWhenSecondResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberResourceAttributesWorkWithUserWhenSecondResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5132,42 +5115,42 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserAttributes() 
 
 	}
 
-@Test
-public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResource() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResource");
+	@Test
+	public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResource");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	Resource fakeResource = new Resource();
-	fakeResource.setName("AttrManTestResource2");
-	fakeResource.setDescription("fake resource");
+		Resource fakeResource = new Resource();
+		fakeResource.setName("AttrManTestResource2");
+		fakeResource.setDescription("fake resource");
 
-	perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
+		perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, resource, member, true);
-	assertNotNull("unable to get required member resource attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, resource, member, true);
+		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-	reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, member, true);
-	assertNotNull("unable to get required member resource attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource and no value set",reqAttr.size() == 0);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, member, true);
+		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set",reqAttr.size() == 0);
 
-	reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member, true);
-	assertNotNull("unable to get required member resource attributes for its services",reqAttr);
-	assertTrue("Should return 4 attributes (but with no value)",reqAttr.size() == 4);
-	// member_resource, user_facility, user, member
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member, true);
+		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
+		assertTrue("Should return 4 attributes (but with no value)",reqAttr.size() == 4);
+		// member_resource, user_facility, user, member
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberResourceAttributesWorkWithUserWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesWorkWithUserWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5179,7 +5162,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test
 	public void getResourceRequiredMemberGroupAttributes() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributes");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberGroupAttributes");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5197,7 +5180,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredMemberGroupAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberGroupAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5211,7 +5194,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test (expected=GroupNotExistsException.class)
 	public void getResourceRequiredMemberGroupAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberGroupAttributesWhenGroupNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5224,7 +5207,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test
 	public void getResourceRequiredMemberGroupAttributesWhenFakeResource() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWhenFakeResource");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberGroupAttributesWhenFakeResource");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5249,7 +5232,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test (expected=MemberNotExistsException.class)
 	public void getResourceRequiredMemberGroupAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberGroupAttributesWhenMemberNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5262,7 +5245,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test
 	public void getResourceRequiredMemberGroupAttributesWorkWithUserAttributes() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberGroupAttributesWorkWithUserAttributes");
+		System.out.println(CLASS_NAME + "getRequiredMemberGroupAttributesWorkWithUserAttributes");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5280,7 +5263,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredMemberGroupAttributesWorkWithUserWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWorkWithUserWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberGroupAttributesWorkWithUserWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5294,7 +5277,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test (expected=GroupNotExistsException.class)
 	public void getResourceRequiredMemberGroupAttributesWorkWithUserWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWorkWithUserWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberGroupAttributesWorkWithUserWhenGroupNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5307,7 +5290,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test
 	public void getResourceRequiredMemberGroupAttributesWorkWithUserWhenFakeResource() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberGroupAttributesWorkWithUserWhenFakeResource");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberGroupAttributesWorkWithUserWhenFakeResource");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5331,7 +5314,7 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 
 	@Test (expected=MemberNotExistsException.class)
 	public void getResourceRequiredMemberGroupAttributesWorkWithUserWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberGroupAttributesWorkWithUserWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberGroupAttributesWorkWithUserWhenMemberNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5342,32 +5325,32 @@ public void getResourceRequiredMemberResourceAttributesWorkWithUserWhenFakeResou
 		// shouldn't find member
 	}
 
-@Test
-public void getResourceRequiredFacilityUserAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredFacilityUserAttributes");
+	@Test
+	public void getResourceRequiredFacilityUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredFacilityUserAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
-	group = setUpGroup();
-	perun.getResourcesManager().assignGroupToResource(sess, group, resource);
-	perun.getGroupsManager().addMember(sess, group, member);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
+		group = setUpGroup();
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getGroupsManager().addMember(sess, group, member);
 
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, facility, user);
-	assertNotNull("unable to get required facility user attributes for its services",reqAttr);
-	assertTrue("should have only 1 req facility user attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, facility, user);
+		assertNotNull("unable to get required facility user attributes for its services",reqAttr);
+		assertTrue("should have only 1 req facility user attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void getResourceRequiredFacilityUserAttributesWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredFacilityUserAttributesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredFacilityUserAttributesWhenFacilityNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5381,9 +5364,9 @@ public void getResourceRequiredFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredFacilityUserAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredFacilityUserAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredFacilityUserAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5396,9 +5379,9 @@ public void getResourceRequiredFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getResourceRequiredFacilityUserAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredFacilityUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredFacilityUserAttributesWhenUserNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5409,53 +5392,53 @@ public void getResourceRequiredFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test
-public void getResourceRequiredFacilityUserAttributesWhenFakeResource() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredFacilityUserAttributesWhenFakeResource");
+	@Test
+	public void getResourceRequiredFacilityUserAttributesWhenFakeResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredFacilityUserAttributesWhenFakeResource");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	Resource fakeResource = new Resource();
-	fakeResource.setName("AttrManTestResource2");
-	fakeResource.setDescription("fake resource");
+		Resource fakeResource = new Resource();
+		fakeResource.setName("AttrManTestResource2");
+		fakeResource.setDescription("fake resource");
 
-	perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
+		perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
 
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, facility, user);
-	assertNotNull("unable to get required facility user attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, facility, user);
+		assertNotNull("unable to get required facility user attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-}
+	}
 
-@Test
-public void getResourceRequiredMemberAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredMemberAttributes");
+	@Test
+	public void getResourceRequiredMemberAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, member);
-	assertNotNull("Unable to get member required attributes for resource", reqAttr);
-	assertTrue("There should be only one required attribute", reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, member);
+		assertNotNull("Unable to get member required attributes for resource", reqAttr);
+		assertTrue("There should be only one required attribute", reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredMemberAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5465,9 +5448,9 @@ public void getResourceRequiredMemberAttributes() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getResourceRequiredMemberAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredMemberAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberAttributesWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5478,44 +5461,44 @@ public void getResourceRequiredMemberAttributes() throws Exception {
 
 	}
 
-@Test
-public void getResourceRequiredMemberAttributesWhenFakeResource() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredMemberAttributesWhenFakeResource");
+	@Test
+	public void getResourceRequiredMemberAttributesWhenFakeResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredMemberAttributesWhenFakeResource");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	Resource fakeResource = setUpResource(); // without service
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		Resource fakeResource = setUpResource(); // without service
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member);
-	assertNotNull("unable to get required member attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member);
+		assertNotNull("unable to get required member attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-}
+	}
 
-@Test
-public void getResourceRequiredUserAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredUserAttributes");
+	@Test
+	public void getResourceRequiredUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredUserAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, user);
-	assertNotNull("Unable to get user required attributes for resource", reqAttr);
-	assertTrue("There should be only one required attribute", reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, user);
+		assertNotNull("Unable to get user required attributes for resource", reqAttr);
+		assertTrue("There should be only one required attribute", reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredUserAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredUserAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredUserAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -5527,9 +5510,9 @@ public void getResourceRequiredUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getResourceRequiredUserAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredUserAttributesWhenUserNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5540,44 +5523,44 @@ public void getResourceRequiredUserAttributes() throws Exception {
 
 	}
 
-@Test
-public void getResourceRequiredUserAttributesWhenFakeResource() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredUserAttributesWhenFakeResource");
+	@Test
+	public void getResourceRequiredUserAttributesWhenFakeResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredUserAttributesWhenFakeResource");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	Resource fakeResource = setUpResource(); // without service
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		Resource fakeResource = setUpResource(); // without service
 
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, user);
-	assertNotNull("unable to get required user attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, user);
+		assertNotNull("unable to get required user attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-}
+	}
 
-@Test
-public void getResourceRequiredGroupResourceAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredGroupResourceAttributes");
+	@Test
+	public void getResourceRequiredGroupResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupResourceAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, group);
-	assertNotNull("unable to get required group resource attributes for its services",reqAttr);
-	assertTrue("should have only 1 req group resource attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, group);
+		assertNotNull("unable to get required group resource attributes for its services",reqAttr);
+		assertTrue("should have only 1 req group resource attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredGroupResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredGroupResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupResourceAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5589,9 +5572,9 @@ public void getResourceRequiredGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredGroupResourceAttributesWhenSecondResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredGroupResourceAttributesWhenSecondResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupResourceAttributesWhenSecondResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5603,42 +5586,42 @@ public void getResourceRequiredGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void getResourceRequiredGroupResourceAttributesWhenFakeResource() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredGroupResourceAttributesWhenFakeResource");
+	@Test
+	public void getResourceRequiredGroupResourceAttributesWhenFakeResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupResourceAttributesWhenFakeResource");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	Resource fakeResource = new Resource();
-	fakeResource.setName("AttrManTestResource2");
-	fakeResource.setDescription("fake resource");
+		Resource fakeResource = new Resource();
+		fakeResource.setName("AttrManTestResource2");
+		fakeResource.setDescription("fake resource");
 
-	perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
+		perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, resource, group);
-	assertNotNull("unable to get required group resource attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, resource, group);
+		assertNotNull("unable to get required group resource attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-	reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, group);
-	assertNotNull("unable to get required group resource attributes for its services",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource and no value set",reqAttr.size() == 0);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, group);
+		assertNotNull("unable to get required group resource attributes for its services",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set",reqAttr.size() == 0);
 
-	reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, group);
-	assertNotNull("unable to get required group resource attributes for its services",reqAttr);
-	assertTrue("Should return 1 attribute (but with no value)",reqAttr.size() == 1);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, group);
+		assertNotNull("unable to get required group resource attributes for its services",reqAttr);
+		assertTrue("Should return 1 attribute (but with no value)",reqAttr.size() == 1);
 
-}
+	}
 
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void getResourceRequiredGroupResourceAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredGroupResourceAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupResourceAttributesWhenGroupNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5649,27 +5632,27 @@ public void getResourceRequiredGroupResourceAttributesWhenFakeResource() throws 
 
 	}
 
-@Test
-public void getResourceRequiredGroupAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredGroupAttributes");
+	@Test
+	public void getResourceRequiredGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, group);
-	assertNotNull("Unable to get group required attributes for resource", reqAttr);
-	assertTrue("There should be only one required attribute", reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, group);
+		assertNotNull("Unable to get group required attributes for resource", reqAttr);
+		assertTrue("There should be only one required attribute", reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredGroupAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredGroupAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -5679,9 +5662,9 @@ public void getResourceRequiredGroupAttributes() throws Exception {
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void getResourceRequiredGroupAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredGroupAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupAttributesWhenGroupNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5692,46 +5675,46 @@ public void getResourceRequiredGroupAttributes() throws Exception {
 
 	}
 
-@Test
-public void getResourceRequiredGroupAttributesWhenFakeResource() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredGroupAttributesWhenFakeResource");
+	@Test
+	public void getResourceRequiredGroupAttributesWhenFakeResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredGroupAttributesWhenFakeResource");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	Resource fakeResource = setUpResource(); // without service
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		Resource fakeResource = setUpResource(); // without service
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, group);
-	assertNotNull("unable to get required group attributes for resource",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, group);
+		assertNotNull("unable to get required group attributes for resource",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-}
+	}
 
-@Test
-public void getResourceRequiredHostAttributes() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredHostAttributes");
+	@Test
+	public void getResourceRequiredHostAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredHostAttributes");
 
-	vo = setUpVo();
-	host = setUpHost().get(0); // also creates Facility
+		vo = setUpVo();
+		host = setUpHost().get(0); // also creates Facility
 
-	// create resource
-	Resource resource = new Resource();
-	resource.setName("AttrTestResource");
-	perun.getResourcesManager().createResource(sess, resource, vo, facility);
+		// create resource
+		Resource resource = new Resource();
+		resource.setName("AttrTestResource");
+		perun.getResourcesManager().createResource(sess, resource, vo, facility);
 
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, host);
-	assertNotNull("Unable to get host required attributes for resource", reqAttr);
-	assertTrue("There should be only one required attribute", reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, host);
+		assertNotNull("Unable to get host required attributes for resource", reqAttr);
+		assertTrue("There should be only one required attribute", reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getResourceRequiredHostAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredHostAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredHostAttributesWhenResourceNotExists");
 
 		host = setUpHost().get(0);
 
@@ -5740,9 +5723,9 @@ public void getResourceRequiredHostAttributes() throws Exception {
 
 	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void getResourceRequiredHostAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getResourceRequiredHostAttributesWhenHostNotExists");
+		System.out.println(CLASS_NAME + "getResourceRequiredHostAttributesWhenHostNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5753,19 +5736,19 @@ public void getResourceRequiredHostAttributes() throws Exception {
 
 	}
 
-@Test
-public void getResourceRequiredHostAttributesWhenFakeResource() throws Exception {
-	System.out.println("attributesManager.getResourceRequiredHostAttributesWhenFakeResource");
+	@Test
+	public void getResourceRequiredHostAttributesWhenFakeResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceRequiredHostAttributesWhenFakeResource");
 
-	host = setUpHost().get(0); // also creates cluster type facility
-	vo = setUpVo();
-	Resource fakeResource = setUpResource(); // without service
+		host = setUpHost().get(0); // also creates cluster type facility
+		vo = setUpVo();
+		Resource fakeResource = setUpResource(); // without service
 
-	List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, host);
-	assertNotNull("unable to get required host attributes for resource",reqAttr);
-	assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, host);
+		assertNotNull("unable to get required host attributes for resource",reqAttr);
+		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-}
+	}
 
 // TODO - doplnit testy na:
 /*
@@ -5775,57 +5758,57 @@ public void getResourceRequiredHostAttributesWhenFakeResource() throws Exception
  *
  */
 
-@Test
-public void getRequiredAttributesDefinition() throws Exception {
-	System.out.println("attributesManager.getRequiredAttributesDefinition");
+	@Test
+	public void getRequiredAttributesDefinition() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredAttributesDefinition");
 
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
 
-	List<AttributeDefinition> reqAttr = attributesManager.getRequiredAttributesDefinition(sess, service);
-	assertNotNull("unable to get required services attribute definition",reqAttr);
-	assertTrue("should have at least 7 req attribute definitions",reqAttr.size() >= 7);
+		List<AttributeDefinition> reqAttr = attributesManager.getRequiredAttributesDefinition(sess, service);
+		assertNotNull("unable to get required services attribute definition",reqAttr);
+		assertTrue("should have at least 7 req attribute definitions",reqAttr.size() >= 7);
 
-}
+	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredAttributesDefinitionWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredAttributesDefinitionWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredAttributesDefinitionWhenServiceNotExists");
 
 		attributesManager.getRequiredAttributesDefinition(sess, new Service());
 		// shouldn't find service
 
 	}
 
-@Test
-public void getRequiredFacilityAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredFacilityAttributesFromOneService");
+	@Test
+	public void getRequiredFacilityAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredFacilityAttributesFromOneService");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, facility);
-	assertNotNull("unable to get required facility attributes for one service",reqAttr);
-	assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, facility);
+		assertNotNull("unable to get required facility attributes for one service",reqAttr);
+		assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredFacilityAttributesFromOneServiceWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredFacilityAttributesFromOneServiceWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredFacilityAttributesFromOneServiceWhenServiceNotExists");
 
 		attributesManager.getRequiredAttributes(sess, new Service(), facility);
 		// shouldn't find service
 
 	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void getRequiredFacilityAttributesFromOneServiceWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredFacilityAttributesFromOneServiceWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getRequiredFacilityAttributesFromOneServiceWhenFacilityNotExists");
 
 		service = setUpService();
 
@@ -5834,26 +5817,26 @@ public void getRequiredFacilityAttributesFromOneService() throws Exception {
 
 	}
 
-@Test
-public void getRequiredResourceAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredResourceAttributesFromOneService");
+	@Test
+	public void getRequiredResourceAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredResourceAttributesFromOneService");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource);
-	assertNotNull("unable to get required resource attributes for one service",reqAttr);
-	assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource);
+		assertNotNull("unable to get required resource attributes for one service",reqAttr);
+		assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredResourceAttributesFromOneServiceWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredResourceAttributesFromOneServiceWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredResourceAttributesFromOneServiceWhenServiceNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5864,9 +5847,9 @@ public void getRequiredResourceAttributesFromOneService() throws Exception {
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getRequiredResourceAttributesFromOneServiceWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredResourceAttributesFromOneServiceWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredResourceAttributesFromOneServiceWhenResourceNotExists");
 
 		service = setUpService();
 
@@ -5875,49 +5858,49 @@ public void getRequiredResourceAttributesFromOneService() throws Exception {
 
 	}
 
-@Test
-public void getRequiredMemberResourceAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneService");
+	@Test
+	public void getRequiredMemberResourceAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesFromOneService");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, member);
-	assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
-	assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, member);
+		assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
+		assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test
-public void getRequiredMembersResourceAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredMembersResourceAttributesFromOneService");
+	@Test
+	public void getRequiredMembersResourceAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredMembersResourceAttributesFromOneService");
 
-	vo = setUpVo();
-	member = setUpMember();
-	List<Member> members = new ArrayList<>();
-	members.add(member);
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	group = setUpGroup(vo, member);
-	resourcesManager.assignGroupToResource(sess, group, resource);
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		List<Member> members = new ArrayList<>();
+		members.add(member);
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		group = setUpGroup(vo, member);
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	HashMap<Member, List<Attribute>> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, members);
-	assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
-	assertTrue("should have only 1 req attribute", reqAttr.size() == 1);
+		HashMap<Member, List<Attribute>> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, members);
+		assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
+		assertTrue("should have only 1 req attribute", reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredMemberResourceAttributesFromOneServiceWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneServiceWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesFromOneServiceWhenServiceNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5929,9 +5912,9 @@ public void getRequiredMembersResourceAttributesFromOneService() throws Exceptio
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getRequiredMemberResourceAttributesFromOneServiceWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneServiceWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesFromOneServiceWhenResourceNotExists");
 
 		service = setUpService();
 		vo = setUpVo();
@@ -5942,9 +5925,9 @@ public void getRequiredMembersResourceAttributesFromOneService() throws Exceptio
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getRequiredMemberResourceAttributesFromOneServiceWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneServiceWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesFromOneServiceWhenMemberNotExists");
 
 
 		vo = setUpVo();
@@ -5958,27 +5941,27 @@ public void getRequiredMembersResourceAttributesFromOneService() throws Exceptio
 
 	}
 
-@Test
-public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUser() throws Exception {
-	System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneServiceWorkWithUser");
+	@Test
+	public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUser() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesFromOneServiceWorkWithUser");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, member, true);
-	assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
-	assertTrue("should have at least 4 req attribute",reqAttr.size() >= 4);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, member, true);
+		assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
+		assertTrue("should have at least 4 req attribute",reqAttr.size() >= 4);
 
-}
+	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenServiceNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -5990,9 +5973,9 @@ public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUser() thro
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenResourceNotExists");
 
 		service = setUpService();
 		vo = setUpVo();
@@ -6003,9 +5986,9 @@ public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUser() thro
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberResourceAttributesFromOneServiceWorkWithUserWhenMemberNotExists");
 
 
 		vo = setUpVo();
@@ -6021,7 +6004,7 @@ public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUser() thro
 
 	@Test
 	public void getRequiredMembersAttributesFromOneService() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberAttributesFromOneService");
+		System.out.println(CLASS_NAME + "getRequiredMemberAttributesFromOneService");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -6041,50 +6024,50 @@ public void getRequiredMemberResourceAttributesFromOneServiceWorkWithUser() thro
 
 	}
 
-@Test
-public void getRequiredMemberAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredMemberAttributesFromOneService");
+	@Test
+	public void getRequiredMemberAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredMemberAttributesFromOneService");
 
-	vo = setUpVo();
-	member = setUpMember();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		member = setUpMember();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, member);
-	assertNotNull("unable to get required member attributes for one service",reqAttr);
-	assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, member);
+		assertNotNull("unable to get required member attributes for one service",reqAttr);
+		assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test
-public void getRequiredMemberAndUserAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredMemberAndUserAttributesFromOneService");
+	@Test
+	public void getRequiredMemberAndUserAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredMemberAndUserAttributesFromOneService");
 
-	vo = setUpVo();
-	member = setUpMember();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
+		vo = setUpVo();
+		member = setUpMember();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
 
-	this.setUpMemberToResource();
+		this.setUpMemberToResource();
 
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, member, true);
-	assertNotNull("unable to get required member attributes for one service",reqAttr);
-	assertEquals("getRequiredAtributes(sess, member, true) returns wrong count of attributes", 2, reqAttr.size());
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, member, true);
+		assertNotNull("unable to get required member attributes for one service",reqAttr);
+		assertEquals("getRequiredAtributes(sess, member, true) returns wrong count of attributes", 2, reqAttr.size());
 
 
-}
+	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredMemberAttributesFromOneServiceWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberAttributesFromOneServiceWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberAttributesFromOneServiceWhenServiceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -6094,9 +6077,9 @@ public void getRequiredMemberAndUserAttributesFromOneService() throws Exception 
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void getRequiredMemberAttributesFromOneServiceWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredMemberAttributesFromOneServiceWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "getRequiredMemberAttributesFromOneServiceWhenMemberNotExists");
 
 		service = setUpService();
 
@@ -6105,27 +6088,27 @@ public void getRequiredMemberAndUserAttributesFromOneService() throws Exception 
 
 	}
 
-@Test
-public void getRequiredGroupResourceAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredGroupResourceAttributesFromOneService");
+	@Test
+	public void getRequiredGroupResourceAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredGroupResourceAttributesFromOneService");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	facility = setUpFacility();
-	resource = setUpResource();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
-	perun.getResourcesManager().assignService(sess, resource, service);
+		vo = setUpVo();
+		group = setUpGroup();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource,group);
-	assertNotNull("unable to get required resource-group attributes for one service",reqAttr);
-	assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource,group);
+		assertNotNull("unable to get required resource-group attributes for one service",reqAttr);
+		assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredGroupResourceAttributesFromOneServiceWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredGroupResourceAttributesFromOneServiceWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredGroupResourceAttributesFromOneServiceWhenServiceNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6137,9 +6120,9 @@ public void getRequiredGroupResourceAttributesFromOneService() throws Exception 
 
 	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void getRequiredGroupResourceAttributesFromOneServiceWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredGroupResourceAttributesFromOneServiceWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredGroupResourceAttributesFromOneServiceWhenResourceNotExists");
 
 		service = setUpService();
 		vo = setUpVo();
@@ -6150,9 +6133,9 @@ public void getRequiredGroupResourceAttributesFromOneService() throws Exception 
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void getRequiredGroupResourceAttributesFromOneServiceWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredGroupResourceAttributesFromOneServiceWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getRequiredGroupResourceAttributesFromOneServiceWhenGroupNotExists");
 
 
 		vo = setUpVo();
@@ -6165,24 +6148,24 @@ public void getRequiredGroupResourceAttributesFromOneService() throws Exception 
 
 	}
 
-@Test
-public void getRequiredGroupAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredGroupAttributesFromOneService");
+	@Test
+	public void getRequiredGroupAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredGroupAttributesFromOneService");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
+		vo = setUpVo();
+		group = setUpGroup();
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, group);
-	assertNotNull("unable to get required group attributes for one service",reqAttr);
-	assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, group);
+		assertNotNull("unable to get required group attributes for one service",reqAttr);
+		assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void getRequiredGroupAttributesFromOneServiceWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredGroupAttributesFromOneServiceWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "getRequiredGroupAttributesFromOneServiceWhenGroupNotExists");
 
 		service = setUpService();
 		attributes = setUpRequiredAttributes();
@@ -6192,9 +6175,9 @@ public void getRequiredGroupAttributesFromOneService() throws Exception {
 
 	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredGroupAttributesFromOneServiceWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredGroupAttributesFromOneServiceWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredGroupAttributesFromOneServiceWhenServiceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -6206,23 +6189,23 @@ public void getRequiredGroupAttributesFromOneService() throws Exception {
 
 // TODO - není metoda na získání pouze req. user atributů z 1 service
 
-@Test
-public void getRequiredHostAttributesFromOneService() throws Exception {
-	System.out.println("attributesManager.getRequiredHostAttributesFromOneService");
+	@Test
+	public void getRequiredHostAttributesFromOneService() throws Exception {
+		System.out.println(CLASS_NAME + "getRequiredHostAttributesFromOneService");
 
-	host = setUpHost().get(0);  // also creates cluster type facility
-	service = setUpService();
-	attributes = setUpRequiredAttributes();
+		host = setUpHost().get(0);  // also creates cluster type facility
+		service = setUpService();
+		attributes = setUpRequiredAttributes();
 
-	List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, host);
-	assertNotNull("Unable to get required host attributes for one service",reqAttr);
-	assertTrue("There should be 1 required host attribute",reqAttr.size() == 1);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, host);
+		assertNotNull("Unable to get required host attributes for one service",reqAttr);
+		assertTrue("There should be 1 required host attribute",reqAttr.size() == 1);
 
-}
+	}
 
-@Test (expected=ServiceNotExistsException.class)
+	@Test (expected=ServiceNotExistsException.class)
 	public void getRequiredHostAttributesFromOneServiceWhenServiceNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredHostAttributesFromOneServiceWhenServiceNotExists");
+		System.out.println(CLASS_NAME + "getRequiredHostAttributesFromOneServiceWhenServiceNotExists");
 
 		host = setUpHost().get(0);  // also creates cluster type facility
 
@@ -6231,9 +6214,9 @@ public void getRequiredHostAttributesFromOneService() throws Exception {
 
 	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void getRequiredHostAttributesFromOneServiceWhenHostNotExists() throws Exception {
-		System.out.println("attributesManager.getRequiredHostAttributesFromOneServiceWhenHostNotExists");
+		System.out.println(CLASS_NAME + "getRequiredHostAttributesFromOneServiceWhenHostNotExists");
 
 		host = setUpHost().get(0);  // also creates cluster type facility
 		int id = host.getId();      // store ID
@@ -6265,24 +6248,24 @@ public void getRequiredHostAttributesFromOneService() throws Exception {
 
 // ==============  11. REMOVE ATTRIBUTE/S / REMOVE ALL ATTRIBUTES ================================
 
-@Test
-public void removeFacilityAttribute() throws Exception {
-	System.out.println("attributesManager.removeFacilityAttribute");
+	@Test
+	public void removeFacilityAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeFacilityAttribute");
 
-	facility = setUpFacility();
-	attributes = setUpFacilityAttribute();
-	attributesManager.setAttribute(sess, facility, attributes.get(0));
-	// create facility and set attribute with value
-	attributesManager.removeAttribute(sess, facility, attributes.get(0));
-	// remove attribute from facility (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
-	assertFalse("our facility shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		facility = setUpFacility();
+		attributes = setUpFacilityAttribute();
+		attributesManager.setAttribute(sess, facility, attributes.get(0));
+		// create facility and set attribute with value
+		attributesManager.removeAttribute(sess, facility, attributes.get(0));
+		// remove attribute from facility (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
+		assertFalse("our facility shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void removeFacilityAttributeWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityAttributeWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityAttributeWhenFacilityNotExists");
 
 		attributes = setUpFacilityAttribute();
 		attributesManager.removeAttribute(sess, new Facility(), attributes.get(0));
@@ -6290,9 +6273,9 @@ public void removeFacilityAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeFacilityAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityAttributeWhenAttributeNotExists");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -6302,9 +6285,9 @@ public void removeFacilityAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeFacilityAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeFacilityAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeFacilityAttributeWhenWrongAttrAssignment");
 
 		facility = setUpFacility();
 		attributes = setUpVoAttribute();
@@ -6313,64 +6296,64 @@ public void removeFacilityAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeFacilityAttributes() throws Exception {
-	System.out.println("attributesManager.removeFacilityAttributes");
+	@Test
+	public void removeFacilityAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeFacilityAttributes");
 
-	facility = setUpFacility();
-	attributes = setUpFacilityAttribute();
-	attributesManager.setAttribute(sess, facility, attributes.get(0));
-	// create facility and set attribute with value
-	attributesManager.removeAttributes(sess, facility, attributes);
-	// remove attributes from facility (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
-	assertFalse("our facility shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		facility = setUpFacility();
+		attributes = setUpFacilityAttribute();
+		attributesManager.setAttribute(sess, facility, attributes.get(0));
+		// create facility and set attribute with value
+		attributesManager.removeAttributes(sess, facility, attributes);
+		// remove attributes from facility (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
+		assertFalse("our facility shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test
-public void removeUserMemberResourceToMemberAndUserToFacilityAttributes() throws Exception {
-	System.out.println("attributesManager.removeUserMemberResourceToMemberAndUserToFacilityAttributes");
+	@Test
+	public void removeUserMemberResourceToMemberAndUserToFacilityAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeUserMemberResourceToMemberAndUserToFacilityAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	member = setUpMember();
-	User user = sess.getPerun().getUsersManager().getUserByMember(sess, member);
-	resource = setUpResource();
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember();
+		User user = sess.getPerun().getUsersManager().getUserByMember(sess, member);
+		resource = setUpResource();
 
-	List<Attribute> attributes_user = setUpUserAttribute();
-	List<Attribute> attributes_member = setUpMemberAttribute();
-	List<Attribute> attributes_user_facility = setUpFacilityUserAttribute();
-	List<Attribute> attributes_member_resource = setUpMemberResourceAttribute();
+		List<Attribute> attributes_user = setUpUserAttribute();
+		List<Attribute> attributes_member = setUpMemberAttribute();
+		List<Attribute> attributes_user_facility = setUpFacilityUserAttribute();
+		List<Attribute> attributes_member_resource = setUpMemberResourceAttribute();
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.addAll(attributes_user);
-	attributes.addAll(attributes_member);
-	attributes.addAll(attributes_user_facility);
-	attributes.addAll(attributes_member_resource);
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.addAll(attributes_user);
+		attributes.addAll(attributes_member);
+		attributes.addAll(attributes_user_facility);
+		attributes.addAll(attributes_member_resource);
 
-	attributesManager.removeAttributes(sess, facility, resource, user, member, attributes);
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, resource, user, member);
+		attributesManager.removeAttributes(sess, facility, resource, user, member, attributes);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, resource, user, member);
 
-	retAttr.retainAll(attributes);
-	assertEquals("Excepted empty array list of Attributes.", new ArrayList<Attribute>(), retAttr);
+		retAttr.retainAll(attributes);
+		assertEquals("Excepted empty array list of Attributes.", new ArrayList<Attribute>(), retAttr);
 
-}
+	}
 
-@Test
-public void removeEntitylessAttribute() throws Exception {
-	System.out.println("attributesManager.removeEntitylessAttribute");
-	attributes = setUpEntitylessAttribute();
-	String key = "Test123456";
-	attributesManager.setAttribute(sess, key, attributes.get(0));
-	attributesManager.removeAttribute(sess, key, attributes.get(0));
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, key);
-	assertFalse("There should not been set this entityless attribute, because it was removed.",retAttr.contains(attributes.get(0)));
-}
+	@Test
+	public void removeEntitylessAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeEntitylessAttribute");
+		attributes = setUpEntitylessAttribute();
+		String key = "Test123456";
+		attributesManager.setAttribute(sess, key, attributes.get(0));
+		attributesManager.removeAttribute(sess, key, attributes.get(0));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, key);
+		assertFalse("There should not been set this entityless attribute, because it was removed.",retAttr.contains(attributes.get(0)));
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void removeFacilityAttributesWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityAttributesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityAttributesWhenFacilityNotExists");
 
 		attributes = setUpFacilityAttribute();
 		attributesManager.removeAttributes(sess, new Facility(), attributes);
@@ -6378,9 +6361,9 @@ public void removeEntitylessAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeFacilityAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityAttributesWhenAttributeNotExists");
 
 		facility = setUpFacility();
 		attributes = setUpFacilityAttribute();
@@ -6390,9 +6373,9 @@ public void removeEntitylessAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeFacilityAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeFacilityAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeFacilityAttributesWhenWrongAttrAssignment");
 
 		facility = setUpFacility();
 		attributes = setUpVoAttribute();
@@ -6401,155 +6384,155 @@ public void removeEntitylessAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeAllGroupResourceAndGroupAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllGroupResourceAttributes");
+	@Test
+	public void removeAllGroupResourceAndGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllGroupResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	group = setUpGroup();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup();
 
-	attributes = setUpGroupResourceAttribute();
-	attributes.addAll(setUpGroupAttribute());
+		attributes = setUpGroupResourceAttribute();
+		attributes.addAll(setUpGroupAttribute());
 
-	attributesManager.setAttributes(sess, resource, group, attributes, true);
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group, true);
-	for(Attribute a: attributes) {
-		assertTrue("our group or group and resource has set this attribute", retAttr.contains(a));
+		attributesManager.setAttributes(sess, resource, group, attributes, true);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group, true);
+		for(Attribute a: attributes) {
+			assertTrue("our group or group and resource has set this attribute", retAttr.contains(a));
+		}
+
+		//remove all of them
+		attributesManager.removeAllAttributes(sess, resource, group, true);
+		retAttr = attributesManager.getAttributes(sess, resource, group, true);
+		for(Attribute a: attributes) {
+			assertFalse("our group or group and resource has not set this attribute", retAttr.contains(a));
+		}
 	}
 
-	//remove all of them
-	attributesManager.removeAllAttributes(sess, resource, group, true);
-	retAttr = attributesManager.getAttributes(sess, resource, group, true);
-	for(Attribute a: attributes) {
-		assertFalse("our group or group and resource has not set this attribute", retAttr.contains(a));
+	@Test
+	public void removeGroupResourceAndGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllGroupResourceAttributes");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup();
+
+		attributes = setUpGroupResourceAttribute();
+		attributes.addAll(setUpGroupAttribute());
+
+		attributesManager.setAttributes(sess, resource, group, attributes, true);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group, true);
+		for(Attribute a: attributes) {
+			assertTrue("our group or group and resource has set this attribute", retAttr.contains(a));
+		}
+
+		//remove all of them
+		attributesManager.removeAttributes(sess, resource, group, attributes, true);
+		retAttr = attributesManager.getAttributes(sess, resource, group, true);
+		for(Attribute a: attributes) {
+			assertFalse("our group or group and resource has not set this attribute", retAttr.contains(a));
+		}
 	}
-}
 
-@Test
-public void removeGroupResourceAndGroupAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllGroupResourceAttributes");
+	@Test
+	public void removeAllFacilityAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllFacilityAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	group = setUpGroup();
+		facility = setUpFacility();
+		attributes = setUpFacilityAttribute();
+		attributesManager.setAttribute(sess, facility, attributes.get(0));
+		// create facility and set attribute with value
+		attributesManager.removeAllAttributes(sess, facility);
+		// remove all attributes from facility (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
+		assertFalse("our facility shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		assertTrue("our facility should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:id")));
 
-	attributes = setUpGroupResourceAttribute();
-	attributes.addAll(setUpGroupAttribute());
-
-	attributesManager.setAttributes(sess, resource, group, attributes, true);
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group, true);
-	for(Attribute a: attributes) {
-		assertTrue("our group or group and resource has set this attribute", retAttr.contains(a));
 	}
 
-	//remove all of them
-	attributesManager.removeAttributes(sess, resource, group, attributes, true);
-	retAttr = attributesManager.getAttributes(sess, resource, group, true);
-	for(Attribute a: attributes) {
-		assertFalse("our group or group and resource has not set this attribute", retAttr.contains(a));
+	@Test
+	public void removeAllFacilityAttributesWithUserFacilityAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllFacilityAttributesExceptUserFacilityAttributes");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpFacilityAttribute();
+		attributesManager.setAttribute(sess, facility, attributes.get(0));
+		attributes.addAll(setUpFacilityUserAttribute());
+		attributesManager.setAttribute(sess, facility, user, attributes.get(1));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
+		retAttr.addAll(attributesManager.getAttributes(sess, facility, user));
+		assertTrue("our facility should have set our facility attribute", retAttr.contains(attributes.get(0)));
+		assertTrue("our facility should have set our user-facility attribute", retAttr.contains(attributes.get(1)));
+
+		// remove all attributes from facility (definition or attribute)
+		attributesManager.removeAllAttributes(sess, facility, true);
+		retAttr.clear();
+		retAttr.addAll(attributesManager.getAttributes(sess, facility));
+		retAttr.addAll(attributesManager.getAttributes(sess, facility, user));
+		assertFalse("our facility should not have set our facility attribute", retAttr.contains(attributes.get(0)));
+		assertFalse("our facility should not have set our user-facility attribute", retAttr.contains(attributes.get(1)));
+		assertTrue("our facility should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:id")));
 	}
-}
 
-@Test
-public void removeAllFacilityAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllFacilityAttributes");
+	@Test
+	public void removeAllFacilityAttributesWithoutUserFacilityAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllFacilityAttributesExceptUserFacilityAttributes");
 
-	facility = setUpFacility();
-	attributes = setUpFacilityAttribute();
-	attributesManager.setAttribute(sess, facility, attributes.get(0));
-	// create facility and set attribute with value
-	attributesManager.removeAllAttributes(sess, facility);
-	// remove all attributes from facility (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
-	assertFalse("our facility shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	assertTrue("our facility should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:id")));
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpFacilityAttribute();
+		attributesManager.setAttribute(sess, facility, attributes.get(0));
+		attributes.addAll(setUpFacilityUserAttribute());
+		attributesManager.setAttribute(sess, facility, user, attributes.get(1));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
+		retAttr.addAll(attributesManager.getAttributes(sess, facility, user));
+		assertTrue("our facility should have set our facility attribute", retAttr.contains(attributes.get(0)));
+		assertTrue("our facility should have set our user-facility attribute", retAttr.contains(attributes.get(1)));
 
-}
+		// remove all attributes from facility (definition or attribute)
+		attributesManager.removeAllAttributes(sess, facility, false);
+		retAttr.clear();
+		retAttr.addAll(attributesManager.getAttributes(sess, facility));
+		retAttr.addAll(attributesManager.getAttributes(sess, facility, user));
+		assertFalse("our facility should not have set our facility attribute", retAttr.contains(attributes.get(0)));
+		assertTrue("our facility should not have set our user-facility attribute", retAttr.contains(attributes.get(1)));
+		assertTrue("our facility should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:id")));
+	}
 
-@Test
-public void removeAllFacilityAttributesWithUserFacilityAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllFacilityAttributesExceptUserFacilityAttributes");
-
-	vo = setUpVo();
-	facility = setUpFacility();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpFacilityAttribute();
-	attributesManager.setAttribute(sess, facility, attributes.get(0));
-	attributes.addAll(setUpFacilityUserAttribute());
-	attributesManager.setAttribute(sess, facility, user, attributes.get(1));
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
-	retAttr.addAll(attributesManager.getAttributes(sess, facility, user));
-	assertTrue("our facility should have set our facility attribute", retAttr.contains(attributes.get(0)));
-	assertTrue("our facility should have set our user-facility attribute", retAttr.contains(attributes.get(1)));
-
-	// remove all attributes from facility (definition or attribute)
-	attributesManager.removeAllAttributes(sess, facility, true);
-	retAttr.clear();
-	retAttr.addAll(attributesManager.getAttributes(sess, facility));
-	retAttr.addAll(attributesManager.getAttributes(sess, facility, user));
-	assertFalse("our facility should not have set our facility attribute", retAttr.contains(attributes.get(0)));
-	assertFalse("our facility should not have set our user-facility attribute", retAttr.contains(attributes.get(1)));
-	assertTrue("our facility should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:id")));
-}
-
-@Test
-public void removeAllFacilityAttributesWithoutUserFacilityAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllFacilityAttributesExceptUserFacilityAttributes");
-
-	vo = setUpVo();
-	facility = setUpFacility();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpFacilityAttribute();
-	attributesManager.setAttribute(sess, facility, attributes.get(0));
-	attributes.addAll(setUpFacilityUserAttribute());
-	attributesManager.setAttribute(sess, facility, user, attributes.get(1));
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility);
-	retAttr.addAll(attributesManager.getAttributes(sess, facility, user));
-	assertTrue("our facility should have set our facility attribute", retAttr.contains(attributes.get(0)));
-	assertTrue("our facility should have set our user-facility attribute", retAttr.contains(attributes.get(1)));
-
-	// remove all attributes from facility (definition or attribute)
-	attributesManager.removeAllAttributes(sess, facility, false);
-	retAttr.clear();
-	retAttr.addAll(attributesManager.getAttributes(sess, facility));
-	retAttr.addAll(attributesManager.getAttributes(sess, facility, user));
-	assertFalse("our facility should not have set our facility attribute", retAttr.contains(attributes.get(0)));
-	assertTrue("our facility should not have set our user-facility attribute", retAttr.contains(attributes.get(1)));
-	assertTrue("our facility should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:id")));
-}
-
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void removeAllFacilityAttributesWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllFacilityAttributesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "removeAllFacilityAttributesWhenFacilityNotExists");
 
 		attributesManager.removeAllAttributes(sess, new Facility());
 		// shouldn't find facility
 
 	}
 
-@Test
-public void removeVoAttribute() throws Exception {
-	System.out.println("attributesManager.removeVoAttribute");
+	@Test
+	public void removeVoAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeVoAttribute");
 
-	vo = setUpVo();
-	attributes = setUpVoAttribute();
-	attributesManager.setAttribute(sess, vo, attributes.get(0));
-	// create vo and set attribute with value
-	attributesManager.removeAttribute(sess, vo, attributes.get(0));
-	// remove attribute from vo (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
-	assertFalse("our vo shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		attributes = setUpVoAttribute();
+		attributesManager.setAttribute(sess, vo, attributes.get(0));
+		// create vo and set attribute with value
+		attributesManager.removeAttribute(sess, vo, attributes.get(0));
+		// remove attribute from vo (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
+		assertFalse("our vo shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=VoNotExistsException.class)
+	@Test (expected=VoNotExistsException.class)
 	public void removeVoAttributeWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.removeVoAttributeWhenVoNotExists");
+		System.out.println(CLASS_NAME + "removeVoAttributeWhenVoNotExists");
 
 		attributes = setUpVoAttribute();
 		attributesManager.removeAttribute(sess, new Vo(), attributes.get(0));
@@ -6557,9 +6540,9 @@ public void removeVoAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeVoAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeVoAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeVoAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		attributes = setUpVoAttribute();
@@ -6569,9 +6552,9 @@ public void removeVoAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeVoAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeVoAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeVoAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		attributes = setUpFacilityAttribute();
@@ -6580,24 +6563,24 @@ public void removeVoAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeVoAttributes() throws Exception {
-	System.out.println("attributesManager.removeVoAttributes");
+	@Test
+	public void removeVoAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeVoAttributes");
 
-	vo = setUpVo();
-	attributes = setUpVoAttribute();
-	attributesManager.setAttribute(sess, vo, attributes.get(0));
-	// create vo and set attribute with value
-	attributesManager.removeAttributes(sess, vo, attributes);
-	// remove attributes from vo (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
-	assertFalse("our vo shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		attributes = setUpVoAttribute();
+		attributesManager.setAttribute(sess, vo, attributes.get(0));
+		// create vo and set attribute with value
+		attributesManager.removeAttributes(sess, vo, attributes);
+		// remove attributes from vo (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
+		assertFalse("our vo shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=VoNotExistsException.class)
+	@Test (expected=VoNotExistsException.class)
 	public void removeVoAttributesWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.removeVoAttributesWhenVoNotExists");
+		System.out.println(CLASS_NAME + "removeVoAttributesWhenVoNotExists");
 
 		attributes = setUpVoAttribute();
 		attributesManager.removeAttributes(sess, new Vo(), attributes);
@@ -6605,9 +6588,9 @@ public void removeVoAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeVoAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeVoAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeVoAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		attributes = setUpVoAttribute();
@@ -6617,9 +6600,9 @@ public void removeVoAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeVoAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeVoAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeVoAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		attributes = setUpFacilityAttribute();
@@ -6628,51 +6611,51 @@ public void removeVoAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllVoAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllVoAttributes");
+	@Test
+	public void removeAllVoAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllVoAttributes");
 
-	vo = setUpVo();
-	attributes = setUpVoAttribute();
-	attributesManager.setAttribute(sess, vo, attributes.get(0));
-	// create vo and set attribute with value
-	attributesManager.removeAllAttributes(sess, vo);
-	// remove all attributes from vo (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
-	assertFalse("our vo shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	assertTrue("our vo should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, vo, "urn:perun:vo:attribute-def:core:id")));
+		vo = setUpVo();
+		attributes = setUpVoAttribute();
+		attributesManager.setAttribute(sess, vo, attributes.get(0));
+		// create vo and set attribute with value
+		attributesManager.removeAllAttributes(sess, vo);
+		// remove all attributes from vo (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, vo);
+		assertFalse("our vo shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		assertTrue("our vo should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, vo, "urn:perun:vo:attribute-def:core:id")));
 
-}
+	}
 
-@Test (expected=VoNotExistsException.class)
+	@Test (expected=VoNotExistsException.class)
 	public void removeAllVoAttributesWhenVoNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllVoAttributesWhenVoNotExists");
+		System.out.println(CLASS_NAME + "removeAllVoAttributesWhenVoNotExists");
 
 		attributesManager.removeAllAttributes(sess, new Vo());
 		// shouldn't find vo
 
 	}
 
-@Test
-public void removeResourceAttribute() throws Exception {
-	System.out.println("attributesManager.removeResourceAttribute");
+	@Test
+	public void removeResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeResourceAttribute");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpResourceAttribute();
-	attributesManager.setAttribute(sess, resource, attributes.get(0));
-	// create resource and set attribute with value
-	attributesManager.removeAttribute(sess, resource, attributes.get(0));
-	// remove attribute from resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
-	assertFalse("our resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpResourceAttribute();
+		attributesManager.setAttribute(sess, resource, attributes.get(0));
+		// create resource and set attribute with value
+		attributesManager.removeAttribute(sess, resource, attributes.get(0));
+		// remove attribute from resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
+		assertFalse("our resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeResourceAttributeWhenResourceNotExists");
 
 		attributes = setUpResourceAttribute();
 		attributesManager.removeAttribute(sess, new Resource(), attributes.get(0));
@@ -6680,9 +6663,9 @@ public void removeResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6694,9 +6677,9 @@ public void removeResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6707,26 +6690,26 @@ public void removeResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeResourceAttributes() throws Exception {
-	System.out.println("attributesManager.removeResourceAttributes");
+	@Test
+	public void removeResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpResourceAttribute();
-	attributesManager.setAttribute(sess, resource, attributes.get(0));
-	// create resource and set attribute with value
-	attributesManager.removeAttributes(sess, resource, attributes);
-	// remove attributes from resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
-	assertFalse("our resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpResourceAttribute();
+		attributesManager.setAttribute(sess, resource, attributes.get(0));
+		// create resource and set attribute with value
+		attributesManager.removeAttributes(sess, resource, attributes);
+		// remove attributes from resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
+		assertFalse("our resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeResourceAttributesWhenResourceNotExists");
 
 		attributes = setUpResourceAttribute();
 		attributesManager.removeAttributes(sess, new Resource(), attributes);
@@ -6734,9 +6717,9 @@ public void removeResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeResourceAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeResourceAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeResourceAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6748,9 +6731,9 @@ public void removeResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeResourceAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeResourceAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeResourceAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6761,54 +6744,54 @@ public void removeResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllResourceAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllResourceAttributes");
+	@Test
+	public void removeAllResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	attributes = setUpResourceAttribute();
-	attributesManager.setAttribute(sess, resource, attributes.get(0));
-	// create resource and set attribute with value
-	attributesManager.removeAllAttributes(sess, resource);
-	// remove all attributes from resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
-	assertFalse("our resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	assertTrue("our resource should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:id")));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		attributes = setUpResourceAttribute();
+		attributesManager.setAttribute(sess, resource, attributes.get(0));
+		// create resource and set attribute with value
+		attributesManager.removeAllAttributes(sess, resource);
+		// remove all attributes from resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource);
+		assertFalse("our resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		assertTrue("our resource should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:id")));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeAllResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeAllResourceAttributesWhenResourceNotExists");
 
 		attributesManager.removeAllAttributes(sess, new Resource());
 		// shouldn't find resource
 
 	}
 
-@Test
-public void removeMemberResourceAttribute() throws Exception {
-	System.out.println("attributesManager.removeMemberResourceAttribute");
+	@Test
+	public void removeMemberResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberResourceAttribute");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	member = setUpMember();
-	attributes = setUpMemberResourceAttribute();
-	attributesManager.setAttribute(sess, resource, member, attributes.get(0));
-	// create member-resource and set attribute with value
-	attributesManager.removeAttribute(sess, resource, member, attributes.get(0));
-	// remove attribute from member-resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
-	assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember();
+		attributes = setUpMemberResourceAttribute();
+		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		// create member-resource and set attribute with value
+		attributesManager.removeAttribute(sess, resource, member, attributes.get(0));
+		// remove attribute from member-resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeMemberResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributeWhenResourceNotExists");
 
 		attributes = setUpMemberResourceAttribute();
 		vo = setUpVo();
@@ -6818,9 +6801,9 @@ public void removeMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void removeMemberResourceAttributeWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberResourceAttributeWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributeWhenMemberNotExists");
 
 		attributes = setUpMemberResourceAttribute();
 		vo = setUpVo();
@@ -6831,9 +6814,9 @@ public void removeMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeMemberResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6846,9 +6829,9 @@ public void removeMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeMemberResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeMemberResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6860,27 +6843,27 @@ public void removeMemberResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeMemberResourceAttributes() throws Exception {
-	System.out.println("attributesManager.removeMemberResourceAttributes");
+	@Test
+	public void removeMemberResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	member = setUpMember();
-	attributes = setUpMemberResourceAttribute();
-	attributesManager.setAttribute(sess, resource, member, attributes.get(0));
-	// create member-resource and set attribute with value
-	attributesManager.removeAttributes(sess, resource, member, attributes);
-	// remove attributes from member-resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
-	assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember();
+		attributes = setUpMemberResourceAttribute();
+		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		// create member-resource and set attribute with value
+		attributesManager.removeAttributes(sess, resource, member, attributes);
+		// remove attributes from member-resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeMemberResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributesWhenResourceNotExists");
 
 		attributes = setUpMemberResourceAttribute();
 		vo = setUpVo();
@@ -6890,9 +6873,9 @@ public void removeMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void removeMemberResourceAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberResourceAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributesWhenMemberNotExists");
 
 		attributes = setUpMemberResourceAttribute();
 		vo = setUpVo();
@@ -6903,9 +6886,9 @@ public void removeMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeMemberResourceAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberResourceAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6918,9 +6901,9 @@ public void removeMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeMemberResourceAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeMemberResourceAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeMemberResourceAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6932,28 +6915,28 @@ public void removeMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllMemberResourceAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllMemberResourceAttributes");
+	@Test
+	public void removeAllMemberResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllMemberResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	member = setUpMember();
-	attributes = setUpMemberResourceAttribute();
-	attributesManager.setAttribute(sess, resource, member, attributes.get(0));
-	// create member-resource and set attribute with value
-	attributesManager.removeAllAttributes(sess, resource, member);
-	// remove all attributes from member-resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
-	assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	// member-resource don't have core attributes ??
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember();
+		attributes = setUpMemberResourceAttribute();
+		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		// create member-resource and set attribute with value
+		attributesManager.removeAllAttributes(sess, resource, member);
+		// remove all attributes from member-resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		// member-resource don't have core attributes ??
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeAllMemberResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllMemberResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeAllMemberResourceAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -6963,9 +6946,9 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void removeAllMemberResourceAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllMemberResourceAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeAllMemberResourceAttributesWhenMemberNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -6978,7 +6961,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test
 	public void removeMemberGroupAttribute() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttribute");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttribute");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -6994,7 +6977,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=GroupNotExistsException.class)
 	public void removeMemberGroupAttributeWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributeWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributeWhenGroupNotExists");
 
 		attributes = setUpMemberGroupAttribute();
 		vo = setUpVo();
@@ -7005,7 +6988,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=MemberNotExistsException.class)
 	public void removeMemberGroupAttributeWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributeWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributeWhenMemberNotExists");
 
 		attributes = setUpMemberGroupAttribute();
 		vo = setUpVo();
@@ -7016,7 +6999,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=AttributeNotExistsException.class)
 	public void removeMemberGroupAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7029,7 +7012,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeMemberGroupAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7041,7 +7024,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test
 	public void removeMemberGroupAttributes() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributes");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributes");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7057,7 +7040,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=GroupNotExistsException.class)
 	public void removeMemberGroupAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributesWhenGroupNotExists");
 
 		attributes = setUpMemberGroupAttribute();
 		vo = setUpVo();
@@ -7068,7 +7051,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=MemberNotExistsException.class)
 	public void removeMemberGroupAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributesWhenMemberNotExists");
 
 		attributes = setUpMemberGroupAttribute();
 		vo = setUpVo();
@@ -7079,7 +7062,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=AttributeNotExistsException.class)
 	public void removeMemberGroupAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7092,7 +7075,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeMemberGroupAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeMemberGroupAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeMemberGroupAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7104,7 +7087,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test
 	public void removeAllMemberGroupAttributes() throws Exception {
-		System.out.println("attributesManager.removeAllMemberGroupAttributes");
+		System.out.println(CLASS_NAME + "removeAllMemberGroupAttributes");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7120,7 +7103,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=GroupNotExistsException.class)
 	public void removeAllMemberGroupAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllMemberGroupAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeAllMemberGroupAttributesWhenGroupNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7131,7 +7114,7 @@ public void removeAllMemberResourceAttributes() throws Exception {
 
 	@Test (expected=MemberNotExistsException.class)
 	public void removeAllMemberGroupAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllMemberGroupAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeAllMemberGroupAttributesWhenMemberNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7140,25 +7123,25 @@ public void removeAllMemberResourceAttributes() throws Exception {
 		// shouldn't find member
 	}
 
-@Test
-public void removeMemberAttribute() throws Exception {
-	System.out.println("attributesManager.removeMemberAttribute");
+	@Test
+	public void removeMemberAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttribute(sess, member, attributes.get(0));
-	// create member and set attribute with value
-	attributesManager.removeAttribute(sess, member, attributes.get(0));
-	// remove attribute from member (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
-	assertFalse("our member shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttribute(sess, member, attributes.get(0));
+		// create member and set attribute with value
+		attributesManager.removeAttribute(sess, member, attributes.get(0));
+		// remove attribute from member (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
+		assertFalse("our member shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void removeMemberAttributeWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberAttributeWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeMemberAttributeWhenMemberNotExists");
 
 		attributes = setUpMemberAttribute();
 		attributesManager.removeAttribute(sess, new Member(), attributes.get(0));
@@ -7166,9 +7149,9 @@ public void removeMemberAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeMemberAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeMemberAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7179,9 +7162,9 @@ public void removeMemberAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeMemberAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeMemberAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeMemberAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7191,60 +7174,60 @@ public void removeMemberAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeMemberAttributesWorkWithUserAttributes() throws Exception {
-	System.out.println("attributesManager.removeMemberAttributesWorkWithUserAttributes");
-	vo = setUpVo();
-	member = setUpMember();
-	User user = sess.getPerun().getUsersManager().getUserByMember(sess, member);
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttributes(sess, member, attributes);
-	List<Attribute> userAttrs = setUpUserAttribute();
-	attributesManager.setAttributes(sess, user, userAttrs);
-	attributes.addAll(userAttrs);
-	attributesManager.removeAttributes(sess, member, true, attributes);
+	@Test
+	public void removeMemberAttributesWorkWithUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberAttributesWorkWithUserAttributes");
+		vo = setUpVo();
+		member = setUpMember();
+		User user = sess.getPerun().getUsersManager().getUserByMember(sess, member);
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttributes(sess, member, attributes);
+		List<Attribute> userAttrs = setUpUserAttribute();
+		attributesManager.setAttributes(sess, user, userAttrs);
+		attributes.addAll(userAttrs);
+		attributesManager.removeAttributes(sess, member, true, attributes);
 
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
-	retAttr.addAll(attributesManager.getAttributes(sess,user));
-	for(Attribute attr:attributes){
-		assertFalse("our member and user (who we getted from this member) shouldn't have set our attribute",retAttr.contains(attr));
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
+		retAttr.addAll(attributesManager.getAttributes(sess,user));
+		for(Attribute attr:attributes){
+			assertFalse("our member and user (who we getted from this member) shouldn't have set our attribute",retAttr.contains(attr));
+		}
+
 	}
 
-}
-
-@Test
-public void removeMemberAttributesWorkWithoutUserAtributes() throws Exception {
-	System.out.println("attributesManager.removeMemberAttributesWorkWithoutUserAtributes");
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttributes(sess, member, attributes);
-	attributesManager.removeAttributes(sess, member, false, attributes);
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
-	for(Attribute attr:attributes){
-		assertFalse("our member shouldn't have set our attribute",retAttr.contains(attr));
+	@Test
+	public void removeMemberAttributesWorkWithoutUserAtributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberAttributesWorkWithoutUserAtributes");
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttributes(sess, member, attributes);
+		attributesManager.removeAttributes(sess, member, false, attributes);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
+		for(Attribute attr:attributes){
+			assertFalse("our member shouldn't have set our attribute",retAttr.contains(attr));
+		}
 	}
-}
 
-@Test
-public void removeMemberAttributes() throws Exception {
-	System.out.println("attributesManager.removeMemberAttributes");
+	@Test
+	public void removeMemberAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttribute(sess, member, attributes.get(0));
-	// create member and set attribute with value
-	attributesManager.removeAttributes(sess, member, attributes);
-	// remove attributes from member (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
-	assertFalse("our member shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttribute(sess, member, attributes.get(0));
+		// create member and set attribute with value
+		attributesManager.removeAttributes(sess, member, attributes);
+		// remove attributes from member (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
+		assertFalse("our member shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void removeMemberAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeMemberAttributesWhenMemberNotExists");
 
 		attributes = setUpMemberAttribute();
 		attributesManager.removeAttributes(sess, new Member(), attributes);
@@ -7252,9 +7235,9 @@ public void removeMemberAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeMemberAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeMemberAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeMemberAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7265,9 +7248,9 @@ public void removeMemberAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeMemberAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeMemberAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeMemberAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7277,53 +7260,53 @@ public void removeMemberAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllMemberAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllMemberAttributes");
+	@Test
+	public void removeAllMemberAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllMemberAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	attributes = setUpMemberAttribute();
-	attributesManager.setAttribute(sess, member, attributes.get(0));
-	// create member and set attribute with value
-	attributesManager.removeAllAttributes(sess, member);
-	// remove all attributes from member (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
-	assertFalse("our member shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	assertTrue("our member should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, member, "urn:perun:member:attribute-def:core:id")));
+		vo = setUpVo();
+		member = setUpMember();
+		attributes = setUpMemberAttribute();
+		attributesManager.setAttribute(sess, member, attributes.get(0));
+		// create member and set attribute with value
+		attributesManager.removeAllAttributes(sess, member);
+		// remove all attributes from member (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member);
+		assertFalse("our member shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		assertTrue("our member should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, member, "urn:perun:member:attribute-def:core:id")));
 
-}
+	}
 
-@Test (expected=MemberNotExistsException.class)
+	@Test (expected=MemberNotExistsException.class)
 	public void removeAllMemberAttributesWhenMemberNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllMemberAttributesWhenMemberNotExists");
+		System.out.println(CLASS_NAME + "removeAllMemberAttributesWhenMemberNotExists");
 
 		attributesManager.removeAllAttributes(sess, new Member());
 		// shouldn't find member
 
 	}
 
-@Test
-public void removeFacilityUserAttribute() throws Exception {
-	System.out.println("attributesManager.removeFacilityUserAttribute");
+	@Test
+	public void removeFacilityUserAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeFacilityUserAttribute");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpFacilityUserAttribute();
-	attributesManager.setAttributes(sess, facility, user, attributes);
-	// create facility-user and set attribute with value
-	attributesManager.removeAttribute(sess, facility, user, attributes.get(0));
-	// remove attribute from facility-user (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
-	assertFalse("our facility-user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpFacilityUserAttribute();
+		attributesManager.setAttributes(sess, facility, user, attributes);
+		// create facility-user and set attribute with value
+		attributesManager.removeAttribute(sess, facility, user, attributes.get(0));
+		// remove attribute from facility-user (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
+		assertFalse("our facility-user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void removeFacilityUserAttributeWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityUserResourceAttributeWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityUserResourceAttributeWhenFacilityNotExists");
 
 		attributes = setUpFacilityUserAttribute();
 		vo = setUpVo();
@@ -7334,9 +7317,9 @@ public void removeFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void removeFacilityUserAttributeWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityUserAttributeWhenUserNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityUserAttributeWhenUserNotExists");
 
 		attributes = setUpFacilityUserAttribute();
 		vo = setUpVo();
@@ -7346,9 +7329,9 @@ public void removeFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeFacilityUserAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityUserAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityUserAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7361,9 +7344,9 @@ public void removeFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeFacilityUserAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeFacilityUserAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeFacilityUserAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7375,27 +7358,27 @@ public void removeFacilityUserAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeFacilityUserAttributes() throws Exception {
-	System.out.println("attributesManager.removeFacilityUserAttributes");
+	@Test
+	public void removeFacilityUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeFacilityUserAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpFacilityUserAttribute();
-	attributesManager.setAttributes(sess, facility, user, attributes);
-	// create facility user and set attribute with value
-	attributesManager.removeAttributes(sess, facility, user, attributes);
-	// remove attributes from facility user (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
-	assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpFacilityUserAttribute();
+		attributesManager.setAttributes(sess, facility, user, attributes);
+		// create facility user and set attribute with value
+		attributesManager.removeAttributes(sess, facility, user, attributes);
+		// remove attributes from facility user (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
+		assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void removeFacilityUserAttributesWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityUserAttributesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityUserAttributesWhenFacilityNotExists");
 
 		attributes = setUpFacilityUserAttribute();
 		vo = setUpVo();
@@ -7406,9 +7389,9 @@ public void removeFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void removeFacilityUserResourceAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityUserAttributesWhenUserNotExists");
 
 		attributes = setUpFacilityUserAttribute();
 		vo = setUpVo();
@@ -7418,9 +7401,9 @@ public void removeFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeFacilityUserAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeFacilityUserAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeFacilityUserAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7433,9 +7416,9 @@ public void removeFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeFacilityUserAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeFacilityUserAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeFacilityUserAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7447,28 +7430,28 @@ public void removeFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllFacilityUserAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllFacilityUserAttributes");
+	@Test
+	public void removeAllFacilityUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllFacilityUserAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpFacilityUserAttribute();
-	attributesManager.setAttributes(sess, facility, user, attributes);
-	// create facility user and set attribute with value
-	attributesManager.removeAllAttributes(sess, facility, user);
-	// remove all attributes from facility user (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
-	assertFalse("our facility-user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	// facility-user don't have core attributes ??
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpFacilityUserAttribute();
+		attributesManager.setAttributes(sess, facility, user, attributes);
+		// create facility user and set attribute with value
+		attributesManager.removeAllAttributes(sess, facility, user);
+		// remove all attributes from facility user (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, facility, user);
+		assertFalse("our facility-user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		// facility-user don't have core attributes ??
 
-}
+	}
 
-@Test (expected=FacilityNotExistsException.class)
+	@Test (expected=FacilityNotExistsException.class)
 	public void removeAllFacilityUserAttributesWhenFacilityNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllFacilityUserAttributesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "removeAllFacilityUserAttributesWhenFacilityNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7479,9 +7462,9 @@ public void removeAllFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void removeAllFacilityUserAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllFacilityUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "removeAllFacilityUserAttributesWhenUserNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7491,26 +7474,26 @@ public void removeAllFacilityUserAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeUserAttribute() throws Exception {
-	System.out.println("attributesManager.removeUserAttribute");
+	@Test
+	public void removeUserAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeUserAttribute");
 
-	vo = setUpVo();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpUserAttribute();
-	attributesManager.setAttributes(sess, user, attributes);
-	// create user and set attribute with value
-	attributesManager.removeAttribute(sess, user, attributes.get(0));
-	// remove attribute from user (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
-	assertFalse("our user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpUserAttribute();
+		attributesManager.setAttributes(sess, user, attributes);
+		// create user and set attribute with value
+		attributesManager.removeAttribute(sess, user, attributes.get(0));
+		// remove attribute from user (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
+		assertFalse("our user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void removeUserAttributeWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.removeUserAttributeWhenUserNotExists");
+		System.out.println(CLASS_NAME + "removeUserAttributeWhenUserNotExists");
 
 		attributes = setUpUserAttribute();
 		attributesManager.removeAttribute(sess, new User(), attributes.get(0));
@@ -7518,9 +7501,9 @@ public void removeUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeUserAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeUserAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeUserAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7532,9 +7515,9 @@ public void removeUserAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeUserAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeUserAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeUserAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7545,26 +7528,26 @@ public void removeUserAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeUserAttributes() throws Exception {
-	System.out.println("attributesManager.removeUserAttributes");
+	@Test
+	public void removeUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeUserAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpUserAttribute();
-	attributesManager.setAttributes(sess, user, attributes);
-	// create user and set attribute with value
-	attributesManager.removeAttributes(sess, user, attributes);
-	// remove attributes from user (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
-	assertFalse("our user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpUserAttribute();
+		attributesManager.setAttributes(sess, user, attributes);
+		// create user and set attribute with value
+		attributesManager.removeAttributes(sess, user, attributes);
+		// remove attributes from user (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
+		assertFalse("our user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void removeUserAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.removeUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "removeUserAttributesWhenUserNotExists");
 
 		attributes = setUpUserAttribute();
 		attributesManager.removeAttributes(sess, new User(), attributes);
@@ -7572,9 +7555,9 @@ public void removeUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeUserAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeUserAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeUserAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7586,9 +7569,9 @@ public void removeUserAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeUserAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeUserAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeUserAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		member = setUpMember();
@@ -7599,52 +7582,52 @@ public void removeUserAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllUserAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllUserAttributes");
+	@Test
+	public void removeAllUserAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllUserAttributes");
 
-	vo = setUpVo();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
-	attributes = setUpUserAttribute();
-	attributesManager.setAttributes(sess, user, attributes);
-	// create user and set attribute with value
-	attributesManager.removeAllAttributes(sess, user);
-	// remove all attributes from user (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
-	assertFalse("our user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	assertTrue("our user should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, user, "urn:perun:user:attribute-def:core:id")));
+		vo = setUpVo();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
+		attributes = setUpUserAttribute();
+		attributesManager.setAttributes(sess, user, attributes);
+		// create user and set attribute with value
+		attributesManager.removeAllAttributes(sess, user);
+		// remove all attributes from user (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, user);
+		assertFalse("our user shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		assertTrue("our user should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, user, "urn:perun:user:attribute-def:core:id")));
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void removeAllUserAttributesWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllUserAttributesWhenUserNotExists");
+		System.out.println(CLASS_NAME + "removeAllUserAttributesWhenUserNotExists");
 
 		attributesManager.removeAllAttributes(sess, new User());
 		// shouldn't find user
 
 	}
 
-@Test
-public void removeGroupAttribute() throws Exception {
-	System.out.println("attributesManager.removeGroupAttribute");
+	@Test
+	public void removeGroupAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupAttribute");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpGroupAttribute();
-	attributesManager.setAttribute(sess, group, attributes.get(0));
-	// create group and set attribute with value
-	attributesManager.removeAttribute(sess, group, attributes.get(0));
-	// remove attribute from group (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
-	assertFalse("our group shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpGroupAttribute();
+		attributesManager.setAttribute(sess, group, attributes.get(0));
+		// create group and set attribute with value
+		attributesManager.removeAttribute(sess, group, attributes.get(0));
+		// remove attribute from group (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
+		assertFalse("our group shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void removeGroupAttributeWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupAttributeWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeGroupAttributeWhenGroupNotExists");
 
 		attributes = setUpGroupAttribute();
 		attributesManager.removeAttribute(sess, new Group(), attributes.get(0));
@@ -7652,9 +7635,9 @@ public void removeGroupAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeGroupAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeGroupAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7665,9 +7648,9 @@ public void removeGroupAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeGroupAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeGroupAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeGroupAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7677,26 +7660,26 @@ public void removeGroupAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeGroupAttributes() throws Exception {
-	System.out.println("attributesManager.removeGroupAttributes");
+	@Test
+	public void removeGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpGroupAttribute();
-	attributesManager.setAttributes(sess, group, attributes);
-	// create group and set attribute with value
-	attributesManager.removeAttributes(sess, group, attributes);
-	// remove attributes from group (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
-	assertNotNull("unable to return group attributes",retAttr);
-	assertFalse("our group shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpGroupAttribute();
+		attributesManager.setAttributes(sess, group, attributes);
+		// create group and set attribute with value
+		attributesManager.removeAttributes(sess, group, attributes);
+		// remove attributes from group (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
+		assertNotNull("unable to return group attributes",retAttr);
+		assertFalse("our group shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void removeGroupAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeGroupAttributesWhenGroupNotExists");
 
 		attributes = setUpUserAttribute();
 		attributesManager.removeAttributes(sess, new Group(), attributes);
@@ -7704,9 +7687,9 @@ public void removeGroupAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeGroupAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeGroupAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7717,9 +7700,9 @@ public void removeGroupAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeGroupAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeGroupAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeGroupAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7729,53 +7712,53 @@ public void removeGroupAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllGroupAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllGroupAttributes");
+	@Test
+	public void removeAllGroupAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllGroupAttributes");
 
-	vo = setUpVo();
-	group = setUpGroup();
-	attributes = setUpGroupAttribute();
-	attributesManager.setAttributes(sess, group, attributes);
-	// create group and set attribute with value
-	attributesManager.removeAllAttributes(sess, group);
-	// remove all attributes from group (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
-	assertFalse("our group shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	// there are no core attributes
+		vo = setUpVo();
+		group = setUpGroup();
+		attributes = setUpGroupAttribute();
+		attributesManager.setAttributes(sess, group, attributes);
+		// create group and set attribute with value
+		attributesManager.removeAllAttributes(sess, group);
+		// remove all attributes from group (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, group);
+		assertFalse("our group shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		// there are no core attributes
 
-}
+	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void removeAllGroupAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllGroupAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeAllGroupAttributesWhenGroupNotExists");
 
 		attributesManager.removeAllAttributes(sess, new Group());
 		// shouldn't find group
 
 	}
 
-@Test
-public void removeGroupResourceAttribute() throws Exception {
-	System.out.println("attributesManager.removeGroupResourceAttribute");
+	@Test
+	public void removeGroupResourceAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupResourceAttribute");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	group = setUpGroup();
-	attributes = setUpGroupResourceAttribute();
-	attributesManager.setAttribute(sess, resource, group, attributes.get(0));
-	// create group-resource and set attribute with value
-	attributesManager.removeAttribute(sess, resource, group, attributes.get(0));
-	// remove attribute from group-resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
-	assertFalse("our group-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup();
+		attributes = setUpGroupResourceAttribute();
+		attributesManager.setAttribute(sess, resource, group, attributes.get(0));
+		// create group-resource and set attribute with value
+		attributesManager.removeAttribute(sess, resource, group, attributes.get(0));
+		// remove attribute from group-resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
+		assertFalse("our group-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeGroupResourceAttributeWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupResourceAttributeWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributeWhenResourceNotExists");
 
 		attributes = setUpGroupResourceAttribute();
 		vo = setUpVo();
@@ -7785,9 +7768,9 @@ public void removeGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void removeGroupResourceAttributeWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupResourceAttributeWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributeWhenGroupNotExists");
 
 		attributes = setUpGroupResourceAttribute();
 		vo = setUpVo();
@@ -7798,9 +7781,9 @@ public void removeGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeGroupResourceAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupResourceAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributeWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7813,9 +7796,9 @@ public void removeGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeGroupResourceAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeGroupResourceAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributeWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7827,27 +7810,27 @@ public void removeGroupResourceAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeGroupResourceAttributes() throws Exception {
-	System.out.println("attributesManager.removeGroupResourceAttributes");
+	@Test
+	public void removeGroupResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	group = setUpGroup();
-	attributes = setUpGroupResourceAttribute();
-	attributesManager.setAttribute(sess, resource, group, attributes.get(0));
-	// create group-resource and set attribute with value
-	attributesManager.removeAttributes(sess, resource, group, attributes);
-	// remove attributes from group-resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
-	assertFalse("our group-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup();
+		attributes = setUpGroupResourceAttribute();
+		attributesManager.setAttribute(sess, resource, group, attributes.get(0));
+		// create group-resource and set attribute with value
+		attributesManager.removeAttributes(sess, resource, group, attributes);
+		// remove attributes from group-resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
+		assertFalse("our group-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeGroupResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributesWhenResourceNotExists");
 
 		attributes = setUpMemberResourceAttribute();
 		vo = setUpVo();
@@ -7857,9 +7840,9 @@ public void removeGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void removeGroupResourceAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupResourceAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributesWhenGroupNotExists");
 
 		attributes = setUpGroupResourceAttribute();
 		vo = setUpVo();
@@ -7870,9 +7853,9 @@ public void removeGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeGroupResourceAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeGroupResourceAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributesWhenAttributeNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7885,9 +7868,9 @@ public void removeGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeGroupResourceAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeGroupResourceAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeGroupResourceAttributesWhenWrongAttrAssignment");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7899,28 +7882,28 @@ public void removeGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllGroupResourceAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllGroupResourceAttributes");
+	@Test
+	public void removeAllGroupResourceAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllGroupResourceAttributes");
 
-	vo = setUpVo();
-	facility = setUpFacility();
-	resource = setUpResource();
-	group = setUpGroup();
-	attributes = setUpGroupResourceAttribute();
-	attributesManager.setAttribute(sess, resource, group, attributes.get(0));
-	// create group-resource and set attribute with value
-	attributesManager.removeAllAttributes(sess, resource, group);
-	// remove all attributes from member-resource (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
-	assertFalse("our group-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	// group-resource don't have core attributes ??
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup();
+		attributes = setUpGroupResourceAttribute();
+		attributesManager.setAttribute(sess, resource, group, attributes.get(0));
+		// create group-resource and set attribute with value
+		attributesManager.removeAllAttributes(sess, resource, group);
+		// remove all attributes from member-resource (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, group);
+		assertFalse("our group-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		// group-resource don't have core attributes ??
 
-}
+	}
 
-@Test (expected=ResourceNotExistsException.class)
+	@Test (expected=ResourceNotExistsException.class)
 	public void removeAllGroupResourceAttributesWhenResourceNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllGroupResourceAttributesWhenResourceNotExists");
+		System.out.println(CLASS_NAME + "removeAllGroupResourceAttributesWhenResourceNotExists");
 
 		vo = setUpVo();
 		group = setUpGroup();
@@ -7930,9 +7913,9 @@ public void removeAllGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test (expected=GroupNotExistsException.class)
+	@Test (expected=GroupNotExistsException.class)
 	public void removeAllGroupResourceAttributesWhenGroupNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllGroupResourceAttributesWhenGroupNotExists");
+		System.out.println(CLASS_NAME + "removeAllGroupResourceAttributesWhenGroupNotExists");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -7943,24 +7926,24 @@ public void removeAllGroupResourceAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeHostAttribute() throws Exception {
-	System.out.println("attributesManager.removeHostAttribute");
+	@Test
+	public void removeHostAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "removeHostAttribute");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
-	attributesManager.setAttribute(sess, host, attributes.get(0));
-	// create host and set attribute with value
-	attributesManager.removeAttribute(sess, host, attributes.get(0));
-	// remove attribute from vo (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
-	assertFalse("our host shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
+		attributesManager.setAttribute(sess, host, attributes.get(0));
+		// create host and set attribute with value
+		attributesManager.removeAttribute(sess, host, attributes.get(0));
+		// remove attribute from vo (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
+		assertFalse("our host shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void removeHostAttributeWhenHostNotExists() throws Exception {
-		System.out.println("attributesManager.removeHostAttributeWhenHostNotExists");
+		System.out.println(CLASS_NAME + "removeHostAttributeWhenHostNotExists");
 
 		attributes = setUpHostAttribute();
 		attributesManager.removeAttribute(sess, new Host(), attributes.get(0));
@@ -7968,9 +7951,9 @@ public void removeHostAttribute() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeHostAttributeWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeHostAttributeWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeHostAttributeWhenAttributeNotExists");
 
 		host = setUpHost().get(0);
 		attributes = setUpHostAttribute();
@@ -7980,9 +7963,9 @@ public void removeHostAttribute() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeHostAttributeWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeHostAttributeWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeHostAttributeWhenWrongAttrAssignment");
 
 		host = setUpHost().get(0);
 		attributes = setUpFacilityAttribute();
@@ -7991,24 +7974,24 @@ public void removeHostAttribute() throws Exception {
 
 	}
 
-@Test
-public void removeHostAttributes() throws Exception {
-	System.out.println("attributesManager.removeHostAttributes");
+	@Test
+	public void removeHostAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeHostAttributes");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
-	attributesManager.setAttribute(sess, host, attributes.get(0));
-	// create host and set attribute with value
-	attributesManager.removeAttributes(sess, host, attributes);
-	// remove attributes from host (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
-	assertFalse("our host shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
+		attributesManager.setAttribute(sess, host, attributes.get(0));
+		// create host and set attribute with value
+		attributesManager.removeAttributes(sess, host, attributes);
+		// remove attributes from host (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
+		assertFalse("our host shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
-}
+	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void removeHostAttributesWhenHostNotExists() throws Exception {
-		System.out.println("attributesManager.removeHostAttributesWhenHostNotExists");
+		System.out.println(CLASS_NAME + "removeHostAttributesWhenHostNotExists");
 
 		attributes = setUpHostAttribute();
 		attributesManager.removeAttributes(sess, new Host(), attributes);
@@ -8016,9 +7999,9 @@ public void removeHostAttributes() throws Exception {
 
 	}
 
-@Test (expected=AttributeNotExistsException.class)
+	@Test (expected=AttributeNotExistsException.class)
 	public void removeHostAttributesWhenAttributeNotExists() throws Exception {
-		System.out.println("attributesManager.removeHostAttributesWhenAttributeNotExists");
+		System.out.println(CLASS_NAME + "removeHostAttributesWhenAttributeNotExists");
 
 		host = setUpHost().get(0);
 		attributes = setUpHostAttribute();
@@ -8028,9 +8011,9 @@ public void removeHostAttributes() throws Exception {
 
 	}
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void removeHostAttributesWhenWrongAttrAssignment() throws Exception {
-		System.out.println("attributesManager.removeHostAttributesWhenWrongAttrAssignment");
+		System.out.println(CLASS_NAME + "removeHostAttributesWhenWrongAttrAssignment");
 
 		host = setUpHost().get(0);
 		attributes = setUpFacilityAttribute();
@@ -8039,25 +8022,25 @@ public void removeHostAttributes() throws Exception {
 
 	}
 
-@Test
-public void removeAllHostAttributes() throws Exception {
-	System.out.println("attributesManager.removeAllHostAttributes");
+	@Test
+	public void removeAllHostAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllHostAttributes");
 
-	host = setUpHost().get(0);
-	attributes = setUpHostAttribute();
-	attributesManager.setAttribute(sess, host, attributes.get(0));
-	// create host and set attribute with value
-	attributesManager.removeAllAttributes(sess, host);
-	// remove all attributes from host (definition or attribute)
-	List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
-	assertFalse("our host shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
-	assertTrue("our host should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, host, "urn:perun:host:attribute-def:core:id")));
+		host = setUpHost().get(0);
+		attributes = setUpHostAttribute();
+		attributesManager.setAttribute(sess, host, attributes.get(0));
+		// create host and set attribute with value
+		attributesManager.removeAllAttributes(sess, host);
+		// remove all attributes from host (definition or attribute)
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, host);
+		assertFalse("our host shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
+		assertTrue("our host should still have core attribute",retAttr.contains(attributesManager.getAttribute(sess, host, "urn:perun:host:attribute-def:core:id")));
 
-}
+	}
 
-@Test (expected=HostNotExistsException.class)
+	@Test (expected=HostNotExistsException.class)
 	public void removeAllHostAttributesWhenHostNotExists() throws Exception {
-		System.out.println("attributesManager.removeAllHostAttributesWhenHostNotExists");
+		System.out.println(CLASS_NAME + "removeAllHostAttributesWhenHostNotExists");
 
 		attributesManager.removeAllAttributes(sess, new Host());
 		// shouldn't find host
@@ -8079,44 +8062,44 @@ public void removeAllHostAttributes() throws Exception {
 
 
 
-@Test
-public void isCoreAttribute() throws Exception {
-	System.out.println("attributesManager.isCoreAttribute");
+	@Test
+	public void isCoreAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "isCoreAttribute");
 
-	AttributeDefinition attrDef = new AttributeDefinition();
-	attrDef.setFriendlyName("attr-manager-test-attribute");
-	attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
-	attrDef.setType(String.class.getName());
-	attrDef.setDescription("AttributesManagerTest");
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setFriendlyName("attr-manager-test-attribute");
+		attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
+		attrDef.setType(String.class.getName());
+		attrDef.setDescription("AttributesManagerTest");
 
-	assertFalse("opt attribute is considered core!!",attributesManager.isCoreAttribute(sess, attrDef));
-	attrDef.setNamespace("urn:perun:facility:attribute-def:core");
-	assertTrue("core attribute is not considered core!!",attributesManager.isCoreAttribute(sess, attrDef));
+		assertFalse("opt attribute is considered core!!",attributesManager.isCoreAttribute(sess, attrDef));
+		attrDef.setNamespace("urn:perun:facility:attribute-def:core");
+		assertTrue("core attribute is not considered core!!",attributesManager.isCoreAttribute(sess, attrDef));
 
-}
+	}
 
 
-@Test
-public void isOptAttribute() throws Exception {
-	System.out.println("attributesManager.isOptAttribute");
+	@Test
+	public void isOptAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "isOptAttribute");
 
-	AttributeDefinition attrDef = new AttributeDefinition();
-	attrDef.setFriendlyName("attr-manager-test-attribute");
-	attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
-	attrDef.setType(String.class.getName());
-	attrDef.setDescription("AttributesManagerTest");
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setFriendlyName("attr-manager-test-attribute");
+		attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
+		attrDef.setType(String.class.getName());
+		attrDef.setDescription("AttributesManagerTest");
 
-	assertTrue("opt attribute is not considered opt!!",attributesManager.isOptAttribute(sess, attrDef));
-	attrDef.setNamespace("urn:perun:facility:attribute-def:core");
-	assertFalse("core attribute is considered opt!!",attributesManager.isOptAttribute(sess, attrDef));
+		assertTrue("opt attribute is not considered opt!!",attributesManager.isOptAttribute(sess, attrDef));
+		attrDef.setNamespace("urn:perun:facility:attribute-def:core");
+		assertFalse("core attribute is considered opt!!",attributesManager.isOptAttribute(sess, attrDef));
 
-}
+	}
 
-@Ignore
-@Test
-public void isCoreManagedAttribute() throws Exception {
-	System.out.println("attributesManager.isCoreManagedAttribute");
-	// TODO co je míněno core managed attributem ??
+	@Ignore
+	@Test
+	public void isCoreManagedAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "isCoreManagedAttribute");
+		// TODO co je míněno core managed attributem ??
 	/*
 		 AttributeDefinition attrDef = new AttributeDefinition();
 		 attrDef.setFriendlyName("attr-manager-test-attribute");
@@ -8128,29 +8111,29 @@ public void isCoreManagedAttribute() throws Exception {
 		 attrDef.setNamespace("urn:perun:facility:attribute-def:core");
 		 assertFalse("core attribute is considered opt!!",attributesManager.isCoreAttribute(sess, attrDef));
 		 */
-}
+	}
 
 
-@Test
-public void isFromNamespace() throws Exception {
-	System.out.println("attributesManager.isFromNamespace");
+	@Test
+	public void isFromNamespace() throws Exception {
+		System.out.println(CLASS_NAME + "isFromNamespace");
 
-	AttributeDefinition attrDef = new AttributeDefinition();
-	attrDef.setFriendlyName("attr-manager-test-attribute");
-	attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
-	attrDef.setType(String.class.getName());
-	attrDef.setDescription("AttributesManagerTest");
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setFriendlyName("attr-manager-test-attribute");
+		attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
+		attrDef.setType(String.class.getName());
+		attrDef.setDescription("AttributesManagerTest");
 
-	assertTrue("bad recognition of attribute namespace",attributesManager.isFromNamespace(sess, attrDef, "urn:perun:facility:attribute-def:opt"));
-	attrDef.setNamespace("urn:perun:facility:attribute-def:core");
-	assertFalse("bad recognition of attribute namespace",attributesManager.isFromNamespace(sess, attrDef, "urn:perun:facility:attribute-def:opt"));
+		assertTrue("bad recognition of attribute namespace",attributesManager.isFromNamespace(sess, attrDef, "urn:perun:facility:attribute-def:opt"));
+		attrDef.setNamespace("urn:perun:facility:attribute-def:core");
+		assertFalse("bad recognition of attribute namespace",attributesManager.isFromNamespace(sess, attrDef, "urn:perun:facility:attribute-def:opt"));
 
-}
+	}
 
 
-@Test (expected=WrongAttributeAssignmentException.class)
+	@Test (expected=WrongAttributeAssignmentException.class)
 	public void checkNamespace() throws Exception {
-		System.out.println("attributesManager.checkNamespace");
+		System.out.println(CLASS_NAME + "checkNamespace");
 
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setFriendlyName("attr-manager-test-attribute");
@@ -8163,138 +8146,138 @@ public void isFromNamespace() throws Exception {
 
 	}
 
-@Test
-public void checkNamespaceList() throws Exception {
-	System.out.println("attributesManager.checkNamespaceList");
+	@Test
+	public void checkNamespaceList() throws Exception {
+		System.out.println(CLASS_NAME + "checkNamespaceList");
 
-	AttributeDefinition attrDef = new AttributeDefinition();
-	attrDef.setFriendlyName("attr-manager-test-attribute");
-	attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
-	attrDef.setType(String.class.getName());
-	attrDef.setDescription("AttributesManagerTest");
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setFriendlyName("attr-manager-test-attribute");
+		attrDef.setNamespace("urn:perun:facility:attribute-def:opt");
+		attrDef.setType(String.class.getName());
+		attrDef.setDescription("AttributesManagerTest");
 
-	Attribute attribute = new Attribute(attrDef);
+		Attribute attribute = new Attribute(attrDef);
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attribute);
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attribute);
 
-	attributesManager.checkNamespace(sess, attributes, "urn:perun:facility:attribute-def:opt");
+		attributesManager.checkNamespace(sess, attributes, "urn:perun:facility:attribute-def:opt");
 
-}
+	}
 
-@Test
-public void getNamespaceFromAttributeName() throws Exception {
-	System.out.println("attributesManager.getNamespaceFromAttributeName");
+	@Test
+	public void getNamespaceFromAttributeName() throws Exception {
+		System.out.println(CLASS_NAME + "getNamespaceFromAttributeName");
 
-	String nameSpace = attributesManager.getNamespaceFromAttributeName("urn:perun:facility:attribute-def:opt:attr-manager-test-attribute");
-	assertTrue("get wrong namespace from name",nameSpace.equals("urn:perun:facility:attribute-def:opt"));
+		String nameSpace = attributesManager.getNamespaceFromAttributeName("urn:perun:facility:attribute-def:opt:attr-manager-test-attribute");
+		assertTrue("get wrong namespace from name",nameSpace.equals("urn:perun:facility:attribute-def:opt"));
 
-}
+	}
 
-@Test
-public void getFriendlyNameFromAttributeName() throws Exception {
-	System.out.println("attributesManager.getFriendlyNameFromAttributeName");
+	@Test
+	public void getFriendlyNameFromAttributeName() throws Exception {
+		System.out.println(CLASS_NAME + "getFriendlyNameFromAttributeName");
 
-	String nameSpace = attributesManager.getFriendlyNameFromAttributeName("urn:perun:facility:attribute-def:opt:attr-manager-test-attribute");
-	assertTrue("get wrong namespace from name",nameSpace.equals("attr-manager-test-attribute"));
+		String nameSpace = attributesManager.getFriendlyNameFromAttributeName("urn:perun:facility:attribute-def:opt:attr-manager-test-attribute");
+		assertTrue("get wrong namespace from name",nameSpace.equals("attr-manager-test-attribute"));
 
-}
+	}
 
-@Test
-public void getLogins() throws Exception {
-	System.out.println("attributesManager.getLogins");
+	@Test
+	public void getLogins() throws Exception {
+		System.out.println(CLASS_NAME + "getLogins");
 
-	vo = setUpVo();
-	member = setUpMember();
-	User user = perun.getUsersManager().getUserByMember(sess, member);
+		vo = setUpVo();
+		member = setUpMember();
+		User user = perun.getUsersManager().getUserByMember(sess, member);
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:user:attribute-def:opt");
-	attr.setFriendlyName("login-namespace:META-login");
-	// je to správná syntaxe pro loginy ??
-	attr.setType(String.class.getName());
-	attr.setValue("UserLoginNamespaceAttribute");
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:user:attribute-def:opt");
+		attr.setFriendlyName("login-namespace:META-login");
+		// je to správná syntaxe pro loginy ??
+		attr.setType(String.class.getName());
+		attr.setValue("UserLoginNamespaceAttribute");
 
-	assertNotNull("unable to create login namespace attribute",attributesManager.createAttribute(sess, attr));
+		assertNotNull("unable to create login namespace attribute",attributesManager.createAttribute(sess, attr));
 
-	attributesManager.setAttribute(sess, user, attr);
+		attributesManager.setAttribute(sess, user, attr);
 
-	List<Attribute> attributes = attributesManager.getLogins(sess, user);
+		List<Attribute> attributes = attributesManager.getLogins(sess, user);
 
-	assertTrue("user should have 1 login-namespace attribute",attributes.size()>=1);
-	assertTrue("our attribute should be returned",attributes.contains(attr));
+		assertTrue("user should have 1 login-namespace attribute",attributes.size()>=1);
+		assertTrue("our attribute should be returned",attributes.contains(attr));
 
-}
+	}
 
-@Test (expected=UserNotExistsException.class)
+	@Test (expected=UserNotExistsException.class)
 	public void getLoginsWhenUserNotExists() throws Exception {
-		System.out.println("attributesManager.getLoginsWhenUserNotExists");
+		System.out.println(CLASS_NAME + "getLoginsWhenUserNotExists");
 
 		attributesManager.getLogins(sess, new User());
 
 	}
 
-@Test
-public void getAttributeRights() throws Exception {
-	System.out.println("attributesManager.getAttributeRights");
+	@Test
+	public void getAttributeRights() throws Exception {
+		System.out.println(CLASS_NAME + "getAttributeRights");
 
-	// setting rights
-	List<ActionType> listOfActions = new ArrayList<ActionType>();
-	listOfActions.add(ActionType.WRITE);
-	listOfActions.add(ActionType.READ);
-	List<AttributeRights> rights = new ArrayList<AttributeRights>();
-	rights.add(new AttributeRights(1, Role.VOADMIN, listOfActions));
-	rights.add(new AttributeRights(1, Role.SELF, new ArrayList<ActionType>()));
-	perun.getAttributesManager().setAttributeRights(sess, rights);
+		// setting rights
+		List<ActionType> listOfActions = new ArrayList<ActionType>();
+		listOfActions.add(ActionType.WRITE);
+		listOfActions.add(ActionType.READ);
+		List<AttributeRights> rights = new ArrayList<AttributeRights>();
+		rights.add(new AttributeRights(1, Role.VOADMIN, listOfActions));
+		rights.add(new AttributeRights(1, Role.SELF, new ArrayList<ActionType>()));
+		perun.getAttributesManager().setAttributeRights(sess, rights);
 
-	// getting rights
-	rights.clear();
-	rights = perun.getAttributesManager().getAttributeRights(sess, 1);
-	assertTrue("list of rights should have 4 items for each role", rights.size() == 4);
-	for (AttributeRights attributeRights : rights) {
-		if (attributeRights.getRole().equals(Role.VOADMIN)) {
-			assertTrue("our attribute 1 should have right READ for VOADMIN", attributeRights.getRights().contains(ActionType.READ));
-			assertTrue("our attribute 1 should have right WRITE for VOADMIN", attributeRights.getRights().contains(ActionType.WRITE));
-		}
-		if (attributeRights.getRole().equals(Role.SELF)) {
-			assertTrue("our attribute 1 should not have rights for SELF", attributeRights.getRights().isEmpty());
-		}
-	}
-}
-
-@Test
-public void setAttributeRights() throws Exception {
-	System.out.println("attributesManager.setAttributeRights");
-	List<ActionType> listOfActions = new ArrayList<ActionType>();
-	listOfActions.add(ActionType.WRITE);
-	listOfActions.add(ActionType.READ);
-	List<AttributeRights> rights = new ArrayList<AttributeRights>();
-	rights.add(new AttributeRights(1, Role.VOADMIN, listOfActions));
-	listOfActions.clear();
-	listOfActions.add(ActionType.READ);
-	rights.add(new AttributeRights(1, Role.SELF, listOfActions));
-	perun.getAttributesManager().setAttributeRights(sess, rights);
-
-	listOfActions.clear();
-	rights.clear();
-	listOfActions.add(ActionType.WRITE);
-	rights.add(new AttributeRights(1, Role.VOADMIN, new ArrayList<ActionType>()));
-	rights.add(new AttributeRights(1, Role.SELF, listOfActions));
-	perun.getAttributesManager().setAttributeRights(sess, rights);
-
-	rights.clear();
-	rights = perun.getAttributesManager().getAttributeRights(sess, 1);
-
-	for (AttributeRights attributeRights : rights) {
-		if (attributeRights.getRole().equals(Role.SELF)) {
-			assertTrue("our attribute 1 should not have right READ for VOADMIN", !(attributeRights.getRights().contains(ActionType.READ)));
-			assertTrue("our attribute 1 should have right WRITE for VOADMIN", attributeRights.getRights().contains(ActionType.WRITE));
-		}
-		if (attributeRights.getRole().equals(Role.VOADMIN)) {
-			assertTrue("our attribute 1 should not have rights for VOADMIN", attributeRights.getRights().isEmpty());
+		// getting rights
+		rights.clear();
+		rights = perun.getAttributesManager().getAttributeRights(sess, 1);
+		assertTrue("list of rights should have 4 items for each role", rights.size() == 4);
+		for (AttributeRights attributeRights : rights) {
+			if (attributeRights.getRole().equals(Role.VOADMIN)) {
+				assertTrue("our attribute 1 should have right READ for VOADMIN", attributeRights.getRights().contains(ActionType.READ));
+				assertTrue("our attribute 1 should have right WRITE for VOADMIN", attributeRights.getRights().contains(ActionType.WRITE));
+			}
+			if (attributeRights.getRole().equals(Role.SELF)) {
+				assertTrue("our attribute 1 should not have rights for SELF", attributeRights.getRights().isEmpty());
+			}
 		}
 	}
-}
+
+	@Test
+	public void setAttributeRights() throws Exception {
+		System.out.println(CLASS_NAME + "setAttributeRights");
+		List<ActionType> listOfActions = new ArrayList<ActionType>();
+		listOfActions.add(ActionType.WRITE);
+		listOfActions.add(ActionType.READ);
+		List<AttributeRights> rights = new ArrayList<AttributeRights>();
+		rights.add(new AttributeRights(1, Role.VOADMIN, listOfActions));
+		listOfActions.clear();
+		listOfActions.add(ActionType.READ);
+		rights.add(new AttributeRights(1, Role.SELF, listOfActions));
+		perun.getAttributesManager().setAttributeRights(sess, rights);
+
+		listOfActions.clear();
+		rights.clear();
+		listOfActions.add(ActionType.WRITE);
+		rights.add(new AttributeRights(1, Role.VOADMIN, new ArrayList<ActionType>()));
+		rights.add(new AttributeRights(1, Role.SELF, listOfActions));
+		perun.getAttributesManager().setAttributeRights(sess, rights);
+
+		rights.clear();
+		rights = perun.getAttributesManager().getAttributeRights(sess, 1);
+
+		for (AttributeRights attributeRights : rights) {
+			if (attributeRights.getRole().equals(Role.SELF)) {
+				assertTrue("our attribute 1 should not have right READ for VOADMIN", !(attributeRights.getRights().contains(ActionType.READ)));
+				assertTrue("our attribute 1 should have right WRITE for VOADMIN", attributeRights.getRights().contains(ActionType.WRITE));
+			}
+			if (attributeRights.getRole().equals(Role.VOADMIN)) {
+				assertTrue("our attribute 1 should not have rights for VOADMIN", attributeRights.getRights().isEmpty());
+			}
+		}
+	}
 
 
 
@@ -8310,268 +8293,268 @@ public void setAttributeRights() throws Exception {
 
 // PRIVATE METHODS ----------------------------------------------
 
-private Vo setUpVo() throws Exception {
+	private Vo setUpVo() throws Exception {
 
-	Vo vo = new Vo();
-	vo.setName("AttributesMangerTestVo");
-	vo.setShortName("AMTVO");
-	assertNotNull("unable to create VO",perun.getVosManager().createVo(sess, vo));
-	return vo;
+		Vo vo = new Vo();
+		vo.setName("AttributesMangerTestVo");
+		vo.setShortName("AMTVO");
+		assertNotNull("unable to create VO",perun.getVosManager().createVo(sess, vo));
+		return vo;
 
-}
+	}
 
-private Member setUpMember() throws Exception {
+	private Member setUpMember() throws Exception {
 
-	String userFirstName = Long.toHexString(Double.doubleToLongBits(Math.random()));
-	String userLastName = Long.toHexString(Double.doubleToLongBits(Math.random()));
-	String extLogin = Long.toHexString(Double.doubleToLongBits(Math.random()));              // his login in external source
+		String userFirstName = Long.toHexString(Double.doubleToLongBits(Math.random()));
+		String userLastName = Long.toHexString(Double.doubleToLongBits(Math.random()));
+		String extLogin = Long.toHexString(Double.doubleToLongBits(Math.random()));              // his login in external source
 
-	Candidate candidate = new Candidate();  //Mockito.mock(Candidate.class);
-	candidate.setFirstName(userFirstName);
-	candidate.setId(0);
-	candidate.setMiddleName("");
-	candidate.setLastName(userLastName);
-	candidate.setTitleBefore("");
-	candidate.setTitleAfter("");
-	UserExtSource userExtSource = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), extLogin);
-	candidate.setUserExtSource(userExtSource);
-	candidate.setAttributes(new HashMap<String,String>());
+		Candidate candidate = new Candidate();  //Mockito.mock(Candidate.class);
+		candidate.setFirstName(userFirstName);
+		candidate.setId(0);
+		candidate.setMiddleName("");
+		candidate.setLastName(userLastName);
+		candidate.setTitleBefore("");
+		candidate.setTitleAfter("");
+		UserExtSource userExtSource = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), extLogin);
+		candidate.setUserExtSource(userExtSource);
+		candidate.setAttributes(new HashMap<String,String>());
 
-	Member member = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate);
-	assertNotNull("No member created", member);
-	usersForDeletion.add(perun.getUsersManager().getUserByMember(sess, member));
-	// save user for deletion after test
-	return member;
-}
+		Member member = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate);
+		assertNotNull("No member created", member);
+		usersForDeletion.add(perun.getUsersManager().getUserByMember(sess, member));
+		// save user for deletion after test
+		return member;
+	}
 
-private Facility setUpFacility() throws Exception {
+	private Facility setUpFacility() throws Exception {
 
-	facility = new Facility();
-	facility.setName("AttributesManagerTestFacility");
-	assertNotNull(perun.getFacilitiesManager().createFacility(sess, facility));
-	return facility;
+		facility = new Facility();
+		facility.setName("AttributesManagerTestFacility");
+		assertNotNull(perun.getFacilitiesManager().createFacility(sess, facility));
+		return facility;
 
-}
+	}
 
-private Resource setUpResource() throws Exception {
+	private Resource setUpResource() throws Exception {
 
-	Resource resource = new Resource();
-	resource.setName("AttributesManagerTestResource");
-	resource.setDescription("testing resource");
-	assertNotNull("unable to create resource",perun.getResourcesManager().createResource(sess, resource, vo, facility));
+		Resource resource = new Resource();
+		resource.setName("AttributesManagerTestResource");
+		resource.setDescription("testing resource");
+		assertNotNull("unable to create resource",perun.getResourcesManager().createResource(sess, resource, vo, facility));
 
-	return resource;
+		return resource;
 
-}
+	}
 
-private Service setUpService() throws Exception {
+	private Service setUpService() throws Exception {
 
-	Service service = new Service();
-	service.setName("AttributesManagerTestService");
-	perun.getServicesManager().createService(sess, service);
+		Service service = new Service();
+		service.setName("AttributesManagerTestService");
+		perun.getServicesManager().createService(sess, service);
 
-	return service;
+		return service;
 
-}
+	}
 
-private Service setUpService2() throws Exception {
+	private Service setUpService2() throws Exception {
 
-	Service service = new Service();
-	service.setName("AttributesManagerTestService2");
-	perun.getServicesManager().createService(sess, service);
+		Service service = new Service();
+		service.setName("AttributesManagerTestService2");
+		perun.getServicesManager().createService(sess, service);
 
-	return service;
-}
+		return service;
+	}
 
-private Group setUpGroup() throws Exception {
+	private Group setUpGroup() throws Exception {
 
-	Group group = perun.getGroupsManager().createGroup(sess, vo, new Group("AttrTestGroup","AttrTestGroupDescription"));
-	assertNotNull("unable to create a group", group);
-	return group;
+		Group group = perun.getGroupsManager().createGroup(sess, vo, new Group("AttrTestGroup","AttrTestGroupDescription"));
+		assertNotNull("unable to create a group", group);
+		return group;
 
-}
+	}
 
-private Group setUpGroup(Vo vo, Member member) throws Exception {
+	private Group setUpGroup(Vo vo, Member member) throws Exception {
 
-	Group group = new Group("ResourcesManagerTestGroup","");
-	group = perun.getGroupsManager().createGroup(sess, vo, group);
-	perun.getGroupsManager().addMember(sess, group, member);
-	return group;
+		Group group = new Group("ResourcesManagerTestGroup","");
+		group = perun.getGroupsManager().createGroup(sess, vo, group);
+		perun.getGroupsManager().addMember(sess, group, member);
+		return group;
 
-}
+	}
 
-private void setUpMemberToResource() throws Exception {
+	private void setUpMemberToResource() throws Exception {
 
-	perun.getGroupsManager().addMember(sess, group, member);
-	perun.getResourcesManager().assignGroupToResource(sess, group, resource);
-}
+		perun.getGroupsManager().addMember(sess, group, member);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+	}
 
-private List<Host> setUpHost() throws Exception {
+	private List<Host> setUpHost() throws Exception {
 
-	Host host = new Host();
-	host.setHostname("AttrTestHost");
-	List<Host> hosts = new ArrayList<Host>();
-	hosts.add(host);
+		Host host = new Host();
+		host.setHostname("AttrTestHost");
+		List<Host> hosts = new ArrayList<Host>();
+		hosts.add(host);
 
-	// create cluster type facility
-	facility = new Facility();
-	facility.setName("AttrTestFacility");
-	facility = perun.getFacilitiesManager().createFacility(sess, facility);
+		// create cluster type facility
+		facility = new Facility();
+		facility.setName("AttrTestFacility");
+		facility = perun.getFacilitiesManager().createFacility(sess, facility);
 
-	hosts = perun.getFacilitiesManager().addHosts(sess, hosts, facility);
-	// save hosts for deletion after test
-	hostsForDeletion.add(hosts.get(0));
+		hosts = perun.getFacilitiesManager().addHosts(sess, hosts, facility);
+		// save hosts for deletion after test
+		hostsForDeletion.add(hosts.get(0));
 
-	return hosts;
+		return hosts;
 
-}
+	}
 
-private List<Attribute> setUpRequiredAttributes() throws Exception {
+	private List<Attribute> setUpRequiredAttributes() throws Exception {
 
-	List<Attribute> attrList = new ArrayList<Attribute>();
+		List<Attribute> attrList = new ArrayList<Attribute>();
 
-	attrList.add(setUpFacilityAttribute().get(0));
-	attrList.add(setUpVoAttribute().get(0));
-	attrList.add(setUpFacilityUserAttribute().get(0));
-	attrList.add(setUpResourceAttribute().get(0));
-	attrList.add(setUpMemberAttribute().get(0));
-	attrList.add(setUpMemberResourceAttribute().get(0));
-	attrList.add(setUpMemberGroupAttribute().get(0));
-	attrList.add(setUpUserAttribute().get(0));
-	attrList.add(setUpHostAttribute().get(0));
-	attrList.add(setUpGroupResourceAttribute().get(0));
-	attrList.add(setUpGroupAttribute().get(0));
+		attrList.add(setUpFacilityAttribute().get(0));
+		attrList.add(setUpVoAttribute().get(0));
+		attrList.add(setUpFacilityUserAttribute().get(0));
+		attrList.add(setUpResourceAttribute().get(0));
+		attrList.add(setUpMemberAttribute().get(0));
+		attrList.add(setUpMemberResourceAttribute().get(0));
+		attrList.add(setUpMemberGroupAttribute().get(0));
+		attrList.add(setUpUserAttribute().get(0));
+		attrList.add(setUpHostAttribute().get(0));
+		attrList.add(setUpGroupResourceAttribute().get(0));
+		attrList.add(setUpGroupAttribute().get(0));
 
-	perun.getServicesManager().addRequiredAttributes(sess, service, attrList);
+		perun.getServicesManager().addRequiredAttributes(sess, service, attrList);
 
-	return attrList;
+		return attrList;
 
-}
+	}
 
-private Attribute setUpResourceRequiredAttributeForService(Service service) throws Exception {
+	private Attribute setUpResourceRequiredAttributeForService(Service service) throws Exception {
 
-	Attribute attribute = new Attribute();
-	List<Attribute> listOfAttrs = new ArrayList<>();
+		Attribute attribute = new Attribute();
+		List<Attribute> listOfAttrs = new ArrayList<>();
 
-	attribute.setNamespace("urn:perun:resource:attribute-def:opt");
-	attribute.setFriendlyName("resource-test-attribute-2");
-	attribute.setType(String.class.getName());
-	attribute.setValue("ResourceAttribute");
-	assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attribute));
-	
-	listOfAttrs.add(attribute);
-	
-	perun.getServicesManager().addRequiredAttributes(sess, service, listOfAttrs);
+		attribute.setNamespace("urn:perun:resource:attribute-def:opt");
+		attribute.setFriendlyName("resource-test-attribute-2");
+		attribute.setType(String.class.getName());
+		attribute.setValue("ResourceAttribute");
+		assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attribute));
 
-	return attribute;
-}
+		listOfAttrs.add(attribute);
 
-private List<Attribute> setUpFacilityUserAttribute() throws Exception {
+		perun.getServicesManager().addRequiredAttributes(sess, service, listOfAttrs);
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:user_facility:attribute-def:opt");
-	attr.setFriendlyName("user-facility-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("UserFacilityAttribute");
+		return attribute;
+	}
 
-	assertNotNull("unable to create user_facility attribute",attributesManager.createAttribute(sess, attr));
-	// create new facility-user attribute
+	private List<Attribute> setUpFacilityUserAttribute() throws Exception {
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:user_facility:attribute-def:opt");
+		attr.setFriendlyName("user-facility-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("UserFacilityAttribute");
 
-	return attributes;
+		assertNotNull("unable to create user_facility attribute",attributesManager.createAttribute(sess, attr));
+		// create new facility-user attribute
 
-}
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
 
-private List<Attribute> setUpFacilityAttribute() throws Exception {
+		return attributes;
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:facility:attribute-def:opt");
-	attr.setFriendlyName("facility-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("FacilityAttribute");
-	assertNotNull("unable to create facility attribute",attributesManager.createAttribute(sess, attr));
-	// create new facility attribute
+	}
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
+	private List<Attribute> setUpFacilityAttribute() throws Exception {
 
-	return attributes;
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:facility:attribute-def:opt");
+		attr.setFriendlyName("facility-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("FacilityAttribute");
+		assertNotNull("unable to create facility attribute",attributesManager.createAttribute(sess, attr));
+		// create new facility attribute
 
-}
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
 
-private List<Attribute> setUpEntitylessAttribute() throws Exception {
+		return attributes;
 
-	Attribute attr = new Attribute();
-	attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
-	attr.setFriendlyName("entityless-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("EntitylessAttribute");
-	assertNotNull("unable to create facility attribute",attributesManager.createAttribute(sess, attr));
-	//create new entityless attribute
+	}
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
-	return attributes;
-}
+	private List<Attribute> setUpEntitylessAttribute() throws Exception {
 
-private List<Attribute> setUpVoAttribute() throws Exception {
+		Attribute attr = new Attribute();
+		attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+		attr.setFriendlyName("entityless-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("EntitylessAttribute");
+		assertNotNull("unable to create facility attribute",attributesManager.createAttribute(sess, attr));
+		//create new entityless attribute
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:vo:attribute-def:opt");
-	attr.setFriendlyName("vo-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("VoAttribute");
-	assertNotNull("unable to create vo attribute",attributesManager.createAttribute(sess, attr));
-	// create new vo attribute
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+		return attributes;
+	}
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
+	private List<Attribute> setUpVoAttribute() throws Exception {
 
-	return attributes;
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:vo:attribute-def:opt");
+		attr.setFriendlyName("vo-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("VoAttribute");
+		assertNotNull("unable to create vo attribute",attributesManager.createAttribute(sess, attr));
+		// create new vo attribute
 
-}
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
 
-private List<Attribute> setUpResourceAttribute() throws Exception {
+		return attributes;
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:resource:attribute-def:opt");
-	attr.setFriendlyName("resource-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("ResourceAttribute");
-	assertNotNull("unable to create resource attribute",attributesManager.createAttribute(sess, attr));
-	// create new resource attribute
+	}
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
+	private List<Attribute> setUpResourceAttribute() throws Exception {
 
-	return attributes;
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:resource:attribute-def:opt");
+		attr.setFriendlyName("resource-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("ResourceAttribute");
+		assertNotNull("unable to create resource attribute",attributesManager.createAttribute(sess, attr));
+		// create new resource attribute
 
-}
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
 
-private List<Attribute> setUpMemberResourceAttribute() throws Exception {
+		return attributes;
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member_resource:attribute-def:opt");
-	attr.setFriendlyName("member-resource-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("MemberResourceAttribute");
-	assertNotNull("unable to create member-resource attribute",attributesManager.createAttribute(sess, attr));
-	// create new resource member attribute
+	}
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
+	private List<Attribute> setUpMemberResourceAttribute() throws Exception {
 
-	return attributes;
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member_resource:attribute-def:opt");
+		attr.setFriendlyName("member-resource-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberResourceAttribute");
+		assertNotNull("unable to create member-resource attribute",attributesManager.createAttribute(sess, attr));
+		// create new resource member attribute
 
-}
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+
+		return attributes;
+
+	}
 
 	private List<Attribute> setUpMemberGroupAttribute() throws Exception {
 
@@ -8590,287 +8573,288 @@ private List<Attribute> setUpMemberResourceAttribute() throws Exception {
 		return attributes;
 	}
 
-private List<Attribute> setUpUserAttribute() throws Exception {
+	private List<Attribute> setUpUserAttribute() throws Exception {
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:user:attribute-def:opt");
-	attr.setFriendlyName("user-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("UserAttribute");
-	assertNotNull("unable to create user attribute",attributesManager.createAttribute(sess, attr));
-	// create new resource member attribute
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:user:attribute-def:opt");
+		attr.setFriendlyName("user-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("UserAttribute");
+		assertNotNull("unable to create user attribute",attributesManager.createAttribute(sess, attr));
+		// create new resource member attribute
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
 
-	return attributes;
+		return attributes;
 
-}
+	}
 
-private List<Attribute> setUpUserLargeAttribute() throws Exception {
+	private List<Attribute> setUpUserLargeAttribute() throws Exception {
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:user:attribute-def:opt");
-	attr.setFriendlyName("user-large-test-attribute");
-	attr.setType(LinkedHashMap.class.getName());
-	Map<String, String> value = new LinkedHashMap<String, String>();
-	value.put("UserLargeAttribute", "test value");
-	attr.setValue(value);
-	assertNotNull("unable to create user attribute",attributesManager.createAttribute(sess, attr));
-	// create new resource member attribute
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:user:attribute-def:opt");
+		attr.setFriendlyName("user-large-test-attribute");
+		attr.setType(LinkedHashMap.class.getName());
+		Map<String, String> value = new LinkedHashMap<String, String>();
+		value.put("UserLargeAttribute", "test value");
+		attr.setValue(value);
+		assertNotNull("unable to create user attribute",attributesManager.createAttribute(sess, attr));
+		// create new resource member attribute
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
-
-	return attributes;
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+
+		return attributes;
 
-}
+	}
 
-private List<Attribute> setUpResourceLargeAttribute() throws Exception {
+	private List<Attribute> setUpResourceLargeAttribute() throws Exception {
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:resource:attribute-def:opt");
-	attr.setFriendlyName("resource-large-test-attribute");
-	attr.setType(LinkedHashMap.class.getName());
-	Map<String, String> value = new LinkedHashMap<String, String>();
-	value.put("ResourceLargeAttribute", "test value");
-	value.put("ResourceTestLargeAttr", "test value 2");
-	attr.setValue(value);
-	assertNotNull("unable to create user attribute",attributesManager.createAttribute(sess, attr));
-	// create new resource member attribute
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:resource:attribute-def:opt");
+		attr.setFriendlyName("resource-large-test-attribute");
+		attr.setType(LinkedHashMap.class.getName());
+		Map<String, String> value = new LinkedHashMap<String, String>();
+		value.put("ResourceLargeAttribute", "test value");
+		value.put("ResourceTestLargeAttr", "test value 2");
+		attr.setValue(value);
+		assertNotNull("unable to create user attribute",attributesManager.createAttribute(sess, attr));
+		// create new resource member attribute
 
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
-	return attributes;
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+		return attributes;
 
-}
+	}
 
-private List<Attribute> setUpMemberAttribute() throws Exception {
+	private List<Attribute> setUpMemberAttribute() throws Exception {
 
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member:attribute-def:opt");
-	attr.setFriendlyName("member-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("MemberAttribute");
-
-	assertNotNull("unable to create member attribute",attributesManager.createAttribute(sess, attr));
-	// create new resource member attribute
-
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
-
-	return attributes;
-
-}
-
-
-private List<Attribute> setUpGroupAttribute() throws Exception {
-
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:group:attribute-def:opt");
-	attr.setFriendlyName("group-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("GroupAttribute");
-
-	assertNotNull("unable to create group attribute",attributesManager.createAttribute(sess, attr));
-	// create new group attribute
-
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
-
-	return attributes;
-
-}
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member:attribute-def:opt");
+		attr.setFriendlyName("member-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("MemberAttribute");
+
+		assertNotNull("unable to create member attribute",attributesManager.createAttribute(sess, attr));
+		// create new resource member attribute
+
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+
+		return attributes;
+
+	}
+
+
+	private List<Attribute> setUpGroupAttribute() throws Exception {
+
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:group:attribute-def:opt");
+		attr.setFriendlyName("group-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("GroupAttribute");
+
+		assertNotNull("unable to create group attribute",attributesManager.createAttribute(sess, attr));
+		// create new group attribute
+
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+
+		return attributes;
+
+	}
 
-private List<Attribute> setUpGroupAttributes() throws Exception {
+	private List<Attribute> setUpGroupAttributes() throws Exception {
 
-	Attribute attr = new Attribute();
-	String namespace = "group-test-uniqueattribute:specialNamespace";
-	attr.setNamespace(AttributesManager.NS_GROUP_ATTR_OPT);
-	attr.setFriendlyName(namespace + "1");
-	attr.setType(String.class.getName());
-	attr.setValue("GroupAttribute");
-
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr));
-	attributes.add(attr);
-
-	Attribute attr2 = new Attribute(attr);
-	attr2.setFriendlyName(namespace + "2");
-	attr2.setValue("next2");
-	assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr2));
-	attributes.add(attr2);
-
-	Attribute attr3 = new Attribute(attr);
-	attr3.setFriendlyName(namespace + "3");
-	attr3.setValue("next3");
-	assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr3));
-	attributes.add(attr3);
-
-	//And one attribute with other name
-	Attribute attr4 = new Attribute(attr);
-	attr4.setFriendlyName("group-test-uniqueEattribute:specialNamespace");
-	attr4.setValue("next4");
-	assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr4));
-
-	//Attribute with null value
-	Attribute attr5 = new Attribute(attr);
-	attr5.setFriendlyName(namespace + "5");
-	assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr5));
-	attributes.add(attr5);
-
-
-	return attributes;
-}
-
-private List<Attribute> setUpResourceAttributes() throws Exception {
-
-	Attribute attr = new Attribute();
-	String namespace = "resource-test-uniqueattribute:specialNamespace";
-	attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_OPT);
-	attr.setFriendlyName(namespace + "1");
-	attr.setType(String.class.getName());
-	attr.setValue("ResourceAttribute");
-
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr));
-	attributes.add(attr);
-
-	Attribute attr2 = new Attribute(attr);
-	attr2.setFriendlyName(namespace + "2");
-	attr2.setValue("next2");
-	assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr2));
-	attributes.add(attr2);
-
-	Attribute attr3 = new Attribute(attr);
-	attr3.setFriendlyName(namespace + "3");
-	attr3.setValue("next3");
-	assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr3));
-	attributes.add(attr3);
-
-	//And one attribute with other name
-	Attribute attr4 = new Attribute(attr);
-	attr4.setFriendlyName("resource-test-uniqueEattribute:specialNamespace");
-	attr4.setValue("next4");
-	assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr4));
-
-	//Attribute with null value
-	Attribute attr5 = new Attribute(attr);
-	attr5.setFriendlyName(namespace + "5");
-	assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr5));
-	attributes.add(attr5);
-
-	return attributes;
-}
-
-private List<Attribute> setUpHostAttribute() throws Exception {
-
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:host:attribute-def:opt");
-	attr.setFriendlyName("host-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("HostAttribute");
-
-	assertNotNull("unable to create host attribute",attributesManager.createAttribute(sess, attr));
-	// create new host attribute
-
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
-
-	return attributes;
-
-}
-
-private List<Attribute> setUpEntitylessAttributeWithListValue() throws Exception {
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:entityless:attribute-def:opt");
-	attr.setFriendlyName("listEntitylessAttributeForTest");
-	attr.setType(ArrayList.class.getName());
-	List<String> listOfTestStrings = new ArrayList<>();
-	listOfTestStrings.add("first");
-	listOfTestStrings.add("second");
-	attr.setValue(listOfTestStrings);
-	assertNotNull("unable to create host attribute",attributesManager.createAttribute(sess, attr));
-	
-	List<Attribute> attributes = new ArrayList<>();
-	attributes.add(attr);
-	
-	return attributes;
-}
-
-private List<Attribute> setUpEntitylessAttributeWithMapValue() throws Exception {
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:entityless:attribute-def:opt");
-	attr.setFriendlyName("mapEntitylessAttributeForTest");
-	attr.setType(LinkedHashMap.class.getName());
-	Map<String, String> mapOfTestStrings = new LinkedHashMap<>();
-	mapOfTestStrings.put("G11", "20005");
-	mapOfTestStrings.put("R27", "11113");
-	mapOfTestStrings.put("N23658", "23658");
-	attr.setValue(mapOfTestStrings);
-	assertNotNull("unable to create host attribute",attributesManager.createAttribute(sess, attr));
-	
-	List<Attribute> attributes = new ArrayList<>();
-	attributes.add(attr);
-	
-	return attributes;
-}
-
-private List<Attribute> setUpGroupResourceAttribute() throws Exception {
-
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:group_resource:attribute-def:opt");
-	attr.setFriendlyName("group-resource-test-attribute");
-	attr.setType(String.class.getName());
-	attr.setValue("GroupResourceAttribute");
-
-	assertNotNull("unable to create Group_Resource attribute",attributesManager.createAttribute(sess, attr));
-	// create new group resource attribute
-
-	List<Attribute> attributes = new ArrayList<Attribute>();
-	attributes.add(attr);
-	// put attribute into list because setAttributes requires it
-
-	return attributes;
-
-}
-
-private Attribute setUpSpecificMemberResourceAttribute(Member member, Resource resource) throws Exception {
-	Attribute attr = new Attribute();
-	attr.setNamespace("urn:perun:member_resource:attribute-def:opt");
-	attr.setFriendlyName("specificMemberResourceAttributeForTest");
-	attr.setType(String.class.getName());
-	attr.setValue("test value");
-
-	assertNotNull("unable to create specific memberResource attribute",attributesManager.createAttribute(sess, attr));
-
-	return attr;
-}
-
-public Attribute setAttributeInNamespace(String namespace) throws Exception {
-	AttributeDefinition attrDef = new AttributeDefinition();
-	attrDef.setNamespace(namespace);
-	attrDef.setDescription("Test attribute description");
-	attrDef.setFriendlyName("testingAttribute");
-	attrDef.setType(String.class.getName());
-	attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
-	Attribute attribute = new Attribute(attrDef);
-	attribute.setValue("Testing value");
-	return attribute;
-}
-
-private Map<AttributeDefinition, Set<AttributeDefinition>> getAllDependenciesMapForTesting() {
-	Map<AttributeDefinition, Set<AttributeDefinition>> allDependenciesForTesting = new HashMap<AttributeDefinition, Set<AttributeDefinition>>();
-	//Prepare every possible way to test Attribute with Attribute
-
-	//TODO FILL THIS MAP FOR USING
-
-	return allDependenciesForTesting;
-}
+		Attribute attr = new Attribute();
+		String namespace = "group-test-uniqueattribute:specialNamespace";
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_OPT);
+		attr.setFriendlyName(namespace + "1");
+		attr.setType(String.class.getName());
+		attr.setValue("GroupAttribute");
+
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr));
+		attributes.add(attr);
+
+		Attribute attr2 = new Attribute(attr);
+		attr2.setFriendlyName(namespace + "2");
+		attr2.setValue("next2");
+		assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr2));
+		attributes.add(attr2);
+
+		Attribute attr3 = new Attribute(attr);
+		attr3.setFriendlyName(namespace + "3");
+		attr3.setValue("next3");
+		assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr3));
+		attributes.add(attr3);
+
+		//And one attribute with other name
+		Attribute attr4 = new Attribute(attr);
+		attr4.setFriendlyName("group-test-uniqueEattribute:specialNamespace");
+		attr4.setValue("next4");
+		assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr4));
+
+		//Attribute with null value
+		Attribute attr5 = new Attribute(attr);
+		attr5.setFriendlyName(namespace + "5");
+		assertNotNull("unable to create group attribute", attributesManager.createAttribute(sess, attr5));
+		attributes.add(attr5);
+
+
+		return attributes;
+	}
+
+	private List<Attribute> setUpResourceAttributes() throws Exception {
+
+		Attribute attr = new Attribute();
+		String namespace = "resource-test-uniqueattribute:specialNamespace";
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_OPT);
+		attr.setFriendlyName(namespace + "1");
+		attr.setType(String.class.getName());
+		attr.setValue("ResourceAttribute");
+
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr));
+		attributes.add(attr);
+
+		Attribute attr2 = new Attribute(attr);
+		attr2.setFriendlyName(namespace + "2");
+		attr2.setValue("next2");
+		assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr2));
+		attributes.add(attr2);
+
+		Attribute attr3 = new Attribute(attr);
+		attr3.setFriendlyName(namespace + "3");
+		attr3.setValue("next3");
+		assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr3));
+		attributes.add(attr3);
+
+		//And one attribute with other name
+		Attribute attr4 = new Attribute(attr);
+		attr4.setFriendlyName("resource-test-uniqueEattribute:specialNamespace");
+		attr4.setValue("next4");
+		assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr4));
+
+		//Attribute with null value
+		Attribute attr5 = new Attribute(attr);
+		attr5.setFriendlyName(namespace + "5");
+		assertNotNull("unable to create resource attribute", attributesManager.createAttribute(sess, attr5));
+		attributes.add(attr5);
+
+		return attributes;
+	}
+
+	private List<Attribute> setUpHostAttribute() throws Exception {
+
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:host:attribute-def:opt");
+		attr.setFriendlyName("host-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("HostAttribute");
+
+		assertNotNull("unable to create host attribute",attributesManager.createAttribute(sess, attr));
+		// create new host attribute
+
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+
+		return attributes;
+
+	}
+
+	private List<Attribute> setUpEntitylessAttributeWithListValue() throws Exception {
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:entityless:attribute-def:opt");
+		attr.setFriendlyName("listEntitylessAttributeForTest");
+		attr.setType(ArrayList.class.getName());
+		List<String> listOfTestStrings = new ArrayList<>();
+		listOfTestStrings.add("first");
+		listOfTestStrings.add("second");
+		attr.setValue(listOfTestStrings);
+		assertNotNull("unable to create host attribute",attributesManager.createAttribute(sess, attr));
+
+		List<Attribute> attributes = new ArrayList<>();
+		attributes.add(attr);
+
+		return attributes;
+	}
+
+	private List<Attribute> setUpEntitylessAttributeWithMapValue() throws Exception {
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:entityless:attribute-def:opt");
+		attr.setFriendlyName("mapEntitylessAttributeForTest");
+		attr.setType(LinkedHashMap.class.getName());
+		Map<String, String> mapOfTestStrings = new LinkedHashMap<>();
+		mapOfTestStrings.put("G11", "20005");
+		mapOfTestStrings.put("R27", "11113");
+		mapOfTestStrings.put("N23658", "23658");
+		attr.setValue(mapOfTestStrings);
+		assertNotNull("unable to create host attribute",attributesManager.createAttribute(sess, attr));
+
+		List<Attribute> attributes = new ArrayList<>();
+		attributes.add(attr);
+
+		return attributes;
+	}
+
+	private List<Attribute> setUpGroupResourceAttribute() throws Exception {
+
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:group_resource:attribute-def:opt");
+		attr.setFriendlyName("group-resource-test-attribute");
+		attr.setType(String.class.getName());
+		attr.setValue("GroupResourceAttribute");
+
+		assertNotNull("unable to create Group_Resource attribute",attributesManager.createAttribute(sess, attr));
+		// create new group resource attribute
+
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.add(attr);
+		// put attribute into list because setAttributes requires it
+
+		return attributes;
+
+	}
+
+	private Attribute setUpSpecificMemberResourceAttribute(Member member, Resource resource) throws Exception {
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:member_resource:attribute-def:opt");
+		attr.setFriendlyName("specificMemberResourceAttributeForTest");
+		attr.setType(String.class.getName());
+		attr.setValue("test value");
+
+		assertNotNull("unable to create specific memberResource attribute",attributesManager.createAttribute(sess, attr));
+
+		return attr;
+	}
+
+	public Attribute setAttributeInNamespace(String namespace) throws Exception {
+		AttributeDefinition attrDef = new AttributeDefinition();
+		attrDef.setNamespace(namespace);
+		attrDef.setDescription("Test attribute description");
+		attrDef.setFriendlyName("testingAttribute");
+		attrDef.setType(String.class.getName());
+		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
+		Attribute attribute = new Attribute(attrDef);
+		attribute.setValue("Testing value");
+		return attribute;
+	}
+
+	private Map<AttributeDefinition, Set<AttributeDefinition>> getAllDependenciesMapForTesting() {
+		Map<AttributeDefinition, Set<AttributeDefinition>> allDependenciesForTesting = new HashMap<AttributeDefinition, Set<AttributeDefinition>>();
+		//Prepare every possible way to test Attribute with Attribute
+
+		//TODO FILL THIS MAP FOR USING
+
+		return allDependenciesForTesting;
+	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntryIntegrationTest.java
@@ -1,13 +1,8 @@
 package cz.metacentrum.perun.core.entry;
 
 import cz.metacentrum.perun.core.api.AuditMessage;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,22 +10,17 @@ import org.junit.Test;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.exceptions.WrongRangeOfCountException;
-import cz.metacentrum.perun.core.blImpl.AuditMessagesManagerBlImpl;
-import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import org.junit.Ignore;
 
 /**
+ * Integration tests of AuditMessagesManager.
+ *
  * @author Michal Stava <stavamichal@gmail.com>
  */
-
 public class AuditMessagesManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	private final String textMismatch = "!@#$%^<<&*()_+<\\><:{[}][]{>} sd";
-	private final String CLASS_NAME = "AuditMessagesManagerEntry";
+	private final String CLASS_NAME = "AuditMessagesManager.";
 	private AuditMessage createdAuditMessage = new AuditMessage();
 
 	public AuditMessagesManagerEntryIntegrationTest(){
@@ -42,10 +32,10 @@ public class AuditMessagesManagerEntryIntegrationTest extends AbstractPerunInteg
 	 */
 	@Before
 	public void setUp() throws Exception {
-
 		createdAuditMessage.setMsg("Tested Message");
 	}
-/*
+
+	/*
 	@Test
 	public void testPollConsumerMessages() throws Exception {
 
@@ -60,7 +50,7 @@ public class AuditMessagesManagerEntryIntegrationTest extends AbstractPerunInteg
 	 */
 	@Test
 	public void testGetFixedNumberOfMessages() throws Exception {
-		System.out.println(CLASS_NAME + ":testGetFixedNumberOfMessages()");
+		System.out.println(CLASS_NAME + "testGetFixedNumberOfMessages");
 		int count = AuditMessagesManager.COUNTOFMESSAGES;
 
 		for (int i = 0; i < count; i++) {
@@ -76,7 +66,7 @@ public class AuditMessagesManagerEntryIntegrationTest extends AbstractPerunInteg
 	 */
 	@Test
 	public void testGetVariableNumberOfMessages() throws Exception {
-		System.out.println(CLASS_NAME + ":testGetVariableNumberOfMessages()");
+		System.out.println(CLASS_NAME + "testGetVariableNumberOfMessages");
 		int count = 33;
 
 		for (int i = 0; i < count; i++) {
@@ -108,12 +98,14 @@ public class AuditMessagesManagerEntryIntegrationTest extends AbstractPerunInteg
 		 }
 		 fail("One of messages need to contain specific message.");
 		 }*/
+
 	/*
 	 * Wrong Range of count exception if count is less than 1 message
 	 */
 	@Test (expected=WrongRangeOfCountException.class)
-		public void testLessThanZeroCountOfMessages() throws Exception {
-			System.out.println(CLASS_NAME + ":testLessThanZeroCountOfMessages()");
-			perun.getAuditMessagesManager().getMessages(sess, -1);
-		}
+	public void testLessThanZeroCountOfMessages() throws Exception {
+		System.out.println(CLASS_NAME + "testLessThanZeroCountOfMessages");
+		perun.getAuditMessagesManager().getMessages(sess, -1);
+	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntryIntegrationTest.java
@@ -1,27 +1,22 @@
 package cz.metacentrum.perun.core.entry;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
+ * Integration tests of DatabaseManager.
  *
- * @author Michal Stava email:&lt;stavamichal@gmail.com&gt;
+ * @author Michal Stava <stavamichal@gmail.com>
  */
 public class DatabaseManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
+	private final String DATABASE_MANAGER = "DatabaseManager";
 	Pattern versionPatter = Pattern.compile("^[1-9][0-9]*[.][1-9][0-9]*[.][1-9][0-9]*");
 	
 	@Before
@@ -30,7 +25,7 @@ public class DatabaseManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getCurrentDBVersion() throws Exception {
-		System.out.println("DatabaseManager.getCurrentDBVersion");
+		System.out.println(DATABASE_MANAGER+".getCurrentDBVersion");
 		String dbVersion = perun.getDatabaseManager().getCurrentDatabaseVersion(sess);
 		Matcher versionMatcher = versionPatter.matcher(dbVersion);
 		assertTrue("DbVersion must match to something like '1.0.0'", versionMatcher.matches());
@@ -38,15 +33,16 @@ public class DatabaseManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	
 	@Test
 	public void getDatabaseDriverInformation() throws Exception {
-		System.out.println("DatabaseManager.getDatabaseDriverInformation");
+		System.out.println(DATABASE_MANAGER+".getDatabaseDriverInformation");
 		String driverInfo = perun.getDatabaseManager().getDatabaseDriverInformation(sess);
 		assertTrue("DB driver info can't be empty", !driverInfo.isEmpty());
 	}
 	
 	@Test
 	public void getDatabaseInformation() throws Exception {
-		System.out.println("DatabaseManager.getDatabaseDriverInformation");
+		System.out.println(DATABASE_MANAGER+".getDatabaseDriverInformation");
 		String dbInfo = perun.getDatabaseManager().getDatabaseInformation(sess);
 		assertTrue("DB info can't be empty", !dbInfo.isEmpty());
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntryIntegrationTest.java
@@ -13,7 +13,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
-import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Group;
@@ -23,18 +22,18 @@ import cz.metacentrum.perun.core.api.exceptions.CandidateNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 
 /**
+ * Integration tests of ExtSourcesManager
+ *
  * @author Jiri Harazim <harazim@mail.muni.cz>
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-
 public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	private static final String EXT_SOURCE_NAME = "ExtSourcesManagerEntryIntegrationTest";
-	private static final String CLASS_NAME = "ExtSourcesManagerEntry.";
+	private static final String CLASS_NAME = "ExtSourcesManager.";
 	private ExtSourcesManager extSourcesManagerEntry;
 	private static ExtSource extSource;
 
@@ -50,7 +49,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test
 	public void testCreateExtSource() throws Exception {
-		System.out.println(CLASS_NAME + "createExtSource()");
+		System.out.println(CLASS_NAME + "createExtSource");
 
 		final ExtSource es = newInstanceExtSource();
 
@@ -65,7 +64,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test(expected=ExtSourceNotExistsException.class)
 	public void testDeleteExtSource() throws Exception {
-		System.out.println(CLASS_NAME + "deleteExtSource()");
+		System.out.println(CLASS_NAME + "deleteExtSource");
 
 		final ExtSource es = newInstanceExtSource();
 		final ExtSource createdExtSource = extSourcesManagerEntry.createExtSource(sess, es);
@@ -81,7 +80,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test
 	public void testGetExtSourceById() throws Exception {
-		System.out.println(CLASS_NAME + "getExtSourceById()");
+		System.out.println(CLASS_NAME + "getExtSourceById");
 
 		final ExtSource es = newInstanceExtSource();
 		final ExtSource createdExtSource = extSourcesManagerEntry.createExtSource(sess, es);
@@ -95,7 +94,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test
 	public void testGetExtSourceByName() throws Exception {
-		System.out.println(CLASS_NAME + "getExtSourceByName()");
+		System.out.println(CLASS_NAME + "getExtSourceByName");
 
 		final ExtSource es = extSourcesManagerEntry.getExtSourceByName(sess, EXT_SOURCE_NAME);
 
@@ -108,7 +107,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test
 	public void testGetVoExtSources() throws Exception {
-		System.out.println(CLASS_NAME + "getVoExtSources()");
+		System.out.println(CLASS_NAME + "getVoExtSources");
 
 		final VosManagerEntry vosManagerEntry = new VosManagerEntry(perun);
 		final Vo createdVo = vosManagerEntry.createVo(sess, new Vo(0,"sjk","kljlk"));
@@ -125,7 +124,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void testGetGroupExtSources() throws Exception {
-		System.out.println(CLASS_NAME + "getGroupExtSources()");
+		System.out.println(CLASS_NAME + "getGroupExtSources");
 
 		final VosManagerEntry vosManagerEntry = new VosManagerEntry(perun);
 		final Vo createdVo = vosManagerEntry.createVo(sess, new Vo(0,"sjk","kljlk"));
@@ -148,7 +147,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test
 	public void testGetExtSources() throws Exception {
-		System.out.println(CLASS_NAME + "testGetExtSources()");
+		System.out.println(CLASS_NAME + "testGetExtSources");
 
 		final List<ExtSource> extSources;
 		extSources = extSourcesManagerEntry.getExtSources(sess);
@@ -161,7 +160,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test
 	public void testAddExtSourceToVo() throws Exception {
-		System.out.println(CLASS_NAME + "addExtSource()");
+		System.out.println(CLASS_NAME + "addExtSource");
 
 		final VosManagerEntry vosManagerEntry = new VosManagerEntry(perun);
 		final Vo createdVo = vosManagerEntry.createVo(sess, new Vo(0,"sjk","kljlk"));
@@ -178,7 +177,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void testAddExtSourceToGroup() throws Exception {
-		System.out.println(CLASS_NAME + "addExtSource()");
+		System.out.println(CLASS_NAME + "addExtSource");
 
 		final VosManagerEntry vosManagerEntry = new VosManagerEntry(perun);
 		final Vo createdVo = vosManagerEntry.createVo(sess, new Vo(0,"sjk","kljlk"));
@@ -201,7 +200,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test
 	public void testCheckOrCreateExtSource() throws Exception {
-		System.out.println(CLASS_NAME + "getVoExtSources()");
+		System.out.println(CLASS_NAME + "getVoExtSources");
 
 		final ExtSource extSource = extSourcesManagerEntry.checkOrCreateExtSource(sess, EXT_SOURCE_NAME, "cz.metacentrum.perun.core.impl.ExtSourceSql");
 		final ExtSource extSource2 = extSourcesManagerEntry.checkOrCreateExtSource(sess, EXT_SOURCE_NAME, "cz.metacentrum.perun.core.impl.ExtSourceSql");
@@ -214,7 +213,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 */
 	@Test
 	public void testRemoveExtSourceFromVo() throws Exception {
-		System.out.println(CLASS_NAME + "removeExtSource()");
+		System.out.println(CLASS_NAME + "removeExtSource");
 
 		final VosManagerEntry vosManagerEntry = new VosManagerEntry(perun);
 		final Vo createdVo = vosManagerEntry.createVo(sess, new Vo(0,"sjk","kljlk"));
@@ -235,7 +234,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void testRemoveExtSourceFromGroup() throws Exception {
-		System.out.println(CLASS_NAME + "removeExtSource()");
+		System.out.println(CLASS_NAME + "removeExtSource");
 
 		final VosManagerEntry vosManagerEntry = new VosManagerEntry(perun);
 		final Vo createdVo = vosManagerEntry.createVo(sess, new Vo(0,"sjk","kljlk"));
@@ -280,7 +279,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	@Ignore
 	@Test (expected=CandidateNotExistsException.class)
 	public void getCandidateWhenCandidateNotExist() throws Exception {
-		System.out.println(CLASS_NAME + "getCandidateWhenCandidateNotExists()");
+		System.out.println(CLASS_NAME + "getCandidateWhenCandidateNotExists");
 
 		// TODO create searchable ExtSource (mock ?)
 		// search for specific Candidate which doesn't exists in ExtSource.
@@ -290,7 +289,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=ExtSourceNotExistsException.class)
 	public void getExtSourceByNameWhenExtSourceNotExist() throws Exception {
-		System.out.println(CLASS_NAME + "getExtSourceByNameWhenExtSourceNotExists()");
+		System.out.println(CLASS_NAME + "getExtSourceByNameWhenExtSourceNotExists");
 
 		extSourcesManagerEntry.getExtSourceByName(sess, "nonsense");
 		// shouldn't find ext source
@@ -299,7 +298,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=ExtSourceNotExistsException.class)
 	public void getExtSourceByIdWhenExtSourceNotExist() throws Exception {
-		System.out.println(CLASS_NAME + "getExtSourceByIdWhenExtSourceNotExists()");
+		System.out.println(CLASS_NAME + "getExtSourceByIdWhenExtSourceNotExists");
 
 		extSourcesManagerEntry.getExtSourceById(sess, 0);
 		// shouldn't find ext source
@@ -308,7 +307,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=VoNotExistsException.class)
 	public void addExtSourceWhenVoNotExists() throws Exception {
-		System.out.println(CLASS_NAME + "addExtSourceWhenVoNotExists()");
+		System.out.println(CLASS_NAME + "addExtSourceWhenVoNotExists");
 
 		extSourcesManagerEntry.addExtSource(sess, new Vo(), extSource);
 		// shouldn't find VO
@@ -317,7 +316,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=ExtSourceNotExistsException.class)
 	public void addExtSourceWhenExtSourceNotExists() throws Exception {
-		System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceNotExists()");
+		System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceNotExists");
 
 		ExtSource source = new ExtSource(0, "Fake", ExtSourcesManager.EXTSOURCE_INTERNAL);
 		Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0, "sjk", "kljlk"));
@@ -328,7 +327,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=ExtSourceAlreadyAssignedException.class)
 	public void addExtSourceWhenExtSourceAlreadyAssigned() throws Exception {
-		System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceAlreadyAssigned()");
+		System.out.println(CLASS_NAME + "addExtSourceWhenExtSourceAlreadyAssigned");
 
 		VosManager vosManager = perun.getVosManager();
 		Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
@@ -341,7 +340,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=ExtSourceNotAssignedException.class)
 	public void removeExtSourceWhenExtSourceNotAssigned() throws Exception {
-		System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotAssigned()");
+		System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotAssigned");
 
 		VosManager vosManager = perun.getVosManager();
 		Vo createdVo = vosManager.createVo(sess, new Vo(0,"sjk","kljlk"));
@@ -353,7 +352,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=ExtSourceNotExistsException.class)
 	public void removeExtSourceWhenExtSourceNotExist() throws Exception {
-		System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotExist()");
+		System.out.println(CLASS_NAME + "removeExtSourceWhenExtSourceNotExist");
 
 		VosManager vosManager = perun.getVosManager();
 		Vo createdVo = vosManager.createVo(sess, new Vo(0, "sjk", "kljlk"));
@@ -366,7 +365,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=VoNotExistsException.class)
 	public void getVoExtSourcesWhenVoNotExists() throws Exception {
-		System.out.println(CLASS_NAME + "getVoExtSourcesWhenVoNotExists()");
+		System.out.println(CLASS_NAME + "getVoExtSourcesWhenVoNotExists");
 
 		extSourcesManagerEntry.getVoExtSources(sess, new Vo());
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -64,7 +64,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	final Facility facility = new Facility(); // always in DB
 	final Owner owner = new Owner(); // always in DB and always own "facility" facility
 
-	private static final String FACILITIES_MANAGER = "FacilitiesManager";
+	private static final String CLASS_NAME = "FacilitiesManager.";
 
 	private Host createdHost;
 	private List<Host> hosts;
@@ -101,7 +101,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getFacilityById() throws Exception {
-		System.out.println("FacilitiesManager.getFacilityById");
+		System.out.println(CLASS_NAME + "getFacilityById");
 
 		Facility returnedFacility = perun.getFacilitiesManager().getFacilityById(sess, facility.getId());
 		assertNotNull("unable to get Facility by ID",returnedFacility);
@@ -111,7 +111,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getFacilitiesByHostName() throws Exception {
-		System.out.println("FacilitiesManager.getFacilitiesByHostname");
+		System.out.println(CLASS_NAME + "getFacilitiesByHostname");
 
 		String hostname = "testHostname";
 		Host host = new Host(15, hostname);
@@ -119,12 +119,12 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		List<Facility> facilities = perun.getFacilitiesManager().getFacilitiesByHostName(sess, hostname);
 		assertNotNull("unable to get facilities by Hostname", facilities);
-		assertEquals("There is only one facility with host with specific hsotname", 1, facilities.size());
+		assertEquals("There is only one facility with host with specific hostname", 1, facilities.size());
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void getFacilityByIdWhenFacilityNotExists() throws Exception {
-		System.out.println("FacilitiesManager.getFacilityByIdWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getFacilityByIdWhenFacilityNotExists");
 
 		facility.setId(0);
 		perun.getFacilitiesManager().getFacilityById(sess, facility.getId());
@@ -134,7 +134,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getFacilityByName() throws Exception {
-		System.out.println("FacilitiesManager.getFacilityByName");
+		System.out.println(CLASS_NAME + "getFacilityByName");
 
 		Facility returnedFacility = perun.getFacilitiesManager().getFacilityByName(sess, facility.getName());
 		assertNotNull("unable to get Facility by Name", returnedFacility);
@@ -144,7 +144,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void getFacilityByNameWhenFacilityNotExists() throws Exception {
-		System.out.println("FacilitiesManager.getFacilityByNameWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getFacilityByNameWhenFacilityNotExists");
 
 		facility.setName("");
 		perun.getFacilitiesManager().getFacilityByName(sess, facility.getName());
@@ -154,7 +154,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getFacilitiesByDestination() throws Exception {
-		System.out.println("FacilitiesManager.getFacilitiesByDestination");
+		System.out.println(CLASS_NAME + "getFacilitiesByDestination");
 
 		Service serv = new Service();
 		serv.setName("TestovaciSluzba");
@@ -172,14 +172,14 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getFacilitiesByDestinationWhenFacilityNotExist() throws Exception {
-		System.out.println("FacilitiesManager.getFacilitiesByDestinationWhenFacilityNotExist");
+		System.out.println(CLASS_NAME + "getFacilitiesByDestinationWhenFacilityNotExist");
 		List<Facility> facilities = perun.getFacilitiesManager().getFacilitiesByDestination(sess,"TestovaciDestinace neexistujici.");
 		assertTrue("No facility with such destination exist.", facilities.isEmpty());
 	}
 
 	@Test
 	public void getFacilities() throws Exception {
-		System.out.println("FacilitiesManager.getFacilities");
+		System.out.println(CLASS_NAME + "getFacilities");
 
 		List<Facility> facilities = perun.getFacilitiesManager().getFacilities(sess);
 		assertTrue("at least one facility should exists", facilities.size() > 0);
@@ -189,7 +189,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getOwners() throws Exception {
-		System.out.println("FacilitiesManager.getOwners");
+		System.out.println(CLASS_NAME + "getOwners");
 
 		List<Owner> owners = perun.getFacilitiesManager().getOwners(sess, facility);
 		assertTrue("there should be 1 owner", owners.size() == 1);
@@ -203,7 +203,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void getOwnersWhenFacilityNotExists() throws Exception {
-		System.out.println("FacilitiesManager.getOwnersWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getOwnersWhenFacilityNotExists");
 
 		perun.getFacilitiesManager().getOwners(sess, new Facility());
 		// shouldn't find facility
@@ -212,7 +212,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addOwner() throws Exception {
-		System.out.println("FacilitiesManager.addOwner");
+		System.out.println(CLASS_NAME + "addOwner");
 
 		Owner secondOwner = new Owner();
 		secondOwner.setName("SecondTestOwner");
@@ -229,7 +229,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=OwnerNotExistsException.class)
 	public void addOwnerWhenOwnerNotExists() throws Exception {
-		System.out.println("FacilitiesManager.addOwnerWhenOwnerNotExists");
+		System.out.println(CLASS_NAME + "addOwnerWhenOwnerNotExists");
 
 		perun.getFacilitiesManager().addOwner(sess, facility, new Owner());
 		// shouldn't be able to add not existing owner
@@ -237,7 +237,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void addOwnerWhenFacilityNotExists() throws Exception {
-		System.out.println("FacilitiesManager.addOwnerWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "addOwnerWhenFacilityNotExists");
 
 		Owner secondOwner = new Owner();
 		secondOwner.setName("SecondTestOwner");
@@ -250,7 +250,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=OwnerAlreadyAssignedException.class)
 	public void addOwnerWhenOwnerAlreadyAssigned() throws Exception {
-		System.out.println("FacilitiesManager.addOwnerWhenOwnerAlreadyAssigned");
+		System.out.println(CLASS_NAME + "addOwnerWhenOwnerAlreadyAssigned");
 
 		perun.getFacilitiesManager().addOwner(sess, facility, owner);
 		// shouldn't be able to add same owner
@@ -259,7 +259,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeOwner() throws Exception {
-		System.out.println("FacilitiesManager.removeOwner");
+		System.out.println(CLASS_NAME + "removeOwner");
 
 		perun.getFacilitiesManager().removeOwner(sess, facility, owner);
 
@@ -270,7 +270,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=OwnerAlreadyRemovedException.class)
 	public void removeOwnerWhenOwnerAlreadyRemoved() throws Exception {
-		System.out.println("FacilitiesManager.removeOwnerWhenOwnerAlreadyRemoved");
+		System.out.println(CLASS_NAME + "removeOwnerWhenOwnerAlreadyRemoved");
 
 		perun.getFacilitiesManager().removeOwner(sess, facility, owner);
 		perun.getFacilitiesManager().removeOwner(sess, facility, owner);
@@ -280,7 +280,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=OwnerNotExistsException.class)
 	public void removeOwnerWhenOwnerNotExists() throws Exception {
-		System.out.println("FacilitiesManager.removeOwnerWhenOwnerNotExists");
+		System.out.println(CLASS_NAME + "removeOwnerWhenOwnerNotExists");
 
 		perun.getFacilitiesManager().removeOwner(sess, facility, new Owner());
 		// shouldn't be able to remove not existing owner
@@ -289,7 +289,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void removeOwnerWhenFacilityNotExists() throws Exception {
-		System.out.println("FacilitiesManager.removeOwnerWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "removeOwnerWhenFacilityNotExists");
 
 		perun.getFacilitiesManager().removeOwner(sess, new Facility(), owner);
 		// shouldn't find facility
@@ -298,7 +298,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAllowedVos() throws Exception {
-		System.out.println("FacilitiesManager.getAllowedVos");
+		System.out.println(CLASS_NAME + "getAllowedVos");
 
 		Vo vo = setUpVo();
 		setUpResource(vo);
@@ -312,7 +312,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAllowedUsers() throws Exception {
-		System.out.println("FacilitiesManager.getAllowedUsers");
+		System.out.println(CLASS_NAME + "getAllowedUsers");
 
 		Vo vo = setUpVo();
 		Resource resource = setUpResource(vo);
@@ -330,7 +330,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAllowedUsersCheckUniqueness() throws Exception {
-		System.out.println("FacilitiesManager.getAllowedUsersCheckUniqueness");
+		System.out.println(CLASS_NAME + "getAllowedUsersCheckUniqueness");
 
 		Vo vo = setUpVo();
 		Resource resource1 = setUpResource(vo);
@@ -351,7 +351,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAllowedUsersWithVoAndServiceFilter() throws Exception {
-		System.out.println("FacilitiesManager.getAllowedUsers");
+		System.out.println(CLASS_NAME + "getAllowedUsers");
 
 		Vo vo = setUpVo();
 
@@ -376,7 +376,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void getAllowedVosWhenFacilityNotExists() throws Exception {
-		System.out.println("FacilitiesManager.getAllowedVosWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getAllowedVosWhenFacilityNotExists");
 
 		perun.getFacilitiesManager().getAllowedVos(sess, new Facility());
 		//shouldn't find facility
@@ -384,7 +384,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAssignedResources() throws Exception {
-		System.out.println("FacilitiesManager.getAssignedResources");
+		System.out.println(CLASS_NAME + "getAssignedResources");
 
 		Vo vo = setUpVo();
 		Resource resource = setUpResource(vo);
@@ -398,7 +398,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void getAssignedResourcesWhenFacilityNotExists() throws Exception {
-		System.out.println("FacilitiesManager.getAssignedResourcesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getAssignedResourcesWhenFacilityNotExists");
 
 		perun.getFacilitiesManager().getAssignedResources(sess, new Facility());
 		// shouldn't find facility
@@ -407,7 +407,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAssignedRichResources() throws Exception {
-		System.out.println("FacilitiesManager.getAssignedRichResources");
+		System.out.println(CLASS_NAME + "getAssignedRichResources");
 
 		Vo vo = setUpVo();
 		Resource resource = setUpResource(vo);
@@ -430,7 +430,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void getAssignedRichResourcesWhenFacilityNotExists() throws Exception {
-		System.out.println("FacilitiesManager.getAssignedRichResourcesWhenFacilityNotExists");
+		System.out.println(CLASS_NAME + "getAssignedRichResourcesWhenFacilityNotExists");
 
 		perun.getFacilitiesManager().getAssignedRichResources(sess, new Facility());
 		// shouldn't find facility
@@ -439,7 +439,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void createFacility() throws Exception {
-		System.out.println("FacilitiesManager.createFacility");
+		System.out.println(CLASS_NAME + "createFacility");
 
 		Facility facility = new Facility();
 		facility.setName("FacilitiesManagerTestSecondFacility");
@@ -452,7 +452,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityExistsException.class)
 	public void createFacilityWhenFacilityExists() throws Exception {
-		System.out.println("FacilitiesManager.createFacilityWhenFacilityExists");
+		System.out.println(CLASS_NAME + "createFacilityWhenFacilityExists");
 
 		Facility facility = new Facility();
 		facility.setName("FacilitiesManagerTestFacility");
@@ -466,7 +466,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void deleteFacility() throws Exception {
-		System.out.println("FacilitiesManager.deleteFacility");
+		System.out.println(CLASS_NAME + "deleteFacility");
 
 		perun.getFacilitiesManager().deleteFacility(sess, facility);
 		perun.getFacilitiesManager().deleteFacility(sess, facility);
@@ -476,7 +476,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=RelationExistsException.class)
 	public void deleteFacilityWhenRelationExist() throws Exception {
-		System.out.println("FacilitiesManager.deleteFacilityWhenRelationExist");
+		System.out.println(CLASS_NAME + "deleteFacilityWhenRelationExist");
 
 		Vo vo = setUpVo();
 		// create VO
@@ -489,7 +489,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getOwnerFacilities() throws Exception {
-		System.out.println("FacilitiesManager.getOwnerFacilities");
+		System.out.println(CLASS_NAME + "getOwnerFacilities");
 
 		List<Facility> facilities = perun.getFacilitiesManager().getOwnerFacilities(sess, owner);
 		assertTrue("our owner should own 1 facility", facilities.size() == 1);
@@ -499,7 +499,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=OwnerNotExistsException.class)
 	public void getOwnerFacilitiesWhenOwnerNotExists() throws Exception {
-		System.out.println("FacilitiesManager.getOwnerFacilitiesWhenOwnerNotExists");
+		System.out.println(CLASS_NAME + "getOwnerFacilitiesWhenOwnerNotExists");
 
 		perun.getFacilitiesManager().getOwnerFacilities(sess, new Owner());
 		// shouldn't find owner
@@ -508,7 +508,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addHosts()throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addHosts()");
+		System.out.println(CLASS_NAME + "addHosts");
 
 		hosts = facilitiesManagerEntry.addHosts(sess, hosts, facility);
 		// set this host for deletion - host is created after adding to facility !!
@@ -524,7 +524,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	@Ignore
 	@Test (expected=HostExistsException.class)
 	public void addHostsWhenHostExistsException()throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addHostsWhenHostExistsException()");
+		System.out.println(CLASS_NAME + "addHostsWhenHostExistsException");
 
 		hosts = facilitiesManagerEntry.addHosts(sess, hosts, facility);
 		// set this host for deletion - host is created after adding to facility !!
@@ -536,7 +536,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void addHostsWhenFacilityNotExists()throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addHostsWhenFacilityNotExists()");
+		System.out.println(CLASS_NAME + "addHostsWhenFacilityNotExists");
 
 		facilitiesManagerEntry.addHosts(sess, hosts, emptyFac);
 		// shouldn't find facility
@@ -545,7 +545,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addHostsWithPattern()throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addHostsWithPattern()");
+		System.out.println(CLASS_NAME + "addHostsWithPattern");
 
 		String hostname = "name[00-01]surname[99-100]cz";
 		List<String> listOfHosts = new ArrayList<String>();
@@ -570,7 +570,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = WrongPatternException.class)
 	public void addHostsWithWrongPattern()throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern()");
+		System.out.println(CLASS_NAME + "addHostsWithWrongPattern");
 
 		String hostname = "name[00]-01]surname[99-100]cz";
 		List<String> listOfHosts = new ArrayList<String>();
@@ -582,7 +582,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = WrongPatternException.class)
 	public void addHostsWithWrongPattern2()throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern2()");
+		System.out.println(CLASS_NAME + "addHostsWithWrongPattern2");
 
 		String hostname = "name[00-a01]surname[99-100]cz";
 		List<String> listOfHosts = new ArrayList<String>();
@@ -594,7 +594,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = WrongPatternException.class)
 	public void addHostsWithWrongPattern3()throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern3()");
+		System.out.println(CLASS_NAME + "addHostsWithWrongPattern3");
 
 		String hostname = "name[01-00]surname[99-100]cz";
 		List<String> listOfHosts = new ArrayList<String>();
@@ -606,7 +606,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getHosts()throws Exception{
-		System.out.println(FACILITIES_MANAGER + ".getHosts()");
+		System.out.println(CLASS_NAME + "getHosts");
 
 		createdHost = facilitiesManagerEntry.addHosts(sess, hosts, facility).get(0);
 		// set this host for deletion - host is created after adding to facility !!
@@ -620,7 +620,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getHostsByHostname()throws Exception{
-		System.out.println(FACILITIES_MANAGER + ".getHostsByHostname()");
+		System.out.println(CLASS_NAME + "getHostsByHostname");
 
 		Facility secondFacility = new Facility(0, "testFacilityGetHostsByHostnname");
 		secondFacility = perun.getFacilitiesManagerBl().createFacility(sess, secondFacility);
@@ -644,7 +644,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void getHostsWhenFacilityNotExists()throws Exception{
-		System.out.println(FACILITIES_MANAGER + ".getHostsFacilityNotExists()");
+		System.out.println(CLASS_NAME + "getHostsFacilityNotExists");
 
 		facilitiesManagerEntry.getHosts(sess, emptyFac);
 		// shouldn't find facility (facility)
@@ -653,7 +653,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeHosts()throws Exception{
-		System.out.println(FACILITIES_MANAGER + ".removeHosts()");
+		System.out.println(CLASS_NAME + "removeHosts");
 
 		facilitiesManagerEntry.addHosts(sess, hosts, facility);
 		assertEquals("Unable to create add host to facility", facilitiesManagerEntry.getHostsCount(sess, facility), 1);
@@ -666,7 +666,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void removeHostsWhenFacilityNotExists()throws Exception{
-		System.out.println(FACILITIES_MANAGER + ".removeHostsWhenFacilityNotExists()");
+		System.out.println(CLASS_NAME + "removeHostsWhenFacilityNotExists");
 
 		facilitiesManagerEntry.removeHosts(sess, hosts, emptyFac);
 		// shouldn't find facility
@@ -674,7 +674,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getFacilitiesCount() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getFacilitiesCount()");
+		System.out.println(CLASS_NAME + "getFacilitiesCount");
 
 		int count = facilitiesManagerEntry.getFacilitiesCount(sess);
 		assertTrue(count > 0);
@@ -682,7 +682,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getHostsCount()throws Exception{
-		System.out.println(FACILITIES_MANAGER + ".getHostsCount()");
+		System.out.println(CLASS_NAME + "getHostsCount");
 
 		facilitiesManagerEntry.addHosts(sess, hosts, facility);
 		// set this host for deletion - host is created after adding to facility !!
@@ -693,7 +693,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test (expected=FacilityNotExistsException.class)
 	public void getHostsCountWhenFacilityNotExists()throws Exception{
-		System.out.println(FACILITIES_MANAGER + ".getHostsCountWhenFacilityNotExists()");
+		System.out.println(CLASS_NAME + "getHostsCountWhenFacilityNotExists");
 
 		assertEquals(facilitiesManagerEntry.getHostsCount(sess, emptyFac), 1);
 		// shouldn't find facility
@@ -703,7 +703,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addAdmin() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addAdmin()");
+		System.out.println(CLASS_NAME + "addAdmin");
 
 		final Member member = setUpMember(vo);
 		User u = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -717,7 +717,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addAdminWithGroup() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addAdminWithGroup()");
+		System.out.println(CLASS_NAME + "addAdminWithGroup");
 
 		final Group group = new Group("testGroup", "just for testing");
 		perun.getGroupsManager().createGroup(sess, vo, group);
@@ -732,7 +732,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAdmins() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getAdmins()");
+		System.out.println(CLASS_NAME + "getAdmins");
 
 		// set up first user
 		final Member member = setUpMember(vo);
@@ -770,7 +770,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getDirectAdmins() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getDirectAdmins()");
+		System.out.println(CLASS_NAME + "getDirectAdmins");
 
 		final Member member = setUpMember(vo);
 		User u = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -781,7 +781,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAdminsIfNotExist() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getAdminsIfNotExist()");
+		System.out.println(CLASS_NAME + "getAdminsIfNotExist");
 
 		final Member member = setUpMember(vo);
 		User u = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -791,7 +791,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAdminGroups() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getAdminGroups()");
+		System.out.println(CLASS_NAME + "getAdminGroups");
 
 		final Group group = new Group("testGroup", "just for testing");
 		perun.getGroupsManager().createGroup(sess, vo, group);
@@ -802,7 +802,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected=UserNotAdminException.class)
 	public void removeAdminWhichNotExists() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeAdminWhichNotExists()");
+		System.out.println(CLASS_NAME + "removeAdminWhichNotExists");
 
 		final Member member = setUpMember(vo);
 		User u = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -812,7 +812,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeAdmin() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeAdmin()");
+		System.out.println(CLASS_NAME + "removeAdmin");
 
 		final Member member = setUpMember(vo);
 		User u = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -828,7 +828,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeAdminWithGroup() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeAdminWithGroup()");
+		System.out.println(CLASS_NAME + "removeAdminWithGroup");
 
 		final Group group = new Group("testGroup", "just for testing");
 		perun.getGroupsManager().createGroup(sess, vo, group);
@@ -840,7 +840,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getFacilitiesWhereUserIsAdmin() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getFacilitiesWhereUserIsAdmin()");
+		System.out.println(CLASS_NAME + "getFacilitiesWhereUserIsAdmin");
 
 		final Member member = setUpMember(vo);
 		User u = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -854,7 +854,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void copyManagers() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".copyManagers");
+		System.out.println(CLASS_NAME + "copyManagers");
 
 		// add user as admin in facility
 		final Member member = setUpMember(vo);
@@ -877,7 +877,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void copyOwners() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".copyOwners");
+		System.out.println(CLASS_NAME + "copyOwners");
 
 		// set up second facility
 		Facility newFacility = new Facility();
@@ -895,7 +895,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void copyAttributes() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".copyAttributes");
+		System.out.println(CLASS_NAME + "copyAttributes");
 
 		// set up second facility
 		Facility newFacility = new Facility();
@@ -932,7 +932,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForUser() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForUser");
+		System.out.println(CLASS_NAME + "addFacilityContactForUser");
 
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -950,7 +950,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForGroup() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForGroup");
+		System.out.println(CLASS_NAME + "addFacilityContactForGroup");
 
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
@@ -968,7 +968,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForOwner() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForOwner");
+		System.out.println(CLASS_NAME + "addFacilityContactForOwner");
 
 		Member member = setUpMember(vo);
 
@@ -985,7 +985,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForAll1() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForAll1");
+		System.out.println(CLASS_NAME + "addFacilityContactForAll1");
 
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
@@ -1009,7 +1009,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForAll2() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForAll2");
+		System.out.println(CLASS_NAME + "addFacilityContactForAll2");
 
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
@@ -1033,7 +1033,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAllContactGroupNames() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getAllContactGroupNames");
+		System.out.println(CLASS_NAME + "getAllContactGroupNames");
 
 		String contactGroupName1 = "testContactGroup01";
 		String contactGroupName2 = "testContactGroup02";
@@ -1056,7 +1056,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeFacilityContactForUser() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeFacilityContactForUser");
+		System.out.println(CLASS_NAME + "removeFacilityContactForUser");
 
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -1078,7 +1078,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeFacilityContactForGroup() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeFacilityContactForGroup");
+		System.out.println(CLASS_NAME + "removeFacilityContactForGroup");
 
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
@@ -1100,7 +1100,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeFacilityContactForOwner() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeFacilityContactForOwner");
+		System.out.println(CLASS_NAME + "removeFacilityContactForOwner");
 
 		Member member = setUpMember(vo);
 
@@ -1121,7 +1121,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeAllFacilityContacts() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeAllFacilityContacts");
+		System.out.println(CLASS_NAME + "removeAllFacilityContacts");
 
 		String contactGroupName1 = "testContactGroup01";
 		String contactGroupName2 = "testContactGroup02";
@@ -1149,7 +1149,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAssignedSecurityTeams() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getAssignedSecurityTeams");
+		System.out.println(CLASS_NAME + "getAssignedSecurityTeams");
 
 		List<SecurityTeam> expected = new ArrayList<>();
 		expected.add(setUpSecurityTeam0());
@@ -1164,7 +1164,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAssignedSecurityTeamsEmpty() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getAssignedSecurityTeamsEmpty");
+		System.out.println(CLASS_NAME + "getAssignedSecurityTeamsEmpty");
 
 		List<SecurityTeam> expected = new ArrayList<>();
 		setUpAssignSecurityTeams(facility, expected);
@@ -1179,7 +1179,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = FacilityNotExistsException.class)
 	public void getAssignedSecurityTeamsFacilityNotExists() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".getAssignedSecurityTeamsFacilityNotExists");
+		System.out.println(CLASS_NAME + "getAssignedSecurityTeamsFacilityNotExists");
 		setUpSecurityTeam0();
 		setUpSecurityTeam1();
 		// should throw an exception
@@ -1188,7 +1188,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void assignSecurityTeam() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".assignSecurityTeam");
+		System.out.println(CLASS_NAME + "assignSecurityTeam");
 
 		SecurityTeam st0 = setUpSecurityTeam0();
 		setUpSecurityTeam1();
@@ -1201,7 +1201,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = FacilityNotExistsException.class)
 	public void assignSecurityTeamFacilityNotExists() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".assignSecurityTeamFacilityNotExists");
+		System.out.println(CLASS_NAME + "assignSecurityTeamFacilityNotExists");
 		SecurityTeam st0 = setUpSecurityTeam0();
 		setUpSecurityTeam1();
 		// should throw an exception
@@ -1210,14 +1210,14 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void assignSecurityTeamSecurityTeamNotExists() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".assignSecurityTeamSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "assignSecurityTeamSecurityTeamNotExists");
 		// should throw an exception
 		facilitiesManagerEntry.assignSecurityTeam(sess, facility, new SecurityTeam(0, "name", "dsc"));
 	}
 
 	@Test(expected = SecurityTeamAlreadyAssignedException.class)
 	public void assignSecurityTeamAlreadyAssigned() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".assignSecurityTeamAlreadyAssigned");
+		System.out.println(CLASS_NAME + "assignSecurityTeamAlreadyAssigned");
 
 		SecurityTeam st0 = setUpSecurityTeam0();
 		List<SecurityTeam> expected = new ArrayList<>();
@@ -1231,7 +1231,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeSecurityTeam() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeSecurityTeam");
+		System.out.println(CLASS_NAME + "removeSecurityTeam");
 
 		SecurityTeam st0 = setUpSecurityTeam0();
 		SecurityTeam st1 = setUpSecurityTeam1();
@@ -1252,7 +1252,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = FacilityNotExistsException.class)
 	public void removeSecurityTeamFacilityNotExists() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeSecurityTeamFacilityNotExists");
+		System.out.println(CLASS_NAME + "removeSecurityTeamFacilityNotExists");
 
 		SecurityTeam st0 = setUpSecurityTeam0();
 		setUpSecurityTeam1();
@@ -1262,7 +1262,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void removeSecurityTeamSecurityTeamNotExists() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeSecurityTeamSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "removeSecurityTeamSecurityTeamNotExists");
 
 		List<SecurityTeam> expected = new ArrayList<>();
 		expected.add(setUpSecurityTeam0());
@@ -1275,7 +1275,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test(expected = SecurityTeamNotAssignedException.class)
 	public void removeSecurityTeamNotAssigned() throws Exception {
-		System.out.println(FACILITIES_MANAGER + ".removeSecurityTeamNotAssigned");
+		System.out.println(CLASS_NAME + "removeSecurityTeamNotAssigned");
 
 		List<SecurityTeam> expected = new ArrayList<>();
 		expected.add(setUpSecurityTeam0());
@@ -1430,4 +1430,5 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 			facilitiesManagerEntry.assignSecurityTeam(sess, facility, st);
 		}
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -29,7 +29,6 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.OwnerType;
 import cz.metacentrum.perun.core.api.Resource;
@@ -44,8 +43,6 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.HostExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
@@ -127,14 +124,14 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getFacilityByIdWhenFacilityNotExists() throws Exception {
-			System.out.println("FacilitiesManager.getFacilityByIdWhenFacilityNotExists");
+	public void getFacilityByIdWhenFacilityNotExists() throws Exception {
+		System.out.println("FacilitiesManager.getFacilityByIdWhenFacilityNotExists");
 
-			facility.setId(0);
-			perun.getFacilitiesManager().getFacilityById(sess, facility.getId());
-			// shouldn't find facility
+		facility.setId(0);
+		perun.getFacilitiesManager().getFacilityById(sess, facility.getId());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void getFacilityByName() throws Exception {
@@ -147,14 +144,14 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getFacilityByNameWhenFacilityNotExists() throws Exception {
-			System.out.println("FacilitiesManager.getFacilityByNameWhenFacilityNotExists");
+	public void getFacilityByNameWhenFacilityNotExists() throws Exception {
+		System.out.println("FacilitiesManager.getFacilityByNameWhenFacilityNotExists");
 
-			facility.setName("");
-			perun.getFacilitiesManager().getFacilityByName(sess, facility.getName());
-			// shouldn't find facility
+		facility.setName("");
+		perun.getFacilitiesManager().getFacilityByName(sess, facility.getName());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void getFacilitiesByDestination() throws Exception {
@@ -206,13 +203,13 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getOwnersWhenFacilityNotExists() throws Exception {
-			System.out.println("FacilitiesManager.getOwnersWhenFacilityNotExists");
+	public void getOwnersWhenFacilityNotExists() throws Exception {
+		System.out.println("FacilitiesManager.getOwnersWhenFacilityNotExists");
 
-			perun.getFacilitiesManager().getOwners(sess, new Facility());
-			// shouldn't find facility
+		perun.getFacilitiesManager().getOwners(sess, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void addOwner() throws Exception {
@@ -232,34 +229,34 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=OwnerNotExistsException.class)
-		public void addOwnerWhenOwnerNotExists() throws Exception {
-			System.out.println("FacilitiesManager.addOwnerWhenOwnerNotExists");
+	public void addOwnerWhenOwnerNotExists() throws Exception {
+		System.out.println("FacilitiesManager.addOwnerWhenOwnerNotExists");
 
-			perun.getFacilitiesManager().addOwner(sess, facility, new Owner());
-			// shouldn't be able to add not existing owner
-		}
+		perun.getFacilitiesManager().addOwner(sess, facility, new Owner());
+		// shouldn't be able to add not existing owner
+	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void addOwnerWhenFacilityNotExists() throws Exception {
-			System.out.println("FacilitiesManager.addOwnerWhenFacilityNotExists");
+	public void addOwnerWhenFacilityNotExists() throws Exception {
+		System.out.println("FacilitiesManager.addOwnerWhenFacilityNotExists");
 
-			Owner secondOwner = new Owner();
-			secondOwner.setName("SecondTestOwner");
-			secondOwner.setContact("testingSecondOwner");
-			secondOwner.setType(OwnerType.technical);
-			perun.getFacilitiesManager().addOwner(sess, new Facility(), secondOwner);
-			// shouldn't facility
+		Owner secondOwner = new Owner();
+		secondOwner.setName("SecondTestOwner");
+		secondOwner.setContact("testingSecondOwner");
+		secondOwner.setType(OwnerType.technical);
+		perun.getFacilitiesManager().addOwner(sess, new Facility(), secondOwner);
+		// shouldn't facility
 
-		}
+	}
 
 	@Test (expected=OwnerAlreadyAssignedException.class)
-		public void addOwnerWhenOwnerAlreadyAssigned() throws Exception {
-			System.out.println("FacilitiesManager.addOwnerWhenOwnerAlreadyAssigned");
+	public void addOwnerWhenOwnerAlreadyAssigned() throws Exception {
+		System.out.println("FacilitiesManager.addOwnerWhenOwnerAlreadyAssigned");
 
-			perun.getFacilitiesManager().addOwner(sess, facility, owner);
-			// shouldn't be able to add same owner
+		perun.getFacilitiesManager().addOwner(sess, facility, owner);
+		// shouldn't be able to add same owner
 
-		}
+	}
 
 	@Test
 	public void removeOwner() throws Exception {
@@ -273,32 +270,32 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=OwnerAlreadyRemovedException.class)
-		public void removeOwnerWhenOwnerAlreadyRemoved() throws Exception {
-			System.out.println("FacilitiesManager.removeOwnerWhenOwnerAlreadyRemoved");
+	public void removeOwnerWhenOwnerAlreadyRemoved() throws Exception {
+		System.out.println("FacilitiesManager.removeOwnerWhenOwnerAlreadyRemoved");
 
-			perun.getFacilitiesManager().removeOwner(sess, facility, owner);
-			perun.getFacilitiesManager().removeOwner(sess, facility, owner);
-			// shouldn't be able to remove owner twice
+		perun.getFacilitiesManager().removeOwner(sess, facility, owner);
+		perun.getFacilitiesManager().removeOwner(sess, facility, owner);
+		// shouldn't be able to remove owner twice
 
-		}
+	}
 
 	@Test (expected=OwnerNotExistsException.class)
-		public void removeOwnerWhenOwnerNotExists() throws Exception {
-			System.out.println("FacilitiesManager.removeOwnerWhenOwnerNotExists");
+	public void removeOwnerWhenOwnerNotExists() throws Exception {
+		System.out.println("FacilitiesManager.removeOwnerWhenOwnerNotExists");
 
-			perun.getFacilitiesManager().removeOwner(sess, facility, new Owner());
-			// shouldn't be able to remove not existing owner
+		perun.getFacilitiesManager().removeOwner(sess, facility, new Owner());
+		// shouldn't be able to remove not existing owner
 
-		}
+	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void removeOwnerWhenFacilityNotExists() throws Exception {
-			System.out.println("FacilitiesManager.removeOwnerWhenFacilityNotExists");
+	public void removeOwnerWhenFacilityNotExists() throws Exception {
+		System.out.println("FacilitiesManager.removeOwnerWhenFacilityNotExists");
 
-			perun.getFacilitiesManager().removeOwner(sess, new Facility(), owner);
-			// shouldn't find facility
+		perun.getFacilitiesManager().removeOwner(sess, new Facility(), owner);
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void getAllowedVos() throws Exception {
@@ -379,12 +376,12 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getAllowedVosWhenFacilityNotExists() throws Exception {
-			System.out.println("FacilitiesManager.getAllowedVosWhenFacilityNotExists");
+	public void getAllowedVosWhenFacilityNotExists() throws Exception {
+		System.out.println("FacilitiesManager.getAllowedVosWhenFacilityNotExists");
 
-			perun.getFacilitiesManager().getAllowedVos(sess, new Facility());
-			//shouldn't find facility
-		}
+		perun.getFacilitiesManager().getAllowedVos(sess, new Facility());
+		//shouldn't find facility
+	}
 
 	@Test
 	public void getAssignedResources() throws Exception {
@@ -401,13 +398,13 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getAssignedResourcesWhenFacilityNotExists() throws Exception {
-			System.out.println("FacilitiesManager.getAssignedResourcesWhenFacilityNotExists");
+	public void getAssignedResourcesWhenFacilityNotExists() throws Exception {
+		System.out.println("FacilitiesManager.getAssignedResourcesWhenFacilityNotExists");
 
-			perun.getFacilitiesManager().getAssignedResources(sess, new Facility());
-			// shouldn't find facility
+		perun.getFacilitiesManager().getAssignedResources(sess, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void getAssignedRichResources() throws Exception {
@@ -433,13 +430,13 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getAssignedRichResourcesWhenFacilityNotExists() throws Exception {
-			System.out.println("FacilitiesManager.getAssignedRichResourcesWhenFacilityNotExists");
+	public void getAssignedRichResourcesWhenFacilityNotExists() throws Exception {
+		System.out.println("FacilitiesManager.getAssignedRichResourcesWhenFacilityNotExists");
 
-			perun.getFacilitiesManager().getAssignedRichResources(sess, new Facility());
-			// shouldn't find facility
+		perun.getFacilitiesManager().getAssignedRichResources(sess, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void createFacility() throws Exception {
@@ -455,41 +452,41 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityExistsException.class)
-		public void createFacilityWhenFacilityExists() throws Exception {
-			System.out.println("FacilitiesManager.createFacilityWhenFacilityExists");
+	public void createFacilityWhenFacilityExists() throws Exception {
+		System.out.println("FacilitiesManager.createFacilityWhenFacilityExists");
 
-			Facility facility = new Facility();
-			facility.setName("FacilitiesManagerTestFacility");
+		Facility facility = new Facility();
+		facility.setName("FacilitiesManagerTestFacility");
 
-			perun.getFacilitiesManager().createFacility(sess, facility);
-			// shouldn't create same facility twice
+		perun.getFacilitiesManager().createFacility(sess, facility);
+		// shouldn't create same facility twice
 
-		}
+	}
 
 
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void deleteFacility() throws Exception {
-			System.out.println("FacilitiesManager.deleteFacility");
+	public void deleteFacility() throws Exception {
+		System.out.println("FacilitiesManager.deleteFacility");
 
-			perun.getFacilitiesManager().deleteFacility(sess, facility);
-			perun.getFacilitiesManager().deleteFacility(sess, facility);
-			// shouldn't find and delete "deleted facility"
+		perun.getFacilitiesManager().deleteFacility(sess, facility);
+		perun.getFacilitiesManager().deleteFacility(sess, facility);
+		// shouldn't find and delete "deleted facility"
 
-		}
+	}
 
 	@Test (expected=RelationExistsException.class)
-		public void deleteFacilityWhenRelationExist() throws Exception {
-			System.out.println("FacilitiesManager.deleteFacilityWhenRelationExist");
+	public void deleteFacilityWhenRelationExist() throws Exception {
+		System.out.println("FacilitiesManager.deleteFacilityWhenRelationExist");
 
-			Vo vo = setUpVo();
-			// create VO
-			setUpResource(vo);
-			// create Resource for our facility
-			perun.getFacilitiesManager().deleteFacility(sess, facility);
-			// shouldn't delete facility with resource
+		Vo vo = setUpVo();
+		// create VO
+		setUpResource(vo);
+		// create Resource for our facility
+		perun.getFacilitiesManager().deleteFacility(sess, facility);
+		// shouldn't delete facility with resource
 
-		}
+	}
 
 	@Test
 	public void getOwnerFacilities() throws Exception {
@@ -502,13 +499,13 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=OwnerNotExistsException.class)
-		public void getOwnerFacilitiesWhenOwnerNotExists() throws Exception {
-			System.out.println("FacilitiesManager.getOwnerFacilitiesWhenOwnerNotExists");
+	public void getOwnerFacilitiesWhenOwnerNotExists() throws Exception {
+		System.out.println("FacilitiesManager.getOwnerFacilitiesWhenOwnerNotExists");
 
-			perun.getFacilitiesManager().getOwnerFacilities(sess, new Owner());
-			// shouldn't find owner
+		perun.getFacilitiesManager().getOwnerFacilities(sess, new Owner());
+		// shouldn't find owner
 
-		}
+	}
 
 	@Test
 	public void addHosts()throws Exception {
@@ -539,13 +536,13 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void addHostsWhenFacilityNotExists()throws Exception {
-			System.out.println(FACILITIES_MANAGER + ".addHostsWhenFacilityNotExists()");
+	public void addHostsWhenFacilityNotExists()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWhenFacilityNotExists()");
 
-			facilitiesManagerEntry.addHosts(sess, hosts, emptyFac);
-			// shouldn't find facility
+		facilitiesManagerEntry.addHosts(sess, hosts, emptyFac);
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void addHostsWithPattern()throws Exception {
@@ -573,40 +570,40 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test(expected = WrongPatternException.class)
-		public void addHostsWithWrongPattern()throws Exception {
-			System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern()");
+	public void addHostsWithWrongPattern()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern()");
 
-			String hostname = "name[00]-01]surname[99-100]cz";
-			List<String> listOfHosts = new ArrayList<String>();
-			listOfHosts.add(hostname);
-			hostname = "local";
-			listOfHosts.add(hostname);
-			hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
-		}
-
-	@Test(expected = WrongPatternException.class)
-		public void addHostsWithWrongPattern2()throws Exception {
-			System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern2()");
-
-			String hostname = "name[00-a01]surname[99-100]cz";
-			List<String> listOfHosts = new ArrayList<String>();
-			listOfHosts.add(hostname);
-			hostname = "local";
-			listOfHosts.add(hostname);
-			hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
-		}
+		String hostname = "name[00]-01]surname[99-100]cz";
+		List<String> listOfHosts = new ArrayList<String>();
+		listOfHosts.add(hostname);
+		hostname = "local";
+		listOfHosts.add(hostname);
+		hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
+	}
 
 	@Test(expected = WrongPatternException.class)
-		public void addHostsWithWrongPattern3()throws Exception {
-			System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern3()");
+	public void addHostsWithWrongPattern2()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern2()");
 
-			String hostname = "name[01-00]surname[99-100]cz";
-			List<String> listOfHosts = new ArrayList<String>();
-			listOfHosts.add(hostname);
-			hostname = "local";
-			listOfHosts.add(hostname);
-			hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
-		}
+		String hostname = "name[00-a01]surname[99-100]cz";
+		List<String> listOfHosts = new ArrayList<String>();
+		listOfHosts.add(hostname);
+		hostname = "local";
+		listOfHosts.add(hostname);
+		hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
+	}
+
+	@Test(expected = WrongPatternException.class)
+	public void addHostsWithWrongPattern3()throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addHostsWithWrongPattern3()");
+
+		String hostname = "name[01-00]surname[99-100]cz";
+		List<String> listOfHosts = new ArrayList<String>();
+		listOfHosts.add(hostname);
+		hostname = "local";
+		listOfHosts.add(hostname);
+		hosts = facilitiesManagerEntry.addHosts(sess, facility, listOfHosts);
+	}
 
 	@Test
 	public void getHosts()throws Exception{
@@ -647,13 +644,13 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getHostsWhenFacilityNotExists()throws Exception{
-			System.out.println(FACILITIES_MANAGER + ".getHostsFacilityNotExists()");
+	public void getHostsWhenFacilityNotExists()throws Exception{
+		System.out.println(FACILITIES_MANAGER + ".getHostsFacilityNotExists()");
 
-			facilitiesManagerEntry.getHosts(sess, emptyFac);
-			// shouldn't find facility (facility)
+		facilitiesManagerEntry.getHosts(sess, emptyFac);
+		// shouldn't find facility (facility)
 
-		}
+	}
 
 	@Test
 	public void removeHosts()throws Exception{
@@ -669,12 +666,12 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void removeHostsWhenFacilityNotExists()throws Exception{
-			System.out.println(FACILITIES_MANAGER + ".removeHostsWhenFacilityNotExists()");
+	public void removeHostsWhenFacilityNotExists()throws Exception{
+		System.out.println(FACILITIES_MANAGER + ".removeHostsWhenFacilityNotExists()");
 
-			facilitiesManagerEntry.removeHosts(sess, hosts, emptyFac);
-			// shouldn't find facility
-		}
+		facilitiesManagerEntry.removeHosts(sess, hosts, emptyFac);
+		// shouldn't find facility
+	}
 
 	@Test
 	public void getFacilitiesCount() throws Exception {
@@ -696,13 +693,13 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getHostsCountWhenFacilityNotExists()throws Exception{
-			System.out.println(FACILITIES_MANAGER + ".getHostsCountWhenFacilityNotExists()");
+	public void getHostsCountWhenFacilityNotExists()throws Exception{
+		System.out.println(FACILITIES_MANAGER + ".getHostsCountWhenFacilityNotExists()");
 
-			assertEquals(facilitiesManagerEntry.getHostsCount(sess, emptyFac), 1);
-			// shouldn't find facility
+		assertEquals(facilitiesManagerEntry.getHostsCount(sess, emptyFac), 1);
+		// shouldn't find facility
 
-		}
+	}
 
 
 	@Test
@@ -757,7 +754,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		candidate.setTitleBefore("");
 		candidate.setTitleAfter("");
 		UserExtSource userExtSource = new UserExtSource(new ExtSource(0, "testExtSource",
-					"cz.metacentrum.perun.core.impl.ExtSourceInternal"), Long.toHexString(Double.doubleToLongBits(Math.random())));
+				"cz.metacentrum.perun.core.impl.ExtSourceInternal"), Long.toHexString(Double.doubleToLongBits(Math.random())));
 		candidate.setUserExtSource(userExtSource);
 		candidate.setAttributes(new HashMap<String,String>());
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -1,16 +1,17 @@
 package cz.metacentrum.perun.core.entry;
 
-import java.lang.Class;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -52,14 +53,12 @@ import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
+ * Integration tests of FacilitiesManager
+ *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-
 public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	final Facility facility = new Facility(); // always in DB
@@ -183,7 +182,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		System.out.println("FacilitiesManager.getFacilities");
 
 		List<Facility> facilities = perun.getFacilitiesManager().getFacilities(sess);
-		assertTrue("at least one facility should exists",facilities.size() > 0);
+		assertTrue("at least one facility should exists", facilities.size() > 0);
 		assertTrue("created facility should exist between others", facilities.contains(facility));
 
 	}
@@ -345,8 +344,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2);
 
 		List<User> users = perun.getFacilitiesManager().getAllowedUsers(sess, facility);
-		assertTrue("our facility should have 1 allowed user",users.size() == 1);
-		assertTrue("our user should be between allowed on facility",users.contains(user));
+		assertTrue("our facility should have 1 allowed user", users.size() == 1);
+		assertTrue("our user should be between allowed on facility", users.contains(user));
 
 	}
 
@@ -933,6 +932,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForUser() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForUser");
+
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 
@@ -949,6 +950,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForGroup() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForGroup");
+
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
 
@@ -965,6 +968,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForOwner() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForOwner");
+
 		Member member = setUpMember(vo);
 
 		String contactGroupName = "testContactGroup01";
@@ -980,6 +985,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForAll1() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForAll1");
+
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -1002,6 +1009,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void addFacilityContactForAll2() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".addFacilityContactForAll2");
+
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -1024,6 +1033,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAllContactGroupNames() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".getAllContactGroupNames");
+
 		String contactGroupName1 = "testContactGroup01";
 		String contactGroupName2 = "testContactGroup02";
 		String contactGroupName3 = "testContactGroup03";
@@ -1045,6 +1056,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeFacilityContactForUser() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".removeFacilityContactForUser");
+
 		Member member = setUpMember(vo);
 		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 
@@ -1065,6 +1078,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeFacilityContactForGroup() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".removeFacilityContactForGroup");
+
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
 
@@ -1085,6 +1100,8 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeFacilityContactForOwner() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".removeFacilityContactForOwner");
+
 		Member member = setUpMember(vo);
 
 		String contactGroupName = "testContactGroup01";
@@ -1104,6 +1121,7 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void removeAllFacilityContacts() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".removeAllFacilityContacts");
 
 		String contactGroupName1 = "testContactGroup01";
 		String contactGroupName2 = "testContactGroup02";
@@ -1131,72 +1149,90 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 	@Test
 	public void getAssignedSecurityTeams() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".getAssignedSecurityTeams");
+
 		List<SecurityTeam> expected = new ArrayList<>();
 		expected.add(setUpSecurityTeam0());
 		expected.add(setUpSecurityTeam1());
 		setUpAssignSecurityTeams(facility, expected);
 		setUpSecurityTeam2();
 		List<SecurityTeam> actual = facilitiesManagerEntry.getAssignedSecurityTeams(sess, facility);
-
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test
 	public void getAssignedSecurityTeamsEmpty() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".getAssignedSecurityTeamsEmpty");
+
 		List<SecurityTeam> expected = new ArrayList<>();
 		setUpAssignSecurityTeams(facility, expected);
 		setUpSecurityTeam0();
 		setUpSecurityTeam1();
 		setUpSecurityTeam2();
 		List<SecurityTeam> actual = facilitiesManagerEntry.getAssignedSecurityTeams(sess, facility);
-
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test(expected = FacilityNotExistsException.class)
 	public void getAssignedSecurityTeamsFacilityNotExists() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".getAssignedSecurityTeamsFacilityNotExists");
 		setUpSecurityTeam0();
 		setUpSecurityTeam1();
-		facilitiesManagerEntry.getAssignedSecurityTeams(sess, new Facility(11, "Name"));
+		// should throw an exception
+		facilitiesManagerEntry.getAssignedSecurityTeams(sess, new Facility(0, "Name"));
 	}
 
 	@Test
 	public void assignSecurityTeam() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".assignSecurityTeam");
+
 		SecurityTeam st0 = setUpSecurityTeam0();
 		setUpSecurityTeam1();
 		facilitiesManagerEntry.assignSecurityTeam(sess, facility, st0);
 
 		List<SecurityTeam> actual = facilitiesManagerEntry.getAssignedSecurityTeams(sess, facility);
-
-		if (actual.size() != 1) {
-			fail();
-		}
-		if (!actual.contains(st0)) {
-			fail();
-		}
+		assertTrue("Facility should have only 1 security team.", actual.size() == 1);
+		assertTrue("Expected security team is not assigned to facility.", actual.contains(st0));
 	}
+
 	@Test(expected = FacilityNotExistsException.class)
 	public void assignSecurityTeamFacilityNotExists() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".assignSecurityTeamFacilityNotExists");
 		SecurityTeam st0 = setUpSecurityTeam0();
 		setUpSecurityTeam1();
-		facilitiesManagerEntry.assignSecurityTeam(sess, new Facility(11, "Name"), st0);
+		// should throw an exception
+		facilitiesManagerEntry.assignSecurityTeam(sess, new Facility(0, "Name"), st0);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void assignSecurityTeamSecurityTeamNotExists() throws Exception {
-		facilitiesManagerEntry.assignSecurityTeam(sess, facility, new SecurityTeam(11, "name", "dsc"));
+		System.out.println(FACILITIES_MANAGER + ".assignSecurityTeamSecurityTeamNotExists");
+		// should throw an exception
+		facilitiesManagerEntry.assignSecurityTeam(sess, facility, new SecurityTeam(0, "name", "dsc"));
 	}
+
 	@Test(expected = SecurityTeamAlreadyAssignedException.class)
 	public void assignSecurityTeamAlreadyAssigned() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".assignSecurityTeamAlreadyAssigned");
+
 		SecurityTeam st0 = setUpSecurityTeam0();
 		List<SecurityTeam> expected = new ArrayList<>();
 		expected.add(st0);
 		expected.add(setUpSecurityTeam1());
 		setUpAssignSecurityTeams(facility, expected);
 		setUpSecurityTeam2();
-
+		// should throw an exception
 		facilitiesManagerEntry.assignSecurityTeam(sess, facility, st0);
 	}
 
 	@Test
 	public void removeSecurityTeam() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".removeSecurityTeam");
+
 		SecurityTeam st0 = setUpSecurityTeam0();
 		SecurityTeam st1 = setUpSecurityTeam1();
 		List<SecurityTeam> expected = new ArrayList<>();
@@ -1208,39 +1244,44 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		expected.remove(st0);
 
 		List<SecurityTeam> actual = facilitiesManagerEntry.getAssignedSecurityTeams(sess, facility);
+		assertTrue("Facility should have only 1 security team.", actual.size() == 1);
+		assertTrue("Facility shouldn't have security team 0 assigned.", !actual.contains(st0));
+		assertTrue("Facility should have security team 1 assigned.", actual.contains(st1));
 
-		if (actual.size() != 1) {
-			fail();
-		}
-		if (actual.contains(st0)) {
-			fail();
-		}
-		if (!actual.contains(st1)) {
-			fail();
-		}
 	}
+
 	@Test(expected = FacilityNotExistsException.class)
 	public void removeSecurityTeamFacilityNotExists() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".removeSecurityTeamFacilityNotExists");
+
 		SecurityTeam st0 = setUpSecurityTeam0();
 		setUpSecurityTeam1();
-		facilitiesManagerEntry.removeSecurityTeam(sess, new Facility(11, "Name"), st0);
+		// should throw an exception
+		facilitiesManagerEntry.removeSecurityTeam(sess, new Facility(0, "Name"), st0);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void removeSecurityTeamSecurityTeamNotExists() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".removeSecurityTeamSecurityTeamNotExists");
+
 		List<SecurityTeam> expected = new ArrayList<>();
 		expected.add(setUpSecurityTeam0());
 		expected.add(setUpSecurityTeam1());
 		setUpAssignSecurityTeams(facility, expected);
 		setUpSecurityTeam2();
-		facilitiesManagerEntry.removeSecurityTeam(sess, facility, new SecurityTeam(11, "name", "dsc"));
+		// should throw an exception
+		facilitiesManagerEntry.removeSecurityTeam(sess, facility, new SecurityTeam(0, "name", "dsc"));
 	}
+
 	@Test(expected = SecurityTeamNotAssignedException.class)
 	public void removeSecurityTeamNotAssigned() throws Exception {
+		System.out.println(FACILITIES_MANAGER + ".removeSecurityTeamNotAssigned");
+
 		List<SecurityTeam> expected = new ArrayList<>();
 		expected.add(setUpSecurityTeam0());
 		expected.add(setUpSecurityTeam1());
 		setUpAssignSecurityTeams(facility, expected);
-
+		// should throw an exception
 		facilitiesManagerEntry.removeSecurityTeam(sess, facility, setUpSecurityTeam2());
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -43,9 +43,13 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 
 /**
+ * Integration tests of GroupsManager
+ *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
 public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
+
+	private final static String CLASS_NAME = "GroupsManager.";
 
 	// these must be setUp"type" before every method to be in DB
 	final ExtSource extSource = new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal");
@@ -76,7 +80,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getGroupsWithAssignedExtSourceInVo() throws Exception {
-		System.out.println("GroupsManager.getGroupsWithAssignedExtSourceInVo()");
+		System.out.println(CLASS_NAME + "getGroupsWithAssignedExtSourceInVo");
 
 		vo = setUpVo();
 		groupsManagerBl.createGroup(sess, vo, group);
@@ -84,7 +88,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 		ExtSource newExtSource = new ExtSource("ExtSourcesManagerEntryIntegrationTest1", ExtSourcesManager.EXTSOURCE_INTERNAL);
 		newExtSource = perun.getExtSourcesManager().createExtSource(sess, newExtSource);
-		
+
 		perun.getExtSourcesManagerBl().addExtSource(sess, vo, newExtSource);
 
 		perun.getExtSourcesManagerBl().addExtSource(sess, group, newExtSource);
@@ -98,7 +102,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getGroupsUsers() throws Exception {
-		System.out.println("GroupsManager.getGroupsUsers");
+		System.out.println(CLASS_NAME + "getGroupsUsers");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -116,7 +120,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void testGroupNameLength() throws Exception {
-		System.out.println("GroupsManager.testGroupNameLength");
+		System.out.println(CLASS_NAME + "testGroupNameLength");
 
 		Vo vo = setUpVo();
 
@@ -152,7 +156,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void createGroup() throws Exception {
-		System.out.println("GroupsManager.createGroup");
+		System.out.println(CLASS_NAME + "createGroup");
 
 		vo = setUpVo();
 
@@ -163,73 +167,73 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void createGroupWhenParentNotExist() throws Exception {
-			System.out.println("GroupsManager.createGroupWhenParentNotExists");
+	public void createGroupWhenParentNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "createGroupWhenParentNotExists");
 
-			groupsManager.createGroup(sess, new Group(), new Group("GroupsManagerTestGroup2","testovaci2"));
+		groupsManager.createGroup(sess, new Group(), new Group("GroupsManagerTestGroup2","testovaci2"));
 
-		}
-	
+	}
+
 	@Test (expected=GroupExistsException.class)
-		public void createGroupWhenTheSameWithTheSameParentGroupExists() throws Exception {
-			System.out.println("GroupsManager.createGroupWhenTheSameWithTheSameParentGroupExists");
+	public void createGroupWhenTheSameWithTheSameParentGroupExists() throws Exception {
+		System.out.println(CLASS_NAME + "createGroupWhenTheSameWithTheSameParentGroupExists");
 
-			vo = setUpVo();
-			Group parentG = new Group("TestingParentGroup01", "testingParentGroup01");
-			groupsManager.createGroup(sess, vo, parentG);
-			Group g1 = new Group("TestingChildGroup01","TestingChildGroup01");
-			Group g2 = new Group("TestingChildGroup01","TestingChildGroup02");
-			groupsManager.createGroup(sess, parentG, g1);
-			groupsManager.createGroup(sess, parentG, g2);
-		}
+		vo = setUpVo();
+		Group parentG = new Group("TestingParentGroup01", "testingParentGroup01");
+		groupsManager.createGroup(sess, vo, parentG);
+		Group g1 = new Group("TestingChildGroup01","TestingChildGroup01");
+		Group g2 = new Group("TestingChildGroup01","TestingChildGroup02");
+		groupsManager.createGroup(sess, parentG, g1);
+		groupsManager.createGroup(sess, parentG, g2);
+	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void createGroupWhenVoNotExist() throws Exception {
-			System.out.println("GroupsManager.createGroupWhenVoNotExists");
+	public void createGroupWhenVoNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "createGroupWhenVoNotExists");
 
-			groupsManager.createGroup(sess, new Vo(), new Group("GroupsManagerTestGroup2","testovaci2"));
+		groupsManager.createGroup(sess, new Vo(), new Group("GroupsManagerTestGroup2","testovaci2"));
 
-		}
+	}
 
 	@Test (expected=GroupExistsException.class)
-		public void createGroupWhenSameGroupExist() throws Exception {
-			System.out.println("GroupsManager.createGroupWhenSameGroupExists");
+	public void createGroupWhenSameGroupExist() throws Exception {
+		System.out.println(CLASS_NAME + "createGroupWhenSameGroupExists");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			groupsManager.createGroup(sess, vo, group);
-			// shouldn't be able to create group with same name
-		}
+		groupsManager.createGroup(sess, vo, group);
+		// shouldn't be able to create group with same name
+	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void deleteGroup() throws Exception {
-			System.out.println("GroupsManager.deleteGroup");
+	public void deleteGroup() throws Exception {
+		System.out.println(CLASS_NAME + "deleteGroup");
 
-			vo = setUpVo();
-			setUpGroup(vo);
-			// assertNotNull(groupsManager.createGroup(sess, group, group2));
-			// create sub-group
-			groupsManager.deleteGroup(sess, group);
-			// delete group including sub-group
-			groupsManager.getGroupById(sess, group.getId());
-			// shouldn't find group
+		vo = setUpVo();
+		setUpGroup(vo);
+		// assertNotNull(groupsManager.createGroup(sess, group, group2));
+		// create sub-group
+		groupsManager.deleteGroup(sess, group);
+		// delete group including sub-group
+		groupsManager.getGroupById(sess, group.getId());
+		// shouldn't find group
 
-		}
-	
+	}
+
 	@Test
 	public void deletesGroups() throws Exception {
-		System.out.println("GroupsManager.deletesGroups");
+		System.out.println(CLASS_NAME + "deletesGroups");
 		Vo newVo = new Vo(0, "voForDeletingGroups", "voForDeletingGroups");
 		newVo = perun.getVosManagerBl().createVo(sess, newVo);
 		List<Group> groups = setUpGroupsWithSubgroups(newVo);
-		
+
 		this.groupsManager.deleteGroups(sess, groups, false);
 	}
 
 	@Test (expected=RelationExistsException.class)
 	public void deleteGroupsWithSubgroupAndNoForceDelete() throws Exception {
-		System.out.println("GroupsManager.deleteGroupsWithSubgroupAndNoForceDelete");
+		System.out.println(CLASS_NAME + "deleteGroupsWithSubgroupAndNoForceDelete");
 		Vo newVo = new Vo(0, "voForDeletingGroups", "voForDeletingGroups");
 		newVo = perun.getVosManagerBl().createVo(sess, newVo);
 		List<Group> groups = setUpGroupsWithSubgroups(newVo);
@@ -241,27 +245,27 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 //		});
 		this.groupsManager.deleteGroups(sess, groups, false);
 	}
-	
+
 	@Test
 	public void deleteGroupsWithSubgroupAndForceDelete() throws Exception {
-		System.out.println("GroupsManager.deleteGroupsWithSubgroupAndForceDelete");
+		System.out.println(CLASS_NAME + "deleteGroupsWithSubgroupAndForceDelete");
 		Vo newVo = new Vo(0, "voForDeletingGroups", "voForDeletingGroups");
 		newVo = perun.getVosManagerBl().createVo(sess, newVo);
 		List<Group> groups = setUpGroupsWithSubgroups(newVo);
-	
+
 		Group subgroup = new Group("Test", "test");
 		subgroup = this.groupsManagerBl.createGroup(sess, groups.get(0), subgroup);
-		
+
 		this.groupsManager.deleteGroups(sess, groups, true);
 	}
-	
+
 	@Test (expected=GroupNotExistsException.class)
-		public void deleteGroupWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.deleteGroupWhenGroupNotExists");
+	public void deleteGroupWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteGroupWhenGroupNotExists");
 
-			groupsManager.deleteGroup(sess, new Group());
+		groupsManager.deleteGroup(sess, new Group());
 
-		}
+	}
 
 	@Test
 	public void trywhat(){
@@ -269,45 +273,45 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=RelationExistsException.class)
-		public void deleteGroupWhenContainsMember() throws Exception {
-			System.out.println("GroupsManager.deleteGroupWhenContainsMember");
+	public void deleteGroupWhenContainsMember() throws Exception {
+		System.out.println(CLASS_NAME + "deleteGroupWhenContainsMember");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			Member member = setUpMember(vo);
-			groupsManager.addMember(sess, group, member);
+		Member member = setUpMember(vo);
+		groupsManager.addMember(sess, group, member);
 
-			groupsManager.deleteGroup(sess, group);
+		groupsManager.deleteGroup(sess, group);
 
-		}
-
-	@Test (expected=GroupNotExistsException.class)
-		public void deleteGroupForce() throws Exception {
-			System.out.println("GroupsManager.deleteGroupForce");
-
-			vo = setUpVo();
-			setUpGroup(vo);
-
-			Member member = setUpMember(vo);
-			groupsManager.addMember(sess, group, member);
-			assertNotNull(groupsManager.createGroup(sess, group, group2)); // create sub-group
-			groupsManager.deleteGroup(sess, group, true); // force delete
-			groupsManager.getGroupById(sess, group2.getId()); // shouldn't find our sub-group even when parent had member
-
-		}
+	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void deleteGroupForceWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.deleteGroupForceWhenGroupNotExists");
+	public void deleteGroupForce() throws Exception {
+		System.out.println(CLASS_NAME + "deleteGroupForce");
 
-			groupsManager.deleteGroup(sess, new Group(), true);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-		}
+		Member member = setUpMember(vo);
+		groupsManager.addMember(sess, group, member);
+		assertNotNull(groupsManager.createGroup(sess, group, group2)); // create sub-group
+		groupsManager.deleteGroup(sess, group, true); // force delete
+		groupsManager.getGroupById(sess, group2.getId()); // shouldn't find our sub-group even when parent had member
+
+	}
+
+	@Test (expected=GroupNotExistsException.class)
+	public void deleteGroupForceWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteGroupForceWhenGroupNotExists");
+
+		groupsManager.deleteGroup(sess, new Group(), true);
+
+	}
 
 	@Test
 	public void deleteAllGroups() throws Exception {
-		System.out.println("GroupsManager.deleteAllGroups");
+		System.out.println(CLASS_NAME + "deleteAllGroups");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -321,7 +325,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test(expected=VoNotExistsException.class)
 	public void deleteAllGroupsWhenVoNotExists() throws Exception {
-		System.out.println("GroupsManager.deleteAllGroupsWhenVoNotExists");
+		System.out.println(CLASS_NAME + "deleteAllGroupsWhenVoNotExists");
 
 		groupsManager.deleteAllGroups(sess, new Vo());
 
@@ -329,7 +333,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void updateGroup() throws Exception {
-		System.out.println("GroupsManager.updateGroup");
+		System.out.println(CLASS_NAME + "updateGroup");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -342,17 +346,17 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void updateGroupWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.updateGroupWhenGroupNotExists");
+	public void updateGroupWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "updateGroupWhenGroupNotExists");
 
-			groupsManager.updateGroup(sess, new Group());
-			// shouldn't be able to update
+		groupsManager.updateGroup(sess, new Group());
+		// shouldn't be able to update
 
-		}
+	}
 
 	@Test
 	public void getGroupById() throws Exception {
-		System.out.println("GroupsManager.getGroupById");
+		System.out.println(CLASS_NAME + "getGroupById");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -365,7 +369,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getAssignedGroupsToResourceWithSubgroups() throws Exception {
-		System.out.println("GroupsManager.getAssignedGroupsToResourceWithSubgroups");
+		System.out.println(CLASS_NAME + "getAssignedGroupsToResourceWithSubgroups");
 		Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0, "testik123", "testik123"));
 		Group parentGroup = new Group("TestGroupParent", "ParentGroup");
 		Group subgroup1 = new Group("TestGroup1", "Test1");
@@ -395,18 +399,18 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		assertTrue("Expected this group is contained in list.",groupsList.remove(subgroupOfSubgroup1));
 		assertTrue(groupsList.isEmpty());
 	}
-	
+
 	@Test
 	public void getMemberGroupsByAttribute() throws Exception {
-		System.out.println("GroupsManager.getMemberGroupsByAttribute");
+		System.out.println(CLASS_NAME + "getMemberGroupsByAttribute");
 		Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0, "testik123456", "testik123456"));
 		Member member = setUpMember(createdVo);
-		
+
 		Group group1 = new Group("Group1Test", "Group1Test");
 		Group group2 = new Group("Group2Test", "Group2Test");
 		Group group3 = new Group("Group3Test", "Group3Test");
 		Group group4 = new Group("Group4Test", "Group4Test");
-		
+
 		group1 = groupsManagerBl.createGroup(sess, createdVo, group1);
 		group2 = groupsManagerBl.createGroup(sess, createdVo, group2);
 		group3 = groupsManagerBl.createGroup(sess, createdVo, group3);
@@ -415,7 +419,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		groupsManagerBl.addMember(sess, group2, member);
 		groupsManagerBl.addMember(sess, group3, member);
 		groupsManagerBl.addMember(sess, group4, member);
-		
+
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setNamespace(AttributesManagerEntry.NS_GROUP_ATTR_DEF);
 		attrDef.setDescription("Test attribute description");
@@ -424,10 +428,10 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
 		Attribute attribute = new Attribute(attrDef);
 		attribute.setValue("Testing value");
-		
+
 		perun.getAttributesManagerBl().setAttribute(sess, group1, attribute);
 		perun.getAttributesManagerBl().setAttribute(sess, group3, attribute);
-		
+
 		AttributeDefinition attrDefBad = new AttributeDefinition();
 		attrDefBad.setNamespace(AttributesManagerEntry.NS_GROUP_ATTR_DEF);
 		attrDefBad.setDescription("Test attribute description 2");
@@ -436,13 +440,13 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		attrDefBad = perun.getAttributesManagerBl().createAttribute(sess, attrDefBad);
 		Attribute attributeBad = new Attribute(attrDefBad);
 		attributeBad.setValue("Testing value");
-		
+
 		perun.getAttributesManagerBl().setAttribute(sess, group2, attributeBad);
 		perun.getAttributesManagerBl().setAttribute(sess, group4, attributeBad);
-		
+
 		List<Group> groups1 = perun.getGroupsManager().getMemberGroupsByAttribute(sess, member, attribute);
 		List<Group> groups2 = perun.getGroupsManager().getMemberGroupsByAttribute(sess, member, attributeBad);
-		
+
 		assertEquals("groups must have only 2 mambers", 2, groups1.size());
 		assertEquals("groups must have only 2 mambers", 2, groups2.size());
 		assertTrue("list of groups must containt this group", groups1.contains(group1));
@@ -453,7 +457,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getAssignedGroupsToResourceWithoutSubgroups() throws Exception {
-		System.out.println("GroupsManager.getAssignedGroupsToResourceWithoutSubgroups");
+		System.out.println(CLASS_NAME + "getAssignedGroupsToResourceWithoutSubgroups");
 		Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0, "testik123", "testik123"));
 		Group parentGroup = new Group("TestGroupParent", "ParentGroup");
 		Group subgroup1 = new Group("TestGroup1", "Test1");
@@ -482,7 +486,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getGroupToSynchronize() throws Exception {
-		System.out.println("GroupsManager.getGroupToSynchronize");
+		System.out.println(CLASS_NAME + "getGroupToSynchronize");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -509,20 +513,20 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getGroupByIdWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.getGroupByIdWhenGroupNotExists");
+	public void getGroupByIdWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupByIdWhenGroupNotExists");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			group.setId(0);
-			groupsManager.getGroupById(sess, group.getId());
+		group.setId(0);
+		groupsManager.getGroupById(sess, group.getId());
 
-		}
+	}
 
 	@Test
 	public void getGroupByName() throws Exception {
-		System.out.println("GroupsManager.getGroupByName");
+		System.out.println(CLASS_NAME + "getGroupByName");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -535,7 +539,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getSubGroupByName() throws Exception {
-		System.out.println("GroupsManager.getSubGroupByName");
+		System.out.println(CLASS_NAME + "getSubGroupByName");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -554,7 +558,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test (expected=VoNotExistsException.class)
 	public void getGroupByNameWhenVoNotExists() throws Exception {
-		System.out.println("GroupsManager.getGroupByNameWhenVoNotExists");
+		System.out.println(CLASS_NAME + "getGroupByNameWhenVoNotExists");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -574,7 +578,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void addMember() throws Exception {
-		System.out.println("GroupsManager.addMember");
+		System.out.println(CLASS_NAME + "addMember");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -591,67 +595,67 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	// FIXME - vymyslet lepší výjímku
 
 	@Test (expected=InternalErrorException.class)
-		public void addMemberWhenMemberFromDifferentVo() throws Exception {
-			System.out.println("GroupsManager.addMemberWhenMemberFromDifferentVo");
+	public void addMemberWhenMemberFromDifferentVo() throws Exception {
+		System.out.println(CLASS_NAME + "addMemberWhenMemberFromDifferentVo");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			Vo vo = new Vo();
-			vo.setName("GroupManagerTestVo2");
-			vo.setShortName("GrpManTest2");
-			vo = perun.getVosManager().createVo(sess, vo);
+		Vo vo = new Vo();
+		vo.setName("GroupManagerTestVo2");
+		vo.setShortName("GrpManTest2");
+		vo = perun.getVosManager().createVo(sess, vo);
 
-			Member member = setUpMember(vo); // put member in different VO
+		Member member = setUpMember(vo); // put member in different VO
 
-			groupsManager.addMember(sess, group, member);
-			// shouldn't add member
+		groupsManager.addMember(sess, group, member);
+		// shouldn't add member
 
-		}
+	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void addMemberWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.addMemberWhenGroupNotExists");
+	public void addMemberWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addMemberWhenGroupNotExists");
 
-			vo = setUpVo();
-			setUpGroup(vo);
-			Member member = setUpMember(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
+		Member member = setUpMember(vo);
 
-			groupsManager.addMember(sess, new Group(), member);
-			// shouldn't find group
+		groupsManager.addMember(sess, new Group(), member);
+		// shouldn't find group
 
-		}
+	}
 
 	@Test (expected=MemberNotExistsException.class)
-		public void addMemberWhenMemberNotExists() throws Exception {
-			System.out.println("GroupsManager.addMemberWhenGroupNotExists");
+	public void addMemberWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addMemberWhenGroupNotExists");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			groupsManager.addMember(sess, group, new Member());
-			// shouldn't find member
+		groupsManager.addMember(sess, group, new Member());
+		// shouldn't find member
 
-		}
+	}
 
 	@Test (expected=AlreadyMemberException.class)
-		public void addMemberWhenAlreadyMember() throws Exception {
-			System.out.println("GroupsManager.addMemberWhenAlreadyMember");
+	public void addMemberWhenAlreadyMember() throws Exception {
+		System.out.println(CLASS_NAME + "addMemberWhenAlreadyMember");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			Member member = setUpMember(vo);
+		Member member = setUpMember(vo);
 
-			groupsManager.addMember(sess, group, member);
-			groupsManager.addMember(sess, group, member);
-			// shouldn't be able to add same member twice
+		groupsManager.addMember(sess, group, member);
+		groupsManager.addMember(sess, group, member);
+		// shouldn't be able to add same member twice
 
-		}
+	}
 
 	@Test
 	public void removeMember() throws Exception {
-		System.out.println("GroupsManager.removeMember");
+		System.out.println(CLASS_NAME + "removeMember");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -666,43 +670,43 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void removeMemberWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.removeMemberWhenGroupNotExists");
+	public void removeMemberWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberWhenGroupNotExists");
 
-			vo = setUpVo();
-			Member member = setUpMember(vo);
-			groupsManager.removeMember(sess, new Group(), member);
+		vo = setUpVo();
+		Member member = setUpMember(vo);
+		groupsManager.removeMember(sess, new Group(), member);
 
-		}
+	}
 
 	@Test (expected=MemberNotExistsException.class)
-		public void removeMemberWhenMemberNotExists() throws Exception {
-			System.out.println("GroupsManager.removeMemberWhenMemberNotExists");
+	public void removeMemberWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberWhenMemberNotExists");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			groupsManager.removeMember(sess, group, new Member());
+		groupsManager.removeMember(sess, group, new Member());
 
-		}
+	}
 
 	@Test (expected=NotGroupMemberException.class)
-		public void removeMemberWhenNotGroupMember() throws Exception {
-			System.out.println("GroupsManager.removeMemberWhenNotGroupMember");
+	public void removeMemberWhenNotGroupMember() throws Exception {
+		System.out.println(CLASS_NAME + "removeMemberWhenNotGroupMember");
 
-			vo = setUpVo();
-			setUpGroup(vo);
-			Member member = setUpMember(vo);
-			groupsManager.addMember(sess, group, member);
-			groupsManager.removeMember(sess, group, member);
-			groupsManager.removeMember(sess, group, member);
-			// shouldn't be able to remove member twice
+		vo = setUpVo();
+		setUpGroup(vo);
+		Member member = setUpMember(vo);
+		groupsManager.addMember(sess, group, member);
+		groupsManager.removeMember(sess, group, member);
+		groupsManager.removeMember(sess, group, member);
+		// shouldn't be able to remove member twice
 
-		}
+	}
 
 	@Test
 	public void getGroupMembers() throws Exception {
-		System.out.println("GroupsManager.getGroupMembers");
+		System.out.println(CLASS_NAME + "getGroupMembers");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -718,7 +722,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getMemberGroups() throws Exception {
-		System.out.println("GroupsManager.getMemberGroups");
+		System.out.println(CLASS_NAME + "getMemberGroups");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -737,24 +741,24 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getGroupMembersWhenGroupNotExist() throws Exception {
-			System.out.println("GroupsManager.getGroupMembersWhenGroupNotExist");
+	public void getGroupMembersWhenGroupNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersWhenGroupNotExist");
 
-			groupsManager.getGroupMembers(sess, new Group());
+		groupsManager.getGroupMembers(sess, new Group());
 
-		}
+	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getGroupMembersPageWhenGroupNotExist() throws Exception {
-			System.out.println("GroupsManager.getGroupMembersPageWhenGroupNotExist");
+	public void getGroupMembersPageWhenGroupNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersPageWhenGroupNotExist");
 
-			groupsManager.getGroupMembers(sess, new Group());
+		groupsManager.getGroupMembers(sess, new Group());
 
-		}
+	}
 
 	@Test
 	public void getGroupMembersCount() throws Exception {
-		System.out.println("GroupsManager.getGroupMembersCount");
+		System.out.println(CLASS_NAME + "getGroupMembersCount");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -768,16 +772,16 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getGroupMembersCountWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.getGroupMembersCountWhenGroupNotExists");
+	public void getGroupMembersCountWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupMembersCountWhenGroupNotExists");
 
-			groupsManager.getGroupMembersCount(sess, new Group());
+		groupsManager.getGroupMembersCount(sess, new Group());
 
-		}
+	}
 
 	@Test
 	public void getAllGroups() throws Exception {
-		System.out.println("GroupsManager.getAllGroups");
+		System.out.println(CLASS_NAME + "getAllGroups");
 
 		vo = setUpVo();
 
@@ -796,16 +800,16 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getAllGroupsWhenVoNotExists() throws Exception {
-			System.out.println("GroupsManager.getAllGroupsWhenVoNotExists");
+	public void getAllGroupsWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getAllGroupsWhenVoNotExists");
 
-			groupsManager.getAllGroups(sess, new Vo());
+		groupsManager.getAllGroups(sess, new Vo());
 
-		}
+	}
 
 	@Test
 	public void getParentGroup() throws Exception {
-		System.out.println("GroupsManager.getParentGroup");
+		System.out.println(CLASS_NAME + "getParentGroup");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -820,7 +824,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getParentGroupWhenParentGroupNotExists() throws Exception {
-		System.out.println("GroupsManager.getParentGroupWhenParentGroupNotExists");
+		System.out.println(CLASS_NAME + "getParentGroupWhenParentGroupNotExists");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -833,7 +837,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getSubGroups() throws Exception {
-		System.out.println("GroupsManager.getSubGroups");
+		System.out.println(CLASS_NAME + "getSubGroups");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -847,12 +851,12 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 		assertTrue(groups.size() == 1);
 		assertTrue(groups.contains(createdGroup21));
-		
+
 	}
 
 	@Test
 	public void getAllSubGroups() throws Exception {
-		System.out.println("GroupsManager.getAllSubGroups");
+		System.out.println(CLASS_NAME + "getAllSubGroups");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -873,24 +877,24 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getSubGroupsWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.getSubGroupsWhenGroupNotExists");
+	public void getSubGroupsWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getSubGroupsWhenGroupNotExists");
 
-			groupsManager.getSubGroups(sess, new Group());
+		groupsManager.getSubGroups(sess, new Group());
 
-		}
+	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getSubGroupsPageWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.getSubGroupsPageWhenGroupNotExists");
+	public void getSubGroupsPageWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getSubGroupsPageWhenGroupNotExists");
 
-			groupsManager.getSubGroups(sess, new Group());
+		groupsManager.getSubGroups(sess, new Group());
 
-		}
+	}
 
 	@Test
 	public void addAdmin() throws Exception {
-		System.out.println("GroupsManager.addAdmin");
+		System.out.println(CLASS_NAME + "addAdmin");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -906,47 +910,47 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void addAdminWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.addAdminWhenGroupNotExists");
+	public void addAdminWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addAdminWhenGroupNotExists");
 
-			vo = setUpVo();
+		vo = setUpVo();
 
-			Member member = setUpMember(vo);
-			User user = perun.getUsersManagerBl().getUserByMember(sess, member);
-			groupsManager.addAdmin(sess, new Group(), user);
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		groupsManager.addAdmin(sess, new Group(), user);
 
-		}
+	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void addAdminWhenUserNotExists() throws Exception {
-			System.out.println("GroupsManager.addAdminWhenGroupNotExists");
+	public void addAdminWhenUserNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addAdminWhenGroupNotExists");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			groupsManager.addAdmin(sess, group, new User());
+		groupsManager.addAdmin(sess, group, new User());
 
-		}
+	}
 
 	@Test (expected=AlreadyAdminException.class)
-		public void addAdminWhenAlreadyAdmin() throws Exception {
-			System.out.println("GroupsManager.addAdminWhenAlreadyAdmin");
-			
-			vo = setUpVo();
-			setUpGroup(vo);
+	public void addAdminWhenAlreadyAdmin() throws Exception {
+		System.out.println(CLASS_NAME + "addAdminWhenAlreadyAdmin");
 
-			Member member = setUpMember(vo);
-			User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			groupsManager.addAdmin(sess, group, user);
-			groupsManager.addAdmin(sess, group, user);
-			// shouldn't add admin twice !!
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
 
-		}
+		groupsManager.addAdmin(sess, group, user);
+		groupsManager.addAdmin(sess, group, user);
+		// shouldn't add admin twice !!
+
+	}
 
 	@Test
 	public void addAdminWithGroup() throws Exception {
-		System.out.println("GroupsManager.addAdminWithGroup");
+		System.out.println(CLASS_NAME + "addAdminWithGroup");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -965,7 +969,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void removeAdmin() throws Exception {
-		System.out.println("GroupsManager.removeAdmins");
+		System.out.println(CLASS_NAME + "removeAdmins");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -981,44 +985,44 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void removeAdminWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.removeAdminsWhenGroupNotExists");
+	public void removeAdminWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeAdminsWhenGroupNotExists");
 
-			vo = setUpVo();
+		vo = setUpVo();
 
-			Member member = setUpMember(vo);
-			User user = perun.getUsersManagerBl().getUserByMember(sess, member);
-			groupsManager.removeAdmin(sess, new Group(), user);
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		groupsManager.removeAdmin(sess, new Group(), user);
 
-		}
+	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void removeAdminWhenUserNotExist() throws Exception {
-			System.out.println("GroupsManager.removeAdminsWhenMemberNotExists");
+	public void removeAdminWhenUserNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "removeAdminsWhenMemberNotExists");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			groupsManager.removeAdmin(sess, group, new User());
+		groupsManager.removeAdmin(sess, group, new User());
 
-		}
+	}
 
 	@Test (expected=UserNotAdminException.class)
-		public void removeAdminWhenNotAdminException() throws Exception {
-			System.out.println("GroupsManager.removeAdminsWhenMemberNotAdmin");
+	public void removeAdminWhenNotAdminException() throws Exception {
+		System.out.println(CLASS_NAME + "removeAdminsWhenMemberNotAdmin");
 
-			vo = setUpVo();
-			setUpGroup(vo);
+		vo = setUpVo();
+		setUpGroup(vo);
 
-			Member member = setUpMember(vo);
-			User user = perun.getUsersManagerBl().getUserByMember(sess, member);
-			groupsManager.removeAdmin(sess, group, user);
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		groupsManager.removeAdmin(sess, group, user);
 
-		}
+	}
 
 	@Test
 	public void removeAdminWithGroup() throws Exception {
-		System.out.println("GroupsManager.removeAdminWithGroup");
+		System.out.println(CLASS_NAME + "removeAdminWithGroup");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1037,7 +1041,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getAdmins() throws Exception {
-		System.out.println("GroupsManager.getAdmins");
+		System.out.println(CLASS_NAME + "getAdmins");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1070,14 +1074,14 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 		// test
 		List<User> admins = groupsManager.getAdmins(sess, group);
-		assertTrue("group shoud have 2 admins",admins.size() == 2);
+		assertTrue("group should have 2 admins",admins.size() == 2);
 		assertTrue("our member as direct user should be admin",admins.contains(user));
 		assertTrue("our member as member of admin group should be admin",admins.contains(user2));
 	}
 
 	@Test
 	public void getDirectAdmins() throws Exception {
-		System.out.println("GroupsManager.getDirectAdmins");
+		System.out.println(CLASS_NAME + "getDirectAdmins");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1087,14 +1091,14 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		groupsManager.addAdmin(sess, group, user);
 
 		List<User> admins = groupsManager.getDirectAdmins(sess, group);
-		assertTrue("group shoud have 1 admin",admins.size() == 1);
+		assertTrue("group should have 1 admin",admins.size() == 1);
 		assertTrue("our member should be admin",admins.contains(user));
 
 	}
 
 	@Test
 	public void getAdminGroups() throws Exception {
-		System.out.println("GroupsManager.getAdminGroups");
+		System.out.println(CLASS_NAME + "getAdminGroups");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1109,16 +1113,16 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getAdminsWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.getAdminsWhenGroupNotExists");
+	public void getAdminsWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getAdminsWhenGroupNotExists");
 
-			groupsManager.getAdmins(sess, new Group());
+		groupsManager.getAdmins(sess, new Group());
 
-		}
+	}
 
 	@Test
 	public void getGroups() throws Exception {
-		System.out.println("GroupsManager.getGroups");
+		System.out.println(CLASS_NAME + "getGroups");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1130,24 +1134,24 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getGroupsWhenVoNotExists() throws Exception {
-			System.out.println("GroupsManager.getGroupsWhenVoNotExists");
+	public void getGroupsWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsWhenVoNotExists");
 
-			groupsManager.getGroups(sess, new Vo());
+		groupsManager.getGroups(sess, new Vo());
 
-		}
+	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getGroupsPageWhenVoNotExists() throws Exception {
-			System.out.println("GroupsManager.getGroupsPageWhenVoNotExists");
+	public void getGroupsPageWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsPageWhenVoNotExists");
 
-			groupsManager.getGroups(sess, new Vo());
+		groupsManager.getGroups(sess, new Vo());
 
-		}
+	}
 
 	@Test
 	public void getVoGroupsCount() throws Exception {
-		System.out.println("GroupsManager.getVoGroupsCount");
+		System.out.println(CLASS_NAME + "getVoGroupsCount");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1159,7 +1163,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getGroupsCount() throws Exception {
-		System.out.println("GroupsManager.getGroupsCount");
+		System.out.println(CLASS_NAME + "getGroupsCount");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1171,7 +1175,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getParentGroupMembersCount() throws Exception{
-		System.out.println("GroupsManager.getParentGroupMembersCount");
+		System.out.println(CLASS_NAME + "getParentGroupMembersCount");
 		vo = setUpVo();
 		this.groupsManager.createGroup(sess, vo, group2);
 		this.groupsManager.createGroup(sess, group2, group);
@@ -1202,7 +1206,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	@Test
 	public void getGroupCountInBiggerGroupStructure() throws Exception{
-		System.out.println("GroupsManager.getGroupCountInBiggerGroupStructure");
+		System.out.println(CLASS_NAME + "getGroupCountInBiggerGroupStructure");
 
 		vo = setUpVo();
 		this.groupsManager.createGroup(sess, vo, group);
@@ -1278,16 +1282,16 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getGroupsCountWhenVoNotExists() throws Exception {
-			System.out.println("GroupsManager.getGroupsCountWhenVoNotExists");
+	public void getGroupsCountWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsCountWhenVoNotExists");
 
-			groupsManager.getGroupsCount(sess, new Vo());
+		groupsManager.getGroupsCount(sess, new Vo());
 
-		}
+	}
 
 	@Test
 	public void getSubGroupsCount() throws Exception {
-		System.out.println("GroupsManager.getSubGroupsCount");
+		System.out.println(CLASS_NAME + "getSubGroupsCount");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1300,16 +1304,16 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getSubGroupsCountWhenGroupNotExists() throws Exception {
-			System.out.println("GroupsManager.getSubGroupsCountWhenGroupNotExists");
+	public void getSubGroupsCountWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getSubGroupsCountWhenGroupNotExists");
 
-			groupsManager.getSubGroupsCount(sess, new Group());
+		groupsManager.getSubGroupsCount(sess, new Group());
 
-		}
+	}
 
 	@Test
 	public void getVo() throws Exception {
-		System.out.println("GroupsManager.getVo");
+		System.out.println(CLASS_NAME + "getVo");
 
 		vo = setUpVo();
 		setUpGroup(vo);
@@ -1321,26 +1325,26 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getVoWhenGroupNotExist() throws Exception {
-			System.out.println("GroupsManager.getVoWhenGroupNotExists");
+	public void getVoWhenGroupNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getVoWhenGroupNotExists");
 
-			groupsManager.getVo(sess, new Group());
+		groupsManager.getVo(sess, new Group());
 
-		}
+	}
 
 
 	@Test ()
-		public void getMembersMembershipType() throws Exception{
-			System.out.println("GroupsManager.getMembersMembershipType");
-			vo = setUpVo();
-			Member member = this.setUpMember(vo);
-			this.groupsManager.createGroup(sess, vo, group);
-			this.groupsManager.createGroup(sess, group, group2);
-			this.groupsManager.addMember(sess, group2, member);
-			assertTrue(this.groupsManager.getGroupMembers(sess, group).size()==1);
-			assertEquals(this.groupsManager.getGroupMembers(sess, group).get(0).getMembershipType(), MembershipType.INDIRECT);
-			assertEquals(this.groupsManager.getGroupMembers(sess, group2).get(0).getMembershipType(), MembershipType.DIRECT);
-		}
+	public void getMembersMembershipType() throws Exception{
+		System.out.println(CLASS_NAME + "getMembersMembershipType");
+		vo = setUpVo();
+		Member member = this.setUpMember(vo);
+		this.groupsManager.createGroup(sess, vo, group);
+		this.groupsManager.createGroup(sess, group, group2);
+		this.groupsManager.addMember(sess, group2, member);
+		assertTrue(this.groupsManager.getGroupMembers(sess, group).size()==1);
+		assertEquals(this.groupsManager.getGroupMembers(sess, group).get(0).getMembershipType(), MembershipType.INDIRECT);
+		assertEquals(this.groupsManager.getGroupMembers(sess, group2).get(0).getMembershipType(), MembershipType.DIRECT);
+	}
 
 	@Test
 	public void convertGroupToRichGroupWithAttributesTest() throws Exception {
@@ -1479,7 +1483,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		assertEquals("created group should be same as returned group",group,returnedGroup);
 
 	}
-	
+
 	private List<Group> setUpGroupsWithSubgroups(Vo vo) throws Exception {
 		Group groupA = new Group("A", "A");
 		Group groupB = new Group("B", "B");
@@ -1497,9 +1501,9 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 		groupC = this.groupsManagerBl.createGroup(sess, groupD, groupC);
 		groupE = this.groupsManagerBl.createGroup(sess, groupC, groupE);
-		
+
 		groupF = this.groupsManagerBl.createGroup(sess, groupE, groupF);
-		
+
 		List<Group> groups = new ArrayList<>();
 		groups.add(groupC);
 		groups.add(groupA);
@@ -1508,7 +1512,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		groups.add(groupB);
 		groups.add(groupD);
 		groups.add(groupE);
-		
+
 		return groups;
 	}
 
@@ -1553,4 +1557,5 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 		return attributes;
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -26,12 +26,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
+ * Integration tests for MembersManager
+ *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-
 public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
-	private static final String MEMBERS_MANAGER_ENTRY = "MembersManagerEntry";
+	private static final String CLASS_NAME = "MembersManager.";
 	private static final String EXT_SOURCE_NAME = "MembersManagerEntryExtSource";
 	private Vo createdVo = null;
 	private ExtSource extSource = new ExtSource(0, EXT_SOURCE_NAME, ExtSourcesManager.EXTSOURCE_INTERNAL);
@@ -92,7 +93,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void createMember() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".createMemberSync()");
+		System.out.println(CLASS_NAME + "createMemberSync");
 
 		final Member m;
 		//createdMember should be initialized in setUp method. if not, do it on my own
@@ -107,10 +108,10 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void createMemberFromCandidateInGroup() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".createMember()");
+		System.out.println(CLASS_NAME + "createMember");
 
 		//Create vo and groups
-		
+
 		//g3in1 - direct, g1 indirect
 		List<Group> groups = new ArrayList<>(Arrays.asList(g3ing1));
 
@@ -134,7 +135,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		//test if member is in vo and also in defined groups
 		assertTrue(perun.getMembersManagerBl().getMembers(sess, createdVo).contains(member));
 		List<Group> returnedGroups = perun.getGroupsManagerBl().getMemberGroups(sess, member);
-		
+
 		assertTrue(returnedGroups.contains(g1));
 		assertTrue(!returnedGroups.contains(g2));
 		assertTrue(returnedGroups.contains(g3ing1));
@@ -145,7 +146,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void findCompleteRichMembers() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".findCompleteRichMembers()");
+		System.out.println(CLASS_NAME + "findCompleteRichMembers");
 
 		User user = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
 
@@ -161,7 +162,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void createMemberFromUserInGroup() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".createMember()");
+		System.out.println(CLASS_NAME + "createMember");
 
 		//get user of existing member
 		User user = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
@@ -182,7 +183,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void createMemberFromCandidateWithExtSourceInGroup() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".createMember()");
+		System.out.println(CLASS_NAME + "createMember");
 
 		List<Group> groups = new ArrayList<>(Arrays.asList(g3ing1));
 
@@ -216,7 +217,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void createMemberFromCandidateWithExtSourceAndLoaInGroup() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".createMember()");
+		System.out.println(CLASS_NAME + "createMember");
 
 		//g3in1 - direct, g1 indirect
 		List<Group> groups = new ArrayList<>(Arrays.asList(g3ing1));
@@ -251,7 +252,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void createServiceMemberFromCandidateInGroup() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".createServiceMember()");
+		System.out.println(CLASS_NAME + "createServiceMember");
 
 		//g3in1 - direct, g1 indirect
 		List<Group> groups = new ArrayList<>(Arrays.asList(g3ing1));
@@ -289,25 +290,25 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void createMemeberWhenVoNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".createMemberSyncWhenVoNotExists()");
+	public void createMemeberWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "createMemberSyncWhenVoNotExists");
 
-			membersManagerEntry.createMember(sess, new Vo(), candidate);
+		membersManagerEntry.createMember(sess, new Vo(), candidate);
 
-		}
+	}
 
 	@Test (expected=AlreadyMemberException.class)
-		public void createMemeberWhenAlreadyMember() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".createMemberSyncWhenAlreadyMember()");
+	public void createMemeberWhenAlreadyMember() throws Exception {
+		System.out.println(CLASS_NAME + "createMemberSyncWhenAlreadyMember");
 
-			membersManagerEntry.createMember(sess, createdVo, candidate);
-			// shouldn't add member twice
+		membersManagerEntry.createMember(sess, createdVo, candidate);
+		// shouldn't add member twice
 
-		}
+	}
 
 	@Test
 	public void getMemberById() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberById()");
+		System.out.println(CLASS_NAME + "getMemberById");
 
 
 		final Member m = membersManagerEntry.getMemberById(sess,
@@ -319,17 +320,17 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test (expected=MemberNotExistsException.class)
-		public void getMemberByIdWhenMemberNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberByIdWhenMemberNotExists()");
+	public void getMemberByIdWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberByIdWhenMemberNotExists");
 
-			membersManagerEntry.getMemberById(sess, 0);
-			// shouldn't find member with ID 0
+		membersManagerEntry.getMemberById(sess, 0);
+		// shouldn't find member with ID 0
 
-		}
+	}
 
 	@Test
 	public void getMemberByExtAuth() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberByExtAuth()");
+		System.out.println(CLASS_NAME + "getMemberByExtAuth");
 
 		final Member expectedMember = membersManagerEntry.getMemberByUserExtSource(sess, createdVo, ues);
 		assertNotNull("unable to return member by Ext auth",expectedMember);
@@ -338,28 +339,28 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getMemberByExtAuthWhenVoNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberByExtAuthWhenVoNotExists()");
+	public void getMemberByExtAuthWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberByExtAuthWhenVoNotExists");
 
-			membersManagerEntry.getMemberByUserExtSource(sess, new Vo(), ues);
-			// shouldn't find VO
+		membersManagerEntry.getMemberByUserExtSource(sess, new Vo(), ues);
+		// shouldn't find VO
 
-		}
+	}
 
 	@Test (expected=MemberNotExistsException.class)
-		public void getMemberByExtAuthWhenMemberNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberByExtAuthWhenMemberNotExists()");
+	public void getMemberByExtAuthWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberByExtAuthWhenMemberNotExists");
 
-			final UserExtSource ues2 = ues;
-			ues2.setLogin("neexistuje");
-			membersManagerEntry.getMemberByUserExtSource(sess, createdVo, ues2);
-			// shouldn't find Member
+		final UserExtSource ues2 = ues;
+		ues2.setLogin("neexistuje");
+		membersManagerEntry.getMemberByUserExtSource(sess, createdVo, ues2);
+		// shouldn't find Member
 
-		}
+	}
 
 	@Test
 	public void getMemberByUser() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberByUser()");
+		System.out.println(CLASS_NAME + "getMemberByUser");
 
 		final User u = perun.getUsersManager().getUserByUserExtSource(sess, ues);
 
@@ -370,41 +371,41 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getMemberByUserWhenVoNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberByUserWhenVoNotExists()");
+	public void getMemberByUserWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberByUserWhenVoNotExists");
 
-			final User u = perun.getUsersManager().getUserByUserExtSource(sess, ues);
+		final User u = perun.getUsersManager().getUserByUserExtSource(sess, ues);
 
-			membersManagerEntry.getMemberByUser(sess, new Vo(), u);
-			// shouldn't find VO
+		membersManagerEntry.getMemberByUser(sess, new Vo(), u);
+		// shouldn't find VO
 
-		}
+	}
 
 	@Test (expected=MemberNotExistsException.class)
-		public void getMemberByUserWhenMemberNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberByUserWhenMemberNotExists()");
+	public void getMemberByUserWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberByUserWhenMemberNotExists");
 
-			final User u = perun.getUsersManager().getUserByUserExtSource(sess, ues);
-			membersManagerEntry.deleteMember(sess, createdMember);
-			membersManagerEntry.getMemberByUser(sess, createdVo, u);
-			// shouldn't find member
+		final User u = perun.getUsersManager().getUserByUserExtSource(sess, ues);
+		membersManagerEntry.deleteMember(sess, createdMember);
+		membersManagerEntry.getMemberByUser(sess, createdVo, u);
+		// shouldn't find member
 
-		}
+	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void getMemberByUserWhenUserNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberByUserWhenUserNotExists()");
+	public void getMemberByUserWhenUserNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberByUserWhenUserNotExists");
 
-			final User u = perun.getUsersManager().getUserByUserExtSource(sess, ues);
-			u.setId(0);
-			membersManagerEntry.getMemberByUser(sess, createdVo, u);
-			// shouldn't find user
+		final User u = perun.getUsersManager().getUserByUserExtSource(sess, ues);
+		u.setId(0);
+		membersManagerEntry.getMemberByUser(sess, createdVo, u);
+		// shouldn't find user
 
-		}
+	}
 
 	@Test
 	public void getMemberVo() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberVo()");
+		System.out.println(CLASS_NAME + "getMemberVo");
 
 		Vo vo = membersManagerEntry.getMemberVo(sess, createdMember);
 		assertNotNull("unable to get VO by member",vo);
@@ -413,17 +414,17 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test (expected=MemberNotExistsException.class)
-		public void getMemberVoWhenMemberNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMemberVoWhenMemberNotExists()");
+	public void getMemberVoWhenMemberNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberVoWhenMemberNotExists");
 
-			membersManagerEntry.getMemberVo(sess, new Member());
-			// shouldn't find Member
+		membersManagerEntry.getMemberVo(sess, new Member());
+		// shouldn't find Member
 
-		}
+	}
 
 	@Test
 	public void getMembersCount() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".getMembersCount()");
+		System.out.println(CLASS_NAME + "getMembersCount");
 
 		final int count = membersManagerEntry.getMembersCount(sess, createdVo);
 		assertTrue("testing VO should have only 1 member", count == 1);
@@ -431,17 +432,17 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getMembersCountWhenVoNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMembersCountWhenVoNotExists()");
+	public void getMembersCountWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersCountWhenVoNotExists");
 
-			membersManagerEntry.getMembersCount(sess, new Vo());
-			// shouldn't find VO
+		membersManagerEntry.getMembersCount(sess, new Vo());
+		// shouldn't find VO
 
-		}
+	}
 
 	@Test
 	public void getMembersCountByStatus() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".getMembersCountByStatus()");
+		System.out.println(CLASS_NAME + "getMembersCountByStatus");
 
 		final int count = membersManagerEntry.getMembersCount(sess, createdVo, Status.SUSPENDED);
 		assertTrue("testing VO should have 0 members with SUSPENDED status", count == 0);
@@ -452,7 +453,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void getMembers() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".getMembers()");
+		System.out.println(CLASS_NAME + "getMembers");
 
 		List<Member> members = membersManagerEntry.getMembers(sess, createdVo);
 		assertTrue("should return only 1 member",members.size() == 1);
@@ -461,17 +462,17 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getMembersWhenVoNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMembersWhenVoNotExists()");
+	public void getMembersWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersWhenVoNotExists");
 
-			membersManagerEntry.getMembers(sess, new Vo());
-			// shouldn't find VO
+		membersManagerEntry.getMembers(sess, new Vo());
+		// shouldn't find VO
 
-		}
+	}
 
 	@Test
 	public void getMembersByUser() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".getMembersByUser()");
+		System.out.println(CLASS_NAME + "getMembersByUser");
 
 		final User u = perun.getUsersManager().getUserByMember(sess, createdMember);
 		List<Member> members = membersManagerEntry.getMembersByUser(sess, u);
@@ -481,19 +482,19 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void getMembersByUserWhenUserNotExists() throws Exception {
-			System.out.println(MEMBERS_MANAGER_ENTRY + ".getMembersByUserWhenUserNotExists()");
+	public void getMembersByUserWhenUserNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getMembersByUserWhenUserNotExists");
 
-			final User u = perun.getUsersManager().getUserByMember(sess, createdMember);
-			u.setId(0);
-			membersManagerEntry.getMembersByUser(sess, u);
-			// shouldn't find user
+		final User u = perun.getUsersManager().getUserByMember(sess, createdMember);
+		u.setId(0);
+		membersManagerEntry.getMembersByUser(sess, u);
+		// shouldn't find user
 
-		}
+	}
 
 	@Test(expected=MemberNotExistsException.class)
 	public void deleteMember() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".deleteMember()");
+		System.out.println(CLASS_NAME + "deleteMember");
 
 		//ensure that the test-member already exists..
 		assertNotNull(membersManagerEntry.getMemberById(sess, createdMember.getId()));
@@ -505,7 +506,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test(expected=MemberNotExistsException.class)
 	public void deleteMemberWhenMemberNotExists() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".deleteMemberWhenMemberNotExists()");
+		System.out.println(CLASS_NAME + "deleteMemberWhenMemberNotExists");
 
 		membersManagerEntry.deleteMember(sess, new Member());
 
@@ -513,7 +514,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test(expected=MemberNotExistsException.class)
 	public void deleteAllMembers() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".deleteAllMembers()");
+		System.out.println(CLASS_NAME + "deleteAllMembers");
 
 		//ensure that the test-member already exists..
 		assertNotNull(membersManagerEntry.getMemberById(sess, createdMember.getId()));
@@ -524,7 +525,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test(expected=VoNotExistsException.class)
 	public void deleteAllMembersWhenVoNotExists() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".deleteAllMembersWhenVoNotExists()");
+		System.out.println(CLASS_NAME + "deleteAllMembersWhenVoNotExists");
 
 		membersManagerEntry.deleteAllMembers(sess, new Vo());
 
@@ -532,7 +533,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void extendMembershipToParticularDate() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".extendMembershipToParticularDate()");
+		System.out.println(CLASS_NAME + "extendMembershipToParticularDate");
 
 		// Set membershipExpirationRules attribute
 		HashMap<String, String> extendMembershipRules = new LinkedHashMap<String, String>();
@@ -567,7 +568,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void extendMembershipBy10Days() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".extendMembershipBy10Days()");
+		System.out.println(CLASS_NAME + "extendMembershipBy10Days");
 
 		// Set membershipExpirationRules attribute
 		HashMap<String, String> extendMembershipRules = new LinkedHashMap<String, String>();
@@ -599,7 +600,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void extendMembershipInGracePeriod() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".extendMembershipInGracePeriod()");
+		System.out.println(CLASS_NAME + "extendMembershipInGracePeriod");
 
 		// Period will be set to the next day
 		Calendar calendar = Calendar.getInstance();
@@ -640,7 +641,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void extendMembershipOutsideGracePeriod() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".extendMembershipOutsideGracePeriod()");
+		System.out.println(CLASS_NAME + "extendMembershipOutsideGracePeriod");
 
 		// Set period to three months later
 		Calendar calendar = Calendar.getInstance();
@@ -681,7 +682,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void extendMembershipForMemberWithSufficientLoa() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".extendMembershipForMemberWithSufficientLoa()");
+		System.out.println(CLASS_NAME + "extendMembershipForMemberWithSufficientLoa");
 
 		// Set membershipExpirationRules attribute
 		HashMap<String, String> extendMembershipRules = new LinkedHashMap<String, String>();
@@ -725,7 +726,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void extendMembershipForMemberWithInsufficientLoa() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".extendMembershipForMemberWithInsufficientLoa()");
+		System.out.println(CLASS_NAME + "extendMembershipForMemberWithInsufficientLoa");
 
 		// Set membershipExpirationRules attribute
 		HashMap<String, String> extendMembershipRules = new LinkedHashMap<String, String>();
@@ -766,7 +767,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void extendMembershipForDefinedLoaAllowed() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".extendMembershipForDefinedLoaAllowed()");
+		System.out.println(CLASS_NAME + "extendMembershipForDefinedLoaAllowed");
 
 		// Set membershipExpirationRules attribute
 		HashMap<String, String> extendMembershipRules = new LinkedHashMap<String, String>();
@@ -816,7 +817,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void canExtendMembershipForDefinedLoaNotAllowed() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".extendMembershipForDefinedLoaNotAllowed()");
+		System.out.println(CLASS_NAME + "extendMembershipForDefinedLoaNotAllowed");
 
 		// Set membershipExpirationRules attribute
 		HashMap<String, String> extendMembershipRules = new LinkedHashMap<String, String>();
@@ -852,7 +853,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	@Test
 	// It extend membership and try to extend it again, it must decline another expiration
 	public void canExtendMembershipInGracePeriod() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".canExtendMembershipInGracePeriod()");
+		System.out.println(CLASS_NAME + "canExtendMembershipInGracePeriod");
 
 		// Set membershipExpirationRules attribute
 		HashMap<String, String> extendMembershipRules = new LinkedHashMap<String, String>();
@@ -888,7 +889,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	@Test
 	// It checks if user with insufficient LoA won't be allowed in to the VO
 	public void canBeMemberLoaNotAllowed() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".canBeMemberLoaNotAllowed()");
+		System.out.println(CLASS_NAME + "canBeMemberLoaNotAllowed");
 
 		String loa = "1";
 
@@ -910,7 +911,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	@Test
 	// It checks if user with sufficient LoA will be allowed in to the VO
 	public void canBeMemberLoaAllowed() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".canBeMemberLoaAllowed()");
+		System.out.println(CLASS_NAME + "canBeMemberLoaAllowed");
 
 		String loa = "1";
 
@@ -932,7 +933,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 
 	@Test
 	public void findMembersInGroup() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".findMembersInGroup()");
+		System.out.println(CLASS_NAME + "findMembersInGroup");
 		Member member = setUpMember(createdVo);
 		Member member2 = setUpMember2(createdVo);
 		groupsManagerEntry.addMember(sess, createdGroup, member);
@@ -960,7 +961,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	@Ignore
 	@Test
 	public void findMembersByName() throws Exception {
-		System.out.println(MEMBERS_MANAGER_ENTRY + ".findMembersByName()");
+		System.out.println(CLASS_NAME + "findMembersByName");
 
 		List<Member> members = membersManagerEntry.findMembersByName(sess, "Pepa Z Depa");
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
@@ -18,40 +17,32 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ExtSource;
-import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.MembersManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Service;
-import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
-import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
 /**
+ * Integration tests of ModulesUtils
+ *
  * @author Michal Stava <stavamichal@gmail.com>
  */
-
 public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	private ModulesUtilsBl modulesUtilsBl;
-	private final static String MODULES_UTILS_ENTRY = "ModulesUtilsBl.";
+	private final static String CLASS_NAME = "ModulesUtilsBl.";
 
 	// these are in DB only when setUp"Type"() and must be used in correct (this) order
 	private Vo vo;
@@ -73,7 +64,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void haveTheSameAttributeWithTheSameNamespace1ForResource() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "haveTheSameAttributeWithTheSameNamespace1()");
+		System.out.println(CLASS_NAME + "haveTheSameAttributeWithTheSameNamespace1");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -90,7 +81,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void haveTheSameAttributeWithTheSameNamespace2ForResource() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "haveTheSameAttributeWithTheSameNamespace2()");
+		System.out.println(CLASS_NAME + "haveTheSameAttributeWithTheSameNamespace2");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -109,7 +100,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void haveTheSameAttributeWithTheSameNamespace3ForResource() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "haveTheSameAttributeWithTheSameNamespace3()");
+		System.out.println(CLASS_NAME + "haveTheSameAttributeWithTheSameNamespace3");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -125,7 +116,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void haveTheSameAttributeWithTheSameNamespace1ForGroup() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "haveTheSameAttributeWithTheSameNamespace1ForGroup()");
+		System.out.println(CLASS_NAME + "haveTheSameAttributeWithTheSameNamespace1ForGroup");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -143,7 +134,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void haveTheSameAttributeWithTheSameNamespace2ForGroup() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "haveTheSameAttributeWithTheSameNamespace2ForGroup()");
+		System.out.println(CLASS_NAME + "haveTheSameAttributeWithTheSameNamespace2ForGroup");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -163,7 +154,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void haveTheSameAttributeWithTheSameNamespace3ForGroup() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "haveTheSameAttributeWithTheSameNamespace3ForGroup()");
+		System.out.println(CLASS_NAME + "haveTheSameAttributeWithTheSameNamespace3ForGroup");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -180,7 +171,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getCommonGIDOfResourcesWithSameNameInSameNamespace() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "getCommonGIDOfResourcesWithSameNameInSameNamespace()");
+		System.out.println(CLASS_NAME + "getCommonGIDOfResourcesWithSameNameInSameNamespace");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -205,7 +196,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getCommonGIDOfGroupsWithSameNameInSameNamespace() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "getCommonGIDOfGroupsWithSameNameInSameNamespace()");
+		System.out.println(CLASS_NAME + "getCommonGIDOfGroupsWithSameNameInSameNamespace");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -231,7 +222,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getFreeGID() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "getFreeGID()");
+		System.out.println(CLASS_NAME + "getFreeGID");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -267,7 +258,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void checkIfGIDIsWithinRange() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "checkIfGIDIsWithinRange");
+		System.out.println(CLASS_NAME + "checkIfGIDIsWithinRange");
 
 		Attribute minGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minGID"));
 		Attribute maxGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-maxGID"));
@@ -296,7 +287,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void haveRightToWriteAttributeInAnyGroupOrResource() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "haveRightToWriteAttributeInAnyGroupOrResource");
+		System.out.println(CLASS_NAME + "haveRightToWriteAttributeInAnyGroupOrResource");
 
 		Attribute minGID = new Attribute(perun.getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minGID"));
 		perun.getAttributesManagerBl().setAttribute(sess, namespace, minGID);
@@ -319,7 +310,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getListOfResourceGIDsFromListOfGroupGIDs() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "getListOfResourceGIDsFromListOfGroupGIDs");
+		System.out.println(CLASS_NAME + "getListOfResourceGIDsFromListOfGroupGIDs");
 
 		List<Attribute> groupAttr = new ArrayList<Attribute>();
 		List<Attribute> attributes = setUpGroupNamesAndGIDForGroupAndResource();
@@ -339,7 +330,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getListOfGroupGIDsFromListOfResourceGIDs() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "getListOfGroupGIDsFromListOfResourceGIDs");
+		System.out.println(CLASS_NAME + "getListOfGroupGIDsFromListOfResourceGIDs");
 
 		List<Attribute> resourceAttr = new ArrayList<Attribute>();
 		List<Attribute> attributes = setUpGroupNamesAndGIDForGroupAndResource();
@@ -359,7 +350,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getSetOfGIDNamespacesWhereFacilitiesHasTheSameGroupNameNamespace() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "getSetOfGIDNamespacesWhereFacilitiesHasTheSameGroupNameNamespace");
+		System.out.println(CLASS_NAME + "getSetOfGIDNamespacesWhereFacilitiesHasTheSameGroupNameNamespace");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -386,7 +377,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getSetOfGroupNameNamespacesWhereFacilitiesHasTheSameGIDNamespace() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "getSetOfGroupNameNamespacesWhereFacilitiesHasTheSameGIDNamespace");
+		System.out.println(CLASS_NAME + "getSetOfGroupNameNamespacesWhereFacilitiesHasTheSameGIDNamespace");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -413,7 +404,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void checkReservedNames() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "checkReservedNames");
+		System.out.println(CLASS_NAME + "checkReservedNames");
 
 		String goodName = "cokoliv";
 		String badName = "sys";
@@ -438,7 +429,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getUnixGroupNameAndGIDNamespaceAttributeWithNotNullValue() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "getUnixGroupNameAndGIDNamespaceAttributeWithNotNullValue");
+		System.out.println(CLASS_NAME + "getUnixGroupNameAndGIDNamespaceAttributeWithNotNullValue");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -460,7 +451,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void isGroupUnixGIDNamespaceFillable() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "isGroupUnixGIDNamespaceFillable");
+		System.out.println(CLASS_NAME + "isGroupUnixGIDNamespaceFillable");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -496,7 +487,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void isNameOfEmailValid() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "isNameOfEmailValid");
+		System.out.println(CLASS_NAME + "isNameOfEmailValid");
 
 		assertTrue(modulesUtilsBl.isNameOfEmailValid((PerunSessionImpl) sess, "user@domain.com"));
 		assertTrue(modulesUtilsBl.isNameOfEmailValid((PerunSessionImpl) sess, "first.second@domain.second.com"));
@@ -506,7 +497,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void testShellValue() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "testShellValue()");
+		System.out.println(CLASS_NAME + "testShellValue");
 
 		Attribute attr = new Attribute();
 		String shell = "/bin/csh";
@@ -516,7 +507,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test(expected=WrongAttributeValueException.class)
 	public void testShellValueWrongFormat() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "testShellValueWrongFormat()");
+		System.out.println(CLASS_NAME + "testShellValueWrongFormat");
 
 		Attribute attr = new Attribute();
 		String shell = "/bin/bash/";
@@ -526,7 +517,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test(expected=WrongAttributeValueException.class)
 	public void testShellValueWrongFormatInvalidCharacter() throws Exception {
-		System.out.println(MODULES_UTILS_ENTRY + "testShellValueWrongFormatInvalidCharacter()");
+		System.out.println(CLASS_NAME + "testShellValueWrongFormatInvalidCharacter");
 
 		Attribute attr = new Attribute();
 		String shell = "/\n";
@@ -1033,4 +1024,5 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		attribute.setValue("Testing value");
 		return attribute;
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/OwnersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/OwnersManagerEntryIntegrationTest.java
@@ -16,14 +16,16 @@ import cz.metacentrum.perun.core.api.OwnersManager;
 import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
 
 /**
+ * Integration tests of OwnersManager.
+ *
  * @author Jiri Harazim <harazim@mail.muni.cz>
  */
-
 public class OwnersManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	private OwnersManager ownersManagerEntry;
-	private final String CLASS_NAME = "OwnersManagerEntry.";
+	private final String CLASS_NAME = "OwnersManager.";
 	private Owner createdOwner;
+
 	/**
 	 * @throws java.lang.Exception
 	 */
@@ -38,7 +40,7 @@ public class OwnersManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	 */
 	@Test
 	public void testCreateOwner() throws Exception {
-		System.out.println(CLASS_NAME + "createOwner()");
+		System.out.println(CLASS_NAME + "createOwner");
 
 		final String umpalumpa = "Umpalumpa";
 		final String contact = "umpalumpa@johny.depp";
@@ -58,21 +60,19 @@ public class OwnersManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	 */
 	@Test(expected=OwnerNotExistsException.class)
 	public void testDeleteOwner() throws Exception {
-		System.out.println(CLASS_NAME + "deleteOwner()");
+		System.out.println(CLASS_NAME + "deleteOwner");
 
 		ownersManagerEntry.deleteOwner(sess, createdOwner, true);
 
 		ownersManagerEntry.getOwnerById(sess, createdOwner.getId());
 	}
 
-
-
 	/**
 	 * Test method for {@link cz.metacentrum.perun.core.entry.OwnersManagerEntry#getOwnerById(cz.metacentrum.perun.core.api.PerunSession, int)}.
 	 */
 	@Test
 	public void testGetOwnerById() throws Exception {
-		System.out.println(CLASS_NAME + "getOwnerById()");
+		System.out.println(CLASS_NAME + "getOwnerById");
 
 		final Owner result = ownersManagerEntry.getOwnerById(sess, createdOwner.getId());
 
@@ -84,7 +84,7 @@ public class OwnersManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	 */
 	@Test
 	public void testGetOwners() throws Exception {
-		System.out.println(CLASS_NAME + "getOwners()");
+		System.out.println(CLASS_NAME + "getOwners");
 
 		final List<Owner> owners = ownersManagerEntry.getOwners(sess);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -28,10 +28,13 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import java.util.ArrayList;
 
 /**
+ * Integration tests of ResourcesManager.
+ *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-
 public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
+
+	private final static String CLASS_NAME = "ResourcesManager.";
 
 	// these are in DB only when needed and must be setUp"type"() in right order before use !!
 	private Vo vo;
@@ -48,15 +51,13 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Before
 	public void setUp() throws Exception {
-
 		resourcesManager = perun.getResourcesManager();
-
 	}
 
 
 	@Test
 	public void getResourceById() throws Exception {
-		System.out.println("ResourcesManager.getResourceById");
+		System.out.println(CLASS_NAME + "getResourceById");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -69,17 +70,17 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void getResourceByIdWhenResourceNotExist() throws Exception {
-			System.out.println("ResourcesManager.getResourceByIdWhenResourceNotExists");
+	public void getResourceByIdWhenResourceNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceByIdWhenResourceNotExists");
 
-			resourcesManager.getResourceById(sess, 0);
-			// shouldn't find Resource
+		resourcesManager.getResourceById(sess, 0);
+		// shouldn't find Resource
 
-		}
+	}
 
 	@Test
 	public void createResource() throws Exception {
-		System.out.println("ResourcesManager.createResource");
+		System.out.println(CLASS_NAME + "createResource");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -94,22 +95,22 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void createResourceWhenFacilityNotExists() throws Exception {
-			System.out.println("ResourcesManager.createResourceWhenFacilityNotExists");
+	public void createResourceWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "createResourceWhenFacilityNotExists");
 
-			vo = setUpVo();
+		vo = setUpVo();
 
-			Resource resource = new Resource();
-			resource.setName("ResourcesManagerTestResource2");
-			resource.setDescription("Testovaci2");
-			resourcesManager.createResource(sess, resource, vo, new Facility());
-			// shouldn't find facility
+		Resource resource = new Resource();
+		resource.setName("ResourcesManagerTestResource2");
+		resource.setDescription("Testovaci2");
+		resourcesManager.createResource(sess, resource, vo, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void deleteResource() throws Exception {
-		System.out.println("ResourcesManager.deleteResource");
+		System.out.println(CLASS_NAME + "deleteResource");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -124,26 +125,26 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Ignore //Resource can be deleted with assigned group
-		@Test (expected=RelationExistsException.class)
-		public void deleteResourceWhenRelationExists() throws Exception {
-			System.out.println("ResourcesManager.deleteResourceWhenRelationExists");
+	@Test (expected=RelationExistsException.class)
+	public void deleteResourceWhenRelationExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteResourceWhenRelationExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
-			assertNotNull("unable to create resource before deletion",resource);
-			member = setUpMember(vo);
-			group = setUpGroup(vo, member);
-			resourcesManager.assignGroupToResource(sess, group, resource);
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		assertNotNull("unable to create resource before deletion",resource);
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		resourcesManager.assignGroupToResource(sess, group, resource);
 
-			resourcesManager.deleteResource(sess, resource);
-			// shouldn't delete resource with assigned group
+		resourcesManager.deleteResource(sess, resource);
+		// shouldn't delete resource with assigned group
 
-		}
+	}
 
 	@Test
 	public void deleteAllResources() throws Exception {
-		System.out.println("ResourcesManager.deleteAllResources");
+		System.out.println(CLASS_NAME + "deleteAllResources");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -158,30 +159,30 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void deleteAllResourcesWhenVoNotExists() throws Exception {
-			System.out.println("ResourcesManager.deleteAllResourcesWhenVoNotExists");
+	public void deleteAllResourcesWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteAllResourcesWhenVoNotExists");
 
-			resourcesManager.deleteAllResources(sess, new Vo());
+		resourcesManager.deleteAllResources(sess, new Vo());
 
-		}
-	
+	}
+
 	@Test
 	public void deleteResourceWithGroupResourceAttributes() throws Exception {
-		System.out.println("ResourcesManager.deleteAllResourcesWhenVoNotExists");
-		
+		System.out.println(CLASS_NAME + "deleteAllResourcesWhenVoNotExists");
+
 		vo = setUpVo();
 		facility = setUpFacility();
 		resource = setUpResource();
 		member = setUpMember(vo);
 		group = setUpGroup(vo, member);
-		
+
 		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
 		List<Attribute> attributes = setUpGroupResourceAttribute(group, resource);
-		
+
 		List<Attribute> retAttributes = perun.getAttributesManagerBl().getAttributes(sess, resource, group, false);
 		assertEquals("Only one group resource attribute is set.",retAttributes.size(), 1);
 		assertEquals("Not the correct attribute returned", attributes.get(0), retAttributes.get(0));
-		
+
 		perun.getResourcesManagerBl().deleteResource(sess, resource);
 		retAttributes = perun.getAttributesManagerBl().getAttributes(sess, resource, group, false);
 		assertEquals("There is still group resource attribute after deleting resource", retAttributes.size(), 0);
@@ -189,7 +190,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void getFacility() throws Exception {
-		System.out.println("ResourcesManager.getFacility");
+		System.out.println(CLASS_NAME + "getFacility");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -202,17 +203,17 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void getFacilityWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.getFacilityWhenResourceNotExists");
+	public void getFacilityWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityWhenResourceNotExists");
 
-			resourcesManager.getFacility(sess, new Resource());
-			// shouldn't find resource
+		resourcesManager.getFacility(sess, new Resource());
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test
 	public void setFacility() throws Exception {
-		System.out.println("ResourcesManager.setFacility");
+		System.out.println(CLASS_NAME + "setFacility");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -238,33 +239,33 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void setFacilityWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.setFacilityWhenResourceNotExists");
+	public void setFacilityWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setFacilityWhenResourceNotExists");
 
-			facility = setUpFacility();
+		facility = setUpFacility();
 
-			resourcesManager.setFacility(sess, new Resource(), facility);
-			// shouldn't find resource
+		resourcesManager.setFacility(sess, new Resource(), facility);
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void setFacilityWhenFacilityNotExists() throws Exception {
-			System.out.println("ResourcesManager.setFacilityWhenFacilityNotExists");
+	public void setFacilityWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "setFacilityWhenFacilityNotExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
-			assertNotNull("unable to create resource",resource);
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		assertNotNull("unable to create resource",resource);
 
-			resourcesManager.setFacility(sess, resource, new Facility());
-			// shouldn't find facility
+		resourcesManager.setFacility(sess, resource, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void getVo() throws Exception {
-		System.out.println("ResourcesManager.getVo");
+		System.out.println(CLASS_NAME + "getVo");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -278,16 +279,16 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void getVoWhenResourceNotExist() throws Exception {
-			System.out.println("ResourcesManager.getVoWhenResourceNotExists");
+	public void getVoWhenResourceNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getVoWhenResourceNotExists");
 
-			resourcesManager.getVo(sess, new Resource());
+		resourcesManager.getVo(sess, new Resource());
 
-		}
+	}
 
 	@Test
 	public void getAllowedMembers() throws Exception {
-		System.out.println("ResourcesManager.getAllowedMembers");
+		System.out.println(CLASS_NAME + "getAllowedMembers");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -305,7 +306,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void getAllowedUsers() throws Exception {
-		System.out.println("ResourcesManager.getAllowedUsers");
+		System.out.println(CLASS_NAME + "getAllowedUsers");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -323,17 +324,17 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void getAllowedMembersWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.getAllowedMembersResourceNotExists");
+	public void getAllowedMembersWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getAllowedMembersResourceNotExists");
 
-			resourcesManager.getAllowedMembers(sess, new Resource());
-			// shouldn't find resource
+		resourcesManager.getAllowedMembers(sess, new Resource());
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test
 	public void assginGroupToResource() throws Exception {
-		System.out.println("ResourcesManager.assignGroupToResource");
+		System.out.println(CLASS_NAME + "assignGroupToResource");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -350,52 +351,52 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void assginGroupToResourceWhenGroupNotExists() throws Exception {
-			System.out.println("ResourcesManager.assignGroupToResourceWhenGroupNotExists");
+	public void assginGroupToResourceWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "assignGroupToResourceWhenGroupNotExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
-			assertNotNull("unable to create resource",resource);
-			resourcesManager.assignGroupToResource(sess, new Group(), resource);
-			// shouldn't find group
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		assertNotNull("unable to create resource",resource);
+		resourcesManager.assignGroupToResource(sess, new Group(), resource);
+		// shouldn't find group
 
-		}
+	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void assginGroupToResourceWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.assignGroupToResourceWhenResourceNotExists");
+	public void assginGroupToResourceWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "assignGroupToResourceWhenResourceNotExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			member = setUpMember(vo);
-			group = setUpGroup(vo, member);
-			resourcesManager.assignGroupToResource(sess, group, new Resource());
-			// shouldn't find resource
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		resourcesManager.assignGroupToResource(sess, group, new Resource());
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test (expected=GroupAlreadyAssignedException.class)
-		public void assginGroupToResourceWhenGroupAlreadyAssigned() throws Exception {
-			System.out.println("ResourcesManager.assignGroupToResourceWhenGroupAlreadyAssigned");
+	public void assginGroupToResourceWhenGroupAlreadyAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "assignGroupToResourceWhenGroupAlreadyAssigned");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			member = setUpMember(vo);
-			group = setUpGroup(vo, member);
-			resource = setUpResource();
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		resource = setUpResource();
 
-			resourcesManager.assignGroupToResource(sess, group, resource);
-			resourcesManager.assignGroupToResource(sess, group, resource);
-			// shouldn't add group twice
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		resourcesManager.assignGroupToResource(sess, group, resource);
+		// shouldn't add group twice
 
-		}
+	}
 
 	// TODO jak otestovat další 2 výjimky na atributy ?
 
 	@Test
 	public void removeGroupFromResource() throws Exception {
-		System.out.println("ResourcesManager.removeGroupFromResource");
+		System.out.println(CLASS_NAME + "removeGroupFromResource");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -411,67 +412,67 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void removeGroupFromResourceWhenGroupNotExists() throws Exception {
-			System.out.println("ResourcesManager.removeGroupFromResourceWhenGroupNotExists");
+	public void removeGroupFromResourceWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupFromResourceWhenGroupNotExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
 
-			resourcesManager.removeGroupFromResource(sess, new Group(), resource);
-			// shouldn't find Group
+		resourcesManager.removeGroupFromResource(sess, new Group(), resource);
+		// shouldn't find Group
 
-		}
+	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void removeGroupFromResourceWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.removeGroupFromResourceWhenResourceNotExists");
+	public void removeGroupFromResourceWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupFromResourceWhenResourceNotExists");
 
-			vo = setUpVo();
-			member = setUpMember(vo);
-			group = setUpGroup(vo, member);
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
 
-			resourcesManager.removeGroupFromResource(sess, group, new Resource());
-			// shouldn't find resource
+		resourcesManager.removeGroupFromResource(sess, group, new Resource());
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test (expected=SubGroupCannotBeRemovedException.class)
-		@Ignore //Because of removing grouper
-		public void removeGroupFromResourceWhichIsSubGroup() throws Exception {
-			System.out.println("ResourcesManager.removeGroupFromResourceWhichIsSubGroup");
+	@Ignore //Because of removing grouper
+	public void removeGroupFromResourceWhichIsSubGroup() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupFromResourceWhichIsSubGroup");
 
-			vo = setUpVo();
-			member = setUpMember(vo);
-			group = setUpGroup(vo, member);
-			subGroup = setUpSubGroup(group);
-			facility = setUpFacility();
-			resource = setUpResource();
-			resourcesManager.assignGroupToResource(sess, group, resource);
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		subGroup = setUpSubGroup(group);
+		facility = setUpFacility();
+		resource = setUpResource();
+		resourcesManager.assignGroupToResource(sess, group, resource);
 
-			resourcesManager.removeGroupFromResource(sess, subGroup, resource);
-			// shouldn't remove subGroup when parent group was assigned
+		resourcesManager.removeGroupFromResource(sess, subGroup, resource);
+		// shouldn't remove subGroup when parent group was assigned
 
-		}
+	}
 
 	@Test (expected=GroupNotDefinedOnResourceException.class)
-		public void removeGroupFromResourceWhichWasNotDefinedOnResource() throws Exception {
-			System.out.println("ResourcesManager.removeGroupFromResourceWhichWasNotDefinedOnResource");
+	public void removeGroupFromResourceWhichWasNotDefinedOnResource() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupFromResourceWhichWasNotDefinedOnResource");
 
-			vo = setUpVo();
-			member = setUpMember(vo);
-			group = setUpGroup(vo, member);
-			facility = setUpFacility();
-			resource = setUpResource();
+		vo = setUpVo();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		facility = setUpFacility();
+		resource = setUpResource();
 
-			resourcesManager.removeGroupFromResource(sess, group, resource);
+		resourcesManager.removeGroupFromResource(sess, group, resource);
 
-		}
+	}
 
 
 	@Test
 	public void getAssignedGroups() throws Exception {
-		System.out.println("ResourcesManager.getAssignedGroups");
+		System.out.println(CLASS_NAME + "getAssignedGroups");
 
 		vo = setUpVo();
 		member = setUpMember(vo);
@@ -488,16 +489,16 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void getAssignedGroupsWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.getAssignedGroupsWhenResourceNotExists");
+	public void getAssignedGroupsWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedGroupsWhenResourceNotExists");
 
-			resourcesManager.getAssignedGroups(sess, new Resource());
-			// shouldn't find resource
-		}
+		resourcesManager.getAssignedGroups(sess, new Resource());
+		// shouldn't find resource
+	}
 
 	@Test
 	public void getAssignedResources() throws Exception {
-		System.out.println("ResourcesManager.getAssignedResources");
+		System.out.println(CLASS_NAME + "getAssignedResources");
 
 		vo = setUpVo();
 		member = setUpMember(vo);
@@ -514,17 +515,17 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getAssignedResourcesWhenGroupNotExists() throws Exception {
-			System.out.println("ResourcesManager.getAssignedResourcesWhenGroupNotExists");
+	public void getAssignedResourcesWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedResourcesWhenGroupNotExists");
 
-			resourcesManager.getAssignedResources(sess, new Group());
-			// shouldn't find group
+		resourcesManager.getAssignedResources(sess, new Group());
+		// shouldn't find group
 
-		}
+	}
 
 	@Test
 	public void getAssignedRichResources() throws Exception {
-		System.out.println("ResourcesManager.getAssignedRichResources");
+		System.out.println(CLASS_NAME + "getAssignedRichResources");
 
 		vo = setUpVo();
 		member = setUpMember(vo);
@@ -546,17 +547,17 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=GroupNotExistsException.class)
-		public void getAssignedRichResourcesWhenGroupNotExists() throws Exception {
-			System.out.println("ResourcesManager.getAssignedRichResourcesWhenGroupNotExists");
+	public void getAssignedRichResourcesWhenGroupNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedRichResourcesWhenGroupNotExists");
 
-			resourcesManager.getAssignedRichResources(sess, new Group());
-			// shouldn't find group
+		resourcesManager.getAssignedRichResources(sess, new Group());
+		// shouldn't find group
 
-		}
+	}
 
 	@Test
 	public void getAssignedResourcesForMember() throws Exception {
-		System.out.println("ResourcesManager.getAssignedResourcesForMember");
+		System.out.println(CLASS_NAME + "getAssignedResourcesForMember");
 
 		vo = setUpVo();
 		member = setUpMember(vo);
@@ -579,7 +580,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void getAssignedRichResourcesForMember() throws Exception {
-		System.out.println("ResourcesManager.getAssignedRichResourcesForMember");
+		System.out.println(CLASS_NAME + "getAssignedRichResourcesForMember");
 
 		vo = setUpVo();
 		member = setUpMember(vo);
@@ -604,7 +605,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void assignService() throws Exception {
-		System.out.println("ResourcesManager.assignService");
+		System.out.println(CLASS_NAME + "assignService");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -619,47 +620,47 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void assignServiceWhenServiceNotExists() throws Exception {
-			System.out.println("ResourcesManager.assignServiceWhenServiceNotExists");
+	public void assignServiceWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "assignServiceWhenServiceNotExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
 
-			resourcesManager.assignService(sess, resource, new Service());
-			// shouldn't find service
+		resourcesManager.assignService(sess, resource, new Service());
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void assignServiceWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.assignServiceWhenResourceNotExists");
+	public void assignServiceWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "assignServiceWhenResourceNotExists");
 
-			service = setUpService();
+		service = setUpService();
 
-			resourcesManager.assignService(sess, new Resource(), service);
-			// shouldn't find resource
+		resourcesManager.assignService(sess, new Resource(), service);
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test (expected=ServiceAlreadyAssignedException.class)
-		public void assignServiceWhenServiceAlreadyAssigned() throws Exception {
-			System.out.println("ResourcesManager.assignServiceWhenServiceAlreadyAssigned");
+	public void assignServiceWhenServiceAlreadyAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "assignServiceWhenServiceAlreadyAssigned");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
-			service = setUpService();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
 
-			resourcesManager.assignService(sess, resource, service);
-			resourcesManager.assignService(sess, resource, service);
-			// shouldn't add service twice
+		resourcesManager.assignService(sess, resource, service);
+		resourcesManager.assignService(sess, resource, service);
+		// shouldn't add service twice
 
-		}
+	}
 
 	@Test
 	public void getAssignedServices() throws Exception {
-		System.out.println("ResourcesManager.getAssignedServices");
+		System.out.println(CLASS_NAME + "getAssignedServices");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -674,17 +675,17 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void getAssignedServicesWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.getAssignedServicesWhenResourceNotExists");
+	public void getAssignedServicesWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedServicesWhenResourceNotExists");
 
-			resourcesManager.getAssignedServices(sess, new Resource());
-			// shouldn't find resource
+		resourcesManager.getAssignedServices(sess, new Resource());
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test
 	public void assignServicesPackage() throws Exception {
-		System.out.println("ResourcesManager.assignServicesPackage");
+		System.out.println(CLASS_NAME + "assignServicesPackage");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -701,33 +702,33 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void assignServicesPackageWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.assignServicesPackageWhenResourceNotExists");
+	public void assignServicesPackageWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "assignServicesPackageWhenResourceNotExists");
 
-			service = setUpService();
-			ServicesPackage servicesPackage = setUpServicesPackage(service);
+		service = setUpService();
+		ServicesPackage servicesPackage = setUpServicesPackage(service);
 
-			resourcesManager.assignServicesPackage(sess, new Resource(), servicesPackage);
-			// shouldn't find resource
+		resourcesManager.assignServicesPackage(sess, new Resource(), servicesPackage);
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test (expected=ServicesPackageNotExistsException.class)
-		public void assignServicesPackageWhenPackageNotExists() throws Exception {
-			System.out.println("ResourcesManager.assignServicesPackageWhenPackageNotExists");
+	public void assignServicesPackageWhenPackageNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "assignServicesPackageWhenPackageNotExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
 
-			resourcesManager.assignServicesPackage(sess, resource, new ServicesPackage());
-			// shouldn't find package
+		resourcesManager.assignServicesPackage(sess, resource, new ServicesPackage());
+		// shouldn't find package
 
-		}
+	}
 
 	@Test
 	public void removeService() throws Exception {
-		System.out.println("ResourcesManager.removeService");
+		System.out.println(CLASS_NAME + "removeService");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -743,46 +744,46 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void removeServiceWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.removeServiceWhenResourceNotExists");
+	public void removeServiceWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeServiceWhenResourceNotExists");
 
-			service = setUpService();
+		service = setUpService();
 
-			resourcesManager.removeService(sess, new Resource(), service);
-			// shouldn't find resource
+		resourcesManager.removeService(sess, new Resource(), service);
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void removeServiceWhenServiceNotExists() throws Exception {
-			System.out.println("ResourcesManager.removeServiceWhenServiceNotExists");
+	public void removeServiceWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeServiceWhenServiceNotExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
 
-			resourcesManager.removeService(sess, resource, new Service());
-			// shouldn't find service
+		resourcesManager.removeService(sess, resource, new Service());
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=ServiceNotAssignedException.class)
-		public void removeServiceWhenServiceNotAssigned() throws Exception {
-			System.out.println("ResourcesManager.removeServiceWhenServiceNotAssigned");
+	public void removeServiceWhenServiceNotAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "removeServiceWhenServiceNotAssigned");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
-			service = setUpService();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
 
-			resourcesManager.removeService(sess, resource, service);
-			// shouldn't be able to remove not added service
+		resourcesManager.removeService(sess, resource, service);
+		// shouldn't be able to remove not added service
 
-		}
+	}
 
 	@Test
 	public void removeServicesPackage() throws Exception {
-		System.out.println("ResourcesManager.removeServicesPackage");
+		System.out.println(CLASS_NAME + "removeServicesPackage");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -799,33 +800,33 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=ResourceNotExistsException.class)
-		public void removeServicesPackageWhenResourceNotExists() throws Exception {
-			System.out.println("ResourcesManager.removeServicesPackageWhenResourceNotExists");
+	public void removeServicesPackageWhenResourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeServicesPackageWhenResourceNotExists");
 
-			service = setUpService();
-			ServicesPackage servicesPackage = setUpServicesPackage(service);
+		service = setUpService();
+		ServicesPackage servicesPackage = setUpServicesPackage(service);
 
-			resourcesManager.removeServicesPackage(sess, new Resource(), servicesPackage);
-			// shouldn't find resource
+		resourcesManager.removeServicesPackage(sess, new Resource(), servicesPackage);
+		// shouldn't find resource
 
-		}
+	}
 
 	@Test (expected=ServicesPackageNotExistsException.class)
-		public void removeServicesPackageWhenPackageNotExists() throws Exception {
-			System.out.println("ResourcesManager.removeServicesPackageWhenPackageNotExists");
+	public void removeServicesPackageWhenPackageNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeServicesPackageWhenPackageNotExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
 
-			resourcesManager.removeServicesPackage(sess, resource, new ServicesPackage());
-			// shouldn't find services package
+		resourcesManager.removeServicesPackage(sess, resource, new ServicesPackage());
+		// shouldn't find services package
 
-		}
+	}
 
 	@Test
 	public void getResources() throws Exception {
-		System.out.println("ResourcesManager.getResources");
+		System.out.println(CLASS_NAME + "getResources");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -838,17 +839,17 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getResourcesWhenVoNotExists() throws Exception {
-			System.out.println("ResourcesManager.getResourcesWhenVoNotExists");
+	public void getResourcesWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getResourcesWhenVoNotExists");
 
-			resourcesManager.getResources(sess, new Vo());
-			// shouldn't find VO
+		resourcesManager.getResources(sess, new Vo());
+		// shouldn't find VO
 
-		}
+	}
 
 	@Test
 	public void getRichResources() throws Exception {
-		System.out.println("ResourcesManager.getRichResources");
+		System.out.println(CLASS_NAME + "getRichResources");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -866,17 +867,17 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test (expected=VoNotExistsException.class)
-		public void getRichResourcesWhenVoNotExists() throws Exception {
-			System.out.println("ResourcesManager.getRichResourcesWhenVoNotExists");
+	public void getRichResourcesWhenVoNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getRichResourcesWhenVoNotExists");
 
-			resourcesManager.getRichResources(sess, new Vo());
-			// shouldn't find VO
+		resourcesManager.getRichResources(sess, new Vo());
+		// shouldn't find VO
 
-		}
+	}
 
 	@Test
 	public void updateResource() throws Exception {
-		System.out.println("ResourcesManager.updateResource");
+		System.out.println(CLASS_NAME + "updateResource");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -900,12 +901,12 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void getAllResourcesTagsForResource() throws Exception {
-		System.out.println("ResourcesManager.getAllResourcesTagsForResource");
+		System.out.println(CLASS_NAME + "getAllResourcesTagsForResource");
 
 		vo = setUpVo();
 		facility = setUpFacility();
 		resource = setUpResource();
-		ResourceTag tag = setUpResoruceTag();
+		ResourceTag tag = setUpResourceTag();
 
 		resourcesManager.assignResourceTagToResource(sess, tag, resource);
 		List<ResourceTag> tags = perun.getResourcesManager().getAllResourcesTagsForResource(sess, resource);
@@ -915,10 +916,10 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void getAllResourcesTagsForVo() throws Exception {
-		System.out.println("ResourcesManager.getAllResourcesTagsForVo");
+		System.out.println(CLASS_NAME + "getAllResourcesTagsForVo");
 
 		vo = setUpVo();
-		ResourceTag tag = setUpResoruceTag();
+		ResourceTag tag = setUpResourceTag();
 		List<ResourceTag> tags = perun.getResourcesManager().getAllResourcesTagsForVo(sess, vo);
 		assertTrue("Created tag is not returned from VO", tags.contains(tag));
 
@@ -926,12 +927,12 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void getAllResourcesByResourceTag() throws Exception {
-		System.out.println("ResourcesManager.getAllResourcesByResourceTag");
+		System.out.println(CLASS_NAME + "getAllResourcesByResourceTag");
 
 		vo = setUpVo();
 		facility = setUpFacility();
 		resource = setUpResource();
-		ResourceTag tag = setUpResoruceTag();
+		ResourceTag tag = setUpResourceTag();
 
 		resourcesManager.assignResourceTagToResource(sess, tag, resource);
 		List<Resource> resources = perun.getResourcesManager().getAllResourcesByResourceTag(sess, tag);
@@ -941,7 +942,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void copyAttributes() throws Exception {
-		System.out.println("ResourcesManager.copyAttributes");
+		System.out.println(CLASS_NAME + "copyAttributes");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -980,7 +981,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void copyServices() throws Exception {
-		System.out.println("ResourcesManager.copyServices");
+		System.out.println(CLASS_NAME + "copyServices");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1002,7 +1003,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void copyGroups() throws Exception {
-		System.out.println("ResourcesManager.copyGroups");
+		System.out.println(CLASS_NAME + "copyGroups");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1025,7 +1026,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	@Test
 	public void getResourcesCount() throws Exception {
-		System.out.println("ResourcesManager.getResourcesCount()");
+		System.out.println(CLASS_NAME + "getResourcesCount");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1046,7 +1047,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	}
 
-	private ResourceTag setUpResoruceTag() throws Exception {
+	private ResourceTag setUpResourceTag() throws Exception {
 
 		ResourceTag tag = new ResourceTag(0, "ResourceManagerTestResourceTag", vo.getId());
 		tag = perun.getResourcesManager().createResourceTag(sess, tag, vo);
@@ -1189,7 +1190,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		attribute.setValue("Testing value for third attribute");
 		return attribute;
 	}
-	
+
 	private List<Attribute> setUpGroupResourceAttribute(Group group, Resource resource) throws Exception {
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setNamespace(AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF);
@@ -1205,4 +1206,5 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		attributes.add(attribute);
 		return attributes;
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
@@ -15,10 +15,14 @@ import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.bl.SearcherBl;
 
 /**
+ * Integration tests of Searcher
+ *
  * @author Michal Šťava <stavamichal@gmail.com>
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-
 public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
+
+	private final static String CLASS_NAME = "Searcher.";
 
 	// these are in DB only when needed and must be setUp"type"() in right order before use !!
 	private User user1;                             // our User
@@ -61,7 +65,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getUsersForIntegerValue() throws Exception {
-		System.out.println("Searcher.getUsersForIntegerValue");
+		System.out.println(CLASS_NAME + "getUsersForIntegerValue");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(integerAttr.getName(), "100");
 		AttributeDefinition attrDef = sess.getPerun().getAttributesManager().getAttributeDefinition(sess, integerAttr.getName());
@@ -74,7 +78,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getUsersForStringValue() throws Exception {
-		System.out.println("Searcher.getUsersForStringValue");
+		System.out.println(CLASS_NAME + "getUsersForStringValue");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(stringAttr.getName(), "UserStringAttribute test value");
 		List<User> users = new ArrayList<User>();
@@ -85,7 +89,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getUsersForListValue() throws Exception {
-		System.out.println("Searcher.getUsersForListValue");
+		System.out.println(CLASS_NAME + "getUsersForListValue");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(listAttr.getName(), "ttribute2");
 		List<User> users = new ArrayList<User>();
@@ -96,7 +100,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getUsersForCoreAttribute() throws Exception {
-		System.out.println("Searcher.getUsersForCoreAttribute");
+		System.out.println(CLASS_NAME + "getUsersForCoreAttribute");
 		Attribute attr = perun.getAttributesManagerBl().getAttribute(sess, user1, "urn:perun:user:attribute-def:core:id");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(attr.getName(), attr.getValue().toString());
@@ -108,7 +112,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getUsersForMapValue() throws Exception {
-		System.out.println("Searcher.getUsersForMapValue");
+		System.out.println(CLASS_NAME + "getUsersForMapValue");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(mapAttr.getName(), "UserLargeAttribute=test value");
 		List<User> users = new ArrayList<User>();
@@ -119,7 +123,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getMembersForIntegerValue() throws Exception {
-		System.out.println("Searcher.getUsersForIntegerValue");
+		System.out.println(CLASS_NAME + "getUsersForIntegerValue");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(integerAttr.getName(), "100");
 		AttributeDefinition attrDef = sess.getPerun().getAttributesManager().getAttributeDefinition(sess, integerAttr.getName());
@@ -132,7 +136,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getMembersForStringValue() throws Exception {
-		System.out.println("Searcher.getUsersForStringValue");
+		System.out.println(CLASS_NAME + "getUsersForStringValue");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(stringAttr.getName(), "UserStringAttribute test value");
 		List<Member> members = new ArrayList<>();
@@ -143,7 +147,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getMembersForListValue() throws Exception {
-		System.out.println("Searcher.getUsersForListValue");
+		System.out.println(CLASS_NAME + "getUsersForListValue");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(listAttr.getName(), "ttribute2");
 		List<Member> members = new ArrayList<>();
@@ -154,7 +158,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getMembersForCoreAttribute() throws Exception {
-		System.out.println("Searcher.getUsersForCoreAttribute");
+		System.out.println(CLASS_NAME + "getUsersForCoreAttribute");
 		Attribute attr = perun.getAttributesManagerBl().getAttribute(sess, user1, "urn:perun:user:attribute-def:core:id");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(attr.getName(), attr.getValue().toString());
@@ -166,7 +170,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getMembersForMapValue() throws Exception {
-		System.out.println("Searcher.getUsersForMapValue");
+		System.out.println(CLASS_NAME + "getUsersForMapValue");
 		Map<String, String> attributesWithSearchingValues = new HashMap<String, String>();
 		attributesWithSearchingValues.put(mapAttr.getName(), "UserLargeAttribute=test value");
 		List<Member> members = new ArrayList<>();
@@ -177,7 +181,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void getMembersByExpiration() throws Exception {
-		System.out.println("Searcher.getMembersByExpiration");
+		System.out.println(CLASS_NAME + "getMembersByExpiration");
 
 		// setup required attribute if not exists
 		try {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.*;
  */
 public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
-	private static final String SECURITY_TEAMS_MANAGER = "SecurityTeamsManager";
+	private static final String CLASS_NAME = "SecurityTeamsManager.";
 
 	private SecurityTeamsManager securityTeamsManagerEntry;
 
@@ -72,21 +72,22 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetSecurityTeamsPerunAdmin() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamsPerunAdmin");
+		System.out.println(CLASS_NAME + "testGetSecurityTeamsPerunAdmin");
 
 		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
 		try {
 			List<SecurityTeam> expected = setUpSecurityTeams();
 			sess.getPerunPrincipal().setRoles(new AuthzRoles(Role.PERUNADMIN));
 			List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
-			assertTrue("Security teams should contain all created.", expected.containsAll(actual));
+			assertTrue("Security teams should contain all created.", actual.containsAll(expected));
 		} finally {
 			sess.getPerunPrincipal().setRoles(roles);
 		}
 	}
+
 	@Test
 	public void testGetSecurityTeamsSecurityAdmin() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamsSecurityAdmin");
+		System.out.println(CLASS_NAME + "testGetSecurityTeamsSecurityAdmin");
 
 		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
 		try {
@@ -104,9 +105,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 			sess.getPerunPrincipal().setRoles(roles);
 		}
 	}
+
 	@Test
 	public void testGetSecurityTeamsSecurityAdmin1() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamsSecurityAdmin1");
+		System.out.println(CLASS_NAME + "testGetSecurityTeamsSecurityAdmin1");
 
 		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
 		try {
@@ -131,7 +133,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetAllSecurityTeams() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAllSecurityTeams");
+		System.out.println(CLASS_NAME + "testGetAllSecurityTeams");
 
 		List<SecurityTeam> expected = setUpSecurityTeams();
 		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
@@ -140,7 +142,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testCreateSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeam");
+		System.out.println(CLASS_NAME + "testCreateSecurityTeam");
 
 		SecurityTeam expected = new SecurityTeam("Name", "Desc");
 		SecurityTeam actual = securityTeamsManagerEntry.createSecurityTeam(sess, expected);
@@ -151,25 +153,28 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		assertNotNull(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test
 	public void testCreateSecurityTeamWithoutDsc() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamWithoutDsc");
+		System.out.println(CLASS_NAME + "testCreateSecurityTeamWithoutDsc");
 
 		SecurityTeam expected = new SecurityTeam("Name", null);
 		SecurityTeam actual = securityTeamsManagerEntry.createSecurityTeam(sess, expected);
 		assertNotNull(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testCreateSecurityTeamWithoutName() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamWithoutName");
+		System.out.println(CLASS_NAME + "testCreateSecurityTeamWithoutName");
 
 		SecurityTeam expected = new SecurityTeam(null, "Desc");
 		securityTeamsManagerEntry.createSecurityTeam(sess, expected);
 	}
+
 	@Test(expected = SecurityTeamExistsException.class)
 	public void testCreateSecurityTeamAlreadyExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamAlreadyExists");
+		System.out.println(CLASS_NAME + "testCreateSecurityTeamAlreadyExists");
 
 		SecurityTeam expected = new SecurityTeam("Name", "Desc");
 		securityTeamsManagerEntry.createSecurityTeam(sess, expected);
@@ -178,16 +183,18 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		assertEquals(expected, actual);
 		securityTeamsManagerEntry.createSecurityTeam(sess, actual);
 	}
+
 	@Test(expected = SecurityTeamExistsException.class)
 	public void testCreateSecurityTeamUniqueName() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamUniqueName");
+		System.out.println(CLASS_NAME + "testCreateSecurityTeamUniqueName");
 
 		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam("UniqueName", "Desc 1"));
 		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam("UniqueName", "Desc 2"));
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testCreateSecurityTeamNameLength() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamNameLength");
+		System.out.println(CLASS_NAME + "testCreateSecurityTeamNameLength");
 
 		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam(
 				"1---------2---------3---------4---------5---------6---------7---------8---------9---------10--------11--------12--------13--------",
@@ -197,7 +204,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testUpdateSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testUpdateSecurityTeam");
+		System.out.println(CLASS_NAME + "testUpdateSecurityTeam");
 
 		List<SecurityTeam> teams = setUpSecurityTeams();
 		SecurityTeam expected = teams.get(0);
@@ -211,16 +218,18 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		assertNotNull(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testUpdateSecurityTeamWithNoName() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testUpdateSecurityTeamWithNoName");
+		System.out.println(CLASS_NAME + "testUpdateSecurityTeamWithNoName");
 
 		SecurityTeam expected = new SecurityTeam("ToUpdate", "Desc");
 		securityTeamsManagerEntry.updateSecurityTeam(sess, expected);
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testUpdateSecurityTeamWithoutName() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testUpdateSecurityTeamWithoutName");
+		System.out.println(CLASS_NAME + "testUpdateSecurityTeamWithoutName");
 
 		List<SecurityTeam> teams = setUpSecurityTeams();
 		SecurityTeam expected = teams.get(0);
@@ -231,7 +240,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testDeleteSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeam");
+		System.out.println(CLASS_NAME + "testDeleteSecurityTeam");
 
 		List<SecurityTeam> expected = setUpSecurityTeams();
 		expected.remove(st0);
@@ -239,9 +248,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
 		assertTrue("SecurityTeam was not deleted.", !actual.contains(st0));
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testDeleteSecurityTeamShouldNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamShouldNotExists");
+		System.out.println(CLASS_NAME + "testDeleteSecurityTeamShouldNotExists");
 
 		setUpSecurityTeams();
 		SecurityTeam actual = securityTeamsManagerEntry.getSecurityTeamById(sess, st0.getId());
@@ -250,39 +260,44 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 		securityTeamsManagerEntry.getSecurityTeamById(sess, st0.getId());
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testDeleteSecurityTeamBeanNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamBeanNotExists");
+		System.out.println(CLASS_NAME + "testDeleteSecurityTeamBeanNotExists");
 
 		st0 = new SecurityTeam("Name", "Desc");
 		st0.setId(10);
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testDeleteSecurityTeamAlreadyDeleted() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamAlreadyDeleted");
+		System.out.println(CLASS_NAME + "testDeleteSecurityTeamAlreadyDeleted");
 
 		setUpSecurityTeams();
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testDeleteSecurityTeamWithNullSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamWithNullSecurityTeam");
+		System.out.println(CLASS_NAME + "testDeleteSecurityTeamWithNullSecurityTeam");
 
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, null);
 	}
+
 	@Test(expected = RelationExistsException.class)
 	public void testDeleteSecurityTeamWithRelationExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamWithRelationExists");
+		System.out.println(CLASS_NAME + "testDeleteSecurityTeamWithRelationExists");
 
 		setUpSecurityTeams();
 		setUpFacilities();
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 	}
+
 	@Test
 	public void testForceDeleteSecurityTeamWithRelationExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testForceDeleteSecurityTeamWithRelationExists");
+		System.out.println(CLASS_NAME + "testForceDeleteSecurityTeamWithRelationExists");
 
 		setUpSecurityTeams();
 		setUpFacilities();
@@ -291,15 +306,16 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetSecurityTeamById() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamById");
+		System.out.println(CLASS_NAME + "testGetSecurityTeamById");
 
 		SecurityTeam expected = setUpSecurityTeams().get(0);
 		SecurityTeam actual = securityTeamsManagerEntry.getSecurityTeamById(sess, expected.getId());
 		assertEquals(expected, actual);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testGetSecurityTeamByIdNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamByIdNotExists");
+		System.out.println(CLASS_NAME + "testGetSecurityTeamByIdNotExists");
 
 		securityTeamsManagerEntry.getSecurityTeamById(sess, 0);
 	}
@@ -307,7 +323,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetAdmins() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAdmins");
+		System.out.println(CLASS_NAME + "testGetAdmins");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -317,9 +333,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test
 	public void testGetAdminsEmpty() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAdminsEmpty");
+		System.out.println(CLASS_NAME + "testGetAdminsEmpty");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -330,14 +347,16 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testGetAdminsWithNullSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAdminsWithNullSecurityTeam");
+		System.out.println(CLASS_NAME + "testGetAdminsWithNullSecurityTeam");
 		securityTeamsManagerEntry.getAdmins(sess, null);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testGetAdminsWithoutSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAdminsWithoutSecurityTeam");
+		System.out.println(CLASS_NAME + "testGetAdminsWithoutSecurityTeam");
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.getAdmins(sess, st);
 	}
@@ -345,7 +364,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testAddAdmin() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdmin");
+		System.out.println(CLASS_NAME + "testAddAdmin");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -360,9 +379,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		if (admins.size() != 1) fail();
 		if (!admins.contains(u0)) fail();
 	}
+
 	@Test(expected = AlreadyAdminException.class)
 	public void testAddAdminAlreadyAdmin() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminAlreadyAdmin");
+		System.out.println(CLASS_NAME + "testAddAdminAlreadyAdmin");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -370,32 +390,36 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 		securityTeamsManagerEntry.addAdmin(sess, st0, u0);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testAddAdminSecurityTeamNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "testAddAdminSecurityTeamNotExists");
 
 		setUpUsers();
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.addAdmin(sess, st, u0);
 	}
+
 	@Test(expected = UserNotExistsException.class)
 	public void testAddAdminUserNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminUserNotExists");
+		System.out.println(CLASS_NAME + "testAddAdminUserNotExists");
 
 		setUpSecurityTeams();
 		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.addAdmin(sess, st0, user);
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testAddAdminNullSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminNullSecurityTeam");
+		System.out.println(CLASS_NAME + "testAddAdminNullSecurityTeam");
 
 		setUpUsers();
 		securityTeamsManagerEntry.addAdmin(sess, null, u0);
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testAddAdminNullUser() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminNullUser");
+		System.out.println(CLASS_NAME + "testAddAdminNullUser");
 
 		setUpSecurityTeams();
 		securityTeamsManagerEntry.addAdmin(sess, st0, (User) null);
@@ -404,7 +428,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testAddGroupAsAdmin() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdmin");
+		System.out.println(CLASS_NAME + "testAddGroupAsAdmin");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -423,9 +447,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		if (admins.contains(u3)) fail();
 		if (admins.contains(u4)) fail();
 	}
+
 	@Test(expected = AlreadyAdminException.class)
 	public void testAddGroupAsAdminAlreadyAdmin() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminAlreadyAdmin");
+		System.out.println(CLASS_NAME + "testAddGroupAsAdminAlreadyAdmin");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -434,34 +459,38 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 		securityTeamsManagerEntry.addAdmin(sess, st0, group);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testAddGroupAsAdminSecurityTeamNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "testAddGroupAsAdminSecurityTeamNotExists");
 
 		setUpUsers();
 		Group group = setUpGroup(u0, u1);
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.addAdmin(sess, st, group);
 	}
+
 	@Test(expected = GroupNotExistsException.class)
 	public void testAddGroupAsAdminGroupNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminGroupNotExists");
+		System.out.println(CLASS_NAME + "testAddGroupAsAdminGroupNotExists");
 
 		setUpSecurityTeams();
 		Group group = new Group("firstName", "lastName");
 		group.setId(0);
 		securityTeamsManagerEntry.addAdmin(sess, st0, group);
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testAddGroupAsAdminNullSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminNullSecurityTeam");
+		System.out.println(CLASS_NAME + "testAddGroupAsAdminNullSecurityTeam");
 
 		setUpUsers();
 		securityTeamsManagerEntry.addAdmin(sess, null, u0);
 	}
+
 	@Test(expected = InternalErrorException.class)
 	public void testAddGroupAsAdminNullGroup() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminNullGroup");
+		System.out.println(CLASS_NAME + "testAddGroupAsAdminNullGroup");
 
 		setUpSecurityTeams();
 		securityTeamsManagerEntry.addAdmin(sess, st0, (Group) null);
@@ -470,7 +499,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testRemoveAdmin() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdmin");
+		System.out.println(CLASS_NAME + "testRemoveAdmin");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -484,9 +513,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
 		if (admins.contains(u0)) fail();
 	}
+
 	@Test
 	public void testRemoveAdminAlsoInGroup() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdminAlsoInGroup");
+		System.out.println(CLASS_NAME + "testRemoveAdminAlsoInGroup");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -501,9 +531,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
 		if (!admins.contains(u1)) fail();
 	}
+
 	@Test(expected = UserNotAdminException.class)
 	public void testRemoveAdminAlreadyRemoved() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdminAlreadyRemoved");
+		System.out.println(CLASS_NAME + "testRemoveAdminAlreadyRemoved");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -511,17 +542,19 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 		securityTeamsManagerEntry.removeAdmin(sess, st0, u3);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testRemoveAdminSecurityTeamNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdminSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "testRemoveAdminSecurityTeamNotExists");
 
 		setUpUsers();
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.removeAdmin(sess, st, u1);
 	}
+
 	@Test(expected = UserNotExistsException.class)
 	public void testRemoveAdminUserNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdminUserNotExists");
+		System.out.println(CLASS_NAME + "testRemoveAdminUserNotExists");
 
 		setUpSecurityTeams();
 		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
@@ -531,7 +564,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testRemoveGroupAsAdmin() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveGroupAsAdmin");
+		System.out.println(CLASS_NAME + "testRemoveGroupAsAdmin");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -548,18 +581,20 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		if (!admins.contains(u1)) fail(); // Shouldn't be removed because is also admin as user
 		if (admins.contains(u2)) fail();
 	}
+
 	@Test(expected = GroupNotAdminException.class)
 	public void testRemoveGroupAsAdminAlreadyRemoved() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveGroupAsAdminAlreadyRemoved");
+		System.out.println(CLASS_NAME + "testRemoveGroupAsAdminAlreadyRemoved");
 
 		setUpSecurityTeams();
 		setUpUsers();
 		Group group = setUpGroup(u1, u2);
 		securityTeamsManagerEntry.removeAdmin(sess, st0, group);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testRemoveGroupAsAdminSecurityTeamNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveGroupAsAdminSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "testRemoveGroupAsAdminSecurityTeamNotExists");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -568,9 +603,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.removeAdmin(sess, st, group);
 	}
+
 	@Test(expected = GroupNotExistsException.class)
 	public void testRemoveGroupAsAdminGroupNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveGroupAsAdminGroupNotExists");
+		System.out.println(CLASS_NAME + "testRemoveGroupAsAdminGroupNotExists");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -583,7 +619,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testAddUserToBlacklist() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddUserToBlacklist");
+		System.out.println(CLASS_NAME + "testAddUserToBlacklist");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -600,9 +636,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		assertTrue("User 0 is not blacklisted by security team 0.", perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u0));
 
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testAddUserToBlacklistSecurityTeamNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddUserToBlacklistSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "testAddUserToBlacklistSecurityTeamNotExists");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -610,9 +647,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		SecurityTeam st = new SecurityTeam(0, "Security0", "Description test 0");
 		securityTeamsManagerEntry.addUserToBlacklist(sess, st, u0, "reason");
 	}
+
 	@Test(expected = UserNotExistsException.class)
 	public void testAddUserToBlacklistUserNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddUserToBlacklistUserNotExists");
+		System.out.println(CLASS_NAME + "testAddUserToBlacklistUserNotExists");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -620,9 +658,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.addUserToBlacklist(sess, st0, user, null);
 	}
+
 	@Test(expected = UserAlreadyBlacklistedException.class)
 	public void testAddUserToBlacklistAlreadyBlacklisted() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddUserToBlacklistAlreadyBlacklisted");
+		System.out.println(CLASS_NAME + "testAddUserToBlacklistAlreadyBlacklisted");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -633,7 +672,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetAssignedFacilitiesForSecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAssignedFacilitiesForSecurityTeam");
+		System.out.println(CLASS_NAME + "testGetAssignedFacilitiesForSecurityTeam");
 
 		setUpSecurityTeams();
 		setUpFacilities();
@@ -657,7 +696,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testRemoveUserFromBlacklist() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveUserFromBlacklist");
+		System.out.println(CLASS_NAME + "testRemoveUserFromBlacklist");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -665,12 +704,13 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpBlacklists();
 
 		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st0, u1);
-		assertTrue("User "+u1+" is blacklisted by "+st0, !perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u1));
+		assertTrue("User " + u1 + " is blacklisted by " + st0, !perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u1));
 
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testRemoveUserFromBlacklistSecurityTeamNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveUserFromBlacklistSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "testRemoveUserFromBlacklistSecurityTeamNotExists");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -679,9 +719,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		SecurityTeam st = new SecurityTeam(0, "Security0", "Description test 0");
 		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st, u1);
 	}
+
 	@Test(expected = UserNotExistsException.class)
 	public void testRemoveUserFromBlacklistUserNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveUserFromBlacklistUserNotExists");
+		System.out.println(CLASS_NAME + "testRemoveUserFromBlacklistUserNotExists");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -690,9 +731,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st0, user);
 	}
+
 	@Test(expected = UserAlreadyRemovedException.class)
 	public void testRemoveUserFromBlacklistUserNotInBlacklist() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveUserFromBlacklistUserNotInBlacklist");
+		System.out.println(CLASS_NAME + "testRemoveUserFromBlacklistUserNotInBlacklist");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -704,7 +746,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetBlacklistBySecurityTeam() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetBlacklistBySecurityTeam");
+		System.out.println(CLASS_NAME + "testGetBlacklistBySecurityTeam");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -720,9 +762,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testGetBlacklistBySecurityTeamSecurityTeamNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetBlacklistBySecurityTeamSecurityTeamNotExists");
+		System.out.println(CLASS_NAME + "testGetBlacklistBySecurityTeamSecurityTeamNotExists");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -736,7 +779,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetBlacklistByFacility() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetBlacklistByFacility");
+		System.out.println(CLASS_NAME + "testGetBlacklistByFacility");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -755,9 +798,10 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
+
 	@Test(expected = FacilityNotExistsException.class)
 	public void testGetBlacklistByFacilityNotExists() throws Exception {
-		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetBlacklistByFacilityNotExists");
+		System.out.println(CLASS_NAME + "testGetBlacklistByFacilityNotExists");
 
 		setUpSecurityTeams();
 		setUpUsers();
@@ -768,7 +812,6 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 		securityTeamsManagerEntry.getBlacklist(sess, facility);
 	}
-
 
 
 	private List<SecurityTeam> setUpSecurityTeams() throws PrivilegeException, InternalErrorException, SecurityTeamExistsException {
@@ -874,4 +917,5 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		Collections.sort(expected);
 		return expected;
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -42,6 +42,8 @@ import java.util.*;
 import static org.junit.Assert.*;
 
 /**
+ * Integration tests of SecurityTeamsManager
+ *
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
  */
 public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
@@ -74,6 +76,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 			sess.getPerunPrincipal().setRoles(new AuthzRoles(Role.PERUNADMIN));
 
 			List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
+			Collections.sort(expected);
+			Collections.sort(actual);
 			assertEquals(expected, actual);
 		} finally {
 			sess.getPerunPrincipal().setRoles(roles);
@@ -122,6 +126,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	public void testGetSecurityTeamsEmpty() throws Exception {
 		List<SecurityTeam> expected = new ArrayList<>();
 		List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
 
@@ -130,12 +136,16 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	public void testGetAllSecurityTeams() throws Exception {
 		List<SecurityTeam> expected = setUpSecurityTeams();
 		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
 	@Test
 	public void testGetAllSecurityTeamsEmpty() throws Exception {
 		List<SecurityTeam> expected = new ArrayList<>();
 		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
 
@@ -218,8 +228,9 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		List<SecurityTeam> expected = setUpSecurityTeams();
 		expected.remove(st0);
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
-
 		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
@@ -289,7 +300,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 		List<User> expected = new ArrayList<>();
 		List<User> actual = securityTeamsManagerEntry.getAdmins(sess, st0);
-
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
 	}
 	@Test(expected = InternalErrorException.class)
@@ -298,7 +310,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testGetAdminsWithoutSecurityTeam() throws Exception {
-		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.getAdmins(sess, st);
 	}
 
@@ -309,8 +321,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpUsers();
 
 		List<User> admins = securityTeamsManagerEntry.getAdmins(sess, st0);
-		if (admins.size() > 0) fail();
-		if (admins.contains(u0)) fail();
+		assertTrue("SecurityTeam shouldn't have any admins.", admins.size() <= 0);
+		assertTrue("User 0 shouldn't be admin of security team.", !admins.contains(u0));
 
 		securityTeamsManagerEntry.addAdmin(sess, st0, u0);
 
@@ -329,13 +341,13 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testAddAdminSecurityTeamNotExists() throws Exception {
 		setUpUsers();
-		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.addAdmin(sess, st, u0);
 	}
 	@Test(expected = UserNotExistsException.class)
 	public void testAddAdminUserNotExists() throws Exception {
 		setUpSecurityTeams();
-		User user = new User(11, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
+		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.addAdmin(sess, st0, user);
 	}
 	@Test(expected = InternalErrorException.class)
@@ -382,13 +394,14 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	public void testAddGroupAsAdminSecurityTeamNotExists() throws Exception {
 		setUpUsers();
 		Group group = setUpGroup(u0, u1);
-		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.addAdmin(sess, st, group);
 	}
 	@Test(expected = GroupNotExistsException.class)
 	public void testAddGroupAsAdminGroupNotExists() throws Exception {
 		setUpSecurityTeams();
-		Group group = new Group(11, "firstName", "lastName");
+		Group group = new Group("firstName", "lastName");
+		group.setId(0);
 		securityTeamsManagerEntry.addAdmin(sess, st0, group);
 	}
 	@Test(expected = InternalErrorException.class)
@@ -443,13 +456,13 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testRemoveAdminSecurityTeamNotExists() throws Exception {
 		setUpUsers();
-		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.removeAdmin(sess, st, u1);
 	}
 	@Test(expected = UserNotExistsException.class)
 	public void testRemoveAdminUserNotExists() throws Exception {
 		setUpSecurityTeams();
-		User user = new User(11, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
+		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.removeAdmin(sess, st0, user);
 	}
 
@@ -484,7 +497,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpUsers();
 		Group group = setUpGroup(u1, u2);
 		setUpAdmins(u0, u1, group);
-		SecurityTeam st = new SecurityTeam(11, "Name", "Desc");
+		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.removeAdmin(sess, st, group);
 	}
 	@Test(expected = GroupNotExistsException.class)
@@ -492,7 +505,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpAdmins(u0, u1, setUpGroup(u1, u2));
-		Group group = new Group(11, "Name", "name");
+		Group group = new Group("Name", "name");
+		group.setId(0);
 		securityTeamsManagerEntry.removeAdmin(sess, st0, group);
 	}
 
@@ -508,18 +522,18 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		securityTeamsManagerEntry.addUserToBlacklist(sess, st0, u0, "reason");
 
 		List<User> actual = securityTeamsManagerEntry.getBlacklist(sess, st0);
+		Collections.sort(expected);
+		Collections.sort(actual);
 		assertEquals(expected, actual);
+		assertTrue("User 0 is not blacklisted by security team 0.", perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u0));
 
-		if (!perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u0)) {
-			fail();
-		}
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testAddUserToBlacklistSecurityTeamNotExists() throws Exception {
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
-		SecurityTeam st = new SecurityTeam(11, "Security0", "Description test 0");
+		SecurityTeam st = new SecurityTeam(0, "Security0", "Description test 0");
 		securityTeamsManagerEntry.addUserToBlacklist(sess, st, u0, "reason");
 	}
 	@Test(expected = UserNotExistsException.class)
@@ -527,7 +541,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
-		User user = new User(11, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
+		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.addUserToBlacklist(sess, st0, user, null);
 	}
 	@Test(expected = UserAlreadyBlacklistedException.class)
@@ -561,7 +575,6 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	}
 
-
 	@Test
 	public void testRemoveUserFromBlacklist() throws Exception {
 		setUpSecurityTeams();
@@ -570,10 +583,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpBlacklists();
 
 		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st0, u1);
+		assertTrue("User "+u1+" is blacklisted by "+st0, !perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u1));
 
-		if (perun.getSecurityTeamsManagerBl().isUserBlacklisted(sess, st0, u1)) {
-			fail();
-		}
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testRemoveUserFromBlacklistSecurityTeamNotExists() throws Exception {
@@ -581,7 +592,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpUsers();
 		setUpFacilities();
 		setUpBlacklists();
-		SecurityTeam st = new SecurityTeam(11, "Security0", "Description test 0");
+		SecurityTeam st = new SecurityTeam(0, "Security0", "Description test 0");
 		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st, u1);
 	}
 	@Test(expected = UserNotExistsException.class)
@@ -590,7 +601,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpUsers();
 		setUpFacilities();
 		setUpBlacklists();
-		User user = new User(11, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
+		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.removeUserFromBlacklist(sess, st0, user);
 	}
 	@Test(expected = UserAlreadyRemovedException.class)
@@ -625,7 +636,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpUsers();
 		setUpFacilities();
 		setUpBlacklists();
-		SecurityTeam st = new SecurityTeam(11, "Security0", "Description test 0");
+		SecurityTeam st = new SecurityTeam(0, "Security0", "Description test 0");
 
 		securityTeamsManagerEntry.getBlacklist(sess, st);
 	}
@@ -657,7 +668,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpFacilities();
 		setUpBlacklists();
 
-		Facility facility = new Facility(11, "facility");
+		Facility facility = new Facility(0, "facility");
 
 		securityTeamsManagerEntry.getBlacklist(sess, facility);
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -48,6 +48,8 @@ import static org.junit.Assert.*;
  */
 public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
+	private static final String SECURITY_TEAMS_MANAGER = "SecurityTeamsManager";
+
 	private SecurityTeamsManager securityTeamsManagerEntry;
 
 	private SecurityTeam st0;
@@ -70,21 +72,22 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetSecurityTeamsPerunAdmin() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamsPerunAdmin");
+
 		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
 		try {
 			List<SecurityTeam> expected = setUpSecurityTeams();
 			sess.getPerunPrincipal().setRoles(new AuthzRoles(Role.PERUNADMIN));
-
 			List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
-			Collections.sort(expected);
-			Collections.sort(actual);
-			assertEquals(expected, actual);
+			assertTrue("Security teams should contain all created.", expected.containsAll(actual));
 		} finally {
 			sess.getPerunPrincipal().setRoles(roles);
 		}
 	}
 	@Test
 	public void testGetSecurityTeamsSecurityAdmin() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamsSecurityAdmin");
+
 		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
 		try {
 			setUpSecurityTeams();
@@ -103,6 +106,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test
 	public void testGetSecurityTeamsSecurityAdmin1() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamsSecurityAdmin1");
+
 		AuthzRoles roles = sess.getPerunPrincipal().getRoles();
 		try {
 			setUpSecurityTeams();
@@ -122,36 +127,21 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 			sess.getPerunPrincipal().setRoles(roles);
 		}
 	}
-	@Test
-	public void testGetSecurityTeamsEmpty() throws Exception {
-		List<SecurityTeam> expected = new ArrayList<>();
-		List<SecurityTeam> actual = securityTeamsManagerEntry.getSecurityTeams(sess);
-		Collections.sort(expected);
-		Collections.sort(actual);
-		assertEquals(expected, actual);
-	}
 
 
 	@Test
 	public void testGetAllSecurityTeams() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAllSecurityTeams");
+
 		List<SecurityTeam> expected = setUpSecurityTeams();
 		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
-		Collections.sort(expected);
-		Collections.sort(actual);
-		assertEquals(expected, actual);
+		assertTrue("Created security teams are not between all.", actual.containsAll(expected));
 	}
-	@Test
-	public void testGetAllSecurityTeamsEmpty() throws Exception {
-		List<SecurityTeam> expected = new ArrayList<>();
-		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
-		Collections.sort(expected);
-		Collections.sort(actual);
-		assertEquals(expected, actual);
-	}
-
 
 	@Test
 	public void testCreateSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeam");
+
 		SecurityTeam expected = new SecurityTeam("Name", "Desc");
 		SecurityTeam actual = securityTeamsManagerEntry.createSecurityTeam(sess, expected);
 		assertNotNull(actual);
@@ -163,6 +153,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test
 	public void testCreateSecurityTeamWithoutDsc() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamWithoutDsc");
+
 		SecurityTeam expected = new SecurityTeam("Name", null);
 		SecurityTeam actual = securityTeamsManagerEntry.createSecurityTeam(sess, expected);
 		assertNotNull(actual);
@@ -170,11 +162,15 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testCreateSecurityTeamWithoutName() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamWithoutName");
+
 		SecurityTeam expected = new SecurityTeam(null, "Desc");
 		securityTeamsManagerEntry.createSecurityTeam(sess, expected);
 	}
 	@Test(expected = SecurityTeamExistsException.class)
 	public void testCreateSecurityTeamAlreadyExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamAlreadyExists");
+
 		SecurityTeam expected = new SecurityTeam("Name", "Desc");
 		securityTeamsManagerEntry.createSecurityTeam(sess, expected);
 		SecurityTeam actual = securityTeamsManagerEntry.createSecurityTeam(sess, expected);
@@ -184,11 +180,15 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamExistsException.class)
 	public void testCreateSecurityTeamUniqueName() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamUniqueName");
+
 		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam("UniqueName", "Desc 1"));
 		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam("UniqueName", "Desc 2"));
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testCreateSecurityTeamNameLength() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testCreateSecurityTeamNameLength");
+
 		securityTeamsManagerEntry.createSecurityTeam(sess, new SecurityTeam(
 				"1---------2---------3---------4---------5---------6---------7---------8---------9---------10--------11--------12--------13--------",
 				"Desc 1"));
@@ -197,6 +197,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testUpdateSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testUpdateSecurityTeam");
+
 		List<SecurityTeam> teams = setUpSecurityTeams();
 		SecurityTeam expected = teams.get(0);
 		expected.setName("Updated");
@@ -211,11 +213,15 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testUpdateSecurityTeamWithNoName() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testUpdateSecurityTeamWithNoName");
+
 		SecurityTeam expected = new SecurityTeam("ToUpdate", "Desc");
 		securityTeamsManagerEntry.updateSecurityTeam(sess, expected);
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testUpdateSecurityTeamWithoutName() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testUpdateSecurityTeamWithoutName");
+
 		List<SecurityTeam> teams = setUpSecurityTeams();
 		SecurityTeam expected = teams.get(0);
 		expected.setName(null);
@@ -225,16 +231,18 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testDeleteSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeam");
+
 		List<SecurityTeam> expected = setUpSecurityTeams();
 		expected.remove(st0);
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 		List<SecurityTeam> actual = securityTeamsManagerEntry.getAllSecurityTeams(sess);
-		Collections.sort(expected);
-		Collections.sort(actual);
-		assertEquals(expected, actual);
+		assertTrue("SecurityTeam was not deleted.", !actual.contains(st0));
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testDeleteSecurityTeamShouldNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamShouldNotExists");
+
 		setUpSecurityTeams();
 		SecurityTeam actual = securityTeamsManagerEntry.getSecurityTeamById(sess, st0.getId());
 		assertNotNull(actual);
@@ -244,28 +252,38 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testDeleteSecurityTeamBeanNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamBeanNotExists");
+
 		st0 = new SecurityTeam("Name", "Desc");
 		st0.setId(10);
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testDeleteSecurityTeamAlreadyDeleted() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamAlreadyDeleted");
+
 		setUpSecurityTeams();
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testDeleteSecurityTeamWithNullSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamWithNullSecurityTeam");
+
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, null);
 	}
 	@Test(expected = RelationExistsException.class)
 	public void testDeleteSecurityTeamWithRelationExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testDeleteSecurityTeamWithRelationExists");
+
 		setUpSecurityTeams();
 		setUpFacilities();
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0);
 	}
 	@Test
 	public void testForceDeleteSecurityTeamWithRelationExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testForceDeleteSecurityTeamWithRelationExists");
+
 		setUpSecurityTeams();
 		setUpFacilities();
 		securityTeamsManagerEntry.deleteSecurityTeam(sess, st0, true);
@@ -273,18 +291,24 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetSecurityTeamById() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamById");
+
 		SecurityTeam expected = setUpSecurityTeams().get(0);
 		SecurityTeam actual = securityTeamsManagerEntry.getSecurityTeamById(sess, expected.getId());
 		assertEquals(expected, actual);
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testGetSecurityTeamByIdNotExists() throws Exception {
-		securityTeamsManagerEntry.getSecurityTeamById(sess, 10);
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetSecurityTeamByIdNotExists");
+
+		securityTeamsManagerEntry.getSecurityTeamById(sess, 0);
 	}
 
 
 	@Test
 	public void testGetAdmins() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAdmins");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		List<User> expected = setUpAdmins(u0, u1, setUpGroup(u1, u2));
@@ -295,6 +319,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test
 	public void testGetAdminsEmpty() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAdminsEmpty");
+
 		setUpSecurityTeams();
 		setUpUsers();
 
@@ -306,10 +332,12 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testGetAdminsWithNullSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAdminsWithNullSecurityTeam");
 		securityTeamsManagerEntry.getAdmins(sess, null);
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testGetAdminsWithoutSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAdminsWithoutSecurityTeam");
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.getAdmins(sess, st);
 	}
@@ -317,6 +345,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testAddAdmin() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdmin");
+
 		setUpSecurityTeams();
 		setUpUsers();
 
@@ -332,6 +362,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = AlreadyAdminException.class)
 	public void testAddAdminAlreadyAdmin() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminAlreadyAdmin");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpAdmins(u0, u1, setUpGroup(u1, u2));
@@ -340,23 +372,31 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testAddAdminSecurityTeamNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminSecurityTeamNotExists");
+
 		setUpUsers();
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.addAdmin(sess, st, u0);
 	}
 	@Test(expected = UserNotExistsException.class)
 	public void testAddAdminUserNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminUserNotExists");
+
 		setUpSecurityTeams();
 		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.addAdmin(sess, st0, user);
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testAddAdminNullSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminNullSecurityTeam");
+
 		setUpUsers();
 		securityTeamsManagerEntry.addAdmin(sess, null, u0);
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testAddAdminNullUser() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddAdminNullUser");
+
 		setUpSecurityTeams();
 		securityTeamsManagerEntry.addAdmin(sess, st0, (User) null);
 	}
@@ -364,6 +404,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testAddGroupAsAdmin() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdmin");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		Group group = setUpGroup(u0, u1);
@@ -383,6 +425,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = AlreadyAdminException.class)
 	public void testAddGroupAsAdminAlreadyAdmin() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminAlreadyAdmin");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		Group group = setUpGroup(u1, u2);
@@ -392,6 +436,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testAddGroupAsAdminSecurityTeamNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminSecurityTeamNotExists");
+
 		setUpUsers();
 		Group group = setUpGroup(u0, u1);
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
@@ -399,6 +445,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = GroupNotExistsException.class)
 	public void testAddGroupAsAdminGroupNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminGroupNotExists");
+
 		setUpSecurityTeams();
 		Group group = new Group("firstName", "lastName");
 		group.setId(0);
@@ -406,11 +454,15 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testAddGroupAsAdminNullSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminNullSecurityTeam");
+
 		setUpUsers();
 		securityTeamsManagerEntry.addAdmin(sess, null, u0);
 	}
 	@Test(expected = InternalErrorException.class)
 	public void testAddGroupAsAdminNullGroup() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddGroupAsAdminNullGroup");
+
 		setUpSecurityTeams();
 		securityTeamsManagerEntry.addAdmin(sess, st0, (Group) null);
 	}
@@ -418,6 +470,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testRemoveAdmin() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdmin");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpAdmins(u0, u1, setUpGroup(u1, u2));
@@ -432,6 +486,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test
 	public void testRemoveAdminAlsoInGroup() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdminAlsoInGroup");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpAdmins(u0, u1, setUpGroup(u1, u2));
@@ -439,7 +495,7 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		List<User> admins = securityTeamsManagerEntry.getAdmins(sess, st0);
 		if (!admins.contains(u1)) fail();
 
-		//Shouldnt remove from admins because he is also in group as admin
+		//Shouldn't remove from admins because he is also in group as admin
 		securityTeamsManagerEntry.removeAdmin(sess, st0, u1);
 
 		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
@@ -447,6 +503,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = UserNotAdminException.class)
 	public void testRemoveAdminAlreadyRemoved() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdminAlreadyRemoved");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpAdmins(u0, u1, setUpGroup(u1, u2));
@@ -455,12 +513,16 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testRemoveAdminSecurityTeamNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdminSecurityTeamNotExists");
+
 		setUpUsers();
 		SecurityTeam st = new SecurityTeam(0, "Name", "Desc");
 		securityTeamsManagerEntry.removeAdmin(sess, st, u1);
 	}
 	@Test(expected = UserNotExistsException.class)
 	public void testRemoveAdminUserNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveAdminUserNotExists");
+
 		setUpSecurityTeams();
 		User user = new User(0, "firstName", "lastName", "middleName", "titleBefore", "titleAfter");
 		securityTeamsManagerEntry.removeAdmin(sess, st0, user);
@@ -469,6 +531,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testRemoveGroupAsAdmin() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveGroupAsAdmin");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		Group group = setUpGroup(u1, u2);
@@ -481,11 +545,13 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		securityTeamsManagerEntry.removeAdmin(sess, st0, group);
 
 		admins = securityTeamsManagerEntry.getAdmins(sess, st0);
-		if (!admins.contains(u1)) fail(); // Shouldnt be removed because is also admin as user
+		if (!admins.contains(u1)) fail(); // Shouldn't be removed because is also admin as user
 		if (admins.contains(u2)) fail();
 	}
 	@Test(expected = GroupNotAdminException.class)
 	public void testRemoveGroupAsAdminAlreadyRemoved() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveGroupAsAdminAlreadyRemoved");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		Group group = setUpGroup(u1, u2);
@@ -493,6 +559,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testRemoveGroupAsAdminSecurityTeamNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveGroupAsAdminSecurityTeamNotExists");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		Group group = setUpGroup(u1, u2);
@@ -502,6 +570,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = GroupNotExistsException.class)
 	public void testRemoveGroupAsAdminGroupNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveGroupAsAdminGroupNotExists");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpAdmins(u0, u1, setUpGroup(u1, u2));
@@ -513,6 +583,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testAddUserToBlacklist() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddUserToBlacklist");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -530,6 +602,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testAddUserToBlacklistSecurityTeamNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddUserToBlacklistSecurityTeamNotExists");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -538,6 +612,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = UserNotExistsException.class)
 	public void testAddUserToBlacklistUserNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddUserToBlacklistUserNotExists");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -546,6 +622,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = UserAlreadyBlacklistedException.class)
 	public void testAddUserToBlacklistAlreadyBlacklisted() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testAddUserToBlacklistAlreadyBlacklisted");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -555,6 +633,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetAssignedFacilitiesForSecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetAssignedFacilitiesForSecurityTeam");
+
 		setUpSecurityTeams();
 		setUpFacilities();
 
@@ -577,6 +657,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testRemoveUserFromBlacklist() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveUserFromBlacklist");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -588,6 +670,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testRemoveUserFromBlacklistSecurityTeamNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveUserFromBlacklistSecurityTeamNotExists");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -597,6 +681,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = UserNotExistsException.class)
 	public void testRemoveUserFromBlacklistUserNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveUserFromBlacklistUserNotExists");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -606,6 +692,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = UserAlreadyRemovedException.class)
 	public void testRemoveUserFromBlacklistUserNotInBlacklist() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testRemoveUserFromBlacklistUserNotInBlacklist");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -616,6 +704,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetBlacklistBySecurityTeam() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetBlacklistBySecurityTeam");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -632,6 +722,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = SecurityTeamNotExistsException.class)
 	public void testGetBlacklistBySecurityTeamSecurityTeamNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetBlacklistBySecurityTeamSecurityTeamNotExists");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -644,6 +736,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 
 	@Test
 	public void testGetBlacklistByFacility() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetBlacklistByFacility");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();
@@ -663,6 +757,8 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 	}
 	@Test(expected = FacilityNotExistsException.class)
 	public void testGetBlacklistByFacilityNotExists() throws Exception {
+		System.out.println(SECURITY_TEAMS_MANAGER + ".testGetBlacklistByFacilityNotExists");
+
 		setUpSecurityTeams();
 		setUpUsers();
 		setUpFacilities();

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
@@ -42,10 +42,13 @@ import cz.metacentrum.perun.core.api.exceptions.ServicesPackageExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServicesPackageNotExistsException;
 
 /**
+ * Integration tests of ServicesManager.
+ *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-
 public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
+
+	private final static String CLASS_NAME = "ServicesManager.";
 
 	// these are in DB only after setUp"Type"() method and must be set up in right order.
 	private Service service;
@@ -62,7 +65,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void createService() throws Exception {
-		System.out.println("ServicesManager.createService");
+		System.out.println(CLASS_NAME + "createService");
 
 		Service service = new Service();
 		service.setName("ServicesManagerTestService");
@@ -72,67 +75,67 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=InternalErrorException.class)
-		public void createServiceWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.createServiceWhenServiceNotExists");
+	public void createServiceWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "createServiceWhenServiceNotExists");
 
-			perun.getServicesManager().createService(sess, new Service());
-			// shouldn't be able to create service in DB (InternalError) when it's not valid Service object
+		perun.getServicesManager().createService(sess, new Service());
+		// shouldn't be able to create service in DB (InternalError) when it's not valid Service object
 
-		}
+	}
 
 	@Test (expected=ServiceExistsException.class)
-		public void createServiceWhenServiceExists() throws Exception {
-			System.out.println("ServicesManager.createService");
+	public void createServiceWhenServiceExists() throws Exception {
+		System.out.println(CLASS_NAME + "createService");
 
-			Service service = new Service();
-			service.setName("ServicesManagerTestService");
-			service = perun.getServicesManager().createService(sess, service);
-			service = perun.getServicesManager().createService(sess, service);
-			// shouldn't create same service twice
+		Service service = new Service();
+		service.setName("ServicesManagerTestService");
+		service = perun.getServicesManager().createService(sess, service);
+		service = perun.getServicesManager().createService(sess, service);
+		// shouldn't create same service twice
 
-		}
-
-	@Test (expected=ServiceNotExistsException.class)
-		public void deleteService() throws Exception {
-			System.out.println("ServicesManager.deleteService");
-
-			service = setUpService();
-			assertNotNull("unable to create service before deletion",service);
-			perun.getServicesManager().deleteService(sess, service);
-			perun.getServicesManager().getServiceById(sess, service.getId());
-			// shouldn't find deleted service
-
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void deleteServiceWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.deleteServiceWhenServiceNotExists");
+	public void deleteService() throws Exception {
+		System.out.println(CLASS_NAME + "deleteService");
 
-			perun.getServicesManager().deleteService(sess, new Service());
-			// shouldn't find service
+		service = setUpService();
+		assertNotNull("unable to create service before deletion",service);
+		perun.getServicesManager().deleteService(sess, service);
+		perun.getServicesManager().getServiceById(sess, service.getId());
+		// shouldn't find deleted service
 
-		}
+	}
+
+	@Test (expected=ServiceNotExistsException.class)
+	public void deleteServiceWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteServiceWhenServiceNotExists");
+
+		perun.getServicesManager().deleteService(sess, new Service());
+		// shouldn't find service
+
+	}
 
 
 	@Test (expected=RelationExistsException.class)
-		public void deleteServiceWhenRelationExists() throws Exception {
-			System.out.println("ServicesManager.deleteServiceWhenWhenRelationExists");
+	public void deleteServiceWhenRelationExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteServiceWhenWhenRelationExists");
 
-			vo = setUpVo();
-			facility = setUpFacility();
-			resource = setUpResource();
-			service = setUpService();
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
 
-			perun.getResourcesManager().assignService(sess, resource, service);
+		perun.getResourcesManager().assignService(sess, resource, service);
 
-			perun.getServicesManager().deleteService(sess, service);
-			// shouldn't deleted service assigned to resource
+		perun.getServicesManager().deleteService(sess, service);
+		// shouldn't deleted service assigned to resource
 
-		}
+	}
 
 	@Test
 	public void updateService() throws Exception {
-		System.out.println("ServicesManager.updateService");
+		System.out.println(CLASS_NAME + "updateService");
 
 		service = setUpService();
 		assertNotNull("unable to create service before update",service);
@@ -146,17 +149,17 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void updateServiceWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.updateServiceWhenServiceNotExists");
+	public void updateServiceWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "updateServiceWhenServiceNotExists");
 
-			perun.getServicesManager().updateService(sess, new Service());
-			// shouldn't find Service
+		perun.getServicesManager().updateService(sess, new Service());
+		// shouldn't find Service
 
-		}
+	}
 
 	@Test
 	public void getServiceById() throws Exception {
-		System.out.println("ServicesManager.getServiceById");
+		System.out.println(CLASS_NAME + "getServiceById");
 
 		service = setUpService();
 		assertNotNull("unable to create service",service);
@@ -167,17 +170,17 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void getServiceByIdWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.getServiceByIdWhenServiceNotExists");
+	public void getServiceByIdWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getServiceByIdWhenServiceNotExists");
 
-			perun.getServicesManager().getServiceById(sess, 0);
-			// shouldn't find service with ID 0
+		perun.getServicesManager().getServiceById(sess, 0);
+		// shouldn't find service with ID 0
 
-		}
+	}
 
 	@Test
 	public void getServiceByName() throws Exception {
-		System.out.println("ServicesManager.getServiceByName");
+		System.out.println(CLASS_NAME + "getServiceByName");
 
 		service = setUpService();
 		assertNotNull("unable to create service",service);
@@ -188,17 +191,17 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void getServiceByNameWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.getServiceByNameWhenServiceNotExists");
+	public void getServiceByNameWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getServiceByNameWhenServiceNotExists");
 
-			perun.getServicesManager().getServiceByName(sess, "");
-			// shouldn't find service with empty name
+		perun.getServicesManager().getServiceByName(sess, "");
+		// shouldn't find service with empty name
 
-		}
+	}
 
 	@Test
 	public void getServices() throws Exception {
-		System.out.println("ServicesManager.getServices");
+		System.out.println(CLASS_NAME + "getServices");
 
 		service = setUpService();
 
@@ -210,7 +213,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getServicesByAttributeDefinition() throws Exception {
-		System.out.println("ServicesManager.getServicesByAttributeDefinition");
+		System.out.println(CLASS_NAME + "getServicesByAttributeDefinition");
 
 		service = setUpService();
 
@@ -226,7 +229,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getAssignedResources() throws Exception {
-		System.out.println("ServicesManager.getAssignedResources");
+		System.out.println(CLASS_NAME + "getAssignedResources");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -242,17 +245,17 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void getAssignedResourcesWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.getAssignedResourcesWhenServiceNotExists");
+	public void getAssignedResourcesWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getAssignedResourcesWhenServiceNotExists");
 
-			perun.getServicesManager().getAssignedResources(sess, new Service());
-			// shouldn't find service
+		perun.getServicesManager().getAssignedResources(sess, new Service());
+		// shouldn't find service
 
-		}
+	}
 
 	@Test
 	public void getServicesPackages() throws Exception {
-		System.out.println("ServicesManager.getServicesPackages");
+		System.out.println(CLASS_NAME + "getServicesPackages");
 
 		service = setUpService();
 		servicesPackage = setUpServicesPackage(service);
@@ -265,7 +268,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getServicesPackageById() throws Exception {
-		System.out.println("ServicesManager.getServicesPackageById");
+		System.out.println(CLASS_NAME + "getServicesPackageById");
 
 		service = setUpService();
 		servicesPackage = setUpServicesPackage(service);
@@ -277,17 +280,17 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServicesPackageNotExistsException.class)
-		public void getServicesPackageByIdWhenPackageNotExists() throws Exception {
-			System.out.println("ServicesManager.getServicesPackageByIdWhenPackageNotExists");
+	public void getServicesPackageByIdWhenPackageNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getServicesPackageByIdWhenPackageNotExists");
 
-			perun.getServicesManager().getServicesPackageById(sess, 0);
-			// shouldn't find package
+		perun.getServicesManager().getServicesPackageById(sess, 0);
+		// shouldn't find package
 
-		}
+	}
 
 	@Test
 	public void getServicesPackageByName() throws Exception {
-		System.out.println("ServicesManager.getServicesPackageByName");
+		System.out.println(CLASS_NAME + "getServicesPackageByName");
 
 		service = setUpService();
 		servicesPackage = setUpServicesPackage(service);
@@ -299,17 +302,17 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServicesPackageNotExistsException.class)
-		public void getServicesPackageByNameWhenServPackNotExists() throws Exception {
-			System.out.println("ServicesManager.getServicesPackageByNameWhenServPackNotExists");
+	public void getServicesPackageByNameWhenServPackNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getServicesPackageByNameWhenServPackNotExists");
 
-			perun.getServicesManager().getServicesPackageByName(sess, "notExists");
-			// shouldn't find services package
+		perun.getServicesManager().getServicesPackageByName(sess, "notExists");
+		// shouldn't find services package
 
-		}
+	}
 
 	@Test
 	public void createServicesPackage() throws Exception {
-		System.out.println("ServicesManager.createServicesPackage");
+		System.out.println(CLASS_NAME + "createServicesPackage");
 
 		service = setUpService();
 		servicesPackage = setUpServicesPackage(service);
@@ -321,60 +324,60 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServicesPackageExistsException.class)
-		public void createServicesPackageWhenServicePackageExists() throws Exception {
-			System.out.println("ServicesManager.createServicesPackageWhenServicePackageExists");
+	public void createServicesPackageWhenServicePackageExists() throws Exception {
+		System.out.println(CLASS_NAME + "createServicesPackageWhenServicePackageExists");
 
-			service = setUpService();
-			servicesPackage = setUpServicesPackage(service);
-			assertNotNull("unable to create services package",servicesPackage);
-			ServicesPackage returnedPackage = perun.getServicesManager().getServicesPackageById(sess, servicesPackage.getId());
-			perun.getServicesManager().createServicesPackage(sess, returnedPackage);
-			// shouldn't add service package twice
+		service = setUpService();
+		servicesPackage = setUpServicesPackage(service);
+		assertNotNull("unable to create services package",servicesPackage);
+		ServicesPackage returnedPackage = perun.getServicesManager().getServicesPackageById(sess, servicesPackage.getId());
+		perun.getServicesManager().createServicesPackage(sess, returnedPackage);
+		// shouldn't add service package twice
 
-		}
-
-	@Test (expected=ServicesPackageNotExistsException.class)
-		public void deleteServicesPackage() throws Exception {
-			System.out.println("ServicesManager.deleteServicesPackage");
-
-			service = setUpService();
-			assertNotNull("unable to create service in DB",service);
-			servicesPackage = setUpServicesPackage(service);
-			assertNotNull("unable to create services package before deletion",servicesPackage);
-
-			perun.getServicesManager().removeServiceFromServicesPackage(sess, servicesPackage, service);
-			// remove service from package so it can be deleted
-			perun.getServicesManager().deleteServicesPackage(sess, servicesPackage);
-			// finally delete package
-			perun.getServicesManager().getServicesPackageById(sess, servicesPackage.getId());
-			// shouldn't find services package in DB after deletion
-
-		}
+	}
 
 	@Test (expected=ServicesPackageNotExistsException.class)
-		public void deleteServicesPackageWhenPackageNotExist() throws Exception {
-			System.out.println("ServicesManager.deleteServicesPackageWhenPackageNotExist");
+	public void deleteServicesPackage() throws Exception {
+		System.out.println(CLASS_NAME + "deleteServicesPackage");
 
-			perun.getServicesManager().deleteServicesPackage(sess, new ServicesPackage());
-			// shouldn't find services package in DB
+		service = setUpService();
+		assertNotNull("unable to create service in DB",service);
+		servicesPackage = setUpServicesPackage(service);
+		assertNotNull("unable to create services package before deletion",servicesPackage);
 
-		}
+		perun.getServicesManager().removeServiceFromServicesPackage(sess, servicesPackage, service);
+		// remove service from package so it can be deleted
+		perun.getServicesManager().deleteServicesPackage(sess, servicesPackage);
+		// finally delete package
+		perun.getServicesManager().getServicesPackageById(sess, servicesPackage.getId());
+		// shouldn't find services package in DB after deletion
+
+	}
+
+	@Test (expected=ServicesPackageNotExistsException.class)
+	public void deleteServicesPackageWhenPackageNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "deleteServicesPackageWhenPackageNotExist");
+
+		perun.getServicesManager().deleteServicesPackage(sess, new ServicesPackage());
+		// shouldn't find services package in DB
+
+	}
 
 	@Test (expected=RelationExistsException.class)
-		public void deleteServicesPackageWhenRealtionExists() throws Exception {
-			System.out.println("ServicesManager.deleteServicesPackage");
+	public void deleteServicesPackageWhenRealtionExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteServicesPackage");
 
-			service = setUpService();
-			servicesPackage = setUpServicesPackage(service);
+		service = setUpService();
+		servicesPackage = setUpServicesPackage(service);
 
-			perun.getServicesManager().deleteServicesPackage(sess, servicesPackage);
-			// shouldn't delete package with service inside
+		perun.getServicesManager().deleteServicesPackage(sess, servicesPackage);
+		// shouldn't delete package with service inside
 
-		}
+	}
 
 	@Test
 	public void addServiceToServicesPackage() throws Exception {
-		System.out.println("ServicesManager.addServiceToServicesPackage");
+		System.out.println(CLASS_NAME + "addServiceToServicesPackage");
 
 		service = setUpService();
 		assertNotNull("unable to create service in DB",service);
@@ -393,34 +396,34 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServicesPackageNotExistsException.class)
-		public void addServiceToServicesPackageWhenPackageNotExists() throws Exception {
-			System.out.println("ServicesManager.addServiceToServicesPackageWhenPackageNotExists");
+	public void addServiceToServicesPackageWhenPackageNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addServiceToServicesPackageWhenPackageNotExists");
 
-			service = setUpService();
-			assertNotNull("unable to create service in DB",service);
+		service = setUpService();
+		assertNotNull("unable to create service in DB",service);
 
-			perun.getServicesManager().addServiceToServicesPackage(sess, new ServicesPackage(), service);
-			// shouldn't find services package
+		perun.getServicesManager().addServiceToServicesPackage(sess, new ServicesPackage(), service);
+		// shouldn't find services package
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void addServiceToServicesPackageWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.addServiceToServicesPackageWhenServiceNotExists");
+	public void addServiceToServicesPackageWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addServiceToServicesPackageWhenServiceNotExists");
 
-			ServicesPackage servicesPackage = new ServicesPackage();
-			servicesPackage.setName("ServicesManagerTestSP");
-			servicesPackage.setDescription("TestingPackage");
-			perun.getServicesManager().createServicesPackage(sess, servicesPackage);
+		ServicesPackage servicesPackage = new ServicesPackage();
+		servicesPackage.setName("ServicesManagerTestSP");
+		servicesPackage.setDescription("TestingPackage");
+		perun.getServicesManager().createServicesPackage(sess, servicesPackage);
 
-			perun.getServicesManager().addServiceToServicesPackage(sess, servicesPackage, new Service());
-			// shouldn't find services package
+		perun.getServicesManager().addServiceToServicesPackage(sess, servicesPackage, new Service());
+		// shouldn't find services package
 
-		}
+	}
 
 	@Test
 	public void removeServiceFromServicesPackage() throws Exception {
-		System.out.println("ServicesManager.removeServiceFromServicesPackage");
+		System.out.println(CLASS_NAME + "removeServiceFromServicesPackage");
 
 		service = setUpService();
 		assertNotNull("unable to create service in DB",service);
@@ -434,33 +437,33 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServicesPackageNotExistsException.class)
-		public void removeServiceFromServicesPackageWhenPackageNotExists() throws Exception {
-			System.out.println("ServicesManager.removeServiceFromServicesPackageWhenPackageNotExists");
+	public void removeServiceFromServicesPackageWhenPackageNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeServiceFromServicesPackageWhenPackageNotExists");
 
-			service = setUpService();
-			assertNotNull("unable to create service in DB",service);
+		service = setUpService();
+		assertNotNull("unable to create service in DB",service);
 
-			perun.getServicesManager().removeServiceFromServicesPackage(sess, new ServicesPackage(), service);
-			// shouldn't find services package
+		perun.getServicesManager().removeServiceFromServicesPackage(sess, new ServicesPackage(), service);
+		// shouldn't find services package
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void removeServiceFromServicesPackageWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.removeServiceFromServicesPackageWhenServiceNotExists");
+	public void removeServiceFromServicesPackageWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeServiceFromServicesPackageWhenServiceNotExists");
 
-			service = setUpService();
-			assertNotNull("unable to create service in DB",service);
-			servicesPackage = setUpServicesPackage(service);
+		service = setUpService();
+		assertNotNull("unable to create service in DB",service);
+		servicesPackage = setUpServicesPackage(service);
 
-			perun.getServicesManager().removeServiceFromServicesPackage(sess, servicesPackage, new Service());
-			// shouldn't find service
+		perun.getServicesManager().removeServiceFromServicesPackage(sess, servicesPackage, new Service());
+		// shouldn't find service
 
-		}
+	}
 
 	@Test
 	public void addRequiredAttribute() throws Exception {
-		System.out.println("ServicesManager.addRequiredAttribute");
+		System.out.println(CLASS_NAME + "addRequiredAttribute");
 
 		service = setUpService();
 		attribute = setUpAttribute();
@@ -472,45 +475,45 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=AttributeNotExistsException.class)
-		public void addRequiredAttributeWhenAttributeNotExists() throws Exception {
-			System.out.println("ServicesManager.addRequiredAttributeWhenAttributeNotExists");
+	public void addRequiredAttributeWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addRequiredAttributeWhenAttributeNotExists");
 
-			service = setUpService();
-			attribute = setUpAttribute();
-			attribute.setId(0);
+		service = setUpService();
+		attribute = setUpAttribute();
+		attribute.setId(0);
 
-			perun.getServicesManager().addRequiredAttribute(sess, service, attribute);
-			// shouldn't find attribute
+		perun.getServicesManager().addRequiredAttribute(sess, service, attribute);
+		// shouldn't find attribute
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void addRequiredAttributeWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.addRequiredAttributeWhenServiceNotExists");
+	public void addRequiredAttributeWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addRequiredAttributeWhenServiceNotExists");
 
-			attribute = setUpAttribute();
+		attribute = setUpAttribute();
 
-			perun.getServicesManager().addRequiredAttribute(sess, new Service(), attribute);
-			// shouldn't find service
+		perun.getServicesManager().addRequiredAttribute(sess, new Service(), attribute);
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=AttributeAlreadyAssignedException.class)
-		public void addRequiredAttributeWhenAttributeAlreadyAssigned() throws Exception {
-			System.out.println("ServicesManager.addRequiredAttributeWhenAttributeAlreadyAssigned");
+	public void addRequiredAttributeWhenAttributeAlreadyAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "addRequiredAttributeWhenAttributeAlreadyAssigned");
 
-			service = setUpService();
-			attribute = setUpAttribute();
+		service = setUpService();
+		attribute = setUpAttribute();
 
-			perun.getServicesManager().addRequiredAttribute(sess, service, attribute);
-			perun.getServicesManager().addRequiredAttribute(sess, service, attribute);
-			// shouldn't add same attribute twice
+		perun.getServicesManager().addRequiredAttribute(sess, service, attribute);
+		perun.getServicesManager().addRequiredAttribute(sess, service, attribute);
+		// shouldn't add same attribute twice
 
-		}
+	}
 
 	@Test
 	public void addRequiredAttributes() throws Exception {
-		System.out.println("ServicesManager.addRequiredAttributes");
+		System.out.println(CLASS_NAME + "addRequiredAttributes");
 
 		service = setUpService();
 		List<AttributeDefinition> attributes = setUpRequiredAttribute();
@@ -522,45 +525,45 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=AttributeNotExistsException.class)
-		public void addRequiredAttributesWhenAttributeNotExists() throws Exception {
-			System.out.println("ServicesManager.addRequiredAttributesWhenAttributeNotExists");
+	public void addRequiredAttributesWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addRequiredAttributesWhenAttributeNotExists");
 
-			service = setUpService();
-			List<AttributeDefinition> attributes = setUpRequiredAttribute();
-			attributes.get(0).setId(0);
+		service = setUpService();
+		List<AttributeDefinition> attributes = setUpRequiredAttribute();
+		attributes.get(0).setId(0);
 
-			perun.getServicesManager().addRequiredAttributes(sess, service, attributes);
-			// shouldn't find attribute
+		perun.getServicesManager().addRequiredAttributes(sess, service, attributes);
+		// shouldn't find attribute
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void addRequiredAttributesWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.addRequiredAttributesWhenServiceNotExists");
+	public void addRequiredAttributesWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addRequiredAttributesWhenServiceNotExists");
 
-			List<AttributeDefinition> attributes = setUpRequiredAttribute();
+		List<AttributeDefinition> attributes = setUpRequiredAttribute();
 
-			perun.getServicesManager().addRequiredAttributes(sess, new Service(), attributes);
-			// shouldn't find service
+		perun.getServicesManager().addRequiredAttributes(sess, new Service(), attributes);
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=AttributeAlreadyAssignedException.class)
-		public void addRequiredAttributesWhenAttributeAlreadyAssigned() throws Exception {
-			System.out.println("ServicesManager.addRequiredAttributeWhenAttributeAlreadyAssigned");
+	public void addRequiredAttributesWhenAttributeAlreadyAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "addRequiredAttributeWhenAttributeAlreadyAssigned");
 
-			service = setUpService();
-			List<AttributeDefinition> attributes = setUpRequiredAttribute();
+		service = setUpService();
+		List<AttributeDefinition> attributes = setUpRequiredAttribute();
 
-			perun.getServicesManager().addRequiredAttributes(sess, service, attributes);
-			perun.getServicesManager().addRequiredAttributes(sess, service, attributes);
-			// shouldn't add same attribute twice
+		perun.getServicesManager().addRequiredAttributes(sess, service, attributes);
+		perun.getServicesManager().addRequiredAttributes(sess, service, attributes);
+		// shouldn't add same attribute twice
 
-		}
+	}
 
 	@Test
 	public void removeRequiredAttribute() throws Exception {
-		System.out.println("ServicesManager.removeRequiredAttribute");
+		System.out.println(CLASS_NAME + "removeRequiredAttribute");
 
 		service = setUpService();
 		attribute = setUpAttribute();
@@ -572,44 +575,44 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=AttributeNotExistsException.class)
-		public void removeRequiredAttributeWhenAttributeNotExists() throws Exception {
-			System.out.println("ServicesManager.removeRequiredAttributeWhenAttributeNotExists");
+	public void removeRequiredAttributeWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeRequiredAttributeWhenAttributeNotExists");
 
-			service = setUpService();
-			attribute = setUpAttribute();
-			attribute.setId(0);
+		service = setUpService();
+		attribute = setUpAttribute();
+		attribute.setId(0);
 
-			perun.getServicesManager().removeRequiredAttribute(sess, service, attribute);
-			// shouldn't find attribute
+		perun.getServicesManager().removeRequiredAttribute(sess, service, attribute);
+		// shouldn't find attribute
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void removeRequiredAttributeWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.removeRequiredAttributeWhenServiceNotExists");
+	public void removeRequiredAttributeWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeRequiredAttributeWhenServiceNotExists");
 
-			attribute = setUpAttribute();
+		attribute = setUpAttribute();
 
-			perun.getServicesManager().removeRequiredAttribute(sess, new Service(), attribute);
-			// shouldn't find service
+		perun.getServicesManager().removeRequiredAttribute(sess, new Service(), attribute);
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=AttributeNotAssignedException.class)
-		public void removeRequiredAttributeWhenAttributeNotAssigned() throws Exception {
-			System.out.println("ServicesManager.removeRequiredAttributeWhenAttributeNotAssigned");
+	public void removeRequiredAttributeWhenAttributeNotAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "removeRequiredAttributeWhenAttributeNotAssigned");
 
-			service = setUpService();
-			attribute = setUpAttribute();
+		service = setUpService();
+		attribute = setUpAttribute();
 
-			perun.getServicesManager().removeRequiredAttribute(sess, service, attribute);
-			// shouldn't remove not assigned attribute
+		perun.getServicesManager().removeRequiredAttribute(sess, service, attribute);
+		// shouldn't remove not assigned attribute
 
-		}
+	}
 
 	@Test
 	public void removeRequiredAttributes() throws Exception {
-		System.out.println("ServicesManager.removeRequiredAttributes");
+		System.out.println(CLASS_NAME + "removeRequiredAttributes");
 
 		service = setUpService();
 		List<AttributeDefinition> attributes = setUpRequiredAttribute();
@@ -621,44 +624,44 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=AttributeNotExistsException.class)
-		public void removeRequiredAttributesWhenAttributeNotExists() throws Exception {
-			System.out.println("ServicesManager.removeRequiredAttributesWhenAttributeNotExists");
+	public void removeRequiredAttributesWhenAttributeNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeRequiredAttributesWhenAttributeNotExists");
 
-			service = setUpService();
-			List<AttributeDefinition> attributes = setUpRequiredAttribute();
-			attributes.get(0).setId(0);
+		service = setUpService();
+		List<AttributeDefinition> attributes = setUpRequiredAttribute();
+		attributes.get(0).setId(0);
 
-			perun.getServicesManager().removeRequiredAttributes(sess, service, attributes);
-			// shouldn't find attribute
+		perun.getServicesManager().removeRequiredAttributes(sess, service, attributes);
+		// shouldn't find attribute
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void removeRequiredAttributesWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.removeRequiredAttributesWhenServiceNotExists");
+	public void removeRequiredAttributesWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeRequiredAttributesWhenServiceNotExists");
 
-			List<AttributeDefinition> attributes = setUpRequiredAttribute();
+		List<AttributeDefinition> attributes = setUpRequiredAttribute();
 
-			perun.getServicesManager().removeRequiredAttributes(sess, new Service(), attributes);
-			// shouldn't find service
+		perun.getServicesManager().removeRequiredAttributes(sess, new Service(), attributes);
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=AttributeNotAssignedException.class)
-		public void removeRequiredAttributesWhenAttributeNotAssigned() throws Exception {
-			System.out.println("ServicesManager.removeRequiredAttributesWhenAttributeNotAssigned");
+	public void removeRequiredAttributesWhenAttributeNotAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "removeRequiredAttributesWhenAttributeNotAssigned");
 
-			service = setUpService();
-			List<AttributeDefinition> attributes = setUpRequiredAttribute();
+		service = setUpService();
+		List<AttributeDefinition> attributes = setUpRequiredAttribute();
 
-			perun.getServicesManager().removeRequiredAttributes(sess, service, attributes);
-			// shouldn't remove not assigned attribute
+		perun.getServicesManager().removeRequiredAttributes(sess, service, attributes);
+		// shouldn't remove not assigned attribute
 
-		}
+	}
 
 	@Test
 	public void removeAllRequiredAttributes() throws Exception {
-		System.out.println("ServicesManager.removeAllRequiredAttributes");
+		System.out.println(CLASS_NAME + "removeAllRequiredAttributes");
 
 		service = setUpService();
 		attribute = setUpAttribute();
@@ -670,17 +673,17 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void removeAllRequiredAttributesWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.removeAllRequiredAttributesWhenServiceNotExists");
+	public void removeAllRequiredAttributesWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllRequiredAttributesWhenServiceNotExists");
 
-			perun.getServicesManager().removeAllRequiredAttributes(sess, new Service());
-			// shouldn't find service
+		perun.getServicesManager().removeAllRequiredAttributes(sess, new Service());
+		// shouldn't find service
 
-		}
+	}
 
 	@Test
 	public void addDestination() throws Exception {
-		System.out.println("ServicesManager.addDestination");
+		System.out.println(CLASS_NAME + "addDestination");
 
 		service = setUpService();
 		facility = setUpFacility();
@@ -696,7 +699,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getDestinationsCount() throws Exception {
-		System.out.println("ServicesManager.getDestinationsCount()");
+		System.out.println(CLASS_NAME + "getDestinationsCount");
 
 		service = setUpService();
 		facility = setUpFacility();
@@ -709,7 +712,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void addDestinationForMoreThanOneService() throws Exception {
-		System.out.println("ServicesManager.addDestinationForMoreThanOneService");
+		System.out.println(CLASS_NAME + "addDestinationForMoreThanOneService");
 
 		List<Service> services = setUpServices();
 		facility = setUpFacility();
@@ -728,46 +731,46 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void addDestinationWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.addDestinationWhenServiceNotExists");
+	public void addDestinationWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addDestinationWhenServiceNotExists");
 
-			facility = setUpFacility();
-			destination = setUpDestination();
+		facility = setUpFacility();
+		destination = setUpDestination();
 
-			perun.getServicesManager().addDestination(sess, new Service(), facility, destination);
-			// shouldn't find service
+		perun.getServicesManager().addDestination(sess, new Service(), facility, destination);
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void addDestinationWhenFacilityNotExists() throws Exception {
-			System.out.println("ServicesManager.addDestinationWhenFacilityNotExists");
+	public void addDestinationWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addDestinationWhenFacilityNotExists");
 
-			service = setUpService();
-			destination = setUpDestination();
+		service = setUpService();
+		destination = setUpDestination();
 
-			perun.getServicesManager().addDestination(sess, service, new Facility(), destination);
-			// shouldn't find facility
+		perun.getServicesManager().addDestination(sess, service, new Facility(), destination);
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test (expected=DestinationAlreadyAssignedException.class)
-		public void addDestinationWhenDestinationAlreadyAssigned() throws Exception {
-			System.out.println("ServicesManager.addDestinationWhenDestinationAlreadyAssigned");
+	public void addDestinationWhenDestinationAlreadyAssigned() throws Exception {
+		System.out.println(CLASS_NAME + "addDestinationWhenDestinationAlreadyAssigned");
 
-			service = setUpService();
-			facility = setUpFacility();
-			destination = setUpDestination();
+		service = setUpService();
+		facility = setUpFacility();
+		destination = setUpDestination();
 
-			perun.getServicesManager().addDestination(sess, service, facility, destination);
-			perun.getServicesManager().addDestination(sess, service, facility, destination);
-			// shouldn't add same destination twice
+		perun.getServicesManager().addDestination(sess, service, facility, destination);
+		perun.getServicesManager().addDestination(sess, service, facility, destination);
+		// shouldn't add same destination twice
 
-		}
+	}
 
 	@Test
 	public void addDestinationsDefinedByHostsOnFacility() throws Exception {
-		System.out.println("ServicesManager.addDestinationsDefinedByHostsOnFacility");
+		System.out.println(CLASS_NAME + "addDestinationsDefinedByHostsOnFacility");
 
 		service = setUpService();
 		facility = setUpNonClusterFacilityWithTwoHosts();
@@ -782,7 +785,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void addDestinationsDefinedByHostsOnFacilityWithListOfServices() throws Exception {
-		System.out.println("ServicesManager.addDestinationsDefinedByHostsOnFacilityWithListOfServices");
+		System.out.println(CLASS_NAME + "addDestinationsDefinedByHostsOnFacilityWithListOfServices");
 
 		List<Service> services = setUpServices();
 		facility = setUpNonClusterFacilityWithTwoHosts();
@@ -799,7 +802,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void addDestinationsDefinedByHostsOnFacilityForAssignedListOfServices() throws Exception {
-		System.out.println("ServicesManager.addDestinationsDefinedByHostsOnFacilityForAssignedListOfServices");
+		System.out.println(CLASS_NAME + "addDestinationsDefinedByHostsOnFacilityForAssignedListOfServices");
 
 		List<Service> services = setUpServices();
 
@@ -822,7 +825,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void addDestinationsForAllServicesOnFacility() throws Exception {
-		System.out.println("ServicesManager.addDestinationsForAllServicesOnFacility");
+		System.out.println(CLASS_NAME + "addDestinationsForAllServicesOnFacility");
 
 		service = setUpService();
 		facility = setUpFacility();
@@ -845,7 +848,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void removeDestination() throws Exception {
-		System.out.println("ServicesManager.removeDestination");
+		System.out.println(CLASS_NAME + "removeDestination");
 
 		service = setUpService();
 		facility = setUpFacility();
@@ -861,45 +864,45 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void removeDestinationWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.removeDestinationWhenServiceNotExists");
+	public void removeDestinationWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeDestinationWhenServiceNotExists");
 
-			facility = setUpFacility();
-			destination = setUpDestination();
+		facility = setUpFacility();
+		destination = setUpDestination();
 
-			perun.getServicesManager().removeDestination(sess, new Service(), facility, destination);
-			// shouldn't find service
+		perun.getServicesManager().removeDestination(sess, new Service(), facility, destination);
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void removeDestinationWhenFacilityNotExists() throws Exception {
-			System.out.println("ServicesManager.removeDestinationWhenFacilityNotExists");
+	public void removeDestinationWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeDestinationWhenFacilityNotExists");
 
-			service = setUpService();
-			destination = setUpDestination();
+		service = setUpService();
+		destination = setUpDestination();
 
-			perun.getServicesManager().removeDestination(sess, service, new Facility(), destination);
-			// shouldn't find facility
+		perun.getServicesManager().removeDestination(sess, service, new Facility(), destination);
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test (expected=DestinationAlreadyRemovedException.class)
-		public void removeDestinationWhenDestinationAlreadyRemoved() throws Exception {
-			System.out.println("ServicesManager.removeDestinationWhenDestinationAlreadyRemoved");
+	public void removeDestinationWhenDestinationAlreadyRemoved() throws Exception {
+		System.out.println(CLASS_NAME + "removeDestinationWhenDestinationAlreadyRemoved");
 
-			service = setUpService();
-			facility = setUpFacility();
-			destination = setUpDestination();
+		service = setUpService();
+		facility = setUpFacility();
+		destination = setUpDestination();
 
-			perun.getServicesManager().removeDestination(sess, service, facility, destination);
-			// shouldn't remove not added destination
+		perun.getServicesManager().removeDestination(sess, service, facility, destination);
+		// shouldn't remove not added destination
 
-		}
+	}
 
 	@Test
 	public void removeAllDestinations() throws Exception {
-		System.out.println("ServicesManager.removeAllDestinations");
+		System.out.println(CLASS_NAME + "removeAllDestinations");
 
 		service = setUpService();
 		facility = setUpFacility();
@@ -915,30 +918,30 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void removeAllDestinationsWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.removeAllDestinationsWhenServiceNotExists");
+	public void removeAllDestinationsWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllDestinationsWhenServiceNotExists");
 
-			facility = setUpFacility();
+		facility = setUpFacility();
 
-			perun.getServicesManager().removeAllDestinations(sess, new Service(), facility);
-			// shouldn't find service
+		perun.getServicesManager().removeAllDestinations(sess, new Service(), facility);
+		// shouldn't find service
 
-		}
+	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void removeAllDestinationsWhenFacilityNotExists() throws Exception {
-			System.out.println("ServicesManager.removeAllDestinationsWhenFacilityNotExists");
+	public void removeAllDestinationsWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllDestinationsWhenFacilityNotExists");
 
-			service = setUpService();
+		service = setUpService();
 
-			perun.getServicesManager().removeAllDestinations(sess, service, new Facility());
-			// shouldn't find facility
+		perun.getServicesManager().removeAllDestinations(sess, service, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void getAllRichDestinationsWithFacility() throws Exception {
-		System.out.println("ServicesManager.getAllRichDestinationsWithFacility");
+		System.out.println(CLASS_NAME + "getAllRichDestinationsWithFacility");
 		service = setUpService();
 		facility = setUpFacility();
 		destination = setUpDestination();
@@ -953,7 +956,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getAllRichDestinationsWithService() throws Exception {
-		System.out.println("ServicesManager.getAllRichDestinationsWithService");
+		System.out.println(CLASS_NAME + "getAllRichDestinationsWithService");
 		service = setUpService();
 		facility = setUpFacility();
 		destination = setUpDestination();
@@ -968,7 +971,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getRichDestinations() throws Exception {
-		System.out.println("ServicesManager.getRichDestinations");
+		System.out.println(CLASS_NAME + "getRichDestinations");
 		service = setUpService();
 		facility = setUpFacility();
 		destination = setUpDestination();
@@ -983,7 +986,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getDestinations() throws Exception {
-		System.out.println("ServicesManager.getDestinations");
+		System.out.println(CLASS_NAME + "getDestinations");
 
 		service = setUpService();
 		facility = setUpFacility();
@@ -995,7 +998,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	@Test
 	public void getDestinationsWithPerunSession() throws Exception {
-		System.out.println("ServicesManager.getDestinations");
+		System.out.println(CLASS_NAME + "getDestinations");
 
 		Service service1 = setUpService();
 		Facility facility1 = setUpFacility();
@@ -1008,30 +1011,30 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void getDestinationsWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.getDestinationsWhenServiceNotExists");
+	public void getDestinationsWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getDestinationsWhenServiceNotExists");
 
-			facility = setUpFacility();
+		facility = setUpFacility();
 
-			perun.getServicesManager().getDestinations(sess, new Service(), facility);
-			// shouldn't find Service
+		perun.getServicesManager().getDestinations(sess, new Service(), facility);
+		// shouldn't find Service
 
-		}
+	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getDestinationsWhenFacilityNotExists() throws Exception {
-			System.out.println("ServicesManager.getDestinationsWhenFacilityNotExists");
+	public void getDestinationsWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getDestinationsWhenFacilityNotExists");
 
-			service = setUpService();
+		service = setUpService();
 
-			perun.getServicesManager().getDestinations(sess, service, new Facility());
-			// shouldn't find facility
+		perun.getServicesManager().getDestinations(sess, service, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test
 	public void getHierarchicalData() throws Exception {
-		System.out.println("ServicesManager.getHierarchicalData");
+		System.out.println(CLASS_NAME + "getHierarchicalData");
 
 		vo = setUpVo();
 		facility = setUpFacility();
@@ -1150,24 +1153,24 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getHierarchicalDataWhenFacilityNotExists() throws Exception {
-			System.out.println("ServicesManager.getHierarchicalDataWhenFacilityNotExists");
+	public void getHierarchicalDataWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getHierarchicalDataWhenFacilityNotExists");
 
-			service = setUpService();
-			perun.getServicesManager().getHierarchicalData(sess, service, new Facility());
-			// shouldn't find facility
+		service = setUpService();
+		perun.getServicesManager().getHierarchicalData(sess, service, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void getHierarchicalDataWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.getHierarchicalDataWhenServiceNotExists");
+	public void getHierarchicalDataWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getHierarchicalDataWhenServiceNotExists");
 
-			facility = setUpFacility();
-			perun.getServicesManager().getHierarchicalData(sess, new Service(), facility);
-			// shouldn't find service
+		facility = setUpFacility();
+		perun.getServicesManager().getHierarchicalData(sess, new Service(), facility);
+		// shouldn't find service
 
-		}
+	}
 
 	// TODO getFlatData() - not implemented yet
 
@@ -1345,28 +1348,28 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 	}
 
 	@Test (expected=FacilityNotExistsException.class)
-		public void getDataWithGroupsWhenFacilityNotExists() throws Exception {
-			System.out.println("ServicesManager.getDataWithGroupsWhenFacilityNotExists");
+	public void getDataWithGroupsWhenFacilityNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getDataWithGroupsWhenFacilityNotExists");
 
-			service = setUpService();
-			perun.getServicesManager().getDataWithGroups(sess, service, new Facility());
-			// shouldn't find facility
+		service = setUpService();
+		perun.getServicesManager().getDataWithGroups(sess, service, new Facility());
+		// shouldn't find facility
 
-		}
+	}
 
 	@Test (expected=ServiceNotExistsException.class)
-		public void getDataWithGroupsWhenServiceNotExists() throws Exception {
-			System.out.println("ServicesManager.getDataWithGroupsWhenServiceNotExists");
+	public void getDataWithGroupsWhenServiceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getDataWithGroupsWhenServiceNotExists");
 
-			facility = setUpFacility();
-			perun.getServicesManager().getDataWithGroups(sess, new Service(), facility);
-			// shouldn't find service
+		facility = setUpFacility();
+		perun.getServicesManager().getDataWithGroups(sess, new Service(), facility);
+		// shouldn't find service
 
-		}
+	}
 
 	@Test
 	public void getFacilitiesDestinations() throws Exception {
-		System.out.println("ServicesManager.getFacilitiesDestinations");
+		System.out.println(CLASS_NAME + "getFacilitiesDestinations");
 		vo = setUpVo();
 		facility = setUpFacility();
 		resource = setUpResource();

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -4,13 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
@@ -23,14 +21,12 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.OwnerType;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.UsersManager;
 import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.exceptions.AlreadyReservedLoginException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -40,21 +36,24 @@ import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
-import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import java.util.ArrayList;
 
 /**
+ * Integration tests of UsersManager.
+ *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
 public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
-	private User user;                             // our User
+	private final static String CLASS_NAME = "UsersManager.";
+
+	private User user;           // our User
 	private User serviceUser1;
 	private User serviceUser2;
 	private Vo vo;
 	String userFirstName = "";
 	String userLastName = "";
-	String extLogin = "";              // his login in external source
+	String extLogin = "";        // his login in external source
 	String extLogin2 = "";
 	String extSourceName = "UserManagerEntryIntegrationTest";
 	final ExtSource extSource = new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal");
@@ -69,7 +68,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		// set random name and logins during every setUp method
 		userFirstName = Long.toHexString(Double.doubleToLongBits(Math.random()));
 		userLastName = Long.toHexString(Double.doubleToLongBits(Math.random()));
-		extLogin = Long.toHexString(Double.doubleToLongBits(Math.random()));              // his login in external source
+		extLogin = Long.toHexString(Double.doubleToLongBits(Math.random()));   // his login in external source
 		extLogin2 = Long.toHexString(Double.doubleToLongBits(Math.random()));
 		vo = setUpVo();
 		setUpUser();
@@ -81,7 +80,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void createUser() throws Exception {
-		System.out.println("UsersManager.createUser");
+		System.out.println(CLASS_NAME + "createUser");
 
 		user = new User();
 		user.setFirstName(userFirstName);
@@ -98,7 +97,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getUserById() throws Exception {
-		System.out.println("UsersManager.getUserById");
+		System.out.println(CLASS_NAME + "getUserById");
 
 		User secondUser = usersManager.getUserById(sess, user.getId());
 		assertNotNull(secondUser);
@@ -108,7 +107,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getAllRichUsersWithAllNonVirutalAttributes() throws Exception {
-		System.out.println("UsersManager.getAllUsersWithAllNonVirutalAttributes");
+		System.out.println(CLASS_NAME + "getAllUsersWithAllNonVirutalAttributes");
 
 		List<RichUser> richUsers = new ArrayList<RichUser>();
 		richUsers.addAll(perun.getUsersManagerBl().getAllRichUsersWithAllNonVirutalAttributes(sess));
@@ -118,17 +117,17 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 
 	@Test (expected=UserNotExistsException.class)
-		public void getUserByIdWhenUserNotExist() throws Exception {
-			System.out.println("UsersManager.getUserByIdWhenUserNotExist");
+	public void getUserByIdWhenUserNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getUserByIdWhenUserNotExist");
 
-			usersManager.getUserById(sess, 0);
-			// shouldn't find user
+		usersManager.getUserById(sess, 0);
+		// shouldn't find user
 
-		}
+	}
 
 	@Test
 	public void getUsers() throws Exception {
-		System.out.println("UsersManager.getUsers");
+		System.out.println(CLASS_NAME + "getUsers");
 
 		List<User> users = usersManager.getUsers(sess);
 		assertNotNull(users);
@@ -139,7 +138,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getServiceUsers() throws Exception {
-		System.out.println("UsersManager.getServiceUsers");
+		System.out.println(CLASS_NAME + "getServiceUsers");
 
 		List<User> users = usersManager.getServiceUsers(sess);
 		assertTrue(users.contains(serviceUser1));
@@ -148,7 +147,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getUsersByServiceUser1() throws Exception {
-		System.out.println("UsersManager.getUsersByServiceUser1");
+		System.out.println(CLASS_NAME + "getUsersByServiceUser1");
 
 		List<User> users = usersManager.getUsersByServiceUser(sess, serviceUser1);
 		assertTrue(users.contains(user));
@@ -157,7 +156,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getUsersByServiceUser2() throws Exception {
-		System.out.println("UsersManager.getUsersByServiceUser2");
+		System.out.println(CLASS_NAME + "getUsersByServiceUser2");
 
 		List<User> users = usersManager.getUsersByServiceUser(sess, serviceUser2);
 		assertTrue(users.contains(user));
@@ -166,7 +165,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getServiceUsersByUser() throws Exception {
-		System.out.println("UsersManager.getServiceUsersByUser");
+		System.out.println(CLASS_NAME + "getServiceUsersByUser");
 
 		List<User> users = usersManager.getServiceUsersByUser(sess, user);
 		assertTrue(users.contains(serviceUser1));
@@ -176,7 +175,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void modifyOwnership() throws Exception {
-		System.out.println("UsersManager.modifyOwnership");
+		System.out.println(CLASS_NAME + "modifyOwnership");
 
 		usersManager.removeServiceUserOwner(sess, user, serviceUser1);
 
@@ -201,45 +200,45 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test (expected= RelationNotExistsException.class)
-		public void removeNotExistingOwnership() throws Exception {
-			System.out.println("UsersManager.removeNotExistingOwnership");
+	public void removeNotExistingOwnership() throws Exception {
+		System.out.println(CLASS_NAME + "removeNotExistingOwnership");
 
-			Member member = setUpMember(vo);
-			User userOfMember = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Member member = setUpMember(vo);
+		User userOfMember = perun.getUsersManagerBl().getUserByMember(sess, member);
 
-			usersManager.removeServiceUserOwner(sess, userOfMember, serviceUser1);
-		}
+		usersManager.removeServiceUserOwner(sess, userOfMember, serviceUser1);
+	}
 
 	@Test (expected= RelationNotExistsException.class)
-		public void removeOwnershipTwiceInRow() throws Exception {
-			System.out.println("UsersManager.removeOwnershipTwiceInRow");
+	public void removeOwnershipTwiceInRow() throws Exception {
+		System.out.println(CLASS_NAME + "removeOwnershipTwiceInRow");
 
-			usersManager.removeServiceUserOwner(sess, user, serviceUser1);
-			usersManager.removeServiceUserOwner(sess, user, serviceUser1);
-		}
-
-	@Test (expected= RelationExistsException.class)
-		public void addExistingOwnership() throws Exception {
-			System.out.println("UsersManager.addExistingOwnership");
-
-			usersManager.addServiceUserOwner(sess, user, serviceUser1);
-
-		}
+		usersManager.removeServiceUserOwner(sess, user, serviceUser1);
+		usersManager.removeServiceUserOwner(sess, user, serviceUser1);
+	}
 
 	@Test (expected= RelationExistsException.class)
-		public void addOwnershipTwiceInRow() throws Exception {
-			System.out.println("UsersManager.addOwnershipTwiceInRow");
+	public void addExistingOwnership() throws Exception {
+		System.out.println(CLASS_NAME + "addExistingOwnership");
 
-			Member member = setUpMember(vo);
-			User userOfMember = perun.getUsersManagerBl().getUserByMember(sess, member);
+		usersManager.addServiceUserOwner(sess, user, serviceUser1);
 
-			usersManager.addServiceUserOwner(sess, userOfMember, serviceUser1);
-			usersManager.addServiceUserOwner(sess, userOfMember, serviceUser1);
-		}
+	}
+
+	@Test (expected= RelationExistsException.class)
+	public void addOwnershipTwiceInRow() throws Exception {
+		System.out.println(CLASS_NAME + "addOwnershipTwiceInRow");
+
+		Member member = setUpMember(vo);
+		User userOfMember = perun.getUsersManagerBl().getUserByMember(sess, member);
+
+		usersManager.addServiceUserOwner(sess, userOfMember, serviceUser1);
+		usersManager.addServiceUserOwner(sess, userOfMember, serviceUser1);
+	}
 
 	@Test
 	public void disableExistingOwnership() throws Exception {
-		System.out.println("UsersManager.disableExistingOwnership");
+		System.out.println(CLASS_NAME + "disableExistingOwnership");
 
 		Member member = setUpMember(vo);
 		User userOfMember = perun.getUsersManagerBl().getUserByMember(sess, member);
@@ -273,7 +272,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void updateUser() throws Exception {
-		System.out.println("UsersManager.updateUser");
+		System.out.println(CLASS_NAME + "updateUser");
 
 		user.setFirstName(Long.toHexString(Double.doubleToLongBits(Math.random())));
 		user.setMiddleName("");
@@ -284,65 +283,65 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		User updatedUser = usersManager.updateUser(sess, user);
 		assertNotNull(updatedUser);
 		assertEquals("users should be the same after update in DB",user,updatedUser);
-		
+
 		User gettingUser = usersManager.getUserById(sess, updatedUser.getId());
 		assertEquals("users should be the same after updated in DB and getting from DB",gettingUser,updatedUser);
 
 	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void updateWhenUserNotExists() throws Exception {
-			System.out.println("UsersManager.updateWhenUserNotExists");
+	public void updateWhenUserNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "updateWhenUserNotExists");
 
-			usersManager.updateUser(sess, new User());
+		usersManager.updateUser(sess, new User());
 
-		}
-	
-	@Test
-		public void updateUserWithNullValues() throws Exception {
-			System.out.println("UsersManager.updateUserWithNullValues");
-		
-			user.setFirstName(null);
-			user.setLastName(Long.toHexString(Double.doubleToLongBits(Math.random())));
-			user.setMiddleName(null);
-			user.setTitleBefore(null);
-			user.setTitleAfter(null);
-			User updatedUser = usersManager.updateUser(sess, user);
-			User gettingUser = usersManager.getUserById(sess, updatedUser.getId());
-			assertNotNull(updatedUser);
-			assertEquals("users should be the same after update in DB", gettingUser, updatedUser);
-		}
-	
-	@Test (expected=cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException.class)
-		public void updateUserWithNullValueInLastName() throws Exception {
-			System.out.println("UsersManager.updateUserWithNullValueInLastName");
-			
-			user.setFirstName(null);
-			user.setLastName(null);
-			User updateUser = usersManager.updateUser(sess, user);
 	}
-	
+
+	@Test
+	public void updateUserWithNullValues() throws Exception {
+		System.out.println(CLASS_NAME + "updateUserWithNullValues");
+
+		user.setFirstName(null);
+		user.setLastName(Long.toHexString(Double.doubleToLongBits(Math.random())));
+		user.setMiddleName(null);
+		user.setTitleBefore(null);
+		user.setTitleAfter(null);
+		User updatedUser = usersManager.updateUser(sess, user);
+		User gettingUser = usersManager.getUserById(sess, updatedUser.getId());
+		assertNotNull(updatedUser);
+		assertEquals("users should be the same after update in DB", gettingUser, updatedUser);
+	}
+
+	@Test (expected=cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException.class)
+	public void updateUserWithNullValueInLastName() throws Exception {
+		System.out.println(CLASS_NAME + "updateUserWithNullValueInLastName");
+
+		user.setFirstName(null);
+		user.setLastName(null);
+		User updateUser = usersManager.updateUser(sess, user);
+	}
+
 	@Test (expected=UserNotExistsException.class)
-		public void deleteUser() throws Exception {
-			System.out.println("UsersManager.deleteUser");
+	public void deleteUser() throws Exception {
+		System.out.println(CLASS_NAME + "deleteUser");
 
-			usersManager.deleteUser(sess, user, true);  // force delete
-			usersManager.getUserById(sess, user.getId());
-			// should be unable to get deleted user by his id
+		usersManager.deleteUser(sess, user, true);  // force delete
+		usersManager.getUserById(sess, user.getId());
+		// should be unable to get deleted user by his id
 
-		}
+	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void deleteUserWhenUserNotExists() throws Exception {
-			System.out.println("UsersManager.deleteUserWhenUserNotExists");
+	public void deleteUserWhenUserNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteUserWhenUserNotExists");
 
-			usersManager.deleteUser(sess, new User(), true);  // force delete
-			// shouldn't find user
-		}
+		usersManager.deleteUser(sess, new User(), true);  // force delete
+		// shouldn't find user
+	}
 
 	@Test (expected=InternalErrorException.class)
 	public void addIDPExtSourcesWithSameLogin() throws Exception {
-		System.out.println("UsersManager.addIDPExtSourcesWithSameLogin");
+		System.out.println(CLASS_NAME + "addIDPExtSourcesWithSameLogin");
 
 		ExtSource ext1 = new ExtSource("test1", ExtSourcesManagerEntry.EXTSOURCE_IDP);
 		ExtSource ext2 = new ExtSource("test2", ExtSourcesManagerEntry.EXTSOURCE_IDP);
@@ -360,7 +359,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void addUserExtSource() throws Exception {
-		System.out.println("UsersManager.addUserExtSource");
+		System.out.println(CLASS_NAME + "addUserExtSource");
 
 		ExtSource externalSource = perun.getExtSourcesManager().getExtSourceByName(sess, extSourceName);
 
@@ -376,24 +375,24 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test (expected=UserExtSourceExistsException.class)
-		public void addUserExtSourceWhenUserExtSourceAlreadyExists() throws Exception {
-			System.out.println("UsersManager.addUserExtSourceWhenUserExtSourceAlreadyExists");
+	public void addUserExtSourceWhenUserExtSourceAlreadyExists() throws Exception {
+		System.out.println(CLASS_NAME + "addUserExtSourceWhenUserExtSourceAlreadyExists");
 
-			usersManager.addUserExtSource(sess, user, userExtSource);
-		}
+		usersManager.addUserExtSource(sess, user, userExtSource);
+	}
 
 
 	@Test (expected=UserNotExistsException.class)
-		public void addUserExtSourceWhenUserNotExists() throws Exception {
-			System.out.println("UsersManager.addUserExtSourceWhenUserNotExists");
+	public void addUserExtSourceWhenUserNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "addUserExtSourceWhenUserNotExists");
 
-			usersManager.addUserExtSource(sess, new User(), userExtSource);
-			// shouldn't find user
-		}
+		usersManager.addUserExtSource(sess, new User(), userExtSource);
+		// shouldn't find user
+	}
 
 	@Test
 	public void getUserByUserExtSource() throws Exception {
-		System.out.println("UsersManager.getUserByUserExtSource");
+		System.out.println(CLASS_NAME + "getUserByUserExtSource");
 
 		User secondUser = usersManager.getUserByUserExtSource(sess, userExtSource);
 		assertEquals("users should be the same from both ext sources",user, secondUser);
@@ -402,7 +401,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getUserByExtSourceNameAndExtLogin() throws Exception {
-		System.out.println("UsersManager.getUserByExtSourceNameAndExtLogin");
+		System.out.println(CLASS_NAME + "getUserByExtSourceNameAndExtLogin");
 
 		String extSourceName = userExtSource.getExtSource().getName();
 		String extLogin = userExtSource.getLogin();
@@ -413,7 +412,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getUserExtSourceByExtLogin() throws Exception {
-		System.out.println("UsersManager.getUserExtSourceByExtLogin");
+		System.out.println(CLASS_NAME + "getUserExtSourceByExtLogin");
 
 		ExtSource externalSource = perun.getExtSourcesManager().getExtSourceByName(sess, extSourceName);
 		UserExtSource returnedUserExtSource = usersManager.getUserExtSourceByExtLogin(sess, externalSource, extLogin);
@@ -426,7 +425,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	/*
 		 @Test (expected=AlreadyReservedLoginException.class)
 		 public void isAlreadyReservedLogin() throws Exception {
-		 System.out.println("UsersManager.isAlreadyReservedLogin");
+		 System.out.println(CLASS_NAME + "isAlreadyReservedLogin");
 
 		 String namespace = "einfra";
 		 String login = "martin_svehla";
@@ -435,25 +434,25 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		 */
 
 	@Test (expected=UserExtSourceNotExistsException.class)
-		public void getUserExtSourceByExtLoginWhenExtLoginNotExists() throws Exception {
-			System.out.println("UsersManager.getUserExtSourceByExtLoginWhenExtLoginNotExists");
+	public void getUserExtSourceByExtLoginWhenExtLoginNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByExtLoginWhenExtLoginNotExists");
 
-			ExtSource externalSource = perun.getExtSourcesManager().getExtSourceByName(sess, extSourceName);
-			usersManager.getUserExtSourceByExtLogin(sess, externalSource, "");
-			// shouldn't find UserExtSource (based on valid ext source and invalid login)
-		}
+		ExtSource externalSource = perun.getExtSourcesManager().getExtSourceByName(sess, extSourceName);
+		usersManager.getUserExtSourceByExtLogin(sess, externalSource, "");
+		// shouldn't find UserExtSource (based on valid ext source and invalid login)
+	}
 
 	@Test (expected=ExtSourceNotExistsException.class)
-		public void getUserExtSourceByExtLoginWhenExtSourceNotExists() throws Exception {
-			System.out.println("UsersManager.getUserExtSourceByExtLoginWhenExtSourceNotExists");
+	public void getUserExtSourceByExtLoginWhenExtSourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByExtLoginWhenExtSourceNotExists");
 
-			usersManager.getUserExtSourceByExtLogin(sess, new ExtSource(), "");
+		usersManager.getUserExtSourceByExtLogin(sess, new ExtSource(), "");
 
-		}
+	}
 
 	@Test
 	public void getUserExtSources() throws Exception {
-		System.out.println("UsersManager.getUserExtSources");
+		System.out.println(CLASS_NAME + "getUserExtSources");
 
 		List<UserExtSource> userExtSources = usersManager.getUserExtSources(sess, user);
 		assertNotNull(userExtSources);
@@ -463,17 +462,17 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void getUserExtSourcesWhenUserNotExists() throws Exception {
-			System.out.println("UsersManager.getUserExtSourcesWhenUserNotExists");
+	public void getUserExtSourcesWhenUserNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourcesWhenUserNotExists");
 
-			usersManager.getUserExtSources(sess, new User());
-			// shouldn't find user
+		usersManager.getUserExtSources(sess, new User());
+		// shouldn't find user
 
-		}
+	}
 
 	@Test
 	public void getUserExtSourceById() throws Exception {
-		System.out.println("UsersManager.getUserExtSourceById");
+		System.out.println(CLASS_NAME + "getUserExtSourceById");
 
 		int id = userExtSource.getId();
 		UserExtSource retUserExtSource = usersManager.getUserExtSourceById(sess, id);
@@ -484,37 +483,37 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test (expected=UserExtSourceNotExistsException.class)
-		public void getUserExtSourceByIdWhenExtSourceNotExists() throws Exception {
-			System.out.println("UsersManager.getUserExtSourceByIdWhenExtSourceNotExists");
+	public void getUserExtSourceByIdWhenExtSourceNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByIdWhenExtSourceNotExists");
 
-			usersManager.getUserExtSourceById(sess, 0);
-			// shouldn't find ext source
+		usersManager.getUserExtSourceById(sess, 0);
+		// shouldn't find ext source
 
-		}
+	}
 
 	@Test (expected=UserExtSourceNotExistsException.class)
-		public void removeUserExtSource() throws Exception {
-			System.out.println("UsersManager.removeUserExtSource");
+	public void removeUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "removeUserExtSource");
 
-			usersManager.removeUserExtSource(sess, user, userExtSource);
+		usersManager.removeUserExtSource(sess, user, userExtSource);
 
-			usersManager.getUserExtSourceById(sess, userExtSource.getId());
-			// shloudn't get removed user ext source from DB
+		usersManager.getUserExtSourceById(sess, userExtSource.getId());
+		// shloudn't get removed user ext source from DB
 
-		}
+	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void removeUserExtSourceWhenUserNotExist() throws Exception {
-			System.out.println("UsersManager.removeUserExtSourceWhenUserNotExist");
+	public void removeUserExtSourceWhenUserNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "removeUserExtSourceWhenUserNotExist");
 
-			usersManager.removeUserExtSource(sess, new User(), userExtSource);
-			// shouldn't find user
+		usersManager.removeUserExtSource(sess, new User(), userExtSource);
+		// shouldn't find user
 
-		}
+	}
 
 	@Test
 	public void getUserByMember() throws Exception {
-		System.out.println("UsersManager.getUserByMember");
+		System.out.println(CLASS_NAME + "getUserByMember");
 
 		Member member = setUpMember(vo);
 
@@ -526,80 +525,80 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test (expected=MemberNotExistsException.class)
-		public void getUserByMemberWhenMemberNotExist() throws Exception {
-			System.out.println("UsersManager.getUserByMemberWhenMemberNotExist");
+	public void getUserByMemberWhenMemberNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getUserByMemberWhenMemberNotExist");
 
-			usersManager.getUserByMember(sess, new Member());
-			// shouldn't find member
+		usersManager.getUserByMember(sess, new Member());
+		// shouldn't find member
 
-		}
-
-	@ Test
-		public void getVosWhereUserIsAdmin() throws Exception {
-			System.out.println("UsersManager.getVosWhereUserIsAdmin");
-
-			Member member = setUpMember(vo);
-			User user = perun.getUsersManagerBl().getUserByMember(sess, member);
-			perun.getVosManager().addAdmin(sess, vo, user);
-
-			List<Vo> vos = usersManager.getVosWhereUserIsAdmin(sess, user);
-			assertTrue("our user should be admin in one VO", vos.size() >= 1);
-
-		}
-
-	@Test (expected=UserNotExistsException.class)
-		public void getVosWhereUserIsAdminWhenUserNotExist() throws Exception {
-			System.out.println("UsersManager.getVosWhereUserIsAdminWhenUserNotExist");
-
-			usersManager.getVosWhereUserIsAdmin(sess, new User());
-			// shouldn't find user
-		}
+	}
 
 	@ Test
-		public void getGroupsWhereUserIsAdmin() throws Exception {
-			System.out.println("UsersManager.getGroupsWhereUserIsAdmin");
+	public void getVosWhereUserIsAdmin() throws Exception {
+		System.out.println(CLASS_NAME + "getVosWhereUserIsAdmin");
 
-			Member member = setUpMember(vo);
-			Group group = setUpGroup(vo, member);
-			User returnedUser = usersManager.getUserByMember(sess, member);
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		perun.getVosManager().addAdmin(sess, vo, user);
 
-			List<Group> groups = usersManager.getGroupsWhereUserIsAdmin(sess, returnedUser);
-			assertTrue("our user should be admin in one group", groups.size() >= 1);
-			assertTrue("created group is not between them", groups.contains(group));
+		List<Vo> vos = usersManager.getVosWhereUserIsAdmin(sess, user);
+		assertTrue("our user should be admin in one VO", vos.size() >= 1);
 
-		}
+	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void getGroupsWhereUserIsAdminWhenUserNotExist() throws Exception {
-			System.out.println("UsersManager.getGroupsWhereUserIsAdminWhenUserNotExist");
+	public void getVosWhereUserIsAdminWhenUserNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getVosWhereUserIsAdminWhenUserNotExist");
 
-			usersManager.getGroupsWhereUserIsAdmin(sess, new User());
-			// shouldn't find user
-		}
+		usersManager.getVosWhereUserIsAdmin(sess, new User());
+		// shouldn't find user
+	}
 
 	@ Test
-		public void getVosWhereUserIsMember() throws Exception {
-			System.out.println("UsersManager.getVosWhereUserIsMember");
+	public void getGroupsWhereUserIsAdmin() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsWhereUserIsAdmin");
 
-			Member member = setUpMember(vo);
+		Member member = setUpMember(vo);
+		Group group = setUpGroup(vo, member);
+		User returnedUser = usersManager.getUserByMember(sess, member);
 
-			User returnedUser = usersManager.getUserByMember(sess, member);
-			List<Vo> vos = usersManager.getVosWhereUserIsMember(sess, returnedUser);
-			assertTrue("our user should be member of one VO", vos.size() >= 1);
+		List<Group> groups = usersManager.getGroupsWhereUserIsAdmin(sess, returnedUser);
+		assertTrue("our user should be admin in one group", groups.size() >= 1);
+		assertTrue("created group is not between them", groups.contains(group));
 
-		}
+	}
 
 	@Test (expected=UserNotExistsException.class)
-		public void getVosWhereUserIsMemberWhenUserNotExist() throws Exception {
-			System.out.println("UsersManager.getVosWhereUserIsMemberWhenUserNotExist");
+	public void getGroupsWhereUserIsAdminWhenUserNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsWhereUserIsAdminWhenUserNotExist");
 
-			usersManager.getVosWhereUserIsMember(sess, new User());
-			// shouldn't find user
-		}
+		usersManager.getGroupsWhereUserIsAdmin(sess, new User());
+		// shouldn't find user
+	}
+
+	@ Test
+	public void getVosWhereUserIsMember() throws Exception {
+		System.out.println(CLASS_NAME + "getVosWhereUserIsMember");
+
+		Member member = setUpMember(vo);
+
+		User returnedUser = usersManager.getUserByMember(sess, member);
+		List<Vo> vos = usersManager.getVosWhereUserIsMember(sess, returnedUser);
+		assertTrue("our user should be member of one VO", vos.size() >= 1);
+
+	}
+
+	@Test (expected=UserNotExistsException.class)
+	public void getVosWhereUserIsMemberWhenUserNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "getVosWhereUserIsMemberWhenUserNotExist");
+
+		usersManager.getVosWhereUserIsMember(sess, new User());
+		// shouldn't find user
+	}
 
 	@Test
 	public void getAllowedResources() throws Exception {
-		System.out.println("UsersManager.getAllowedResources");
+		System.out.println(CLASS_NAME + "getAllowedResources");
 
 		Member member = setUpMember(vo);
 		Group group = setUpGroup(vo, member);
@@ -632,7 +631,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void findUsers() throws Exception {
-		System.out.println("UsersManager.findUsers");
+		System.out.println(CLASS_NAME + "findUsers");
 
 		// Create second user
 		User user2 = new User();
@@ -660,7 +659,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void findUsersByNameFullText() throws Exception {
-		System.out.println("UsersManager.findUsersByNameFullText");
+		System.out.println(CLASS_NAME + "findUsersByNameFullText");
 
 		// Create second user
 		User user2 = new User();
@@ -688,7 +687,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void findUsersByNameUsingExactFields() throws Exception {
-		System.out.println("UsersManager.findUsersByNameUsingExactFields");
+		System.out.println(CLASS_NAME + "findUsersByNameUsingExactFields");
 
 		// Create second user
 		User user2 = new User();
@@ -716,7 +715,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getUsersByAttribute() throws Exception {
-		System.out.println("UsersManager.getUsersByAttribute");
+		System.out.println(CLASS_NAME + "getUsersByAttribute");
 
 		// Check if the attribute already exists
 		Attribute attr;
@@ -744,7 +743,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void findUsersByExactName() throws Exception {
-		System.out.println("UsersManager.findUsersByExactName");
+		System.out.println(CLASS_NAME + "findUsersByExactName");
 
 		String searchString = user.getFirstName()+user.getLastName();
 		List<User> users = perun.getUsersManager().findUsersByExactName(sess, searchString);
@@ -761,7 +760,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void findRichUsersWithAttributesByExactMatch() throws Exception {
-		System.out.println("UsersManager.findRichUsersWithAttributesByExactMatch");
+		System.out.println(CLASS_NAME + "findRichUsersWithAttributesByExactMatch");
 
 		ArrayList<String> attrNames = new ArrayList<>();
 		attrNames.add("urn:perun:user:attribute-def:def:preferredMail");
@@ -774,7 +773,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	@Test
 	public void getUsersCount() throws Exception {
-		System.out.println("UsersManager.getUsersCount()");
+		System.out.println(CLASS_NAME + "getUsersCount");
 
 		setUpUser();
 		int count = perun.getUsersManager().getUsersCount(sess);
@@ -925,4 +924,5 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		candidate.setAttributes(new HashMap<String,String>());
 		return candidate;
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/VosManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/VosManagerEntryIntegrationTest.java
@@ -28,9 +28,10 @@ import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 
 /**
+ * Integration tests of VosManager.
+ *
  * @author Jiri Harazim <harazim@mail.muni.cz>
  */
-
 public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	private VosManager vosManagerEntry;
@@ -41,7 +42,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 	private final String voShortName = "TestShortN-" + someNumber;
 	private final String voName = "Test Vo Name " + someNumber;
 	private final static String extSourceName = "VosManagerEntryIntegrationTest";
-	private final static String VOS_MANAGER_ENTRY = "VosManagerEntry.";
+	private final static String CLASS_NAME = "VosManager.";
 
 	@Before
 	public void setUp() throws Exception {
@@ -54,40 +55,40 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void createVo() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "createVo()");
+		System.out.println(CLASS_NAME + "createVo");
 
 		final Vo newVo = vosManagerEntry.createVo(sess, myVo);
 
 		assertTrue("id must be greater than zero", newVo.getId() > 0);
 	}
-	
+
 	@Test
 	public void createAndUpdateVoWithLongShortName() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "createAndUpdateVoWithLongShortName()");
+		System.out.println(CLASS_NAME + "createAndUpdateVoWithLongShortName");
 		String longName = "1234567890123456789";
 		String longerName = "12345678901234567890123456789012";
 		Vo voWithLongShortname = new Vo(0, longName, longName);
-		
+
 		Vo newVo = vosManagerEntry.createVo(sess, voWithLongShortname);
 		assertTrue("id must be greater than zero", newVo.getId() > 0);
-		
+
 		newVo.setShortName(longerName);
 		newVo = vosManagerEntry.updateVo(sess, newVo);
 		assertTrue("newVo shortName has 32 characters length", newVo.getShortName().length() == 32);
 	}
-	
-	@Test(expected = VoExistsException.class)
-		public void createVoWhichAlreadyExists() throws Exception {
-			System.out.println(VOS_MANAGER_ENTRY + "createVoWhichAlreadyExists()");
 
-			vosManagerEntry.createVo(sess, myVo);
-			// this should throw exception
-			vosManagerEntry.createVo(sess, myVo);
-		}
+	@Test(expected = VoExistsException.class)
+	public void createVoWhichAlreadyExists() throws Exception {
+		System.out.println(CLASS_NAME + "createVoWhichAlreadyExists");
+
+		vosManagerEntry.createVo(sess, myVo);
+		// this should throw exception
+		vosManagerEntry.createVo(sess, myVo);
+	}
 
 	@Test
 	public void getVoById() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "getVoById()");
+		System.out.println(CLASS_NAME + "getVoById");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 		final Vo returnedVo = vosManagerEntry.getVoById(sess, myVo.getId());
@@ -106,7 +107,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void getVoByShortName() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "getVoByShortName()");
+		System.out.println(CLASS_NAME + "getVoByShortName");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 		final Vo returnedVo = vosManagerEntry.getVoByShortName(sess, voShortName);
@@ -115,16 +116,16 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 	}
 
 	@Test(expected = VoNotExistsException.class)
-		public void getVoWhichNotExists() throws Exception {
-			System.out.println(VOS_MANAGER_ENTRY + "getVoWhichNotExists()");
+	public void getVoWhichNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "getVoWhichNotExists");
 
-			final String nonExistingShortName = "_i_am_not_in_db_";
-			vosManagerEntry.getVoByShortName(sess, nonExistingShortName);
-		}
+		final String nonExistingShortName = "_i_am_not_in_db_";
+		vosManagerEntry.getVoByShortName(sess, nonExistingShortName);
+	}
 
 	@Test
 	public void getVos() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "getVos()");
+		System.out.println(CLASS_NAME + "getVos");
 
 		final Vo vo = vosManagerEntry.createVo(sess, myVo);
 		final List<Vo> vos = vosManagerEntry.getVos(sess);
@@ -134,7 +135,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void getVosNotNull() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "getVosNotNull()");
+		System.out.println(CLASS_NAME + "getVosNotNull");
 
 		// should not never return null or throw exception, even if no result
 		// found
@@ -143,7 +144,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void updateVo() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "updateVo()");
+		System.out.println(CLASS_NAME + "updateVo");
 
 		Vo voToUpdate = vosManagerEntry.createVo(sess, myVo);
 		voToUpdate.setName("Cosa");
@@ -154,16 +155,16 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 	}
 
 	@Test(expected = VoNotExistsException.class)
-		public void updateVoWhichNotExists() throws Exception {
-			System.out.println(VOS_MANAGER_ENTRY + "updateVoWhichNotExists()");
+	public void updateVoWhichNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "updateVoWhichNotExists");
 
-			vosManagerEntry.updateVo(sess, new Vo());
-		}
+		vosManagerEntry.updateVo(sess, new Vo());
+	}
 
 	@Test
 	@Ignore
 	public void findCandidates() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "findCandidates()");
+		System.out.println(CLASS_NAME + "findCandidates");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -180,19 +181,19 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 	}
 
 	@Test(expected = VoNotExistsException.class)
-		@Ignore
-		public void findCandidatesForNonExistingVo() throws Exception {
-			System.out.println(VOS_MANAGER_ENTRY + "findCandidatesForNonExistingVo()");
+	@Ignore
+	public void findCandidatesForNonExistingVo() throws Exception {
+		System.out.println(CLASS_NAME + "findCandidatesForNonExistingVo");
 
-			addExtSourceDelegate(new Vo());
+		addExtSourceDelegate(new Vo());
 
-			vosManagerEntry.findCandidates(sess, new Vo(), "kouril");
-		}
+		vosManagerEntry.findCandidates(sess, new Vo(), "kouril");
+	}
 
 	@Test
 	@Ignore
 	public void findCandidatesWithOneResult() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "findCandidatesWithOneResult()");
+		System.out.println(CLASS_NAME + "findCandidatesWithOneResult");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -208,7 +209,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void addAdmin() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "addAdmin()");
+		System.out.println(CLASS_NAME + "addAdmin");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -223,7 +224,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test(expected=VoNotExistsException.class)
 	public void addAdminIntoNonExistingVo() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "addAdminIntoNonExistingVo()");
+		System.out.println(CLASS_NAME + "addAdminIntoNonExistingVo");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 		final Member member = createMemberFromExtSource(createdVo);
@@ -234,7 +235,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test(expected=UserNotExistsException.class)
 	public void addAdminAsNonExistingUser() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "addAdminAsNonExistingMember()");
+		System.out.println(CLASS_NAME + "addAdminAsNonExistingMember");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -243,7 +244,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void addAdminWithGroup() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "addAdminWithGroup()");
+		System.out.println(CLASS_NAME + "addAdminWithGroup");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -261,7 +262,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void getAdmins() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "getAdmins()");
+		System.out.println(CLASS_NAME + "getAdmins");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -284,7 +285,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 		candidate.setTitleBefore("");
 		candidate.setTitleAfter("");
 		UserExtSource userExtSource = new UserExtSource(new ExtSource(0, "testExtSource",
-					"cz.metacentrum.perun.core.impl.ExtSourceInternal"), Long.toHexString(Double.doubleToLongBits(Math.random())));
+				"cz.metacentrum.perun.core.impl.ExtSourceInternal"), Long.toHexString(Double.doubleToLongBits(Math.random())));
 		candidate.setUserExtSource(userExtSource);
 		candidate.setAttributes(new HashMap<String,String>());
 
@@ -294,14 +295,14 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 		// test
 		List<User> admins = vosManagerEntry.getAdmins(sess, createdVo);
-		assertTrue("group shoud have 2 admins",admins.size() == 2);
+		assertTrue("group should have 2 admins",admins.size() == 2);
 		assertTrue("our member as direct user should be admin",admins.contains(user));
 		assertTrue("our member as member of admin group should be admin",admins.contains(user2));
 	}
 
 	@Test
 	public void getDirectAdmins() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "getDirectAdmins()");
+		System.out.println(CLASS_NAME + "getDirectAdmins");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -314,7 +315,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void getAdminGroups() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "getAdminGroups()");
+		System.out.println(CLASS_NAME + "getAdminGroups");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -327,7 +328,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test(expected=UserNotExistsException.class)
 	public void removeAdminWhichNotExists() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "removeAdminWhichNotExists()");
+		System.out.println(CLASS_NAME + "removeAdminWhichNotExists");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -336,7 +337,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void removeAdmin() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "removeAdmin()");
+		System.out.println(CLASS_NAME + "removeAdmin");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 		final Member member = createMemberFromExtSource(createdVo);
@@ -351,7 +352,7 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void removeAdminWithGroup() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + "removeAdminWithGroup()");
+		System.out.println(CLASS_NAME + "removeAdminWithGroup");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
@@ -365,29 +366,28 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 	}
 
 	@Test(expected = VoNotExistsException.class)
-		public void deleteVo() throws Exception {
-			System.out.println(VOS_MANAGER_ENTRY + "deleteVo()");
+	public void deleteVo() throws Exception {
+		System.out.println(CLASS_NAME + "deleteVo");
 
-			final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
-			vosManagerEntry.deleteVo(sess, createdVo);
-			vosManagerEntry.getVoById(sess, createdVo.getId());
-		}
+		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
+		vosManagerEntry.deleteVo(sess, createdVo);
+		vosManagerEntry.getVoById(sess, createdVo.getId());
+	}
 
 	@Test(expected = VoNotExistsException.class)
-		public void deleteVoWhichNotExists() throws Exception {
-			System.out.println(VOS_MANAGER_ENTRY + "deleteVoWhichNotExists()");
+	public void deleteVoWhichNotExists() throws Exception {
+		System.out.println(CLASS_NAME + "deleteVoWhichNotExists");
 
-			vosManagerEntry.deleteVo(sess, new Vo());
-		}
+		vosManagerEntry.deleteVo(sess, new Vo());
+	}
 
 	// private methods ------------------------------------------------------------------
 
-	private Member createMemberFromExtSource(final Vo createdVo)
-		throws Exception {
+	private Member createMemberFromExtSource(final Vo createdVo) throws Exception {
 
 		//This is obsolete approach which is dependent on extSource, remove these lines in future...
-	//addExtSourceDelegate(createdVo);
-//final List<Candidate> candidates = vosManagerEntry.findCandidates(sess,
+		//addExtSourceDelegate(createdVo);
+		//final List<Candidate> candidates = vosManagerEntry.findCandidates(sess,
 		//		createdVo, "kouril", 1);
 
 		final Candidate candidate = prepareCandidate();
@@ -433,11 +433,12 @@ public class VosManagerEntryIntegrationTest extends AbstractPerunIntegrationTest
 
 	@Test
 	public void getVosCount() throws Exception {
-		System.out.println(VOS_MANAGER_ENTRY + ".getVosCount()");
+		System.out.println(CLASS_NAME + "getVosCount");
 
 		final Vo createdVo = vosManagerEntry.createVo(sess, myVo);
 
 		int count = vosManagerEntry.getVosCount(sess);
 		assertTrue(count>0);
 	}
+
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/SynchronizerIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/SynchronizerIntegrationTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class SynchronizerIntegrationTest extends AbstractPerunIntegrationTest {
 
+	private final static String CLASS_NAME = "Synchronizer.";
+
 	private final static String EXPIRATION_URN = "urn:perun:member:attribute-def:def:membershipExpiration";
 	private ExtSource extSource = new ExtSource(0, "testExtSource", ExtSourcesManager.EXTSOURCE_INTERNAL);
 	private Vo vo = new Vo(0, "SynchronizerTestVo", "SyncTestVo");
@@ -38,7 +40,7 @@ public class SynchronizerIntegrationTest extends AbstractPerunIntegrationTest {
 
 	@Test
 	public void checkMembersState() throws Exception {
-		System.out.println("SynchronizerIntegrationTest.checkMembersState");
+		System.out.println(CLASS_NAME + "checkMembersState");
 
 		// setup expiration date
 		Calendar calendar = Calendar.getInstance();

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/UtilsIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/UtilsIntegrationTest.java
@@ -8,7 +8,11 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-
+/**
+ * Tests of methods from Utils class.
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
 public class UtilsIntegrationTest {
 
 	@Before
@@ -125,4 +129,5 @@ public class UtilsIntegrationTest {
 		assertEquals("Kurka mladsi", parsedRawName.get(lastNameString));
 		assertEquals("CSc.", parsedRawName.get(titleAfterString));
 	}
+
 }


### PR DESCRIPTION
- Added javadoc to ContactGroup object.
- Fixed compareTo() in Facility and SecurityTeam object.
- Fixed column renaming in SQLs for security teams. We must use
  compatibility class.
- Fixed some typos in AuthzResolverBlImpl.
- Convert empty string to null in entry and impl layer for SecurityTeam.
  description and blacklisted user description.
- Indentation fix to FacilitiesManagerEntryIntegrationTest.

- When deleting User, delete him also from all blacklists.
- When deleting SecurityTeam delete also its own blacklist
  and assignment to Facilities.
- When deleting Facility, delete also all ContactGroups and
  assigned Facilities.
- deleteSecurityTeam() can use force. If false, team is not deleted
   if any user is blacklisted by the team or team is trusted (assigned)
   to facility.
- getSecurityTeams() moved to entry from Bl. Fixed usage of .hasRole()
  to .isAuthorized().
- Added isUserBlacklisted(User).
- Added removeUserFromAllBlacklists(User).
- Added getAssignedFacilities(SecurityTeam) to FacilitiesManager.
- Added tests for new cases.

- Use again Collections.sort() on lists when asserting equals.
- Added println("testName") missing in FacilitiesManager tests.
- Changed "if () fail()" to assertTrue() with message.
- Some source formatting and added javadoc.
- Use id=0 instead of 11 for objects we expect to not exists. Since
  when using real db for test, Group,SecurityTeam or Facility with
  id = 11 can exists and test would fail.

- Fixed tests in SecurityTeamsManager they were expecting empty DB.
- Fixed compareTo() for Facility (NullPointerException was not thrown).
- Fixed compareTo() for SecurityTeam (description in NullPointerException).
- Added println() messages to SecurityTeamsManager.