### PR TITLE
GUI: Disable application form and password reset modules

### DIFF
--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -119,8 +119,10 @@
 				  gwt-maven-plugin documentation at codehaus.org -->
 				<configuration>
 					<modules>
+						<!-- We use new WUI apps for these
 						<module>cz.metacentrum.perun.webgui.application-form</module>
 						<module>cz.metacentrum.perun.webgui.password-reset</module>
+						-->
 						<module>cz.metacentrum.perun.webgui.perun-web</module>
 					</modules>
 					<runTarget>PerunWeb.html</runTarget>
@@ -244,8 +246,10 @@
 						  gwt-maven-plugin documentation at codehaus.org -->
 						<configuration>
 							<modules>
+								<!-- We use new WUI apps for these
 								<module>cz.metacentrum.perun.webgui.application-form-prod</module>
 								<module>cz.metacentrum.perun.webgui.password-reset-prod</module>
+								-->
 								<module>cz.metacentrum.perun.webgui.perun-web-prod</module>
 							</modules>
 							<runTarget>PerunWeb.html</runTarget>


### PR DESCRIPTION
- We do use new WUI apps for user registration and password reset.
  Build of old modules is now disabled in pom.xml. Only main Perun GUI
  will be build and deployed.