### PR TITLE
Fix engine race

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -171,16 +171,18 @@ public class SchedulingPoolImpl implements SchedulingPool {
 		TaskStatus old = task.getStatus();
 		task.setStatus(status);
 		// move task to the appropriate place
-		if (!old.equals(status)) {
-			if(pool.get(old) != null) {
-				pool.get(old).remove(task);
-			} else {
-				log.warn("task unknown by status");
-			}
-			if(pool.get(status) != null) {
-				pool.get(status).add(task);
-			} else {
-				log.error("no task pool for status " + status.toString());
+		synchronized(pool) {
+			if (!old.equals(status)) {
+				if(pool.get(old) != null) {
+					pool.get(old).remove(task);
+				} else {
+					log.warn("task unknown by status");
+				}
+				if(pool.get(status) != null) {
+					pool.get(status).add(task);
+				} else {
+					log.error("no task pool for status " + status.toString());
+				}
 			}
 		}
 		taskManager.updateTask(task);
@@ -199,27 +201,37 @@ public class SchedulingPoolImpl implements SchedulingPool {
 
 	@Override
 	public List<Task> getWaitingTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.NONE));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.NONE));
+		}
 	}
 
 	@Override
 	public List<Task> getDoneTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.DONE));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.DONE));
+		}
 	}
 
 	@Override
 	public List<Task> getErrorTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.ERROR));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.ERROR));
+		}
 	}
 
 	@Override
 	public List<Task> getProcessingTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.PROCESSING));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.PROCESSING));
+		}
 	}
 
 	@Override
 	public List<Task> getPlannedTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.PLANNED));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.PLANNED));
+		}
 	}
 
 	@Override

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -109,9 +109,11 @@ public class SchedulingPoolImpl implements SchedulingPool{
 		TaskStatus old = task.getStatus();
 		task.setStatus(status);
 		// move task to the appropriate place
-		if (!old.equals(status)) {
-			pool.get(old).remove(task);
-			pool.get(status).add(task);
+		synchronized(pool) {
+			if (!old.equals(status)) {
+				pool.get(old).remove(task);
+				pool.get(status).add(task);
+			}
 		}
 		taskManager.updateTask(task, 0);
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -81,27 +81,37 @@ public class SchedulingPoolImpl implements SchedulingPool{
 
 	@Override
 	public List<Task> getPlannedTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.PLANNED));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.PLANNED));
+		}
 	}
 
 	@Override
 	public List<Task> getNewTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.NONE));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.NONE));
+		}
 	}
 
 	@Override
 	public List<Task> getProcessingTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.PROCESSING));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.PROCESSING));
+		}
 	}
 
 	@Override
 	public List<Task> getErrorTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.ERROR));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.ERROR));
+		}
 	}
 
 	@Override
 	public List<Task> getDoneTasks() {
-		return new ArrayList<Task>(pool.get(TaskStatus.DONE));
+		synchronized(pool) {
+			return new ArrayList<Task>(pool.get(TaskStatus.DONE));
+		}
 	}
 
 	@Override
@@ -111,8 +121,16 @@ public class SchedulingPoolImpl implements SchedulingPool{
 		// move task to the appropriate place
 		synchronized(pool) {
 			if (!old.equals(status)) {
-				pool.get(old).remove(task);
-				pool.get(status).add(task);
+				if(pool.get(old) != null) {
+					pool.get(old).remove(task);
+				} else {
+					log.warn("Task " + task.getId() + "not known by old status");
+				}
+				if(pool.get(status) != null) {
+					pool.get(status).add(task);
+				} else {
+					log.error("No task pool for status " + status.toString());
+				}
 			}
 		}
 		taskManager.updateTask(task, 0);


### PR DESCRIPTION
Fix possible race condition, where tasks can be forgotten when moving from one state (internal data structure) to another. Also avoid theoretically possible exception when no internal queue exists for given state, and add one more test for undetected presence of completed tasks.