### PR TITLE
GUI: Fixed ConcurrentModificationException on resizing

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
@@ -737,16 +737,16 @@ public class UiElements {
 	 * @param visible true = show log / false = hide log
 	 */
 	private native void setLogVisible(boolean visible)/*-{
-        var logHeight = 200;
-        var logBottomSpace = 30;
+		var logHeight = 200;
+		var logBottomSpace = 30;
 
-        if (visible) {
-            $wnd.jQuery("#perun-log").animate({ bottom: logBottomSpace + "px"}, 'fast');
-        }
-        else {
-            $wnd.jQuery("#perun-log").animate({ bottom: (-logHeight - 10) + "px" }, 'fast');
-        }
-    }-*/;
+		if (visible) {
+			$wnd.jQuery("#perun-log").animate({ bottom: logBottomSpace + "px"}, 'fast');
+		}
+		else {
+			$wnd.jQuery("#perun-log").animate({ bottom: (-logHeight - 10) + "px" }, 'fast');
+		}
+	}-*/;
 
 	/**
 	 * Adds log entry into the devel log widget.
@@ -864,18 +864,18 @@ public class UiElements {
 	 */
 	public native void setStatus(String text)/*-{
 
-        clearTimeout($wnd.hideStatusTimeout);
+		clearTimeout($wnd.hideStatusTimeout);
 
-        $wnd.jQuery("#perun-status").text(text);
-        $wnd.jQuery("#perun-status").animate({ top: "0px" }, 200);
+		$wnd.jQuery("#perun-status").text(text);
+		$wnd.jQuery("#perun-status").animate({ top: "0px" }, 200);
 
-        // after a while, hide it
-        $wnd.hideStatusTimeout = setTimeout(function () {
-            $wnd.jQuery("#perun-status").animate({ top: "-300px" }, 500);
-            $wnd.jQuery("#perun-status").text("");
-        }, 5000);
+		// after a while, hide it
+		$wnd.hideStatusTimeout = setTimeout(function () {
+			$wnd.jQuery("#perun-status").animate({ top: "-300px" }, 500);
+			$wnd.jQuery("#perun-status").text("");
+		}, 5000);
 
-    }-*/;
+	}-*/;
 
 	/**
 	 * Returns the MainMenu class
@@ -1352,7 +1352,7 @@ public class UiElements {
         /* Chrome 19+, Firefox 14+, Explorer 9+ */
 
         /* Opera and IE8 fallback */
-		if (isOperaBeforeFifteen() || isExplorerBeforeNine()) {
+		if (isExplorerBeforeNine()) {
 
 			// autoresize
 			UiElements.addResizeCommand(new Command() {
@@ -1408,27 +1408,27 @@ public class UiElements {
 
 	public static native boolean isOperaBeforeFifteen() /*-{
 
-        if (typeof opera != "undefined") {
-            //do stuffs, for example
-            return ($wnd.opera.version().indexOf("15.") == -1);
-        }
-        return false;
+		if (typeof opera != "undefined") {
+			//do stuffs, for example
+			return ($wnd.opera.version().indexOf("15.") == -1);
+		}
+		return false;
 
-    }-*/;
+	}-*/;
 
 	public static native boolean isExplorerBeforeNine() /*-{
 
-        if (navigator.appName.indexOf("Internet Explorer") != -1) {
-            var number = navigator.appVersion.match(/MSIE ([\d.]+)/)[1];
-            if (number != null) {
-                if (number < 9.0) {
-                    return true;
-                }
-            }
-        }
-        return false;
+		if (navigator.appName.indexOf("Internet Explorer") != -1) {
+			var number = navigator.appVersion.match(/MSIE ([\d.]+)/)[1];
+			if (number != null) {
+				if (number < 9.0) {
+					return true;
+				}
+			}
+		}
+		return false;
 
-    }-*/;
+	}-*/;
 
 	/**
 	 * Changes the position of tab headers - when more tabs than page width
@@ -1438,37 +1438,37 @@ public class UiElements {
 	 */
 	public static native void moveTabs(int position, boolean absolute) /*-{
 
-        // get current
-        var left;
-        var newLeft;
+		// get current
+		var left;
+		var newLeft;
 
-        if (absolute) {
-            newLeft = position;
-            left = 30;
-        } else {
-            left = parseInt($wnd.jQuery(".mainTabPanel .gwt-TabLayoutPanelTabs").first().css("left"), 10);
-            newLeft = left + position;
-        }
+		if (absolute) {
+			newLeft = position;
+			left = 30;
+		} else {
+			left = parseInt($wnd.jQuery(".mainTabPanel .gwt-TabLayoutPanelTabs").first().css("left"), 10);
+			newLeft = left + position;
+		}
 
-        // if wrong value
-        if (newLeft > 30) {
+		// if wrong value
+		if (newLeft > 30) {
 
-            // if already 0
-            if (left == 30) {
-                return;
-            }
+			// if already 0
+			if (left == 30) {
+				return;
+			}
 
-            // if higher - move to 0
-            newLeft = 30;
-        }
+			// if higher - move to 0
+			newLeft = 30;
+		}
 
-        // update - without animation
-        //$wnd.jQuery(".mainTabPanel .gwt-TabLayoutPanelTabs").first().css("left", newLeft + "px");
+		// update - without animation
+		//$wnd.jQuery(".mainTabPanel .gwt-TabLayoutPanelTabs").first().css("left", newLeft + "px");
 
-        // update - with animation
-        $wnd.jQuery(".mainTabPanel .gwt-TabLayoutPanelTabs").first().animate({ left: newLeft }, 'fast');
+		// update - with animation
+		$wnd.jQuery(".mainTabPanel .gwt-TabLayoutPanelTabs").first().animate({ left: newLeft }, 'fast');
 
-    }-*/;
+	}-*/;
 
 	/**
 	 * Return tabs offset
@@ -1477,10 +1477,10 @@ public class UiElements {
 	 */
 	public static native int getTabsLeftOffset() /*-{
 
-        // get current
-        return parseInt($wnd.jQuery(".mainTabPanel .gwt-TabLayoutPanelTabs").first().css("left"), 10);
+		// get current
+		return parseInt($wnd.jQuery(".mainTabPanel .gwt-TabLayoutPanelTabs").first().css("left"), 10);
 
-    }-*/;
+	}-*/;
 
 
 	/**
@@ -1691,7 +1691,7 @@ public class UiElements {
 				}
 
                 /* WE CAN SET WIDTH BY CSS NOW */
-				if (isOperaBeforeFifteen() || isExplorerBeforeNine()) {
+				if (isExplorerBeforeNine()) {
                     /* Opera and IE8 fallback */
 					if (resizeWidth) {
 						int clientWidth = (Window.getClientWidth() > WebGui.MIN_CLIENT_WIDTH) ? Window.getClientWidth() : WebGui.MIN_CLIENT_WIDTH;
@@ -1820,7 +1820,10 @@ public class UiElements {
 	 */
 	static public void runResizeCommands(boolean allTabs) {
 
-		final Iterator<Command> resizeIterator = resizeCommands.iterator();
+		Set<Command> commands = new HashSet<>();
+		commands.addAll(resizeCommands);
+		final Iterator<Command> resizeIterator = commands.iterator();
+
 		Scheduler.get().scheduleIncremental(new Scheduler.RepeatingCommand() {
 			@Override
 			public boolean execute() {
@@ -1843,24 +1846,28 @@ public class UiElements {
 
 		// RUN ALL
 		if (allTabs) {
-			for (Map.Entry<TabItem, Set<Command>> entry : resizeCommandsForTabs.entrySet()) {
+			HashMap<TabItem, Set<Command>> commandsForTab = new HashMap<>();
+			commandsForTab.putAll(resizeCommandsForTabs);
 
-				final Iterator<Command> iterator = entry.getValue().iterator();
-				Scheduler.get().scheduleIncremental(new Scheduler.RepeatingCommand() {
-					@Override
-					public boolean execute() {
-						if (iterator.hasNext()) {
-							iterator.next().execute();
-							return true;
+			for (Map.Entry<TabItem, Set<Command>> entry : commandsForTab.entrySet()) {
+				if (entry.getValue() != null && !entry.getValue().isEmpty()) {
+					final Iterator<Command> iterator = entry.getValue().iterator();
+					Scheduler.get().scheduleIncremental(new Scheduler.RepeatingCommand() {
+						@Override
+						public boolean execute() {
+							if (iterator.hasNext()) {
+								iterator.next().execute();
+								return true;
+							}
+							return false;
 						}
-						return false;
-					}
-				});
+					});
 				/*
 				for (Command command : entry.getValue()) {
 					Scheduler.get().scheduleDeferred(command);
 				}
 				*/
+				}
 			}
 			// if all, exits
 			return;
@@ -1878,20 +1885,26 @@ public class UiElements {
 	 * @param tab tab to trigger resize commands for
 	 */
 	static public void runResizeCommands(TabItem tab) {
-		Set<Command> commandQueue = resizeCommandsForTabs.get(tab);
-		if (commandQueue != null) {
+		Set<Command> commandQueue = new HashSet<>();
+		if (resizeCommandsForTabs.get(tab) != null) {
+			commandQueue.addAll(resizeCommandsForTabs.get(tab));
+		}
+		if (!commandQueue.isEmpty()) {
 
 			final Iterator<Command> resizeIterator = commandQueue.iterator();
-			Scheduler.get().scheduleIncremental(new Scheduler.RepeatingCommand() {
-				@Override
-				public boolean execute() {
-					if (resizeIterator.hasNext()) {
-						resizeIterator.next().execute();
-						return true;
+			if (resizeIterator != null) {
+				Scheduler.get().scheduleIncremental(new Scheduler.RepeatingCommand() {
+					@Override
+					public boolean execute() {
+						if (resizeIterator.hasNext()) {
+							Command command = resizeIterator.next();
+							if (command != null) command.execute();
+							return true;
+						}
+						return false;
 					}
-					return false;
-				}
-			});
+				});
+			}
 
 			/*
 			// run resize queue for each tab


### PR DESCRIPTION
- When running resize commands in UI there was concurrent access
  to the map/set of tabs/commands. We previously iterated over changing
  collection.
  It's now fixed including possible null pointer when no resize command is present.
  This fix should prevent "empty tabs" when JS hangs before drawing the content.

- Source format and indentation.
- Removed check on Opera <15 since its not supported by GWT.