### PR TITLE
CORE, GUI: Complete rework of password management for MU

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -907,7 +907,8 @@ public interface UsersManager {
 		throws InternalErrorException, UserNotExistsException, VoNotExistsException, PrivilegeException;
 
 	/**
-	 * Allow users to manually add login in supported namespace if same login is not reserved
+	 * Allow users to manually add login in supported namespace if same login is not reserved.
+	 * Can be set only to own service or guest users => specific users.
 	 *
 	 * @param sess
 	 * @param user

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.api;
 
 import java.util.List;
+import java.util.Map;
 
 import cz.metacentrum.perun.core.api.exceptions.*;
 
@@ -1003,4 +1004,24 @@ public interface UsersManager {
 	 * @throws UserExtSourceNotExistsException
 	 */
 	void updateUserExtSourceLastAccess(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException, PrivilegeException, UserExtSourceNotExistsException;
+
+	/**
+	 * Generate user account in a backend system associated with login-namespace in Perun.
+	 *
+	 * This method consumes optional parameters map. Requirements are implementation-dependant
+	 * for each login-namespace.
+	 *
+	 * Returns map with
+	 * 1: key=login-namespace attribute urn, value=generated login
+	 * 2: rest of opt response attributes...
+	 *
+	 * @param session
+	 * @param namespace Namespace to generate account in
+	 * @param parameters Optional parameters
+	 * @return Map of data from backed response
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException, PrivilegeException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.bl;
 
 import java.util.List;
+import java.util.Map;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
@@ -1096,4 +1097,23 @@ public interface UsersManagerBl {
 	 * @throws InternalErrorException
 	 */
 	int getUsersCount(PerunSession perunSession) throws InternalErrorException;
+
+	/**
+	 * Generate user account in a backend system associated with login-namespace in Perun.
+	 *
+	 * This method consumes optional parameters map. Requirements are implementation-dependant
+	 * for each login-namespace.
+	 *
+	 * Returns map with
+	 * 1: key=login-namespace attribute urn, value=generated login
+	 * 2: rest of opt response attributes...
+	 *
+	 * @param session
+	 * @param namespace Namespace to generate account in
+	 * @param parameters Optional parameters
+	 * @return Map of data from backed response
+	 * @throws InternalErrorException
+	 */
+	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1794,4 +1794,10 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	public int getUsersCount(PerunSession sess) throws InternalErrorException {
 		return getUsersManagerImpl().getUsersCount(sess);
 	}
+
+	@Override
+	public Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException {
+		return getUsersManagerImpl().generateAccount(session, namespace, parameters);
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1167,6 +1167,47 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 				kerberosLoginsAttr.setValue(kerberosLogins);
 				getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
 
+			} else if (loginNamespace.equals("ics.muni.cz")) {
+
+				List<String> kerberosLogins = new ArrayList<String>();
+
+				ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "ICS.MUNI.CZ");
+				UserExtSource ues = new UserExtSource(extSource, userLogin + "@ICS.MUNI.CZ");
+				ues.setLoa(0);
+
+				try {
+					getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
+					kerberosLogins.add(userLogin + "@ICS.MUNI.CZ");
+				} catch(UserExtSourceExistsException ex) {
+					//this is OK
+				}
+
+				// Store also Kerberos logins
+				Attribute kerberosLoginsAttr;
+				try {
+					kerberosLoginsAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
+					if (kerberosLoginsAttr != null && kerberosLoginsAttr.getValue() != null) {
+						kerberosLogins.addAll((List<String>) kerberosLoginsAttr.getValue());
+					}
+				} catch (AttributeNotExistsException e) {
+					AttributeDefinition kerberosLoginsAttrDef = getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_USER_ATTR_DEF + ":" + "kerberosLogins");
+					kerberosLoginsAttr = new Attribute(kerberosLoginsAttrDef);
+				}
+				kerberosLoginsAttr.setValue(kerberosLogins);
+				getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
+
+			} else if (loginNamespace.equals("mu")) {
+
+				ExtSource extSource = getPerunBl().getExtSourcesManagerBl().getExtSourceByName(sess, "https://idp2.ics.muni.cz/idp/shibboleth");
+				UserExtSource ues = new UserExtSource(extSource, userLogin + "@muni.cz");
+				ues.setLoa(2);
+
+				try {
+					getPerunBl().getUsersManagerBl().addUserExtSource(sess, user, ues);
+				} catch(UserExtSourceExistsException ex) {
+					//this is OK
+				}
+
 			}
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1002,7 +1002,7 @@ public class UsersManagerEntry implements UsersManager {
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.SELF, user) && !user.isServiceUser()) {
+		if (!AuthzResolver.isAuthorized(sess, Role.SELF, user) && !user.isSpecificUser()) {
 			throw new PrivilegeException(sess, "setLogin");
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.entry;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
@@ -1095,4 +1096,19 @@ public class UsersManagerEntry implements UsersManager {
 
 		getUsersManagerBl().updateUserExtSourceLastAccess(sess, userExtSource);
 	}
+
+	@Override
+	public Map<String,String> generateAccount(PerunSession sess, String namespace, Map<String, String> parameters) throws InternalErrorException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.REGISTRAR)) {
+			throw new PrivilegeException(sess, "generateAccount");
+		}
+
+		return getUsersManagerBl().generateAccount(sess, namespace, parameters);
+
+	}
+
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1184,21 +1184,14 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 		PasswordManagerModule module = getPasswordManagerModule(session, namespace);
 		if (module != null) {
-			return module.generateAccount(session, namespace, parameters);
+			return module.generateAccount(session, parameters);
 		}
 		return null;
 
 	}
 
-	/**
-	 * Return instance of PasswordManagerModule for specified namespace or throw exception.
-	 *
-	 * @param session
-	 * @param namespace Namespace to get PWDMGR module.
-	 * @return
-	 * @throws InternalErrorException
-	 */
-	private PasswordManagerModule getPasswordManagerModule(PerunSession session, String namespace) throws InternalErrorException {
+	@Override
+	public PasswordManagerModule getPasswordManagerModule(PerunSession session, String namespace) throws InternalErrorException {
 
 		if (namespace == null || namespace.isEmpty()) throw new InternalErrorException("Login-namespace to get password manager module must be specified.");
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -6,11 +6,13 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.sql.DataSource;
 
 import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -1176,4 +1178,39 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	public void checkUserExists(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException {
 		if(!userExists(sess, user)) throw new UserNotExistsException("User: " + user);
 	}
+
+	@Override
+	public Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException {
+
+		PasswordManagerModule module = getPasswordManagerModule(session, namespace);
+		if (module != null) {
+			return module.generateAccount(session, namespace, parameters);
+		}
+		return null;
+
+	}
+
+	/**
+	 * Return instance of PasswordManagerModule for specified namespace or throw exception.
+	 *
+	 * @param session
+	 * @param namespace Namespace to get PWDMGR module.
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	private PasswordManagerModule getPasswordManagerModule(PerunSession session, String namespace) throws InternalErrorException {
+
+		if (namespace == null || namespace.isEmpty()) throw new InternalErrorException("Login-namespace to get password manager module must be specified.");
+
+		namespace = namespace.replaceAll("[^A-Za-z0-9]", "");
+		namespace = Character.toUpperCase(namespace.charAt(0)) + namespace.substring(1);
+
+		try {
+			return (PasswordManagerModule) Class.forName("cz.metacentrum.perun.core.impl.modules.pwdmgr." + namespace + "PasswordManagerModule").newInstance();
+		} catch (Exception ex) {
+			throw new InternalErrorException("Unable to instantiate password manager module.", ex);
+		}
+
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -1,0 +1,287 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Password manager implementation for MU login-namespace.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class MuPasswordManagerModule implements PasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(MuPasswordManagerModule.class);
+	private final static String CRLF = "\r\n"; // Line separator required by multipart/form-data.
+
+	@Override
+	public Map<String, String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException {
+
+		try {
+			int requestID = (new Random()).nextInt(1000000) + 1;
+			InputStream response = makeCall(getGenerateAccountRequest(parameters, requestID), requestID);
+			return parseResponse(response, requestID);
+		} catch (IOException e) {
+			throw new InternalErrorException(e);
+		}
+
+	}
+
+	@Override
+	public void reservePassword(PerunSession session, String userLogin, String loginNamespace, String password) throws InternalErrorException{
+		throw new InternalErrorException("Reserving password in login namespace 'mu' is not supported.");
+	}
+
+	@Override
+	public void reserveRandomPassword(PerunSession session, String userLogin, String loginNamespace) throws InternalErrorException {
+		throw new InternalErrorException("Reserving random password in login namespace 'mu' is not supported.");
+	}
+
+	@Override
+	public void changePassword(PerunSession sess, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword) {
+
+
+
+	}
+
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException {
+		throw new InternalErrorException("Validating password in login namespace 'mu' is not supported.");
+	}
+
+	@Override
+	public void deletePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException {
+
+	}
+
+	/**
+	 * Makes secure SSL connection to IS MU and perform required password manager action
+	 *
+	 * @param dataToPass XML request body
+	 * @param requestId unique ID of a request
+	 * @return InputStream response to be parsed
+	 * @throws InternalErrorException
+	 * @throws IOException
+	 */
+	private InputStream makeCall(String dataToPass, int requestId) throws InternalErrorException, IOException {
+
+		//prepare sslFactory
+		SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+		HttpsURLConnection.setDefaultSSLSocketFactory(factory);
+
+		String uri = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "uri");
+		String login = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "login");
+		String password = BeansUtils.getPropertyFromCustomConfiguration("pwchange.mu.is", "password");
+
+		URL myurl = new URL(uri);
+		HttpURLConnection con = (HttpURLConnection) myurl.openConnection();
+		String boundary = Long.toHexString(System.currentTimeMillis()); //random number for purpose of creating boundaries in multipart
+
+		// Prepare the basic auth, if the username and password was specified
+		if (login != null && password != null) {
+			String val = (new StringBuffer(login).append(":").append(password)).toString();
+			Base64 encoder = new Base64();
+			String base64Encoded = new String(encoder.encode(val.getBytes()));
+			base64Encoded = base64Encoded.trim();
+			String authorizationString = "Basic " + base64Encoded;
+			con.setRequestProperty("Authorization", authorizationString);
+		}
+		con.setAllowUserInteraction(false);
+
+		//set request header if is required (set in extSource xml)
+		con.setDoOutput(true);
+		con.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+		try (
+				OutputStream output = con.getOutputStream();
+				PrintWriter writer = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8), true);
+		) {
+			// Send param about return
+			writer.append("--" + boundary).append(CRLF);
+			writer.append("Content-Disposition: form-data; name=\"out\"").append(CRLF);
+			writer.append(CRLF).append("xml").append(CRLF).flush();
+
+			// Send xml file.
+			writer.append("--" + boundary).append(CRLF);
+			writer.append("Content-Disposition: form-data; name=\"xml\"; filename=\"perun-pwd-manager.xml\"").append(CRLF);
+			writer.append("Content-Type: text/xml; charset=" + StandardCharsets.UTF_8).append(CRLF); // Text file itself must be saved in this charset!
+			writer.append(CRLF).flush();
+			writer.append(dataToPass);
+			output.flush(); // Important before continuing with writer!
+			writer.append(CRLF).flush(); // CRLF is important! It indicates end of boundary.
+
+			// End of multipart/form-data.
+			writer.append("--" + boundary + "--").append(CRLF).flush();
+		}
+
+		int responseCode = con.getResponseCode();
+		if (responseCode == 200) {
+			return con.getInputStream();
+		}
+
+		throw new InternalErrorException("Wrong response code while opening connection on uri '" + uri + "'. Response code: " + responseCode + ". Request ID: " + requestId);
+
+	}
+
+	/**
+	 * Generate XML request body from passed parameters in order to generate account.
+	 *
+	 * @param parameters request parameters to pass
+	 * @param requestID unique ID of a request
+	 * @return XML request body
+	 */
+	private String getGenerateAccountRequest(Map<String, String> parameters, int requestID) {
+
+		log.debug("Making request with ID: " + requestID + " to IS MU.");
+
+		String params = "";
+		if (parameters != null && !parameters.isEmpty()) {
+
+			if (parameters.get("urn:perun:user:attribute-def:core:firstName") != null && !parameters.get("urn:perun:user:attribute-def:core:firstName").isEmpty())
+				params = "<jmeno>" + parameters.get("urn:perun:user:attribute-def:core:firstName") + "</jmeno>\n";
+
+			if (parameters.get("urn:perun:user:attribute-def:core:lastName") != null && !parameters.get("urn:perun:user:attribute-def:core:lastName").isEmpty())
+				params = "<prijmeni>" + parameters.get("urn:perun:user:attribute-def:core:lastName") + "</prijmeni>\n";
+
+			if (parameters.get("urn:perun:user:attribute-def:core:titleBefore") != null && !parameters.get("urn:perun:user:attribute-def:core:titleBefore").isEmpty())
+				params = "<titul_pred>" + parameters.get("urn:perun:user:attribute-def:core:titleBefore") + "</titul_pred>\n";
+
+			if (parameters.get("urn:perun:user:attribute-def:core:titleAfter") != null && !parameters.get("urn:perun:user:attribute-def:core:titleAfter").isEmpty())
+				params = "<titul_za>" + parameters.get("urn:perun:user:attribute-def:core:titleAfter") + "</titul_za>\n";
+
+			if (parameters.get("urn:perun:user:attribute-def:def:birthDay") != null && !parameters.get("urn:perun:user:attribute-def:def:birthDay").isEmpty())
+				params = "<datum_narozeni>" + parameters.get("urn:perun:user:attribute-def:def:birthDay") + "</datum_narozeni>\n";
+
+			if (parameters.get("urn:perun:user:attribute-def:def:rc") != null && !parameters.get("urn:perun:user:attribute-def:def:rc").isEmpty())
+				params = "<rodne_cislo>" + parameters.get("urn:perun:user:attribute-def:def:rc") + "</rodne_cislo>\n";
+
+			if (parameters.get("urn:perun:member:attribute-def:def:mail") != null && !parameters.get("urn:perun:member:attribute-def:def:mail").isEmpty())
+				params = "<email>" + parameters.get("urn:perun:member:attribute-def:def:mail") + "</email>\n";
+
+			if (parameters.get("password") != null && !parameters.get("password").isEmpty())
+				params = "<heslo>" + parameters.get("password") + "</heslo>\n";
+
+		}
+
+		return	"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+				"<request>\n" +
+				"<osoba reqid=\"" + requestID + "\">\n" +
+				"<uco></uco>\n" +
+				params +
+				"<operace>INS</operace>\n" +
+				"</osoba>\n" +
+				"</request>";
+
+	}
+
+	/**
+	 * Parse XML body response from InputStream and convert it to map of parameters.
+	 *
+	 * @param inputStream XML response to be parsed
+	 * @param requestID unique ID of a request
+	 * @return Map of response params
+	 * @throws InternalErrorException
+	 */
+	private Map<String, String> parseResponse(InputStream inputStream, int requestID) throws InternalErrorException {
+
+		Map<String, String> result = new HashMap<>();
+
+		//Create new document factory builder
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		DocumentBuilder builder;
+		try {
+			builder = factory.newDocumentBuilder();
+		} catch (ParserConfigurationException ex) {
+			throw new InternalErrorException("Error when creating newDocumentBuilder. Request ID: " + requestID, ex);
+		}
+
+		Document doc;
+		try {
+			doc = builder.parse(inputStream);
+		} catch (SAXParseException ex) {
+			throw new InternalErrorException("Error when parsing uri by document builder. Request ID: " + requestID, ex);
+		} catch (SAXException ex) {
+			throw new InternalErrorException("Problem with parsing is more complex, not only invalid characters. Request ID: " + requestID, ex);
+		} catch (IOException ex) {
+			throw new InternalErrorException("Error when parsing uri by document builder. Problem with input or output. Request ID: " + requestID, ex);
+		}
+
+		//Prepare xpath expression
+		XPathFactory xPathfactory = XPathFactory.newInstance();
+		XPath xpath = xPathfactory.newXPath();
+		XPathExpression isErrorExpr;
+		XPathExpression getErrorTextExpr;
+		XPathExpression ucoExpr;
+		try {
+			isErrorExpr = xpath.compile("/resp/stav/text()");
+			getErrorTextExpr = xpath.compile("/resp/error/text()");
+			ucoExpr = xpath.compile("/resp/uco/text()");
+		} catch (XPathExpressionException ex) {
+			throw new InternalErrorException("Error when compiling xpath query. Request ID: " + requestID, ex);
+		}
+
+		// OK or ERROR
+		String responseStatus;
+		try {
+			responseStatus = (String) isErrorExpr.evaluate(doc, XPathConstants.STRING);
+		} catch (XPathExpressionException ex) {
+			throw new InternalErrorException("Error when evaluate xpath query on document to resolve response status. Request ID: " + requestID, ex);
+		}
+
+		if ("OK".equals(responseStatus)) {
+
+			try {
+
+				String uco = (String) ucoExpr.evaluate(doc, XPathConstants.STRING);
+				result.put("urn:perun:user:attribute-def:def:login-namespace:mu", uco);
+
+			} catch (XPathExpressionException ex) {
+				throw new InternalErrorException("Error when evaluate xpath query on resulting document for request ID: " + requestID, ex);
+			}
+
+		} else {
+
+			try {
+				String error = (String) getErrorTextExpr.evaluate(doc, XPathConstants.STRING);
+				throw new InternalErrorException("IS MU (password manager backend) responded with error to a Request ID: " + requestID + " Error: "+ error);
+			} catch (XPathExpressionException ex) {
+				throw new InternalErrorException("Error when evaluate xpath query on document to resolve error status. Request ID: " + requestID, ex);
+			}
+
+		}
+
+		return result;
+
+	}
+
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 
 /**
  * UsersManager can find users.
@@ -689,5 +690,15 @@ public interface UsersManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException;
+
+	/**
+	 * Return instance of PasswordManagerModule for specified namespace or throw exception.
+	 *
+	 * @param session
+	 * @param namespace Namespace to get PWDMGR module.
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	public PasswordManagerModule getPasswordManagerModule(PerunSession session, String namespace) throws InternalErrorException;
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.implApi;
 
 import java.util.List;
+import java.util.Map;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -670,4 +671,23 @@ public interface UsersManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	int getUsersCount(PerunSession perunSession) throws InternalErrorException;
+
+	/**
+	 * Generate user account in a backend system associated with login-namespace in Perun.
+	 *
+	 * This method consumes optional parameters map. Requirements are implementation-dependant
+	 * for each login-namespace.
+	 *
+	 * Returns map with
+	 * 1: key=login-namespace attribute urn, value=generated login
+	 * 2: rest of opt response attributes...
+	 *
+	 * @param session
+	 * @param namespace Namespace to generate account in
+	 * @param parameters Optional parameters
+	 * @return Map of data from backed response
+	 * @throws InternalErrorException
+	 */
+	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
@@ -1,0 +1,28 @@
+package cz.metacentrum.perun.core.implApi.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+
+import java.util.Map;
+
+/**
+ * Interface defining function of password manager module.
+ * Each login-namespace in Perun can define own Module.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public interface PasswordManagerModule {
+
+	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException;
+
+	void reservePassword(PerunSession session, String userLogin, String loginNamespace, String password) throws InternalErrorException;
+
+	void reserveRandomPassword(PerunSession session, String userLogin, String loginNamespace) throws InternalErrorException;
+
+	void changePassword(PerunSession sess, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword);
+
+	void validatePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException;
+
+	void deletePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException;
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
@@ -1,7 +1,6 @@
 package cz.metacentrum.perun.core.implApi.modules.pwdmgr;
 
 import cz.metacentrum.perun.core.api.PerunSession;
-import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 
@@ -15,16 +14,18 @@ import java.util.Map;
  */
 public interface PasswordManagerModule {
 
-	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException;
+	Map<String,String> generateAccount(PerunSession session, Map<String, String> parameters) throws InternalErrorException;
 
-	void reservePassword(PerunSession session, String userLogin, String loginNamespace, String password) throws InternalErrorException;
+	void reservePassword(PerunSession session, String userLogin, String password) throws InternalErrorException;
 
-	void reserveRandomPassword(PerunSession session, String userLogin, String loginNamespace) throws InternalErrorException;
+	void reserveRandomPassword(PerunSession session, String userLogin) throws InternalErrorException;
 
-	void changePassword(PerunSession sess, User user, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword) throws InternalErrorException, LoginNotExistsException;
+	void checkPassword(PerunSession sess, String userLogin, String password) throws InternalErrorException, LoginNotExistsException;
 
-	void validatePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException;
+	void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException, LoginNotExistsException;
 
-	void deletePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException;
+	void validatePassword(PerunSession sess, String userLogin) throws InternalErrorException;
+
+	void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException;
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
@@ -1,7 +1,9 @@
 package cz.metacentrum.perun.core.implApi.modules.pwdmgr;
 
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 
 import java.util.Map;
 
@@ -19,7 +21,7 @@ public interface PasswordManagerModule {
 
 	void reserveRandomPassword(PerunSession session, String userLogin, String loginNamespace) throws InternalErrorException;
 
-	void changePassword(PerunSession sess, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword);
+	void changePassword(PerunSession sess, User user, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword) throws InternalErrorException, LoginNotExistsException;
 
 	void validatePassword(PerunSession sess, String userLogin, String loginNamespace) throws InternalErrorException;
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.rpc.methods;
 
+import java.util.HashMap;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.*;
@@ -10,6 +11,7 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 public enum UsersManagerMethod implements ManagerMethod {
 
@@ -1141,7 +1143,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	/*#
 	 * Updates user's userExtSource last access time in DB. We can get information which userExtSource has been used as a last one.
 	 *
-	 * @param UserExtSource int UserExtSource <code>id</code>
+	 * @param userExtSource int UserExtSource <code>id</code>
 	 */
 	updateUserExtSourceLastAccess {
 
@@ -1153,5 +1155,33 @@ public enum UsersManagerMethod implements ManagerMethod {
 
 			return null;
 		}
+	},
+
+	/*#
+	 * Generate user account in a backend system associated with login-namespace in Perun.
+	 *
+	 * This method consumes optional parameters map. Requirements are implementation-dependant
+	 * for each login-namespace.
+	 *
+	 * Returns map with
+	 * 1: key=login-namespace attribute urn, value=generated login
+	 * 2: rest of opt response attributes...
+	 *
+	 * @param namespace String
+	 * @param parameters Map
+	 *
+	 * @return Map<String, String> Map of data from backed response
+	 * @throws InternalErrorException
+	 */
+	generateAccount {
+
+		@Override
+		public Map<String, String> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+			return ac.getUsersManager().generateAccount(ac.getSession(),
+					parms.readString("namespace"),
+					parms.read("parameters", HashMap.class));
+		}
+
 	};
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -996,7 +996,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 	/*#
 	 * Set new login in namespace if login is available and user doesn't have login in that namespace.
-	 * !! Works only for service users !!
+	 * !! Works only for service/guest users => specific users !!
 	 *
 	 * @param user int User <code>id</code>
 	 * @param login String Login

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.webgui.client;
 
 import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Unit;
@@ -13,6 +14,7 @@ import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.Location;
 import com.google.gwt.user.client.ui.*;
+import cz.metacentrum.perun.webgui.client.resources.ExceptionLogger;
 import cz.metacentrum.perun.webgui.client.resources.LargeIcons;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
 import cz.metacentrum.perun.webgui.json.GetGuiConfiguration;
@@ -73,28 +75,39 @@ public class WebGui implements EntryPoint, ValueChangeHandler<String> {
 	 */
 	public void onModuleLoad() {
 
-		// IF IS MAIL VERIFICATION REQUEST
-		if (checkIfMailVerification()) return;
+		ExceptionLogger exceptionHandler = new ExceptionLogger();
+		GWT.setUncaughtExceptionHandler(exceptionHandler);
 
-		// LOAD PERUN WEB GUI
+		try {
 
-		// Get web page's BODY
-		body = RootLayoutPanel.get();
-		body.setStyleName("mainPanel");
+			// IF IS MAIL VERIFICATION REQUEST
+			if (checkIfMailVerification()) return;
 
-		// check RPC url
-		if(session.getRpcUrl().isEmpty()){
-			VerticalPanel bodyContents = new VerticalPanel();
-			bodyContents.setSize("100%", "300px");
-			bodyContents.add(new HTML(new Image(LargeIcons.INSTANCE.errorIcon())+"<h2>RPC SERVER NOT FOUND!</h2>"));
-			bodyContents.setCellHorizontalAlignment(bodyContents.getWidget(0), HasHorizontalAlignment.ALIGN_CENTER);
-			bodyContents.setCellVerticalAlignment(bodyContents.getWidget(0), HasVerticalAlignment.ALIGN_BOTTOM);
-			body.add(bodyContents);
-			return;
+
+
+			// LOAD PERUN WEB GUI
+
+			// Get web page's BODY
+			body = RootLayoutPanel.get();
+			body.setStyleName("mainPanel");
+
+			// check RPC url
+			if(session.getRpcUrl().isEmpty()){
+				VerticalPanel bodyContents = new VerticalPanel();
+				bodyContents.setSize("100%", "300px");
+				bodyContents.add(new HTML(new Image(LargeIcons.INSTANCE.errorIcon())+"<h2>RPC SERVER NOT FOUND!</h2>"));
+				bodyContents.setCellHorizontalAlignment(bodyContents.getWidget(0), HasHorizontalAlignment.ALIGN_CENTER);
+				bodyContents.setCellVerticalAlignment(bodyContents.getWidget(0), HasVerticalAlignment.ALIGN_BOTTOM);
+				body.add(bodyContents);
+				return;
+			}
+
+			// load principal
+			loadPerunPrincipal();
+
+		} catch (Exception ex) {
+			exceptionHandler.onUncaughtException(ex);
 		}
-
-		// load principal
-		loadPerunPrincipal();
 
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/ExceptionLogger.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/ExceptionLogger.java
@@ -1,0 +1,36 @@
+package cz.metacentrum.perun.webgui.client.resources;
+
+import com.google.gwt.core.client.GWT;
+import com.google.web.bindery.event.shared.UmbrellaException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Logs all uncaught exceptions to the browser console.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class ExceptionLogger implements GWT.UncaughtExceptionHandler {
+
+	private static Logger rootLogger = Logger.getLogger("");
+
+	@Override
+	public void onUncaughtException(Throwable wrapped) {
+
+		Throwable t = unwrapUmbrella(wrapped);
+		rootLogger.log(Level.SEVERE, "", t);
+
+	}
+
+	private Throwable unwrapUmbrella(Throwable e) {
+		if(e instanceof UmbrellaException) {
+			UmbrellaException ue = (UmbrellaException) e;
+			if(ue.getCauses().size() == 1) {
+				return unwrapUmbrella(ue.getCauses().iterator().next());
+			}
+		}
+		return e;
+	}
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/CreateSpecificMember.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/CreateSpecificMember.java
@@ -129,7 +129,7 @@ public class CreateSpecificMember {
 			errorMsg += "Wrong <strong>Email</strong> parameter.<br />";
 			result = false;
 		}
-		if(!namespace.isEmpty() && login.isEmpty()){
+		if(!namespace.isEmpty() && !namespace.equals("mu") && login.isEmpty()){
 			errorMsg += "Wrong <strong>login-namespace</strong> parameter.<br />";
 			result = false;
 		}
@@ -157,7 +157,7 @@ public class CreateSpecificMember {
 		// attributes object !! login !!
 		JSONObject attrs = new JSONObject();
 
-		if (!namespace.isEmpty()) {
+		if (!namespace.isEmpty() && !namespace.equals("mu")) {
 			attrs.put("urn:perun:user:attribute-def:def:login-namespace:"+namespace, new JSONString(login));
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/CreatePassword.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/CreatePassword.java
@@ -246,4 +246,43 @@ public class CreatePassword {
 		return jsonQuery;
 	}
 
+	/**
+	 * Validates password and sets user ext sources
+	 *
+	 * @param userId user to set password for
+	 * @param login used for validation only
+	 * @param namespace defined login in namespace
+	 */
+	public void validateAndSetUserExtSources(int userId, String login, String namespace) {
+
+		this.userId = userId;
+		this.namespace = namespace;
+		this.login = login;
+
+		// test arguments
+		String errorMsg = "";
+
+		if(userId == 0){
+			errorMsg += "<p>User ID can't be 0.";
+		}
+
+		if(namespace.isEmpty()){
+			errorMsg += "<p>Namespace can't be empty.";
+		}
+
+		if(login.isEmpty()){
+			errorMsg += "<p>Login to create password for can't be empty.";
+		}
+
+		if(errorMsg.length()>0){
+			Confirm c = new Confirm("Error while creating password.", new HTML(errorMsg), true);
+			c.show();
+			return;
+		}
+
+		JsonPostClient jspc = new JsonPostClient(events);
+		jspc.sendData(JSON_URL_VALIDATE_AND_SET_USER_EXT_SOURCE, validateCallJSON());
+
+	}
+
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/GenerateAccount.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/GenerateAccount.java
@@ -1,0 +1,141 @@
+package cz.metacentrum.perun.webgui.json.usersManager;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONString;
+import com.google.gwt.user.client.ui.HTML;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.JsonPostClient;
+import cz.metacentrum.perun.webgui.model.GeneralObject;
+import cz.metacentrum.perun.webgui.model.PerunError;
+import cz.metacentrum.perun.webgui.widgets.Confirm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Generate users account
+ *
+ * @author Pavel Zlamal <256627@mail.muni.cz>
+ */
+
+public class GenerateAccount {
+
+	// web session
+	private PerunWebSession session = PerunWebSession.getInstance();
+	// URL to call
+	final String JSON_URL = "usersManager/generateAccount";
+
+	// external events
+	private JsonCallbackEvents events = new JsonCallbackEvents();
+
+	// local variables for entity to send
+	private String namespace = "";
+	private String pass = "";
+	private Map<String, String> params = new HashMap<>();
+
+	/**
+	 * Creates a new request
+	 */
+	public GenerateAccount() {
+	}
+
+	/**
+	 * Creates a new request with custom events passed from tab or page
+	 * @param events custom events
+	 */
+	public GenerateAccount(final JsonCallbackEvents events) {
+		this.events = events;
+	}
+
+	/**
+	 * Generates account in namespace with optional password
+	 *
+	 * @param namespace defined namespace
+	 * @param pass password to set
+	 * @param params optional params as map of attribute urn and string value
+	 */
+	public void generateAccount(String namespace, String pass, Map<String, String> params) {
+
+		this.namespace = namespace;
+		this.pass = pass;
+		this.params = params;
+
+		// test arguments
+		if(!this.testAdding()){
+			return;
+		}
+
+		// final events
+		final JsonCallbackEvents newEvents = new JsonCallbackEvents(){
+			public void onError(PerunError error) {
+				session.getUiElements().setLogErrorText("Creating account failed.");
+				events.onError(error); // custom events
+			};
+
+			public void onFinished(JavaScriptObject jso) {
+				session.getUiElements().setLogSuccessText("Account created successfully.");
+				events.onFinished(jso);
+			};
+			@Override
+			public void onLoadingStart() {
+				events.onLoadingStart();
+			};
+		};
+
+		// sending data
+		JsonPostClient jspc = new JsonPostClient(newEvents);
+		jspc.sendData(JSON_URL, prepareJSONObject());
+
+	}
+
+	/**
+	 * Tests the values, if the process can continue
+	 *
+	 * @return true/false for continue/stop
+	 */
+	private boolean testAdding() {
+
+		boolean result = true;
+		String errorMsg = "";
+
+		if(namespace.isEmpty()){
+			errorMsg += "<p>Namespace can't be empty.";
+			result = false;
+		}
+
+		if (errorMsg.length()>0) {
+			Confirm c = new Confirm("Error while creating password.", new HTML(errorMsg), true);
+			c.show();
+		}
+
+		return result;
+	}
+
+	/**
+	 * Prepares a JSON object for password reservation.
+	 *
+	 * @return JSONObject the whole query
+	 */
+	private JSONObject prepareJSONObject() {
+
+		JSONObject jsonQuery = new JSONObject();
+		jsonQuery.put("namespace", new JSONString(namespace));
+
+		JSONObject param = new JSONObject();
+
+		if (pass != null && !pass.isEmpty()) {
+			param.put("password", new JSONString(pass));
+		}
+		for (String key : params.keySet()) {
+			param.put(key, new JSONString(params.get(key)));
+		}
+
+		jsonQuery.put("parameters", param);
+
+		return jsonQuery;
+
+	}
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/BasicOverlayType.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/BasicOverlayType.java
@@ -74,8 +74,11 @@ public class BasicOverlayType extends JavaScriptObject {
 	}
 
 	public final native String getCustomProperty(String property) /*-{
-		if(typeof this[property] == "undefined") return "";
+		if (!this[property]) return "";
+		if (typeof this[property] === 'undefined') return "";
+		if (this[property] === null) return "";
 		return this[property];
 	}-*/;
+
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web.gwt.xml
@@ -47,4 +47,19 @@
 	<source path='tabs' />
 	<source path='widgets' />
 
+	<!-- enable logging -->
+	<set-property name="compiler.useSourceMaps" value="true" />
+
+	<inherits name="com.google.gwt.logging.Logging" />
+
+	<set-property name="gwt.logging.logLevel" value="SEVERE"/>
+	<set-property name="gwt.logging.enabled" value="TRUE"/>
+	<set-property name="gwt.logging.consoleHandler" value="ENABLED"/>
+	<set-property name="gwt.logging.systemHandler" value="ENABLED"/>
+	<set-property name="gwt.logging.developmentModeHandler" value="ENABLED"/>
+
+	<set-property name="compiler.stackMode" value="emulated" />
+	<set-configuration-property name="compiler.emulatedStack.recordLineNumbers" value="true"/>
+	<set-configuration-property name="compiler.emulatedStack.recordFileNames" value="true"/>
+
 </module>

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
@@ -390,9 +390,17 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 
 															UiElements.generateInfo("Assigned login", "You were assigned with login <b>"+login+"</b> in namespace MU.");
 
-															// validate member when all logins are set
-															ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
-															req2.validateMemberAsync(member);
+															// VALIDATE PASSWORD - SET EXT SOURCES AND VALIDATE MEMBER
+															CreatePassword req = new CreatePassword(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents(){
+																@Override
+																public void onFinished(JavaScriptObject jso) {
+
+																	// validate member when all kerberos logins are set
+																	ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
+																	req2.validateMemberAsync(member);
+																}
+															}));
+															req.validateAndSetUserExtSources(member.getUserId(), serviceUserLogin.getTextBox().getValue().trim(), namespace.getValue(namespace.getSelectedIndex()));
 
 														}
 														@Override
@@ -452,18 +460,11 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 										if (namespace.getSelectedValue().equals("mu")) {
 
 											final GenerateAccount req = new GenerateAccount(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents() {
-
+												@Override
 												public void onFinished(JavaScriptObject jso) {
 
-													GWT.log("WAS HERE");
-
 													BasicOverlayType basic = jso.cast();
-
-													GWT.log("WAS HERE2");
-
 													final String login = basic.getCustomProperty("urn:perun:user:attribute-def:def:login-namespace:mu");
-
-													GWT.log("WAS HERE3");
 
 													SetLogin setLogin = new SetLogin(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents() {
 														@Override
@@ -471,9 +472,17 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 
 															UiElements.generateInfo("Assigned login", "You were assigned with login <b>" + login + "</b> in namespace MU.");
 
-															// validate member when all logins are set
-															ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
-															req2.validateMemberAsync(member);
+															// VALIDATE PASSWORD - SET EXT SOURCES AND VALIDATE MEMBER
+															CreatePassword req = new CreatePassword(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents(){
+																@Override
+																public void onFinished(JavaScriptObject jso) {
+
+																	// validate member when all kerberos logins are set
+																	ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
+																	req2.validateMemberAsync(member);
+																}
+															}));
+															req.validateAndSetUserExtSources(member.getUserId(), serviceUserLogin.getTextBox().getValue().trim(), namespace.getValue(namespace.getSelectedIndex()));
 
 														}
 														@Override

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.webgui.tabs.memberstabs;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.regexp.shared.RegExp;
@@ -18,7 +19,9 @@ import cz.metacentrum.perun.webgui.json.membersManager.CreateSpecificMember;
 import cz.metacentrum.perun.webgui.json.membersManager.ValidateMemberAsync;
 import cz.metacentrum.perun.webgui.json.usersManager.CreatePassword;
 import cz.metacentrum.perun.webgui.json.usersManager.FindUsers;
+import cz.metacentrum.perun.webgui.json.usersManager.GenerateAccount;
 import cz.metacentrum.perun.webgui.json.usersManager.IsLoginAvailable;
+import cz.metacentrum.perun.webgui.json.usersManager.SetLogin;
 import cz.metacentrum.perun.webgui.model.*;
 import cz.metacentrum.perun.webgui.tabs.MembersTabs;
 import cz.metacentrum.perun.webgui.tabs.TabItem;
@@ -28,6 +31,7 @@ import cz.metacentrum.perun.webgui.widgets.*;
 import cz.metacentrum.perun.webgui.widgets.CustomButton;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -252,13 +256,18 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 		layout.setWidget(3, 1, namespace);
 		layout.setHTML(4, 0, "<strong>Login: </strong>");
 		layout.setWidget(4, 1, serviceUserLogin);
-		layout.setHTML(5, 0, "<strong>Subject DN: </strong>");
-		layout.setWidget(5, 1, certDN);
-		layout.setHTML(6, 0, "<strong>Issuer DN: </strong>");
-		layout.setWidget(6, 1, cacertDN);
+		final Label label = new Label("You will be assigned with available login");
+		label.setVisible(false);
+		layout.setWidget(5, 0, label);
+		layout.getFlexCellFormatter().setStyleName(5, 0, "inputFormInlineComment");
+		layout.getFlexCellFormatter().setColSpan(5, 0, 2);
+		layout.setHTML(6, 0, "<strong>Subject DN: </strong>");
+		layout.setWidget(6, 1, certDN);
+		layout.setHTML(7, 0, "<strong>Issuer DN: </strong>");
+		layout.setWidget(7, 1, cacertDN);
 		if (session.isPerunAdmin()) {
-			layout.setHTML(7, 0, "<strong>User type: </strong>");
-			layout.setWidget(7, 1, userType);
+			layout.setHTML(8, 0, "<strong>User type: </strong>");
+			layout.setWidget(8, 1, userType);
 		}
 
 		final FlexTable firstTabLayout = new FlexTable();
@@ -284,7 +293,10 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 			public void onClick(ClickEvent clickEvent) {
 
 				// check
-				if (namespace.getSelectedIndex() != 0 && !loginValidator.validateTextBox()) return;
+				if (!namespace.getSelectedValue().equals("mu") &&
+						namespace.getSelectedIndex() != 0 &&
+						!loginValidator.validateTextBox()) return;
+
 				if (!nameValidator.validateTextBox()) return;
 				if (!emailValidator.validateTextBox()) return;
 				if (!certDNValidator.validateTextBox()) return;
@@ -350,6 +362,7 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 									session.getTabManager().closeTab(tab, true);
 									return;
 								}
+
 								// change to small tab
 								session.getTabManager().changeStyleOfInnerTab(false);
 
@@ -363,15 +376,71 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 											return;
 										}
 
-										// create password which sets also user ext sources
-										CreatePassword req = new CreatePassword(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents(){
-											public void onFinished(JavaScriptObject jso) {
-												// validate member when all kerberos logins are set
-												ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
-												req2.validateMemberAsync(member);
-											}
-										}));
-										req.createPassword(member.getUserId(), serviceUserLogin.getTextBox().getValue().trim(), namespace.getValue(namespace.getSelectedIndex()), serviceUserPassword.getTextBox().getValue().trim());
+										if (namespace.getSelectedValue().equals("mu")) {
+
+											final GenerateAccount req = new GenerateAccount(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents() {
+												public void onFinished(JavaScriptObject jso) {
+
+													BasicOverlayType basic = jso.cast();
+													final String login = basic.getCustomProperty("urn:perun:user:attribute-def:def:login-namespace:mu");
+
+													SetLogin setLogin = new SetLogin(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents(){
+														@Override
+														public void onFinished(JavaScriptObject jso) {
+
+															UiElements.generateInfo("Assigned login", "You were assigned with login <b>"+login+"</b> in namespace MU.");
+
+															// validate member when all logins are set
+															ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
+															req2.validateMemberAsync(member);
+
+														}
+														@Override
+														public void onError(PerunError error) {
+
+															UiElements.generateError(error, "Saving login failed", "You were assigned with login <b>"+login+"</b> in namespace MU but saving it to user failed. <b>Please copy your login and contact support at <a href=\"mailto:"+Utils.perunReportEmailAddress()+"\">"+Utils.perunReportEmailAddress()+"</a>.</b>");
+
+															// validate member when all logins are set
+															ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
+															req2.validateMemberAsync(member);
+
+														}
+													}));
+													setLogin.setLogin(member.getUserId(), "mu", login);
+
+												}
+											}));
+
+											final Map<String, String> params = new HashMap<String, String>();
+
+											GetEntityById get = new GetEntityById(PerunEntity.RICH_MEMBER, member.getId(), JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents(){
+												@Override
+												public void onFinished(JavaScriptObject jso) {
+													RichMember rm = jso.cast();
+
+													params.put("urn:perun:user:attribute-def:core:firstName", rm.getUser().getFirstName());
+													params.put("urn:perun:user:attribute-def:core:lastName", rm.getUser().getLastName());
+													params.put("urn:perun:member:attribute-def:def:mail", serviceUserEmail.getTextBox().getValue().trim());
+
+													req.generateAccount(namespace.getValue(namespace.getSelectedIndex()), serviceUserPassword.getTextBox().getValue().trim(), params);
+
+												}
+											}));
+											get.retrieveData();
+
+										} else {
+
+											// create password which sets also user ext sources
+											CreatePassword req = new CreatePassword(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents(){
+												public void onFinished(JavaScriptObject jso) {
+													// validate member when all kerberos logins are set
+													ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
+													req2.validateMemberAsync(member);
+												}
+											}));
+											req.createPassword(member.getUserId(), serviceUserLogin.getTextBox().getValue().trim(), namespace.getValue(namespace.getSelectedIndex()), serviceUserPassword.getTextBox().getValue().trim());
+
+										}
 
 									}
 								});
@@ -379,15 +448,80 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 								final CustomButton skipButton = new CustomButton("Skip", SmallIcons.INSTANCE.arrowRightIcon());
 								skipButton.addClickHandler(new ClickHandler() {
 									public void onClick(ClickEvent clickEvent) {
-										CreatePassword req = new CreatePassword(JsonCallbackEvents.disableButtonEvents(skipButton, new JsonCallbackEvents(){
-											public void onFinished(JavaScriptObject jso) {
-												// validate member when all kerberos logins are set
-												ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(skipButton, tab));
-												req2.validateMemberAsync(member);
-											}
-										}));
-										// set empty password for service member if "skipped"
-										req.createRandomPassword(member.getUserId(), serviceUserLogin.getTextBox().getValue().trim(), namespace.getValue(namespace.getSelectedIndex()));
+
+										if (namespace.getSelectedValue().equals("mu")) {
+
+											final GenerateAccount req = new GenerateAccount(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents() {
+
+												public void onFinished(JavaScriptObject jso) {
+
+													GWT.log("WAS HERE");
+
+													BasicOverlayType basic = jso.cast();
+
+													GWT.log("WAS HERE2");
+
+													final String login = basic.getCustomProperty("urn:perun:user:attribute-def:def:login-namespace:mu");
+
+													GWT.log("WAS HERE3");
+
+													SetLogin setLogin = new SetLogin(JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents() {
+														@Override
+														public void onFinished(JavaScriptObject jso) {
+
+															UiElements.generateInfo("Assigned login", "You were assigned with login <b>" + login + "</b> in namespace MU.");
+
+															// validate member when all logins are set
+															ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
+															req2.validateMemberAsync(member);
+
+														}
+														@Override
+														public void onError(PerunError error) {
+
+															// validate member when all logins are set
+															ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(button, tab));
+															req2.validateMemberAsync(member);
+
+														}
+													}));
+													setLogin.setLogin(member.getUserId(), "mu", login);
+
+												}
+											}));
+
+											final Map<String, String> params = new HashMap<String, String>();
+
+											GetEntityById get = new GetEntityById(PerunEntity.RICH_MEMBER, member.getId(), JsonCallbackEvents.disableButtonEvents(button, new JsonCallbackEvents() {
+												@Override
+												public void onFinished(JavaScriptObject jso) {
+													RichMember rm = jso.cast();
+
+													params.put("urn:perun:user:attribute-def:core:firstName", rm.getUser().getFirstName());
+													params.put("urn:perun:user:attribute-def:core:lastName", rm.getUser().getLastName());
+													params.put("urn:perun:member:attribute-def:def:mail", serviceUserEmail.getTextBox().getValue().trim());
+
+													req.generateAccount(namespace.getValue(namespace.getSelectedIndex()), null, params);
+
+												}
+											}));
+											get.retrieveData();
+
+										} else {
+
+
+											CreatePassword req = new CreatePassword(JsonCallbackEvents.disableButtonEvents(skipButton, new JsonCallbackEvents() {
+												public void onFinished(JavaScriptObject jso) {
+													// validate member when all kerberos logins are set
+													ValidateMemberAsync req2 = new ValidateMemberAsync(JsonCallbackEvents.closeTabDisableButtonEvents(skipButton, tab));
+													req2.validateMemberAsync(member);
+												}
+											}));
+											// set empty password for service member if "skipped"
+											req.createRandomPassword(member.getUserId(), serviceUserLogin.getTextBox().getValue().trim(), namespace.getValue(namespace.getSelectedIndex()));
+
+										}
+
 									}
 								});
 
@@ -415,25 +549,33 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 						}));
 
 						request.createMember(voId, serviceUserName.getTextBox().getValue().trim(),
-									serviceUserEmail.getTextBox().getValue().trim(),
-									itemsTable.getList(),
-									namespace.getValue(namespace.getSelectedIndex()),
-									serviceUserLogin.getTextBox().getValue().trim(),
-									certDN.getTextBox().getValue().trim(),
-									cacertDN.getTextBox().getValue().trim(),
-									userType.getSelectedValue()
-								);
+								serviceUserEmail.getTextBox().getValue().trim(),
+								itemsTable.getList(),
+								namespace.getValue(namespace.getSelectedIndex()),
+								serviceUserLogin.getTextBox().getValue().trim(),
+								certDN.getTextBox().getValue().trim(),
+								cacertDN.getTextBox().getValue().trim(),
+								userType.getSelectedValue()
+						);
 
 					}
 				});
-				cb.setEnabled(false);
+				// we have ourselves already assigned
+				//cb.setEnabled(false);
 
 				CustomButton button = TabMenu.getPredefinedButton(ButtonType.ADD, "Add selected users to service member");
 				button.addClickHandler(new ClickHandler() {
 					public void onClick(ClickEvent clickEvent) {
 						ArrayList<User> list = callback.getTableSelectedList();
 						if (UiElements.cantSaveEmptyListDialogBox(list)) {
-							itemsTable.addItems(list);
+							// skip self
+							ArrayList<User> list2 = new ArrayList<User>();
+							for (User user : list) {
+								if (user != null && user.getId() != session.getUser().getId()) {
+									list2.add(user);
+								}
+							}
+							itemsTable.addItems(list2);
 							cb.setEnabled(true);
 							callback.clearTableSelectedSet();
 						}
@@ -516,20 +658,20 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 								}
 							}
 						}
-					@Override
-					public void onLoadingStart(){
-						if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-							serviceUserLogin.removeHardError();
-							serviceUserLogin.setProcessing(true);
+						@Override
+						public void onLoadingStart(){
+							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
+								serviceUserLogin.removeHardError();
+								serviceUserLogin.setProcessing(true);
+							}
 						}
-					}
-					@Override
-					public void onError(PerunError error) {
-						if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-							serviceUserLogin.setProcessing(false);
-							serviceUserLogin.setHardError("Unable to check if login is available!");
+						@Override
+						public void onError(PerunError error) {
+							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
+								serviceUserLogin.setProcessing(false);
+								serviceUserLogin.setHardError("Unable to check if login is available!");
+							}
 						}
-					}
 					}).retrieveData();
 				}
 			}
@@ -543,8 +685,13 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 					// do not set login
 					serviceUserLogin.getTextBox().setEnabled(false);
 					serviceUserLogin.getTextBox().setValue(null);
+					label.setVisible(false);
+				} else if (namespace.getSelectedValue().equals("mu")) {
+					serviceUserLogin.getTextBox().setEnabled(false);
+					label.setVisible(true);
 				} else {
 					serviceUserLogin.getTextBox().setEnabled(true);
+					label.setVisible(false);
 				}
 
 				final String login = serviceUserLogin.getTextBox().getValue().trim();
@@ -565,34 +712,34 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 								}
 							}
 						}
-					@Override
-					public void onLoadingStart(){
-						if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-							serviceUserLogin.removeHardError();
-							serviceUserLogin.setProcessing(true);
-							loginValidator.validateTextBox();
+						@Override
+						public void onLoadingStart(){
+							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
+								serviceUserLogin.removeHardError();
+								serviceUserLogin.setProcessing(true);
+								loginValidator.validateTextBox();
+							}
 						}
-					}
-					@Override
-					public void onError(PerunError error) {
-						if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
-							serviceUserLogin.setProcessing(false);
-							serviceUserLogin.setHardError("Unable to check if login is available!");
+						@Override
+						public void onError(PerunError error) {
+							if (serviceUserLogin.getTextBox().getValue().trim().equals(login)) {
+								serviceUserLogin.setProcessing(false);
+								serviceUserLogin.setHardError("Unable to check if login is available!");
+							}
 						}
-					}
 					}).retrieveData();
 				}
 			}
 		});
 
 		if (session.isPerunAdmin()) {
+			layout.setWidget(9, 0, cb);
+			layout.getFlexCellFormatter().setHorizontalAlignment(9, 0, HasHorizontalAlignment.ALIGN_RIGHT);
+			layout.getFlexCellFormatter().setColSpan(9, 0, 2);
+		} else {
 			layout.setWidget(8, 0, cb);
 			layout.getFlexCellFormatter().setHorizontalAlignment(8, 0, HasHorizontalAlignment.ALIGN_RIGHT);
 			layout.getFlexCellFormatter().setColSpan(8, 0, 2);
-		} else {
-			layout.setWidget(7, 0, cb);
-			layout.getFlexCellFormatter().setHorizontalAlignment(7, 0, HasHorizontalAlignment.ALIGN_RIGHT);
-			layout.getFlexCellFormatter().setColSpan(7, 0, 2);
 		}
 
 		this.contentWidget.setWidget(mainTab);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/AddRemoveItemsTable.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/AddRemoveItemsTable.java
@@ -100,8 +100,8 @@ public class AddRemoveItemsTable<T extends JavaScriptObject> extends Composite {
 	 */
 	public void removeItem(T object) {
 		list.remove(object);
-		buildWidget();
 		events.onRemove(object);
+		buildWidget();
 	}
 
 	/**


### PR DESCRIPTION
- Introduced PasswordManagerModule in perun-core which can be used to customize or completely implement Peruns password manager for specified namespace.
- For now, module is implemented for MU namespace. If module not found, general/previous implementation is used.
- Added mostly generic generateAccount() function which can be used to create account in a backend and returned login is later assigned to the user.
- Validating password in ICS.MUNI.CZ and MU namespaces will generate UES and kerberos logins attributes if necessary.
- Added multiple exceptions in GUI behavior for MU namespace, since login is generated.