### PR TITLE
Change lightweight synchronization procedure

### DIFF
--- a/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
+++ b/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
@@ -370,7 +370,9 @@ public class AuditParserTest {
 		attributesMap1.put("test1", null);
 		attributesMap1.put(null, null);
 		Candidate candidate1 = new Candidate(userExtSource1, attributesMap1);
-		Candidate candidate2 = new Candidate(null, null);
+		Candidate candidate2 = new Candidate();
+		candidate2.setUserExtSource(null);
+		candidate2.setAttributes(null);
 		candidate1.setId(5);
 		candidate2.setId(6);
 		candidate1.setAdditionalUserExtSources(null);

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
@@ -26,6 +26,20 @@ public class Candidate extends User {
 	public Candidate() {
 	}
 
+	//Special constructor to get candidate from user
+	public Candidate(User user, UserExtSource userExtSource) {
+		if(user != null) {
+			this.setFirstName(user.getFirstName());
+			this.setLastName(user.getLastName());
+			this.setMiddleName(user.getMiddleName());
+			this.setTitleAfter(user.getTitleAfter());
+			this.setTitleBefore(user.getTitleBefore());
+			this.setServiceUser(user.isServiceUser());
+			this.setSponsoredUser(user.isSponsoredUser());
+		}
+		this.userExtSource = userExtSource;
+	}
+
 	public Candidate(UserExtSource userExtSource, Map<String, String> attributes) {
 		this();
 		this.userExtSource = userExtSource;


### PR DESCRIPTION
 - set just existence in groups (add and remove, do not update at all)
 - try to find member first just by login and if not, use normal way
 - much quicker way if members are already synchronized and we don't
   need to care about update attributes there (some other group do that)