### PR TITLE
CORE: Added attribute module for VŠUP UČO

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import org.springframework.jdbc.core.JdbcPerunTemplate;
 
 import java.util.List;
 
@@ -60,4 +61,13 @@ public interface DatabaseManagerBl {
 	 * @throws InternalErrorException if 1.there is an error reading file, 2.currentDBVersion was not found 3.DBVersion does not match pattern 4.DB versions are not ordered as they should be
 	 */
 	List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException;
+
+
+	/**
+	 * Return JDBC template for performing custom simple SQLs where jdbc is not normally available
+	 *
+	 * @return Peruns JDBC template
+	 */
+	public JdbcPerunTemplate getJdbcPerunTemplate();
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/DatabaseManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/DatabaseManagerBlImpl.java
@@ -11,6 +11,7 @@ import java.beans.Beans;
 import java.sql.SQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcPerunTemplate;
 
 import java.util.List;
 
@@ -49,6 +50,10 @@ public class DatabaseManagerBlImpl implements DatabaseManagerBl {
 
 	public List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException {
 		return this.databaseManagerImpl.getChangelogVersions(currentDBVersion, fileName);
+	}
+
+	public JdbcPerunTemplate getJdbcPerunTemplate() {
+		return this.databaseManagerImpl.getJdbcPerunTemplate();
 	}
 
 	protected void initialize() throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/DatabaseManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/DatabaseManagerImpl.java
@@ -186,4 +186,9 @@ public class DatabaseManagerImpl implements DatabaseManagerImplApi {
 
 		return versions;
 	}
+
+	public JdbcPerunTemplate getJdbcPerunTemplate() {
+		return jdbc;
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_ucoVsup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_ucoVsup.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
+
+/**
+ * Attribute module for generating unique UČO for every person in VŠUP.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class urn_perun_user_attribute_def_def_ucoVsup extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+
+		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "UČO can't be null.");
+
+	}
+
+	@Override
+	public Attribute fillAttribute(PerunSessionImpl sess, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+
+		Attribute attr = new Attribute(attribute);
+		int uco = Utils.getNewId(sess.getPerunBl().getDatabaseManagerBl().getJdbcPerunTemplate(), "vsup_uco_seq");
+		attr.setValue(uco);
+		return attr;
+
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("ucoVsup");
+		attr.setDisplayName("UČO");
+		attr.setType(Integer.class.getName());
+		attr.setDescription("Unique University person identifier.");
+		return attr;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/DatabaseManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/DatabaseManagerImplApi.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.implApi;
 
 import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import org.springframework.jdbc.core.JdbcPerunTemplate;
 
 import java.util.List;
 
@@ -70,4 +71,12 @@ public interface DatabaseManagerImplApi {
 	 * @throws InternalErrorException if 1.there is error reading file, 2.currentDBVersion was not found 3.db version does not match pattern 4.db versions are not ordered as they should be
 	 */
 	List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException;
+
+	/**
+	 * Return JDBC template for performing custom simple SQLs where jdbc is not normally available
+	 *
+	 * @return Peruns JDBC template
+	 */
+	public JdbcPerunTemplate getJdbcPerunTemplate();
+
 }


### PR DESCRIPTION
- Implemented fill() on VŠUP UČO. It will get new IDs from
  DB sequence "vsup_uco_seq"
- We can get JDBC template from DatabaseManagerBl now for usage
  where it's hard to get it from spring context - eg. attr modules.