### PR TITLE
BASE, GUI: Updated default task recurrence and delay

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/ExecService.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/ExecService.java
@@ -17,7 +17,7 @@ public class ExecService extends PerunBean implements Serializable {
 	}
 
 	private int defaultDelay;
-	private int defaultRecurrence = 5;
+	private int defaultRecurrence = 2;
 	private boolean enabled;
 	private Service service;
 	private String script;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/AddExecServiceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/AddExecServiceTabItem.java
@@ -44,7 +44,7 @@ public class AddExecServiceTabItem implements TabItem {
 	 */
 	private Label titleWidget = new Label("Loading service");
 
-	private static final String DEFAULT_DELAY = "60";
+	private static final String DEFAULT_DELAY = "10";
 
 	// data
 	private Service service;


### PR DESCRIPTION
- When creating ExecService (and from it Task), set default
  delay from 60 min to 10 min. Also change default recurrence
  from 5 times to 2 times.

  This should speed up Task processing in Engine and after 2 retries
  return error Task to Dispatcher to plan it again if ended in error.