### PR TITLE
check for empty received message before trying to parse it

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueProcessor.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueProcessor.java
@@ -186,7 +186,17 @@ public class SystemQueueProcessor {
 			// destinations
 			// (empty for DONE tasks)
 
+			if(null == systemMessagetext) {
+				throw new MessageFormatException("Client (Perun-Engine) sent empty message");
+			}
+			
 			String[] clientIDsplitter = systemMessagetext.split(":", 3);
+			if(clientIDsplitter.length < 3) {
+				throw new MessageFormatException(
+						"Client (Perun-Engine) sent a malformed message ["
+								+ systemMessagetext + "]");
+				
+			}
 			int clientID = 0;
 			try {
 				clientID = Integer.parseInt(clientIDsplitter[1]);
@@ -217,6 +227,12 @@ public class SystemQueueProcessor {
 				dispatcherQueuePool.removeDispatcherQueue(clientID);
 			} else if (clientIDsplitter[0].equalsIgnoreCase("task")) {
 				clientIDsplitter = systemMessagetext.split(":", 5);
+				if(clientIDsplitter.length < 5) {
+					throw new MessageFormatException(
+							"Client (Perun-Engine) sent a malformed message ["
+									+ systemMessagetext + "]");
+					
+				}
 				// task complete...
 				propagationMaintainer.onTaskComplete(
 						Integer.parseInt(clientIDsplitter[2]), clientID,

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
@@ -593,7 +593,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 			} else {
 				log.error("No TaskResult bean found in message {} from engine {}", string, clientID);
 			}
-		} catch (InternalErrorException e) {
+		} catch (Exception e) {
 			log.error("Could not save taskresult message {} from engine " + clientID, string);
 			log.debug("Error storing taskresult message: " + e.getMessage());
 		}


### PR DESCRIPTION
Fixes possible exceptions when dispatcher receives empty message from JMS. Also catches runtime exceptions when inserting task result. Both of these changes should prevent message reading thread from exiting. 