### PR TITLE
New workflow for ability to synchronize members by list of their logins

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -121,6 +121,11 @@
 			<version>2.5</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- OTHERS -->
 

--- a/perun-base/src/test/java/BeansUtilsTest.java
+++ b/perun-base/src/test/java/BeansUtilsTest.java
@@ -1,0 +1,168 @@
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import static org.hamcrest.CoreMatchers.isA;
+import org.junit.Assert;
+import static org.junit.Assert.fail;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Michal Krajčovič <mkrajcovic@mail.muni.cz>
+ */
+public class BeansUtilsTest {
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private String identifier = "table.identifier";
+
+	@Test
+	public void prepareInSQLClauseForValuesTestWithValidParameters() {
+		String expected = " ( table.identifier in ('8','1','2','3','4','5') ) ";
+		List<String> values = Arrays.asList("8", "1", "2", "3", "4", "5");
+
+		try {
+			Assert.assertEquals(expected, BeansUtils.prepareInSQLClauseForValues(values, identifier));
+		} catch (InternalErrorException e) {
+			fail();
+		}
+	}
+
+	@Test
+	public void prepareInSQLClauseForValuesTestWithALotOfValidParameters() {
+		List<String> values = new ArrayList<>(2653);
+		String expected = getExpectedResultForALotOfValues(values, 2653);
+		try {
+			Assert.assertEquals(expected, BeansUtils.prepareInSQLClauseForValues(values, identifier));
+		} catch (InternalErrorException e) {
+			fail();
+		}
+	}
+
+
+	@Test
+	public void prepareInSQLClauseForValuesTestWithEmptyValues() {
+		String expected = " ( table.identifier in () ) ";
+		List<String> values = Collections.emptyList();
+
+		try {
+			Assert.assertEquals(expected, BeansUtils.prepareInSQLClauseForValues(values, identifier));
+		} catch (InternalErrorException e) {
+			fail();
+		}
+	}
+
+	@Test
+	public void prepareInSQLClauseForValuesTestWithEmptyIdentifier() throws InternalErrorException {
+		expectedException.expectCause(isA(IllegalArgumentException.class));
+
+		String identifier = "";
+		List<String> values = Arrays.asList("8", "1", "2", "3", "4", "5");
+
+		BeansUtils.prepareInSQLClauseForValues(values, identifier);
+	}
+
+	@Test
+	public void prepareInSQLClauseForValuesTestWithNullValues() throws InternalErrorException {
+		expectedException.expectCause(isA(NullPointerException.class));
+
+		List<String> values = null;
+
+		BeansUtils.prepareInSQLClauseForValues(values, identifier);
+	}
+
+	@Test
+	public void prepareInSQLClauseForValuesTestWithNullIdentifier() throws InternalErrorException {
+		expectedException.expectCause(isA(NullPointerException.class));
+
+		String identifier = null;
+		List<String> values = Arrays.asList("8", "1", "2", "3", "4", "5");
+
+		BeansUtils.prepareInSQLClauseForValues(values, identifier);
+	}
+
+	@Test
+	public void prepareInSQLClauseForValuesTestWithSomeNullValues() {
+		String expected = " ( table.identifier in ('1','2','4','5') ) ";
+		List<String> values = Arrays.asList(null, "1", "2", null, "4", "5");
+
+		try {
+			Assert.assertEquals(expected, BeansUtils.prepareInSQLClauseForValues(values, identifier));
+		} catch (InternalErrorException e) {
+			fail();
+		}
+	}
+
+	@Test
+	public void beanValuesToStringTestWithValidValues() {
+		String expected = "'8','1','2','3','4','5'";
+		List<String> values = Arrays.asList("8", "1", "2", "3", "4", "5");
+
+		try {
+			Assert.assertEquals(expected, BeansUtils.beanValuesToString(values));
+		} catch (InternalErrorException e) {
+			fail();
+		}
+	}
+
+	@Test
+	public void beanValuesToStringTestWithSomeNullValues() {
+		String expected = "'8','1','3','5'";
+		List<String> values = Arrays.asList("8", "1", null, "3", null, "5");
+
+		try {
+			Assert.assertEquals(expected, BeansUtils.beanValuesToString(values));
+		} catch (InternalErrorException e) {
+			fail();
+		}
+	}
+
+	@Test
+	public void beanValuesToStringTestWithNullValues() throws InternalErrorException {
+		expectedException.expectCause(isA(NullPointerException.class));
+		List<String> values = null;
+
+		BeansUtils.beanValuesToString(values);
+	}
+
+	@Test
+	public void beanValuesToStringTestWithSomeEmptyValues() {
+		List<String> values = Collections.emptyList();
+
+		try {
+			Assert.assertEquals("", BeansUtils.beanValuesToString(values));
+		} catch (InternalErrorException e) {
+			fail();
+		}
+	}
+
+	private String getExpectedResultForALotOfValues(List<String> values, int max) {
+		int loops = max / 1000;
+		String expected = " ( table.identifier in ('0'";
+		values.add("0");
+		int j = 1;
+		for (int i = 0; i < loops; i++) {
+			for (; j < (i + 1) * 1000; j++) {
+				String current = Integer.toString(j);
+				values.add(current);
+				expected += ",'" + current + "'";
+			}
+			expected += ") or table.identifier in ('" + j + "'";
+			values.add(Integer.toString(j));
+			j++;
+		}
+		for (; j < max; j++) {
+			String current = Integer.toString(j);
+			values.add(current);
+			expected += ",'" + current + "'";
+		}
+		expected += ") ) ";
+		return expected;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -93,7 +93,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private Map<AttributeDefinition, Set<AttributeDefinition>> inverseStrongDependencies = new ConcurrentHashMap<AttributeDefinition, Set<AttributeDefinition>>();
 	private Map<AttributeDefinition, Set<AttributeDefinition>> allDependencies = new ConcurrentHashMap<AttributeDefinition, Set<AttributeDefinition>>();
 
-	private final static int MAX_SIZE_OF_BULK_IN_SQL = 10000;
+	public final static int MAX_SIZE_OF_BULK_IN_SQL = 10000;
 
 	/**
 	 * Constructor.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1030,14 +1030,11 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			List<RichMember> actualGroupMembers = getPerunBl().getGroupsManagerBl().getGroupRichMembers(sess, group);
 
 			if(lightweightSynchronization) {
+				//Do not care about updating users, just create new one and remove former members (membership is important)
 				categorizeMembersForLightweightSynchronization(sess, group, source, membersSource, actualGroupMembers, candidatesToAdd, membersToRemove, skippedMembers);
 			} else {
-				//Get subjects from extSource
-				List<Map<String, String>> subjects = getSubjectsFromExtSource(sess, source, group);
-				//Convert subjects to candidates
-				List<Candidate> candidates = convertSubjectsToCandidates(sess, subjects, membersSource, source, skippedMembers);
-
-				categorizeMembersForSynchronization(sess, actualGroupMembers, candidates, candidatesToAdd, membersToUpdate, membersToRemove);
+				//Also care about updating attributes of members
+				categorizeMembersForSynchronization(sess, group, source, membersSource, actualGroupMembers, candidatesToAdd, membersToRemove, membersToUpdate, skippedMembers);
 			}
 
 			//Update members already presented in group
@@ -1050,6 +1047,8 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			removeFormerMembersWhileSynchronization(sess, group, membersToRemove);
 			
 			log.info("Group synchronization {}: ended.", group);
+		} catch (ExtSourceUnsupportedOperationException ex) {
+			throw new InternalErrorException("ExtSource do not support specific operation.", ex);
 		} finally {
 			closeExtSourcesAfterSynchronization(membersSource, source);
 		}
@@ -1557,7 +1556,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	//----------- PRIVATE METHODS FOR  GROUP SYNCHRONIZATION -----------
 
 	/**
-	 * For lightweight synchronization prepare candidate to add and members to remove.
+	 * For lightweight synchronization prepare candidates to add and members to remove.
 	 *
 	 * Get all subjects from loginSource and try to find users in Perun by their login and this ExtSource.
 	 * If found, look if this user is already in synchronized Group. If yes skip him, if not add him to candidateToAdd
@@ -1570,19 +1569,22 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * 2. membersToRemove - Former members who are not in synchronized ExtSource now
 	 *
 	 * @param sess
-	 * @param group
-	 * @param loginSource
-	 * @param memberSource
-	 * @param groupMembers
-	 * @param candidatesToAdd
-	 * @param membersToRemove
-	 * @param skippedMembers
+	 * @param group  to be synchronized
+	 * @param loginSource extSource for getting logins
+	 * @param memberSource extSource for getting members (can be same if there is just one extSource for both)
+	 * @param groupMembers actual members of group before synchronization
+	 * @param candidatesToAdd 1. container (more above)
+	 * @param membersToRemove 2. container (more above)
+	 * @param skippedMembers list of all skipped members
+	 * 
 	 * @throws InternalErrorException
 	 * @throws ExtSourceNotExistsException
+	 * @throws ExtSourceUnsupportedOperationException
 	 */
-	private void categorizeMembersForLightweightSynchronization(PerunSession sess, Group group, ExtSource loginSource, ExtSource memberSource, List<RichMember> groupMembers, List<Candidate> candidatesToAdd, List<RichMember> membersToRemove, List<String> skippedMembers) throws InternalErrorException, ExtSourceNotExistsException {
+	private void categorizeMembersForLightweightSynchronization(PerunSession sess, Group group, ExtSource loginSource, ExtSource memberSource, List<RichMember> groupMembers, List<Candidate> candidatesToAdd, List<RichMember> membersToRemove, List<String> skippedMembers) throws InternalErrorException, ExtSourceNotExistsException, ExtSourceUnsupportedOperationException {
 		//Get subjects from loginSource
-		List<Map<String, String>> subjects = getSubjectsFromExtSource(sess, loginSource, group);
+		List<Map<String, String>> subjects;
+		subjects = getSubjectsFromExtSource(sess, loginSource, group, null);
 
 		//Prepare structure of userIds with richMembers to better work with actual members
 		Map<Integer, RichMember> idsOfUsersInGroup = new HashMap<>();
@@ -1591,6 +1593,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 
 		//try to find users by login and loginSource
+		List<String> loginsToAdd = new ArrayList<>();
 		for(Map<String, String> subjectFromLoginSource : subjects) {
 			String login = subjectFromLoginSource.get("login");
 			// Skip subjects, which doesn't have login
@@ -1608,27 +1611,26 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
 				if(!idsOfUsersInGroup.containsKey(user.getId())) {
 					candidate = new Candidate(user, userExtSource);
+					candidatesToAdd.add(candidate);
+				} else {
+					idsOfUsersInGroup.remove(user.getId());
 				}
+			//If not found,
 			} catch (UserExtSourceNotExistsException | UserNotExistsException ex) {
-				//If not find, get more information about him from member extSource
-				List<Map<String, String>> subjectToConvert = Arrays.asList(subjectFromLoginSource);
-				List<Candidate> converetedCandidatesList = convertSubjectsToCandidates(sess, subjectToConvert, memberSource, loginSource, skippedMembers);
-				//Empty means not found (skipped)
-				if(!converetedCandidatesList.isEmpty()) {
-					//We add one subject so we take the one converted candidate
-					candidate = converetedCandidatesList.get(0);
-				}
+				loginsToAdd.add(login);
 			}
+		}
 
-			//If user is not null now, we found it so we can use it from perun, in other case he is not in perun at all
-			if(user != null && candidate == null) {
-				//we can skip this one, because he is already in group, and remove him from the map
-				idsOfUsersInGroup.remove(user.getId());
-			} else if (candidate != null) {
-				candidatesToAdd.add(candidate);
-			} else {
-				//Both null means that we can't find subject by login in extSource at all (will be in skipped members)
-				log.debug("Subject with login {} was skipped because can't be found in extSource {}.", login, memberSource);
+		//If possible get subjects from ExtSource by bulk, if not, get them one by one
+		try {
+			subjects = getSubjectsFromExtSource(sess, memberSource, group, loginsToAdd);
+			candidatesToAdd.addAll(convertSubjectsToCandidates(sess, subjects, memberSource, skippedMembers, false));
+		} catch (ExtSourceUnsupportedOperationException ex) {
+			for(String login: loginsToAdd) {
+				Map<String, String> subjectByLogin = new HashMap<>();
+				subjectByLogin.put("login", login);
+				List<Map<String, String>> subjectToConvert = Arrays.asList(subjectByLogin);
+				candidatesToAdd.addAll(convertSubjectsToCandidates(sess, subjectToConvert, memberSource, skippedMembers, false));
 			}
 		}
 
@@ -1637,21 +1639,62 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	/**
+	 * For normal synchronization prepare candidates to add, members to remove and members for update.
+	 *
+	 * Get all subjects by loginSource and try to convert them to Candidates. It can be done
+	 * from the list of subjects itself (if there are all attributes) or by logins one
+	 * by one (or by bulks) from membersSource.
+	 *
 	 * This method fill 3 member structures which get as parameters:
-	 * 1. membersToUpdate - Candidates with equivalent Members from Perun for purpose of updating attributes and statuses
-	 * 2. candidateToAdd - New members of the group
-	 * 3. membersToRemove - Former members who are not in synchronized ExtSource now
+	 * 1. candidateToAdd - New members of the group
+	 * 2. membersToRemove - Former members who are not in synchronized ExtSource now
+	 * 3. membersToUpdate - Candidates with equivalent Members from Perun for purpose of updating attributes and statuses
 	 *
 	 * @param sess
-	 * @param groupMembers current group members
-	 * @param candidates to be synchronized from extSource
-	 * @param membersToUpdate 1. container (more above)
-	 * @param candidatesToAdd 2. container (more above)
-	 * @param membersToRemove 3. container (more above)
-	 *
-	 * @throws InternalErrorException if getting RichMembers without attributes for the group fail
+	 * @param group  to be synchronized
+	 * @param loginSource extSource for getting logins
+	 * @param memberSource extSource for getting members (can be same if there is just one extSource for both)
+	 * @param groupMembers actual members of group before synchronization
+	 * @param candidatesToAdd 1. container (more above)
+	 * @param membersToRemove 2. container (more above)
+	 * @param membersToUpdate 3. container (more above)
+	 * @param skippedMembers list of all skipped members
+	 * 
+	 * @throws InternalErrorException
+	 * @throws ExtSourceNotExistsException
+	 * @throws ExtSourceUnsupportedOperationException
 	 */
-	private void categorizeMembersForSynchronization(PerunSession sess, List<RichMember> groupMembers, List<Candidate> candidates, List<Candidate> candidatesToAdd, Map<Candidate, RichMember> membersToUpdate, List<RichMember> membersToRemove) throws InternalErrorException {
+	private void categorizeMembersForSynchronization(PerunSession sess, Group group, ExtSource loginSource, ExtSource membersSource, List<RichMember> groupMembers, List<Candidate> candidatesToAdd, List<RichMember> membersToRemove, Map<Candidate, RichMember> membersToUpdate, List<String> skippedMembers) throws InternalErrorException, ExtSourceNotExistsException, ExtSourceUnsupportedOperationException {
+		//Get subjects from login extSource
+		List<Map<String, String>> subjectsFromLoginSource = getSubjectsFromExtSource(sess, loginSource, group, null);
+		//Convert subjects to candidates
+		List<Candidate> candidates;
+
+		//Choose the way converting subjects to candidates (get from loginSource itself, get by login again from memberSource or get by list of logins from membersSource)
+		if(!loginSource.equals(membersSource)) {
+			//get all logins from map
+			List<String> logins = new ArrayList<>();
+			for(Map<String, String> subject: subjectsFromLoginSource) {
+				if(subject.containsKey("login")) logins.add(subject.get("login"));
+			}
+			try {
+				List<Map<String, String>> subjectsFromMemberSource = getSubjectsFromExtSource(sess, membersSource, group, logins);
+				candidates = convertSubjectsToCandidates(sess, subjectsFromMemberSource, membersSource, skippedMembers, false);
+			} catch (ExtSourceUnsupportedOperationException ex) {
+				//do not support getting subject by list of logins, so use the old way
+				candidates = convertSubjectsToCandidates(sess, subjectsFromLoginSource, membersSource, skippedMembers, true);
+			}
+
+		} else if (membersSource instanceof ExtSourceApi) {
+			//They are the same and extSourceApi is
+			candidates = convertSubjectsToCandidates(sess, subjectsFromLoginSource, membersSource, skippedMembers, false);
+		} else if (membersSource instanceof ExtSourceSimpleApi) {
+			candidates = convertSubjectsToCandidates(sess, subjectsFromLoginSource, membersSource, skippedMembers, true);
+		} else {
+			// this should not happen without change in extSource API code
+			throw new InternalErrorException("ExtSource is other instance than SimpleApi or Api and this is not supported!");
+		}
+
 		candidatesToAdd.addAll(candidates);
 		membersToRemove.addAll(groupMembers);
 		//mapping structure for more efficient searching
@@ -1789,12 +1832,14 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * @param sess
 	 * @param source to get subjects from
 	 * @param group to be synchronized
+	 * @param logins if not null, use it for filtering logins from extSource
 	 *
 	 * @return list of subjects
 	 *
 	 * @throws InternalErrorException if internal error occurs
+	 * @throws ExtSourceUnsupportedOperationException if extSource do not support getGroupBySubject with or without logins
 	 */
-	private List<Map<String, String>> getSubjectsFromExtSource(PerunSession sess, ExtSource source, Group group) throws InternalErrorException {
+	private List<Map<String, String>> getSubjectsFromExtSource(PerunSession sess, ExtSource source, Group group, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		//Get all group attributes and store tham to map (info like query, time interval etc.)
 		List<Attribute> groupAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, group);
 		Map<String, String> groupAttributesMap = new HashMap<String, String>();
@@ -1805,37 +1850,35 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 		//-- Get Subjects in form of map where left string is name of attribute and right string is value of attribute, every subject is one map
 		List<Map<String, String>> subjects;
-		try {
+		if(logins == null) {
 			subjects = ((ExtSourceSimpleApi) source).getGroupSubjects(groupAttributesMap);
-			log.debug("Group synchronization {}: external group contains {} members.", group, subjects.size());
-		} catch (ExtSourceUnsupportedOperationException e2) {
-			throw new InternalErrorException("ExtSource " + source.getName() + " doesn't support getGroupSubjects", e2);
+			log.debug("Group synchronization {}: get members for external group. It contains {} members.", group, subjects.size());
+		} else {
+			subjects = ((ExtSourceSimpleApi) source).getGroupSubjects(groupAttributesMap, logins);
+			log.debug("Group synchronization {}: get members for external group by list of logins. It contains {} members.", group, subjects.size());
 		}
+			
 		return subjects;
 	}
 
 	/**
-	 * Convert List of subjects to list of Candidates.
+	 * Convert all subjects to candidates.
 	 *
-	 * To getting Candidate can use 1 of 3 possible options:
-	 * 1] membersSource and source are not equals => we have just login, other attributes neet to get from membersSource
-	 * 2] membersSource==source and membersSource is instance of ExtSourceApi => we already have all attributes in subject
-	 * 3] membersSource==source and membersSource is instance of SimplExtSourceApi => we have just login, need to read other attributes again
-	 *
-	 * If candidate cannot be get for some reason, add this reason to skippedMembers list and skip him.
+	 * If "onlyLoginInMap" is true, it means we need to get all data from membersSource by login (one by one).
+	 * If "onlyLoginInMap" is false, it means we have all data already so we can just create candidate without
+	 * query to membersSource.
 	 *
 	 * @param sess
-	 * @param subjects list of subjects from ExtSource (at least login should be here)
-	 * @param membersSource optional member ExtSource (if members attributes are from other source then their logins)
-	 * @param source default group ExtSource
-	 * @param skippedMembers not successfully synchronized members are skipped and information about it should be added here
+	 * @param subjects list of subjects or just their logins
+	 * @param membersSource extSource for getting members with attributes
+	 * @param skippedMembers list of skipped members
+	 * @param onlyLoginsInMap true if only logins in subjects, false if all other attributes are already there
 	 *
-	 * @return list of successfully created candidates from subjects
-	 *
-	 * @throws InternalErrorException if some internal error occurs
-	 * @throws ExtSourceNotExistsException if membersSource not exists in Perun
+	 * @return list of converted subjects to candidates
+	 * @throws InternalErrorException
+	 * @throws ExtSourceNotExistsException
 	 */
-	private List<Candidate> convertSubjectsToCandidates(PerunSession sess, List<Map<String, String>> subjects, ExtSource membersSource, ExtSource source, List<String> skippedMembers) throws InternalErrorException, ExtSourceNotExistsException {
+	private List<Candidate> convertSubjectsToCandidates(PerunSession sess, List<Map<String, String>> subjects, ExtSource membersSource, List<String> skippedMembers, boolean onlyLoginsInMap) throws InternalErrorException, ExtSourceNotExistsException {
 		List<Candidate> candidates = new ArrayList<>();
 		for (Map<String, String> subject: subjects) {
 			String login = subject.get("login");
@@ -1846,35 +1889,20 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				continue;
 			}
 			try {
-				// One of three possible ways should happen to get Candidate
-				// 1] sources of login and other attributes are not same
-				if(!membersSource.equals(source)) {
-					//need to read attributes from the new memberSource, we can't use locally data there (there are from other extSource)
-					candidates.add((getPerunBl().getExtSourcesManagerBl().getCandidate(sess, membersSource, login)));
-				// 2] sources are same and we work with source which is instance of ExtSourceApi
-				} else if (membersSource instanceof ExtSourceApi) {
-					// we can use the data from this source without reading them again (all exists in the map of subject attributes)
-					candidates.add((getPerunBl().getExtSourcesManagerBl().getCandidate(sess, subject, membersSource, login)));
-				// 3] sources are same and we work with source which is instace of ExtSourceSimpleApi
-				} else if (membersSource instanceof ExtSourceSimpleApi) {
-					// we can't use the data from this source, we need to read them again (they are not in the map of subject attributes)
+				if(onlyLoginsInMap) {
 					candidates.add((getPerunBl().getExtSourcesManagerBl().getCandidate(sess, membersSource, login)));
 				} else {
-					// this could not happen without change in extSource API code
-					throw new InternalErrorException("ExtSource is other instance than SimpleApi or Api and this is not supported!");
+					candidates.add((getPerunBl().getExtSourcesManagerBl().getCandidate(sess, subject, membersSource, login)));
 				}
 			} catch (CandidateNotExistsException e) {
 				log.warn("getGroupSubjects subjects returned login {}, but it cannot be obtained using getCandidate()", login);
 				skippedMembers.add("MemberEntry:[" + subject + "] was skipped because candidate can't be found by login:'" + login + "' in extSource " + membersSource);
-				continue;
 			} catch (ExtSourceUnsupportedOperationException e) {
 				log.warn("ExtSource {} doesn't support getCandidate operation.", membersSource);
 				skippedMembers.add("MemberEntry:[" + subject + "] was skipped because extSource " + membersSource + " not support method getCandidate");
-				continue;
 			} catch (ParserException e) {
 				log.warn("Can't parse value {} from candidate with login {}", e.getParsedValue(), login);
 				skippedMembers.add("MemberEntry:[" + subject + "] was skipped because of problem with parsing value '" + e.getParsedValue() + "'");
-				continue;
 			}
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -118,8 +118,15 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
         return null;
     }
 
-    @Override
-    public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return getGroupSubjects(attributes, null);
+	}
+
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		if(logins != null) throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
+
         try {
             // Get the query for the group subjects
             String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
@@ -186,6 +186,12 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 
 	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return getGroupSubjects(attributes, null);
+	}
+
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		if(logins != null) throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
 		try {
 			// Get the query for the group subjects
 			String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -58,7 +58,14 @@ public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException {
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return getGroupSubjects(attributes, null);
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		if(logins != null) throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
+
 		// Get the url query for the group subjects
 		String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
@@ -36,8 +36,13 @@ public class ExtSourceIdp extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
+	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
 	}
 
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
@@ -36,8 +36,13 @@ public class ExtSourceInternal extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
+	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
 	}
 
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
@@ -36,8 +36,13 @@ public class ExtSourceKerberos extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
+	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
 	}
 
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -106,7 +106,13 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		return subjects.get(0);
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException {
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return getGroupSubjects(attributes, null);
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		if(logins == null) throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
 
 		NamingEnumeration<SearchResult> results = null;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -100,7 +100,13 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 		return subject;
 	}
 
+	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return getGroupSubjects(attributes, null);
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		if(logins != null) throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
 		setEnviroment();
 		// Get the query for the group subjects
 		String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -16,9 +17,11 @@ import org.slf4j.LoggerFactory;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
+import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 
 /**
@@ -68,7 +71,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 			throw new InternalErrorException("query attribute is required");
 		}
 
-		return this.querySource(query, searchString, maxResults);
+		return this.querySource(query, searchString, maxResults, null);
 	}
 
 	public Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException {
@@ -77,7 +80,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 			throw new InternalErrorException("loginQuery attribute is required");
 		}
 
-		List<Map<String, String>> subjects = this.querySource(query, login, 0);
+		List<Map<String, String>> subjects = this.querySource(query, login, 0, null);
 
 		if (subjects.size() < 1) {
 			throw new SubjectNotExistsException("Login: " + login);
@@ -89,16 +92,29 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 		return subjects.get(0);
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException {
-		// Get the sql query for the group subjects
-		String sqlQueryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
-
-		return this.querySource(sqlQueryForGroup, null, 0);
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return this.getGroupSubjects(attributes, null);
 	}
 
-	protected List<Map<String,String>> querySource(String query, String searchString, int maxResults) throws InternalErrorException {
-		PreparedStatement st = null;
-		ResultSet rs = null;
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		//If we want to get bulk of subjects from extSource by list of logins
+		if(logins != null) {
+			String bulkQuery = getAttributes().get("bulkQuery");
+			if (bulkQuery == null) {
+				throw new ExtSourceUnsupportedOperationException("ExtSource do not support bulkQuery in perun-extSources.xml.");
+			}
+			return this.querySource(bulkQuery, null, 0, logins);
+		//If not, use the normal way of getting data
+		} else {
+			// Get the sql query for the group subjects
+			String sqlQueryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+			return this.querySource(sqlQueryForGroup, null, 0, null);
+		}
+	}
+
+	protected List<Map<String,String>> querySource(String query, String searchString, int maxResults, List<String> logins) throws InternalErrorException {
 
 		if (getAttributes().get("url") == null) {
 			throw new InternalErrorException("url attribute is required");
@@ -117,11 +133,42 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 		}
 
 		try {
-		  // Check if we have existing connection. In case of Oracle also checks the connection validity
-		  if (this.con == null || (this.isOracle && !this.con.isValid(0))) {
-					this.createConnection();
+			// Check if we have existing connection. In case of Oracle also checks the connection validity
+			if (this.con == null || (this.isOracle && !this.con.isValid(0))) {
+				this.createConnection();
 			}
+		} catch (SQLException e) {
+			log.error("SQL exception during creating connection.");
+			throw new InternalErrorRuntimeException(e);
+		}
 
+		List<Map<String, String>> subjects = new ArrayList<>();
+		//If logins are null, it means use the old fashion way
+		if(logins == null) {
+			subjects = this.normalQuery(query, maxResults, searchString);
+		//If logins are not null, we want to use bulk calling
+		} else {
+			if(logins.size() <= AttributesManagerBlImpl.MAX_SIZE_OF_BULK_IN_SQL) subjects = bulkQuery(query, logins);
+			else {
+				int from = 0;
+				int to = AttributesManagerBlImpl.MAX_SIZE_OF_BULK_IN_SQL;
+
+				do {
+					subjects.addAll(bulkQuery(query, logins.subList(from, to)));
+					from+=AttributesManagerBlImpl.MAX_SIZE_OF_BULK_IN_SQL;
+					to+=AttributesManagerBlImpl.MAX_SIZE_OF_BULK_IN_SQL;
+				} while (logins.size()>to);
+				subjects.addAll(bulkQuery(query, logins.subList(from, logins.size())));
+			}
+		}
+		return subjects;
+	}
+
+	protected List<Map<String, String>> normalQuery(String query, int maxResults, String searchString) throws InternalErrorException {
+		PreparedStatement st = null;
+		ResultSet rs = null;
+
+		try {
 			st = this.con.prepareStatement(query);
 
 			// Substitute the ? in the query by the seachString
@@ -134,7 +181,6 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 			// Limit results
 			if (maxResults > 0) {
 				st.setMaxRows(maxResults);
-
 			}
 			rs = st.executeQuery();
 
@@ -218,6 +264,114 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 			}
 
 			log.debug("Returning {} subjects from external source {} for searchString {}", new Object[] {subjects.size(), this, searchString});
+			return subjects;
+
+		} catch (SQLException e) {
+			log.error("SQL exception during searching for subject '{}'", query);
+			throw new InternalErrorRuntimeException(e);
+		} finally {
+			try {
+				if (rs != null) rs.close();
+				if (st != null) st.close();
+			} catch (SQLException e) {
+				log.error("SQL exception during closing the resultSet or statement, while searching for subject '{}'", query);
+				throw new InternalErrorRuntimeException(e);
+			}
+		}
+	}
+
+	protected List<Map<String, String>> bulkQuery(String query, List<String> logins) throws InternalErrorException {
+		PreparedStatement st = null;
+		ResultSet rs = null;
+
+		List<Map<String, String>> subjects = new ArrayList<>();
+
+		try {
+			//set (in (...) or in (...) ...) instead of "?", no identifier there
+			query = query.replace("?", BeansUtils.prepareInSQLClauseForValues(logins, ""));
+
+			st = this.con.prepareStatement(query);
+
+			rs = st.executeQuery();
+
+			log.trace("Query {}", query);
+
+			while (rs.next()) {
+				Map<String, String> map = new HashMap<>();
+
+				try {
+					map.put("firstName", rs.getString("firstName"));
+				} catch (SQLException e) {
+					// If the column doesn't exists, ignore it
+					map.put("firstName", null);
+				}
+				try {
+					map.put("lastName", rs.getString("lastName"));
+				} catch (SQLException e) {
+					// If the column doesn't exists, ignore it
+					map.put("lastName", null);
+				}
+				try {
+					map.put("middleName", rs.getString("middleName"));
+				} catch (SQLException e) {
+					// If the column doesn't exists, ignore it
+					map.put("middleName", null);
+				}
+				try {
+					map.put("titleBefore", rs.getString("titleBefore"));
+				} catch (SQLException e) {
+					// If the column doesn't exists, ignore it
+					map.put("titleBefore", null);
+				}
+				try {
+					map.put("titleAfter", rs.getString("titleAfter"));
+				} catch (SQLException e) {
+					// If the column doesn't exists, ignore it
+					map.put("titleAfter", null);
+				}
+				try {
+					map.put("login", rs.getString("login"));
+				} catch (SQLException e) {
+					// If the column doesn't exists, ignore it
+					map.put("login", null);
+				}
+
+				for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
+					String columnName = rs.getMetaData().getColumnLabel(i);
+					log.trace("Iterating through attribute {}", columnName);
+					// Now go through all other attributes. If the column name(=attribute name) contains ":", then it represents an attribute
+					if (columnName.contains(":")) {
+						// Decode the attribute name (column name has limited size, so we need to code the attribute names)
+						// Coded attribute name: x:y:z
+						// x - m: member, u: user, f: facility, r: resource, mr: member-resource, uf: user-facility, h: host, v: vo, g: group, gr: group-resource
+						// y - d: def, o: opt
+						String[] attributeRaw = columnName.split(":", 3);
+						String attributeName = null;
+						if (!attributeNameMapping.containsKey(attributeRaw[0])) {
+							log.error("Unknown attribute type '{}' for user {} {}, attributeRaw {}", new Object[] {attributeRaw[0], map.get("firstName"), map.get("lastName"), attributeRaw});
+						} else if (!attributeNameMapping.containsKey(attributeRaw[1])) {
+							log.error("Unknown attribute type '{}' for user {} {}, attributeRaw {}", new Object[] {attributeRaw[1], map.get("firstName"), map.get("lastName"), attributeRaw});
+						} else {
+							attributeName = attributeNameMapping.get(attributeRaw[0]) + attributeNameMapping.get(attributeRaw[1]) + attributeRaw[2];
+							log.trace("Adding attribute {} with value {}", attributeName, rs.getString(i));
+						}
+
+						String attributeValue = rs.getString(i);
+						if (rs.wasNull()) {
+							map.put(attributeName, null);
+						} else {
+							map.put(attributeName, attributeValue);
+						}
+					} else if (columnName.toLowerCase().startsWith(ExtSourcesManagerImpl.USEREXTSOURCEMAPPING)) {
+						// additionalUserExtSources, we must do lower case because some DBs changes lower to upper
+						map.put(columnName.toLowerCase(), rs.getString(i));
+						log.trace("Adding attribute {} with value {}", columnName, rs.getString(i));
+					}
+				}
+				subjects.add(map);
+			}
+
+			log.debug("Returning {} subjects from external source {}", new Object[] {subjects.size(), this});
 			return subjects;
 
 		} catch (SQLException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
@@ -157,6 +157,11 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
     }
 
     @Override
+    public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        throw new UnsupportedOperationException("This is not implemented yet");
+    }
+
+    @Override
     public void close() throws ExtSourceUnsupportedOperationException {
         throw new ExtSourceUnsupportedOperationException(
                 "For VOOT using this method is not optimized, use findSubjects instead.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
@@ -36,8 +36,13 @@ public class ExtSourceX509 extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
+	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
 	}
 
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -132,7 +132,13 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 		return subjects.get(0);
 	}
 
+	@Override
 	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return getGroupSubjects(attributes, null);
+	}
+
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		if(logins != null) throw new ExtSourceUnsupportedOperationException("Not supported to get subjects for this extSource by list of logins.");
 		// Get the query for the group subjects
 		String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 		

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
@@ -67,6 +67,17 @@ public interface ExtSourceSimpleApi {
 	List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException;
 
 	/**
+	 * Get the list of the subjects in the external group just for array of logins.
+	 *
+	 * @param attributes map of attributes used for quering the external source
+	 * @param logins array of logins to get subjects for them
+	 * @return list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
+	 * @throws InternalErrorException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	List<Map<String, String>> getGroupSubjects(Map<String, String> attributes, List<String> logins) throws InternalErrorException, ExtSourceUnsupportedOperationException;
+
+	/**
 	 * If extSource needs to be closed, this method must be called.
 	 *
 	 * @throws InternalErrorException

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/jdbc/PerunNotifPoolMessageDaoImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/jdbc/PerunNotifPoolMessageDaoImpl.java
@@ -89,7 +89,7 @@ public class PerunNotifPoolMessageDaoImpl extends JdbcDaoSupport implements Peru
 
 		logger.debug("Removing poolMessages from db with ids: {}", proccessedIds);
 		StringBuffer buffer = new StringBuffer();
-		buffer.append("delete from pn_pool_message where " + BeansUtils.prepareInSQLClause(new ArrayList<Integer>(proccessedIds), "id"));
+		buffer.append("delete from pn_pool_message where " + BeansUtils.prepareInSQLClauseForIds(new ArrayList<Integer>(proccessedIds), "id"));
 		this.getJdbcTemplate().update(buffer.toString());
 		logger.debug("PoolMessages with id: {}, removed.", proccessedIds);
 	}


### PR DESCRIPTION
- new method getGroupSubjects which can get subjects from extSource by
  list of Logins in one or more bulks (not just one by one)
- redesing of the synchronization process, new method
  categorizeMembersForSynchronization and changes in other methods to
  clear the differences between lightweight and normal synchronization
- prepare behavior for extSourceSQL and extSourceSQLComplex to be able
  to work with bulk of logins
- add methods to beansUtils for creating SQLInCaluse for values (not
  just of ids)
- fix name of method in notification perun module
- added tests for BeansUtils
