### PR TITLE
REGISTRAR: Log operations with application mails

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/MailManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/MailManager.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationForm;
 import cz.metacentrum.perun.registrar.model.ApplicationMail;
 import cz.metacentrum.perun.registrar.model.ApplicationMail.MailType;
+import org.springframework.dao.DuplicateKeyException;
 
 public interface MailManager {
 
@@ -25,8 +26,9 @@ public interface MailManager {
 	 * @param mail ApplicationMail to be stored
 	 * @return ApplicationMail with ID property set returned from DB (null on error)
 	 * @throws PerunException
+	 * @throws DuplicateKeyException When mail definition already exists.
 	 */
-	public Integer addMail(PerunSession sess, ApplicationForm form, ApplicationMail mail) throws PerunException;
+	public Integer addMail(PerunSession sess, ApplicationForm form, ApplicationMail mail) throws PerunException, DuplicateKeyException;
 
 	/**
 	 * Delete mail notification from DB based on ID property.

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -86,6 +86,16 @@ public interface RegistrarManager {
 	ApplicationForm getFormForGroup(Group group) throws PerunException;
 
 	/**
+	 * Gets an application form for a given Id.
+	 *
+	 * @param sess PerunSession for authz
+	 * @param id ID of application form to get
+	 * @return registration form
+	 * @throws PerunException
+	 */
+	ApplicationForm getFormById(PerunSession sess, int id) throws PerunException;
+
+	/**
 	 * Adds a new item to a form.
 	 *
 	 * @param user            the user that adds the items


### PR DESCRIPTION
- Log simple message to peruns auditer log when application
  mail is created, deleted or updated.
- Copying mails is now transactional, duplicate notifications are
  skipped (and logged) and rest is copied.
- Added method getFormById to registrar for logging and authz purpose.