### PR TITLE
Fix reading messages from auditer in LDAPc

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
@@ -143,6 +143,9 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 						Thread.sleep(sleepTime);
 						sleepTime+=sleepTime;
 					}
+
+					//If there are no messages, sleep for 1 sec and then try it again
+					if(messages == null) Thread.sleep(1000);
 				} while(messages == null);
 				//If new messages exist, resolve them all
 				Iterator<AuditMessage> messagesIter = messages.iterator();


### PR DESCRIPTION
 - when no new messages exist, sleep for 1s and then try it again
 - this should prevent calling this method too much in state where no
   new messages exist yet