### PR TITLE
CORE: Fixed updateSecurityTeam()

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
@@ -135,7 +135,15 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		}
 
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
-		getSecurityTeamsManagerBl().checkSecurityTeamUniqueName(sess, securityTeam);
+
+		try {
+			SecurityTeam existingTeam = getSecurityTeamsManagerBl().getSecurityTeamByName(sess, securityTeam.getName());
+			if (existingTeam != null && existingTeam.getId() != securityTeam.getId()) {
+				throw new SecurityTeamExistsException("SecurityTeam with name='" + securityTeam.getName() + "' already exists.");
+			}
+		} catch (SecurityTeamNotExistsException ex) {
+			// OK since we are renaming security team to non-taken value
+		}
 
 		// don't store empty description
 		if (securityTeam.getDescription() != null && securityTeam.getDescription().trim().isEmpty()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -111,11 +112,12 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 		try {
 			Map<String, Object> map = jdbc.queryForMap("select name, description from security_teams where id=?", securityTeam.getId());
 
-			if (!securityTeam.getName().equals(map.get("name"))) {
+			if (!Objects.equals(securityTeam.getName(), map.get("name"))) {
 				jdbc.update("update security_teams set name=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + "  where id=?",
 						securityTeam.getName(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), securityTeam.getId());
 			}
-			if (!securityTeam.getDescription().equals(map.get("description"))) {
+
+			if (!Objects.equals(securityTeam.getDescription(), map.get("description"))) {
 				jdbc.update("update security_teams set description=?, modified_by=?, modified_by_uid=?, modified_at=" + Compatibility.getSysdate() + "  where id=?",
 						securityTeam.getDescription(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), securityTeam.getId());
 			}


### PR DESCRIPTION
- Fixed check on already taken security team name in entry layer. It was
  preventing update when name was not changed.
- Fixed equals on security team params when updating. Was using
  unsafe a.equals(b) when a could be null. Now using safe Objects.equals(a,b).