### PR TITLE
Remove attribute value if extSource return null for it

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1741,7 +1741,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 							if(userAttribute.getName().equals(attributeName)) {
 								attributeFound = true;
 								Object subjectAttributeValue = getPerunBl().getAttributesManagerBl().stringToAttributeValue(candidate.getAttributes().get(attributeName), userAttribute.getType());
-								if (subjectAttributeValue != null && !userAttribute.getValue().equals(subjectAttributeValue)) {
+								if (!userAttribute.getValue().equals(subjectAttributeValue)) {
 									log.trace("Group synchronization {}: value of the attribute {} for memberId {} changed. Original value {}, new value {}.",
 											new Object[] {group, userAttribute, richMember.getId(), userAttribute.getValue(), subjectAttributeValue});
 									userAttribute.setValue(subjectAttributeValue);


### PR DESCRIPTION
 - if extSource return null for some attribute, remove this attribute if
   it is member attribute or user with overwrite process
 - if it is user attribute without overwrite process, method
   mergeUserAttributes will not remove current value in Perun