### PR TITLE
REGISTRAR: Approve only auto-approval group applications

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2634,6 +2634,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			// if new => skipp user will approve automatically by verifying email
 			if (a.getState().equals(AppState.NEW)) continue;
 
+			// approve applications only for auto-approve forms
+			if (!getFormForGroup(a.getGroup()).isAutomaticApproval()) continue;
+
 			try {
 				registrarManager.approveApplicationInternal(sess, a.getId());
 			} catch (RegistrarException ex) {


### PR DESCRIPTION
- When approving any users application. Try to auto-approve
  only those group applications, which have auto-approve form.