### PR TITLE
Remove "newVersionOfLDAP" variable from ldapc initializer

### DIFF
--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/beans/PerunInitializer.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/beans/PerunInitializer.java
@@ -20,28 +20,14 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  */
 public class PerunInitializer {
 
-	private PerunBl perunBl;
-	private AbstractApplicationContext springCtx;
-	private PerunSession perunSession;
-	private PerunPrincipal perunPrincipal;
-	private BufferedWriter outputWriter;
+	private final PerunBl perunBl;
+	private final AbstractApplicationContext springCtx;
+	private final PerunSession perunSession;
+	private final PerunPrincipal perunPrincipal;
+	private final BufferedWriter outputWriter;
 	private final String consumerName = "ldapcConsumer";
 
-	public PerunInitializer() throws InternalErrorException, FileNotFoundException {
-		//null means STDOUT
-		this(false, null);
-	}
-
-	public PerunInitializer(boolean newVersionOfLDAP) throws InternalErrorException, FileNotFoundException {
-		//null means STDOUT
-		this(newVersionOfLDAP, null);
-	}
-
 	public PerunInitializer(String outputFileName) throws InternalErrorException, FileNotFoundException {
-		this(false, outputFileName);
-	}
-
-	public PerunInitializer(boolean newVersionOfLDAP, String outputFileName) throws InternalErrorException, FileNotFoundException {
 		this.perunPrincipal = new PerunPrincipal("perunLdapInitializer", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
 		this.springCtx = new ClassPathXmlApplicationContext("perun-core.xml", "perun-core-jdbc.xml", "perun-core-transaction-manager.xml");
 		this.perunBl = springCtx.getBean("perun", PerunBl.class);

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/main/Main.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/main/Main.java
@@ -23,24 +23,16 @@ public class Main {
 
 	public static void main(String[] args) throws Exception {
 		//Default is old version and stdout (null file)
-		boolean newVersionOfLDAP = false;
 		String fileName = null;
 
-		if(args.length == 0 || args.length > 2) {
+		if(args.length > 1 || args.length == 0) {
 			System.out.println(help());
 		} else if(args[0].equals("-h") || args[0].equals("--help")) {
 			System.out.println(help());
-		} else if(args[0].equals("-g")) {
-			if(args.length == 2) fileName = args[1];
-			Main main;
-			main = new Main(fileName, newVersionOfLDAP);
-		} else if(args[0].equals("-gnew")) {
-			newVersionOfLDAP = true;
-			if(args.length == 2) fileName = args[1];
-			Main main;
-			main = new Main(fileName, newVersionOfLDAP);
 		} else {
-			System.out.println(help());
+			fileName = args[0];
+			Main main;
+			main = new Main(fileName);
 		}
 	}
 
@@ -54,11 +46,11 @@ public class Main {
 	 * 
 	 * @throws InternalErrorException
 	 */
-	public Main(String fileName, boolean newLDAPversion) throws InternalErrorException {
+	public Main(String fileName) throws InternalErrorException {
 		PerunInitializer perunInitializer = null;
 		try {
 			try {
-				perunInitializer = new PerunInitializer(newLDAPversion, fileName);
+				perunInitializer = new PerunInitializer(fileName);
 			} catch (InternalErrorException ex) {
 				System.err.println("There is problem with Initializing of PerunInitializer. More info can be found in " + fileName);
 				throw ex;


### PR DESCRIPTION
 - only file is mandatory option for execute ldapc initialization
 - remove "newVersionOfLDAP" from whole initializator