### PR TITLE
Fix of catching Runtime exceptions in Group Arithmetic

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -658,49 +658,83 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
-	public List<Integer> getRelatedGroupsIds(PerunSession sess, int groupId) {
-		return jdbc.queryForList("SELECT result_gid FROM groups_groups WHERE operand_gid=" + groupId, Integer.class);
-	}
-
-	@Override
-	public void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException {
-		if (0 == jdbc.update("DELETE FROM groups_groups WHERE result_gid = ? AND operand_gid = ?",
-				resultGroup.getId(), operandGroup.getId())) {
-			throw new InternalErrorException("There is no relation between " + resultGroup + " and " + operandGroup);
+	public List<Integer> getRelatedGroupsIds(PerunSession sess, int groupId) throws InternalErrorException {
+		try {
+			return jdbc.queryForList("SELECT result_gid FROM groups_groups WHERE operand_gid=" + groupId, Integer.class);
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<Integer>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public void removeResultGroupRelations(PerunSession sess, Group resultGroup) {
-		jdbc.update("DELETE FROM groups_groups WHERE result_gid = ?", resultGroup.getId());
+	public void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException {
+		try {
+			if (0 == jdbc.update("DELETE FROM groups_groups WHERE result_gid = ? AND operand_gid = ?",
+					resultGroup.getId(), operandGroup.getId())) {
+				throw new InternalErrorException("There is no relation between " + resultGroup + " and " + operandGroup);
+			}
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public void removeResultGroupRelations(PerunSession sess, Group resultGroup) throws InternalErrorException {
+		try {
+			jdbc.update("DELETE FROM groups_groups WHERE result_gid = ?", resultGroup.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
 	}
 
 	@Override
 	public void saveGroupRelation(PerunSession sess, Group resultGroup, Group operandGroup, boolean parentFlag) throws InternalErrorException {
-		jdbc.update("INSERT INTO groups_groups(result_gid, operand_gid, created_at, created_by, " +
+		try {
+			jdbc.update("INSERT INTO groups_groups(result_gid, operand_gid, created_at, created_by, " +
 						"modified_at, modified_by, parent_flag) VALUES(?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)",
-				resultGroup.getId(), operandGroup.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), parentFlag);
+					resultGroup.getId(), operandGroup.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), parentFlag);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
 	}
 	
-	public boolean isRelationRemovable(PerunSession sess, Group resultGroup, Group operandGroup) {
-		return 1 > jdbc.queryForInt("SELECT parent_flag FROM groups_groups WHERE result_gid=? AND operand_gid=?", 
-				resultGroup.getId(), operandGroup.getId());
+	public boolean isRelationRemovable(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException {
+		try {
+			return 1 > jdbc.queryForInt("SELECT parent_flag FROM groups_groups WHERE result_gid=? AND operand_gid=?",
+					resultGroup.getId(), operandGroup.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
 	}
 
 	@Override
-	public boolean isRelationBetweenGroups(Group group1, Group group2) {
-		return 1 <= jdbc.queryForInt("SELECT count(1) FROM groups_groups WHERE (result_gid = ? AND operand_gid = ?) OR (result_gid = ? AND operand_gid = ?)",
+	public boolean isRelationBetweenGroups(Group group1, Group group2) throws InternalErrorException {
+		try {
+			return 1 <= jdbc.queryForInt("SELECT count(1) FROM groups_groups WHERE (result_gid = ? AND operand_gid = ?) OR (result_gid = ? AND operand_gid = ?)",
 				group1.getId(), group2.getId(), group2.getId(), group1.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
 	}
 
 	@Override
-	public boolean isOneWayRelationBetweenGroups(Group resultGroup, Group operandGroup) {
-		return 1 <= jdbc.queryForInt("SELECT count(1) FROM groups_groups WHERE result_gid = ? AND operand_gid = ?",
-				resultGroup.getId(), operandGroup.getId());
+	public boolean isOneWayRelationBetweenGroups(Group resultGroup, Group operandGroup) throws InternalErrorException {
+		try {
+			return 1 <= jdbc.queryForInt("SELECT count(1) FROM groups_groups WHERE result_gid = ? AND operand_gid = ?",
+					resultGroup.getId(), operandGroup.getId());
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
 	}
 
 	@Override
-	public List<Integer> getGroupRelations(PerunSession sess, int groupId) {
-		return jdbc.queryForList("SELECT result_gid FROM groups_groups WHERE operand_gid=?", Integer.class, groupId);
+	public List<Integer> getGroupRelations(PerunSession sess, int groupId) throws InternalErrorException {
+		try {
+			return jdbc.queryForList("SELECT result_gid FROM groups_groups WHERE operand_gid=?", Integer.class, groupId);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -497,8 +497,10 @@ public interface GroupsManagerImplApi {
 	 * @param sess perun session
 	 * @param groupId operand group id
 	 * @return related groups ids
+	 *
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
-	List<Integer> getRelatedGroupsIds(PerunSession sess, int groupId);
+	List<Integer> getRelatedGroupsIds(PerunSession sess, int groupId) throws InternalErrorException;
 
 	/**
 	 * Removes a relation between two groups.
@@ -506,6 +508,7 @@ public interface GroupsManagerImplApi {
 	 * @param sess perun session
 	 * @param resultGroup result group
 	 * @param operandGroup operand group
+	 *
 	 * @throws InternalErrorException if there is no relation of the given type between the groups
 	 */
 	void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException;
@@ -515,8 +518,10 @@ public interface GroupsManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param resultGroup result group
+	 *
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
-	void removeResultGroupRelations(PerunSession sess, Group resultGroup);
+	void removeResultGroupRelations(PerunSession sess, Group resultGroup) throws InternalErrorException;
 
 	/**
 	 * Saves union operation between result group and operand group.
@@ -524,6 +529,8 @@ public interface GroupsManagerImplApi {
 	 * @param resultGroup group to which members are added
 	 * @param operandGroup group from which members are taken
 	 * @param parentFlag if true union cannot be deleted; false otherwise (it flags relations created by hierarchical structure)
+	 *
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
 	void saveGroupRelation(PerunSession sess, Group resultGroup, Group operandGroup, boolean parentFlag) throws InternalErrorException;
 
@@ -534,8 +541,10 @@ public interface GroupsManagerImplApi {
 	 * @param group1 group
 	 * @param group2 group
 	 * @return true if there is a relation, false otherwise
+	 *
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
-	boolean isRelationBetweenGroups(Group group1, Group group2);
+	boolean isRelationBetweenGroups(Group group1, Group group2) throws InternalErrorException;
 
 	/**
 	 * Check if the relation between given groups can be deleted. 
@@ -543,8 +552,10 @@ public interface GroupsManagerImplApi {
 	 * It matters which group is resultGroup and which is operandGroup!!!
 	 * 
 	 * @return true if it can be deleted; false otherwise
+	 *
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
-	boolean isRelationRemovable(PerunSession sess, Group resultGroup, Group operandGroup);
+	boolean isRelationRemovable(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException;
 	
 	/**
 	 * Checks if relation exists between result group and operand group.
@@ -553,8 +564,10 @@ public interface GroupsManagerImplApi {
 	 * @param resultGroup result group
 	 * @param operandGroup operand group
 	 * @return true if there is a one-way relation, false otherwise
+	 *
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
-	boolean isOneWayRelationBetweenGroups(Group resultGroup, Group operandGroup);
+	boolean isOneWayRelationBetweenGroups(Group resultGroup, Group operandGroup) throws InternalErrorException;
 
 	/**
 	 * Return all group relations.
@@ -562,6 +575,8 @@ public interface GroupsManagerImplApi {
 	 * @param sess perun session
 	 * @param groupId group id
 	 * @return list of group ids
+	 * 
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
-	List<Integer> getGroupRelations(PerunSession sess, int groupId);
+	List<Integer> getGroupRelations(PerunSession sess, int groupId) throws InternalErrorException;
 }


### PR DESCRIPTION
 - for all GroupsManagerImpl SQL calls using in Group Arithmetic, catch
   runtime exception and throw InternalErrorException instead