### PR TITLE
GUI,REGISTRAR: Added new RegistrarModule logic canBeApproved() and beforeApprove()

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.registrar;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.exceptions.DuplicateRegistrationAttemptException;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationForm;
@@ -291,6 +292,20 @@ public interface RegistrarManager {
 	 * @throws PerunException
 	 */
 	Application approveApplicationInternal(PerunSession session, int appId) throws PerunException;
+
+	/**
+	 * Throws exception if application can't be approved based on form module rules.
+	 * Is meant to be used from GUI before actual approval happens so VO/Group admin can override
+	 * this default behavior.
+	 *
+	 * @param session Who wants to approve application
+	 * @param application Application to check approval for
+	 * @throws CantBeApprovedException
+	 * @throws PrivilegeException
+	 * @throws InternalErrorException
+	 * @throws PerunException
+	 */
+	void canBeApproved(PerunSession session, Application application) throws PerunException;
 
 	/**
 	 * Manually rejects an application. Expected to be called as a result of direct VO administrator action in the web UI.

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
@@ -65,6 +65,6 @@ public interface RegistrarModule {
 	 * @param session who approves the application
 	 * @param app application
 	 */
-	void canBeApproved(PerunSession session, Application app) throws CantBeApprovedException;
+	void canBeApproved(PerunSession session, Application app) throws PerunException;
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 
@@ -14,6 +15,13 @@ import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
 public interface RegistrarModule {
+
+	/**
+	 * Sets registrar manager for usage in a module code.
+	 *
+	 * @param registrar
+	 */
+	void setRegistrar(RegistrarManager registrar);
 
 	/**
 	 * Creates a new application.
@@ -42,5 +50,21 @@ public interface RegistrarModule {
 	 * @param reason optional reason of rejection displayed to user
 	 */
 	Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException;
+
+	/**
+	 * Calls custom logic before approving of application starts -> e.g do not validate passwords when this fails
+	 *
+	 * @param session who approves the application
+	 * @param app application
+	 */
+	Application beforeApprove(PerunSession session, Application app) throws PerunException;
+
+	/**
+	 * Custom logic for checking method before application approval from GUI
+	 *
+	 * @param session who approves the application
+	 * @param app application
+	 */
+	void canBeApproved(PerunSession session, Application app) throws CantBeApprovedException;
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/CantBeApprovedException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/CantBeApprovedException.java
@@ -1,0 +1,23 @@
+package cz.metacentrum.perun.registrar.exceptions;
+
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+
+/**
+ * Exception throw when application can't be approved by custom VO rules.
+ * It's not meant as a "hard" error but only as a notice to GUI.
+ *
+ * @author Pavel Zlamal <256627@mail.muni.cz>
+ */
+public class CantBeApprovedException extends PerunException {
+
+	private static final long serialVersionUID = 1L;
+
+	public CantBeApprovedException(String message) {
+		super(message);
+	}
+
+	public CantBeApprovedException(String message, Throwable ex) {
+		super(message, ex);
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/CantBeApprovedException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/CantBeApprovedException.java
@@ -12,12 +12,51 @@ public class CantBeApprovedException extends PerunException {
 
 	private static final long serialVersionUID = 1L;
 
+	private String reason = null;
+	private String category = null;
+	private String affiliation = null;
+
 	public CantBeApprovedException(String message) {
 		super(message);
+	}
+
+	public CantBeApprovedException(String message, String reason, String category, String affiliation) {
+		super(message);
+		this.reason = reason;
+		this.category = category;
+		this.affiliation = affiliation;
 	}
 
 	public CantBeApprovedException(String message, Throwable ex) {
 		super(message, ex);
 	}
 
+	public CantBeApprovedException(String message, String reason, Throwable ex) {
+		super(message, ex);
+		this.reason = reason;
+	}
+
+	public String getReason() {
+		return reason;
+	}
+
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+
+	public String getCategory() {
+		return category;
+	}
+
+	public void setCategory(String category) {
+		this.category = category;
+	}
+
+	public String getAffiliation() {
+		return affiliation;
+	}
+
+	public void setAffiliation(String affiliation) {
+		this.affiliation = affiliation;
+	}
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Du.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Du.java
@@ -1,0 +1,116 @@
+package cz.metacentrum.perun.registrar.modules;
+
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.registrar.RegistrarManager;
+import cz.metacentrum.perun.registrar.RegistrarModule;
+import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
+import cz.metacentrum.perun.registrar.model.Application;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Custom logic for all CESNET DataCenter VOs
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class Du implements RegistrarModule {
+
+	final static Logger log = LoggerFactory.getLogger(Du.class);
+
+	private RegistrarManager registrar;
+
+	@Override
+	public void setRegistrar(RegistrarManager registrar) {
+		this.registrar = registrar;
+	}
+
+	@Override
+	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
+		return data;
+	}
+
+	@Override
+	public Application approveApplication(PerunSession session, Application app) throws PerunException {
+		return app;
+	}
+
+	@Override
+	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
+		return app;
+	}
+
+	@Override
+	public Application beforeApprove(PerunSession session, Application app) throws PerunException {
+
+		List<ApplicationFormItemData> data = registrar.getApplicationDataById(session, app.getId());
+
+		// if hostel with LoA = 2 => OK
+		if (Objects.equals(app.getExtSourceName(), "https://idp.hostel.eduid.cz/idp/shibboleth") &&
+				app.getExtSourceLoa() == 2) return app;
+
+		// For others check IdP attributes
+		String category = "";
+		String affiliation = "";
+
+		for (ApplicationFormItemData item : data) {
+			if (item.getFormItem() != null && Objects.equals("md_entityCategory", item.getFormItem().getFederationAttribute())) {
+				if (item.getValue() != null && !item.getValue().trim().isEmpty()) {
+					category = item.getValue();
+					break;
+				}
+			}
+		}
+
+		for (ApplicationFormItemData item : data) {
+			if (item.getFormItem() != null && Objects.equals("affiliation", item.getFormItem().getFederationAttribute())) {
+				if (item.getValue() != null && !item.getValue().trim().isEmpty()) {
+					affiliation = item.getValue();
+					break;
+				}
+			}
+		}
+
+		switch(category) {
+			case "university" : {
+				if (affiliation.contains("employee@") ||
+						affiliation.contains("faculty@") ||
+						affiliation.contains("member@") ||
+						affiliation.contains("student@") ||
+						affiliation.contains("staff@"))
+					return app;
+			}
+			case "avcr" : {
+				if (affiliation.contains("member@")) return app;
+			}
+			case "library" : {
+				if (affiliation.contains("employee@")) return app;
+			}
+			case "hospital" : {
+				if (affiliation.contains("employee@")) return app;
+			}
+			case "other" : {
+				if (affiliation.contains("employee@") || affiliation.contains("member@")) return app;
+			}
+
+		}
+
+		throw new CantBeApprovedException("User is not active academia member or submitted his registration using non-academic identity. Please reject this application and let user know that he has to use different identity to log-in to registration interface.");
+
+	}
+
+	@Override
+	public void canBeApproved(PerunSession session, Application app) throws CantBeApprovedException {
+		try {
+			beforeApprove(session, app);
+		} catch (PerunException ex) {
+			if (ex instanceof CantBeApprovedException) throw (CantBeApprovedException) ex;
+			throw new CantBeApprovedException(ex.getMessage(), ex);
+		}
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Du.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Du.java
@@ -99,18 +99,15 @@ public class Du implements RegistrarModule {
 
 		}
 
-		throw new CantBeApprovedException("User is not active academia member or submitted his registration using non-academic identity. Please reject this application and let user know that he has to use different identity to log-in to registration interface.");
+		throw new CantBeApprovedException("User is not active academia member", "NOT_ACADEMIC", category, affiliation);
 
 	}
 
 	@Override
-	public void canBeApproved(PerunSession session, Application app) throws CantBeApprovedException {
-		try {
-			beforeApprove(session, app);
-		} catch (PerunException ex) {
-			if (ex instanceof CantBeApprovedException) throw (CantBeApprovedException) ex;
-			throw new CantBeApprovedException(ex.getMessage(), ex);
-		}
+	public void canBeApproved(PerunSession session, Application app) throws PerunException {
+
+		beforeApprove(session, app);
+
 	}
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ELIXIRCILogonDNGenerator.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ELIXIRCILogonDNGenerator.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
@@ -46,6 +47,13 @@ public class ELIXIRCILogonDNGenerator implements RegistrarModule {
 
 	public static String RDN_TRUNCATE_SIGN = "...";
 	public static int RDN_MAX_SIZE = 64;
+
+	private RegistrarManager registrarManager;
+
+	@Override
+	public void setRegistrar(RegistrarManager registrar) {
+		this.registrarManager = registrar;
+	}
 
 	@Override
 	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
@@ -117,6 +125,15 @@ public class ELIXIRCILogonDNGenerator implements RegistrarModule {
 	@Override
 	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
 		return app;
+	}
+
+	@Override
+	public Application beforeApprove(PerunSession session, Application app) throws PerunException {
+		return app;
+	}
+
+	@Override
+	public void canBeApproved(PerunSession session, Application app) throws PerunException {
 	}
 
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
@@ -2,7 +2,9 @@ package cz.metacentrum.perun.registrar.modules;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
+import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
@@ -16,6 +18,13 @@ import java.util.List;
 public class EduGain implements RegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(Metacentrum.class);
+
+	private RegistrarManager registrar;
+
+	@Override
+	public void setRegistrar(RegistrarManager registrar) {
+		this.registrar = registrar;
+	}
 
 	@Override
 	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
@@ -47,6 +56,16 @@ public class EduGain implements RegistrarModule {
 	@Override
 	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
 		return app;
+	}
+
+	@Override
+	public Application beforeApprove(PerunSession session, Application app) throws PerunException {
+		return app;
+	}
+
+	@Override
+	public void canBeApproved(PerunSession session, Application app) throws CantBeApprovedException {
+
 	}
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
@@ -64,7 +64,7 @@ public class EduGain implements RegistrarModule {
 	}
 
 	@Override
-	public void canBeApproved(PerunSession session, Application app) throws CantBeApprovedException {
+	public void canBeApproved(PerunSession session, Application app) throws PerunException {
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
@@ -3,13 +3,17 @@ package cz.metacentrum.perun.registrar.modules;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
+import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
+import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Module for VO Metacentrum
@@ -19,6 +23,13 @@ import java.util.List;
 public class Metacentrum implements RegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(Metacentrum.class);
+
+	private RegistrarManager registrar;
+
+	@Override
+	public void setRegistrar(RegistrarManager registrar) {
+		this.registrar = registrar;
+	}
 
 	@Override
 	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
@@ -55,4 +66,80 @@ public class Metacentrum implements RegistrarModule {
 	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
 		return app;
 	}
+
+	@Override
+	public Application beforeApprove(PerunSession session, Application app) throws PerunException {
+		return app;
+	}
+
+	@Override
+	public void canBeApproved(PerunSession session, Application app) throws CantBeApprovedException {
+
+		try {
+
+			// allow only Education & Research community members to
+			if (Application.AppType.EXTENSION.equals(app.getType())) {
+
+				// allow hostel with loa=2
+				if (Objects.equals(app.getExtSourceName(), "https://idp.hostel.eduid.cz/idp/shibboleth") &&
+						app.getExtSourceLoa() == 2) return;
+
+				List<ApplicationFormItemData> data = registrar.getApplicationDataById(session, app.getId());
+
+				String category = "";
+				String affiliation = "";
+
+				for (ApplicationFormItemData item : data) {
+					if (item.getFormItem() != null && Objects.equals("md_entityCategory", item.getFormItem().getFederationAttribute())) {
+						if (item.getValue() != null && !item.getValue().trim().isEmpty()) {
+							category = item.getValue();
+							break;
+						}
+					}
+				}
+
+				for (ApplicationFormItemData item : data) {
+					if (item.getFormItem() != null && Objects.equals("affiliation", item.getFormItem().getFederationAttribute())) {
+						if (item.getValue() != null && !item.getValue().trim().isEmpty()) {
+							affiliation = item.getValue();
+							break;
+						}
+					}
+				}
+
+				switch (category) {
+					case "university": {
+						if (affiliation.contains("employee@") ||
+								affiliation.contains("faculty@") ||
+								affiliation.contains("member@") ||
+								affiliation.contains("student@") ||
+								affiliation.contains("staff@"))
+							return;
+					}
+					case "avcr": {
+						if (affiliation.contains("member@")) return;
+					}
+					case "library": {
+						if (affiliation.contains("employee@")) return;
+					}
+					case "hospital": {
+						if (affiliation.contains("employee@")) return;
+					}
+					case "other": {
+						if (affiliation.contains("employee@") || affiliation.contains("member@")) return;
+					}
+
+				}
+
+				throw new CantBeApprovedException("User is not active academia member or submitted his registration using non-academic identity. Please reject this application and let user know that he has to use different identity to log-in to registration interface.");
+
+			}
+
+		} catch (Exception ex) {
+			if (ex instanceof CantBeApprovedException) throw (CantBeApprovedException) ex;
+			throw new CantBeApprovedException(ex.getMessage(), ex);
+		}
+
+	}
+
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -595,6 +595,24 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Check if application can be approved based on form module rules. Throws exception if not.
+	 * Expected to be called from Web UI before actual approving happens, so VO admin
+	 * can override this default behavior.
+	 *
+	 * @param id int Application <code>id</code>
+	 * @throw CantBeApprovedException When application can't be approved based on form module rules.
+	 */
+	canBeApproved {
+
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getRegistrarManager().canBeApproved(ac.getSession(), ac.getApplicationById(parms.readInt("id")));
+			return null;
+		}
+
+	},
+
+	/*#
 	 * Manually rejects an application.
 	 * Expected to be called as a result of direct VO administrator action in the web UI.
 	 *

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/HandleApplication.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/HandleApplication.java
@@ -201,7 +201,15 @@ public class HandleApplication {
 					FlexTable layout = new FlexTable();
 
 					layout.setWidget(0, 0, new HTML("<p>" + new Image(LargeIcons.INSTANCE.errorIcon())));
-					layout.setHTML(0, 1, "<p>" + error.getErrorInfo() + "<p>If needed, you can override above restriction by clicking 'Approve' button again.");
+
+					if ("NOT_ACADEMIC".equals(error.getReason())) {
+						layout.setHTML(0, 1, "<p>User is not active academia member and application shouldn't be approved.<p><b>LoA:</b> " + app.getExtSourceLoa() +
+								"</br><b>IdP category:</b> " + (!(error.getCategory().equals("")) ? error.getCategory() : "N/A") +
+								"</br><b>Affiliation:</b> " + (!(error.getAffiliation().equals("")) ? error.getAffiliation().replace(";", ", ") : "N/A") +
+								"<p>You can try to override above restriction by clicking 'Approve' button again.");
+					} else {
+						layout.setHTML(0, 1, "<p>" + error.getErrorInfo() + "<p>You can try to override this restriction by clicking 'Approve anyway' button again.");
+					}
 
 					layout.getFlexCellFormatter().setAlignment(0, 0, HasHorizontalAlignment.ALIGN_LEFT, HasVerticalAlignment.ALIGN_TOP);
 					layout.getFlexCellFormatter().setAlignment(0, 1, HasHorizontalAlignment.ALIGN_LEFT, HasVerticalAlignment.ALIGN_TOP);
@@ -223,7 +231,7 @@ public class HandleApplication {
 						}
 					}, true);
 
-					c.setOkButtonText("Approve");
+					c.setOkButtonText("Approve anyway");
 					c.setNonScrollable(true);
 					c.show();
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PerunError.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/PerunError.java
@@ -71,6 +71,30 @@ public class PerunError extends JavaScriptObject {
 		return this.reason;
 	}-*/;
 
+	/**
+	 * Return IdP category for CantBeApprovedException
+	 *
+	 * @return IdP category for CantBeApprovedException
+	 */
+	public final native String getCategory() /*-{
+		if (!this.category) {
+			return "";
+		}
+		return this.category;
+	}-*/;
+
+	/**
+	 * Return users affiliation for CantBeApprovedException
+	 *
+	 * @return users affiliation for CantBeApprovedException
+	 */
+	public final native String getAffiliation() /*-{
+		if (!this.affiliation) {
+			return "";
+		}
+		return this.affiliation;
+	}-*/;
+
     public final native void setType(String type) /*-{
 		this.type = type;
 	}-*/;


### PR DESCRIPTION
- We can now use custom beforeApprove() method, which is called
  before application is approved. More specifically, before password is
  validated since it's non reversible change.
- Implemented filter for Educational && Research community which prevents
  approving of application if proper IdP attributes are not passed to form.
- Added check canBeApproved() - for any application can be performed on demand.
- Call this check from GUI before actually approving application. If it throws
   exception - VO/Group admin can still override it and approve registration.
   If it's ok, process continues as before.
   If check must be enforced, same logic needs to be implemented in a module
   method beforeApproval() which makes approving fail the hard way.
- Above logic satisfy DU and Meta different requirements.
- Allow LoA = 2 from hostel IdP for Meta and DU.