### PR TITLE
CORE: Removed unnecessary code

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1623,7 +1623,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		} catch (VoNotExistsException e) {
 			throw new ConsistencyErrorException("Member " + member + " of non-existing VO id=" + member.getVoId());
 		} catch (AttributeNotExistsException e) {
-			// No rules set, so leave it as it is
+			// There is no attribute definition for membership expiration rules.
 			return new Pair<Boolean, Date>(true, null);
 		} catch (WrongAttributeAssignmentException e) {
 			throw new InternalErrorException("Shouldn't happen.");
@@ -1646,15 +1646,8 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			membershipExpirationAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member,
 					AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration");
 		} catch (AttributeNotExistsException e) {
-			// membershipExpiration was not set, so calculate it in a next phase
-			try {
-				AttributeDefinition membershipExpirationAttributeDefinition = getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess,
-						AttributesManager.NS_MEMBER_ATTR_DEF + ":membershipExpiration");
-				membershipExpirationAttribute = new Attribute(membershipExpirationAttributeDefinition);
-			} catch (AttributeNotExistsException e1) {
-				throw new ConsistencyErrorException("Attribute: " + AttributesManager.NS_MEMBER_ATTR_DEF +
+			throw new ConsistencyErrorException("Attribute: " + AttributesManager.NS_MEMBER_ATTR_DEF +
 						":membershipExpiration" + " must be defined in order to use membershipExpirationRules");
-			}
 		} catch (WrongAttributeAssignmentException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -4941,7 +4941,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		attr.setDisplayName("User title after");
 		attributes.add(attr);
 
-		//User.titleAfter
+		//User.serviceUser
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_USER_ATTR_CORE);
 		attr.setType(Boolean.class.getName());


### PR DESCRIPTION
- When AttributeNotExists exception is thrown, do not try
  to retrieve definition of attribute, since it doesn't exists.