### PR TITLE
CORE,GUI: Allow security admins to create new team

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -187,10 +187,10 @@ public class VosManagerBlImpl implements VosManagerBl {
 			try {
 				addAdmin(sess, vo, sess.getPerunPrincipal().getUser());
 			} catch(AlreadyAdminException ex) {
-				throw new ConsistencyErrorException("Add manager to newly created VO failed because there is particalar manager already assigned", ex);
+				throw new ConsistencyErrorException("Add manager to newly created VO failed because there is a particular manager already assigned", ex);
 			}
 		} else {
-			log.error("Can't set VO manager during creting of the VO. User from perunSession is null. {} {}", vo, sess);
+			log.error("Can't set VO manager during creating of the VO. User from perunSession is null. {} {}", vo, sess);
 		}
 
 		log.debug("Vo {} created", vo);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
@@ -94,7 +94,8 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		Utils.notNull(securityTeam, "securityTeam");
 		Utils.notNull(securityTeam.getName(), "securityTeam.name");
 
-		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)
+				&& !AuthzResolver.isAuthorized(sess, Role.SECURITYADMIN)) {
 			throw new PrivilegeException(sess, "createSecurityTeam");
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/CreateSecurityTeamTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/CreateSecurityTeamTabItem.java
@@ -182,7 +182,7 @@ public class CreateSecurityTeamTabItem implements TabItem {
 
 	public boolean isAuthorized() {
 
-		if (session.isPerunAdmin()) {
+		if (session.isPerunAdmin() || session.isSecurityAdmin()) {
 			return true;
 		} else {
 			return false;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamSelectTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamSelectTabItem.java
@@ -77,43 +77,38 @@ public class SecurityTeamSelectTabItem implements TabItem, TabItemWithUrl {
 		firstTabPanel.add(tabMenu);
 		firstTabPanel.setCellHeight(tabMenu, "30px");
 
-		if (session.isPerunAdmin()) {
+		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CREATE, ButtonTranslation.INSTANCE.createSecurityTeam(), new ClickHandler() {
+			@Override
+			public void onClick(ClickEvent event) {
+				session.getTabManager().addTabToCurrentTab(new CreateSecurityTeamTabItem());
+			}
+		}));
 
-			// do not display to sec admins only
-			tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CREATE, ButtonTranslation.INSTANCE.createSecurityTeam(), new ClickHandler() {
-				@Override
-				public void onClick(ClickEvent event) {
-					session.getTabManager().addTabToCurrentTab(new CreateSecurityTeamTabItem());
-				}
-			}));
+		final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.DELETE, buttonTranslation.deleteSecurityTeam());
+		removeButton.addClickHandler(new ClickHandler() {
+			@Override
+			public void onClick(ClickEvent event) {
 
-			final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.DELETE, buttonTranslation.deleteSecurityTeam());
-			removeButton.addClickHandler(new ClickHandler() {
-				@Override
-				public void onClick(ClickEvent event) {
-
-					final ArrayList<SecurityTeam> itemsToRemove = teams.getTableSelectedList();
-					UiElements.showDeleteConfirm(itemsToRemove, new ClickHandler() {
-						@Override
-						public void onClick(ClickEvent clickEvent) {
-							// TODO - SHOULD HAVE ONLY ONE CALLBACK TO CORE !!
-							for (int i = 0; i < itemsToRemove.size(); i++) {
-								DeleteSecurityTeam request;
-								if (i == itemsToRemove.size() - 1) {
-									request = new DeleteSecurityTeam(JsonCallbackEvents.disableButtonEvents(removeButton, events));
-								} else {
-									request = new DeleteSecurityTeam(JsonCallbackEvents.disableButtonEvents(removeButton));
-								}
-								request.deleteSecurityTeam(itemsToRemove.get(i).getId(), false);
+				final ArrayList<SecurityTeam> itemsToRemove = teams.getTableSelectedList();
+				UiElements.showDeleteConfirm(itemsToRemove, new ClickHandler() {
+					@Override
+					public void onClick(ClickEvent clickEvent) {
+						// TODO - SHOULD HAVE ONLY ONE CALLBACK TO CORE !!
+						for (int i = 0; i < itemsToRemove.size(); i++) {
+							DeleteSecurityTeam request;
+							if (i == itemsToRemove.size() - 1) {
+								request = new DeleteSecurityTeam(JsonCallbackEvents.disableButtonEvents(removeButton, events));
+							} else {
+								request = new DeleteSecurityTeam(JsonCallbackEvents.disableButtonEvents(removeButton));
 							}
+							request.deleteSecurityTeam(itemsToRemove.get(i).getId(), false);
 						}
-					});
+					}
+				});
 
-				}
-			});
-			tabMenu.addWidget(removeButton);
-
-		}
+			}
+		});
+		tabMenu.addWidget(removeButton);
 
 		// filter
 		tabMenu.addFilterWidget(new ExtendedSuggestBox(teams.getOracle()), new PerunSearchEvent() {


### PR DESCRIPTION
- If user is already security admin, allow him to create new team.
- When new security team is created, add creator as admin.
- Allow create/delete of SecurityTeam in GUI.
- Fixed typos in debug messages in VosManager.