### PR TITLE
CORE,GUI: Fixed support for member-resource attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1200,7 +1200,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			return jdbc.queryForObject("select " + getAttributeMappingSelectQuery("mem") + " from attr_names " +
 					"left join   member_resource_attr_values mem    on id=mem.attr_id and mem.resource_id=? and member_id=? " +
 					"where attr_name=?",
-					new AttributeRowMapper(sess, this, null), resource.getId(), member.getId(), attributeName);
+					new AttributeRowMapper(sess, this, resource, member), resource.getId(), member.getId(), attributeName);
 
 
 		} catch(EmptyResultDataAccessException ex) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesV2.java
@@ -69,11 +69,19 @@ public class GetAttributesV2 implements JsonCallback, JsonCallbackTable<Attribut
 
 	private boolean editable = true;
 	private boolean checkable = true;
+	private boolean ownClear = false;
 
 	/**
 	 * Creates new instance of callback
 	 */
 	public GetAttributesV2() {}
+
+	/**
+	 * Creates new instance of callback
+	 */
+	public GetAttributesV2(boolean ownClear) {
+		this.ownClear = ownClear;
+	}
 
 	/**
 	 * Creates new instance of callback
@@ -450,7 +458,7 @@ public class GetAttributesV2 implements JsonCallback, JsonCallbackTable<Attribut
 	public void onFinished(JavaScriptObject jso) {
 		loaderImage.loadingFinished();
 		friendlyTable.clear();
-		clearTable();
+		if (!ownClear) clearTable();
 		int counter = 0;
 		for (Attribute a : JsonUtils.<Attribute>jsoAsList(jso)) {
 			if (!a.getDefinition().equals("core")) {
@@ -481,7 +489,7 @@ public class GetAttributesV2 implements JsonCallback, JsonCallbackTable<Attribut
 	}
 
 	public void setList(ArrayList<Attribute> list) {
-		clearTable();
+		if (!ownClear) clearTable();
 		this.list.addAll(list);
 		dataProvider.flush();
 		dataProvider.refresh();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupSettingsTabItem.java
@@ -121,7 +121,7 @@ public class GroupSettingsTabItem implements TabItem, TabItemWithUrl {
 		ids.put("group", groupId);
 
 		// define GET ATTRIBUTES callback
-		final GetAttributesV2 jsonCallback = new GetAttributesV2();
+		final GetAttributesV2 jsonCallback = new GetAttributesV2(true);
 		jsonCallback.setIds(ids);
 		if (!session.isGroupAdmin(groupId) && !session.isVoAdmin(group.getVoId())) jsonCallback.setCheckable(false);
 		final CellTable<Attribute> table = jsonCallback.getEmptyTable();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberSettingsTabItem.java
@@ -92,7 +92,7 @@ public class MemberSettingsTabItem implements TabItem {
 		menu.addWidget(UiElements.getRefreshButton(this));
 
 		// callbacks
-		final GetAttributesV2 callback = new GetAttributesV2();
+		final GetAttributesV2 callback = new GetAttributesV2(true);
 		if (!session.isVoAdmin(member.getVoId()) && !session.isGroupAdmin(groupId)) {
 			callback.setCheckable(false);
 		}


### PR DESCRIPTION
CORE
- Fixed usage of AttributeRowMapper for getting mem-res attribute by name.

GUI
- Do not clear table on loading finished in GetAttributes since it's
  filled by multiple calls.
  This will allow us to see member-resource attributes on member
  settings and group settings page.