### PR TITLE
DB, CORE: Fixed column type on Oracle for created_at, modified_at

### DIFF
--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,9 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.34
+update configurations set value='3.1.34' where property='DATABASE VERSION';
+
 3.1.33
 alter table service_denials drop constraint srvden_u;
 alter table service_denials add constraint srvden_u check(exec_service_id is not null and ((facility_id is not null and destination_id is null) or (facility_id is null and destination_id is not null)));

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -3,6 +3,40 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.34
+-- fix create_at and modified_at column types timestamp -> date
+alter table security_teams add created_at2 date;
+alter table security_teams add modified_at2 date;
+update security_teams set created_at2=(select to_date(substr(created_at,0,18),'DD-MON-YY HH24.MI.SS') from security_teams);
+update security_teams set modified_at2=(select to_date(substr(modified_at,0,18),'DD-MON-YY HH24.MI.SS') from security_teams);
+alter table security_teams drop column created_at;
+alter table security_teams drop column modified_at;
+alter table security_teams rename column created_at2 to created_at;
+alter table security_teams rename column modified_at2 to modified_at;
+alter table security_teams modify CREATED_AT default sysdate not null;
+alter table security_teams modify MODIFIED_AT default sysdate not null;
+alter table security_teams_facilities add created_at2 date;
+alter table security_teams_facilities add modified_at2 date;
+update security_teams_facilities set created_at2=(select to_date(substr(created_at,0,18),'DD-MON-YY HH24.MI.SS') from security_teams_facilities);
+update security_teams_facilities set modified_at2=(select to_date(substr(modified_at,0,18),'DD-MON-YY HH24.MI.SS') from security_teams_facilities);
+alter table security_teams_facilities drop column created_at;
+alter table security_teams_facilities drop column modified_at;
+alter table security_teams_facilities rename column created_at2 to created_at;
+alter table security_teams_facilities rename column modified_at2 to modified_at;
+alter table security_teams_facilities modify CREATED_AT default sysdate not null;
+alter table security_teams_facilities modify MODIFIED_AT default sysdate not null;
+alter table blacklists add created_at2 date;
+alter table blacklists add modified_at2 date;
+update blacklists set created_at2=(select to_date(substr(created_at,0,18),'DD-MON-YY HH24.MI.SS') from blacklists);
+update blacklists set modified_at2=(select to_date(substr(modified_at,0,18),'DD-MON-YY HH24.MI.SS') from blacklists);
+alter table blacklists drop column created_at;
+alter table blacklists drop column modified_at;
+alter table blacklists rename column created_at2 to created_at;
+alter table blacklists rename column modified_at2 to modified_at;
+alter table blacklists modify CREATED_AT default sysdate not null;
+alter table blacklists modify MODIFIED_AT default sysdate not null;
+update configurations set value='3.1.34' where property='DATABASE VERSION';
+
 3.1.33
 update configurations set value='3.1.33' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -3,6 +3,9 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.34
+update configurations set value='3.1.34' where property='DATABASE VERSION';
+
 3.1.33
 alter table service_denials drop constraint srvden_u;
 alter table service_denials add constraint srvden_u check(exec_service_id is not null and ((facility_id is not null and destination_id is null) or (facility_id is null and destination_id is not null)));

--- a/perun-core/src/main/resources/test-data.sql
+++ b/perun-core/src/main/resources/test-data.sql
@@ -2088,7 +2088,7 @@ insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routin
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,2,timestamp '2011-11-15 14:43:13.3','PERUNV3',timestamp '2011-11-15 14:43:13.3','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6071,timestamp '2015-01-21 13:05:00.4',timestamp '2015-01-16 14:29:29.6','PERUNV3',timestamp '2015-01-16 14:29:29.6','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6060,timestamp '2015-01-16 14:25:00.6',timestamp '2015-01-16 09:39:07.6','PERUNV3',timestamp '2015-01-16 09:39:07.6','PERUNV3','0');
-insert into configurations (property,value) values ('DATABASE VERSION','3.1.33');
+insert into configurations (property,value) values ('DATABASE VERSION','3.1.34');
 
 drop sequence service_principals_id_seq;
 create sequence service_principals_id_seq start with 1;

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.33 (don't forget to update insert statement at the end of file)
+-- database version 3.1.34 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1057,9 +1057,9 @@ create table security_teams (
 	id integer not null,
 	name nvarchar2(128) not null,
 	description nvarchar2(1024),
-	created_at timestamp default sysdate not null,
+	created_at date default sysdate not null,
 	created_by nvarchar2(1024) default user not null,
-	modified_at timestamp default sysdate not null,
+	modified_at date default sysdate not null,
 	modified_by nvarchar2(1024) default user not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -1068,9 +1068,9 @@ create table security_teams (
 create table security_teams_facilities (
 	security_team_id integer not null,
 	facility_id integer not null,
-	created_at timestamp default sysdate not null,
+	created_at date default sysdate not null,
 	created_by nvarchar2(1024) default user not null,
-	modified_at timestamp default sysdate not null,
+	modified_at date default sysdate not null,
 	modified_by nvarchar2(1024) default user not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -1080,9 +1080,9 @@ create table blacklists (
 	security_team_id integer not null,
 	user_id integer not null,
 	description nvarchar2(1024),
-	created_at timestamp default sysdate not null,
+	created_at date default sysdate not null,
 	created_by nvarchar2(1024) default user not null,
-	modified_at timestamp default sysdate not null,
+	modified_at date default sysdate not null,
 	modified_by nvarchar2(1024) default user not null,
 	created_by_uid integer,
 	modified_by_uid integer
@@ -1724,4 +1724,4 @@ constraint pwdreset_u_fk foreign key (user_id) references users(id)
 );
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.33');
+insert into configurations values ('DATABASE VERSION','3.1.34');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.33 (don't forget to update insert statement at the end of file)
+-- database version 3.1.34 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table "vos" (
@@ -1774,4 +1774,4 @@ grant all on security_teams_facilities to perun;
 grant all on blacklists to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.33');
+insert into configurations values ('DATABASE VERSION','3.1.34');


### PR DESCRIPTION
- We use DATE and not TIMESTAMP for created_at, modified_at columns.
- Updated DB version and all changelogs to 3.1.34