### PR TITLE
CORE,RPC,GUI: Use blacklists with description

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/SecurityTeamsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/SecurityTeamsManager.java
@@ -242,28 +242,28 @@ public interface SecurityTeamsManager {
 	 */
 	List<User> getBlacklist(PerunSession perunSession, Facility facility) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, FacilityNotExistsException;
 
-        /**
+	/**
 	 * get list of blacklisted users by security team containing also description
 	 *
 	 * @param perunSession
 	 * @param securityTeam
-	 * @return map of blacklisted users by security team
+	 * @return List of Pairs with blacklisted users by security team
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
 	 * @throws SecurityTeamNotExistsException
 	 */
-	Map<User,String> getBlacklistWithDescription(PerunSession perunSession, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
+	List<Pair<User,String>> getBlacklistWithDescription(PerunSession perunSession, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException;
 
 	/**
 	 * get union of blacklists of all security teams assigned to facility containing also description
 	 *
 	 * @param perunSession
 	 * @param facility
-	 * @return map of blacklisted users for facility
+	 * @return List of Pairs with blacklisted users for facility
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException Can do only PerunAdmin or SecurityAdmin of the SecurityTeam
 	 * @throws SecurityTeamNotExistsException
 	 * @throws FacilityNotExistsException
 	 */
-	Map<User,String> getBlacklistWithDescription(PerunSession perunSession, Facility facility) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, FacilityNotExistsException;
+	List<Pair<User,String>> getBlacklistWithDescription(PerunSession perunSession, Facility facility) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, FacilityNotExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SecurityTeamsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SecurityTeamsManagerBl.java
@@ -1,14 +1,15 @@
 package cz.metacentrum.perun.core.bl;
 
+
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.*;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
@@ -197,25 +198,25 @@ public interface SecurityTeamsManagerBl {
 	 */
 	List<User> getBlacklist(PerunSession sess, Facility facility) throws InternalErrorException;
 
-        /**
+	/**
 	 * get blacklist of security team containing also description
 	 *
 	 * @param sess
 	 * @param securityTeam
-	 * @return map of blacklisted users by security team
+	 * @return List of pairs of blacklisted users by security team
 	 * @throws InternalErrorException
 	 */
-	Map<User, String> getBlacklistWithDescription(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
+	List<Pair<User, String>> getBlacklistWithDescription(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
 
 	/**
 	 * get union of blacklists of all security teams assigned to facility containing also description
 	 *
 	 * @param sess
 	 * @param facility
-	 * @return map of blacklisted users for facility
+	 * @return List of pairs of blacklisted users for facility
 	 * @throws InternalErrorException
 	 */
-	Map<User, String> getBlacklistWithDescription(PerunSession sess, Facility facility) throws InternalErrorException;
+	List<Pair<User, String>> getBlacklistWithDescription(PerunSession sess, Facility facility) throws InternalErrorException;
 
 	/**
 	 * check if security team exists

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.blImpl;
 import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Role;
@@ -27,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
@@ -189,18 +189,18 @@ public class SecurityTeamsManagerBlImpl implements SecurityTeamsManagerBl {
 		return getSecurityTeamsManagerImpl().getBlacklist(sess, securityTeams);
 	}
 
-        @Override
-        public Map<User, String> getBlacklistWithDescription(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException {
+	@Override
+	public List<Pair<User, String>> getBlacklistWithDescription(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException {
 		List<SecurityTeam> wrapper = new ArrayList<>();
 		wrapper.add(securityTeam);
 		return getSecurityTeamsManagerImpl().getBlacklistWithDescription(sess, wrapper);
-        }
+	}
 
-        @Override
-        public Map<User, String> getBlacklistWithDescription(PerunSession sess, Facility facility) throws InternalErrorException {
+	@Override
+	public List<Pair<User, String>> getBlacklistWithDescription(PerunSession sess, Facility facility) throws InternalErrorException {
 		List<SecurityTeam> securityTeams = perunBl.getFacilitiesManagerBl().getAssignedSecurityTeams(sess, facility);
 		return getSecurityTeamsManagerImpl().getBlacklistWithDescription(sess, securityTeams);
-        }
+	}
 
 	@Override
 	public void checkSecurityTeamExists(PerunSession sess, SecurityTeam securityTeam) throws SecurityTeamNotExistsException, InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.entry;
 import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Role;
@@ -28,7 +29,6 @@ import cz.metacentrum.perun.core.impl.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
@@ -332,7 +332,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 	}
 
 	@Override
-	public Map<User, String> getBlacklistWithDescription(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException {
+	public List<Pair<User, String>> getBlacklistWithDescription(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException {
 		Utils.checkPerunSession(sess);
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);
 
@@ -344,7 +344,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 	}
 
 	@Override
-	public Map<User, String> getBlacklistWithDescription(PerunSession sess, Facility facility) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, FacilityNotExistsException {
+	public List<Pair<User, String>> getBlacklistWithDescription(PerunSession sess, Facility facility) throws InternalErrorException, PrivilegeException, SecurityTeamNotExistsException, FacilityNotExistsException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.User;
@@ -23,7 +24,6 @@ import javax.sql.DataSource;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -250,9 +250,9 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 	}
 
         @Override
-	public Map<User, String> getBlacklistWithDescription(PerunSession sess, List<SecurityTeam> securityTeams) throws InternalErrorException {
+	public List<Pair<User, String>> getBlacklistWithDescription(PerunSession sess, List<SecurityTeam> securityTeams) throws InternalErrorException {
 		try {
-			Map<User, String> result = new HashMap<>();
+			List<Pair<User, String>> result = new ArrayList<>();
 			for (SecurityTeam st : securityTeams) {
 
 				result = jdbc.query("select " + UsersManagerImpl.userMappingSelectQuery +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -34,8 +34,6 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.implApi.UsersManagerImplApi;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.exceptions.ServiceUserOwnerAlreadyRemovedException;
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
 /**
@@ -97,14 +95,14 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		}
 	};
 
-        protected static final ResultSetExtractor<Map<User,String>> USERBLACKLIST_EXTRACTOR = new ResultSetExtractor<Map<User,String>>(){
+        protected static final ResultSetExtractor<List<Pair<User,String>>> USERBLACKLIST_EXTRACTOR = new ResultSetExtractor<List<Pair<User,String>>>(){
             @Override
-            public Map<User,String> extractData(ResultSet rs) throws SQLException{
-                Map<User, String> result = new HashMap<>();
+            public List<Pair<User,String>> extractData(ResultSet rs) throws SQLException{
+                List<Pair<User, String>> result = new ArrayList<>();
 
                 int row = 0;
                 while(rs.next()){
-                    result.put(USER_MAPPER.mapRow(rs, row), rs.getString("description"));
+                    result.add(new Pair<User, String>(USER_MAPPER.mapRow(rs, row), rs.getString("description")));
                     row++;
                 }
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SecurityTeamsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SecurityTeamsManagerImplApi.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.implApi;
 
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.User;
@@ -12,7 +13,6 @@ import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
@@ -134,15 +134,15 @@ public interface SecurityTeamsManagerImplApi {
 	 */
 	List<User> getBlacklist(PerunSession sess, List<SecurityTeam> securityTeams) throws InternalErrorException;
 
-        /**
+	/**
 	 * get union of blacklists of security teams containing also description
 	 *
 	 * @param sess
 	 * @param securityTeams
-	 * @return map of blacklisted users and description for list of given security teams
+	 * @return List of pairs of blacklisted users and description for list of given security teams
 	 * @throws InternalErrorException
 	 */
-	Map<User, String> getBlacklistWithDescription(PerunSession sess, List<SecurityTeam> securityTeams) throws InternalErrorException;
+	List<Pair<User, String>> getBlacklistWithDescription(PerunSession sess, List<SecurityTeam> securityTeams) throws InternalErrorException;
 
 	/**
 	 * check if security team exists

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntryIntegrationTest.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.SecurityTeamsManager;
@@ -772,28 +773,18 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpFacilities();
 		setUpBlacklists();
 
-		Map<User, String> expected = new TreeMap<>(
-			new Comparator<User>() {
+		List<Pair<User, String>> expected = new ArrayList<>();
+		expected.add(new Pair<>(u1, "reason"));
+		String nullString = null;
+		expected.add(new Pair<>(u2, nullString));
 
-			@Override
-			public int compare(User o1, User o2) {
-				return o1.compareTo(o2);
-			}
-		});
-		expected.put(u1, "reason");
-		expected.put(u2, null);
+		List<Pair<User, String>> actual = new ArrayList<>();
+		actual.addAll(securityTeamsManagerEntry.getBlacklistWithDescription(sess, st0));
 
-		Map<User, String> actual = new TreeMap<>(
-			new Comparator<User>() {
+		for (Pair<User,String> pair : actual) {
+			assertTrue("Blacklisted user with reason is not present ", expected.contains(pair));
+		}
 
-			@Override
-			public int compare(User o1, User o2) {
-				return o1.compareTo(o2);
-			}
-		});
-		actual.putAll(securityTeamsManagerEntry.getBlacklistWithDescription(sess, st0));
-                
-		assertEquals(expected, actual);
 	}
 
 	@Test(expected = SecurityTeamNotExistsException.class)
@@ -841,28 +832,18 @@ public class SecurityTeamsManagerEntryIntegrationTest extends AbstractPerunInteg
 		setUpFacilities();
 		setUpBlacklists();
 
-		Map<User, String> expected = new TreeMap<>(
-			new Comparator<User>() {
+		List<Pair<User, String>> expected = new ArrayList<>();
+		expected.add(new Pair<>(u1, "reason"));
+		String nullString = null;
+		expected.add(new Pair<>(u2, nullString));
 
-			@Override
-			public int compare(User o1, User o2) {
-				return o1.compareTo(o2);
-			}
-		});
-		expected.put(u1, "reason");
-		expected.put(u2, null);
+		List<Pair<User, String>> actual = new ArrayList<>();
+		actual.addAll(securityTeamsManagerEntry.getBlacklistWithDescription(sess, f1));
 
-		Map<User, String> actual = new TreeMap<>(
-			new Comparator<User>() {
+		for (Pair<User,String> pair : actual) {
+			assertTrue("Blacklisted user with reason is not present ", expected.contains(pair));
+		}
 
-			@Override
-			public int compare(User o1, User o2) {
-				return o1.compareTo(o2);
-			}
-		});
-		actual.putAll(securityTeamsManagerEntry.getBlacklistWithDescription(sess, f1));
-                
-		assertEquals(expected, actual);
 	}
 
 	@Test(expected = FacilityNotExistsException.class)

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -591,11 +591,11 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 			if(parms.contains("onlyDirectAdmins")) {
 				return ac.getFacilitiesManager().getAdmins(ac.getSession(),
-					ac.getFacilityById(parms.readInt("facility")),
-					parms.readBoolean("onlyDirectAdmins"));
+						ac.getFacilityById(parms.readInt("facility")),
+						parms.readBoolean("onlyDirectAdmins"));
 			} else {
 				return ac.getFacilitiesManager().getAdmins(ac.getSession(),
-					ac.getFacilityById(parms.readInt("facility")));
+						ac.getFacilityById(parms.readInt("facility")));
 			}
 		}
 	},
@@ -662,13 +662,13 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 
 			if(parms.contains("onlyDirectAdmins")) {
 				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
-					ac.getFacilityById(parms.readInt("facility")),
-					parms.readList("specificAttributes", String.class),
-					parms.readBoolean("allUserAttributes"),
-					parms.readBoolean("onlyDirectAdmins"));
+						ac.getFacilityById(parms.readInt("facility")),
+						parms.readList("specificAttributes", String.class),
+						parms.readBoolean("allUserAttributes"),
+						parms.readBoolean("onlyDirectAdmins"));
 			} else {
 				return ac.getFacilitiesManager().getRichAdmins(ac.getSession(),
-					ac.getFacilityById(parms.readInt("facility")));
+						ac.getFacilityById(parms.readInt("facility")));
 			}
 		}
 	},
@@ -889,16 +889,16 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 		public List<ContactGroup> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if(parms.contains("owner")) {
 				return ac.getFacilitiesManager().getFacilityContactGroups(ac.getSession(),
-				  ac.getOwnerById(parms.readInt("owner")));
+						ac.getOwnerById(parms.readInt("owner")));
 			} else if(parms.contains("user")) {
 				return ac.getFacilitiesManager().getFacilityContactGroups(ac.getSession(),
-				  ac.getUserById(parms.readInt("user")));
+						ac.getUserById(parms.readInt("user")));
 			} else if(parms.contains("group")) {
 				return ac.getFacilitiesManager().getFacilityContactGroups(ac.getSession(),
-				  ac.getGroupById(parms.readInt("group")));
+						ac.getGroupById(parms.readInt("group")));
 			} else if(parms.contains("facility")) {
 				return ac.getFacilitiesManager().getFacilityContactGroups(ac.getSession(),
-				  ac.getFacilityById(parms.readInt("facility")));
+						ac.getFacilityById(parms.readInt("facility")));
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "owner or user or group or facility");
 			}
@@ -917,7 +917,7 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 		public ContactGroup call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if(parms.contains("facility") && parms.contains("name")) {
 				return ac.getFacilitiesManager().getFacilityContactGroup(ac.getSession(),
-					ac.getFacilityById(parms.readInt("facility")), parms.readString("name"));
+						ac.getFacilityById(parms.readInt("facility")), parms.readString("name"));
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility and name");
 			}
@@ -1005,10 +1005,11 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * return assigned security teams for specific facility
+	 * Return assigned security teams for specific facility
 	 *
-	 * @param facility
-	 * @return assigned security teams fot given facility
+	 * @param facility int Facility <code>id</code>
+	 * @return List<SecurityTeam> assigned security teams fot given facility
+	 * @throw FacilityNotExistsException When Facility with given <code>id</code> doesn't exists.
 	 */
 	getAssignedSecurityTeams {
 		@Override
@@ -1020,8 +1021,11 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	/*#
 	 * Assign given security team to given facility (means the facility trusts the security team)
 	 *
-	 * @param facility
-	 * @param securityTeam
+	 * @param facility int Facility <code>id</code>
+	 * @param securityTeam int SecurityTeam <code>id</code>
+	 * @throw SecurityTeamAlreadyAssignedException When SecurityTeam with given <code>id</code> is already assigned.
+	 * @throw SecurityTeamNotExistsException When SecurityTeam with given <code>id</code> doesn't exists.
+	 * @throw FacilityNotExistsException When Facility with given <code>id</code> doesn't exists.
 	 */
 	assignSecurityTeam {
 		@Override
@@ -1035,8 +1039,11 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	/*#
 	 * Remove (Unassign) given security team from given facility
 	 *
-	 * @param facility
-	 * @param securityTeam
+	 * @param facility int Facility <code>id</code>
+	 * @param securityTeam int SecurityTeam <code>id</code>
+	 * @throw SecurityTeamNotAssignedException When SecurityTeam with given <code>id</code> is not assigned.
+	 * @throw SecurityTeamNotExistsException When SecurityTeam with given <code>id</code> doesn't exists.
+	 * @throw FacilityNotExistsException When Facility with given <code>id</code> doesn't exists.
 	 */
 	removeSecurityTeam {
 		@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SecurityTeamsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SecurityTeamsManagerMethod.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.rpc.methods;
 
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
@@ -8,7 +9,6 @@ import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 
 import java.util.List;
-import java.util.Map;
 
 public enum SecurityTeamsManagerMethod implements ManagerMethod {
 
@@ -40,7 +40,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	 * Create SecurityTeam.
 	 *
 	 * @param securityTeam SecurityTeam Security team to create
-	 * @throws SecurityTeamExistsException When name of SecurityTeam is not unique.
+	 * @throw SecurityTeamExistsException When name of SecurityTeam is not unique.
 	 * @return SecurityTeam Newly create SecurityTeam with <code>id</code> set.
 	 */
 	createSecurityTeam {
@@ -53,12 +53,12 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Update existing SecurityTeam name and description by teams <code>id</id>.
+	 * Update existing SecurityTeam name and description by teams <code>id</code>.
 	 * Name must be <= 128 and must be unique.
 	 *
 	 * @param securityTeam SecurityTeam Security team <code>id</code>
-	 * @throws SecurityTeamNotExistsException When <code>id</code> of a team doesn't exists in Perun.
-	 * @throws SecurityTeamExistsException When new name of security team is not unique.
+	 * @throw SecurityTeamNotExistsException When <code>id</code> of a team doesn't exists in Perun.
+	 * @throw SecurityTeamExistsException When new name of security team is not unique.
 	 * @return SecurityTeam Team with updated values
 	 */
 	updateSecurityTeam {
@@ -99,7 +99,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Get existing SecurityTeam by <code>id</id>.
+	 * Get existing SecurityTeam by <code>id</code>.
 	 *
 	 * @param id int Security team <code>id</code>
 	 * @return SecurityTeam Team with given <code>id</code>
@@ -112,7 +112,7 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Get all managers (members) of SecurityTeam by its <code>id</id>.
+	 * Get all managers (members) of SecurityTeam by its <code>id</code>.
 	 *
 	 * @param securityTeam int Security team <code>id</code>
 	 * @return List<User> List of Users who are managers (members) of specified SecurityTeam.
@@ -240,21 +240,21 @@ public enum SecurityTeamsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Get blacklisted users on selected Facility. Map consists of a union of all blacklists of
-	 * SecurityTeams assigned to selected Facility and a description why the users are on the blacklist.
+	 * Get blacklisted users on selected Facility. List consists of Pairs. Left is a item from union of all blacklists of
+	 * SecurityTeams assigned to selected Facility and right item is a description why the user is on the blacklist.
 	 *
 	 * @param facility int <code>id</code> of Facility to get blacklist for
-	 * @return Map<User,String> List of users blacklisted on selected facility.
+	 * @return List<Pair<User,String>> List of users blacklisted on selected facility.
 	 */
 	/*#
 	 * Get users blacklisted by selected SecurityTeam with a description why the users are on the blacklist.
 	 *
 	 * @param securityTeam int <code>id</code> of SecurityTeam to get blacklist for
-	 * @return Map<User,String> Blacklisted users with description
+	 * @return List<Pair<User,String>> Blacklisted users with description
 	 */
 	getBlacklistWithDescription {
 		@Override
-		public Map<User,String> call(ApiCaller ac, Deserializer parms) throws PerunException {
+		public List<Pair<User,String>> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if (parms.contains("facility")) {
 				return ac.getSecurityTeamsManager().getBlacklistWithDescription(ac.getSession(), ac.getFacilityById(parms.readInt("facility")));
 			} else {

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -139,6 +139,10 @@ $objectExamples{"SecurityTeam"} = "{ \"id\" : 924 , \"name\" : \"CSIRT\" , \"des
 $objectExamples{"List&lt;SecurityTeam&gt;"} = $listPrepend . $objectExamples{"SecurityTeam"} . $listAppend;
 $objectExamples{"List<SecurityTeam>"} = $objectExamples{"List&lt;SecurityTeam&gt;"};
 
+$objectExamples{"Pair<User,String>"} = "{ \"left\" : " . $objectExamples{"User"} ." , \"right\" : \"Some reason\" }";
+$objectExamples{"List&lt;Pair&lt;User,String&gt;&gt;"} = $listPrepend . $objectExamples{"Pair<User,String>"} . $listAppend;
+$objectExamples{"List<Pair<User,String>>"} = $objectExamples{"List&lt;Pair&lt;User,String&gt;&gt;"};
+
 # SUB HELP
 # help info
 sub help {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/TableSorter.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/TableSorter.java
@@ -153,6 +153,27 @@ public class TableSorter<T> {
 	 * Returns sorted list of objects
 	 *
 	 * @param list of objects to be sorted
+	 * @return ArrayList<T> sorted list of objects by their Names
+	 * or FullNames (for Member/User/RichMember)
+	 */
+	public ArrayList<T> sortByLeft(ArrayList<T> list){
+		if(list == null) return null;
+		Collections.sort(list, new Comparator<T>(){
+			public int compare(T o1, T o2) {
+				Collator customCollator = Collator.getInstance();
+				Pair<User,String> o11 = ((Pair<User,String>) o1);
+				Pair<User,String> o22 = ((Pair<User,String>) o2);
+				return customCollator.compare(o11.getLeft().getFullName(), o22.getLeft().getFullName());
+			}
+		});
+		return list;
+
+	}
+
+	/**
+	 * Returns sorted list of objects
+	 *
+	 * @param list of objects to be sorted
 	 * @return ArrayList<T> sorted list of objects by their hostname (Hosts)
 	 */
 	public ArrayList<T> sortByHostname(ArrayList<T> list){

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/keyproviders/PairKeyProvider.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/keyproviders/PairKeyProvider.java
@@ -1,0 +1,17 @@
+package cz.metacentrum.perun.webgui.json.keyproviders;
+
+import com.google.gwt.view.client.ProvidesKey;
+import cz.metacentrum.perun.webgui.model.Pair;
+
+/**
+ * Provides key for Pair objects (left is expected to be key)
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class PairKeyProvider<T,E> implements ProvidesKey<Pair<T,E>> {
+
+	@Override
+	public Object getKey(Pair<T, E> item) {
+		return item.getLeft();
+	}
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/securityTeamsManager/GetBlacklistWithDescription.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/securityTeamsManager/GetBlacklistWithDescription.java
@@ -1,0 +1,366 @@
+package cz.metacentrum.perun.webgui.json.securityTeamsManager;
+
+import com.google.gwt.cell.client.FieldUpdater;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.cellview.client.Column;
+import com.google.gwt.user.cellview.client.ColumnSortEvent.ListHandler;
+import com.google.gwt.user.cellview.client.TextColumn;
+import com.google.gwt.view.client.DefaultSelectionEventManager;
+import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.MultiSelectionModel;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
+import cz.metacentrum.perun.webgui.client.resources.TableSorter;
+import cz.metacentrum.perun.webgui.json.*;
+import cz.metacentrum.perun.webgui.json.keyproviders.PairKeyProvider;
+import cz.metacentrum.perun.webgui.model.*;
+import cz.metacentrum.perun.webgui.widgets.AjaxLoaderImage;
+import cz.metacentrum.perun.webgui.widgets.PerunTable;
+import cz.metacentrum.perun.webgui.widgets.UnaccentMultiWordSuggestOracle;
+import cz.metacentrum.perun.webgui.widgets.cells.CustomClickableTextCell;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+
+/**
+ * The list of blacklisted users for security team or facility
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class GetBlacklistWithDescription implements JsonCallback, JsonCallbackTable<Pair<User,String>>, JsonCallbackOracle<Pair<User,String>> {
+
+	// JSON URL
+	private final String JSON_URL = "securityTeamsManager/getBlacklistWithDescription";
+	// session
+	private PerunWebSession session = PerunWebSession.getInstance();
+	// Data provider.
+	private ListDataProvider<Pair<User,String>> dataProvider = new ListDataProvider<Pair<User,String>>();
+	// Table itself
+	private PerunTable<Pair<User,String>> table;
+	// Table list
+	private ArrayList<Pair<User,String>> list = new ArrayList<Pair<User,String>>();
+	// Selection model
+	final MultiSelectionModel<Pair<User,String>> selectionModel = new MultiSelectionModel<Pair<User,String>>(new PairKeyProvider<User,String>());
+	// Custom events
+	private JsonCallbackEvents events = new JsonCallbackEvents();
+	// Table field updater
+	private FieldUpdater<Pair<User,String>, String> tableFieldUpdater;
+	// loader image
+	private AjaxLoaderImage loaderImage = new AjaxLoaderImage();
+	// oracle
+	private ArrayList<Pair<User,String>> fullBackup = new ArrayList<Pair<User,String>>();
+	private UnaccentMultiWordSuggestOracle oracle = new UnaccentMultiWordSuggestOracle(" ");
+	private boolean checkable = true;
+
+	private PerunEntity entity;
+	private int entityId;
+
+	/**
+	 * Creates a new instance of the request
+	 *
+	 * @param entity
+	 * @param id
+	 */
+	public GetBlacklistWithDescription(PerunEntity entity, int id) {
+		this.entity = entity;
+		this.entityId = id;
+	}
+
+	/**
+	 * Creates a new instance of the request with custom events
+	 * @param events Custom events
+	 * @param entity
+	 * @param id
+	 */
+	public GetBlacklistWithDescription(PerunEntity entity, int id, JsonCallbackEvents events) {
+		this.entity = entity;
+		this.entityId = id;
+		this.events = events;
+	}
+
+	public void retrieveData(){
+
+		JsonClient js = new JsonClient();
+
+		if (entity != null && entity.equals(PerunEntity.SECURITY_TEAM)) {
+			js.retrieveData(JSON_URL, "securityTeam="+entityId, this);
+		} else if (entity != null && entity.equals(PerunEntity.FACILITY)) {
+			js.retrieveData(JSON_URL, "facility="+entityId, this);
+		}
+
+	}
+
+	/**
+	 * Returns the table widget with VOs and custom onclick.
+	 * @param fu Field Updater instance
+	 * @return The table Widget
+	 */
+	public CellTable<Pair<User,String>> getTable(FieldUpdater<Pair<User,String>, String> fu){
+		this.tableFieldUpdater = fu;
+		return this.getTable();
+	}
+
+
+	/**
+	 * Returns the table widget with VOs.
+	 * @return The table Widget
+	 */
+	public CellTable<Pair<User,String>> getTable(){
+
+		// retrieve data
+		retrieveData();
+
+		// Table data provider.
+		dataProvider = new ListDataProvider<Pair<User,String>>(list);
+
+		// Cell table
+		table = new PerunTable<Pair<User,String>>(list);
+		table.setHyperlinksAllowed(false); // prevent double loading when clicked on vo name
+
+		// Connect the table to the data provider.
+		dataProvider.addDataDisplay(table);
+
+		// Sorting
+		ListHandler<Pair<User,String>> columnSortHandler = new ListHandler<Pair<User,String>>(dataProvider.getList());
+		table.addColumnSortHandler(columnSortHandler);
+
+		// table selection
+		table.setSelectionModel(selectionModel, DefaultSelectionEventManager.<Pair<User,String>> createCheckboxManager());
+
+		// set empty content & loader
+		table.setEmptyTableWidget(loaderImage);
+
+		loaderImage.setEmptyResultMessage("Blacklist is empty.");
+
+		// columns
+		if (checkable) {
+			table.addCheckBoxColumn();
+		}
+
+		Column<Pair<User,String>, String> idColumn = JsonUtils.addColumn(
+				new JsonUtils.GetValue<Pair<User,String>, String>() {
+					public String getValue(Pair<User,String> object) {
+						return String.valueOf(object.getLeft().getId());
+					}
+				}, tableFieldUpdater);
+
+		idColumn.setSortable(true);
+		// comparator
+		columnSortHandler.setComparator(idColumn, new Comparator<Pair<User, String>>() {
+			@Override
+			public int compare(Pair<User, String> o1, Pair<User, String> o2) {
+				return o1.getLeft().getId() - o2.getLeft().getId();
+			}
+		});
+
+		// adding columns
+		table.addColumn(idColumn, "User ID");
+		table.setColumnWidth(idColumn, "150px");
+
+		Column<Pair<User,String>,String> nameColumn = JsonUtils.addColumn(new CustomClickableTextCell(), new JsonUtils.GetValue<Pair<User,String>, String>() {
+			@Override
+			public String getValue(Pair<User, String> object) {
+				return object.getLeft().getFullNameWithTitles();
+			}
+		}, tableFieldUpdater);
+
+		nameColumn.setSortable(true);
+		columnSortHandler.setComparator(nameColumn, new Comparator<Pair<User,String>>() {
+			public int compare(Pair<User,String> o1, Pair<User,String> o2) {
+				return o1.getLeft().getFullName().compareToIgnoreCase(o2.getLeft().getFullName());
+			}
+		});
+		table.addColumn(nameColumn, "Name");
+		table.setColumnWidth(nameColumn, "40%");
+
+		// Type column
+		TextColumn<Pair<User,String>> reasonColumn = new TextColumn<Pair<User,String>>() {
+			@Override
+			public String getValue(Pair<User,String> pair) {
+				return pair.getRight();
+			}
+		};
+
+		// sort type column
+		reasonColumn.setSortable(true);
+		columnSortHandler.setComparator(reasonColumn, new Comparator<Pair<User,String>>() {
+			public int compare(Pair<User,String> o1, Pair<User,String> o2) {
+				return o1.getRight().compareToIgnoreCase(o2.getRight());
+			}
+		});
+
+		// Add columns to table
+		table.addColumn(reasonColumn, "Reason");
+		table.setColumnWidth(reasonColumn, "50%");
+
+		return table;
+
+	}
+
+	/**
+	 * Return selected Vos from Table
+	 *
+	 * @return ArrayList<Vo> selected items
+	 */
+	public ArrayList<Pair<User,String>> getTableSelectedList() {
+		return JsonUtils.setToList(selectionModel.getSelectedSet());
+	}
+
+	/**
+	 *  clears list of selected items
+	 */
+	public void clearTableSelectedSet(){
+		selectionModel.clear();
+	}
+
+	/**
+	 * Sorts table by objects ID
+	 */
+	public void sortTable() {
+		// TODO
+		list = new TableSorter<Pair<User,String>>().sortByLeft(getList());
+		dataProvider.flush();
+		dataProvider.refresh();
+	}
+
+	/**
+	 * Add object as new row to table
+	 *
+	 * @param object VO to be added as new row
+	 */
+	public void addToTable(Pair<User,String> object) {
+		list.add(object);
+		oracle.add(object.getLeft().getFullName());
+		dataProvider.flush();
+		dataProvider.refresh();
+	}
+
+	/**
+	 * Removes object as row from table
+	 *
+	 * @param object VO to be removed as row
+	 */
+	public void removeFromTable(Pair<User,String> object) {
+		list.remove(object.getLeft());
+		selectionModel.getSelectedSet().remove(object.getLeft());
+		dataProvider.flush();
+		dataProvider.refresh();
+	}
+
+	/**
+	 * Clear all table content
+	 */
+	public void clearTable(){
+		loaderImage.loadingStart();
+		list.clear();
+		oracle.clear();
+		fullBackup.clear();
+		selectionModel.clear();
+		dataProvider.flush();
+		dataProvider.refresh();
+	}
+
+	/**
+	 * Called when the query successfully finishes.
+	 * @param jso The JavaScript object returned by the query.
+	 */
+	public void onFinished(JavaScriptObject jso) {
+		setList(JsonUtils.<Pair<User,String>>jsoAsList(jso));
+		sortTable();
+		session.getUiElements().setLogText("Blacklisted users loaded: " + list.size());
+		events.onFinished(jso);
+		loaderImage.loadingFinished();
+	}
+
+	/**
+	 * Called when an error occurs.
+	 */
+	public void onError(PerunError error) {
+		session.getUiElements().setLogErrorText("Error while loading Blacklist.");
+		loaderImage.loadingError(error);
+		events.onError(error);
+	}
+
+	/**
+	 * Called when loading starts.
+	 */
+	public void onLoadingStart() {
+		session.getUiElements().setLogText("Loading Blacklist started.");
+		events.onLoadingStart();
+	}
+
+	public void insertToTable(int index, Pair<User,String> object) {
+		list.add(index, object);
+		oracle.add(object.getLeft().getFullName());
+		dataProvider.flush();
+		dataProvider.refresh();
+	}
+
+	public void setEditable(boolean editable) {
+		// TODO Auto-generated method stub
+	}
+
+	public void setCheckable(boolean checkable) {
+		this.checkable = checkable;
+	}
+
+	public void setList(ArrayList<Pair<User,String>> list) {
+		clearTable();
+		this.list.addAll(list);
+		for (Pair<User,String> user : list) {
+			oracle.add(user.getLeft().getFullName());
+		}
+		dataProvider.flush();
+		dataProvider.refresh();
+	}
+
+	public ArrayList<Pair<User,String>> getList() {
+		return this.list;
+	}
+
+	@Override
+	public void filterTable(String filter) {
+
+		// store list only for first time
+		if (fullBackup.isEmpty() || fullBackup == null) {
+			fullBackup.addAll(list);
+		}
+
+		// always clear selected items
+		selectionModel.clear();
+		list.clear();
+
+		if (filter.equalsIgnoreCase("")) {
+			list.addAll(fullBackup);
+		} else {
+			for (Pair<User,String> pair : fullBackup){
+				// store facility by filter
+				if (pair.getLeft().getFullName().toLowerCase().contains(filter.toLowerCase())) {
+					list.add(pair);
+				}
+			}
+		}
+
+		if (list.isEmpty() && !filter.isEmpty()) {
+			loaderImage.setEmptyResultMessage("No Blacklisted user matching '"+filter+"' found.");
+		} else {
+			loaderImage.setEmptyResultMessage("Blacklist is empty.");
+		}
+
+		dataProvider.flush();
+		dataProvider.refresh();
+		loaderImage.loadingFinished();
+
+	}
+
+	@Override
+	public UnaccentMultiWordSuggestOracle getOracle() {
+		return this.oracle;
+	}
+
+	@Override
+	public void setOracle(UnaccentMultiWordSuggestOracle oracle) {
+		this.oracle = oracle;
+	}
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Pair.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Pair.java
@@ -1,0 +1,21 @@
+package cz.metacentrum.perun.webgui.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class Pair<T,E> extends JavaScriptObject {
+
+	protected Pair() {
+	}
+
+	public final native T getLeft() /*-{
+		return this.left;
+	}-*/;
+
+	public final native E getRight() /*-{
+		return this.right;
+	}-*/;
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityBlacklistTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityBlacklistTabItem.java
@@ -11,8 +11,9 @@ import cz.metacentrum.perun.webgui.client.mainmenu.MainMenu;
 import cz.metacentrum.perun.webgui.client.resources.*;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
-import cz.metacentrum.perun.webgui.json.securityTeamsManager.GetBlacklist;
+import cz.metacentrum.perun.webgui.json.securityTeamsManager.GetBlacklistWithDescription;
 import cz.metacentrum.perun.webgui.model.Facility;
+import cz.metacentrum.perun.webgui.model.Pair;
 import cz.metacentrum.perun.webgui.model.User;
 import cz.metacentrum.perun.webgui.tabs.FacilitiesTabs;
 import cz.metacentrum.perun.webgui.tabs.TabItem;
@@ -85,7 +86,7 @@ public class FacilityBlacklistTabItem implements TabItem, TabItemWithUrl {
 		VerticalPanel firstTabPanel = new VerticalPanel();
 		firstTabPanel.setSize("100%","100%");
 
-		final GetBlacklist securityTeams = new GetBlacklist(PerunEntity.FACILITY, facilityId);
+		final GetBlacklistWithDescription securityTeams = new GetBlacklistWithDescription(PerunEntity.FACILITY, facilityId);
 
 		// menu
 		TabMenu menu = new TabMenu();
@@ -97,12 +98,12 @@ public class FacilityBlacklistTabItem implements TabItem, TabItemWithUrl {
 			}
 		}, ButtonTranslation.INSTANCE.filterSecurityTeam());
 
-		CellTable<User> table;
+		CellTable<Pair<User,String>> table;
 		if (session.isPerunAdmin() || session.isSecurityAdmin()) {
-			table = securityTeams.getTable(new FieldUpdater<User, String>() {
+			table = securityTeams.getTable(new FieldUpdater<Pair<User,String>, String>() {
 				@Override
-				public void update(int index, User object, String value) {
-					session.getTabManager().addTab(new UserDetailTabItem(object));
+				public void update(int index, Pair<User,String> object, String value) {
+					session.getTabManager().addTab(new UserDetailTabItem(object.getLeft()));
 				}
 			});
 		} else {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamBlacklistTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamBlacklistTabItem.java
@@ -14,8 +14,9 @@ import cz.metacentrum.perun.webgui.client.mainmenu.MainMenu;
 import cz.metacentrum.perun.webgui.client.resources.*;
 import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
-import cz.metacentrum.perun.webgui.json.securityTeamsManager.GetBlacklist;
+import cz.metacentrum.perun.webgui.json.securityTeamsManager.GetBlacklistWithDescription;
 import cz.metacentrum.perun.webgui.json.securityTeamsManager.RemoveUserFromBlacklist;
+import cz.metacentrum.perun.webgui.model.Pair;
 import cz.metacentrum.perun.webgui.model.SecurityTeam;
 import cz.metacentrum.perun.webgui.model.User;
 import cz.metacentrum.perun.webgui.tabs.SecurityTabs;
@@ -91,7 +92,7 @@ public class SecurityTeamBlacklistTabItem implements TabItem, TabItemWithUrl {
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(securityTeam.getName())+": "+"blacklist");
 
 		// Get vos request
-		final GetBlacklist teams = new GetBlacklist(PerunEntity.SECURITY_TEAM, securityTeamId);
+		final GetBlacklistWithDescription teams = new GetBlacklistWithDescription(PerunEntity.SECURITY_TEAM, securityTeamId);
 
 		// Events for reloading when finished
 		final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(teams);
@@ -114,7 +115,7 @@ public class SecurityTeamBlacklistTabItem implements TabItem, TabItemWithUrl {
 			@Override
 			public void onClick(ClickEvent event) {
 
-				final ArrayList<User> itemsToRemove = teams.getTableSelectedList();
+				final ArrayList<Pair<User,String>> itemsToRemove = teams.getTableSelectedList();
 				UiElements.showDeleteConfirm(itemsToRemove, new ClickHandler() {
 					@Override
 					public void onClick(ClickEvent clickEvent) {
@@ -126,7 +127,7 @@ public class SecurityTeamBlacklistTabItem implements TabItem, TabItemWithUrl {
 							} else {
 								request = new RemoveUserFromBlacklist(securityTeamId, JsonCallbackEvents.disableButtonEvents(removeButton));
 							}
-							request.removeUserFromBlacklist(itemsToRemove.get(i).getId());
+							request.removeUserFromBlacklist(itemsToRemove.get(i).getLeft().getId());
 						}
 					}
 				});
@@ -145,13 +146,13 @@ public class SecurityTeamBlacklistTabItem implements TabItem, TabItemWithUrl {
 
 		final TabItem tab = this;
 
-		CellTable<User> table;
+		CellTable<Pair<User,String>> table;
 		if (session.isPerunAdmin()) {
 			// get the table with custom onclick
-			table = teams.getTable(new FieldUpdater<User, String>() {
+			table = teams.getTable(new FieldUpdater<Pair<User,String>, String>() {
 				@Override
-				public void update(int i, User user, String string) {
-					session.getTabManager().addTab(new UserDetailTabItem(user));
+				public void update(int i, Pair<User,String> pair, String string) {
+					session.getTabManager().addTab(new UserDetailTabItem(pair.getLeft()));
 					session.getTabManager().closeTab(tab, false);
 				}
 			});


### PR DESCRIPTION
- When serialized by RPC, former implementation with Map<User,String>
  caused User to object to be printed using toString().
- Now method return List<Pair<User,String>> which is recognized as object
  and serialized correctly. We can also simply access properties in GUI
  using getLeft() and getRight().
- Display reason of blacklisting on Facility and securityTeam blacklist page.
- Fixed javadoc and source formatting, fixed tests.
- Fixed RPC javadoc a parsing of related methods.