### PR TITLE
REGISTRAR: Check also actor and extSource for existing applications

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1754,12 +1754,12 @@ public class RegistrarManagerImpl implements RegistrarManager {
 						} else {
 							// user isn't member of group
 							regs.clear();
-							regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id=? and user_id=? and state=?",
+							regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id=? and state=? and (user_id=? or (created_by=? and extSourceName=?))",
 									new SingleColumnRowMapper<Integer>(Integer.class),
-									AppType.INITIAL.toString(), vo.getId(), group.getId(), user.getId(), AppState.NEW.toString()));
-							regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id=? and user_id=? and state=?",
+									AppType.INITIAL.toString(), vo.getId(), group.getId(), AppState.NEW.toString(), user.getId(), actor, extSourceName));
+							regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id=? and state=? and (user_id=? or (created_by=? and extSourceName=?))",
 									new SingleColumnRowMapper<Integer>(Integer.class),
-									AppType.INITIAL.toString(), vo.getId(), group.getId(), user.getId(), AppState.VERIFIED.toString()));
+									AppType.INITIAL.toString(), vo.getId(), group.getId(), AppState.VERIFIED.toString(), user.getId(), actor, extSourceName));
 							if (!regs.isEmpty()) {
 								// user have unprocessed application for group
 								throw new DuplicateRegistrationAttemptException("Initial application for Group: "+group.getName()+" already exists.", actor, extSourceName, regs.get(0));
@@ -1775,12 +1775,12 @@ public class RegistrarManagerImpl implements RegistrarManager {
 					if (group != null) {
 						// not member of VO - check for unprocessed applications to Group
 						regs.clear();
-						regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id=? and user_id=? and state=?",
+						regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id=? and state=? and (user_id=? or (created_by=? and extSourceName=?))",
 								new SingleColumnRowMapper<Integer>(Integer.class),
-								AppType.INITIAL.toString(), vo.getId(), group.getId(), user.getId(), AppState.NEW.toString()));
-						regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id=? and user_id=? and state=?",
+								AppType.INITIAL.toString(), vo.getId(), group.getId(), AppState.NEW.toString(), user.getId(), actor, extSourceName));
+						regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id=? and state=? and (user_id=? or (created_by=? and extSourceName=?))",
 								new SingleColumnRowMapper<Integer>(Integer.class),
-								AppType.INITIAL.toString(), vo.getId(), group.getId(), user.getId(), AppState.VERIFIED.toString()));
+								AppType.INITIAL.toString(), vo.getId(), group.getId(), AppState.VERIFIED.toString(), user.getId(), actor, extSourceName));
 						if (!regs.isEmpty()) {
 							// user have unprocessed application for group - can't post more
 							throw new DuplicateRegistrationAttemptException("Initial application for Group: "+group.getName()+" already exists.", actor, extSourceName, regs.get(0));
@@ -1789,12 +1789,12 @@ public class RegistrarManagerImpl implements RegistrarManager {
 					} else {
 						// not member of VO - check for unprocessed applications
 						regs.clear();
-						regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id is null and user_id=? and state=?",
+						regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id is null and state=? and (user_id=? or (created_by=? and extSourceName=?))",
 								new SingleColumnRowMapper<Integer>(Integer.class),
-								AppType.INITIAL.toString(), vo.getId(), user.getId(), AppState.NEW.toString()));
-						regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id is null and user_id=? and state=?",
+								AppType.INITIAL.toString(), vo.getId(), AppState.NEW.toString(), user.getId(), actor, extSourceName));
+						regs.addAll(jdbc.query("select id from application where apptype=? and vo_id=? and group_id is null and state=? and (user_id=? or (created_by=? and extSourceName=?))",
 								new SingleColumnRowMapper<Integer>(Integer.class),
-								AppType.INITIAL.toString(), vo.getId(), user.getId(), AppState.VERIFIED.toString()));
+								AppType.INITIAL.toString(), vo.getId(), AppState.VERIFIED.toString(), user.getId(), actor, extSourceName));
 						if (!regs.isEmpty()) {
 							// user have unprocessed application for VO - can't post more
 							throw new DuplicateRegistrationAttemptException("Initial application for VO: "+vo.getName()+" already exists.", actor, extSourceName, regs.get(0));

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1632,8 +1632,12 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 		try {
 			PerunPrincipal pp = sess.getPerunPrincipal();
-			// sort by ID which respect latest applications
-			return jdbc.query(APP_SELECT + " where a.created_by=? and extsourcename=? order by a.id desc", APP_MAPPER, pp.getActor(), pp.getExtSourceName());
+			if (pp.getUser() != null) {
+				return jdbc.query(APP_SELECT + " where user_id=? or (a.created_by=? and extsourcename=?) order by a.id desc", APP_MAPPER, pp.getUserId(), pp.getActor(), pp.getExtSourceName());
+			} else {
+				// sort by ID which respect latest applications
+				return jdbc.query(APP_SELECT + " where a.created_by=? and extsourcename=? order by a.id desc", APP_MAPPER, pp.getActor(), pp.getExtSourceName());
+			}
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<Application>();
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -449,12 +449,14 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Gets all applications for the current user.
+	 * Gets all applications for the current user
+	 * based on authz and internal user ID.
 	 *
 	 * @return List<Application> Found applications
 	 */
 	/*#
-	 * Gets all applications for a specific user.
+	 * Gets all applications for a specific user
+	 * by user ID. Ignores session data.
 	 *
 	 * @param id int User <code>id</code>
 	 * @return List<Application> Found applications


### PR DESCRIPTION
- When checking for already submitted applications, check also by
  actor and extSourceName even when user is known, since they can
  submit application by unknown identity and become know during
  the process.
  This previously failed when vo application was automatic and
  group manual. Next visit to registration form offered group application
  again, since know userId was not set back to group application.