### PR TITLE
CORE: Improved getAssignedResources() in Bl and Impl

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -258,6 +258,20 @@ public interface FacilitiesManagerBl {
 	List<Resource> getAssignedResources(PerunSession perunSession, Facility facility) throws InternalErrorException;
 
 	/**
+	 * Returns all resources assigned to the facility with optionally VO and Service specified
+	 *
+	 * @param perunSession
+	 * @param facility
+	 * @param specificVo
+	 * @param specificService
+	 *
+	 * @return list of resources assigned to the facility
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getAssignedResources(PerunSession perunSession, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
+
+	/**
 	 * Returns all rich resources assigned to the facility with VO property filled
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -210,22 +210,9 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 
 	@Override
 	public List<User> getAllowedUsers(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException {
+
 		//Get all facilities resources
-		List<Resource> resources = this.getAssignedResources(sess, facility);
-
-		//Remove all resources which are not in specific VO (if is specific)
-		if(specificVo != null) {
-			Iterator<Resource> iter = resources.iterator();
-			while(iter.hasNext()) {
-				if(specificVo.getId() != iter.next().getVoId()) iter.remove();
-			}
-		}
-
-		//Remove all resources which has not assigned specific service (if is specific)
-		if(specificService != null) {
-			List<Resource> resourcesWhereServiceIsAssigned = getPerunBl().getServicesManagerBl().getAssignedResources(sess, specificService);
-			resources.retainAll(resourcesWhereServiceIsAssigned);
-		}
+		List<Resource> resources = getAssignedResources(sess, facility, specificVo, specificService);
 
 		List<User> users =  new ArrayList<User>();
 		for (Resource resource: resources) {
@@ -237,6 +224,11 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 
 	public List<Resource> getAssignedResources(PerunSession sess, Facility facility) throws InternalErrorException {
 		return getFacilitiesManagerImpl().getAssignedResources(sess, facility);
+	}
+
+	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException {
+		if (specificVo == null && specificService == null) return getAssignedResources(sess, facility);
+		return getFacilitiesManagerImpl().getAssignedResources(sess, facility, specificVo, specificService);
 	}
 
 	public List<RichResource> getAssignedRichResources(PerunSession sess, Facility facility) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -28,6 +28,7 @@ import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
@@ -405,6 +406,38 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 		try {
 			return jdbc.query("select " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources where facility_id=?",
 					ResourcesManagerImpl.RESOURCE_MAPPER, facility.getId());
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public List<Resource> getAssignedResources(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException {
+
+		try {
+
+			if (specificVo != null && specificService != null) {
+
+				return jdbc.query("select " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resource_services join resources on " +
+						"resource_services.resource_id=resources.id where facility_id=? and vo_id=? and service_id=?",
+						ResourcesManagerImpl.RESOURCE_MAPPER, facility.getId(), specificVo.getId(), specificService.getId());
+
+			} else if (specificVo != null) {
+
+				return jdbc.query("select " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources where facility_id=? and vo_id=?",
+						ResourcesManagerImpl.RESOURCE_MAPPER, facility.getId(), specificVo.getId());
+
+			} else if (specificService != null) {
+
+				return jdbc.query("select " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resource_services join resources on " +
+						"resource_services.resource_id=resources.id where facility_id=? and service_id=?",
+						ResourcesManagerImpl.RESOURCE_MAPPER, facility.getId(), specificService.getId());
+
+			} else {
+
+				return getAssignedResources(sess, facility);
+
+			}
+
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -14,11 +14,10 @@ import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.HostAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.HostNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -26,7 +25,6 @@ import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException;
-import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 
 /**
  * Facility manager can create a new facility or find an existing facility.
@@ -175,6 +173,20 @@ public interface FacilitiesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Resource> getAssignedResources(PerunSession perunSession, Facility facility) throws InternalErrorException;
+
+	/**
+	 * Returns all resources assigned to the facility with optionally VO and Service specified.
+	 *
+	 * @param perunSession
+	 * @param facility
+	 * @param specificVo
+	 * @param specificService
+	 *
+	 * @return list of resources assigned to the facility with optionally filter for VO and Service.
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getAssignedResources(PerunSession perunSession, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
 
 	/**
 	 * Returns all rich resources assigned to the facility.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -371,9 +371,114 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		Group group = setUpGroup(vo, member);
 		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
 
+		// second vo and member, assign group but no service
+		Vo vo2 = new Vo();
+		vo2.setName("FacilitiesMangerTestVo2");
+		vo2.setShortName("FMTVO2");
+		assertNotNull("unable to create VO",perun.getVosManager().createVo(sess, vo2));
+
+		Member member2 = setUpMember(vo2);
+		User user2 = perun.getUsersManagerBl().getUserByMember(sess, member2);
+		Group group2 = setUpGroup(vo2, member2);
+		Resource resource2 = setUpResource(vo2);
+		perun.getResourcesManager().assignService(sess, resource2, serv);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2);
+
 		List<User> users = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo, serv);
 		assertTrue("our facility should have 1 allowed user",users.size() == 1);
 		assertTrue("our user should be between allowed on facility",users.contains(user));
+
+		List<User> users2 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, serv);
+		assertTrue("our facility should have 1 allowed user",users2.size() == 1);
+		assertTrue("our user should be between allowed on facility",users2.contains(user2));
+
+		List<User> users3 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, null, serv);
+		assertTrue("our facility should have 1 allowed user",users3.size() == 2);
+		assertTrue("our user should be between allowed on facility",users3.contains(user));
+		assertTrue("our user should be between allowed on facility",users3.contains(user2));
+
+		List<User> users4 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo, null);
+		assertTrue("our facility should have 1 allowed user",users4.size() == 1);
+		assertTrue("our user should be between allowed on facility",users4.contains(user));
+
+		List<User> users5 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, null);
+		assertTrue("our facility should have 1 allowed user",users5.size() == 1);
+		assertTrue("our user should be between allowed on facility",users5.contains(user2));
+
+		// remove service from resource2 to test other edge cases
+		perun.getResourcesManager().removeService(sess, resource2, serv);
+
+		List<User> users6 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo, serv);
+		assertTrue("our facility should have 1 allowed user",users6.size() == 1);
+		assertTrue("our user should be between allowed on facility",users6.contains(user));
+
+		List<User> users7 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, serv);
+		assertTrue("our user shouldn't be allowed on facility with vo filter on", users7.size() == 0);
+
+		List<User> users8 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, null, serv);
+		assertTrue("our facility should have 1 allowed user",users8.size() == 1);
+		assertTrue("our user should be between allowed on facility",users8.contains(user));
+		assertTrue("our user shouldn't be between allowed on facility",!users8.contains(user2));
+
+		List<User> users9 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo, null);
+		assertTrue("our facility should have 1 allowed user",users9.size() == 1);
+		assertTrue("our user should be between allowed on facility",users9.contains(user));
+
+		List<User> users10 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, null);
+		assertTrue("our facility should have 1 allowed user",users10.size() == 1);
+		assertTrue("our user should be between allowed on facility",users10.contains(user2));
+
+		// create different service to test another edge cases
+
+		Service serv2 = new Service();
+		serv2.setName("TestService2");
+		serv2 = perun.getServicesManager().createService(sess, serv2);
+		perun.getResourcesManager().assignService(sess, resource2, serv2);
+
+		List<User> users11 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo, serv2);
+		assertTrue("our facility shouldn't have allowed user with vo and service filter on",users11.size() == 0);
+
+		List<User> users12 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, serv2);
+		assertTrue("our facility should have 1 allowed user",users12.size() == 1);
+		assertTrue("our user should be between allowed on facility",users12.contains(user2));
+
+		List<User> users13 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, null, serv2);
+		assertTrue("our facility should have 1 allowed user",users13.size() == 1);
+		assertTrue("our user should be between allowed on facility",users13.contains(user2));
+
+		List<User> users14 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo, null);
+		assertTrue("our facility should have 1 allowed user",users14.size() == 1);
+		assertTrue("our user should be between allowed on facility",users14.contains(user));
+
+		List<User> users15 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, null);
+		assertTrue("our facility should have 1 allowed user",users15.size() == 1);
+		assertTrue("our user should be between allowed on facility",users15.contains(user2));
+
+		List<User> users16 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, null, null);
+		assertTrue("our facility should have 2 allowed users",users16.size() == 2);
+		assertTrue("our user should be between allowed on facility",users16.contains(user));
+		assertTrue("our user should be between allowed on facility",users16.contains(user2));
+
+		// disabled members shouldn't be allowed
+		perun.getMembersManager().setStatus(sess, member, Status.DISABLED);
+
+		List<User> users17 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, null, null);
+		assertTrue("our facility should have 1 allowed user",users17.size() == 1);
+		assertTrue("our user should be between allowed on facility",users17.contains(user2));
+
+		List<User> users18 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo, null);
+		assertTrue("our facility shouldn't have allowed user with vo filter on",users18.size() == 0);
+
+		List<User> users19 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, null);
+		assertTrue("our facility should have 1 allowed user",users19.size() == 1);
+		assertTrue("our user should be between allowed on facility",users19.contains(user2));
+
+		List<User> users20 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, serv);
+		assertTrue("our facility shouldn't have allowed user with vo and service filter on",users20.size() == 0);
+
+		List<User> users21 = perun.getFacilitiesManager().getAllowedUsers(sess, facility, vo2, serv2);
+		assertTrue("our facility should have 1 allowed user",users21.size() == 1);
+		assertTrue("our user should be between allowed on facility",users21.contains(user2));
 
 	}
 


### PR DESCRIPTION
- We can now optionally specify VO or Service when retrieving
  assigned resources from facility. Implemented on DB layer,
  so no more multiple calls and for cycling when used by
  others like getAllowedUsers() method.
- Added more verbose testing of getAllowedUsers() when vo and service
  can be specified. Method implementation changed and uses new method
  from bl/impl with direct selects (for assigned resources).
  Since new method is not in Entry layer, we can't test it directly. Plus these
  edge cases should have been tested in previous versions too anyway.
- Cherry-picked from #1148 since these changes are safe to merge.