### PR TITLE
DISPATCHER,ENGINE: Fixes when reloading Tasks and managing pool

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
@@ -27,13 +26,11 @@ import cz.metacentrum.perun.taskslib.service.TaskManager;
 @org.springframework.stereotype.Service("schedulingPool")
 public class SchedulingPoolImpl implements SchedulingPool {
 
-	private final static Logger log = LoggerFactory
-			.getLogger(SchedulingPoolImpl.class);
+	private final static Logger log = LoggerFactory.getLogger(SchedulingPoolImpl.class);
 
-	private Map<Integer, Pair<Task, DispatcherQueue>> tasksById = new ConcurrentHashMap<Integer, Pair<Task, DispatcherQueue>>();
-	private Map<Pair<Integer, Integer>, Task> tasksByServiceAndFacility = new ConcurrentHashMap<Pair<Integer, Integer>, Task>();
-	private Map<TaskStatus, List<Task>> pool = new EnumMap<TaskStatus, List<Task>>(
-			TaskStatus.class);
+	private final Map<Integer, Pair<Task, DispatcherQueue>> tasksById = new ConcurrentHashMap<Integer, Pair<Task, DispatcherQueue>>();
+	private final Map<Pair<Integer, Integer>, Task> tasksByServiceAndFacility = new ConcurrentHashMap<Pair<Integer, Integer>, Task>();
+	private final Map<TaskStatus, List<Task>> pool = new EnumMap<TaskStatus, List<Task>>(TaskStatus.class);
 
 	@Autowired
 	private TaskManager taskManager;
@@ -267,7 +264,7 @@ public class SchedulingPoolImpl implements SchedulingPool {
                     continue;
             }
             */
-			if (!pool.get(task.getStatus()).contains(task.getId())) {
+			if (!pool.get(task.getStatus()).contains(task)) {
 				pool.get(task.getStatus()).add(task);
 			}
 			DispatcherQueue queue = dispatcherQueuePool.getDispatcherQueueByClient(pair.getRight()); 

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -33,8 +33,8 @@ public class SchedulingPoolImpl implements SchedulingPool{
 
 	private final static Logger log = LoggerFactory.getLogger(SchedulingPoolImpl.class);
 
-	private Map<TaskStatus, List<Task>> pool = new EnumMap<TaskStatus, List<Task>>(TaskStatus.class);
-	private Map<Integer, Task> taskIdMap = new ConcurrentHashMap<Integer, Task>();
+	private final Map<TaskStatus, List<Task>> pool = new EnumMap<TaskStatus, List<Task>>(TaskStatus.class);
+	private final Map<Integer, Task> taskIdMap = new ConcurrentHashMap<Integer, Task>();
 
 	/*
 	 * private BufferedWriter out = null; private FileWriter fstream = null;
@@ -61,7 +61,7 @@ public class SchedulingPoolImpl implements SchedulingPool{
 			if (status == null) {
 				task.setStatus(TaskStatus.NONE);
 			}
-			if (!pool.get(task.getStatus()).contains(task.getId())) {
+			if (!pool.get(task.getStatus()).contains(task)) {
 				pool.get(task.getStatus()).add(task);
 			}
 		}
@@ -206,6 +206,7 @@ public class SchedulingPoolImpl implements SchedulingPool{
 		 */
 	}
 
+	/* FIXME - if ever used, do not re-assign, but clear final variables
 	private void clearPool() {
 		pool = new EnumMap<TaskStatus, List<Task>>(TaskStatus.class);
 		taskIdMap = new ConcurrentHashMap<Integer, Task>();
@@ -213,6 +214,7 @@ public class SchedulingPoolImpl implements SchedulingPool{
 			pool.put(status, new ArrayList<Task>());
 		}
 	}
+	*/
 
 	/*
 	 * class Serializator implements Runnable { private Pair<ExecService,


### PR DESCRIPTION
- When reloading all Tasks from DB there was contains()
  on a List<Task> against Task.getId() which was always false.
  Hence by condition every passed Task was always added.
  Same bug was in engine when adding Task to pool (always added).

- Make variables we synchronize on final (pool,...). We do not re-assign them,
  but just for case somebody would try it. Fixed in engine too (commented unused
  re-assign).