### PR TITLE
BASE,RPC: Added filtered Serializer for perun-engine usage

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONSIMPLE.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONSIMPLE.java
@@ -1,0 +1,139 @@
+package cz.metacentrum.perun.rpc.serializer;
+
+import cz.metacentrum.perun.cabinet.model.Authorship;
+import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.RpcException;
+import org.codehaus.jackson.JsonEncoding;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * JSON simple serializer which strips a lot of object params (used by engine).
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public final class JsonSerializerJSONSIMPLE implements Serializer {
+
+	@JsonIgnoreProperties({"name", "createdAt", "createdBy", "modifiedAt", "modifiedBy", "createdByUid",
+			"modifiedByUid", "valueCreatedAt", "valueCreatedBy", "valueModifiedAt", "valueModifiedBy", "beanName",
+			"writable", "displayName", "description", "entity", "baseFriendlyName", "friendlyNameParameter", "id", "type"})
+	private interface AttributeMixIn {
+	}
+
+	@JsonIgnoreProperties({"name", "createdAt", "createdBy", "modifiedAt", "modifiedBy", "createdByUid",
+			"modifiedByUid", "beanName", "writable", "displayName", "description", "entity", "baseFriendlyName",
+			"friendlyNameParameter", "id", "type"})
+	private interface AttributeDefinitionMixIn {
+	}
+
+	@JsonIgnoreProperties({"commonName", "displayName", "createdAt", "createdBy", "modifiedAt", "modifiedBy",
+			"createdByUid", "modifiedByUid", "beanName"})
+	private interface UserMixIn {
+	}
+
+	@JsonIgnoreProperties({"cause", "localizedMessage", "stackTrace", "beanName"})
+	private interface ExceptionMixIn {
+	}
+
+	@JsonIgnoreProperties({"userExtSources", "beanName"})
+	private interface CandidateMixIn {
+	}
+
+	@JsonIgnoreProperties({"createdAt", "createdBy", "modifiedAt", "modifiedBy", "createdByUid", "modifiedByUid", "beanName"})
+	private interface PerunBeanMixIn {
+	}
+
+	@JsonIgnoreProperties({"perunPrincipal", "beanName"})
+	private interface PerunRequestMixIn {
+	}
+
+	@JsonIgnoreProperties({})
+	private interface AuthorshipMixIn {
+	}
+
+	public static final String CONTENT_TYPE = "application/json; charset=utf-8";
+	private static final ObjectMapper mapper = new ObjectMapper();
+
+	static {
+		mapper.getSerializationConfig().addMixInAnnotations(Attribute.class, AttributeMixIn.class);
+		mapper.getSerializationConfig().addMixInAnnotations(AttributeDefinition.class, AttributeDefinitionMixIn.class);
+		mapper.getSerializationConfig().addMixInAnnotations(User.class, UserMixIn.class);
+		mapper.getSerializationConfig().addMixInAnnotations(Candidate.class, CandidateMixIn.class);
+		mapper.getSerializationConfig().addMixInAnnotations(PerunException.class, ExceptionMixIn.class);
+		mapper.getSerializationConfig().addMixInAnnotations(PerunRuntimeException.class, ExceptionMixIn.class);
+		mapper.getSerializationConfig().addMixInAnnotations(PerunBean.class, PerunBeanMixIn.class);
+		mapper.getSerializationConfig().addMixInAnnotations(Authorship.class, AuthorshipMixIn.class);
+		mapper.getSerializationConfig().addMixInAnnotations(PerunRequest.class, PerunRequestMixIn.class);
+	}
+
+	private static final JsonFactory jsonFactory = new JsonFactory();
+
+	static {
+		//FIXME odstraneno disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)
+		jsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET).disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT).setCodec(mapper);
+	}
+
+	private OutputStream out;
+
+	/**
+	 * @param out {@code OutputStream} to output serialized data
+	 * @throws IOException if an IO error occurs
+	 */
+	public JsonSerializerJSONSIMPLE(OutputStream out) throws IOException {
+		this.out = out;
+	}
+
+	@Override
+	public String getContentType() {
+		return CONTENT_TYPE;
+	}
+
+	@Override
+	public void write(Object object) throws RpcException, IOException {
+		JsonGenerator gen = jsonFactory.createJsonGenerator(out, JsonEncoding.UTF8);
+
+		try {
+			gen.writeObject(object);
+			gen.flush();
+			gen.close();
+		} catch (JsonProcessingException ex) {
+			throw new RpcException(RpcException.Type.CANNOT_SERIALIZE_VALUE, ex);
+		}
+	}
+
+	@Override
+	public void writePerunException(PerunException pex) throws IOException {
+
+		JsonGenerator gen = jsonFactory.createJsonGenerator(out, JsonEncoding.UTF8);
+		if (pex == null) {
+			throw new IllegalArgumentException("pex is null");
+		} else {
+			gen.writeObject(pex);
+			gen.flush();
+		}
+		gen.close();
+
+	}
+
+	@Override
+	public void writePerunRuntimeException(PerunRuntimeException prex) throws IOException {
+
+		JsonGenerator gen = jsonFactory.createJsonGenerator(out, JsonEncoding.UTF8);
+		if (prex == null) {
+			throw new IllegalArgumentException("prex is null");
+		} else {
+			gen.writeObject(prex);
+			gen.flush();
+		}
+		gen.close();
+
+	}
+}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.codehaus.jackson.JsonNode;
+import cz.metacentrum.perun.rpc.serializer.JsonSerializerJSONSIMPLE;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ObjectNode;
 import org.slf4j.Logger;
@@ -616,6 +616,8 @@ public class Api extends HttpServlet {
 				return new JsonSerializer(out);
 			case voot:
 				return new JsonSerializer(out);
+			case jsonsimple:
+				return new JsonSerializerJSONSIMPLE(out);
 			default:
 				throw new RpcException(RpcException.Type.UNKNOWN_SERIALIZER_FORMAT, format);
 		}
@@ -625,6 +627,7 @@ public class Api extends HttpServlet {
 		switch (Formats.match(format)) {
 			case json:
 			case jsonp:
+			case jsonsimple:
 				return new JsonDeserializer(req);
 			case urlinjsonout:
 			case voot:
@@ -643,7 +646,8 @@ public class Api extends HttpServlet {
 		urlinjsonout,
 		json,
 		jsonp,
-		voot;
+		voot,
+		jsonsimple;
 
 		/**
 		 * Matches a string with the enum's values.

--- a/perun-rpc/src/main/perl/Perun/Agent.pm
+++ b/perun-rpc/src/main/perl/Perun/Agent.pm
@@ -52,6 +52,12 @@ use constant {
 sub new {
 	my $self = fields::new(shift);
 
+	# load custom data format
+	my $wanted_format = shift;
+	if (defined $wanted_format) {
+		$format = $wanted_format;
+	}
+
 	# Check if the PERUN_URL is defined
 	if (!defined($ENV{PERUN_URL})) { die Perun::Exception->fromHash({ type => MISSING_URL }); };
 	$self->{_url} = $ENV{PERUN_URL};
@@ -68,8 +74,8 @@ sub new {
 	$self->{_lwpUserAgent} = LWP::UserAgent->new(agent => "Agent.pm/$agentVersion", timeout => 600);
 	# Enable cookies if the HOME env is available
 	if (defined($ENV{HOME})) {
-                my $hostname = hostname();
-                my $grp=getpgrp;
+				my $hostname = hostname();
+				my $grp=getpgrp;
 		local $SIG{'__WARN__'} = sub { warn @_ unless $_[0] =~ /does not seem to contain cookies$/; };  #supress one concrete warning message from package HTTP::Cookies
 #		$self->{_lwpUserAgent}->cookie_jar({ file => $ENV{HOME} . "/.perun-engine-cookies.txt", autosave => 1, ignore_discard => 1 });
 		$self->{_lwpUserAgent}->cookie_jar({ file => $ENV{HOME} . "/perun-cookie-$hostname-$grp.txt", autosave => 1, ignore_discard => 1 });
@@ -359,13 +365,13 @@ sub getNotificationsAgent {
 }
 
 sub getRegistrarAgent {
-        my $self = shift;
+	my $self = shift;
 
-        if (!$self->{_registrarAgent}) {
-                $self->{_registrarAgent} = Perun::RegistrarAgent->new($self);
+	if (!$self->{_registrarAgent}) {
+		$self->{_registrarAgent} = Perun::RegistrarAgent->new($self);
 
-        return $self->{_registrarAgent};
-        }
+		return $self->{_registrarAgent};
+	}
 }
 
 sub getSecurityTeamsAgent {


### PR DESCRIPTION
- Added JsonSerializerJSONSIMPLE.
- We want GUI like filtering on object properties, but returned as standard JSON
  and not JSONP. Like this we can make transfered data smaller when
  generating big services.
- In order to use it, we must use different URL:
  https://hostname/krb/rpc/jsonsimple/manager/method?params

Allow Agent.pm to be instantiated with custom data transfer format

- Default is 'json' but for gen scripts we will use 'jsonsimple' since it crops
  big data portion and prevent oom killer from stopping process.