### PR TITLE
DISPATCHER: Keep JMS running on receiving wrongly formatted message

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueReceiver.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueReceiver.java
@@ -6,6 +6,7 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 
+import cz.metacentrum.perun.dispatcher.exceptions.MessageFormatException;
 import org.hornetq.api.jms.HornetQJMSClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,9 +73,15 @@ public class SystemQueueReceiver implements Runnable {
 						log.debug("System message received["
 								+ messageReceived.getText() + "]");
 					}
-					systemQueueProcessor
-							.processDispatcherQueueAndMatchingRule(messageReceived
-									.getText());
+					try {
+						systemQueueProcessor
+								.processDispatcherQueueAndMatchingRule(messageReceived
+										.getText());
+					} catch (MessageFormatException ex) {
+						// engine sent wrongly formatted messages
+						// shouldn't kill whole messaging process
+						log.error(ex.toString(), ex);
+					}
 					messageReceived.acknowledge();
 				}
 				if (log.isDebugEnabled()) {


### PR DESCRIPTION
- One wrong JMS message shouldn't kill whole messaging process and stop
  all services provisioning for a day until we notice.
- Log it and mark it as read, so it's not processed all over (on next dispatcher restart
  or worse next run of a while cycle).