### PR TITLE
Fix creation cookie

### DIFF
--- a/perun-rpc/src/main/perl/Perun/Agent.pm
+++ b/perun-rpc/src/main/perl/Perun/Agent.pm
@@ -72,12 +72,14 @@ sub new {
 	}
 
 	$self->{_lwpUserAgent} = LWP::UserAgent->new(agent => "Agent.pm/$agentVersion", timeout => 600);
-	# Enable cookies if the HOME env is available
-	if (defined($ENV{HOME})) {
-				my $hostname = hostname();
-				my $grp=getpgrp;
+	# Enable cookies if enviromental variable with path exists or home env is available
+	if (defined($EVN{PERUN_COOKIE})) {
 		local $SIG{'__WARN__'} = sub { warn @_ unless $_[0] =~ /does not seem to contain cookies$/; };  #supress one concrete warning message from package HTTP::Cookies
-#		$self->{_lwpUserAgent}->cookie_jar({ file => $ENV{HOME} . "/.perun-engine-cookies.txt", autosave => 1, ignore_discard => 1 });
+		$self->{_lwpUserAgent}->cookie_jar({ file => $ENV{PERUN_COOKIE}, autosave => 1, ignore_discard => 1 });
+	} elsif (defined($ENV{HOME})) {
+		my $hostname = hostname();
+		my $grp=getpgrp;
+		local $SIG{'__WARN__'} = sub { warn @_ unless $_[0] =~ /does not seem to contain cookies$/; };  #supress one concrete warning message from package HTTP::Cookies
 		$self->{_lwpUserAgent}->cookie_jar({ file => $ENV{HOME} . "/perun-cookie-$hostname-$grp.txt", autosave => 1, ignore_discard => 1 });
 	}
 


### PR DESCRIPTION
Create cookie if specific path or home exists in env
   
 - if there is enviromental variable PERUN_COOKIE set, use this path to save cookie
 - if not and there is at least enviromental variable HOME with path to HOME directory, use this path to save cookie
 - in other case do not save cookie at all