### PR TITLE
Remove useless call to getExtSourceByName.

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ELIXIRCILogonDNGenerator.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ELIXIRCILogonDNGenerator.java
@@ -100,9 +100,7 @@ public class ELIXIRCILogonDNGenerator implements RegistrarModule {
 			String dn = DNPREFIX + displayName + " " + CILogonHash;
 
 			// Store the userExtSource
-			ExtSource extSource = perun.getExtSourcesManagerBl().getExtSourceByName(session, CADN);
-
-			perun.getExtSourcesManagerBl().checkOrCreateExtSource(session, CADN, ExtSourcesManager.EXTSOURCE_X509);
+			ExtSource extSource = perun.getExtSourcesManagerBl().checkOrCreateExtSource(session, CADN, ExtSourcesManager.EXTSOURCE_X509);
 				
 			UserExtSource userExtSource = new UserExtSource(extSource, dn);
 			try {


### PR DESCRIPTION
This call fails when the userExtSource is not there, so the next call to checkOrCreateExtSource will not occur.