### PR TITLE
DISPATCHER: Fix loading of routing rules

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/dao/jdbc/RulesDaoJdbc.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/dao/jdbc/RulesDaoJdbc.java
@@ -13,9 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 import cz.metacentrum.perun.dispatcher.dao.RulesDao;
 
 /**
- * 
+ * DAO layer for loading routing rules which map events to engines.
+ *
  * @author Michal Karm Babacek JavaDoc coming soon...
- * 
  */
 @Transactional
 public class RulesDaoJdbc extends JdbcDaoSupport implements RulesDao {
@@ -24,8 +24,7 @@ public class RulesDaoJdbc extends JdbcDaoSupport implements RulesDao {
 
 		public EngineRules mapRow(ResultSet rs, int i) throws SQLException {
 			EngineRules engineRules = new EngineRules();
-			// Integer clientID = rs.getInt("engine_id");
-			Integer clientID = 2;
+			Integer clientID = rs.getInt("engine_id");
 			engineRules.setEngineID(clientID);
 			engineRules.setRoutingRules(loadRoutingRulesForEngine(clientID));
 			return engineRules;


### PR DESCRIPTION
- Removed forgotten hack which mapped all routing rules to
  engine with ID=2. It was probably for testing and forced all
  events to be passed to queue2 even if engine was registered
  in queue1.

Before deploying to production, we must check engine_routing_rules
table to see if engine_id matches engines.id in use.