### PR TITLE
GUI: Better exception message when name can't be resolved from IdP

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages.java
@@ -153,6 +153,9 @@ public interface ApplicationMessages extends Messages {
 	@DefaultMessage("<h2>Your IDP doesn`t provide data required by application form.</h2><h2>Please contact your IDP to resolve this issue or try to log-in with different IDP.</h2>")
 	String missingDataFromIDP();
 
+	@DefaultMessage("<strong>Can`t reconstruct '{0}'. Missing IDP attributes: displayName, cn, givenName, sn.</strong>")
+	String cantResolveIDPNameAttribute(String attrName);
+
 	@DefaultMessage("<strong>Missing IDP attribute: </strong>")
 	String missingIDPAttribute();
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
@@ -180,8 +180,13 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 			String missingItems = "<p>";
 			if (error.getFormItems() != null) {
 				for (int i = 0; i < error.getFormItems().length(); i++) {
-					missingItems += ApplicationMessages.INSTANCE.missingIDPAttribute();
-					missingItems += error.getFormItems().get(i).getFormItem().getFederationAttribute();
+					String fedAttrName = error.getFormItems().get(i).getFormItem().getFederationAttribute();
+					if (fedAttrName.equals("displayName") || fedAttrName.equals("cn") || fedAttrName.equals("givenName") || fedAttrName.equals("sn")) {
+						missingItems += ApplicationMessages.INSTANCE.cantResolveIDPNameAttribute(fedAttrName);
+					} else {
+						missingItems += ApplicationMessages.INSTANCE.missingIDPAttribute();
+						missingItems += error.getFormItems().get(i).getFormItem().getFederationAttribute();
+					}
 					missingItems += "<br />";
 				}
 			}

--- a/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages_cs.properties
+++ b/perun-web-gui/src/main/resources/common/cz/metacentrum/perun/webgui/client/localization/ApplicationMessages_cs.properties
@@ -24,6 +24,7 @@ errorWhileCreatingApplicationMessage=Přihláška nebyla uložena! <p>Došlo k c
 voAdministratorWasNotified=VO administrátor byl informován o této chybě a měl by vše brzy napravit.
 duplicateRegistrationAttemptExceptionText=<h2>Již máte podánu iniciální přihlášku do této VO / skupiny.</h2><h2>Prosím počkejte, až administrátor Vaši přihlášku schválí nebo zamítne.</h2>
 missingDataFromIDP=<h2>Váš IDP neposkytuje informace vyžadované přihláškovým formulářem.</h2><h2>Prosím kontaktuje svého IDP, aby provedl opravu, nebo se zkuste přihlásit přes jiného IDP.</h2>
+cantResolveIDPNameAttribute=<strong>Nelze sestavit \'{0}\'. Chybějící IDP atributy: displayName, cn, givenName, sn.</strong>
 missingIDPAttribute=<strong>Chybějící IDP atribut: </strong>
 noFormDefined=<h2>VO nemá definovanou přihlášku.</h2>
 alreadyVoMember=<h2>Již jste členem VO.</h2>


### PR DESCRIPTION
- Print better exception message. When user can't access registration
  form because of missing name from IdP.