### PR TITLE
REGISTRAR: provide also kerberos-like identities for joining

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
@@ -493,6 +493,8 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 							ues.getExtSource().setName("https://extidp.cesnet.cz/idp/shibboleth&authnContextClassRef=urn:cesnet:extidp:authn:"+type);
 						}
 						es.add(ues.getExtSource());
+					} else if (ues.getExtSource().getType().equals(ExtSourcesManagerEntry.EXTSOURCE_KERBEROS)) {
+						es.add(ues.getExtSource());
 					}
 				}
 				identity.setIdentities(es);


### PR DESCRIPTION
- When sending similar user info to registrar, send also ext sources
  of KERBEROS type. It's not used in GUI yet.