### PR TITLE
CORE: Fixed selects of attributes for 32000+ users

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1936,6 +1936,11 @@ public interface AttributesManagerBl {
 	 */
 	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException;
 
+	HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
+	HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
+	HashMap<Member, List<Attribute>> getRequiredMemberAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
+	HashMap<Member, List<Attribute>> getRequiredMemberResourceAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
+
 	/**
 	 * Get member-group attributes which are required by the service.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1936,12 +1936,77 @@ public interface AttributesManagerBl {
 	 */
 	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException;
 
+	/**
+	 * Get User attributes required by service on specified facility for all allowed users.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param facility Facility to get allowed users
+	 * @param resource Resource to get allowed users (todo)
+	 * @return Map of Users (as keys) with their required user attributes (as values)
+	 * @throws InternalErrorException
+	 */
 	HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Get User-Facility attributes required by service on specified facility for all allowed users.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param facility Facility to get allowed users
+	 * @param resource Resource to get allowed users (todo)
+	 * @return Map of Users (as keys) with their required user-facility attributes (as values)
+	 * @throws InternalErrorException
+	 */
 	HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Get Member attributes required by service on specified facility for all allowed members.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param resource Resource to get allowed members
+	 * @return Map of Members (as keys) with their required member attributes (as values)
+	 * @throws InternalErrorException
+	 */
 	HashMap<Member, List<Attribute>> getRequiredMemberAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Get Member-Resource attributes required by service on specified facility for all allowed members.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param resource Resource to get allowed members
+	 * @return Map of Members (as keys) with their required member-resource attributes (as values)
+	 * @throws InternalErrorException
+	 */
 	HashMap<Member, List<Attribute>> getRequiredMemberResourceAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
 
+	/**
+	 * Get all required attributes for specified service of members allowed on specified facility and resource.
+	 * User, Member, Member-Resource and User-Facility attributes are retrieved.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param facility Facility for purpose of AttributeMapper only
+	 * @param resource Resource to get allowed members
+	 * @return Map of allowed members (as a keys) and list of required attributes (as values).
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
 	HashMap<Member, List<Attribute>> getAllRequiredAttributesOfAllowedMembers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get all required attributes for specified service of users allowed on specified facility.
+	 * Only User and User-Facility attributes are retrieved.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param facility Facility to get allowed users
+	 * @return Map of allowed users (as a keys) and list of required attributes (as values).
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
 	HashMap<User, List<Attribute>> getAllRequiredAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1936,10 +1936,13 @@ public interface AttributesManagerBl {
 	 */
 	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException;
 
-	HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
-	HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
+	HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
+	HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
 	HashMap<Member, List<Attribute>> getRequiredMemberAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
 	HashMap<Member, List<Attribute>> getRequiredMemberResourceAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
+
+	HashMap<Member, List<Attribute>> getAllRequiredAttributesOfAllowedMembers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException, WrongAttributeAssignmentException;
+	HashMap<User, List<Attribute>> getAllRequiredAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get member-group attributes which are required by the service.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -977,7 +977,10 @@ public interface UsersManagerBl {
 	 * @return list of RichUsers
 	 * @throws InternalErrorException
 	 */
-	List<RichUser> getAllRichUsersWithAllNonVirutalAttributes(PerunSession sess) throws InternalErrorException;
+	// FIXME - this method is totally unused and very specific - bringing complexity to users manager
+	// FIXME - please please remove !!
+	@Deprecated
+	List<RichUser> getAllRichUsersWithAllNonVirtualAttributes(PerunSession sess) throws InternalErrorException;
 
 	/**
 	 * Allow users to manually add login in supported namespace if same login is not reserved

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -971,18 +971,6 @@ public interface UsersManagerBl {
 	List<RichUser> getAllRichUsersWithAttributes(PerunSession sess, boolean includedSpecificUsers, List<String> attrsNames) throws InternalErrorException, UserNotExistsException;
 
 	/**
-	 * Get All RichUsers without UserExtSources and without virtual attributes.
-	 *
-	 * @param sess
-	 * @return list of RichUsers
-	 * @throws InternalErrorException
-	 */
-	// FIXME - this method is totally unused and very specific - bringing complexity to users manager
-	// FIXME - please please remove !!
-	@Deprecated
-	List<RichUser> getAllRichUsersWithAllNonVirtualAttributes(PerunSession sess) throws InternalErrorException;
-
-	/**
 	 * Allow users to manually add login in supported namespace if same login is not reserved
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2183,13 +2183,23 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException {
-		return getAttributesManagerImpl().getRequiredUserAttributesOfAllowedUsers(sess, service, facility);
+	public HashMap<Member, List<Attribute>> getAllRequiredAttributesOfAllowedMembers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException, WrongAttributeAssignmentException {
+		return getAttributesManagerImpl().getAllRequiredAttributesOfAllowedMembers(sess, service, facility, resource);
 	}
 
 	@Override
-	public HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException {
-		return getAttributesManagerImpl().getRequiredUserFacilityAttributesOfAllowedUsers(sess, service, facility);
+	public HashMap<User, List<Attribute>> getAllRequiredAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException, WrongAttributeAssignmentException {
+		return getAttributesManagerImpl().getAllRequiredAttributesOfAllowedUsers(sess, service, facility);
+	}
+
+	@Override
+	public HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredUserAttributesOfAllowedUsers(sess, service, facility, resource);
+	}
+
+	@Override
+	public HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredUserFacilityAttributesOfAllowedUsers(sess, service, facility, resource);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2183,6 +2183,26 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
+	public HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredUserAttributesOfAllowedUsers(sess, service, facility);
+	}
+
+	@Override
+	public HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredUserFacilityAttributesOfAllowedUsers(sess, service, facility);
+	}
+
+	@Override
+	public HashMap<Member, List<Attribute>> getRequiredMemberAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredMemberAttributesOfAllowedMembers(sess, service, resource);
+	}
+
+	@Override
+	public HashMap<Member, List<Attribute>> getRequiredMemberResourceAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException {
+		return getAttributesManagerImpl().getRequiredMemberResourceAttributesOfAllowedMembers(sess, service, resource);
+	}
+
+	@Override
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException {
 		return getAttributesManagerImpl().getRequiredAttributes(sess, service, member, group);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -141,12 +141,10 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		ServiceAttributes resourceServiceAttributes = new ServiceAttributes();
 		resourceServiceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, resource));
 
-		List<Member> members;
-		members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		HashMap<Member, List<Attribute>> attributes;
 
 		try {
-			attributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility, resource, members, true);
+			attributes = getPerunBl().getAttributesManagerBl().getAllRequiredAttributesOfAllowedMembers(sess, service, facility, resource);
 		} catch(WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -175,15 +173,13 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 		ServiceAttributes membersAbstractSA = new ServiceAttributes();
 		Map<Member, ServiceAttributes> memberAttributes = new HashMap<Member, ServiceAttributes>();
-		List<Member> members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		HashMap<Member, List<Attribute>> attributes;
 
 		try {
-			attributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility, resource, members, true);
+			attributes = getPerunBl().getAttributesManagerBl().getAllRequiredAttributesOfAllowedMembers(sess, service, facility, resource);
 		} catch(WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
-
 		for (Member mem : attributes.keySet()) {
 			ServiceAttributes tmpAttributes = new ServiceAttributes();
 			tmpAttributes.addAttributes(attributes.get(mem));
@@ -297,17 +293,18 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		}
 
 		ServiceAttributes allUsersServiceAttributes = new ServiceAttributes();
-		List<User> facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility, null, service);
 
 		// get attributes for all users at once !
-		HashMap<User, List<Attribute>> userFacilityAttributes = getPerunBl().getAttributesManagerBl().getRequiredUserFacilityAttributesOfAllowedUsers(sess, service, facility);
-		HashMap<User, List<Attribute>> userAttributes = getPerunBl().getAttributesManagerBl().getRequiredUserAttributesOfAllowedUsers(sess, service, facility);
+		HashMap<User, List<Attribute>> userAttributes = new HashMap<>();
+		try {
+			userAttributes = getPerunBl().getAttributesManagerBl().getAllRequiredAttributesOfAllowedUsers(sess, service, facility);
+		} catch (WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
 
-		for (User user : facilityUsers) {
+		for (User user : userAttributes.keySet()) {
 			ServiceAttributes userServiceAttributes = new ServiceAttributes();
-			// Depending on a service requirements we might get null user or user-facility attributes
 			if (userAttributes.get(user) != null) userServiceAttributes.addAttributes(userAttributes.get(user));
-			if (userFacilityAttributes.get(user) != null) userServiceAttributes.addAttributes(userFacilityAttributes.get(user));
 			allUsersServiceAttributes.addChildElement(userServiceAttributes);
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -16,7 +16,6 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Service;
@@ -301,8 +300,8 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		List<User> facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility, null, service);
 
 		// get attributes for all users at once !
-		HashMap<User, List<Attribute>> userFacilityAttributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility, facilityUsers);
-		HashMap<User, List<Attribute>> userAttributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facilityUsers);
+		HashMap<User, List<Attribute>> userFacilityAttributes = getPerunBl().getAttributesManagerBl().getRequiredUserFacilityAttributesOfAllowedUsers(sess, service, facility);
+		HashMap<User, List<Attribute>> userAttributes = getPerunBl().getAttributesManagerBl().getRequiredUserAttributesOfAllowedUsers(sess, service, facility);
 
 		for (User user : facilityUsers) {
 			ServiceAttributes userServiceAttributes = new ServiceAttributes();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1597,20 +1597,6 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	}
 
-	public List<RichUser> getAllRichUsersWithAllNonVirtualAttributes(PerunSession sess) throws InternalErrorException {
-
-		HashMap<User, List<Attribute>> usersWithNonVirtAttrs = usersManagerImpl.getAllRichUsersWithAllNonVirtualAttributes(sess);
-		List<RichUser> richUsersWithAttributes = new ArrayList<RichUser>();
-
-		for (User u : usersWithNonVirtAttrs.keySet()) {
-			RichUser ru = new RichUser(u, null, usersWithNonVirtAttrs.get(u));
-			richUsersWithAttributes.add(ru);
-		}
-
-		return richUsersWithAttributes;
-	}
-
-
 	public void setLogin(PerunSession sess, User user, String loginNamespace, String login) throws InternalErrorException {
 
 		// should always pass, since isLoginAvailable() in ENTRY does the same

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1597,29 +1597,13 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	}
 
-	public List<RichUser> getAllRichUsersWithAllNonVirutalAttributes(PerunSession sess) throws InternalErrorException {
-		List<Pair<User, Attribute>> usersWithNonVirtAttrs = usersManagerImpl.getAllRichUsersWithAllNonVirutalAttributes(sess);
-		Map<User,List<Attribute>> sortingMap = new HashMap<User, List<Attribute>>();
+	public List<RichUser> getAllRichUsersWithAllNonVirtualAttributes(PerunSession sess) throws InternalErrorException {
 
-		//User map for sorting users with all their attributes
-		for(Pair<User, Attribute> p: usersWithNonVirtAttrs) {
-			if(sortingMap.containsKey(p.getLeft())) {
-				sortingMap.get(p.getLeft()).add(p.getRight());
-			} else {
-				List<Attribute> attributes = new ArrayList<Attribute>();
-				attributes.add(p.getRight());
-				sortingMap.put(p.getLeft(), attributes);
-			}
-		}
-
-		//Add extSources and VirtualAttributes
+		HashMap<User, List<Attribute>> usersWithNonVirtAttrs = usersManagerImpl.getAllRichUsersWithAllNonVirtualAttributes(sess);
 		List<RichUser> richUsersWithAttributes = new ArrayList<RichUser>();
-		Set<User> usersSet = sortingMap.keySet();
-		for(User u: usersSet) {
-			//Without UserExtSources and VirtualAttributes
-			//List<UserExtSource> ues = getPerunBl().getUsersManagerBl().getUserExtSources(sess, u);
-			List<Attribute> allAttrsOfUser = sortingMap.get(u);
-			RichUser ru = new RichUser(u, null, allAttrsOfUser);
+
+		for (User u : usersWithNonVirtAttrs.keySet()) {
+			RichUser ru = new RichUser(u, null, usersWithNonVirtAttrs.get(u));
 			richUsersWithAttributes.add(ru);
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -200,9 +200,9 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					if (Compatibility.isOracle()) {
 						Clob clob = null;
 						if (attrValuesTableName == null) {
-							rs.getClob("attr_value_text");
+							clob = rs.getClob("attr_value_text");
 						} else {
-							rs.getClob(attrValuesTableName+".attr_value_text");
+							clob = rs.getClob(attrValuesTableName+".attr_value_text");
 						}
 						char[] cbuf = null;
 						if(clob == null) {
@@ -572,7 +572,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 						if (attrValueTableName == null) {
 							clob = rs.getClob("attr_value_text");
 						} else {
-							rs.getClob(attrValueTableName+"_attr_value_text");
+							clob = rs.getClob(attrValueTableName+"_attr_value_text");
 						}
 						char[] cbuf = null;
 						if(clob == null) {
@@ -1041,8 +1041,8 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	public List<Attribute> getAttributes(PerunSession sess, User user) throws InternalErrorException {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("usr") + " from attr_names " +
-					"left join      user_attr_values    usr    on      id=usr.attr_id    and   user_id=? " +
-					"where namespace=? or (namespace in (?,?) and (attr_value is not null or attr_value_text is not null))",
+							"left join user_attr_values usr on id=usr.attr_id and user_id=? " +
+							"where namespace=? or (namespace in (?,?) and (attr_value is not null or attr_value_text is not null))",
 					new AttributeRowMapper(sess, this, "usr", user), user.getId(),
 					AttributesManager.NS_USER_ATTR_CORE, AttributesManager.NS_USER_ATTR_DEF, AttributesManager.NS_USER_ATTR_OPT);
 		} catch(EmptyResultDataAccessException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -12,20 +12,28 @@ import java.util.Set;
 
 import javax.sql.DataSource;
 
-import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
-import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.implApi.UsersManagerImplApi;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserOwnerAlreadyRemovedException;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
@@ -56,7 +64,6 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 	private JdbcPerunTemplate jdbc;
 	private NamedParameterJdbcTemplate  namedParameterJdbcTemplate;
-	private AttributesManagerImpl attrManagerImpl;
 
 	protected static final RowMapper<User> USER_MAPPER = new RowMapper<User>() {
 		public User mapRow(ResultSet rs, int i) throws SQLException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -142,7 +142,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	public List<Pair<User, Attribute>> getAllRichUsersWithAllNonVirutalAttributes(PerunSession sess) throws InternalErrorException {
-		AttributeAndUserRowMapper<User> attributeAndUserRowMapper = new AttributeAndUserRowMapper<User>(USER_MAPPER, AttributesManagerImpl.ATTRIBUTE_MAPPER);
+		AttributeAndUserRowMapper<User> attributeAndUserRowMapper = new AttributeAndUserRowMapper<User>(USER_MAPPER, AttributesManagerImpl.getAttributeMapper(null));
 		try {
 			return jdbc.query("select " + userMappingSelectQuery + ", " + AttributesManagerImpl.getAttributeMappingSelectQuery("usr") + " from users " +
 					"left join user_attr_values usr on usr.user_id=users.id " +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -3,7 +3,7 @@
  */
 package cz.metacentrum.perun.core.implApi;
 
-import cz.metacentrum.perun.core.api.ActionType;
+import cz.metacentrum.perun.core.api.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -1214,11 +1214,33 @@ public interface AttributesManagerImplApi {
 	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException;
 
 
-	HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
-	HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
+	HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
+	HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
 	HashMap<Member, List<Attribute>> getRequiredMemberAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
 	HashMap<Member, List<Attribute>> getRequiredMemberResourceAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
 
+	/**
+	 * Return all user, user_facility, member and member_resource attributes required by service for members allowed on resource
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes for
+	 * @param facility Facility to specify allowed members
+	 * @param resource Resource to specify allowed members
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	HashMap<Member, List<Attribute>> getAllRequiredAttributesOfAllowedMembers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Return all user, user_facility attributes required by service for users allowed on facility
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes for
+	 * @param facility Facility to specify allowed members
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	HashMap<User, List<Attribute>> getAllRequiredAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
 
 	/**
 	 * Get member-group attributes which are required by the service.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1213,6 +1213,13 @@ public interface AttributesManagerImplApi {
 	 */
 	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException;
 
+
+	HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
+	HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
+	HashMap<Member, List<Attribute>> getRequiredMemberAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
+	HashMap<Member, List<Attribute>> getRequiredMemberResourceAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
+
+
 	/**
 	 * Get member-group attributes which are required by the service.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -3,7 +3,7 @@
  */
 package cz.metacentrum.perun.core.implApi;
 
-import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.api.ActionType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -1213,32 +1213,76 @@ public interface AttributesManagerImplApi {
 	 */
 	HashMap<User, List<Attribute>> getRequiredAttributes(PerunSession sess, Service service, List<User> users) throws InternalErrorException;
 
-
+	/**
+	 * Get User attributes required by service on specified facility for all allowed users.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param facility Facility to get allowed users
+	 * @param resource Resource to get allowed users (todo)
+	 * @return Map of Users (as keys) with their required user attributes (as values)
+	 * @throws InternalErrorException
+	 */
 	HashMap<User, List<Attribute>> getRequiredUserAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Get User-Facility attributes required by service on specified facility for all allowed users.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param facility Facility to get allowed users
+	 * @param resource Resource to get allowed users (todo)
+	 * @return Map of Users (as keys) with their required user-facility attributes (as values)
+	 * @throws InternalErrorException
+	 */
 	HashMap<User, List<Attribute>> getRequiredUserFacilityAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Get Member attributes required by service on specified facility for all allowed members.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param resource Resource to get allowed members
+	 * @return Map of Members (as keys) with their required member attributes (as values)
+	 * @throws InternalErrorException
+	 */
 	HashMap<Member, List<Attribute>> getRequiredMemberAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Get Member-Resource attributes required by service on specified facility for all allowed members.
+	 *
+	 * @param sess
+	 * @param service Service to get required attributes
+	 * @param resource Resource to get allowed members
+	 * @return Map of Members (as keys) with their required member-resource attributes (as values)
+	 * @throws InternalErrorException
+	 */
 	HashMap<Member, List<Attribute>> getRequiredMemberResourceAttributesOfAllowedMembers(PerunSession sess, Service service, Resource resource) throws InternalErrorException;
 
 	/**
-	 * Return all user, user_facility, member and member_resource attributes required by service for members allowed on resource
+	 * Get all required attributes for specified service of members allowed on specified facility and resource.
+	 * User, Member, Member-Resource and User-Facility attributes are retrieved.
 	 *
 	 * @param sess
-	 * @param service Service to get required attributes for
-	 * @param facility Facility to specify allowed members
-	 * @param resource Resource to specify allowed members
-	 * @return
+	 * @param service Service to get required attributes
+	 * @param facility Facility for purpose of AttributeMapper only
+	 * @param resource Resource to get allowed members
+	 * @return Map of allowed members (as a keys) and list of required attributes (as values).
 	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
 	 */
 	HashMap<Member, List<Attribute>> getAllRequiredAttributesOfAllowedMembers(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException;
 
 	/**
-	 * Return all user, user_facility attributes required by service for users allowed on facility
+	 * Get all required attributes for specified service of users allowed on specified facility.
+	 * Only User and User-Facility attributes are retrieved.
 	 *
 	 * @param sess
-	 * @param service Service to get required attributes for
-	 * @param facility Facility to specify allowed members
-	 * @return
+	 * @param service Service to get required attributes
+	 * @param facility Facility to get allowed users
+	 * @return Map of allowed users (as a keys) and list of required attributes (as values).
 	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
 	 */
 	HashMap<User, List<Attribute>> getAllRequiredAttributesOfAllowedUsers(PerunSession sess, Service service, Facility facility) throws InternalErrorException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.implApi;
 
+import java.util.HashMap;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
@@ -569,7 +570,10 @@ public interface UsersManagerImplApi {
 	 * @return list of richUsers
 	 * @throws InternalErrorException
 	 */
-	List<Pair<User, Attribute>> getAllRichUsersWithAllNonVirutalAttributes(PerunSession sess) throws InternalErrorException;
+	// FIXME - this method is totally unused and very specific - bringing complexity to users manager
+	// FIXME - please please remove !!
+	@Deprecated
+	HashMap<User, List<Attribute>> getAllRichUsersWithAllNonVirtualAttributes(PerunSession sess) throws InternalErrorException;
 
 	/**
 	 * Store request of change of user's preferred email address.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -564,18 +564,6 @@ public interface UsersManagerImplApi {
 	public void deleteUsersReservedLogins(User user);
 
 	/**
-	 * Get All RichUsers without UserExtSources and without virtual attributes.
-	 *
-	 * @param sess
-	 * @return list of richUsers
-	 * @throws InternalErrorException
-	 */
-	// FIXME - this method is totally unused and very specific - bringing complexity to users manager
-	// FIXME - please please remove !!
-	@Deprecated
-	HashMap<User, List<Attribute>> getAllRichUsersWithAllNonVirtualAttributes(PerunSession sess) throws InternalErrorException;
-
-	/**
 	 * Store request of change of user's preferred email address.
 	 * Change in attribute value is not done, until email
 	 * address is verified by link in email notice.

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -236,7 +236,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	</bean>
 	<bean id="usersManagerImpl" class="cz.metacentrum.perun.core.impl.UsersManagerImpl" scope="singleton" depends-on="databaseManagerBl">
 		<constructor-arg ref="dataSource" />
-		<constructor-arg ref="attributesManagerImpl" />
 	</bean>
 	<bean id="groupsManagerImpl" class="cz.metacentrum.perun.core.impl.GroupsManagerImpl" scope="singleton" depends-on="databaseManagerBl">
 		<constructor-arg ref="dataSource" />

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -236,6 +236,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	</bean>
 	<bean id="usersManagerImpl" class="cz.metacentrum.perun.core.impl.UsersManagerImpl" scope="singleton" depends-on="databaseManagerBl">
 		<constructor-arg ref="dataSource" />
+		<constructor-arg ref="attributesManagerImpl" />
 	</bean>
 	<bean id="groupsManagerImpl" class="cz.metacentrum.perun.core.impl.GroupsManagerImpl" scope="singleton" depends-on="databaseManagerBl">
 		<constructor-arg ref="dataSource" />

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
@@ -1177,7 +1177,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 			memAttr.addAll(members.get(i).getAttributes());
 
 		}
-		assertNotNull("Unable to get member attrbutes required for service",memAttr);
+		assertNotNull("Unable to get member attributes required for service",memAttr);
 		assertTrue("Only one member attribute should be returned for each member",memAttr.size()==members.size());
 		assertEquals("Wrong attribute returned for 1st member",memAttr.get(0),reqMemAttr);
 		assertEquals("Wrong attribute returned for 2nd member",memAttr.get(1),reqMemAttr);
@@ -1260,7 +1260,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
 		facilities.add(perun.getServicesManager().getDataWithGroups(sess, service, facility));
 		assertNotNull("Unable to get hierarchical data with groups",facilities);
-		assertTrue("Only 1 facility shoud be returned",facilities.size()==1);
+		assertTrue("Only 1 facility should be returned",facilities.size()==1);
 		assertNotNull("returned facility shouldn't be null",facilities.get(0));
 
 		// get all required facility attributes

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -108,34 +107,6 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		assertEquals("both users should be the same",user,secondUser);
 
 	}
-
-	@Test
-	public void getAllRichUsersWithAllNonVirtualAttributes() throws Exception {
-		System.out.println(CLASS_NAME + "getAllUsersWithAllNonVirtualAttributes");
-
-		Attribute attr = new Attribute();
-		attr.setNamespace("urn:perun:user:attribute-def:opt");
-		attr.setFriendlyName("testAttr");
-		attr.setType(String.class.getName());
-		attr.setValue("UserAttrValue");
-		perun.getAttributesManager().createAttribute(sess, attr);
-		perun.getAttributesManager().setAttribute(sess, user, attr);
-
-		List<RichUser> richUsers = new ArrayList<RichUser>();
-		richUsers.addAll(perun.getUsersManagerBl().getAllRichUsersWithAllNonVirtualAttributes(sess));
-
-		assertTrue(richUsers.size() > 0);
-		for (RichUser ru : richUsers) {
-			// make sure we have some attributes (at least CORE !)
-			assertTrue(ru.getUserAttributes().size() > 0);
-			if (ru.getId() == user.getId()) {
-				// make sure we retrieved our attribute with user
-				assertTrue(ru.getUserAttributes().contains(attr));
-			}
-		}
-
-	}
-
 
 	@Test (expected=UserNotExistsException.class)
 	public void getUserByIdWhenUserNotExist() throws Exception {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -109,13 +110,30 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test
-	public void getAllRichUsersWithAllNonVirutalAttributes() throws Exception {
-		System.out.println(CLASS_NAME + "getAllUsersWithAllNonVirutalAttributes");
+	public void getAllRichUsersWithAllNonVirtualAttributes() throws Exception {
+		System.out.println(CLASS_NAME + "getAllUsersWithAllNonVirtualAttributes");
+
+		Attribute attr = new Attribute();
+		attr.setNamespace("urn:perun:user:attribute-def:opt");
+		attr.setFriendlyName("testAttr");
+		attr.setType(String.class.getName());
+		attr.setValue("UserAttrValue");
+		perun.getAttributesManager().createAttribute(sess, attr);
+		perun.getAttributesManager().setAttribute(sess, user, attr);
 
 		List<RichUser> richUsers = new ArrayList<RichUser>();
-		richUsers.addAll(perun.getUsersManagerBl().getAllRichUsersWithAllNonVirutalAttributes(sess));
+		richUsers.addAll(perun.getUsersManagerBl().getAllRichUsersWithAllNonVirtualAttributes(sess));
 
 		assertTrue(richUsers.size() > 0);
+		for (RichUser ru : richUsers) {
+			// make sure we have some attributes (at least CORE !)
+			assertTrue(ru.getUserAttributes().size() > 0);
+			if (ru.getId() == user.getId()) {
+				// make sure we retrieved our attribute with user
+				assertTrue(ru.getUserAttributes().contains(attr));
+			}
+		}
+
 	}
 
 


### PR DESCRIPTION
WIP - tests passed, but code needs to be cleaned and documented.
- Updated attribute (value) mapper to handle multiple types in single select.
- Added getAllRequiredAttributesOfAllowedMembers()
- Added getAllRequiredAttributesOfAllowedUsers()
- Removed duplicate code in attributes mappers.
- Updated select mapping to handle *_attr_values table name.
- Added RowExtractor to handle multiple namespaces.
- We now retrieve user,member,user_facility,member_resource attributes in
  a single select.
- Updated getFlatData() and getHierarchicalData() to load required structures
  using new methods.
- If *attr_values table is renamed in a select, always pass renamed
  table name to attribute select and mapper.
- We must always rename -> specify attribute value table in order to prevent
  duplicate "created_at" like columns (attr_def vs. attr_value).
- Removed fugly unused method getAllRichUsersWithNonVirtualAttributes().
