### PR TITLE
DB: Insert into membership_types when creating DB schema

### DIFF
--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1777,3 +1777,7 @@ constraint pwdreset_u_fk foreign key (user_id) references users(id)
 
 -- set initial Perun DB version
 insert into configurations values ('DATABASE VERSION','3.1.36');
+
+-- insert membership types
+insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
+insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added into subgroup');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1827,3 +1827,7 @@ grant all on membership_types to perun;
 
 -- set initial Perun DB version
 insert into configurations values ('DATABASE VERSION','3.1.36');
+
+-- insert membership types
+insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
+insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added into subgroup');


### PR DESCRIPTION
- We have 2 fixed MembershipTypes, insert them in an empty schema
  so they are not missing on runtime (creating member in VO, adding
  to VO).