### PR TITLE
Use prefixes in user virt CertDNs

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Main.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Main.java
@@ -366,10 +366,14 @@ public class Main {
 			if(attrOrganization == null || attrOrganization.getValue() == null) o= null;
 			else o+= (String) attrOrganization.getValue();
 			Map<String, String> certDNs = null;
-			Set<String> certSubjects = null;
+			Set<String> certSubjectsWithPrefix = null;
+			Set<String> certSubjectsWithoutPrefix = new HashSet<>();
 			if(attrVirtCertDNs != null && attrVirtCertDNs.getValue() != null) {
 				certDNs = (Map) attrVirtCertDNs.getValue();
-				certSubjects = certDNs.keySet();
+				certSubjectsWithPrefix = certDNs.keySet();
+				for(String certSubject: certSubjectsWithPrefix) {
+					certSubjectsWithoutPrefix.add(certSubject.replaceFirst("^[0-9]+[:]", ""));
+				}
 			}
 			writer.write(dn + '\n');
 			writer.write(oc1 + '\n');
@@ -388,8 +392,8 @@ public class Main {
 			if(mail != null) writer.write(mail + '\n');
 			if(preferredMail != null) writer.write(preferredMail + '\n');
 			if(o != null) writer.write(o + '\n');
-			if(certSubjects != null && !certSubjects.isEmpty()) {
-				for(String s: certSubjects) {
+			if(certSubjectsWithoutPrefix != null && !certSubjectsWithoutPrefix.isEmpty()) {
+				for(String s: certSubjectsWithoutPrefix) {
 					writer.write("userCertificateSubject: " + s + '\n');
 				}
 			}

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
@@ -332,11 +332,15 @@ public class Utils {
 			else preferredMail+= (String) attrPreferredMail.getValue();
 			if(attrOrganization == null || attrOrganization.getValue() == null) o= null;
 			else o+= (String) attrOrganization.getValue();
-			Map<String, String> certDNs;
-			Set<String> certSubjects = null;
+			Map<String, String> certDNs = null;
+			Set<String> certSubjectsWithPrefix = null;
+			Set<String> certSubjectsWithoutPrefix = new HashSet<>();
 			if(attrVirtCertDNs != null && attrVirtCertDNs.getValue() != null) {
 				certDNs = (Map) attrVirtCertDNs.getValue();
-				certSubjects = certDNs.keySet();
+				certSubjectsWithPrefix = certDNs.keySet();
+				for(String certSubject: certSubjectsWithPrefix) {
+					certSubjectsWithoutPrefix.add(certSubject.replaceFirst("^[0-9]+[:]", ""));
+				}
 			}
 			writer.write(dn + '\n');
 			writer.write(oc1 + '\n');
@@ -355,8 +359,8 @@ public class Utils {
 			if(mail != null) writer.write(mail + '\n');
 			if(preferredMail != null) writer.write(preferredMail + '\n');
 			if(o != null) writer.write(o + '\n');
-			if(certSubjects != null && !certSubjects.isEmpty()) {
-				for(String s: certSubjects) {
+			if(certSubjectsWithoutPrefix != null && !certSubjectsWithoutPrefix.isEmpty()) {
+				for(String s: certSubjectsWithoutPrefix) {
 					writer.write("userCertificateSubject: " + s + '\n');
 				}
 			}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -478,8 +479,13 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 							updateUserAttribute("userCertificateSubject", null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
 						}
 					} else {
-						Set<String> certSubjects =((Map) this.attribute.getValue()).keySet();
-						String[] subjectsArray = Arrays.copyOf(certSubjects.toArray(), certSubjects.toArray().length, String[].class);
+						Set<String> certSubjectsWithPrefixes =((Map) this.attribute.getValue()).keySet();
+						Set<String> certSubjectsWithoutPrefixes = new HashSet<>();
+						//remove prefixes from certificates
+						for(String key: certSubjectsWithPrefixes) {
+							certSubjectsWithoutPrefixes.add(key.replaceFirst("^[0-9]+[:]", ""));
+						}
+						String[] subjectsArray = Arrays.copyOf(certSubjectsWithoutPrefixes.toArray(), certSubjectsWithoutPrefixes.toArray().length, String[].class);
 						ldapConnector.updateUsersCertSubjects(String.valueOf(this.user.getId()), subjectsArray);
 					}
 				//USER LIBRARY IDs WILL BE SET (special method for updating)


### PR DESCRIPTION
 - add prefix to getValue method of userCertDNs virt attribute module
 - reason: possibility to existence more than 1 duplicit subject DNs
   with different values (unique is only subject DN + user cert DN)
 - update also Initialization of LDAP from core and updating of this
   attribute in LDAPc