### PR TITLE
Fix force propagation

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/impl/EventProcessorImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/impl/EventProcessorImpl.java
@@ -192,6 +192,7 @@ public class EventProcessorImpl implements EventProcessor {
 						task.setDestinations(null);
 						// signal that task needs to regenerate data
 						task.setSourceUpdated(true);
+						task.setPropagationForced(false);
 						task.setRecurrence(0);
 					} else {
 						// no such task yet, create one
@@ -202,11 +203,13 @@ public class EventProcessorImpl implements EventProcessor {
 						task.setRecurrence(0);
 						task.setSchedule(new Date(System.currentTimeMillis()));
 						task.setSourceUpdated(false);
+						task.setPropagationForced(false);
 						schedulingPool.addToPool(task, dispatcherQueue);
 						log.debug("  Created new task and added to the pool.");
 					}
-					final Task task_final = task;
 					if (event.getData().contains("force propagation:")) {
+						task.setPropagationForced(true);
+						final Task task_final = task;
 						// expedite task processing
 						taskExecutor.execute(new Runnable() {
 							@Override

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
@@ -504,9 +504,13 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 					if (dependantTask != null && dependantService.getExecServiceType().equals(ExecServiceType.SEND)) {
 						dependantTask.setSourceUpdated(false);
 					}
+					if(completedTask.isPropagationForced() && dependantTask.isPropagationForced()) {
+						log.debug("Going to force schedule dependant task " + dependantTask.getId());
+						taskScheduler.scheduleTask(dependantTask);
+					}
 				}
 			} 
-			
+			completedTask.setPropagationForced(false);
 		} else {
 			if (string.isEmpty()) {
 				// weird - task is in error and no destinations reported as

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
@@ -317,11 +317,8 @@ public class TaskSchedulerImpl implements TaskScheduler {
 									+ " is in PROCESSING so we are gonna wait.");
 							// we do not need to put it back in pool here
 							// justWait(facility, execService);
-							if (dependencyScope.equals(DependencyScope.SERVICE) && !task.isPropagationForced()) {
+							if (dependencyScope.equals(DependencyScope.SERVICE)) {
 								proceed = false;
-							}
-							if(task.isPropagationForced()) {
-								rescheduleTask(dependencyServiceTask, execService, dispatcherQueue);
 							}
 							break;
 						default:

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
@@ -320,6 +320,9 @@ public class TaskSchedulerImpl implements TaskScheduler {
 							if (dependencyScope.equals(DependencyScope.SERVICE)) {
 								proceed = false;
 							}
+							if(dependencyServiceTask.isPropagationForced()) {
+								rescheduleTask(dependencyServiceTask, execService, dispatcherQueue);
+							}
 							break;
 						default:
 							throw new IllegalArgumentException(

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventParserImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventParserImpl.java
@@ -53,12 +53,12 @@ public class EventParserImpl implements EventParser {
 		 * https://projekty.ics.muni.cz/perunv3/trac
 		 * /wiki/PerunEngineDispatcherController event|x|[timestamp][Event
 		 * header][Event data] New format:
-		 * "task|[engine_id]|[task_id][exec_service_id][facility]|[destination_list]|[dependency_list]"
+		 * "task|[engine_id]|[task_id][is_forced][exec_service_id][facility]|[destination_list]|[dependency_list]"
 		 * 
 		 */
 		// String eventParsingPattern =
 		// "^event\\|([0-9]{1,6})\\|\\[([a-zA-Z0-9: ]+)\\]\\[([^\\]]+)\\]\\[(.*)\\]$";
-		String eventParsingPattern = "^task\\|([0-9]{1,6})\\|\\[([0-9]+)\\]\\[([0-9]+)\\]\\[([^\\|]+)\\]\\|\\[([^\\|]+)\\]|\\[(.*)\\]$";
+		String eventParsingPattern = "^task\\|([0-9]{1,6})\\|\\[([0-9]+)\\]\\[([^\\]]+)\\]\\[([0-9]+)\\]\\[([^\\|]+)\\]\\|\\[([^\\|]+)\\]|\\[(.*)\\]$";
 		Pattern pattern = Pattern.compile(eventParsingPattern);
 		Matcher matcher = pattern.matcher(event);
 		boolean matchFound = matcher.find();
@@ -77,12 +77,14 @@ public class EventParserImpl implements EventParser {
 			// Data should provide information regarding the target ExecService
 			// (Processing rule).
 			String eventTaskId = matcher.group(2);
-			String eventExecService = matcher.group(3);
-			String eventFacility = matcher.group(4);
-			String eventDestinationList = matcher.group(5);
-			String eventDependencyList = matcher.group(6);
+			String eventIsForced = matcher.group(3);
+			String eventExecService = matcher.group(4);
+			String eventFacility = matcher.group(5);
+			String eventDestinationList = matcher.group(6);
+			String eventDependencyList = matcher.group(7);
 
 			log.debug("Event data to be parsed: task id " + eventTaskId
+					+ ", forced " + eventIsForced
 					+ ", facility " + eventFacility + ", exec service "
 					+ eventExecService + ", destination list "
 					+ eventDestinationList + ", dependency list "
@@ -139,7 +141,8 @@ public class EventParserImpl implements EventParser {
 			task.setDestinations(destinationList);
 			task.setDelay(execService.getDefaultDelay());
 			task.setRecurrence(execService.getDefaultRecurrence());
-
+			task.setPropagationForced(Boolean.parseBoolean(eventIsForced));
+			
 			// resolve list of dependencies
 			if (eventDependencyList != null) {
 				for (String token : eventDependencyList.split("[\t ]*,[\t ]*")) {

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/TaskExecutorEngine.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/TaskExecutorEngine.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.engine.scheduling;
 
 import org.springframework.core.task.TaskExecutor;
 
+import cz.metacentrum.perun.taskslib.model.Task;
+
 /**
  * 
  * @author Michal Karm Babacek JavaDoc coming soon...
@@ -10,6 +12,8 @@ import org.springframework.core.task.TaskExecutor;
 public interface TaskExecutorEngine {
 
 	void beginExecuting();
+
+	public void runTask(Task task);
 
 	public DependenciesResolver getDependencyResolver();
 

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -29,7 +29,7 @@ import cz.metacentrum.perun.taskslib.service.TaskManager;
 @org.springframework.stereotype.Service(value = "schedulingPool")
 // Spring 3.0 default...
 @Scope(value = "singleton")
-public class SchedulingPoolImpl implements SchedulingPool, TaskResultListener {
+public class SchedulingPoolImpl implements SchedulingPool{
 
 	private final static Logger log = LoggerFactory.getLogger(SchedulingPoolImpl.class);
 
@@ -213,22 +213,6 @@ public class SchedulingPoolImpl implements SchedulingPool, TaskResultListener {
 		for (TaskStatus status : TaskStatus.class.getEnumConstants()) {
 			pool.put(status, new ArrayList<Task>());
 		}
-	}
-
-	// implementation of TaskResultListener interface
-	// - meant for GEN tasks
-	// - does not take into account destinations, once the method is called, the
-	// task status is set accordingly
-	@Override
-	public void onTaskDestinationDone(Task task, Destination destination,
-			TaskResult result) {
-		this.setTaskStatus(task, TaskStatus.DONE);
-	}
-
-	@Override
-	public void onTaskDestinationError(Task task, Destination destination,
-			TaskResult result) {
-		this.setTaskStatus(task, TaskStatus.ERROR);
 	}
 
 	/*

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskExecutorEngineImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskExecutorEngineImpl.java
@@ -161,7 +161,7 @@ public class TaskExecutorEngineImpl implements TaskExecutorEngine {
 	 *            Task to start.
 	 * 
 	 */
-	private void runTask(Task task) {
+	public void runTask(Task task) {
 		schedulingPool.setTaskStatus(task, TaskStatus.PROCESSING);
 		task.setStartTime(new Date(System.currentTimeMillis()));
 		List<Task> dependencies = dependencyResolver.getDependencies(task);
@@ -222,11 +222,10 @@ public class TaskExecutorEngineImpl implements TaskExecutorEngine {
 		executorEngineWorker.setFacility(task.getFacility());
 		executorEngineWorker.setExecService(task.getExecService());
 		executorEngineWorker.setDestination(destination);
+		executorEngineWorker.setResultListener((TaskResultListener) taskStatusManager);
 		if (task.getExecService().getExecServiceType().equals(ExecServiceType.GENERATE)) {
-			executorEngineWorker.setResultListener((TaskResultListener) schedulingPool);
 			taskExecutorGenWorkers.execute(executorEngineWorker);
 		} else {
-			executorEngineWorker.setResultListener((TaskResultListener) taskStatusManager);
 			taskExecutorSendWorkers.execute(executorEngineWorker);
 		}
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskSchedulerImpl.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.engine.scheduling.DenialsResolver;
 import cz.metacentrum.perun.engine.scheduling.DependenciesResolver;
 import cz.metacentrum.perun.engine.scheduling.PropagationMaintainer;
 import cz.metacentrum.perun.engine.scheduling.SchedulingPool;
+import cz.metacentrum.perun.engine.scheduling.TaskExecutorEngine;
 import cz.metacentrum.perun.engine.scheduling.TaskScheduler;
 import cz.metacentrum.perun.engine.scheduling.TaskStatusManager;
 import cz.metacentrum.perun.taskslib.dao.ExecServiceDenialDao;
@@ -57,6 +58,8 @@ public class TaskSchedulerImpl implements TaskScheduler {
 	private PerunSession perunSession;
 	@Autowired
 	private DenialsResolver denialsResolver;
+	@Autowired
+	private TaskExecutorEngine taskExecutorEngine;
 	/*
 	 * @Autowired private TaskManager taskManager;
 	 * 
@@ -129,6 +132,10 @@ public class TaskSchedulerImpl implements TaskScheduler {
 			schedulingPool.setTaskStatus(task, TaskStatus.PLANNED);
 			taskStatusManager.clearTaskStatus(task);
 			task.setSchedule(time);
+			if(task.isPropagationForced()) {
+				// we are in special thread anyway...
+				taskExecutorEngine.runTask(task);
+			}
 		}
 	}
 

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskStatusManagerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskStatusManagerImpl.java
@@ -3,17 +3,21 @@ package cz.metacentrum.perun.engine.scheduling.impl;
 import java.util.Map;
 import java.util.HashMap;
 
+import javax.jms.JMSException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.engine.jms.JMSQueueManager;
 import cz.metacentrum.perun.engine.scheduling.SchedulingPool;
 import cz.metacentrum.perun.engine.scheduling.TaskResultListener;
 import cz.metacentrum.perun.engine.scheduling.TaskStatus;
 import cz.metacentrum.perun.engine.scheduling.TaskStatusManager;
 import cz.metacentrum.perun.engine.scheduling.TaskStatus.TaskDestinationStatus;
+import cz.metacentrum.perun.taskslib.model.ExecService.ExecServiceType;
 import cz.metacentrum.perun.taskslib.model.Task;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
 
@@ -25,7 +29,9 @@ public class TaskStatusManagerImpl implements TaskStatusManager,
 
 	@Autowired
 	private SchedulingPool schedulingPool;
-
+	@Autowired
+	private JMSQueueManager jmsQueueManager;
+	
 	private Map<Integer, TaskStatus> taskToStatusMap;
 
 	public TaskStatusManagerImpl() {
@@ -57,34 +63,56 @@ public class TaskStatusManagerImpl implements TaskStatusManager,
 	@Override
 	public void onTaskDestinationDone(Task task, Destination destination,
 			TaskResult result) {
-		TaskStatus taskStatus = this.getTaskStatus(task);
-		try {
-			taskStatus.setDestinationStatus(destination,
-					TaskDestinationStatus.DONE);
-			taskStatus.setDestinationResult(destination, result);
-		} catch (InternalErrorException e) {
-			log.error("Error setting DONE status for task " + task.toString()
-					+ ": " + e.getMessage());
+		if(task.getExecService().getExecServiceType().equals(ExecServiceType.GENERATE)) {
+			schedulingPool.setTaskStatus(task, cz.metacentrum.perun.taskslib.model.Task.TaskStatus.DONE);
+		} else {
+			TaskStatus taskStatus = this.getTaskStatus(task);
+			try {
+				taskStatus.setDestinationStatus(destination,
+						TaskDestinationStatus.DONE);
+				taskStatus.setDestinationResult(destination, result);
+			} catch (InternalErrorException e) {
+				log.error("Error setting DONE status for task " + task.toString()
+						+ ": " + e.getMessage());
+			}
+			if (taskStatus.isTaskFinished()) {
+				schedulingPool.setTaskStatus(task, taskStatus.getTaskStatus());
+			}
 		}
-		if (taskStatus.isTaskFinished()) {
-			schedulingPool.setTaskStatus(task, taskStatus.getTaskStatus());
+		// report success on forced propagations immediately...
+		if(task.isPropagationForced() && task.getStatus().equals(cz.metacentrum.perun.taskslib.model.Task.TaskStatus.DONE)) {
+			log.debug("TASK " + task.toString() + " finished");
+			try {
+				log.debug("TASK reported as finished at "
+						+ System.currentTimeMillis());
+				jmsQueueManager.reportFinishedTask(task, "Destinations []");
+				schedulingPool.removeTask(task);
+				log.debug("TASK {} removed from database.", task.getId());
+			} catch (JMSException e) {
+				log.error("Failed to report finished task " + task.toString()
+						+ ": " + e.getMessage());
+			}
 		}
 	}
 
 	@Override
 	public void onTaskDestinationError(Task task, Destination destination,
 			TaskResult result) {
-		TaskStatus taskStatus = this.getTaskStatus(task);
-		try {
-			taskStatus.setDestinationStatus(destination,
-					TaskDestinationStatus.ERROR);
-			taskStatus.setDestinationResult(destination, result);
-		} catch (InternalErrorException e) {
-			log.error("Error setting ERROR status for task " + task.toString()
-					+ ": " + e.getMessage());
-		}
-		if (taskStatus.isTaskFinished()) {
-			schedulingPool.setTaskStatus(task, taskStatus.getTaskStatus());
+		if(task.getExecService().getExecServiceType().equals(ExecServiceType.GENERATE)) {
+			schedulingPool.setTaskStatus(task, cz.metacentrum.perun.taskslib.model.Task.TaskStatus.ERROR);
+		} else {
+			TaskStatus taskStatus = this.getTaskStatus(task);
+			try {
+				taskStatus.setDestinationStatus(destination,
+						TaskDestinationStatus.ERROR);
+				taskStatus.setDestinationResult(destination, result);
+			} catch (InternalErrorException e) {
+				log.error("Error setting ERROR status for task " + task.toString()
+						+ ": " + e.getMessage());
+			}
+			if (taskStatus.isTaskFinished()) {
+				schedulingPool.setTaskStatus(task, taskStatus.getTaskStatus());
+			}
 		}
 	}
 

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/EventParserImplTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/EventParserImplTest.java
@@ -32,7 +32,7 @@ public class EventParserImplTest extends AbstractEngineTest {
 	public void parseEventTest() throws Exception {
 		System.out.println("EventParserImpl.parseEventTest");
 
-		String testEvent = "task|"+engineId+"|[" + task1.getId() + "][" + task1.getExecServiceId() + "]["
+		String testEvent = "task|"+engineId+"|[" + task1.getId() + "][false][" + task1.getExecServiceId() + "]["
 				+ task1.getFacility().serializeToString() + "]|[Destinations [";
 
 		for (Destination destination : task1.getDestinations()) {

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/model/Task.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/model/Task.java
@@ -31,7 +31,8 @@ public class Task implements Serializable {
 	private List<Destination> destinations;
 	private TaskStatus status;
 	private boolean sourceUpdated;	
-
+	private boolean propagationForced; 
+	
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -170,5 +171,13 @@ public class Task implements Serializable {
 
 	public void setSourceUpdated(boolean sourceUpdated) {
 		this.sourceUpdated = sourceUpdated;
+	}
+
+	public boolean isPropagationForced() {
+		return propagationForced;
+	}
+
+	public void setPropagationForced(boolean propagationForced) {
+		this.propagationForced = propagationForced;
 	}
 }


### PR DESCRIPTION
This patchset moves processing of forced propagations into special thread both in dispatcher and engine and leaves out all scheduling/execution intervals present for normal propagations. Forcing the propagation now also restarts currently processing tasks, both SEND and GEN.