### PR TITLE
Fix race condition in extSource SQL

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package cz.metacentrum.perun.core.impl;
 
 import java.sql.Connection;
@@ -30,7 +27,7 @@ import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceSql.class);
-	private static Map<String, String> attributeNameMapping;
+	private static final Map<String, String> attributeNameMapping = new HashMap<>();
 	private Connection con;
 	private boolean isOracle = false;
 
@@ -42,8 +39,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 		return perun;
 	}
 
-	public ExtSourceSql() {
-		attributeNameMapping = new HashMap<String, String>();
+	static {
 		attributeNameMapping.put("m", "urn:perun:member");
 		attributeNameMapping.put("u", "urn:perun:user");
 		attributeNameMapping.put("f", "urn:perun:facility");
@@ -54,9 +50,12 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 		attributeNameMapping.put("mr", "urn:perun:member_resource");
 		attributeNameMapping.put("uf", "urn:perun:user_facility");
 		attributeNameMapping.put("gr", "urn:perun:group_resource");
-
 		attributeNameMapping.put("o", ":attribute-def:opt:");
 		attributeNameMapping.put("d", ":attribute-def:def:");
+	}
+
+
+	public ExtSourceSql() {
 	}
 
 	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException {


### PR DESCRIPTION
 - there is race condition when creating map of attribute name
 - every new calling of sql extSourceSQL create new empty hash and then
   put all values to it (there can be time where some value are not in
   the map yet)