### PR TITLE
UTILS: Fixed generic script for password management in Kerberos

### DIFF
--- a/perun-utils/password-manager/perun.passwordManager
+++ b/perun-utils/password-manager/perun.passwordManager
@@ -27,7 +27,7 @@ function check() {
 	KERBEROS)
 		TMP_FILE=/tmp/perun.passwd.check
 		# Check old password
-		echo -n $PASSWORD | kinit -c ${TMP_FILE} --password-file=STDIN ${USERLOGIN}@${REALM}
+		echo -n "$PASSWORD" | kinit -c ${TMP_FILE} --password-file=STDIN ${USERLOGIN}@${REALM}
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordChange: old password doesn't match for $LOGINNAMESPACE:$USERLOGIN"
 			rm -f ${TMP_FILE}
@@ -179,13 +179,13 @@ esac
 case $1 in
         change)
 		# Read password
-		read PASSWORD
+		read -r PASSWORD
 
                 change
                 ;;
         check)
 		# Read password
-		read PASSWORD
+		read -r PASSWORD
 
                 check
                 ;;
@@ -194,7 +194,7 @@ case $1 in
 		;;
 	reserve)
 		# Read password
-		read PASSWORD
+		read -r PASSWORD
 
 		reserve
 		;;


### PR DESCRIPTION
- Corrected password reading. It failed when password contained "\",
  because of the way we handled password variable.