### PR TITLE
Fix membership expiration

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1786,9 +1786,10 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 					}
 
 					// Set the date to which the membershi should be extended, can be changed if there was grace period, see next part of the code
-					calendar.set(year, month-1, day); // month is 0-based
 					if (extensionInNextYear) {
-						calendar.add(Calendar.YEAR, 1);
+						calendar.set(year+1, month-1, day);
+					} else {
+						calendar.set(year, month-1, day);
 					}
 
 					// ***** GRACE PERIOD *****


### PR DESCRIPTION
 - problem with expiration at 29.2. (only once in 4 years)
 - we are using period without year and in callendar there is
   always a year (ex. 1970) and this should not be the leap year,
   so date can be converted bad from 29.2. to 1.3.
 - fix it in vo membershipExpirationRules module
 - fix it in manageMembershipExpiration method
 - rework method standardFormatDate in module (to be more readable)