### PR TITLE
CLI: Safer and better printing, added bean object methods

### DIFF
--- a/perun-rpc/src/main/perl/Perun/beans/Group.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/Group.pm
@@ -106,4 +106,12 @@ sub setVoId
 	my $self = shift;
 	$self->{_voId} = shift;
 }
+sub getCommonArrayRepresentation {
+	my $self = shift;
+	return ($self->{_id}, $self->{_voId}, $self->{_name}, $self->{_description});
+}
+
+sub getCommonArrayRepresentationHeading {
+	return ('ID', 'VO ID', 'Name', 'Description');
+}
 1;

--- a/perun-rpc/src/main/perl/Perun/beans/Member.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/Member.pm
@@ -27,7 +27,6 @@ sub TO_JSON
 	}
 
 	my $userId = $self->{_userId};
-	my $vo = $self->{_vo};
 
 	return {id => $id, userId => $userId};
 }
@@ -67,13 +66,18 @@ sub getStatus {
     return $self->{_status};
 }
 
+sub getMembershipType {
+	my $self = shift;
+	return $self->{_membershipType};
+}
+
 sub getCommonArrayRepresentation {
 	my $member = shift;
-	return ($member->getId, $member->getUserId);
+	return ($member->getId, $member->getUserId, $member->getStatus, $member->getMembershipType);
 }
 
 sub getCommonArrayRepresentationHeading {
-	return ('Id', 'UserId');                                                                                                                                                                      
+	return ('Id', 'UserId', 'Status', 'Membership type');
 }
 
 1;

--- a/perun-rpc/src/main/perl/Perun/beans/RichMember.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/RichMember.pm
@@ -60,6 +60,10 @@ sub getStatus {
         return shift->{_status};
 }
 
+sub getMembershipType {
+	return shift->{_membershipType};
+}
+
 sub getCommonName {
 	my $user = shift->{_user};
 
@@ -86,11 +90,11 @@ sub getDisplayName {
 
 sub getCommonArrayRepresentation {
 	my $self = shift;
-	return ($self->{_id}, $self->{_user}->{id}, $self->getDisplayName, $self->{_status});
+	return ($self->{_id}, $self->{_user}->{id}, $self->getDisplayName, $self->{_status}, $self->{_membershipType});
 }
 
 sub getCommonArrayRepresentationHeading {
-	return ('Member Id', 'User Id', 'Name', 'Status');
+	return ('Member Id', 'User Id', 'Name', 'Status', 'Membership type');
 }
 
 1;

--- a/perun-rpc/src/main/perl/Perun/beans/User.pm
+++ b/perun-rpc/src/main/perl/Perun/beans/User.pm
@@ -169,9 +169,15 @@ sub getDisplayName
 	return (($self->{_titleBefore} ? $self->{_titleBefore} . ' ' : "") . ($self->{_firstName} ? $self->{_firstName} . ' ' : "") . ($self->{_middleName} ? $self->{_middleName} . ' ' : "") . ($self->{_lastName} ? $self->{_lastName} . ' ': "") . ($self->{_titleAfter} ? $self->{_titleAfter} : ""));
 }
 
+# used only for sorting purpose: LastName FirstName MiddleName
+sub getSortingName {
+	my $self = shift;
+	return (($self->{_lastName} ? $self->{_lastName} . ' ': "") . ($self->{_firstName} ? $self->{_firstName} . ' ' : "") . ($self->{_middleName} ? $self->{_middleName} . ' ' : ""));
+}
+
 sub getCommonArrayRepresentation {
 	my $user = shift;
-	return ($user->getId, $user->getFirstName . " " . ($user->getMiddleName ? $user->getMiddleName . " " : "" ) . $user->getLastName);
+	return ($user->getId, $user->getDisplayName);
 }
 
 sub getCommonArrayRepresentationHeading {

--- a/perun-rpc/src/main/perl/addVoMember
+++ b/perun-rpc/src/main/perl/addVoMember
@@ -57,7 +57,7 @@ if ((scalar(@candidates) > 1) && $batch) {
 # We are not in the batch mode, so there can be more then one matching user for the searchString, let the user select
 my $candidate;
 if (!$batch) {
-	my $table = Text::ASCIITable->new();
+	my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 	$table->setCols("Candidate\nnumber",'name','login in the external source', 'external source');
 
 	my $i = 0;

--- a/perun-rpc/src/main/perl/exportGroupMembers
+++ b/perun-rpc/src/main/perl/exportGroupMembers
@@ -101,7 +101,7 @@ unless(@richMembers) { printMessage "No member found", $batch; exit 0; }
 
 #output
 my $table = Text::ASCIITable->new({utf8=>0});
-#my $table = Text::ASCIITable->new();
+#my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 
 $table->setCols('Name', 'Status', sort keys(%attrShort));
 

--- a/perun-rpc/src/main/perl/exportVoMembers
+++ b/perun-rpc/src/main/perl/exportVoMembers
@@ -88,7 +88,7 @@ unless(@richMembers) { printMessage "No member found", $batch; exit 0; }
 
 #output
 my $table = Text::ASCIITable->new({utf8=>0});
-#my $table = Text::ASCIITable->new();
+#my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 
 $table->setCols('Name', 'Status', sort keys(%attrShort));
 

--- a/perun-rpc/src/main/perl/getAttribute
+++ b/perun-rpc/src/main/perl/getAttribute
@@ -64,7 +64,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 			 unless(@attributes) { printMessage "No Attribute found", $batch; exit 0;}
 
 #output
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('ID','Name', 'Type', 'Value');
 
 			 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/getContactsAssignedToGroup
+++ b/perun-rpc/src/main/perl/getContactsAssignedToGroup
@@ -58,7 +58,7 @@ my @contactGroups;
 unless (@contactGroups) { printMessage "No Contacts found", $batch; exit 0;} 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Name','Facility','facilityId');
 
 foreach my $contactGroup (sort $sortingFunction @contactGroups) {

--- a/perun-rpc/src/main/perl/getContactsAssignedToOwner
+++ b/perun-rpc/src/main/perl/getContactsAssignedToOwner
@@ -52,7 +52,7 @@ my @contactGroups;
 unless (@contactGroups) { printMessage "No Contacts found", $batch; exit 0;} 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Name','Facility','facilityId');
 
 foreach my $contactGroup (sort $sortingFunction @contactGroups) {

--- a/perun-rpc/src/main/perl/getContactsAssignedToUser
+++ b/perun-rpc/src/main/perl/getContactsAssignedToUser
@@ -40,7 +40,7 @@ my @contactGroups;
 unless (@contactGroups) { printMessage "No Contacts found", $batch; exit 0;} 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Name','Facility','facilityId');
 
 foreach my $contactGroup (sort $sortingFunction @contactGroups) {

--- a/perun-rpc/src/main/perl/getContactsOfFacility
+++ b/perun-rpc/src/main/perl/getContactsOfFacility
@@ -53,7 +53,7 @@ my @contactGroups;
 unless (@contactGroups) { printMessage "No Contact found", $batch; exit 0;} 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 if (defined($displayIds)) {
     $table->setCols('Name','Owner','OwnerId','User','userId','Group','groupId');
 

--- a/perun-rpc/src/main/perl/getFacilityBlackList
+++ b/perun-rpc/src/main/perl/getFacilityBlackList
@@ -45,7 +45,7 @@ my @users = $securityTeamsAgent->getBlacklist(facility => $facilityId);
 unless (@users) { printMessage "No blacklisted users found", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 
 $table->setCols('User Id','User Name');
 foreach my $user (sort $sortingFunction @users) {

--- a/perun-rpc/src/main/perl/getSecurityTeamBlackList
+++ b/perun-rpc/src/main/perl/getSecurityTeamBlackList
@@ -40,7 +40,7 @@ my @users = $securityTeamsAgent->getBlacklist(securityTeam => $securityTeamId);
 unless (@users) { printMessage "No blacklisted users found", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 printMessage "\nSecurityTeamId: ".$securityTeamId.", SecurityTeamName: ".$securityTeam->getName, $batch;
 
 $table->setCols('User Id','User Name');

--- a/perun-rpc/src/main/perl/getSecurityTeamDetails
+++ b/perun-rpc/src/main/perl/getSecurityTeamDetails
@@ -42,7 +42,7 @@ my @users = $securityTeamsAgent->getBlacklist(securityTeam => $securityTeamId);
 unless (@users) { printMessage "No blacklisted users found", $batch; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Id:'.$securityTeamId.','.$securityTeam->getName,'User Id','User Name');
 $ii=0;
 foreach my $admin (sort $sortingFunction @admins) {

--- a/perun-rpc/src/main/perl/getSecurityTeamManagers
+++ b/perun-rpc/src/main/perl/getSecurityTeamManagers
@@ -40,7 +40,7 @@ my @admins = $securityTeamsAgent->getAdmins(securityTeam => $securityTeamId);
 unless (@admins) { printMessage "No managers found", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 printMessage "\nSecurityTeamId: ".$securityTeamId.", SecurityTeamName: ".$securityTeam->getName, $batch;
 
 $table->setCols('Admins Id','Admins Name');

--- a/perun-rpc/src/main/perl/getSecurityTeamsOfFacility
+++ b/perun-rpc/src/main/perl/getSecurityTeamsOfFacility
@@ -53,7 +53,7 @@ my @securityTeams;
 unless (@securityTeams) { printMessage "No securityTeams found", $batch; exit 0;} 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 
 $table->setCols('Id','Name');
 

--- a/perun-rpc/src/main/perl/getUserByMember
+++ b/perun-rpc/src/main/perl/getUserByMember
@@ -32,7 +32,7 @@ my $usersAgent = $agent->getUsersAgent;
 my $user = $usersAgent->getUserByMember(member => $memberId);
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name');
 my $name = $user->getFirstName . " " . ($user->getMiddleName ? $user->getMiddleName . " " : "" ) . $user->getLastName;
 $table->addRow($user->getId, $name);

--- a/perun-rpc/src/main/perl/getUsersByAttribute
+++ b/perun-rpc/src/main/perl/getUsersByAttribute
@@ -39,7 +39,7 @@ my $usersAgent = $agent->getUsersAgent;
 my @users = $usersAgent->getUsersByAttribute(attributeName => $attributeName, attributeValue => $attributeValue);
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name');
 
 foreach my $user (sort $sortingFunction @users) {

--- a/perun-rpc/src/main/perl/listOfAllFacilitiesGroupContacts
+++ b/perun-rpc/src/main/perl/listOfAllFacilitiesGroupContacts
@@ -29,7 +29,7 @@ my @contactGroupsNames = $FacilitiesAgent->getAllContactGroupNames;
 unless(@contactGroupsNames) { printMessage "No ContactGroups found",$batch; exit 0;}
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ContactGroupName');
 
 foreach my $cgname (@contactGroupsNames) {

--- a/perun-rpc/src/main/perl/listOfAllowedVosOnFacility
+++ b/perun-rpc/src/main/perl/listOfAllowedVosOnFacility
@@ -46,7 +46,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 
 #output
 			 unless(@vos) { printMessage "No VOs assigned", $batch; exit 0; }
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('VO id','VO shortName');
 
 			 foreach my $vo (sort $sortingFunction @vos) {

--- a/perun-rpc/src/main/perl/listOfAssignedFacilityResources
+++ b/perun-rpc/src/main/perl/listOfAssignedFacilityResources
@@ -46,7 +46,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 			 unless(@resources) { printMessage "No Resources assigned", $batch; exit 0; }
 
 #output
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('ID','Name');
 
 			 foreach my $resource (sort $sortingFunction @resources) {

--- a/perun-rpc/src/main/perl/listOfAttributesDefinition
+++ b/perun-rpc/src/main/perl/listOfAttributesDefinition
@@ -34,7 +34,7 @@ my @attrs = $attrAgent->getAttributesDefinition;
 unless(@attrs) { printMessage "No Attribute found", $batch; exit 0; }
 
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Id','namespace','friendlyName', 'type', 'Description');
 
 for my $attribute (sort $sortingFunction @attrs) {

--- a/perun-rpc/src/main/perl/listOfBans
+++ b/perun-rpc/src/main/perl/listOfBans
@@ -42,7 +42,7 @@ if (defined($resourceId) and defined($memberId)) { die "ERROR: only one of resou
 if (defined($facilityId) and defined($userId)) { die "ERROR: only one of facility or use can be entered \n";} 
 
 my $agent = Perun::Agent->new();
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 
 unless (defined $sortingFunction) {$sortingFunction = getSortingFunction('getValidityTo');}
 

--- a/perun-rpc/src/main/perl/listOfExpiredMembers
+++ b/perun-rpc/src/main/perl/listOfExpiredMembers
@@ -67,7 +67,7 @@ my @richMembers = $membersAgent->getCompleteRichMembers(vo => $voId, allowedStat
 unless(@richMembers) { printMessage "No such member found", $batch; exit 0; }
 
 # output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Logname','Name','Expiration');
 my @lognames;
 

--- a/perun-rpc/src/main/perl/listOfExtSources
+++ b/perun-rpc/src/main/perl/listOfExtSources
@@ -37,7 +37,7 @@ unless(@sources) { printMessage "No ExternalSources found", $batch; exit 0;}
 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Id','Name', 'Type');
 
 foreach my $source (sort $sortingFunction @sources) {

--- a/perun-rpc/src/main/perl/listOfFacilities
+++ b/perun-rpc/src/main/perl/listOfFacilities
@@ -36,7 +36,7 @@ unless(@facilities) { printMessage "No Facilities found", $batch; exit 0;}
 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name','Description');
 
 foreach my $facility (sort $sortingFunction @facilities) {

--- a/perun-rpc/src/main/perl/listOfFacilityAttributes
+++ b/perun-rpc/src/main/perl/listOfFacilityAttributes
@@ -48,7 +48,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 
 
 #output
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('ID','Name', 'Type', 'Value');
 
 			 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfFacilityDestinations
+++ b/perun-rpc/src/main/perl/listOfFacilityDestinations
@@ -50,7 +50,7 @@ GetOptions("help|h" => sub { print help; exit 0; } ,
 		 unless(@destinations) { printMessage "No destinations found", $batch; exit 0;}
 
 #output
-		 my $table = Text::ASCIITable->new();
+		 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 		 $table->setCols('ID', 'Destination', 'Type');
 
 		 foreach my $destination (@destinations) {

--- a/perun-rpc/src/main/perl/listOfFacilityHosts
+++ b/perun-rpc/src/main/perl/listOfFacilityHosts
@@ -45,7 +45,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 			 unless(@hosts) { printMessage "No host found", $batch; exit 0;}
 
 #output
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('ID','Name');
 
 			 foreach my $host (sort $sortingFunction @hosts) {

--- a/perun-rpc/src/main/perl/listOfGroupAttributes
+++ b/perun-rpc/src/main/perl/listOfGroupAttributes
@@ -58,7 +58,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 
 
 #output
-	 my $table = Text::ASCIITable->new();
+	 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 	 $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
 	 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfGroupResourceAttributes
+++ b/perun-rpc/src/main/perl/listOfGroupResourceAttributes
@@ -62,7 +62,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 
 
 #output
- my $table = Text::ASCIITable->new();
+ my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
  $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
  foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfGroupResources
+++ b/perun-rpc/src/main/perl/listOfGroupResources
@@ -39,7 +39,7 @@ unless(@resources) { printMessage "No Group's Resources found", $batch; exit 0; 
 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name', 'Facility ID');
 
 foreach my $resource (sort $sortingFunction @resources) {

--- a/perun-rpc/src/main/perl/listOfGroupsAssignedToResource
+++ b/perun-rpc/src/main/perl/listOfGroupsAssignedToResource
@@ -40,7 +40,7 @@ unless(@groups) { printMessage "No group found.", $batch; exit 0; }
 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name', 'Description');
 
 foreach my $group (sort $sortingFunction @groups) {

--- a/perun-rpc/src/main/perl/listOfHostAttributes
+++ b/perun-rpc/src/main/perl/listOfHostAttributes
@@ -40,7 +40,7 @@ unless(@attributes) { printMessage "No Attribute found", $batch; exit 0;}
 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name', 'Type', 'Value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfMemberAttributes
+++ b/perun-rpc/src/main/perl/listOfMemberAttributes
@@ -41,7 +41,7 @@ unless(@attributes) { printMessage "No Attribute found", $batch; exit 0;}
 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name', 'Type', 'Value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfMemberGroupAttributes
+++ b/perun-rpc/src/main/perl/listOfMemberGroupAttributes
@@ -61,7 +61,7 @@ my @attributes = $attributesAgent->getAttributes(member => $memberId, group => $
 unless(@attributes) { printMessage "No Attribute found", $batch; exit 0;}
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name', 'Type', 'Value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfMemberResourceAttributes
+++ b/perun-rpc/src/main/perl/listOfMemberResourceAttributes
@@ -42,7 +42,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 			 unless(@attributes) { printMessage "No Attribute found", $batch; exit 0;}
 
 #output
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('ID','Name', 'Type', 'Value');
 
 			 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfPrincipalRoles
+++ b/perun-rpc/src/main/perl/listOfPrincipalRoles
@@ -28,7 +28,7 @@ my @roles = $authzResolverAgent->getPrincipalRoleNames;
 unless(@roles) { printMessage "No Roles found", $batch; exit 0;}
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Role Name');
 
 foreach my $role (@roles) {

--- a/perun-rpc/src/main/perl/listOfPublications
+++ b/perun-rpc/src/main/perl/listOfPublications
@@ -37,7 +37,7 @@ my @publications = $cabinetAgent->findPublicationsByGUIFilter();
 unless (@publications) { printMessage "No publications found", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name', 'Rank','Year', 'Cathegory ID', 'Locked' );
 
 foreach my $publication (sort $sortingFunction @publications) {

--- a/perun-rpc/src/main/perl/listOfRequiredFacilityAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredFacilityAttributes
@@ -47,7 +47,7 @@ my @attributes = $attributesAgent->getRequiredAttributes(facility => $facilityId
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredGroupAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredGroupAttributes
@@ -62,7 +62,7 @@ my @attributes = $attributesAgent->getResourceRequiredAttributes(resourceToGetSe
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredGroupResourceAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredGroupResourceAttributes
@@ -63,7 +63,7 @@ my @attributes = $attributesAgent->getResourceRequiredAttributes(group => $group
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredMemberAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredMemberAttributes
@@ -46,7 +46,7 @@ if ($resourceId) {
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredMemberGroupAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredMemberGroupAttributes
@@ -68,7 +68,7 @@ if ($resourceId) {
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredMemberResourceAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredMemberResourceAttributes
@@ -49,7 +49,7 @@ if ($opt) {
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredResourceAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredResourceAttributes
@@ -42,7 +42,7 @@ my @attributes = $attributesAgent->getRequiredAttributes(%params);
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredServiceAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredServiceAttributes
@@ -48,7 +48,7 @@ GetOptions ("help|h" => sub { print help; exit 0;} ,
 				unless(@attributes) { printMessage "No Attribute found", $batch; exit 0; }
 
 
-				my $table = Text::ASCIITable->new();
+				my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 				$table->setCols('Id','namespace','friendlyName', 'type');
 
 				for my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredUserAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredUserAttributes
@@ -47,7 +47,7 @@ if ($resourceId) {
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredUserFacilityAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredUserFacilityAttributes
@@ -57,7 +57,7 @@ if ($resourceId) {
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','Name', 'Type', 'Value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfRequiredVoAttributes
+++ b/perun-rpc/src/main/perl/listOfRequiredVoAttributes
@@ -46,7 +46,7 @@ my @attributes = $attributesAgent->getRequiredAttributes(vo =>$voId);
 
 unless(@attributes) { printMessage "No required attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','attribute friendly name','namespace', 'value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfResourceAttributes
+++ b/perun-rpc/src/main/perl/listOfResourceAttributes
@@ -40,7 +40,7 @@ GetOptions ("help|h" => sub { print help; exit 0;} ,
 					unless(@attributes) { printMessage "No Attribute found", $batch; exit 0; }
 
 #output
-					my $table = Text::ASCIITable->new();
+					my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 					$table->setCols('ID','Name', 'Type', 'Value');
 
 					foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfResourceMembers
+++ b/perun-rpc/src/main/perl/listOfResourceMembers
@@ -37,7 +37,7 @@ my @members = $resourcesAgent->getAllowedMembers(resource => $resourceId);
 unless(@members) { printMessage "No Member found\n", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Id','Name');
 
 foreach my $member (sort $sortingFunction @members) {

--- a/perun-rpc/src/main/perl/listOfResourceUsers
+++ b/perun-rpc/src/main/perl/listOfResourceUsers
@@ -37,7 +37,7 @@ my @users = $resourcesAgent->getAllowedUsers(resource => $resourceId);
 unless(@users) { printMessage "No Member found\n", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Id','Name');
 
 foreach my $user (sort $sortingFunction @users) {

--- a/perun-rpc/src/main/perl/listOfResourcesAssignedToService
+++ b/perun-rpc/src/main/perl/listOfResourcesAssignedToService
@@ -46,7 +46,7 @@ my @resources = $servicesAgent->getAssignedResources(service => $serviceId);
 unless(@resources) { printMessage "No Resource found", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name','VO','Facility');
 
 foreach my $resource (sort $sortingFunction @resources) {

--- a/perun-rpc/src/main/perl/listOfServices
+++ b/perun-rpc/src/main/perl/listOfServices
@@ -33,7 +33,7 @@ my @services = $servicesAgent->getServices;
 unless(@services) { printMessage "No Services found", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name');
 
 foreach my $service (sort $sortingFunction @services) {

--- a/perun-rpc/src/main/perl/listOfServicesAssignedToDestination
+++ b/perun-rpc/src/main/perl/listOfServicesAssignedToDestination
@@ -58,7 +58,7 @@ while (@facilities) {
 
 #output
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('Service for '.$destination);
 
 foreach my $service (sort keys (%services)) {

--- a/perun-rpc/src/main/perl/listOfServicesAssignedToResource
+++ b/perun-rpc/src/main/perl/listOfServicesAssignedToResource
@@ -38,7 +38,7 @@ my @services = $resourcesAgent->getAssignedServices(resource => $resourceId);
 unless(@services) { printMessage "No Service found", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name');
 
 foreach my $service (sort $sortingFunction @services) {

--- a/perun-rpc/src/main/perl/listOfServicesPackages
+++ b/perun-rpc/src/main/perl/listOfServicesPackages
@@ -33,7 +33,7 @@ my @packages = $servicesAgent->getServicesPackages;
 unless(@packages) { printMessage "No Service Packages found", $batch; exit 0; }
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name');
 
 foreach my $package (sort $sortingFunction @packages) {

--- a/perun-rpc/src/main/perl/listOfUserAttributes
+++ b/perun-rpc/src/main/perl/listOfUserAttributes
@@ -40,7 +40,7 @@ unless(@attributes) { printMessage "No Attribute found", $batch; exit 0;}
 
 
 #output
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('ID','Name', 'Type', 'Value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfUserFacilityAttributes
+++ b/perun-rpc/src/main/perl/listOfUserFacilityAttributes
@@ -50,7 +50,7 @@ my @attributes = $attributesAgent->getAttributes(facility =>$facilityId,user => 
 
 unless(@attributes) { printMessage "No attributes found", $batch;  exit 0; }
 
-my $table = Text::ASCIITable->new();
+my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 $table->setCols('attribute Id','Name', 'Type', 'Value');
 
 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfUsers
+++ b/perun-rpc/src/main/perl/listOfUsers
@@ -5,7 +5,7 @@ use warnings;
 use Getopt::Long qw(:config no_ignore_case);
 use Text::ASCIITable;
 use Perun::Agent;
-use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+use Perun::Common qw(printMessage getSortingFunction printTable);
 
 sub help {
 	return qq{
@@ -19,28 +19,20 @@ sub help {
 	};
 }
 
-my ($batch, $sortingFunction);
+our $batch;
+my $sortingFunction;
 GetOptions("help|h" => sub { print help; exit 0;} ,
 	"orderById|i" => sub { $sortingFunction = getSortingFunction("getId") } ,
-	"orderByName|n" => sub { $sortingFunction = getSortingFunction("getLastName", 1) } ,
+	"orderByName|n" => sub { $sortingFunction = getSortingFunction("getSortingName", 1) } ,
 	"batch|b" => \$batch) || die help;
 
 my $agent = Perun::Agent->new();
 my $usersAgent = $agent->getUsersAgent;
 
 #options check
-unless(defined $sortingFunction) { $sortingFunction = getSortingFunction("getLastName", 1); }
+unless(defined $sortingFunction) { $sortingFunction = getSortingFunction("getSortingName", 1); }
 
 my @users = $usersAgent->getUsers();
 unless(@users) { printMessage "No users found", $batch; exit 0; }
 
-#output
-my $table = Text::ASCIITable->new();
-$table->setCols('ID','Name');
-
-foreach my $user (sort $sortingFunction @users) {
-	my $name = $user->getFirstName . " " . ($user->getMiddleName ? $user->getMiddleName . " " : "" ) . $user->getLastName;
-	$table->addRow($user->getId, $name);
-}
-
-print tableToPrint($table, $batch);
+print printTable($sortingFunction, @users);

--- a/perun-rpc/src/main/perl/listOfVoAttributes
+++ b/perun-rpc/src/main/perl/listOfVoAttributes
@@ -48,7 +48,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 
 
 #output
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('ID','Name', 'Type', 'Value');
 
 			 foreach my $attribute (sort $sortingFunction @attributes) {

--- a/perun-rpc/src/main/perl/listOfVoExtSources
+++ b/perun-rpc/src/main/perl/listOfVoExtSources
@@ -45,7 +45,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 			 unless(@sources) { printMessage "No ExternalSources found", $batch; exit 0; }
 
 #output
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('ID','Name', 'Type');
 
 			 foreach my $source (sort $sortingFunction @sources) {

--- a/perun-rpc/src/main/perl/listOfVoGroups
+++ b/perun-rpc/src/main/perl/listOfVoGroups
@@ -69,7 +69,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 		 }
 
 #output
-		 my $table = Text::ASCIITable->new();
+		 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 		 $table->setCols('ID','Name', 'Description');
 
 		 $table->addRow($membersGroup->getId, $membersGroup->getName, "build-in group containg all Vo members");

--- a/perun-rpc/src/main/perl/listOfVoResources
+++ b/perun-rpc/src/main/perl/listOfVoResources
@@ -45,7 +45,7 @@ GetOptions("help|h" => sub { print help; exit 0;} ,
 
 
 #output
-			 my $table = Text::ASCIITable->new();
+			 my $table = Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
 			 $table->setCols('ID','Name', 'Facility ID');
 
 			 foreach my $resource (sort $sortingFunction @resources) {


### PR DESCRIPTION
- Added getter methods to Member,RichMember.
- Added getter for sorting function for User.
- Added getter methods for printing tables to Group.
- ListOfUsers (sort them, use common printing function), fixes
   problems with printing empty names.

- Converted all: Text::ASCIITable->new();
   to: Text::ASCIITable->new({reportErrors => 0, utf8 => 0});
   in order to print wide characters correctly
   We really should use our common function printTable() in all
   listing tools where possible.