### PR TITLE
REGISTRAR: fill users name on application notifications

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -1646,6 +1646,21 @@ public class MailManagerImpl implements MailManager {
 					}
 				}
 			}
+
+			if (nameText.isEmpty()) {
+				User user = null;
+				if (app.getUser() != null) {
+					user = app.getUser();
+				} else {
+					try {
+						user = usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
+					} catch (Exception ex) {
+						// user not found is ok
+					}
+				}
+				if (user != null) nameText = user.getDisplayName();
+			}
+
 			mailText = mailText.replace("{displayName}", nameText);
 		}
 
@@ -1660,6 +1675,21 @@ public class MailManagerImpl implements MailManager {
 					}
 				}
 			}
+
+			if (nameText.isEmpty()) {
+				User user = null;
+				if (app.getUser() != null) {
+					user = app.getUser();
+				} else {
+					try {
+						user = usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
+					} catch (Exception ex) {
+						// user not found is ok
+					}
+				}
+				if (user != null) nameText = user.getFirstName();
+			}
+
 			mailText = mailText.replace("{firstName}", nameText);
 		}
 
@@ -1674,7 +1704,23 @@ public class MailManagerImpl implements MailManager {
 					}
 				}
 			}
+
+			if (nameText.isEmpty()) {
+				User user = null;
+				if (app.getUser() != null) {
+					user = app.getUser();
+				} else {
+					try {
+						user = usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
+					} catch (Exception ex) {
+						// user not found is ok
+					}
+				}
+				if (user != null) nameText = user.getLastName();
+			}
+
 			mailText = mailText.replace("{lastName}", nameText);
+
 		}
 
 		// replace exceptions


### PR DESCRIPTION
- When firstName, lastName or displayName is not present on application form,
  fill value from user entity present with application or retrieved by ext source
  data.