### PR TITLE
RPC: Make local Tomcat to keep session in a cookie

### DIFF
--- a/perun-rpc/tomcat.xml
+++ b/perun-rpc/tomcat.xml
@@ -24,7 +24,7 @@
 
 		<Engine name="Catalina" defaultHost="localhost">
 			<Host name="localhost" appBase="" deployOnStartup="false" autoDeploy="false">
-				<Context path="/perun-rpc" docBase="../perun-rpc.war"/>
+				<Context path="/perun-rpc" docBase="../perun-rpc.war" sessionCookieName="PERUNSESSION" sessionCookiePath="/" />
 			</Host>
 		</Engine>
 


### PR DESCRIPTION
- Locally started Tomcat didn't kept session (opposite to
  production deployment). Now it stores exactly same session
  and we can better debug any session relative code.