### PR TITLE
DISPATCHER: Fixed audit message parsing

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/impl/EventExecServiceResolverImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/impl/EventExecServiceResolverImpl.java
@@ -87,7 +87,7 @@ public class EventExecServiceResolverImpl implements EventExecServiceResolver {
 		 * /wiki/PerunEngineDispatcherController event|x|[timestamp][Event
 		 * header][Event data]
 		 */
-		String eventParsingPattern = "^\\[([a-zA-Z0-9: ]+)\\]\\[([^\\]]+)\\]\\[(.*)\\]$";
+		String eventParsingPattern = "^\\[([a-zA-Z0-9+: ]+)\\]\\[([^\\]]+)\\]\\[(.*)\\]$";
 		Pattern pattern = Pattern.compile(eventParsingPattern);
 		Matcher matcher = pattern.matcher(event);
 		boolean matchFound = matcher.find();


### PR DESCRIPTION
- Allow "+" in message date.
- Depending on your environment locale, you can get date printed
  in different manners.
  Mon May 02 07:42:45 CEST 2016
  Mon May 02 06:49:58 GMT+01:00 2016
  Hence regex for parsing message must be more friendly.