### PR TITLE
Bans on resources and facilities

### DIFF
--- a/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
+++ b/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
@@ -67,6 +67,8 @@ public class AuditParser {
 				else if(p.getLeft().equals("ResourceTag")) perunBean = createResourceTag(p.getRight());
 				else if(p.getLeft().equals("ExecService")) perunBean = createExecService(p.getRight());
 				else if(p.getLeft().equals("SecurityTeam")) perunBean = createSecurityTeam(p.getRight());
+				else if(p.getLeft().equals("BanOnResource")) perunBean = createBanOnResource(p.getRight());
+				else if(p.getLeft().equals("BanOnFacility")) perunBean = createBanOnFacility(p.getRight());
 				else loger.debug("Object of this type can't be parsed cause there is no such object in parser's branches. ObjectName:" + p.getLeft());
 				if(perunBean != null) listPerunBeans.add(perunBean);
 			} catch (RuntimeException e) {
@@ -504,6 +506,34 @@ public class AuditParser {
 		securityTeam.setName(BeansUtils.eraseEscaping(beanAttr.get("name")));
 		securityTeam.setDescription(BeansUtils.eraseEscaping(beanAttr.get("description")));
 		return securityTeam;
+	}
+
+	private static Ban createBanOnResource(Map<String, String> beanAttr) {
+		if(beanAttr==null) return null;
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setId(Integer.valueOf(beanAttr.get("id")));
+		banOnResource.setMemberId(Integer.valueOf(beanAttr.get("memberId")));
+		banOnResource.setResourceId(Integer.valueOf(beanAttr.get("resourceId")));
+		banOnResource.setDescription(BeansUtils.eraseEscaping(beanAttr.get("description")));
+		Date validityTo;
+		if(beanAttr.get("validityTo").equals("\\0")) validityTo = null;
+		else validityTo = new Date(Long.valueOf(beanAttr.get("validityTo")));
+		banOnResource.setValidityTo(validityTo);
+		return banOnResource;
+	}
+
+	private static Ban createBanOnFacility(Map<String, String> beanAttr) {
+		if(beanAttr==null) return null;
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setId(Integer.valueOf(beanAttr.get("id")));
+		banOnFacility.setUserId(Integer.valueOf(beanAttr.get("userId")));
+		banOnFacility.setFacilityId(Integer.valueOf(beanAttr.get("facilityId")));
+		banOnFacility.setDescription(BeansUtils.eraseEscaping(beanAttr.get("description")));
+		Date validityTo;
+		if(beanAttr.get("validityTo").equals("\\0")) validityTo = null;
+		else validityTo = new Date(Long.valueOf(beanAttr.get("validityTo")));
+		banOnFacility.setValidityTo(validityTo);
+		return banOnFacility;
 	}
 
 	//--------------------------------------------------------------------------

--- a/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
+++ b/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
@@ -61,6 +61,10 @@ public class AuditParserTest {
 	private SecurityTeam securityTeam2 = new SecurityTeam(2, null, null);
 	private ExecService exService1 = new ExecService();
 	private ExecService exService2 = new ExecService();
+	private BanOnResource banOnResource1 = new BanOnResource(3, new Date(), "neco" , 10, 12);
+	private BanOnResource banOnResource2 = new BanOnResource(4, null, null, 10, 12);
+	private BanOnFacility banOnFacility1 = new BanOnFacility(5, new Date(), "neco", 10, 12);
+	private BanOnFacility banOnFacility2 = new BanOnFacility(6, null, null, 10, 12);
 
 	@Before
 	public void setUp() throws Exception {
@@ -376,6 +380,22 @@ public class AuditParserTest {
 		assertEquals(securityTeam.getName(), ((SecurityTeam) scsInList.get(0)).getName());
 		assertEquals(securityTeam.getDescription(), ((SecurityTeam) scsInList.get(0)).getDescription());
 
+		//FOR BAN ON RESOURCE
+		List<PerunBean> banOnResourceInList = AuditParser.parseLog(banOnResource1.serializeToString());
+		assertEquals(banOnResource1.toString(), ((BanOnResource) banOnResourceInList.get(0)).toString());
+		assertEquals(banOnResource1.getMemberId(), ((BanOnResource) banOnResourceInList.get(0)).getMemberId());
+		assertEquals(banOnResource1.getResourceId(), ((BanOnResource) banOnResourceInList.get(0)).getResourceId());
+		assertEquals(banOnResource1.getDescription(), ((BanOnResource) banOnResourceInList.get(0)).getDescription());
+		assertEquals(banOnResource1.getValidityTo(), ((BanOnResource) banOnResourceInList.get(0)).getValidityTo());
+
+		//FOR BAN ON FACILITY
+		List<PerunBean> banOnFacilityInList = AuditParser.parseLog(banOnFacility1.serializeToString());
+		assertEquals(banOnFacility1.toString(), ((BanOnFacility) banOnFacilityInList.get(0)).toString());
+		assertEquals(banOnFacility1.getUserId(), ((BanOnFacility) banOnFacilityInList.get(0)).getUserId());
+		assertEquals(banOnFacility1.getFacilityId(), ((BanOnFacility) banOnFacilityInList.get(0)).getFacilityId());
+		assertEquals(banOnFacility1.getDescription(), ((BanOnFacility) banOnFacilityInList.get(0)).getDescription());
+		assertEquals(banOnFacility1.getValidityTo(), ((BanOnFacility) banOnFacilityInList.get(0)).getValidityTo());
+
 		//FOR RICHMEMBER
 		RichMember richMember1 = new RichMember(null, member, null);
 		//List<UserExtSource> userExtSources = new ArrayList<UserExtSource>();
@@ -510,6 +530,10 @@ public class AuditParserTest {
 		assertEquals(exService1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(exService1.serializeToString())));
 		assertEquals(securityTeam1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(securityTeam1.serializeToString())));
 		assertEquals(securityTeam2.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(securityTeam2.serializeToString())));
+		assertEquals(banOnResource1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(banOnResource1.serializeToString())));
+		assertEquals(banOnResource2.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(banOnResource2.serializeToString())));
+		assertEquals(banOnFacility1.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(banOnFacility1.serializeToString())));
+		assertEquals(banOnFacility2.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(banOnFacility2.serializeToString())));
 		//test also some null serializing
 		Resource newResource = new Resource(20, null, null, 5);
 		assertEquals(newResource.toString(), BeansUtils.eraseEscaping(BeansUtils.replacePointyBracketsByApostrophe(newResource.serializeToString())));
@@ -527,11 +551,12 @@ public class AuditParserTest {
 			attribute1.serializeToString() + richMember.serializeToString() + richDestination.serializeToString() +
 			richResource.serializeToString() + richUser.serializeToString() + richGroup.serializeToString() +
 			richFacility.serializeToString() + resourceTag1.serializeToString() + exService1.serializeToString() +
-			securityTeam1.serializeToString();
+			securityTeam1.serializeToString() + banOnResource1.serializeToString() + banOnResource2.serializeToString() +
+			banOnFacility1.serializeToString()+ banOnFacility2.serializeToString();
 
 		List<PerunBean> perunBeans = new ArrayList<PerunBean>();
 		perunBeans = AuditParser.parseLog(bigLog);
-		assertEquals(24, perunBeans.size());
+		assertEquals(28, perunBeans.size());
 		assertTrue(perunBeans.contains(user));
 		assertTrue(perunBeans.contains(attribute1));
 		assertTrue(perunBeans.contains(attributeDefinition1));

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Ban.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Ban.java
@@ -1,0 +1,135 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.Date;
+
+/**
+ * Represents ban for someone on something in perun.
+ * Description and timestamp.
+ *
+ * @author  Michal Stava
+ */
+public abstract class Ban extends Auditable implements Comparable<PerunBean> {
+	private Date validityTo;
+	private String description;
+	
+	/**
+	 * Constructs a new instance.
+	 */
+	public Ban() {
+		super();
+	}
+
+	public Ban(int id, Date validityTo) {
+		super(id);
+		//set precision for validity on seconds
+		if(validityTo == null) this.validityTo = validityTo;
+		else validityTo = new Date(validityTo.getTime() / 1000 * 1000);
+		this.validityTo = validityTo;
+	}
+
+	public Ban(int id, Date validityTo, String description) {
+		this(id, validityTo);
+		this.description = description;
+	}
+
+	public Date getValidityTo() {
+		return validityTo;
+	}
+
+	public void setValidityTo(Date validityTo) {
+		//set precision for validity on seconds
+		if(validityTo == null) this.validityTo = validityTo;
+		else validityTo = new Date(validityTo.getTime() / 1000 * 1000);
+		this.validityTo = validityTo;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	/**
+	 * Class name of specific ban.
+	 *
+	 * @return class name of specific ban
+	 */
+	public abstract String getType();
+	
+	/**
+	 * Id of subject who is banned on target.
+	 * 
+	 * @return id of affected subject
+	 */
+	public abstract int getSubjectId();
+
+	/**
+	 * Id of target where subject is banned on.
+	 *
+	 * @return id of affected target
+	 */
+	public abstract int getTargetId();
+
+
+	@Override
+	public String serializeToString() {
+		StringBuilder str = new StringBuilder();
+
+		return str.append(this.getClass().getSimpleName()).append(":[").append(
+			"id=<").append(getId()).append(">").append(
+			", validityTo=<").append(getValidityTo() == null ? "\\0" : getValidityTo().getTime()).append(">").append(
+			", description=<").append(getDescription() == null ? "\\0" : BeansUtils.createEscaping(getDescription())).append(">").append(
+			']').toString();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+
+		Long validityInMiliseconds = null;
+		if(getValidityTo() != null) validityInMiliseconds = getValidityTo().getTime();
+
+		return str.append(getClass().getSimpleName()).append(":[id='").append(getId()
+			).append("', validityTo='").append(validityInMiliseconds
+			).append("', description='").append(description).append("']").toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final Ban other = (Ban) obj;
+		if (this.getId() != other.getId()) {
+			return false;
+		}
+		if (this.validityTo == null ? other.getValidityTo()!= null : this.validityTo.getTime() != other.getValidityTo().getTime()) {
+			return false;
+		}
+		if (this.description == null ? other.getDescription() != null : !this.description.equals(other.getDescription())) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int compareTo(PerunBean perunBean) {
+		if(perunBean == null) throw new NullPointerException("PerunBean to compare with is null.");
+		if(perunBean instanceof Ban) {
+			Ban ban = (Ban) perunBean;
+			if (this.validityTo == null && ban.getValidityTo() != null) return -1;
+			if (ban.getValidityTo() == null && this.validityTo != null) return 1;
+			if (ban.getValidityTo() == null && this.validityTo == null) return 0;
+			Long thisValidity = this.validityTo.getTime();
+			Long otherValidity = ban.getValidityTo().getTime();
+			return thisValidity.compareTo(otherValidity);
+		} else {
+			return (this.getId() - perunBean.getId());
+		}
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BanOnFacility.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BanOnFacility.java
@@ -1,0 +1,127 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.Date;
+
+/**
+ * Represents specific ban of user on facility.
+ *
+ * @author  Michal Stava
+ */
+public class BanOnFacility extends Ban implements Comparable<PerunBean> {
+	private int userId;
+	private int facilityId;
+
+	/**
+	 * Constructs a new instance.
+	 */
+	public BanOnFacility() {
+		super();
+	}
+
+	public BanOnFacility(int id, Date validityTo, String description, int userId, int facilityId) {
+		super(id, validityTo, description);
+		this.userId = userId;
+		this.facilityId = facilityId;
+	}
+
+	public int getUserId() {
+		return userId;
+	}
+
+	public void setUserId(int userId) {
+		this.userId = userId;
+	}
+
+	public int getFacilityId() {
+		return facilityId;
+	}
+
+	public void setFacilityId(int facilityId) {
+		this.facilityId = facilityId;
+	}
+
+	@Override
+	public String getType() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	public int getSubjectId() {
+		return this.getUserId();
+	}
+
+	@Override
+	public int getTargetId() {
+		return this.getFacilityId();
+	}
+
+	@Override
+	public String serializeToString() {
+		StringBuilder str = new StringBuilder();
+
+		return str.append(this.getClass().getSimpleName()).append(":[").append(
+			"id=<").append(getId()).append(">").append(
+			", userId=<").append(getUserId()).append(">").append(
+			", facilityId=<").append(getFacilityId()).append(">").append(
+			", validityTo=<").append(getValidityTo() == null ? "\\0" : getValidityTo().getTime()).append(">").append(
+			", description=<").append(getDescription() == null ? "\\0" : BeansUtils.createEscaping(getDescription())).append(">").append(
+			']').toString();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+
+		Long validityInMiliseconds = null;
+		if(getValidityTo() != null) validityInMiliseconds = getValidityTo().getTime();
+
+		return str.append(getClass().getSimpleName()).append(":[id='").append(getId()
+			).append("', userId='").append(getUserId()
+			).append("', facilityId='").append(getFacilityId()
+			).append("', validityTo='").append(validityInMiliseconds
+			).append("', description='").append(this.getDescription()).append("']").toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final BanOnFacility other = (BanOnFacility) obj;
+		if (this.getId() != other.getId()) {
+			return false;
+		}
+		if (this.getUserId()!= other.getUserId()) {
+			return false;
+		}
+		if (this.getFacilityId()!= other.getFacilityId()) {
+			return false;
+		}
+		if (this.getValidityTo() == null ? other.getValidityTo()!= null : this.getValidityTo().getTime() != other.getValidityTo().getTime()) {
+			return false;
+		}
+		if (this.getDescription() == null ? other.getDescription() != null : !this.getDescription().equals(other.getDescription())) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int compareTo(PerunBean perunBean) {
+		if(perunBean == null) throw new NullPointerException("PerunBean to compare with is null.");
+		if(perunBean instanceof Ban) {
+			Ban ban = (Ban) perunBean;
+			if (this.getValidityTo() == null && ban.getValidityTo() != null) return -1;
+			if (ban.getValidityTo() == null && this.getValidityTo() != null) return 1;
+			if (ban.getValidityTo() == null && this.getValidityTo() == null) return 0;
+			Long thisValidity = this.getValidityTo().getTime();
+			Long otherValidity = ban.getValidityTo().getTime();
+			return thisValidity.compareTo(otherValidity);
+		} else {
+			return (this.getId() - perunBean.getId());
+		}
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BanOnResource.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BanOnResource.java
@@ -1,0 +1,127 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.Date;
+
+/**
+ * Represents specific ban of member on resource.
+ *
+ * @author  Michal Stava
+ */
+public class BanOnResource extends Ban implements Comparable<PerunBean> {
+	private int memberId;
+	private int resourceId;
+
+	/**
+	 * Constructs a new instance.
+	 */
+	public BanOnResource() {
+		super();
+	}
+
+	public BanOnResource(int id, Date validityTo, String description, int memberId, int resourceId) {
+		super(id, validityTo, description);
+		this.memberId = memberId;
+		this.resourceId = resourceId;
+	}
+
+	public int getMemberId() {
+		return memberId;
+	}
+
+	public void setMemberId(int memberId) {
+		this.memberId = memberId;
+	}
+
+	public int getResourceId() {
+		return resourceId;
+	}
+
+	public void setResourceId(int resourceId) {
+		this.resourceId = resourceId;
+	}
+
+	@Override
+	public String getType() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	public int getSubjectId() {
+		return this.getMemberId();
+	}
+
+	@Override
+	public int getTargetId() {
+		return this.getResourceId();
+	}
+
+	@Override
+	public String serializeToString() {
+		StringBuilder str = new StringBuilder();
+
+		return str.append(this.getClass().getSimpleName()).append(":[").append(
+			"id=<").append(getId()).append(">").append(
+			", memberId=<").append(getMemberId()).append(">").append(
+			", resourceId=<").append(getResourceId()).append(">").append(
+			", validityTo=<").append(getValidityTo() == null ? "\\0" : getValidityTo().getTime()).append(">").append(
+			", description=<").append(getDescription() == null ? "\\0" : BeansUtils.createEscaping(getDescription())).append(">").append(
+			']').toString();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+
+		Long validityInMiliseconds = null;
+		if(getValidityTo() != null) validityInMiliseconds = getValidityTo().getTime();
+
+		return str.append(getClass().getSimpleName()).append(":[id='").append(getId()
+			).append("', memberId='").append(getMemberId()
+			).append("', resourceId='").append(getResourceId()
+			).append("', validityTo='").append(validityInMiliseconds
+			).append("', description='").append(this.getDescription()).append("']").toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		final BanOnResource other = (BanOnResource) obj;
+		if (this.getId() != other.getId()) {
+			return false;
+		}
+		if (this.getMemberId() != other.getMemberId()) {
+			return false;
+		}
+		if (this.getResourceId() != other.getResourceId()) {
+			return false;
+		}
+		if (this.getValidityTo() == null ? other.getValidityTo()!= null : this.getValidityTo().getTime() != other.getValidityTo().getTime()) {
+			return false;
+		}
+		if (this.getDescription() == null ? other.getDescription() != null : !this.getDescription().equals(other.getDescription())) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int compareTo(PerunBean perunBean) {
+		if(perunBean == null) throw new NullPointerException("PerunBean to compare with is null.");
+		if(perunBean instanceof Ban) {
+			Ban ban = (Ban) perunBean;
+			if (this.getValidityTo() == null && ban.getValidityTo() != null) return -1;
+			if (ban.getValidityTo() == null && this.getValidityTo() != null) return 1;
+			if (ban.getValidityTo() == null && this.getValidityTo() == null) return 0;
+			Long thisValidity = this.getValidityTo().getTime();
+			Long otherValidity = ban.getValidityTo().getTime();
+			return thisValidity.compareTo(otherValidity);
+		} else {
+			return (this.getId() - perunBean.getId());
+		}
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/BanAlreadyExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/BanAlreadyExistsException.java
@@ -1,0 +1,38 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Ban;
+
+/**
+ * Checked version of BanAlreadyExistsException
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
+public class BanAlreadyExistsException extends EntityExistsException {
+
+	private Ban ban;
+
+	public BanAlreadyExistsException(String message) {
+		super(message);
+	}
+
+	public BanAlreadyExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public BanAlreadyExistsException(Throwable cause) {
+		super(cause);
+	}
+
+	public BanAlreadyExistsException(Ban ban) {
+		super("Ban of type: " + ban.getType() + " already exists for subjectID: " + ban.getSubjectId() + " and targetID: " + ban.getTargetId());
+		this.ban = ban;
+	}
+
+	public Ban getBan() {
+		return ban;
+	}
+
+	public void setBan(Ban ban) {
+		this.ban = ban;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/BanNotExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/BanNotExistsException.java
@@ -1,0 +1,38 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Ban;
+
+/**
+ * Checked version of BanNotExistsException
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
+public class BanNotExistsException extends EntityExistsException {
+
+	private Ban ban;
+
+	public BanNotExistsException(String message) {
+		super(message);
+	}
+
+	public BanNotExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public BanNotExistsException(Throwable cause) {
+		super(cause);
+	}
+
+	public BanNotExistsException(Ban ban) {
+		super("Ban of type: " + ban.getType() + " not exists for subjectID: " + ban.getSubjectId() + " and targetID: " + ban.getTargetId());
+		this.ban = ban;
+	}
+
+	public Ban getBan() {
+		return ban;
+	}
+
+	public void setBan(Ban ban) {
+		this.ban = ban;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -3,6 +3,8 @@ package cz.metacentrum.perun.core.api;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
@@ -1008,4 +1010,104 @@ public interface FacilitiesManager {
 	 */
 	void removeSecurityTeam(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, SecurityTeamNotExistsException, SecurityTeamNotAssignedException;
 
+	/**
+	 * Set ban for user on facility.
+	 * 
+	 * @param sess
+	 * @param banOnFacility the ban
+	 * @return ban on facility
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws BanAlreadyExistsException
+	 * @throws UserNotExistsException
+	 * @throws FacilityNotExistsException
+	 */
+	BanOnFacility setBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException, PrivilegeException, BanAlreadyExistsException, UserNotExistsException, FacilityNotExistsException;
+
+	/**
+	 * Get Ban for user on facility by it's id
+	 *
+	 * @param sess
+	 * @param banId the id of ban
+	 * @return facility ban by it's id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 * @throws PrivilegeException
+	 */
+	BanOnFacility getBanById(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException, PrivilegeException;
+
+	/**
+	 * Get ban by userId and facilityId.
+	 *
+	 * @param sess
+	 * @param userId the id of user
+	 * @param faclityId the id of facility
+	 * @return specific ban for user on facility
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws FacilityNotExistsException
+	 */
+	BanOnFacility getBan(PerunSession sess, int userId, int faclityId) throws InternalErrorException, BanNotExistsException, PrivilegeException, UserNotExistsException, FacilityNotExistsException;
+
+	/**
+	 * Get all bans for user on any facility.
+	 *
+	 * @param sess
+	 * @param userId the id of user
+	 * @return list of bans for user on any facility
+	 * @throws InternalErrorException
+	 * @throws UserNotExistsException
+	 */
+	List<BanOnFacility> getBansForUser(PerunSession sess, int userId) throws InternalErrorException, UserNotExistsException;
+
+	/**
+	 * Get all bans for users on the facility
+	 *
+	 * @param sess
+	 * @param facilityId the id of facility
+	 * @return list of bans for all users on the facility
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws FacilityNotExistsException
+	 */
+	List<BanOnFacility> getBansForFacility(PerunSession sess, int facilityId) throws InternalErrorException, PrivilegeException, FacilityNotExistsException;
+
+	/**
+	 * Update existing ban (description and validation timestamp)
+	 *
+	 * @param sess
+	 * @param banOnFacility the existing ban
+	 * @return updated ban
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws FacilityNotExistsException
+	 * @throws UserNotExistsException
+	 * @throws BanNotExistsException
+	 */
+	BanOnFacility updateBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, UserNotExistsException, BanNotExistsException;
+
+	/**
+	 * Remove existing ban by it's id.
+	 *
+	 * @param sess
+	 * @param banId the id of ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 * @throws PrivilegeException
+	 */
+	void removeBan(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException, PrivilegeException;
+
+	/**
+	 * Remove existing ban by id of user and facility.
+	 *
+	 * @param sess
+	 * @param userId the id of user
+	 * @param facilityId the id of facility
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 * @throws PrivilegeException
+	 */
+	void removeBan(PerunSession sess, int userId, int facilityId) throws InternalErrorException, BanNotExistsException, PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.core.api;
 
+import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
@@ -725,4 +727,103 @@ public interface ResourcesManager {
 	 */
 	public void copyGroups(PerunSession sess, Resource sourceResource, Resource destinationResource) throws InternalErrorException, ResourceNotExistsException, PrivilegeException;
 
+	/**
+	 * Set ban for member on resource.
+	 *
+	 * @param sess
+	 * @param banOnResource the ban
+	 * @return ban on resource
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws BanAlreadyExistsException
+	 */
+	BanOnResource setBan(PerunSession sess, BanOnResource banOnResource) throws InternalErrorException, PrivilegeException, BanAlreadyExistsException;
+
+	/**
+	 * Get Ban for member on resource by it's id
+	 *
+	 * @param sess
+	 * @param banId the id of ban
+	 * @return resource ban by it's id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 * @throws PrivilegeException
+	 */
+	BanOnResource getBanById(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException, PrivilegeException;
+
+	/**
+	 * Get ban by memberId and resource id
+	 *
+	 * @param sess
+	 * @param memberId the id of member
+	 * @param resourceId the id of resource
+	 * @return specific ban for member on resource
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 * @throws PrivilegeException
+	 * @throws MemberNotExistsException
+	 * @throws ResourceNotExistsException
+	 */
+	BanOnResource getBan(PerunSession sess, int memberId, int resourceId) throws InternalErrorException, BanNotExistsException, PrivilegeException, MemberNotExistsException, ResourceNotExistsException;
+
+	/**
+	 * Get all bans for member on any resource.
+	 *
+	 * @param sess
+	 * @param memberId the id of member
+	 * @return list of bans for member on any resource
+	 * @throws InternalErrorException
+	 * @throws MemberNotExistsException
+	 */
+	List<BanOnResource> getBansForMember(PerunSession sess, int memberId) throws InternalErrorException, MemberNotExistsException;
+
+	/**
+	 * Get all bans for members on the resource.
+	 *
+	 * @param sess
+	 * @param resourceId the id of resource
+	 * @return list of all members bans on the resource
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws ResourceNotExistsException
+	 */
+	List<BanOnResource> getBansForResource(PerunSession sess, int resourceId) throws InternalErrorException, PrivilegeException, ResourceNotExistsException;
+
+	/**
+	 * Update existing ban (description, validation timestamp)
+	 *
+	 * @param sess
+	 * @param banOnResource the specific ban
+	 * @return updated ban
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws FacilityNotExistsException
+	 * @throws MemberNotExistsException
+	 * @throws BanNotExistsException
+	 * @throws ResourceNotExistsException
+	 */
+	BanOnResource updateBan(PerunSession sess, BanOnResource banOnResource) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, MemberNotExistsException, BanNotExistsException, ResourceNotExistsException;
+
+	/**
+	 * Remove specific ban by it's id.
+	 *
+	 * @param sess
+	 * @param banId the id of ban
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int banId) throws InternalErrorException, PrivilegeException, BanNotExistsException;
+
+	/**
+	 * Remove specific ban by memberId and resourceId.
+	 *
+	 * @param sess
+	 * @param memberId the id of member
+	 * @param resourceId the id of resource
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 * @throws PrivilegeException
+	 */
+	void removeBan(PerunSession sess, int memberId, int resourceId) throws InternalErrorException, BanNotExistsException, PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.bl;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.ContactGroup;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
@@ -20,6 +21,8 @@ import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
@@ -1037,4 +1040,155 @@ public interface FacilitiesManagerBl {
 	 */
 	void checkSecurityTeamAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws SecurityTeamNotAssignedException, InternalErrorException;
 
+	/**
+	 * Set ban for user on facility
+	 *
+	 * @param sess
+	 * @param banOnFacility the ban
+	 * @return ban on facility
+	 * @throws InternalErrorException
+	 * @throws BanAlreadyExistsException
+	 *
+	 */
+	BanOnFacility setBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException, BanAlreadyExistsException;
+
+	/**
+	 * Get Ban for user on facility by it's id
+	 *
+	 * @param sess
+	 * @param banId the ban id
+	 * @return facility ban by it's id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	BanOnFacility getBanById(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get true if any ban for user and facility exists.
+	 *
+	 * @param sess
+	 * @param userId id of user
+	 * @param facilityId id of facility
+	 * @return true if ban exists
+	 * @throws InternalErrorException
+	 */
+	boolean banExists(PerunSession sess, int userId, int facilityId) throws InternalErrorException;
+
+	/**
+	 * Get true if any band defined by id exists for any user and facility.
+	 *
+	 * @param sess
+	 * @param banId id of ban
+	 * @return true if ban exists
+	 * @throws InternalErrorException
+	 */
+	boolean banExists(PerunSession sess, int banId) throws InternalErrorException;
+
+	/**
+	 * Check if ban already exists.
+	 *
+	 * Throw exception if no.
+	 *
+	 * @param sess
+	 * @param userId user id
+	 * @param facilityId facility id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void checkBanExists(PerunSession sess, int userId, int facilityId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Check if ban already exists.
+	 *
+	 * Throw exception if no.
+	 *
+	 * @param sess
+	 * @param banId ban id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void checkBanExists(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get specific facility ban.
+	 *
+	 * @param sess
+	 * @param userId the user id
+	 * @param faclityId the facility id
+	 * @return specific facility ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	BanOnFacility getBan(PerunSession sess, int userId, int faclityId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get all facilities bans for user.
+	 *
+	 * @param sess
+	 * @param userId the user id
+	 * @return list of bans for user on any facility
+	 * @throws InternalErrorException
+	 */
+	List<BanOnFacility> getBansForUser(PerunSession sess, int userId) throws InternalErrorException;
+
+	/**
+	 * Get all users bans for facility
+	 *
+	 * @param sess
+	 * @param facilityId the facility id
+	 * @return list of all users bans on facility
+	 * @throws InternalErrorException
+	 */
+	List<BanOnFacility> getBansForFacility(PerunSession sess, int facilityId) throws InternalErrorException;
+
+	/**
+	 * Get all expired bans on any facility to now date
+	 *
+	 * @param sess
+	 * @return list of expired bans for any facility
+	 * @throws InternalErrorException
+	 */
+	List<BanOnFacility> getAllExpiredBansOnFacilities(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * Update description and validity timestamp of specific ban.
+	 *
+	 * @param sess
+	 * @param banOnFacility ban to be updated
+	 * @return updated ban
+	 * @throws InternalErrorException
+	 */
+	BanOnFacility updateBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException;
+
+	/**
+	 * Remove ban by id from facilities bans.
+	 *
+	 * @param sess
+	 * @param banId id of specific ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Remove ban by user_id and facility_id.
+	 *
+	 * @param sess
+	 * @param userId the id of user
+	 * @param facilityId the id of facility
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int userId, int facilityId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Remove all expired bans on facilities to now date.
+	 *
+	 * Get all expired bans and remove them one by one with auditing process.
+	 * This method is for purpose of removing expired bans using some cron tool.
+	 *
+	 * @param sess
+	 * @throws InternalErrorException
+	 */
+	void removeAllExpiredBansOnFacilities(PerunSession sess) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.bl;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
@@ -15,6 +16,8 @@ import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.ServicesPackage;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyAssignedException;
@@ -703,4 +706,155 @@ public interface ResourcesManagerBl {
 	void checkResourceExists(PerunSession sess, Resource resource) throws InternalErrorException, ResourceNotExistsException;
 
 	void checkResourceTagExists(PerunSession sess, ResourceTag resourceTag) throws InternalErrorException, ResourceTagNotExistsException;
+
+	/**
+	 * Set ban for member on resource
+	 *
+	 * @param sess
+	 * @param banOnresource the ban
+	 * @return ban on resource
+	 * @throws InternalErrorException
+	 * @throws BanAlreadyExistsException
+	 */
+	BanOnResource setBan(PerunSession sess, BanOnResource banOnresource) throws InternalErrorException, BanAlreadyExistsException;
+
+	/**
+	 * Get Ban for member on resource by it's id
+	 *
+	 * @param sess
+	 * @param banId the ban id
+	 * @return resource ban by it's id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	BanOnResource getBanById(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get true if any ban for member and resource exists.
+	 *
+	 * @param sess
+	 * @param memberId id of member
+	 * @param resourceId id of resource
+	 * @return true if ban exists
+	 * @throws InternalErrorException
+	 */
+	boolean banExists(PerunSession sess, int memberId, int resourceId) throws InternalErrorException;
+
+	/**
+	 * Get true if any band defined by id exists for any user and facility.
+	 *
+	 * @param sess
+	 * @param banId id of ban
+	 * @return true if ban exists
+	 * @throws InternalErrorException
+	 */
+	boolean banExists(PerunSession sess, int banId) throws InternalErrorException;
+
+	/**
+	 * Check if ban already exists.
+	 *
+	 * Throw exception if no.
+	 *
+	 * @param sess
+	 * @param memberId user id
+	 * @param resourceId facility id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void checkBanExists(PerunSession sess, int memberId, int resourceId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Check if ban already exists.
+	 *
+	 * Throw exception if no.
+	 *
+	 * @param sess
+	 * @param banId ban id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void checkBanExists(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get specific resource ban.
+	 *
+	 * @param sess
+	 * @param memberId the member id
+	 * @param resourceId the resource id
+	 * @return specific resource ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	BanOnResource getBan(PerunSession sess, int memberId, int resourceId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get all resources bans for member.
+	 *
+	 * @param sess
+	 * @param memberId the member id
+	 * @return list of bans for member on any resource
+	 * @throws InternalErrorException
+	 */
+	List<BanOnResource> getBansForMember(PerunSession sess, int memberId) throws InternalErrorException;
+
+	/**
+	 * Get all members bans for resource
+	 *
+	 * @param sess
+	 * @param resourceId the resource id
+	 * @return list of all members bans on resource
+	 * @throws InternalErrorException
+	 */
+	List<BanOnResource> getBansForResource(PerunSession sess, int resourceId) throws InternalErrorException;
+
+	/**
+	 * Get all expired bans on any resource to now date
+	 *
+	 * @param sess
+	 * @return list of expired bans for any resource
+	 * @throws InternalErrorException
+	 */
+	List<BanOnResource> getAllExpiredBansOnResources(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * Update description and validity timestamp of specific ban.
+	 *
+	 * @param sess
+	 * @param banOnResource ban to be updated
+	 * @return updated ban
+	 * @throws InternalErrorException
+	 */
+	BanOnResource updateBan(PerunSession sess, BanOnResource banOnResource) throws InternalErrorException;
+
+	/**
+	 * Remove ban by id from resources bans.
+	 *
+	 * @param sess
+	 * @param banId id of specific ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Remove ban by member_id and facility_id
+	 *
+	 * @param sess
+	 * @param memberId the id of member
+	 * @param resourceId the id of resource
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int memberId, int resourceId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Remove all expired bans on resources to now date.
+	 *
+	 * Get all expired bans and remove them one by one with auditing process.
+	 * This method is for purpose of removing expired bans using some cron tool.
+	 *
+	 * @param sess
+	 * @throws InternalErrorException
+	 */
+	void removeAllExpiredBansOnResources(PerunSession sess) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -24,6 +24,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.AuthzResolver;
+import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Facility;
@@ -44,6 +45,7 @@ import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.CandidateNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
@@ -162,7 +164,16 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			}
 		}
 
-
+		//Remove all members bans
+		List<BanOnResource> bansOnResource = getPerunBl().getResourcesManagerBl().getBansForMember(sess, member.getId());
+		for(BanOnResource banOnResource : bansOnResource) {
+			try {
+				getPerunBl().getResourcesManagerBl().removeBan(sess, banOnResource.getId());
+			} catch (BanNotExistsException ex) {
+				//it is ok, we just want to remove it anyway
+			}
+		}
+		
 		/* TODO this can be used for future optimization. If the user is not asigned to the facility anymore all user-facility attributes (for this facility) can be safely removed.
 			 for (Facility facility: facilitiesBeforeMemberRemove) {
 		// Remove user-facility attributes

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -404,6 +404,16 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		//Remove user authz
 		AuthzResolverBlImpl.removeAllUserAuthz(sess, user);
 
+		//Remove all users bans
+		List<BanOnFacility> bansOnFacility = getPerunBl().getFacilitiesManagerBl().getBansForUser(sess, user.getId());
+		for(BanOnFacility banOnFacility : bansOnFacility) {
+			try {
+				getPerunBl().getFacilitiesManagerBl().removeBan(sess, banOnFacility.getId());
+			} catch (BanNotExistsException ex) {
+				//it is ok, we just want to remove it anyway
+			}
+		}
+
 		// Finally delete the user
 		if(user.isSpecificUser()) {
 			// Remove all sponsored user authz of his owners

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import cz.metacentrum.perun.core.api.AuthzResolver;
+import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.ContactGroup;
 import cz.metacentrum.perun.core.api.FacilitiesManager;
 import cz.metacentrum.perun.core.api.Facility;
@@ -27,6 +28,8 @@ import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
@@ -1174,6 +1177,124 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		}
 
 		this.getFacilitiesManagerBl().removeSecurityTeam(sess, facility, securityTeam);
+	}
+
+	@Override
+	public BanOnFacility setBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException, PrivilegeException, BanAlreadyExistsException, FacilityNotExistsException, UserNotExistsException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(banOnFacility, "banOnFacility");
+		User user = getPerunBl().getUsersManagerBl().getUserById(sess, banOnFacility.getUserId());
+		Facility facility = this.getFacilitiesManagerBl().getFacilityById(sess, banOnFacility.getFacilityId());
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "setBan");
+		}
+
+		return getFacilitiesManagerBl().setBan(sess, banOnFacility);
+	}
+
+	@Override
+	public BanOnFacility getBanById(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		BanOnFacility ban = getFacilitiesManagerBl().getBanById(sess, banId);
+
+		Facility facility = new Facility();
+		facility.setId(ban.getId());
+		
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "getBanById");
+		}
+
+		return ban;
+	}
+
+	public BanOnFacility getBan(PerunSession sess, int userId, int faclityId) throws InternalErrorException, BanNotExistsException, PrivilegeException, UserNotExistsException, FacilityNotExistsException {
+		Utils.checkPerunSession(sess);
+		User user = getPerunBl().getUsersManagerBl().getUserById(sess, userId);
+		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityById(sess, faclityId);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "getBan");
+		}
+		
+		return getFacilitiesManagerBl().getBan(sess, userId, faclityId);
+	}
+
+	public List<BanOnFacility> getBansForUser(PerunSession sess, int userId) throws InternalErrorException, UserNotExistsException {
+		Utils.checkPerunSession(sess);
+		User user = getPerunBl().getUsersManagerBl().getUserById(sess, userId);
+
+		List<BanOnFacility> usersBans = getFacilitiesManagerBl().getBansForUser(sess, userId);
+		//filtering
+		Iterator<BanOnFacility> iterator = usersBans.iterator();
+		while(iterator.hasNext()) {
+			BanOnFacility banForFiltering = iterator.next();
+			Facility facility = new Facility();
+			facility.setId(banForFiltering.getFacilityId());
+			if(!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) iterator.remove();
+		}
+
+		return usersBans;
+	}
+
+	public List<BanOnFacility> getBansForFacility(PerunSession sess, int facilityId) throws InternalErrorException, PrivilegeException, FacilityNotExistsException {
+		Utils.checkPerunSession(sess);
+		Facility facility = this.getFacilitiesManagerBl().getFacilityById(sess, facilityId);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "getBansForFacility");
+		}
+
+		return getFacilitiesManagerBl().getBansForFacility(sess, facilityId);
+	}
+
+	public BanOnFacility updateBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, UserNotExistsException, BanNotExistsException {
+		Utils.checkPerunSession(sess);
+		this.getFacilitiesManagerBl().checkBanExists(sess, banOnFacility.getId());
+		Facility facility = this.getFacilitiesManagerBl().getFacilityById(sess, banOnFacility.getFacilityId());
+		User user = getPerunBl().getUsersManagerBl().getUserById(sess, banOnFacility.getUserId());
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "updateBan");
+		}
+
+		banOnFacility = getFacilitiesManagerBl().updateBan(sess, banOnFacility);
+		return banOnFacility;
+	}
+
+	public void removeBan(PerunSession sess, int banId) throws InternalErrorException, PrivilegeException, BanNotExistsException {
+		Utils.checkPerunSession(sess);
+		BanOnFacility ban = this.getFacilitiesManagerBl().getBanById(sess, banId);
+
+		Facility facility = new Facility();
+		facility.setId(ban.getId());
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "removeBan");
+		}
+
+		getFacilitiesManagerBl().removeBan(sess, banId);
+	}
+
+	public void removeBan(PerunSession sess, int userId, int facilityId) throws InternalErrorException, BanNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		BanOnFacility ban = this.getFacilitiesManagerBl().getBan(sess, userId, facilityId);
+		
+		Facility facility = new Facility();
+		facility.setId(ban.getId());
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "removeBan");
+		}
+
+		getFacilitiesManagerBl().removeBan(sess, userId, facilityId);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Compatibility.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Compatibility.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import java.sql.Date;
+import java.sql.Timestamp;
 
 /**
  * This class provide support for compatibility issues.
@@ -42,6 +44,19 @@ public class Compatibility {
 			return "'now'";
 		} else if (dbType.equals("hsqldb")) {
 			return "current_date";
+		} else {
+			throw new InternalErrorException("unknown DB type");
+		}
+	}
+
+	public static Object getDate(long dateInMiliseconds) throws InternalErrorException {
+		String dbType = BeansUtils.getPropertyFromConfiguration("perun.db.type");
+		if (dbType.equals("oracle")) {
+			return new Date(dateInMiliseconds);
+		} else if (dbType.equals("postgresql")) {
+			return new Timestamp(dateInMiliseconds);
+		} else if (dbType.equals("hsqldb")) {
+			return new Timestamp(dateInMiliseconds);
 		} else {
 			throw new InternalErrorException("unknown DB type");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -15,6 +15,7 @@ import org.springframework.jdbc.core.RowMapper;
 
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.ContactGroup;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
@@ -29,6 +30,7 @@ import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
@@ -71,6 +73,11 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	
 	protected final static String facilityContactsMappingSelectQueryWithAllEntities = facilityContactsMappingSelectQuery + ", " + UsersManagerImpl.userMappingSelectQuery + ", " + 
 	  facilityMappingSelectQuery + ", " + OwnersManagerImpl.ownerMappingSelectQuery + ", " + GroupsManagerImpl.groupMappingSelectQuery;
+
+	protected final static String banOnFacilityMappingSelectQuery = "facilities_bans.id as fac_bans_id, facilities_bans.description as fac_bans_description, " +
+		"facilities_bans.user_id as fac_bans_user_id, facilities_bans.facility_id as fac_bans_facility_id, facilities_bans.banned_to as fac_bans_validity_to, " +
+		"facilities_bans.created_at as fac_bans_created_at, facilities_bans.created_by as fac_bans_created_by, facilities_bans.modified_at as fac_bans_modified_at, " +
+		"facilities_bans.modified_by as fac_bans_modified_by, facilities_bans.created_by_uid as fac_bans_created_by_uid, facilities_bans.modified_by_uid as fac_bans_modified_by_uid";
 
 	public static final RowMapper<Facility> FACILITY_MAPPER = new RowMapper<Facility>() {
 		public Facility mapRow(ResultSet rs, int i) throws SQLException {
@@ -208,6 +215,26 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 		public String mapRow(ResultSet rs, int i) throws SQLException {
 
 			return rs.getString("name");
+		}
+	};
+
+	protected static final RowMapper<BanOnFacility> BAN_ON_FACILITY_MAPPER = new RowMapper<BanOnFacility>() {
+		public BanOnFacility mapRow(ResultSet rs, int i) throws SQLException {
+			BanOnFacility banOnFacility = new BanOnFacility();
+			banOnFacility.setId(rs.getInt("fac_bans_id"));
+			banOnFacility.setUserId(rs.getInt("fac_bans_user_id"));
+			banOnFacility.setFacilityId(rs.getInt("fac_bans_facility_id"));
+			banOnFacility.setDescription(rs.getString("fac_bans_description"));
+			banOnFacility.setValidityTo(rs.getTimestamp("fac_bans_validity_to"));
+			banOnFacility.setCreatedAt(rs.getString("fac_bans_created_at"));
+			banOnFacility.setCreatedBy(rs.getString("fac_bans_created_by"));
+			banOnFacility.setModifiedAt(rs.getString("fac_bans_modified_at"));
+			banOnFacility.setModifiedBy(rs.getString("fac_bans_modified_by"));
+			if(rs.getInt("fac_bans_modified_by_uid") == 0) banOnFacility.setModifiedByUid(null);
+			else banOnFacility.setModifiedByUid(rs.getInt("fac_bans_modified_by_uid"));
+			if(rs.getInt("fac_bans_created_by_uid") == 0) banOnFacility.setCreatedByUid(null);
+			else banOnFacility.setCreatedByUid(rs.getInt("fac_bans_created_by_uid"));
+			return banOnFacility;
 		}
 	};
 
@@ -1015,6 +1042,126 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 							"select security_teams_facilities.facility_id from security_teams_facilities where security_team_id=?" +
 							") " + Compatibility.getAsAlias("assigned_ids")+ " ON facilities.id=assigned_ids.facility_id",
 					FACILITY_MAPPER, securityTeam.getId());
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public boolean banExists(PerunSession sess, int userId, int facilityId) throws InternalErrorException {
+		try {
+			return 1 == jdbc.queryForInt("select 1 from facilities_bans where user_id=? and facility_id=?", userId, facilityId);
+		} catch(EmptyResultDataAccessException ex) {
+			return false;
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public boolean banExists(PerunSession sess, int banId) throws InternalErrorException {
+		try {
+			return 1 == jdbc.queryForInt("select 1 from facilities_bans where id=?", banId);
+		} catch(EmptyResultDataAccessException ex) {
+			return false;
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public BanOnFacility setBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException {
+		Utils.notNull(banOnFacility.getValidityTo(), "banOnFacility.getValidityTo");
+
+		try {
+			int newId = Utils.getNewId(jdbc, "facilities_bans_id_seq");
+
+			jdbc.update("insert into facilities_bans(id, description, banned_to, user_id, facility_id, created_by, created_at,modified_by,modified_at,created_by_uid,modified_by_uid) " +
+					"values (?,?,?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)",
+					newId, banOnFacility.getDescription(), Compatibility.getDate(banOnFacility.getValidityTo().getTime()), banOnFacility.getUserId(), banOnFacility.getFacilityId(), sess.getPerunPrincipal().getActor(),
+					sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
+
+			banOnFacility.setId(newId);
+
+			return banOnFacility;
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public BanOnFacility getBanById(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException {
+		try {
+			return jdbc.queryForObject("select " + banOnFacilityMappingSelectQuery + " from facilities_bans where id=? ", BAN_ON_FACILITY_MAPPER, banId);
+		} catch (EmptyResultDataAccessException ex) {
+			throw new BanNotExistsException("Ban with id " + banId + " not exists for any facility.");
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public BanOnFacility getBan(PerunSession sess, int userId, int faclityId) throws InternalErrorException, BanNotExistsException {
+		try {
+			return jdbc.queryForObject("select " + banOnFacilityMappingSelectQuery + " from facilities_bans where user_id=? and facility_id=?", BAN_ON_FACILITY_MAPPER, userId, faclityId);
+		} catch (EmptyResultDataAccessException ex) {
+			throw new BanNotExistsException("Ban for user " + userId + " and facility " + faclityId + " not exists.");
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public List<BanOnFacility> getBansForUser(PerunSession sess, int userId) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + banOnFacilityMappingSelectQuery + " from facilities_bans where user_id=?", BAN_ON_FACILITY_MAPPER, userId);
+		} catch (EmptyResultDataAccessException ex) {
+			return new ArrayList<>();
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public List<BanOnFacility> getBansForFacility(PerunSession sess, int facilityId) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + banOnFacilityMappingSelectQuery + " from facilities_bans where facility_id=?", BAN_ON_FACILITY_MAPPER, facilityId);
+		} catch (EmptyResultDataAccessException ex) {
+			return new ArrayList<>();
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public List<BanOnFacility> getAllExpiredBansOnFacilities(PerunSession sess) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + banOnFacilityMappingSelectQuery + " from facilities_bans where banned_to < " + Compatibility.getSysdate(), BAN_ON_FACILITY_MAPPER);
+		} catch (EmptyResultDataAccessException ex) {
+			return new ArrayList<>();
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public BanOnFacility updateBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException {
+		try {
+			jdbc.update("update facilities_bans set description=?, banned_to=?, modified_by=?, modified_by_uid=?, modified_at=" +
+							Compatibility.getSysdate() + " where id=?",
+							banOnFacility.getDescription(), Compatibility.getDate(banOnFacility.getValidityTo().getTime()), sess.getPerunPrincipal().getActor(),
+							sess.getPerunPrincipal().getUserId(), banOnFacility.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+
+		return banOnFacility;
+	}
+
+	public void removeBan(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException {
+		try {
+			int numAffected = jdbc.update("delete from facilities_bans where id=?", banId);
+			if(numAffected != 1) throw new BanNotExistsException("Ban with id " + banId + " can't be remove, because not exists yet.");
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public void removeBan(PerunSession sess, int userId, int facilityId) throws InternalErrorException, BanNotExistsException {
+		try {
+			int numAffected = jdbc.update("delete from facilities_bans where user_id=? and facility_id=?", userId, facilityId);
+			if(numAffected != 1) throw new BanNotExistsException("Ban for user " + userId + " and facility " + facilityId + " can't be remove, because not exists yet.");
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
@@ -164,6 +164,20 @@ public class Synchronizer {
 
 	}
 
+	public void removeAllExpiredBans() {
+		if(perunBl.isPerunReadOnly()) {
+			log.debug("This instance is just read only so skip removing expired bans.");
+			return;
+		}
+
+		try {
+			getPerun().getResourcesManagerBl().removeAllExpiredBansOnResources(sess);
+			getPerun().getFacilitiesManagerBl().removeAllExpiredBansOnFacilities(sess);
+		} catch (InternalErrorException ex) {
+			log.error("Synchronizer: removeAllExpiredBans, exception {}", ex);
+		}
+	}
+
 	public void initialize() throws InternalErrorException {
 		String synchronizerPrincipal = "perunSynchronizer";
 		this.sess = perunBl.getPerunSession(new PerunPrincipal(synchronizerPrincipal, ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
@@ -1,0 +1,67 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberVirtualAttributesModuleImplApi;
+
+/**
+ * Module for getting information if member is banned on resource.
+ *
+ * Get true if exists ban of member on resource or his user on facility.
+ *
+ * @author Michal Stava
+ */
+public class urn_perun_member_resource_attribute_def_virt_isBanned extends ResourceMemberVirtualAttributesModuleAbstract implements ResourceMemberVirtualAttributesModuleImplApi {
+
+    public Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Member member, AttributeDefinition attributeDefinition) throws InternalErrorException {
+        Attribute attribute = new Attribute(attributeDefinition);
+		//Default value is false
+		attribute.setValue(false);
+
+		Facility facility;
+		try {
+			facility = sess.getPerunBl().getFacilitiesManagerBl().getFacilityById(sess, resource.getFacilityId());
+		} catch (FacilityNotExistsException ex) {
+			throw new InternalErrorException("Facility for Resource " + resource + " not exists!");
+		}
+
+		User user;
+		try {
+			user = sess.getPerunBl().getUsersManagerBl().getUserById(sess, member.getUserId());
+		} catch (UserNotExistsException ex) {
+			throw new InternalErrorException("User for Member " + member + " not exists!");
+		}
+
+		//Ban on resource exists?
+		if(sess.getPerunBl().getResourcesManagerBl().banExists(sess, member.getId(), resource.getId())) attribute.setValue(true);
+		//Ban on facility exists?
+        if(sess.getPerunBl().getFacilitiesManagerBl().banExists(sess, user.getId(), facility.getId())) attribute.setValue(true);
+        
+        return attribute;
+
+    }
+
+    public AttributeDefinition getAttributeDefinition() {
+        AttributeDefinition attr = new AttributeDefinition();
+        attr.setNamespace(AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT);
+        attr.setFriendlyName("isBanned");
+        attr.setDisplayName("Is banned on Resource or Facility");
+        attr.setType(Boolean.class.getName());
+        attr.setDescription("True if member is banned on resource or all facility.");
+        return attr;
+    }
+
+
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.implApi;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.ContactGroup;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
@@ -15,6 +16,7 @@ import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
@@ -704,4 +706,117 @@ public interface FacilitiesManagerImplApi {
 	 */
 	List<Facility> getAssignedFacilities(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
 
+	/**
+	 * Get true if any ban for user and facility exists.
+	 * 
+	 * @param sess
+	 * @param userId id of user
+	 * @param facilityId id of facility
+	 * @return true if ban exists
+	 * @throws InternalErrorException 
+	 */
+	boolean banExists(PerunSession sess, int userId, int facilityId) throws InternalErrorException;
+
+	/**
+	 * Get true if any band defined by id exists for any user and facility.
+	 *
+	 * @param sess
+	 * @param banId id of ban
+	 * @return true if ban exists
+	 * @throws InternalErrorException
+	 */
+	boolean banExists(PerunSession sess, int banId) throws InternalErrorException;
+
+	/**
+	 * Set ban for user on facility
+	 * 
+	 * @param sess
+	 * @param banOnFacility the ban
+	 * @return ban on facility
+	 * @throws InternalErrorException 
+	 */
+	BanOnFacility setBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException;
+
+	/**
+	 * Get Ban for user on facility by it's id
+	 *
+	 * @param sess
+	 * @param banId the ban id
+	 * @return facility ban by it's id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	BanOnFacility getBanById(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get specific facility ban.
+	 *
+	 * @param sess
+	 * @param userId the user id
+	 * @param faclityId the facility id
+	 * @return specific facility ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	BanOnFacility getBan(PerunSession sess, int userId, int faclityId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get all facilities bans for user.
+	 *
+	 * @param sess
+	 * @param userId the user id
+	 * @return list of bans for user on any facility
+	 * @throws InternalErrorException
+	 */
+	List<BanOnFacility> getBansForUser(PerunSession sess, int userId) throws InternalErrorException;
+
+	/**
+	 * Get all users bans for facility
+	 *
+	 * @param sess
+	 * @param facilityId the facility id
+	 * @return list of all users bans on facility
+	 * @throws InternalErrorException
+	 */
+	List<BanOnFacility> getBansForFacility(PerunSession sess, int facilityId) throws InternalErrorException;
+
+	/**
+	 * Get all expired bans on any facility to now date
+	 *
+	 * @param sess
+	 * @return list of expired bans for any facility
+	 * @throws InternalErrorException
+	 */
+	List<BanOnFacility> getAllExpiredBansOnFacilities(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * Update description and validity timestamp of specific ban.
+	 *
+	 * @param sess
+	 * @param banOnFacility ban to be updated
+	 * @return updated ban
+	 * @throws InternalErrorException
+	 */
+	BanOnFacility updateBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException;
+
+	/**
+	 * Remove ban by id from facilities bans.
+	 *
+	 * @param sess
+	 * @param banId id of specific ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Remove ban by user_id and facility_id.
+	 *
+	 * @param sess
+	 * @param userId the id of user
+	 * @param facilityId the id of facility
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int userId, int facilityId) throws InternalErrorException, BanNotExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.implApi;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
@@ -13,6 +14,7 @@ import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -550,4 +552,118 @@ public interface ResourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<ResourceTag> getAllResourcesTagsForResource(PerunSession perunSession, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Get true if any ban for member and resource exists.
+	 *
+	 * @param sess
+	 * @param memberId id of member
+	 * @param resourceId id of resource
+	 * @return true if ban exists
+	 * @throws InternalErrorException
+	 */
+	boolean banExists(PerunSession sess, int memberId, int resourceId) throws InternalErrorException;
+
+	/**
+	 * Get true if any band defined by id exists for any member and resource.
+	 *
+	 * @param sess
+	 * @param banId id of ban
+	 * @return true if ban exists
+	 * @throws InternalErrorException
+	 */
+	boolean banExists(PerunSession sess, int banId) throws InternalErrorException;
+
+	/**
+	 * Set ban for member on resource
+	 *
+	 * @param sess
+	 * @param banOnResource the ban
+	 * @return ban on resource
+	 * @throws InternalErrorException
+	 */
+	BanOnResource setBan(PerunSession sess, BanOnResource banOnResource) throws InternalErrorException;
+
+	/**
+	 * Get Ban for member on resource by it's id
+	 *
+	 * @param sess
+	 * @param banId the ban id
+	 * @return resource ban by it's id
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	BanOnResource getBanById(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get specific resource ban.
+	 *
+	 * @param sess
+	 * @param memberId the member id
+	 * @param resourceId the resource id
+	 * @return specific resource ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	BanOnResource getBan(PerunSession sess, int memberId, int resourceId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Get all resources bans for member.
+	 *
+	 * @param sess
+	 * @param memberId the member id
+	 * @return list of bans for member on any resource
+	 * @throws InternalErrorException
+	 */
+	List<BanOnResource> getBansForMember(PerunSession sess, int memberId) throws InternalErrorException;
+
+	/**
+	 * Get all members bans for resource
+	 *
+	 * @param sess
+	 * @param resourceId the resource id
+	 * @return list of all members bans on resource
+	 * @throws InternalErrorException
+	 */
+	List<BanOnResource> getBansForResource(PerunSession sess, int resourceId) throws InternalErrorException;
+
+	/**
+	 * Get all expired bans on any resource to now date
+	 *
+	 * @param sess
+	 * @return list of expired bans for any resource
+	 * @throws InternalErrorException
+	 */
+	List<BanOnResource> getAllExpiredBansOnResources(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * Update description and validity timestamp of specific ban.
+	 *
+	 * @param sess
+	 * @param banOnResource ban to be updated
+	 * @return updated ban
+	 * @throws InternalErrorException
+	 */
+	BanOnResource updateBan(PerunSession sess, BanOnResource banOnResource) throws InternalErrorException;
+
+	/**
+	 * Remove ban by id from resources bans.
+	 *
+	 * @param sess
+	 * @param banId id of specific ban
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int banId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Remove ban by member_id and facility_id
+	 *
+	 * @param sess
+	 * @param memberId the id of member
+	 * @param resourceId the id of resource
+	 * @throws InternalErrorException
+	 * @throws BanNotExistsException
+	 */
+	void removeBan(PerunSession sess, int memberId, int resourceId) throws InternalErrorException, BanNotExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleAbstract.java
@@ -1,0 +1,43 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract class for Resource Member Virtual Attributes modules.
+ * Implements methods for modules to perform default function.
+ * In the function that the method in the module does nothing, it is not necessary to implement it, simply extend this abstract class.
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
+public abstract class ResourceMemberVirtualAttributesModuleAbstract extends ResourceMemberAttributesModuleAbstract implements ResourceMemberVirtualAttributesModuleImplApi{
+
+
+	public Attribute getAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException {
+		return new Attribute(attribute);
+	}
+
+	public boolean setAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		return false;
+	}
+
+	public boolean removeAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return false;
+	}
+
+	@Override
+	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		return new ArrayList<String>();
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleImplApi.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * This interface serves as a template for virtual attributes.
+ *
+ * @author Michal Stava
+ */
+public interface ResourceMemberVirtualAttributesModuleImplApi extends ResourceMemberAttributesModuleImplApi, VirtualAttributesModuleImplApi {
+
+	/**
+	 * This method will return computed value.
+	 *
+	 * @param sess perun session
+	 * @param resource resource which is needed for computing the value
+	 * @param member member which is needed for computing the value
+	 * @param attribute attribute to operate on
+	 * @return
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 */
+	Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException;
+
+	/**
+	 * Method sets attributes' values which are dependent on this virtual attribute.
+	 *
+	 * @param sess
+	 * @param resource resource which is needed for computing the value
+	 * @param member member which is needed for computing the value
+	 * @param attribute attribute to operate on
+	 * @return true if attribute was really changed
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 */
+	boolean setAttributeValue(PerunSessionImpl sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Currently do nothing.
+	 *
+	 * @param sess
+	 * @param resource resource which is needed for computing the value
+	 * @param member member which is needed for computing the value
+	 * @param attribute attribute to operate on
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 */
+	boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+}

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -3,6 +3,27 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.36
+create table resources_bans ( id integer not null, member_id integer not null, resource_id integer not null, description varchar(1024), banned_to timestamp not null, created_at timestamp default now not null, created_by varchar(1024) default user not null, modified_at timestamp default now not null, modified_by varchar(1024) default user not null, created_by_uid integer, modified_by_uid integer);
+create table facilities_bans ( id integer not null, user_id integer not null, facility_id integer not null, description varchar(1024), banned_to timestamp not null, created_at timestamp default now not null, created_by varchar(1024) default user not null, modified_at timestamp default now not null, modified_by varchar(1024) default user not null, created_by_uid integer, modified_by_uid integer);
+create sequence resources_bans_id_seq start with 10 increment by 1;                           
+create sequence facilities_bans_id_seq start with 10 increment by 1;
+alter table resources_bans add constraint res_bans_pk primary key (id);
+alter table resources_bans add constraint res_bans_u unique (member_id, resource_id);
+alter table resources_bans add constraint res_bans_mem_fk foreign key (member_id) references members (id);
+alter table resources_bans add constraint res_bans_res_fk foreign key (resource_id) references resources (id);
+alter table facilities_bans add constraint fac_bans_pk primary key (id);
+alter table facilities_bans add constraint fac_bans_u unique (user_id, facility_id);
+alter table facilities_bans add constraint fac_bans_usr_fk foreign key (user_id) references users (id);
+alter table facilities_bans add constraint fac_bans_fac_fk foreign key (facility_id) references facilities (id);
+create index idx_fk_res_ban_member on resources_bans (member_id);                             
+create index idx_fk_res_ban_res on resources_bans (resource_id);
+create index idx_fk_res_ban_member_res on resources_bans (member_id, resource_id);
+create index idx_fk_fac_ban_user on facilities_bans (user_id);
+create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
+create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
+update configurations set value='3.1.36' where property='DATABASE VERSION';
+
 3.1.35
 alter table users add sponsored_acc char(1) default '0' not null;
 drop index idx_fk_servu_u_ui;

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -3,6 +3,21 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.36
+create table resources_bans (  id integer not null, member_id integer not null, resource_id integer not null, description nvarchar2(1024), banned_to date not null, created_at date default sysdate not null, created_by nvarchar2(1024) default user not null, modified_at date default sysdate not null, modified_by nvarchar2(1024) default user not null, created_by_uid integer, modified_by_uid integer);
+create table facilities_bans (  id integer not null, user_id integer not null, facility_id integer not null, description nvarchar2(1024), banned_to date not null, created_at date default sysdate not null, created_by nvarchar2(1024) default user not null, modified_at date default sysdate not null, modified_by nvarchar2(1024) default user not null, created_by_uid integer, modified_by_uid integer);
+create sequence RESOURCES_BANS_ID_SEQ maxvalue 1.0000E+28 nocache;
+create sequence FACILITIES_BANS_ID_SEQ maxvalue 1.0000E+28 nocache;
+alter table resources_bans add ( constraint res_bans_pk primary key (id), constraint res_bans_u unique(member_id, resource_id), constraint res_bans_mem_fk foreign key (member_id) references members (id), constraint res_bans_res_fk foreign key (resource_id) references resources (id) );
+alter table facilities_bans add ( constraint fac_bans_pk primary key (id), constraint fac_bans_u unique(user_id, facility_id), constraint fac_bans_usr_fk foreign key (user_id) references users (id), constraint fac_bans_fac_fk foreign key (facility_id) references facilities (id) );
+create index IDX_FK_RES_BAN_MEMBER on resources_bans (member_id);
+create index IDX_FK_RES_BAN_RES on resources_bans (resource_id);
+create index IDX_FK_RES_BAN_MEMBER_RES on resources_bans (member_id, resource_id);
+create index IDX_FK_FAC_BAN_USER on facilities_bans (user_id);
+create index IDX_FK_FAC_BAN_FAC on facilities_bans (facility_id);
+create index IDX_FK_FAC_BAN_USER_FAC on facilities_bans (user_id, facility_id);
+update configurations set value='3.1.36' where property='DATABASE VERSION';
+
 3.1.35
 alter table users add sponsored_acc char(1) default '0' not null;
 drop index IDX_FK_SERVU_U_UI;

--- a/perun-core/src/main/resources/perun-core-synchronizers.xml
+++ b/perun-core/src/main/resources/perun-core-synchronizers.xml
@@ -13,6 +13,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		<task:scheduled-tasks scheduler="scheduler">
 			<task:scheduled ref="synchronizer" method="synchronizeGroups" cron="0 0/5 * * * ?"/> <!-- every 5 minutes -->
 			<task:scheduled ref="synchronizer" method="checkMembersState" cron="0 0 0 * * ?"/> <!-- every day -->
+			<task:scheduled ref="synchronizer" method="removeAllExpiredBans" cron="0 0 0 * * ?"/> <!-- every day -->
 		</task:scheduled-tasks>
 	</beans>
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -3,6 +3,29 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.36
+create table "resources_bans" ( id integer not null, member_id integer not null, resource_id integer not null, description varchar(1024), banned_to timestamp not null, created_at timestamp default now() not null, created_by varchar(1024) default user not null, modified_at timestamp default now() not null, modified_by varchar(1024) default user not null, created_by_uid integer, modified_by_uid integer);
+create table "facilities_bans" ( id integer not null, user_id integer not null, facility_id integer not null, description varchar(1024), banned_to timestamp not null, created_at timestamp default now() not null, created_by varchar(1024) default user not null, modified_at timestamp default now() not null, modified_by varchar(1024) default user not null, created_by_uid integer, modified_by_uid integer);
+create sequence "resources_bans_id_seq" maxvalue 9223372036854775807;
+create sequence "facilities_bans_id_seq" maxvalue 9223372036854775807;
+alter table resources_bans add constraint res_bans_pk primary key (id);
+alter table resources_bans add constraint res_bans_u unique (member_id, resource_id);
+alter table resources_bans add constraint res_bans_mem_fk foreign key (member_id) references members (id);
+alter table resources_bans add constraint res_bans_res_fk foreign key (resource_id) references resources (id);
+alter table facilities_bans add constraint fac_bans_pk primary key (id);
+alter table facilities_bans add constraint fac_bans_u unique (user_id, facility_id);
+alter table facilities_bans add constraint fac_bans_usr_fk foreign key (user_id) references users (id);
+alter table facilities_bans add constraint fac_bans_fac_fk foreign key (facility_id) references facilities (id);
+create index idx_fk_res_ban_member on resources_bans (member_id);
+create index idx_fk_res_ban_res on resources_bans (resource_id);
+create index idx_fk_res_ban_member_res on resources_bans (member_id, resource_id);
+create index idx_fk_fac_ban_user on facilities_bans (user_id);
+create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
+create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
+grant all on resources_bans to perun;                                                         
+grant all on facilities_bans to perun;
+update configurations set value='3.1.36' where property='DATABASE VERSION';
+
 3.1.35
 alter table users add sponsored_acc char(1) default '0' not null;
 drop index idx_fk_servu_u_ui;

--- a/perun-core/src/main/resources/schema.sql
+++ b/perun-core/src/main/resources/schema.sql
@@ -1084,6 +1084,34 @@ create table blacklists (
 	modified_by_uid integer
 );
 
+create table resources_bans (
+	id integer not null,
+	member_id integer not null,
+	resource_id integer not null,
+	description varchar(1024),
+	banned_to timestamp not null,
+	created_at timestamp default now not null,
+	created_by varchar(1024) default user not null,
+	modified_at timestamp default now not null,
+	modified_by varchar(1024) default user not null,
+	created_by_uid integer,
+	modified_by_uid integer
+);
+
+create table facilities_bans (
+	id integer not null,
+	user_id integer not null,
+	facility_id integer not null,
+	description varchar(1024),
+	banned_to timestamp not null,
+	created_at timestamp default now not null,
+	created_by varchar(1024) default user not null,
+	modified_at timestamp default now not null,
+	modified_by varchar(1024) default user not null,
+	created_by_uid integer,
+	modified_by_uid integer
+);
+
 create sequence attr_names_id_seq;
 create sequence auditer_consumers_id_seq;
 create sequence auditer_log_id_seq;
@@ -1132,6 +1160,8 @@ create sequence res_tags_seq;
 create sequence mailchange_id_seq;
 create sequence pwdreset_id_seq;
 create sequence security_teams_id_seq start with 10 increment by 1;
+create sequence resources_bans_id_seq start with 10 increment by 1;
+create sequence facilities_bans_id_seq start with 10 increment by 1;
 
 create index idx_namespace on attr_names(namespace);
 create index idx_authz_user_role_id on authz(user_id,role_id);
@@ -1273,6 +1303,12 @@ create index idx_fk_security_teams_facilities_security_team on security_teams_fa
 create index idx_fk_security_teams_facilities_facilities on security_teams_facilities (facility_id);
 create index idx_fk_bllist_user on blacklists (user_id);
 create index idx_fk_bllist_secteam on blacklists (security_team_id);
+create index idx_fk_res_ban_member on resources_bans (member_id);
+create index idx_fk_res_ban_res on resources_bans (resource_id);
+create index idx_fk_res_ban_member_res on resources_bans (member_id, resource_id);
+create index idx_fk_fac_ban_user on facilities_bans (user_id);
+create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
+create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
 
 alter table auditer_log add constraint audlog_pk primary key (id);
 
@@ -1578,6 +1614,16 @@ alter table security_teams_facilities add constraint security_teams_facilities_f
 alter table blacklists add constraint bllist_pk primary key (security_team_id,user_id);
 alter table blacklists add constraint bllist_secteam_fk foreign key (security_team_id) references security_teams (id);
 alter table blacklists add constraint bllist_user_fk foreign key (user_id) references users(id);
+
+alter table resources_bans add constraint res_bans_pk primary key (id);
+alter table resources_bans add constraint res_bans_u unique (member_id, resource_id);
+alter table resources_bans add constraint res_bans_mem_fk foreign key (member_id) references members (id);
+alter table resources_bans add constraint res_bans_res_fk foreign key (resource_id) references resources (id);
+
+alter table facilities_bans add constraint fac_bans_pk primary key (id);
+alter table facilities_bans add constraint fac_bans_u unique (user_id, facility_id);
+alter table facilities_bans add constraint fac_bans_usr_fk foreign key (user_id) references users (id);
+alter table facilities_bans add constraint fac_bans_fac_fk foreign key (facility_id) references facilities (id);
 
 alter table authz add constraint authz_role_fk foreign key (role_id) references roles(id);
 alter table authz add constraint authz_user_fk foreign key (user_id) references users(id);

--- a/perun-core/src/main/resources/test-data.sql
+++ b/perun-core/src/main/resources/test-data.sql
@@ -2089,7 +2089,7 @@ insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routin
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,2,timestamp '2011-11-15 14:43:13.3','PERUNV3',timestamp '2011-11-15 14:43:13.3','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6071,timestamp '2015-01-21 13:05:00.4',timestamp '2015-01-16 14:29:29.6','PERUNV3',timestamp '2015-01-16 14:29:29.6','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6060,timestamp '2015-01-16 14:25:00.6',timestamp '2015-01-16 09:39:07.6','PERUNV3',timestamp '2015-01-16 09:39:07.6','PERUNV3','0');
-insert into configurations (property,value) values ('DATABASE VERSION','3.1.35');
+insert into configurations (property,value) values ('DATABASE VERSION','3.1.36');
 
 drop sequence service_principals_id_seq;
 create sequence service_principals_id_seq start with 1;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntryIntegrationTest.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.Candidate;
 import cz.metacentrum.perun.core.api.ContactGroup;
 import cz.metacentrum.perun.core.api.Destination;
@@ -56,6 +57,7 @@ import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import cz.metacentrum.perun.core.blImpl.FacilitiesManagerBlImpl;
+import java.util.Date;
 
 /**
  * Integration tests of FacilitiesManager
@@ -1406,6 +1408,252 @@ public class FacilitiesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		facilitiesManagerEntry.removeSecurityTeam(sess, facility, setUpSecurityTeam2());
 	}
 
+	@Test
+	public void setBan() throws Exception {
+		System.out.println(CLASS_NAME + "setBan");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		banOnFacility.setValidityTo(new Date());
+
+		BanOnFacility returnedBan = facilitiesManagerEntry.setBan(sess, banOnFacility);
+		banOnFacility.setId(returnedBan.getId());
+		assertEquals(banOnFacility, returnedBan);
+	}
+
+	@Test
+	public void getBanById() throws Exception {
+		System.out.println(CLASS_NAME + "getBanById");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		banOnFacility.setValidityTo(new Date());
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+
+		BanOnFacility returnedBan = facilitiesManagerEntry.getBanById(sess, banOnFacility.getId());
+		assertEquals(banOnFacility, returnedBan);
+	}
+
+	@Test
+	public void getBan() throws Exception {
+		System.out.println(CLASS_NAME + "getBan");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		banOnFacility.setValidityTo(new Date());
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+
+		BanOnFacility returnedBan = facilitiesManagerEntry.getBan(sess, banOnFacility.getUserId(), banOnFacility.getFacilityId());
+		assertEquals(banOnFacility, returnedBan);
+	}
+
+	@Test
+	public void getBansForUser() throws Exception {
+		System.out.println(CLASS_NAME + "getBansForUser");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		banOnFacility.setValidityTo(new Date());
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+
+		List<BanOnFacility> returnedBans = facilitiesManagerEntry.getBansForUser(sess, banOnFacility.getUserId());
+		assertEquals(banOnFacility, returnedBans.get(0));
+	}
+
+	@Test
+	public void getBansForFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getBansForFacility");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		banOnFacility.setValidityTo(new Date());
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+
+		List<BanOnFacility> returnedBans = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertEquals(banOnFacility, returnedBans.get(0));
+	}
+
+	@Test
+	public void updateBan() throws Exception {
+		System.out.println(CLASS_NAME + "updateBan");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		banOnFacility.setValidityTo(new Date());
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+		banOnFacility.setDescription("New description");
+		banOnFacility.setValidityTo(new Date(banOnFacility.getValidityTo().getTime() + 1000000));
+		facilitiesManagerEntry.updateBan(sess, banOnFacility);
+
+		BanOnFacility returnedBan = facilitiesManagerEntry.getBanById(sess, banOnFacility.getId());
+		assertEquals(banOnFacility, returnedBan);
+	}
+
+	@Test
+	public void removeBanById() throws Exception {
+		System.out.println(CLASS_NAME + "removeBan");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		banOnFacility.setValidityTo(new Date());
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+
+		List<BanOnFacility> bansOnFacility = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertTrue(bansOnFacility.size() == 1);
+
+		perun.getFacilitiesManagerBl().removeBan(sess, banOnFacility.getId());
+
+		bansOnFacility = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertTrue(bansOnFacility.isEmpty());
+	}
+
+	@Test
+	public void removeBan() throws Exception {
+		System.out.println(CLASS_NAME + "removeBan");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		banOnFacility.setValidityTo(new Date());
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+
+		List<BanOnFacility> bansOnFacility = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertTrue(bansOnFacility.size() == 1);
+
+		perun.getFacilitiesManagerBl().removeBan(sess, banOnFacility.getUserId(), banOnFacility.getFacilityId());
+
+		bansOnFacility = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertTrue(bansOnFacility.isEmpty());
+	}
+
+	@Test
+	public void removeExpiredBansIfExist() throws Exception {
+		System.out.println(CLASS_NAME + "removeExpiredBansIfExist");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		Date now = new Date();
+		Date yesterday = new Date(now.getTime() - (1000 * 60 * 60 * 24));
+		banOnFacility.setValidityTo(yesterday);
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+		
+		List<BanOnFacility> bansOnFacility = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertTrue(bansOnFacility.size() == 1);
+
+		perun.getFacilitiesManagerBl().removeAllExpiredBansOnFacilities(sess);
+
+		bansOnFacility = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertTrue(bansOnFacility.isEmpty());
+	}
+
+	@Test
+	public void removeExpiredBansIfNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "removeExpiredBansIfNotExist");
+		Vo vo = setUpVo();
+		Resource resource = setUpResource(vo);
+
+		Member member = setUpMember(vo);
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		Group group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnFacility banOnFacility = new BanOnFacility();
+		banOnFacility.setUserId(user.getId());
+		banOnFacility.setFacilityId(facility.getId());
+		banOnFacility.setDescription("Popisek");
+		Date now = new Date();
+		Date tommorow = new Date(now.getTime() + (1000 * 60 * 60 * 24));
+		banOnFacility.setValidityTo(tommorow);
+		banOnFacility = facilitiesManagerEntry.setBan(sess, banOnFacility);
+
+		List<BanOnFacility> bansOnFacility = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertTrue(bansOnFacility.size() == 1);
+
+		perun.getFacilitiesManagerBl().removeAllExpiredBansOnFacilities(sess);
+
+		bansOnFacility = facilitiesManagerEntry.getBansForFacility(sess, banOnFacility.getFacilityId());
+		assertTrue(bansOnFacility.size() == 1);
+	}
 
 // PRIVATE METHODS -------------------------------------------------------
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -26,6 +26,8 @@ import cz.metacentrum.perun.core.api.exceptions.ServicesPackageNotExistsExceptio
 import cz.metacentrum.perun.core.api.exceptions.SubGroupCannotBeRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import java.util.ArrayList;
+import java.util.Date;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Integration tests of ResourcesManager.
@@ -1034,6 +1036,243 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 		int count = resourcesManager.getResourcesCount(sess);
 		assertTrue(count>0);
+	}
+
+	@Test
+	public void setBan() throws Exception {
+		System.out.println(CLASS_NAME + "setBan");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		banOnResource.setValidityTo(new Date());
+
+		BanOnResource returnedBan = resourcesManager.setBan(sess, banOnResource);
+		banOnResource.setId(returnedBan.getId());
+		assertEquals(banOnResource, returnedBan);
+	}
+
+	@Test
+	public void getBanById() throws Exception {
+		System.out.println(CLASS_NAME + "getBanById");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		banOnResource.setValidityTo(new Date());
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+
+		BanOnResource returnedBan = resourcesManager.getBanById(sess, banOnResource.getId());
+		assertEquals(banOnResource, returnedBan);
+	}
+
+	@Test
+	public void getBan() throws Exception {
+		System.out.println(CLASS_NAME + "getBan");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		banOnResource.setValidityTo(new Date());
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+
+		BanOnResource returnedBan = resourcesManager.getBan(sess, banOnResource.getMemberId(), banOnResource.getResourceId());
+		assertEquals(banOnResource, returnedBan);
+	}
+
+	@Test
+	public void getBansForMember() throws Exception {
+		System.out.println(CLASS_NAME + "getBansForMember");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		banOnResource.setValidityTo(new Date());
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+
+		List<BanOnResource> returnedBans = resourcesManager.getBansForMember(sess, banOnResource.getMemberId());
+		assertEquals(banOnResource, returnedBans.get(0));
+	}
+
+	@Test
+	public void getBansForResource() throws Exception {
+		System.out.println(CLASS_NAME + "getBansForResource");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		banOnResource.setValidityTo(new Date());
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+
+		List<BanOnResource> returnedBans = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertEquals(banOnResource, returnedBans.get(0));
+	}
+
+	@Test
+	public void updateBan() throws Exception {
+		System.out.println(CLASS_NAME + "updateBan");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		banOnResource.setValidityTo(new Date());
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+		banOnResource.setDescription("New description");
+		banOnResource.setValidityTo(new Date(banOnResource.getValidityTo().getTime() + 1000000));
+		resourcesManager.updateBan(sess, banOnResource);
+
+		BanOnResource returnedBan = resourcesManager.getBanById(sess, banOnResource.getId());
+		assertEquals(banOnResource, returnedBan);
+	}
+
+	@Test
+	public void removeBanById() throws Exception {
+		System.out.println(CLASS_NAME + "removeBan");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		banOnResource.setValidityTo(new Date());
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+
+		List<BanOnResource> bansOnResource = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertTrue(bansOnResource.size() == 1);
+
+		perun.getResourcesManagerBl().removeBan(sess, banOnResource.getId());
+
+		bansOnResource = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertTrue(bansOnResource.isEmpty());
+	}
+
+	@Test
+	public void removeBan() throws Exception {
+		System.out.println(CLASS_NAME + "removeBan");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		banOnResource.setValidityTo(new Date());
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+
+		List<BanOnResource> bansOnResource = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertTrue(bansOnResource.size() == 1);
+
+		perun.getResourcesManagerBl().removeBan(sess, banOnResource.getMemberId(), banOnResource.getResourceId());
+
+		bansOnResource = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertTrue(bansOnResource.isEmpty());
+	}
+
+	@Test
+	public void removeExpiredBansIfExist() throws Exception {
+		System.out.println(CLASS_NAME + "removeExpiredBansIfExist");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		Date now = new Date();
+		Date yesterday = new Date(now.getTime() - (1000 * 60 * 60 * 24));
+		banOnResource.setValidityTo(yesterday);
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+
+		List<BanOnResource> bansOnResource = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertTrue(bansOnResource.size() == 1);
+
+		perun.getResourcesManagerBl().removeAllExpiredBansOnResources(sess);
+
+		bansOnResource = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertTrue(bansOnResource.isEmpty());
+	}
+
+	@Test
+	public void removeExpiredBansIfNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "removeExpiredBansIfNotExist");
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		BanOnResource banOnResource = new BanOnResource();
+		banOnResource.setMemberId(member.getId());
+		banOnResource.setResourceId(resource.getId());
+		banOnResource.setDescription("Popisek");
+		Date now = new Date();
+		Date tommorow = new Date(now.getTime() + (1000 * 60 * 60 * 24));
+		banOnResource.setValidityTo(tommorow);
+		banOnResource = resourcesManager.setBan(sess, banOnResource);
+
+		List<BanOnResource> bansOnResource = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertTrue(bansOnResource.size() == 1);
+
+		perun.getResourcesManagerBl().removeAllExpiredBansOnResources(sess);
+
+		bansOnResource = resourcesManager.getBansForResource(sess, banOnResource.getResourceId());
+		assertTrue(bansOnResource.size() == 1);
 	}
 
 	// PRIVATE METHODS -----------------------------------------------------------

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1091,6 +1091,34 @@ create table blacklists (
 	modified_by_uid integer
 );
 
+create table resources_bans (
+  id integer not null,
+  member_id integer not null,
+  resource_id integer not null,
+  description nvarchar2(1024),                                                                       
+  banned_to date not null,
+  created_at date default sysdate not null,
+  created_by nvarchar2(1024) default user not null,
+  modified_at date default sysdate not null,
+  modified_by nvarchar2(1024) default user not null,
+  created_by_uid integer,
+  modified_by_uid integer
+);
+
+create table facilities_bans (
+	id integer not null,
+  user_id integer not null,
+  facility_id integer not null,
+  description nvarchar2(1024),                                                                       
+  banned_to date not null,
+  created_at date default sysdate not null,
+  created_by nvarchar2(1024) default user not null,
+  modified_at date default sysdate not null,
+  modified_by nvarchar2(1024) default user not null,
+  created_by_uid integer,
+  modified_by_uid integer
+);
+
 create sequence ATTR_NAMES_ID_SEQ maxvalue 1.0000E+28 nocache;
 create sequence AUDITER_CONSUMERS_ID_SEQ maxvalue 1.0000E+28 nocache;
 create sequence AUDITER_LOG_ID_SEQ maxvalue 1.0000E+28 nocache;
@@ -1138,6 +1166,8 @@ create sequence ACTION_TYPES_SEQ maxvalue 1.0000E+28 nocache;
 create sequence RES_TAGS_SEQ maxvalue 1.0000E+28 nocache;
 create sequence MAILCHANGE_ID_SEQ maxvalue 1.0000E+28 nocache;
 create sequence PWDRESET_ID_SEQ maxvalue 1.0000E+28 nocache;
+create sequence RESOURCES_BANS_ID_SEQ maxvalue 1.0000E+28 nocache;
+create sequence FACILITIES_BANS_ID_SEQ maxvalue 1.0000E+28 nocache;
 
 create index idx_namespace on attr_names(namespace);
 create index idx_authz_user_role_id on authz (user_id,role_id);
@@ -1273,6 +1303,12 @@ create index IDX_FK_SEC_TEAM_FACS_SEC on security_teams_facilities (security_tea
 create index IDX_FK_SEC_TEAM_FACS_FAC on security_teams_facilities (facility_id);
 create index IDX_FK_BLLIST_USER on blacklists (user_id);
 create index IDX_FK_BLLIST_SECTEAM on blacklists (security_team_id);
+create index IDX_FK_RES_BAN_MEMBER on resources_bans (member_id);
+create index IDX_FK_RES_BAN_RES on resources_bans (resource_id);
+create index IDX_FK_RES_BAN_MEMBER_RES on resources_bans (member_id, resource_id);
+create index IDX_FK_FAC_BAN_USER on facilities_bans (user_id);
+create index IDX_FK_FAC_BAN_FAC on facilities_bans (facility_id);
+create index IDX_FK_FAC_BAN_USER_FAC on facilities_bans (user_id, facility_id);
 
 alter table auditer_log add (constraint AUDLOG_PK primary key (id));
 alter table auditer_consumers add (constraint AUDCON_PK primary key (id),
@@ -1534,6 +1570,20 @@ constraint BLLIST_SECTEAM_FK foreign key (security_team_id) references security_
 constraint BLLIST_USER_FK foreign key (user_id) references users(id)
 );
 
+alter table resources_bans add (
+constraint res_bans_pk primary key (id),
+constraint res_bans_u unique(member_id, resource_id),
+constraint res_bans_mem_fk foreign key (member_id) references members (id),
+constraint res_bans_res_fk foreign key (resource_id) references resources (id)
+);
+
+alter table facilities_bans add (
+constraint fac_bans_pk primary key (id),
+constraint fac_bans_u unique(user_id, facility_id),
+constraint fac_bans_usr_fk foreign key (user_id) references users (id),
+constraint fac_bans_fac_fk foreign key (facility_id) references facilities (id)
+);
+
 alter table authz add (
 constraint AUTHZ_ROLE_FK foreign key (role_id) references roles(id),
 constraint AUTHZ_USER_FK foreign key (user_id) references users(id),
@@ -1728,4 +1778,4 @@ constraint pwdreset_u_fk foreign key (user_id) references users(id)
 );
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.35');
+insert into configurations values ('DATABASE VERSION','3.1.36');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1173,6 +1173,34 @@ create table "blacklists" (
 	modified_by_uid integer
 );
 
+create table "resources_bans" (
+	id integer not null,
+	member_id integer not null,
+	resource_id integer not null,
+	description varchar(1024),
+	banned_to timestamp not null,
+	created_at timestamp default now() not null,
+	created_by varchar(1024) default user not null,
+	modified_at timestamp default now() not null,
+	modified_by varchar(1024) default user not null,
+	created_by_uid integer,
+	modified_by_uid integer
+);
+
+create table "facilities_bans" (
+	id integer not null.
+	user_id integer not null,
+	facility_id integer not null,
+	description varchar(1024),
+	banned_to timestamp not null,
+	created_at timestamp default now() not null,
+	created_by varchar(1024) default user not null,
+	modified_at timestamp default now() not null,
+	modified_by varchar(1024) default user not null,
+	created_by_uid integer,
+	modified_by_uid integer
+);
+
 create sequence "attr_names_id_seq" maxvalue 9223372036854775807;
 create sequence "auditer_consumers_id_seq" maxvalue 9223372036854775807;
 create sequence "auditer_log_id_seq" maxvalue 9223372036854775807;
@@ -1221,6 +1249,8 @@ create sequence "res_tags_seq" maxvalue 9223372036854775807;
 create sequence "mailchange_id_seq" maxvalue 9223372036854775807;
 create sequence "pwdreset_id_seq" maxvalue 9223372036854775807;
 create sequence "security_teams_id_seq" maxvalue 9223372036854775807;
+create sequence "resources_bans_id_seq" maxvalue 9223372036854775807;
+create sequence "facilities_bans_id_seq" maxvalue 9223372036854775807;
 
 create index idx_namespace on attr_names(namespace);
 create index idx_authz_user_role_id on authz (user_id,role_id);
@@ -1361,7 +1391,12 @@ create index idx_fk_security_teams_facilities_security_team on security_teams_fa
 create index idx_fk_security_teams_facilities_facilities on security_teams_facilities (facility_id);
 create index idx_fk_bllist_user on blacklists (user_id);
 create index idx_fk_bllist_secteam on blacklists (security_team_id);
-
+create index idx_fk_res_ban_member on resources_bans (member_id);
+create index idx_fk_res_ban_res on resources_bans (resource_id);
+create index idx_fk_res_ban_member_res on resources_bans (member_id, resource_id);
+create index idx_fk_fac_ban_user on facilities_bans (user_id);
+create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
+create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
 
 alter table auditer_log add constraint audlog_pk primary key (id);
 
@@ -1662,6 +1697,16 @@ alter table blacklists add constraint bllist_pk primary key (security_team_id,us
 alter table blacklists add constraint bllist_secteam_fk foreign key (security_team_id) references security_teams (id);
 alter table blacklists add constraint bllist_user_fk foreign key (user_id) references users(id);
 
+alter table resources_bans add constraint res_bans_pk primary key (id);
+alter table resources_bans add constraint res_bans_u unique (member_id, resource_id);
+alter table resources_bans add constraint res_bans_mem_fk foreign key (member_id) references members (id);
+alter table resources_bans add constraint res_bans_res_fk foreign key (resource_id) references resources (id);
+
+alter table facilities_bans add constraint fac_bans_pk primary key (id);
+alter table facilities_bans add constraint fac_bans_u unique (user_id, facility_id);
+alter table facilities_bans add constraint fac_bans_usr_fk foreign key (user_id) references users (id);
+alter table facilities_bans add constraint fac_bans_fac_fk foreign key (facility_id) references facilities (id);
+
 alter table authz add constraint authz_role_fk foreign key (role_id) references roles(id);
 alter table authz add constraint authz_user_fk foreign key (user_id) references users(id);
 alter table authz add constraint authz_authz_group_fk foreign key (authorized_group_id) references groups(id);
@@ -1776,7 +1821,9 @@ grant all on pwdreset to perun;
 grant all on security_teams to perun;
 grant all on security_teams_facilities to perun;
 grant all on blacklists to perun;
+grant all on resources_bans to perun;
+grant all on facilities_bans to perun;
 grant all on membership_types to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.35');
+insert into configurations values ('DATABASE VERSION','3.1.36');

--- a/perun-db/table_order
+++ b/perun-db/table_order
@@ -32,6 +32,8 @@ host_attr_values
 auditer_consumers
 security_teams_facilities
 blacklists
+resources_bans
+facilities_bans
 service_processing_rule
 service_required_attrs
 specific_user_users

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -17,6 +17,8 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.AuditMessagesManager;
+import cz.metacentrum.perun.core.api.BanOnFacility;
+import cz.metacentrum.perun.core.api.BanOnResource;
 import cz.metacentrum.perun.core.api.DatabaseManager;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.ExtSource;
@@ -281,6 +283,14 @@ public class ApiCaller {
 
 	public SecurityTeam getSecurityTeamById(int id) throws PerunException {
 		return getSecurityTeamsManager().getSecurityTeamById(rpcSession, id);
+	}
+
+	public BanOnFacility getBanOnFacility(int id) throws PerunException {
+		return getFacilitiesManager().getBanById(rpcSession, id);
+	}
+
+	public BanOnResource getBanOnResource(int id) throws PerunException {
+		return getResourcesManager().getBanById(rpcSession, id);
 	}
 
 	public AttributeDefinition getAttributeDefinitionById(int id) throws PerunException {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -1052,5 +1052,138 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 					ac.getSecurityTeamById(parms.readInt("securityTeam")));
 			return null;
 		}
+	},
+
+	/*#
+	 *  Set ban for user on facility.
+	 *
+	 * @param banOnFacility BanOnFacility JSON object
+	 * @return BanOnFacility Created banOnFacility
+	 */
+	setBan {
+
+		@Override
+		public BanOnFacility call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			return ac.getFacilitiesManager().setBan(ac.getSession(),
+					parms.read("banOnFacility", BanOnFacility.class));
+
+		}
+	},
+
+	/*#
+	 *  Get Ban for user on facility by it's id.
+	 *
+	 * @param banId int BanOnFacility <code>id</code>
+	 * @return BanOnFacility banOnFacility
+	 */
+	getBanById {
+
+		@Override
+		public BanOnFacility call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getFacilitiesManager().getBanById(ac.getSession(),
+					parms.readInt("banId"));
+
+		}
+	},
+
+	/*#
+	 *  Get ban by userId and facilityId.
+	 *
+	 * @param userId int User <code>id</code>
+	 * @param facilityId int Facility <code>id</code>
+	 * @return BanOnFacility banOnFacility
+	 */
+	getBan {
+
+		@Override
+		public BanOnFacility call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getFacilitiesManager().getBan(ac.getSession(),
+					parms.readInt("userId"), parms.readInt("facilityId"));
+
+		}
+	},
+
+	/*#
+	 * Get all bans for user on any facility.
+	 *
+	 * @param userId int User <code>id</code>
+	 * @return List<BanOnFacility> userBansOnFacilities
+	 */
+	getBansForUser {
+
+		@Override
+		public List<BanOnFacility> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getFacilitiesManager().getBansForUser(ac.getSession(),
+					parms.readInt("userId"));
+
+		}
+	},
+
+	/*#
+	 * Get all bans for user on the facility.
+	 *
+	 * @param facilityId int Facility <code>id</code>
+	 * @return List<BanOnFacility> usersBansOnFacility
+	 */
+	getBansForFacility {
+
+		@Override
+		public List<BanOnFacility> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getFacilitiesManager().getBansForFacility(ac.getSession(),
+					parms.readInt("facilityId"));
+
+		}
+	},
+
+	/*#
+	 * Update existing ban (description, validation timestamp)
+	 *
+	 * @param banOnFacility BanOnFacility JSON object
+	 * @return BanOnFacility updated banOnFacility
+	 */
+	updateBan {
+
+		@Override
+		public BanOnFacility call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			return ac.getFacilitiesManager().updateBan(ac.getSession(),
+					ac.getBanOnFacility(parms.readInt("banOnFacility")));
+
+		}
+	},
+
+	/*#
+	 * Remove specific ban by it's id.
+	 *
+	 * @param banId int BanOnFacility <code>id</code>
+	 */
+	/*#
+	 * Remove specific ban by userId and facilityId.
+	 *
+	 * @param userId int User <code>id</code>
+	 * @param facilityId int Facility <code>id</code>
+	 */
+	removeBan {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			if(parms.contains("banId")) {
+				ac.getFacilitiesManager().removeBan(ac.getSession(),
+					parms.readInt("banId"));
+			} else {
+				ac.getFacilitiesManager().removeBan(ac.getSession(),
+					parms.readInt("userId"), parms.readInt("facilityId"));
+			}
+			return null;
+		}
 	};
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.rpc.methods;
 
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,6 +18,7 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
+import cz.metacentrum.perun.core.api.BanOnResource;
 
 public enum ResourcesManagerMethod implements ManagerMethod {
 
@@ -771,6 +773,139 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 			return ac.getResourcesManager().getAssignedServices(ac.getSession(),
 					ac.getResourceById(parms.readInt("resource")));
 
+		}
+	},
+
+	/*#
+	 *  Set ban for member on resource.
+	 *
+	 * @param banOnResource BanOnResource JSON object
+	 * @return BanOnResource Created banOnResource
+	 */
+	setBan {
+
+		@Override
+		public BanOnResource call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			return ac.getResourcesManager().setBan(ac.getSession(),
+					parms.read("banOnResource", BanOnResource.class));
+
+		}
+	},
+
+	/*#
+	 *  Get Ban for member on resource by it's id.
+	 *
+	 * @param banId int BanOnResource <code>id</code>
+	 * @return BanOnResource banOnResource
+	 */
+	getBanById {
+
+		@Override
+		public BanOnResource call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getResourcesManager().getBanById(ac.getSession(),
+					parms.readInt("banId"));
+
+		}
+	},
+
+	/*#
+	 *  Get ban by memberId and resource id.
+	 *
+	 * @param memberId int Member <code>id</code>
+	 * @param resourceId int Resource <code>id</code>
+	 * @return BanOnResource banOnResource
+	 */
+	getBan {
+
+		@Override
+		public BanOnResource call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getResourcesManager().getBan(ac.getSession(),
+					parms.readInt("memberId"), parms.readInt("resourceId"));
+
+		}
+	},
+
+	/*#
+	 * Get all bans for member on any resource.
+	 *
+	 * @param memberId int Member <code>id</code>
+	 * @return List<BanOnResource> memberBansOnResources
+	 */
+	getBansForMember {
+
+		@Override
+		public List<BanOnResource> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getResourcesManager().getBansForMember(ac.getSession(),
+					parms.readInt("memberId"));
+
+		}
+	},
+
+	/*#
+	 * Get all bans for members on the resource.
+	 *
+	 * @param resourceId int Resource <code>id</code>
+	 * @return List<BanOnResource> membersBansOnResource
+	 */
+	getBansForResource {
+
+		@Override
+		public List<BanOnResource> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getResourcesManager().getBansForResource(ac.getSession(),
+					parms.readInt("resourceId"));
+
+		}
+	},
+
+	/*#
+	 * Update existing ban (description, validation timestamp)
+	 *
+	 * @param banOnResource BanOnResource JSON object
+	 * @return BanOnResource updated banOnResource
+	 */
+	updateBan {
+
+		@Override
+		public BanOnResource call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+			
+			return ac.getResourcesManager().updateBan(ac.getSession(),
+					ac.getBanOnResource(parms.readInt("banOnResource")));
+
+		}
+	},
+
+	/*#
+	 * Remove specific ban by it's id.
+	 *
+	 * @param banId int BanOnResource <code>id</code>
+	 */
+	/*#
+	 * Remove specific ban by memberId and resourceId.
+	 *
+	 * @param memberId int Member <code>id</code>
+	 * @param resourceId int Resource <code>id</code>
+	 */
+	removeBan {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			if(parms.contains("banId")) {
+				ac.getResourcesManager().removeBan(ac.getSession(),
+					parms.readInt("banId"));
+			} else {
+				ac.getResourcesManager().removeBan(ac.getSession(),
+					parms.readInt("memberId"), parms.readInt("resourceId"));
+			}
+			return null;
 		}
 	};
 }


### PR DESCRIPTION
 - all changes to database changelogs and schemas (oracle, postgresql,
   hsqldb)
 - new objects for work with bans (Ban, BanOnFacility and BanOnResource)
 - parsing and testing of parsing for new objects (auditParser)
 - new methods for work with bans (get, set, update, remove) to
   resourcesManagers and facilitiesManagers
 - add new methods also to RPC
 - tests for all new methods in entry (facility and resource tests)
 - add new method to Synchronizer and create cron job for calling this
   method (for purpose of removing already expired bans once a day)
 - new virtual attribute member_resource isBanned to get information if
   member is banned somewhere on resource or facility
 - needed abstract module and api for member resource virtual attribute
   modules
 - new Compatibility method getDate to get sql date or timestamp by type
   of database
 - new exceptions (banAlreadyExists and banNotExists) for better
   information in the new funcionality