### PR TITLE
CORE,RPC,GUI: Allow listing of all subgroup hierarchy

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -804,7 +804,7 @@ public interface GroupsManager {
 	List<RichGroup> getAllRichGroupsWithAttributesByNames(PerunSession sess, Vo vo, List<String> attrNames) throws InternalErrorException, VoNotExistsException, PrivilegeException;
 
 	/**
-	 * Return all RichSubGroups in parentGroup containing selected attributes
+	 * Return RichSubGroups in parentGroup (only 1 level subgroups) containing selected attributes
 	 *
 	 * @param sess
 	 * @param parentGroup
@@ -814,6 +814,18 @@ public interface GroupsManager {
 	 * @throws GroupNotExistsException
 	 */
 	List<RichGroup> getRichSubGroupsWithAttributesByNames(PerunSession sess, Group parentGroup, List<String> attrNames) throws InternalErrorException, GroupNotExistsException, VoNotExistsException, PrivilegeException;
+
+	/**
+	 * Return all RichSubGroups in parentGroup (all levels sub groups) containing selected attributes
+	 *
+	 * @param sess
+	 * @param parentGroup
+	 * @param attrNames if attrNames is null method will return RichGroups containing all attributes
+	 * @return List of RichGroups
+	 * @throws InternalErrorException
+	 * @throws GroupNotExistsException
+	 */
+	List<RichGroup> getAllRichSubGroupsWithAttributesByNames(PerunSession sess, Group parentGroup, List<String> attrNames) throws InternalErrorException, GroupNotExistsException, VoNotExistsException, PrivilegeException;
 
 	/**
 	 * Return RichGroup selected by id containing selected attributes

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -979,7 +979,7 @@ public interface GroupsManagerBl {
 	List<RichGroup> getAllRichGroupsWithAttributesByNames(PerunSession sess, Vo vo, List<String> attrNames) throws InternalErrorException;
 	
 	/**
-	 * Returns all RichSubGroups from parentGroup containing selected attributes
+	 * Returns RichSubGroups from parentGroup containing selected attributes (only 1 level subgroups)
 	 * 
 	 * @param sess
 	 * @param parentGroup
@@ -988,7 +988,18 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException 
 	 */
 	List<RichGroup> getRichSubGroupsWithAttributesByNames(PerunSession sess, Group parentGroup, List<String> attrNames) throws InternalErrorException;
-	
+
+	/**
+	 * Returns all RichSubGroups from parentGroup containing selected attributes (all levels subgroups)
+	 *
+	 * @param sess
+	 * @param parentGroup
+	 * @param attrNames if attrNames is null method will return RichGroups containing all attributes
+	 * @return List of RichGroups
+	 * @throws InternalErrorException
+	 */
+	List<RichGroup> getAllRichSubGroupsWithAttributesByNames(PerunSession sess, Group parentGroup, List<String> attrNames) throws InternalErrorException;
+
 	/**
 	 * Returns RichGroup selected by id containing selected attributes
 	 * 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -743,7 +743,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns all RichSubGroups from parent group containing selected attributes
+	 * Returns RichSubGroups from parent group containing selected attributes (only 1 level sub groups).
 	 *
 	 * @param group int <code>id</code> of group
 	 * @param attrNames List<String> if attrNames is null method will return RichGroups containing all attributes
@@ -755,6 +755,24 @@ public enum GroupsManagerMethod implements ManagerMethod {
 		public List<RichGroup> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
 			return ac.getGroupsManager().getRichSubGroupsWithAttributesByNames(ac.getSession(),
+					ac.getGroupById(parms.readInt("group")),
+					parms.readList("attrNames", String.class));
+		}
+	},
+
+	/*#
+	 * Returns all AllRichSubGroups from parent group containing selected attributes (all level subgroups).
+	 *
+	 * @param group int <code>id</code> of group
+	 * @param attrNames List<String> if attrNames is null method will return RichGroups containing all attributes
+	 * @return List<RichGroup> RichGroups containing selected attributes
+	 */
+	getAllRichSubGroupsWithAttributesByNames {
+
+		@Override
+		public List<RichGroup> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getGroupsManager().getAllRichSubGroupsWithAttributesByNames(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")),
 					parms.readList("attrNames", String.class));
 		}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichSubGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichSubGroups.java
@@ -8,7 +8,11 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent.ListHandler;
-import com.google.gwt.user.client.ui.*;
+import com.google.gwt.user.client.ui.FlexTable;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.HasVerticalAlignment;
+import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.view.client.DefaultSelectionEventManager;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.MultiSelectionModel;
@@ -17,12 +21,21 @@ import cz.metacentrum.perun.webgui.client.resources.LargeIcons;
 import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
 import cz.metacentrum.perun.webgui.client.resources.TableSorter;
-import cz.metacentrum.perun.webgui.json.*;
+import cz.metacentrum.perun.webgui.json.GetEntityById;
+import cz.metacentrum.perun.webgui.json.JsonCallback;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.JsonCallbackOracle;
+import cz.metacentrum.perun.webgui.json.JsonCallbackTable;
+import cz.metacentrum.perun.webgui.json.JsonClient;
+import cz.metacentrum.perun.webgui.json.JsonUtils;
 import cz.metacentrum.perun.webgui.json.keyproviders.GeneralKeyProvider;
-import cz.metacentrum.perun.webgui.model.RichGroup;
 import cz.metacentrum.perun.webgui.model.PerunError;
-import cz.metacentrum.perun.webgui.widgets.*;
+import cz.metacentrum.perun.webgui.model.RichGroup;
+import cz.metacentrum.perun.webgui.widgets.AjaxLoaderImage;
+import cz.metacentrum.perun.webgui.widgets.Confirm;
 import cz.metacentrum.perun.webgui.widgets.CustomButton;
+import cz.metacentrum.perun.webgui.widgets.PerunTable;
+import cz.metacentrum.perun.webgui.widgets.UnaccentMultiWordSuggestOracle;
 import cz.metacentrum.perun.webgui.widgets.cells.CustomClickableInfoCellWithImageResource;
 
 import java.util.ArrayList;
@@ -34,7 +47,7 @@ import java.util.Comparator;
  * @author Vaclav Mach <374430@mail.muni.cz>
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
  */
-public class GetRichSubGroups implements JsonCallback, JsonCallbackTable<RichGroup>, JsonCallbackOracle<RichGroup> {
+public class GetAllRichSubGroups implements JsonCallback, JsonCallbackTable<RichGroup>, JsonCallbackOracle<RichGroup> {
 
 	// Session
 	private PerunWebSession session = PerunWebSession.getInstance();
@@ -45,7 +58,7 @@ public class GetRichSubGroups implements JsonCallback, JsonCallbackTable<RichGro
 	// Selection model
 	final MultiSelectionModel<RichGroup> selectionModel = new MultiSelectionModel<RichGroup>(new GeneralKeyProvider<RichGroup>());
 	// JSON URL
-	static final private String JSON_URL = "groupsManager/getRichSubGroupsWithAttributesByNames";
+	static final private String JSON_URL = "groupsManager/getAllRichSubGroupsWithAttributesByNames";
 	// Table data provider
 	private ListDataProvider<RichGroup> dataProvider = new ListDataProvider<RichGroup>();
 	// The table itself
@@ -67,7 +80,7 @@ public class GetRichSubGroups implements JsonCallback, JsonCallbackTable<RichGro
 	 *
 	 * @param id Parent group id
 	 */
-	public GetRichSubGroups(int id, ArrayList<String> attrNames) {
+	public GetAllRichSubGroups(int id, ArrayList<String> attrNames) {
 		this.parentId = id;
 		this.attrNames = attrNames;
 	}
@@ -77,7 +90,7 @@ public class GetRichSubGroups implements JsonCallback, JsonCallbackTable<RichGro
 	 *
 	 * @param id Parent group id
 	 */
-	public GetRichSubGroups(int id, JsonCallbackEvents events ) {
+	public GetAllRichSubGroups(int id, JsonCallbackEvents events ) {
 		this.parentId = id;
 		this.events = events;
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetSubGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetSubGroups.java
@@ -131,7 +131,7 @@ public class GetSubGroups implements JsonCallback, JsonCallbackTable<Group>, Jso
 	 * Sorts table by objects Name
 	 */
 	public void sortTable() {
-		list = new TableSorter<Group>().sortByService(getList());
+		list = new TableSorter<Group>().sortByName(getList());
 		dataProvider.flush();
 		dataProvider.refresh();
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/SubgroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/SubgroupsTabItem.java
@@ -16,7 +16,7 @@ import cz.metacentrum.perun.webgui.json.GetEntityById;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
 import cz.metacentrum.perun.webgui.json.groupsManager.DeleteGroups;
-import cz.metacentrum.perun.webgui.json.groupsManager.GetRichSubGroups;
+import cz.metacentrum.perun.webgui.json.groupsManager.GetAllRichSubGroups;
 import cz.metacentrum.perun.webgui.model.Group;
 import cz.metacentrum.perun.webgui.model.RichGroup;
 import cz.metacentrum.perun.webgui.tabs.GroupsTabs;
@@ -113,7 +113,7 @@ public class SubgroupsTabItem implements TabItem, TabItemWithUrl{
 		attrNames.add("urn:perun:group:attribute-def:def:lastSuccessSynchronizationTimestamp");
 		attrNames.add("urn:perun:group:attribute-def:def:authoritativeGroup");
 
-		final GetRichSubGroups subgroups = new GetRichSubGroups(groupId, attrNames);
+		final GetAllRichSubGroups subgroups = new GetAllRichSubGroups(groupId, attrNames);
 
 		// Events for reloading when group is created
 		final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(subgroups);


### PR DESCRIPTION
- Added method getAllRichSubGroupsWithAttributesByNames().
- Updated javadoc for getRichSubGroupsWithAttributesByNames().
- This allows us to display all sub-group hierarchy on a group detail
   subgroups tab in GUI.
- Fixed sorting of subgroups in GUI.
- When deleting groups, delete also "contact groups" and "ext sources" from
  a sub-groups in order for them to be deletable.