### PR TITLE
Fix ISMU extSource and synchronize group behavior

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -124,7 +124,7 @@ public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 
 				// Each line looks like:
 				// UCO  ;;          ;"title before. title before. firstName lastName, title after
-				// 39642;;080adf9c6c;"RNDr. Igor Peterlík, Ph.D."
+				// 39700;;“RNDr. Michal Procházka";Procházka;Michal;
 
 				// Parse the line
 				String[] entries = line.split(";");
@@ -137,15 +137,15 @@ public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 				if (login.isEmpty()) login = null;
 				map.put("login", login);
 
-				String name = entries[3];
+				String name = entries[2];
 				// Remove "" from name
 				name.replaceAll("^\"|\"$", "");
 				// entries[3] contains name of the user, so parse it to get titleBefore, firstName, lastName and titleAfter in separate fields
 				map.putAll(Utils.parseCommonName(name));
 
-				// Add additional userExtSource for MU IdP
+				// Add additional userExtSource for MU IdP with loa 2
 				map.put(ExtSourcesManagerImpl.USEREXTSOURCEMAPPING + "1",
-						"https://idp2.ics.muni.cz/idp/shibboleth|cz.metacentrum.perun.core.impl.ExtSourceIdp|" + login + "@muni.cz");
+						"https://idp2.ics.muni.cz/idp/shibboleth|cz.metacentrum.perun.core.impl.ExtSourceIdp|" + login + "@muni.cz|2");
 
 				subjects.add(map);
 			}


### PR DESCRIPTION
 - reason for fix extSource ISMU is the change in format of the input
   - Old format is: 39642;;080adf9c6c;“RNDr. Igor Peterlík, Ph.D.”
   - New format is: 39700;;“RNDr. Michal Procházka";Procházka;Michal;
   - so we need to parse name from the different position on the line
 - reason for fix method synchronize Group is BUG in behavior
   - in the case that extSource was other type than memberExtSource,
     there is need to get all attributes for new candidate from the
     memberExtSource again (we have just attributes from the extSource)
   - this is possible only if memberExtSource is instance of
     ExtSourceApi (not ExtSourceSimpleApi)
 - add loa 2 to ISMU extSource (there is missing part in additional
   extSource and if wrong use, it can throw IndexOutOfBoundException)