### PR TITLE
Delete member-resource attributes when deleting resource

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -102,6 +102,18 @@ public interface AttributesManagerBl {
 	void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Remove all non-virtual member-resource attributes assigned to resource
+	 *
+	 * @param sess
+	 * @param resource
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void removeAllMemberResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
 	 * Get all virtual attributes associated with the member-resource attributes.
 	 *
 	 * @param sess perun session
@@ -2910,7 +2922,6 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeValueException
 	 */
 	void removeAllUserFacilityAttributes(PerunSession sess, User user) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
-
 
 	/**
 	 * Unset particular attribute for the user. Core attributes can't be removed this way.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2879,6 +2879,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		return changed;
 	}
 
+	public void removeAllMemberResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		this.attributesManagerImpl.removeAllMemberResourceAttributes(sess, resource);
+		this.getPerunBl().getAuditer().log(sess, "All non-virtual member-resource attributes removed for all members and {}", resource);
+	}
+
 	public void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		List<Group> groups = this.getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
 		for (Group group : groups) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -124,6 +124,13 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		//Remove all resources tags
 		this.removeAllResourcesTagFromResource(sess, resource);
 
+		//Because resource will be tottaly deleted, we can also delete all member-resource attributes
+		try {
+			this.perunBl.getAttributesManagerBl().removeAllMemberResourceAttributes(sess, resource);
+		} catch (WrongAttributeValueException | WrongAttributeAssignmentException | WrongReferenceAttributeValueException ex) {
+			throw new InternalErrorException(ex);
+		}
+
 		// Get the resource VO
 		Vo vo = this.getVo(sess, resource);
 		getResourcesManagerImpl().deleteResource(sess, vo, resource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3920,6 +3920,14 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 	}
+
+	public void removeAllMemberResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException {
+		try {
+			jdbc.update("delete from member_resource_attr_values where resource_id=?", resource.getId());
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
 	
 	public boolean removeAttribute(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException {
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1691,6 +1691,15 @@ public interface AttributesManagerImplApi {
 	void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
+	 * Remove all non-virtual member-resource attributes assigned to resource
+	 *
+	 * @param sess
+	 * @param resource
+	 * @throws InternalErrorException
+	 */
+	void removeAllMemberResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException;
+
+	/**
 	 * Unset particular attribute for the vo.
 	 *
 	 * @param sess perun session


### PR DESCRIPTION
 - when deleting resource, we need to remove all member-resource
   attributes, it means remove also attributes of not assigned members
   (they were removed with group before this operation, but attrs
   persist)