### PR TITLE
Do not use unlimited bulk of ids to one SQL query

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -92,6 +92,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private Map<AttributeDefinition, Set<AttributeDefinition>> inverseStrongDependencies = new ConcurrentHashMap<AttributeDefinition, Set<AttributeDefinition>>();
 	private Map<AttributeDefinition, Set<AttributeDefinition>> allDependencies = new ConcurrentHashMap<AttributeDefinition, Set<AttributeDefinition>>();
 
+	private final static int MAX_SIZE_OF_BULK_IN_SQL = 10000;
+
 	/**
 	 * Constructor.
 	 */
@@ -2075,8 +2077,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 
 		if(!workWithUserAttributes) {
-			HashMap<Member, List<Attribute>> resourceMemberAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
-			HashMap<Member, List<Attribute>> memberAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
+			HashMap<Member, List<Attribute>> resourceMemberAttributes = getRequiredAttributes(sess, service, resource, members);
+			HashMap<Member, List<Attribute>> memberAttributes = getRequiredAttributes(sess, resource, service, members);
 
 			for (Member mem : memberAttributes.keySet()) {
 				if (!resourceMemberAttributes.containsKey(mem)) {
@@ -2109,10 +2111,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 
 		// get 4 maps from Impl getRequiredAttributes
-		HashMap<Member, List<Attribute>> resourceMemberAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
-		HashMap<Member, List<Attribute>> memberAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
-		HashMap<User, List<Attribute>> userFacilityAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users);
-		HashMap<User, List<Attribute>> userAttributes = getAttributesManagerImpl().getRequiredAttributes(sess, service, users);
+		HashMap<Member, List<Attribute>> resourceMemberAttributes = getRequiredAttributes(sess, service, resource, members);
+		HashMap<Member, List<Attribute>> memberAttributes = getRequiredAttributes(sess, resource, service, members);
+		HashMap<User, List<Attribute>> userFacilityAttributes = getRequiredAttributes(sess, service, facility, users);
+		HashMap<User, List<Attribute>> userAttributes = getRequiredAttributes(sess, service, users);
 
 		for (Member mem : memberAttributes.keySet()) {
 			if (!resourceMemberAttributes.containsKey(mem)) {
@@ -2153,7 +2155,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Resource resource, List<Member> members) throws InternalErrorException {
 		if (!members.isEmpty()) {
-			return getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
+			return getRequiredAttributesForBulk(sess, service, resource, members);
 		}
 		return new HashMap<>();
 	}
@@ -2161,7 +2163,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public HashMap<Member, List<Attribute>> getRequiredAttributes(PerunSession sess, Resource resource, Service service, List<Member> members) throws InternalErrorException {
 		if (!members.isEmpty()) {
-			return getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
+			return getRequiredAttributesForBulk(sess, resource, service, members);
 		}
 		return new HashMap<>();
 	}
@@ -2169,7 +2171,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, Facility facility, List<User> users) throws InternalErrorException {
 		if (!users.isEmpty()) {
-			return getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users);
+			return getRequiredAttributesForBulk(sess, service, facility, users);
 		}
 		return new HashMap<>();
 	}
@@ -2177,7 +2179,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException {
 		if (!users.isEmpty()) {
-			return getAttributesManagerImpl().getRequiredAttributes(sess, service, users);
+			return getRequiredAttributesForBulk(sess, service, users);
 		}
 		return new HashMap<>();
 	}
@@ -6204,4 +6206,146 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		return attributeToConvert;
 	}
 
+	/**
+	 * Get Map of members with list of member-resource attributes in values.
+	 *
+	 * This method calls 'getRequiredAttributes(session, service, resource, List members)' for
+	 * every MAX_SIZE_OF_BULL_IN_SQL records (default 10000 records) in list of members.
+	 *
+	 * Example: if there are 25000 records in list of members, this method call it by 3 separate
+	 * queries instead of 1, if less or equal to 10000 records are in list of members, than this method
+	 * calls getRequiredAttributes just once without any changes
+	 * 
+	 * Reason: SQL error in Oracle for too much records in one SQL query
+	 *
+	 * @param sess perunSession
+	 * @param service service to get required attributes for
+	 * @param resource resource to get required attributes for
+	 * @param members members to get required attributes for
+	 * @return map of members in keys with list of their member-resource attributes in value
+	 * @throws InternalErrorException
+	 */
+	private HashMap<Member, List<Attribute>> getRequiredAttributesForBulk(PerunSession sess, Service service, Resource resource, List<Member> members) throws InternalErrorException {
+		if(members.size() <= MAX_SIZE_OF_BULK_IN_SQL) return getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members);
+		
+		HashMap<Member, List<Attribute>> memberResourceAttrs = new HashMap<>();
+
+		int from = 0;
+		int to = MAX_SIZE_OF_BULK_IN_SQL;
+		do {
+			memberResourceAttrs.putAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members.subList(from, to)));
+			from+=MAX_SIZE_OF_BULK_IN_SQL;
+			to+=MAX_SIZE_OF_BULK_IN_SQL;
+		} while (members.size()>to);
+		memberResourceAttrs.putAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, members.subList(from, members.size())));
+
+		return memberResourceAttrs;
+	}
+
+	/**
+	 * Get Map of members with list of member attributes in values.
+	 *
+	 * This method calls 'getRequiredAttributes(session, resource, service, List members)' for
+	 * every MAX_SIZE_OF_BULL_IN_SQL records (default 10000 records) in list of members.
+	 *
+	 * Example: if there are 25000 records in list of members, this method call it by 3 separate
+	 * queries instead of 1, if less or equal to 10000 records are in list of members, than this method
+	 * calls getRequiredAttributes just once without any changes
+	 *
+	 * Reason: SQL error in Oracle for too much records in one SQL query
+	 *
+	 * @param sess perunSession
+	 * @param resource resource to get required attributes for
+	 * @param service service to get required attributes for
+	 * @param members members to get required attributes for
+	 * @return map of members in keys with list of their member attributes in value
+	 * @throws InternalErrorException
+	 */
+	private HashMap<Member, List<Attribute>> getRequiredAttributesForBulk(PerunSession sess, Resource resource, Service service, List<Member> members) throws InternalErrorException {
+		if(members.size() <= MAX_SIZE_OF_BULK_IN_SQL) return getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members);
+
+		HashMap<Member, List<Attribute>> memberAttrs = new HashMap<>();
+
+		int from = 0;
+		int to = MAX_SIZE_OF_BULK_IN_SQL;
+		do {
+			memberAttrs.putAll(getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members.subList(from, to)));
+			from+=MAX_SIZE_OF_BULK_IN_SQL;
+			to+=MAX_SIZE_OF_BULK_IN_SQL;
+		} while (members.size()>to);
+		memberAttrs.putAll(getAttributesManagerImpl().getRequiredAttributes(sess, resource, service, members.subList(from, members.size())));
+
+		return memberAttrs;
+	}
+
+	/**
+	 * Get Map of users with list of user-facility attributes in values.
+	 *
+	 * This method calls 'getRequiredAttributes(session, service, facility, List users)' for
+	 * every MAX_SIZE_OF_BULL_IN_SQL records (default 10000 records) in list of users.
+	 *
+	 * Example: if there are 25000 records in list of users, this method call it by 3 separate
+	 * queries instead of 1, if less or equal to 10000 records are in list of users, than this method
+	 * calls getRequiredAttributes just once without any changes
+	 *
+	 * Reason: SQL error in Oracle for too much records in one SQL query
+	 *
+	 * @param sess perunSession
+	 * @param service service to get required attributes for
+	 * @param facility facility to get required attributes for
+	 * @param users users to get required attributes for
+	 * @return map of users in keys with list of their user-facility attributes in value
+	 * @throws InternalErrorException
+	 */
+	private HashMap<User, List<Attribute>> getRequiredAttributesForBulk(PerunSession sess, Service service, Facility facility, List<User> users) throws InternalErrorException {
+		if(users.size() <= MAX_SIZE_OF_BULK_IN_SQL) return getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users);
+
+		HashMap<User, List<Attribute>> userFacAttrs = new HashMap<>();
+
+		int from = 0;
+		int to = MAX_SIZE_OF_BULK_IN_SQL;
+		do {
+			userFacAttrs.putAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users.subList(from, to)));
+			from+=MAX_SIZE_OF_BULK_IN_SQL;
+			to+=MAX_SIZE_OF_BULK_IN_SQL;
+		} while (users.size()>to);
+		userFacAttrs.putAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, users.subList(from, users.size())));
+
+		return userFacAttrs;
+	}
+
+	/**
+	 * Get Map of users with list of user attributes in values.
+	 *
+	 * This method calls 'getRequiredAttributes(session, service, List users)' for
+	 * every MAX_SIZE_OF_BULL_IN_SQL records (default 10000 records) in list of users.
+	 *
+	 * Example: if there are 25000 records in list of users, this method call it by 3 separate
+	 * queries instead of 1, if less or equal to 10000 records are in list of users, than this method
+	 * calls getRequiredAttributes just once without any changes
+	 *
+	 * Reason: SQL error in Oracle for too much records in one SQL query
+	 *
+	 * @param sess perunSession
+	 * @param service service to get required attributes for
+	 * @param users users to get required attributes for
+	 * @return map of users in keys with list of their user attributes in value
+	 * @throws InternalErrorException
+	 */
+	private HashMap<User, List<Attribute>> getRequiredAttributesForBulk(PerunSession sess, Service service, List<User> users) throws InternalErrorException {
+		if(users.size() <= MAX_SIZE_OF_BULK_IN_SQL) return getAttributesManagerImpl().getRequiredAttributes(sess, service, users);
+
+		HashMap<User, List<Attribute>> userAttrs = new HashMap<>();
+
+		int from = 0;
+		int to = MAX_SIZE_OF_BULK_IN_SQL;
+		do {
+			userAttrs.putAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, users.subList(from, to)));
+			from+=MAX_SIZE_OF_BULK_IN_SQL;
+			to+=MAX_SIZE_OF_BULK_IN_SQL;
+		} while (users.size()>to);
+		userAttrs.putAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, users.subList(from, users.size())));
+
+		return userAttrs;
+	}
 }


### PR DESCRIPTION
 - Oracle does not support unlimited number of IDs for 'in clause' even
   with or between them, so we need to separate one query to more of
   them. For now we use default value 10000 records per one query.
 - new method getRequiredAttributesForBulk which calls more SQL queries
   for one bulk of IDs (member or user ids)
 - for example: if there are 33000 records, than we will call 4 queries
   (10000+10000+10000+3000) instead of 1 (33000)