### PR TITLE
add task database cross-check

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/job/MaintenanceJob.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/job/MaintenanceJob.java
@@ -6,6 +6,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 
+import cz.metacentrum.perun.dispatcher.scheduling.PropagationMaintainer;
+import cz.metacentrum.perun.dispatcher.scheduling.SchedulingPool;
 import cz.metacentrum.perun.dispatcher.service.DispatcherManager;
 
 /**
@@ -18,18 +20,20 @@ public class MaintenanceJob extends QuartzJobBean {
 	private final static Logger log = LoggerFactory
 			.getLogger(MaintenanceJob.class);
 
-	private DispatcherManager dispatcherManager;
+	private SchedulingPool schedulingPool;
 
 	protected void executeInternal(JobExecutionContext arg0)
 			throws JobExecutionException {
 		log.debug("Entering MaintenanceJob...");
+		schedulingPool.checkTasksDb();
 	}
 
-	public DispatcherManager getDispatcherManager() {
-		return dispatcherManager;
+	public SchedulingPool getSchedulingPool() {
+		return schedulingPool;
 	}
 
-	public void setDispatcherManager(DispatcherManager dispatcherManager) {
-		this.dispatcherManager = dispatcherManager;
+	public void setSchedulingPool(SchedulingPool schedulingPool) {
+		this.schedulingPool = schedulingPool;
 	}
+
 }

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
@@ -23,4 +23,5 @@ public interface PropagationMaintainer {
 	void closeTasksForEngine(int clientID);
 
 	void onTaskComplete(int parseInt, int clientID, String status, String string);
+
 }

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/SchedulingPool.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/SchedulingPool.java
@@ -66,4 +66,6 @@ public interface SchedulingPool {
 
 	void reloadTasks();
 
+	void checkTasksDb();
+
 }

--- a/perun-dispatcher/src/main/resources/perun-dispatcher-scheduler.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher-scheduler.xml
@@ -17,7 +17,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 	<bean id="perunScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="triggers">
 			<list>
-				<!--<ref bean="maintenanceJobTrigger" />-->
+				<ref bean="maintenanceJobTrigger" />
 				<!-- <ref bean="checkInJobTrigger" /> -->
 				<ref bean="processPoolJobTrigger" />
 				<ref bean="propagationMaintainerJobTrigger" />
@@ -30,7 +30,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.MaintenanceJob" />
 		<property name="jobDataAsMap">
 			<map>
-				<entry key="dispatcherManager" value-ref="dispatcherManager" />
+				<entry key="schedulingPool" value-ref="schedulingPool" />
 			</map>
 		</property>
 	</bean>
@@ -40,7 +40,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 		<!-- Every 20 minutes -->
 		<!--<property name="cronExpression" value="0 0/20 * * * ?" /> -->
 		<!-- Every 5 seconds -->
-		<property name="cronExpression" value="0/5 * * * * ?" />
+		<property name="cronExpression" value="${dispatcher.cron.maintenance}" />
 	</bean>
 
 	<bean id="propagationMaintainerJob" class="org.springframework.scheduling.quartz.JobDetailBean">

--- a/perun-dispatcher/src/main/resources/perun-dispatcher.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher.xml
@@ -182,6 +182,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 					<prop key="dispatcher.cron.propagation">45 0/4 * * * ?</prop>
 					<prop key="dispatcher.cron.processpool">0 0/2 * * * ?</prop>
 					<prop key="dispatcher.cron.cleantaskresults">0 0 1 * * ?</prop>
+					<prop key="dispatcher.cron.maintenance">0 0 2 * * ?</prop>
 				</props>
 			</property>
 		</bean>
@@ -197,6 +198,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 					<prop key="dispatcher.cron.propagation">45 0/4 * * * ?</prop>
 					<prop key="dispatcher.cron.processpool">0 0/2 * * * ?</prop>
 					<prop key="dispatcher.cron.cleantaskresults">0 0 1 * * ?</prop>
+					<prop key="dispatcher.cron.maintenance">0 0 2 * * ?</prop>
 				</props>
 			</property>
 		</bean>


### PR DESCRIPTION
Adds periodic task to dispatcher that goes through all tasks listed in central database and updates internal dispatcher structures in case of discrepancies (ie jobs missing, listed in wrong status etc.)