### PR TITLE
Controller,GUI: Throw exception when banning service on facility twice

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ServiceAlreadyBannedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ServiceAlreadyBannedException.java
@@ -1,0 +1,44 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Service;
+
+/**
+ * Service is already blocked/banned on facility.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class ServiceAlreadyBannedException extends PerunException {
+
+	static final long serialVersionUID = 0;
+
+	private Service service;
+	private Facility facility;
+
+	public ServiceAlreadyBannedException(String message) {
+		super(message);
+	}
+
+	public ServiceAlreadyBannedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ServiceAlreadyBannedException(Throwable cause) {
+		super(cause);
+	}
+
+	public ServiceAlreadyBannedException(Service service, Facility facility) {
+		this(service.toString() + " is already banned on " + facility.toString());
+		this.service = service;
+		this.facility = facility;
+	}
+
+	public Service getService() {
+		return service;
+	}
+
+	public Facility getFacility() {
+		return facility;
+	}
+
+}

--- a/perun-controller/src/main/java/cz/metacentrum/perun/controller/service/GeneralServiceManager.java
+++ b/perun-controller/src/main/java/cz/metacentrum/perun/controller/service/GeneralServiceManager.java
@@ -4,10 +4,16 @@ import java.util.List;
 
 import cz.metacentrum.perun.controller.model.ServiceForGUI;
 import cz.metacentrum.perun.core.api.Facility;
-import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Service;
-import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.taskslib.model.ExecService;
 import cz.metacentrum.perun.taskslib.model.ExecService.ExecServiceType;
 

--- a/perun-controller/src/main/java/cz/metacentrum/perun/controller/service/GeneralServiceManager.java
+++ b/perun-controller/src/main/java/cz/metacentrum/perun/controller/service/GeneralServiceManager.java
@@ -7,14 +7,7 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Service;
-import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.OwnerNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
-import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedException;
-import cz.metacentrum.perun.core.api.exceptions.ServiceExistsException;
-import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.*;
 import cz.metacentrum.perun.taskslib.model.ExecService;
 import cz.metacentrum.perun.taskslib.model.ExecService.ExecServiceType;
 
@@ -143,8 +136,9 @@ public interface GeneralServiceManager {
 	 * @param execService The execService to be banned on the facility
 	 * @param facility The facility on which we want to ban the execService
 	 * @throws InternalErrorException
+	 * @throws ServiceAlreadyBannedException
 	 */
-	public void banExecServiceOnFacility(PerunSession perunSession, ExecService execService, Facility facility) throws InternalErrorException;
+	public void banExecServiceOnFacility(PerunSession perunSession, ExecService execService, Facility facility) throws InternalErrorException, ServiceAlreadyBannedException;
 
 	/**
 	 * Bans execService on destination.

--- a/perun-controller/src/main/java/cz/metacentrum/perun/controller/service/impl/GeneralServiceManagerImpl.java
+++ b/perun-controller/src/main/java/cz/metacentrum/perun/controller/service/impl/GeneralServiceManagerImpl.java
@@ -3,7 +3,6 @@ package cz.metacentrum.perun.controller.service.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import cz.metacentrum.perun.core.api.exceptions.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,10 +12,17 @@ import org.springframework.transaction.annotation.Transactional;
 import cz.metacentrum.perun.controller.model.ServiceForGUI;
 import cz.metacentrum.perun.controller.service.GeneralServiceManager;
 import cz.metacentrum.perun.core.api.Facility;
-import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.ServicesManager;
+import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.taskslib.dao.ExecServiceDao;
 import cz.metacentrum.perun.taskslib.dao.ExecServiceDenialDao;
 import cz.metacentrum.perun.taskslib.dao.ExecServiceDependencyDao;
@@ -90,6 +96,7 @@ public class GeneralServiceManagerImpl implements GeneralServiceManager {
 	}
 
 	@Override
+	@Transactional(rollbackFor = Exception.class)
 	public void banExecServiceOnFacility(PerunSession sess, ExecService execService, Facility facility) throws InternalErrorException, ServiceAlreadyBannedException {
 		try {
 			execServiceDenialDao.banExecServiceOnFacility(execService.getId(), facility.getId());

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,12 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.33
+alter table service_denials drop constraint srvden_u;
+alter table service_denials add constraint srvden_u check(exec_service_id is not null and ((facility_id is not null and destination_id is null) or (facility_id is null and destination_id is not null)));
+create unique index idx_srvden_u ON service_denials(exec_service_id,facility_id,destination_id);
+update configurations set value='3.1.33' where property='DATABASE VERSION';
+
 3.1.32
 alter table users alter column title_before varchar(40);
 alter table users alter column title_after varchar(40);

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -3,6 +3,9 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.33
+update configurations set value='3.1.33' where property='DATABASE VERSION';
+
 3.1.32
 alter table users modify title_before varchar2(40);
 alter table users modify title_after varchar2(40);

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -3,6 +3,12 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.33
+alter table service_denials drop constraint srvden_u;
+alter table service_denials add constraint srvden_u check(exec_service_id is not null and ((facility_id is not null and destination_id is null) or (facility_id is null and destination_id is not null)));
+create unique index idx_srvden_u ON service_denials(COALESCE(exec_service_id, '0'), COALESCE(facility_id, '0'), COALESCE(destination_id, '0'));
+update configurations set value='3.1.33' where property='DATABASE VERSION';
+
 3.1.32
 alter table users alter column title_before type varchar(40);
 alter table users alter column title_after type varchar(40);

--- a/perun-core/src/main/resources/schema.sql
+++ b/perun-core/src/main/resources/schema.sql
@@ -1183,6 +1183,7 @@ create index idx_fk_taskres_eng on tasks_results(engine_id);
 create index idx_fk_srvden_exsrv on service_denials(exec_service_id);
 create index idx_fk_srvden_fac on service_denials(facility_id);
 create index idx_fk_srvden_dest on service_denials(destination_id);
+create unique index idx_srvden_u ON service_denials(exec_service_id,facility_id,destination_id);
 create index idx_fk_srvdep_exsrv on service_dependencies(exec_service_id);
 create index idx_fk_srvdep_depexsrv on service_dependencies(dependency_id);
 create index idx_fk_srvreqattr_srv on service_required_attrs(service_id);
@@ -1385,7 +1386,7 @@ alter table service_denials add constraint srvden_pk primary key (id);
 alter table service_denials add constraint srvden_exsrv_fk foreign key (exec_service_id) references exec_services(id);
 alter table service_denials add constraint srvden_fac_fk foreign key (facility_id) references facilities(id);
 alter table service_denials add constraint srvden_dest_fk foreign key (destination_id) references destinations(id);
-alter table service_denials add constraint srvden_u unique(exec_service_id,facility_id,destination_id);
+alter table service_denials add constraint srvden_u check(exec_service_id is not null and ((facility_id is not null and destination_id is null) or (facility_id is null and destination_id is not null)));
 
 alter table service_dependencies add constraint srvdep_exsrv_fk foreign key (exec_service_id) references exec_services(id);
 alter table service_dependencies add constraint srvdep_depexsrv_fk foreign key (dependency_id) references exec_services(id);

--- a/perun-core/src/main/resources/test-data.sql
+++ b/perun-core/src/main/resources/test-data.sql
@@ -2088,7 +2088,7 @@ insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routin
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,2,timestamp '2011-11-15 14:43:13.3','PERUNV3',timestamp '2011-11-15 14:43:13.3','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6071,timestamp '2015-01-21 13:05:00.4',timestamp '2015-01-16 14:29:29.6','PERUNV3',timestamp '2015-01-16 14:29:29.6','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6060,timestamp '2015-01-16 14:25:00.6',timestamp '2015-01-16 09:39:07.6','PERUNV3',timestamp '2015-01-16 09:39:07.6','PERUNV3','0');
-insert into configurations (property,value) values ('DATABASE VERSION','3.1.32');
+insert into configurations (property,value) values ('DATABASE VERSION','3.1.33');
 
 drop sequence service_principals_id_seq;
 create sequence service_principals_id_seq start with 1;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.32 (don't forget to update insert statement at the end of file)
+-- database version 3.1.33 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table "vos" (
@@ -1276,6 +1276,7 @@ create index idx_fk_taskres_eng on tasks_results(engine_id);
 create index idx_fk_srvden_exsrv on service_denials(exec_service_id);
 create index idx_fk_srvden_fac on service_denials(facility_id);
 create index idx_fk_srvden_dest on service_denials(destination_id);
+create unique index idx_srvden_u ON service_denials(COALESCE(exec_service_id, '0'), COALESCE(facility_id, '0'), COALESCE(destination_id, '0'));
 create index idx_fk_srvdep_exsrv on service_dependencies(exec_service_id);
 create index idx_fk_srvdep_depexsrv on service_dependencies(dependency_id);
 create index idx_fk_srvreqattr_srv on service_required_attrs(service_id);
@@ -1474,7 +1475,7 @@ alter table service_denials add constraint srvden_pk primary key (id);
 alter table service_denials add constraint srvden_exsrv_fk foreign key (exec_service_id) references exec_services(id);
 alter table service_denials add constraint srvden_fac_fk foreign key (facility_id) references facilities(id);
 alter table service_denials add constraint srvden_dest_fk foreign key (destination_id) references destinations(id);
-alter table service_denials add constraint srvden_u unique(exec_service_id,facility_id,destination_id);
+alter table service_denials add constraint srvden_u check(exec_service_id is not null and ((facility_id is not null and destination_id is null) or (facility_id is null and destination_id is not null)));
 
 alter table service_dependencies add constraint srvdep_exsrv_fk foreign key (exec_service_id) references exec_services(id);
 alter table service_dependencies add constraint srvdep_depexsrv_fk foreign key (dependency_id) references exec_services(id);
@@ -1773,4 +1774,4 @@ grant all on security_teams_facilities to perun;
 grant all on blacklists to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.32');
+insert into configurations values ('DATABASE VERSION','3.1.33');

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GeneralServiceManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GeneralServiceManagerMethod.java
@@ -135,6 +135,7 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 	 *
 	 * @param service int Service <code>id</code>
 	 * @param facility int Facility <code>id</code>
+	 * @throw ServiceAlreadyBannedException When service is already banned on facility.
 	 */
 	banExecServiceOnFacility {
 	    public Void call(ApiCaller ac, Deserializer parms) throws PerunException {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -712,6 +712,14 @@ public class JsonErrorHandler {
 				return "Same service is already assigned to resource.";
 			}
 
+		} else if ("ServiceAlreadyBannedException".equalsIgnoreCase(errorName)) {
+
+			if (error.getService() != null && error.getFacility() != null) {
+				return "Service " + error.getService().getName() + " is already banned on facility "+error.getFacility().getName()+".";
+			} else {
+				return "Same service is already banned on facility.";
+			}
+
 		} else if ("ServiceExistsException".equalsIgnoreCase(errorName)) {
 
 			if (error.getService() != null) {


### PR DESCRIPTION
- When banning service (exec service) on facility twice, we throw new
  ServiceAlreadyBannedException. GUI will better notify user about the problem.
- Updated javadoc.