### PR TITLE
catch runtime exception if the TaskExecutor refuses to accept task

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventProcessorImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventProcessorImpl.java
@@ -113,17 +113,21 @@ public class EventProcessorImpl implements EventProcessor {
 				schedulingPool.addToPool(task);
 				if(task.isPropagationForced()) {
 					final Task ntask = task;
-					taskExecutorEventProcessor.execute(new Runnable() {
-						@Override
-						public void run() {
-							try {
-								taskScheduler.propagateService(ntask, new Date(
-										System.currentTimeMillis()));
-							} catch (InternalErrorException e) {
-								log.error(e.toString());
+					try {
+						taskExecutorEventProcessor.execute(new Runnable() {
+							@Override
+							public void run() {
+								try {
+									taskScheduler.propagateService(ntask, new Date(
+											System.currentTimeMillis()));
+								} catch (InternalErrorException e) {
+									log.error(e.toString());
+								}
 							}
-						}
-					});
+						});
+					} catch(Exception e) {
+						log.error("Error queuing task to executor: " + e.toString());
+					}
 				}
 			} else {
 				// currentTask.setSourceUpdated(true);

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskExecutorEngineImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskExecutorEngineImpl.java
@@ -200,8 +200,12 @@ public class TaskExecutorEngineImpl implements TaskExecutorEngine {
 					log.error("Error setting status for destination {} of task {}",
 							destination, task.toString());
 				}
-				startWorker(task, destination);
-				started = true;
+				try {
+					startWorker(task, destination);
+					started = true;
+				} catch(Exception e) {
+					log.error("Error queuing worker for execution: " + e.toString());
+				}
 			}
 		}
 		if(!started) {


### PR DESCRIPTION
If the thread scheduling pool of TaskExecutor is full, TaskExecutor refuses to queue new tasks; this patch catches the resulting exception and logs it instead of letting it go to the stderr.