### PR TITLE
CLI: Fixed printing of attribute value in export functions

### DIFF
--- a/perun-rpc/src/main/perl/exportGroupMembers
+++ b/perun-rpc/src/main/perl/exportGroupMembers
@@ -19,36 +19,36 @@ sub help {
 	--groupName    | -G  Group name
 	--voId         | -v  VO idetifier
 	--voShortName  | -V  VO short name
-        --attrList     | -a  list of attributes to print *)
-        --statuses     | -s  list of allowed statuses   **)
+	--attrList     | -a  list of attributes to print *)
+	--statuses     | -s  list of allowed statuses   **)
 	--orderByName  | -n  order by member's name
 	--batch        | -b  batch
 	--help         | -h  prints this help
 
-        *) names of attributes are required in short form like
-           u:d:organization = urn:perun:user:attribute-def:def:organization,
-           m:d:organization = urn:perun:member:attribute-def:def:organization
-           u:d:preferredMail = urn:perun:user:attribute-def:def:preferredMail
-           ...
-           default value -a u:d:preferredMail m:d:organization
-        **)if parameter -s is not used the default value is 
-           VALID+INVALID+SUSPENDED
-           if parameter -s is used but the list of statuses is empty
-           ALL statuses are listed
+		*) names of attributes are required in short form like
+		   u:d:organization = urn:perun:user:attribute-def:def:organization,
+		   m:d:organization = urn:perun:member:attribute-def:def:organization
+		   u:d:preferredMail = urn:perun:user:attribute-def:def:preferredMail
+		   ...
+		   default value -a u:d:preferredMail m:d:organization
+		**)if parameter -s is not used the default value is
+		   VALID+INVALID+SUSPENDED
+		   if parameter -s is used but the list of statuses is empty
+		   ALL statuses are listed
 	};
 }
 
 our $batch;
 my ($groupId, $groupName, $voId, $voShortName, $sortingFunction, @attributes, @statuses);
 GetOptions("help|h" => sub { print help; exit 0;} ,
-"groupId|g=i" => \$groupId,
-"groupName|G=s" => \$groupName,
-"voId|v=i" => \$voId,
-"voShortName|V=s" => \$voShortName,
-'attrList|am=s@{1,}' => \@attributes,
-'statusList|s=s@{0,}' => \@statuses,
-"orderByName|n" => sub { $sortingFunction = getSortingFunction("getLastName",1) },
-"batch|b" => \$batch) || die help;
+	"groupId|g=i" => \$groupId,
+	"groupName|G=s" => \$groupName,
+	"voId|v=i" => \$voId,
+	"voShortName|V=s" => \$voShortName,
+	'attrList|am=s@{1,}' => \@attributes,
+	'statusList|s=s@{0,}' => \@statuses,
+	"orderByName|n" => sub { $sortingFunction = getSortingFunction("getLastName",1) },
+	"batch|b" => \$batch) || die help;
 
 my $agent = Perun::Agent->new();
 my $groupsAgent = $agent->getGroupsAgent;
@@ -58,24 +58,24 @@ my $membersAgent = $agent->getMembersAgent;
 #options check
 unless(defined $sortingFunction) { $sortingFunction = getSortingFunction("getLastName",1); }
 unless(defined $groupId) {
-    unless(defined $groupName) { die "ERROR: Group specification required.\n"; }
-    unless(defined $voId) {
-        unless(defined $voShortName) { die "ERROR: VO specification required.\n"; }
-        my $vo = $agent->getVosAgent->getVoByShortName(shortName => $voShortName);
-        $voId = $vo->getId;
-    }
-    my $group = $groupsAgent->getGroupByName(vo => $voId, name => $groupName);
-    $groupId = $group->getId;
+	unless(defined $groupName) { die "ERROR: Group specification required.\n"; }
+	unless(defined $voId) {
+		unless(defined $voShortName) { die "ERROR: VO specification required.\n"; }
+		my $vo = $agent->getVosAgent->getVoByShortName(shortName => $voShortName);
+		$voId = $vo->getId;
+	}
+	my $group = $groupsAgent->getGroupByName(vo => $voId, name => $groupName);
+	$groupId = $group->getId;
 }
 
 unless (defined $statuses[0]) {
-    @statuses=("VALID","INVALID","SUSPENDED");
+	@statuses=("VALID","INVALID","SUSPENDED");
 }
 if (defined $statuses[0] and $statuses[0] eq "") {
-    @statuses=();
+	@statuses=();
 }
 foreach my $stat (@statuses) {
-    if ($stat ne "VALID" and $stat ne "INVALID" and $stat ne "SUSPENDED" and $stat ne "EXPIRED" and $stat ne "DISABLED") {die "ERROR: wrong status value. \n";}
+	if ($stat ne "VALID" and $stat ne "INVALID" and $stat ne "SUSPENDED" and $stat ne "EXPIRED" and $stat ne "DISABLED") {die "ERROR: wrong status value. \n";}
 }
 
 my $parentGroup=0;
@@ -84,16 +84,16 @@ my %entities = ("u"=>"user","m"=>"member");
 my %types = ("d"=>"def","o"=>"opt","v"=>"virt","c"=>"core");
 
 unless(@attributes) {
-    @attributes=("u:d:preferredMail","m:d:organization");
+	@attributes=("u:d:preferredMail","m:d:organization");
 }
 foreach my $attr (@attributes) {
-    my $attrName="urn:perun:";
-    if ($attr =~ /^(\w)\:(\w)\:(\w+)$/) {
-        $attrName=$attrName.$entities{$1}.":attribute-def:".$types{$2}.":".$3;
-        $attrShort{$attr}=$attrName;
-    } else {    
-        printMessage "Wrong attribute name:$attr", $batch;
-    }
+	my $attrName="urn:perun:";
+	if ($attr =~ /^(\w)\:(\w)\:(\w+)$/) {
+		$attrName=$attrName.$entities{$1}.":attribute-def:".$types{$2}.":".$3;
+		$attrShort{$attr}=$attrName;
+	} else {
+		printMessage "Wrong attribute name:$attr", $batch;
+	}
 }
 
 my @richMembers = $membersAgent->getCompleteRichMembers(group => $groupId, attrsNames => [values %attrShort], allowedStatuses => \@statuses, lookingInParentGroup => $parentGroup);
@@ -106,23 +106,23 @@ my $table = Text::ASCIITable->new({utf8=>0});
 $table->setCols('Name', 'Status', sort keys(%attrShort));
 
 foreach my $richMember (sort $sortingFunction @richMembers) {
-        my @uattributes = $richMember->getUserAttributes;
-        my @mattributes = $richMember->getMemberAttributes; 
-        my @dispAtt;
-        
-        foreach my $shnam (sort keys (%attrShort)) {
-            foreach my $ua (@uattributes) {
-                if ($attrShort{$shnam} eq $ua->getName) {
-                    push (@dispAtt,$ua->getValue);
-                }
-            }      
-            foreach my $ma (@mattributes) {
-                if ($attrShort{$shnam} eq $ma->getName) {
-                    push (@dispAtt,$ma->getValue);
-                }
-            }      
-        }
-        $table->addRow($richMember->getDisplayName,$richMember->getStatus,@dispAtt);
+	my @uattributes = $richMember->getUserAttributes;
+	my @mattributes = $richMember->getMemberAttributes;
+	my @dispAtt;
+
+	foreach my $shnam (sort keys (%attrShort)) {
+		foreach my $ua (@uattributes) {
+			if ($attrShort{$shnam} eq $ua->getName) {
+				push (@dispAtt,$ua->getValueAsScalar);
+			}
+		}
+		foreach my $ma (@mattributes) {
+			if ($attrShort{$shnam} eq $ma->getName) {
+				push (@dispAtt,$ma->getValueAsScalar);
+			}
+		}
+	}
+	$table->addRow($richMember->getDisplayName,$richMember->getStatus,@dispAtt);
 }
 
 print tableToPrint($table, $batch);

--- a/perun-rpc/src/main/perl/exportVoMembers
+++ b/perun-rpc/src/main/perl/exportVoMembers
@@ -14,34 +14,34 @@ sub help {
 	Available options:
 	--voId         | -v  VO idetifier
 	--voShortName  | -V  VO short name
-        --attrList     | -a  list of attributes to print *)
-        --statuses     | -s  list of allowed statuses   **)
+	--attrList     | -a  list of attributes to print *)
+	--statuses     | -s  list of allowed statuses   **)
 	--orderByName  | -n  order by member's name
 	--batch        | -b  batch
 	--help         | -h  prints this help
 
-        *) names of attributes are required in short form like
-           u:d:organization = urn:perun:user:attribute-def:def:organization,
-           m:d:organization = urn:perun:member:attribute-def:def:organization
-           u:d:preferredMail = urn:perun:user:attribute-def:def:preferredMail
-           ...
-           default value -a u:d:preferredMail m:d:organization
-        **)if parameter -s is not used the default value is 
-           VALID+INVALID+SUSPENDED
-           if parameter -s is used but the list of statuses is empty
-           ALL statuses are listed
+		*) names of attributes are required in short form like
+		   u:d:organization = urn:perun:user:attribute-def:def:organization,
+		   m:d:organization = urn:perun:member:attribute-def:def:organization
+		   u:d:preferredMail = urn:perun:user:attribute-def:def:preferredMail
+		   ...
+		   default value -a u:d:preferredMail m:d:organization
+		**)if parameter -s is not used the default value is
+		   VALID+INVALID+SUSPENDED
+		   if parameter -s is used but the list of statuses is empty
+		   ALL statuses are listed
 	};
 }
 
 our $batch;
 my ($voId, $voShortName, $sortingFunction, @attributes, @statuses);
 GetOptions("help|h" => sub { print help; exit 0;} ,
-"voId|v=i" => \$voId,
-"voShortName|V=s" => \$voShortName,
-'attrList|a=s@{1,}' => \@attributes,
-'statusList|s=s@{0,}' => \@statuses,
-"orderByName|n" => sub { $sortingFunction = getSortingFunction("getLastName",1) },
-"batch|b" => \$batch) || die help;
+	"voId|v=i" => \$voId,
+	"voShortName|V=s" => \$voShortName,
+	'attrList|a=s@{1,}' => \@attributes,
+	'statusList|s=s@{0,}' => \@statuses,
+	"orderByName|n" => sub { $sortingFunction = getSortingFunction("getLastName",1) },
+	"batch|b" => \$batch) || die help;
 
 my $agent = Perun::Agent->new();
 my $groupsAgent = $agent->getGroupsAgent;
@@ -51,19 +51,19 @@ my $membersAgent = $agent->getMembersAgent;
 #options check
 unless(defined $sortingFunction) { $sortingFunction = getSortingFunction("getLastName",1); }
 unless(defined $voId) {
-    unless(defined $voShortName) { die "ERROR: VO specification required.\n"; }
-    my $vo = $agent->getVosAgent->getVoByShortName(shortName => $voShortName);
-    $voId = $vo->getId;
+	unless(defined $voShortName) { die "ERROR: VO specification required.\n"; }
+	my $vo = $agent->getVosAgent->getVoByShortName(shortName => $voShortName);
+	$voId = $vo->getId;
 }
 
 unless (defined $statuses[0]) {
-    @statuses=("VALID","INVALID","SUSPENDED");
+	@statuses=("VALID","INVALID","SUSPENDED");
 }
 if (defined $statuses[0] and $statuses[0] eq "") {
-    @statuses=();
+	@statuses=();
 }
 foreach my $stat (@statuses) {
-    if ($stat ne "VALID" and $stat ne "INVALID" and $stat ne "SUSPENDED" and $stat ne "EXPIRED" and $stat ne "DISABLED") {die "ERROR: wrong status value. \n";}
+	if ($stat ne "VALID" and $stat ne "INVALID" and $stat ne "SUSPENDED" and $stat ne "EXPIRED" and $stat ne "DISABLED") {die "ERROR: wrong status value. \n";}
 }
 
 my %attrShort;
@@ -71,16 +71,16 @@ my %entities = ("u"=>"user","m"=>"member");
 my %types = ("d"=>"def","o"=>"opt","v"=>"virt","c"=>"core");
 
 unless(@attributes) {
-    @attributes=("u:d:preferredMail","m:d:organization");
+	@attributes=("u:d:preferredMail","m:d:organization");
 }
 foreach my $attr (@attributes) {
-    my $attrName="urn:perun:";
-    if ($attr =~ /^(\w)\:(\w)\:(\w+)$/) {
-        $attrName=$attrName.$entities{$1}.":attribute-def:".$types{$2}.":".$3;
-        $attrShort{$attr}=$attrName;
-    } else {    
-        printMessage "Wrong attribute name:$attr", $batch;
-    }
+	my $attrName="urn:perun:";
+	if ($attr =~ /^(\w)\:(\w)\:(\w+)$/) {
+		$attrName=$attrName.$entities{$1}.":attribute-def:".$types{$2}.":".$3;
+		$attrShort{$attr}=$attrName;
+	} else {
+		printMessage "Wrong attribute name:$attr", $batch;
+	}
 }
 
 my @richMembers = $membersAgent->getCompleteRichMembers(vo => $voId, attrsNames => [values %attrShort], allowedStatuses => \@statuses);
@@ -93,23 +93,23 @@ my $table = Text::ASCIITable->new({utf8=>0});
 $table->setCols('Name', 'Status', sort keys(%attrShort));
 
 foreach my $richMember (sort $sortingFunction @richMembers) {
-        my @uattributes = $richMember->getUserAttributes;
-        my @mattributes = $richMember->getMemberAttributes; 
-        my @dispAtt;
-        
-        foreach my $shnam (sort keys (%attrShort)) {
-            foreach my $ua (@uattributes) {
-                if ($attrShort{$shnam} eq $ua->getName) {
-                    push (@dispAtt,$ua->getValue);
-                }
-            }      
-            foreach my $ma (@mattributes) {
-                if ($attrShort{$shnam} eq $ma->getName) {
-                    push (@dispAtt,$ma->getValue);
-                }
-            }      
-        }
-        $table->addRow($richMember->getDisplayName,$richMember->getStatus,@dispAtt);
+	my @uattributes = $richMember->getUserAttributes;
+	my @mattributes = $richMember->getMemberAttributes;
+	my @dispAtt;
+
+	foreach my $shnam (sort keys (%attrShort)) {
+		foreach my $ua (@uattributes) {
+			if ($attrShort{$shnam} eq $ua->getName) {
+				push (@dispAtt,$ua->getValueAsScalar);
+			}
+		}
+		foreach my $ma (@mattributes) {
+			if ($attrShort{$shnam} eq $ma->getName) {
+				push (@dispAtt,$ma->getValueAsScalar);
+			}
+		}
+	}
+	$table->addRow($richMember->getDisplayName,$richMember->getStatus,@dispAtt);
 }
 
 print tableToPrint($table, $batch);


### PR DESCRIPTION
- Use $attr->getValueAsScalar instead of getValue in order to print
  readable attribute value in ASCIITable.
- Fixed indentation (spaces->tabs).