### PR TITLE
CORE: Allow configurable list of logins for which we don't lookup users

### DIFF
--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -34,6 +34,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<prop key="perun.registrar.principals"></prop>
 					<prop key="perun.notification.principals">perunNotifications</prop>
 					<prop key="perun.rpc.principal">perunRpc</prop>
+					<prop key="perun.dont.lookup.users">perunTests, perunController, perunEngine, perunDispatcher, perunRegistrar, perunSynchronizer, perunCabinet, perunNotifications, perunRpc</prop>
 					<prop key="perun.db.type">hsqldb</prop>
 					<prop key="perun.group.synchronization.interval">1</prop>
 					<prop key="perun.group.synchronization.timeout">10</prop>
@@ -67,6 +68,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<prop key="perun.registrar.principals"></prop>
 					<prop key="perun.notification.principals">perunNotifications</prop>
 					<prop key="perun.rpc.principal">perunRpc</prop>
+					<prop key="perun.dont.lookup.users">perunTests, perunController, perunEngine, perunDispatcher, perunRegistrar, perunSynchronizer, perunCabinet, perunNotifications, perunRpc</prop>
 					<prop key="perun.db.type">hsqldb</prop>
 					<prop key="perun.group.synchronization.interval">1</prop>
 					<prop key="perun.group.synchronization.timeout">10</prop>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -51,8 +51,8 @@ import cz.metacentrum.perun.core.bl.VosManagerBl;
 import cz.metacentrum.perun.core.impl.Auditer;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Implementation of Perun.
@@ -98,7 +98,7 @@ public class PerunBlImpl implements PerunBl {
 
 	final static Logger log = LoggerFactory.getLogger(PerunBlImpl.class);
 
-	final static List<String> dontLookupUsersForLogins = new ArrayList<String>();
+	final static Set<String> dontLookupUsersForLogins = new HashSet<>();
 
 	// fill list of logins we don't want to lookup users for
 	static {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -51,6 +51,9 @@ import cz.metacentrum.perun.core.bl.VosManagerBl;
 import cz.metacentrum.perun.core.impl.Auditer;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Implementation of Perun.
  *
@@ -95,6 +98,27 @@ public class PerunBlImpl implements PerunBl {
 
 	final static Logger log = LoggerFactory.getLogger(PerunBlImpl.class);
 
+	final static List<String> dontLookupUsersForLogins = new ArrayList<String>();
+
+	// fill list of logins we don't want to lookup users for
+	static {
+
+		String propValue = null;
+		try {
+			propValue = BeansUtils.getPropertyFromConfiguration("perun.dont.lookup.users");
+		} catch (InternalErrorException e) {
+			log.error("Unable to load logins for which we don't lookup users");
+		}
+
+		if (propValue != null) {
+			String[] dontLogins = propValue.split(",");
+			for (String str : dontLogins) {
+				dontLookupUsersForLogins.add(str.trim());
+			}
+		}
+
+	}
+
 	public PerunBlImpl() {
 
 	}
@@ -102,10 +126,7 @@ public class PerunBlImpl implements PerunBl {
 	public PerunSession getPerunSession(PerunPrincipal principal) throws InternalErrorException {
 		if (principal.getUser() == null &&
 				this.getUsersManagerBl() != null &&
-				!principal.getExtSourceType().equals(ExtSourcesManager.EXTSOURCE_INTERNAL) &&
-				!principal.getActor().equals("perunv3/rpc-lib@META") &&
-				!principal.getActor().equals("perunv3/admin@META") &&
-				!principal.getActor().equals("perunv3/engine@META")) {
+				!dontLookupUsersForLogins.contains(principal.getActor())) {
 			// Get the user if we are completely initialized
 			try {
 				principal.setUser(this.getUsersManagerBl().getUserByExtSourceNameAndExtLogin(getPerunSession(), principal.getExtSourceName(), principal.getActor()));


### PR DESCRIPTION
- To lessen number of unnecessary exceptions in a log we can now configure
  a list of logins for which perun doesn't lookup users in DB.
  This also allows us to assign basic auth identity to a real user.
- Default list of logins is taken from config /etc/perun/perun.properties
  perun.dont.lookup.users and should match other internal logins in same
  config file.