### PR TITLE
GUI: Increase min app size of GUI from 960x600 to 1200x700.

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
@@ -55,8 +55,8 @@ public class WebGui implements EntryPoint, ValueChangeHandler<String> {
 	private UrlMapper urlMapper;
 
 	// min client height & width
-	static final public int MIN_CLIENT_HEIGHT = 600;  // when changed update .css file too !!
-	static final public int MIN_CLIENT_WIDTH = 980; // when changed update .css file too !!
+	static final public int MIN_CLIENT_HEIGHT = 700;  // when changed update .css file too !!
+	static final public int MIN_CLIENT_WIDTH = 1200; // when changed update .css file too !!
 
 	// perun loaded (is checked when page loads)
 	private boolean perunLoaded = false;

--- a/perun-web-gui/src/main/webapp/PerunWeb.css
+++ b/perun-web-gui/src/main/webapp/PerunWeb.css
@@ -7,15 +7,15 @@
  */
 
 .mainPanel{
-    min-height:600px;
-    min-width:960px;
+    min-height:700px;
+    min-width:1200px;
     height: 100%;
 }
 
 /* Header */
 .perun-header {
     width: 100%;
-    min-width: 960px;
+    min-width: 1200px;
     height: 64px;
     max-height: 64px;
 }


### PR DESCRIPTION
- It will fix display of bigger data tables like the one for TaskResults.