### PR TITLE
UTILS: Log stdout/stderr of perun engine to perun-engine-out.log

### DIFF
--- a/perun-utils/init.d-scripts/perun-engine.debian
+++ b/perun-utils/init.d-scripts/perun-engine.debian
@@ -15,6 +15,8 @@
 # 14.04.2015 Modified path to perun.conf.custom and log4j to /etc/perun
 # 04.05.2015 Create, chown and delete pidfile in order to allow user "perun" to start/stop the service
 # 24.03.2016 Create /var/run/perun if not exists, will work when started on system boot
+# 24.03.2016 Own logging for perun-engine to /var/log/perun-engine/
+# 04.04.2015 Log stdout/stderr to perun-engine-out.log
 #
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Perun Engine"
@@ -72,9 +74,13 @@ do_start () {
 	# Create empty pidfile
 	touch $PIDFILE;
 	chown $DAEMON_USER $PIDFILE;
+
+	# Start with output logging, but we need to create log-file first for perun:perun
 	start-stop-daemon --make-pidfile --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \
-        --pidfile $PIDFILE --chdir $EXEC_DIR --background --exec $DAEMON -- $DAEMON_OPTS \
+        --pidfile $PIDFILE --chdir $EXEC_DIR --background --no-close --startas /bin/bash -- \
+        -c "exec $DAEMON $DAEMON_OPTS >> /var/log/perun-engine/perun-engine-out.log 2>&1" \
         || return 2
+
 }
 
 # Stop Perun Engine.


### PR DESCRIPTION
- Start daemon with stdout/stderr redirection.