### PR TITLE
GUI: Implemented safe switching between attr tables

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesV2.java
@@ -518,4 +518,13 @@ public class GetAttributesV2 implements JsonCallback, JsonCallbackTable<Attribut
 		return this.ids;
 	}
 
+	/**
+	 * Returns selection model of table
+	 *
+	 * @return selection model
+	 */
+	public MultiSelectionModel<Attribute> getSelectionModel() {
+		return selectionModel;
+	}
+
 }


### PR DESCRIPTION
- When switching between all/service-required attr tables
  on facility and resource detail, safely switch widgets
  instead of handling a single table.

  Previously on slow connections tables could be filled with
  old request data along side with new request. We switch own
  table widgets for each call.

- Fixed switching between showing all/assigned services only when
  wrong service was auto-selected on return.