### PR TITLE
RPC: Gather users GUI url from "Referer" header

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1012,7 +1012,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 			ac.stateChangingCheck();
 
 			ac.getUsersManager().requestPreferredEmailChange(ac.getSession(),
-					parms.getServletRequest().getRequestURL().toString(),
+					parms.getServletRequest().getHeader("Referer"),
 					ac.getUserById(parms.readInt("user")),
 					parms.readString("email"));
 


### PR DESCRIPTION
- Previous value getRequestUrl() belonged to Tomcat and
  not Apache. By using Referer header we can determine on
  what webpage user was when request was triggered.

  Since we have URL with standard scheme, we can later in
  code determine, which authz use when sending links in mails.