### PR TITLE
DISPATCHER: Fix reading of input messages

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueReceiver.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueReceiver.java
@@ -12,9 +12,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * 
+ *
  * @author Michal Karm Babacek JavaDoc coming soon...
- * 
+ *
  */
 @org.springframework.stereotype.Service(value = "systemQueueReceiver")
 public class SystemQueueReceiver implements Runnable {
@@ -85,12 +85,21 @@ public class SystemQueueReceiver implements Runnable {
 				Thread.sleep(periodicity);
 			} catch (JMSException e) {
 				log.error(e.toString(), e);
+				systemQueueProcessor.stopProcessingSystemMessages();
+				systemQueueProcessor.startProcessingSystemMessages();
+				try {
+					Thread.sleep(10000);
+				} catch (InterruptedException ex) {
+					log.error(ex.toString(), ex);
+					stop();
+				}
 			} catch (InterruptedException e) {
 				log.error(e.toString(), e);
+				stop();
 			} catch (Exception e) {
 				log.error(e.toString(), e);
+				stop();
 			}
-			// TODO: Close connection and restart SystemQueueProcessor?
 		}
 		try {
 			messageConsumer.close();

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/parser/impl/AuditerListenerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/parser/impl/AuditerListenerImpl.java
@@ -44,8 +44,8 @@ public class AuditerListenerImpl implements AuditerListener {
 							}
 							event.setData(message);
 							eventQueue.add(event);
-							Thread.sleep(1000);
 						}
+						Thread.sleep(1000);
 					}
 				} catch (InternalErrorException e) {
 					log.error("Error in AuditerConsumer: " + e.getMessage() + ", trying to recover by getting a new one.");


### PR DESCRIPTION
- Move sleep out of the inner loop handling messages to the loop polling for available input.
- Restart internal HornetQ JMS server in case of JMSExceptions

Changes made by @mvocu in a single new commit.