### PR TITLE
CORE: Fixed sponsored user deletion in impl layer

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -429,14 +429,10 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 			}
 		}
 
+		// Remove all sponsored user authz of his owners
+		if(user.isSponsoredUser()) AuthzResolverBlImpl.removeAllSponsoredUserAuthz(sess, user);
 		// Finally delete the user
-		if(user.isSpecificUser()) {
-			// Remove all sponsored user authz of his owners
-			if(user.isSponsoredUser()) AuthzResolverBlImpl.removeAllSponsoredUserAuthz(sess, user);
-			getUsersManagerImpl().deleteSpecificUser(sess, user);
-		} else {
-			getUsersManagerImpl().deleteUser(sess, user);
-		}
+		getUsersManagerImpl().deleteUser(sess, user);
 		getPerunBl().getAuditer().log(sess, "{} deleted.", user);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -152,15 +152,6 @@ public interface UsersManagerImplApi {
 	List<User> getSpecificUsers(PerunSession sess) throws InternalErrorException;
 
 	/**
-	 * Delete specific user and all connection between specific user and other users
-	 *
-	 * @param sess
-	 * @param specificUser the specific user
-	 * @throws InternalErrorException
-	 */
-	void deleteSpecificUser(PerunSession sess, User specificUser) throws InternalErrorException, SpecificUserAlreadyRemovedException;
-
-	/**
 	 * Returns user by VO member.
 	 *
 	 * @param perunSession
@@ -201,14 +192,15 @@ public interface UsersManagerImplApi {
 
 
 	/**
-	 *  Deletes user.
+	 *  Deletes user (normal or specific) including all relations to other users (normal,specific,sponsor)
 	 *
-	 * @param perunSession
-	 * @param user
+	 * @param perunSession Session for authz
+	 * @param user User to delete
 	 * @throws InternalErrorException
-	 * @throws UserAlreadyRemovedException
+	 * @throws UserAlreadyRemovedException  When user is already deleted
+	 * @throws SpecificUserAlreadyRemovedException When specific user is already deleted
 	 */
-	void deleteUser(PerunSession perunSession, User user) throws InternalErrorException, UserAlreadyRemovedException;
+	void deleteUser(PerunSession perunSession, User user) throws InternalErrorException, UserAlreadyRemovedException, SpecificUserAlreadyRemovedException;
 
 	/**
 	 *  Updates users data in DB.


### PR DESCRIPTION
- We allow user connections like: "user -> sponsored -> service".
  This means, that "sponsored" user ID is stored in both DB columns
   (user_id, specific_user_id) as per relation (for his service, for his owner).
  When deleting sponsored user, we must delete all rows, where users id
  is in any of those two columns to remove both sides of relations.
- New version of deleteUser() can handle both normal and specific users.
- Removed deleteSpecificUser()