### PR TITLE
#3008 Create method groupsManager.getGroupUnions()

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -884,7 +884,7 @@ public interface GroupsManager {
 	 * @return list of groups.
 	 *
 	 * @throws GroupNotExistsException
-	 * @throws InternalErrorException when relation does not exist
+	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 */
 	List<Group> getGroupUnions(PerunSession sess, Group group, boolean reverseDirection) throws InternalErrorException, GroupNotExistsException, PrivilegeException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -874,4 +874,18 @@ public interface GroupsManager {
 	 * @throws PrivilegeException
 	 */
 	void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupOperationsException;
+
+	/**
+	 * Get list of group unions for specified group.
+	 * @param sess perun session
+	 * @param group group
+	 * @param reverseDirection if false get all operand groups of requested result group
+	 *                         if true get all result groups of requested operand group   
+	 * @return list of groups.
+	 *
+	 * @throws GroupNotExistsException
+	 * @throws InternalErrorException when relation does not exist
+	 * @throws PrivilegeException
+	 */
+	List<Group> getGroupUnions(PerunSession sess, Group group, boolean reverseDirection) throws InternalErrorException, GroupNotExistsException, PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -1115,4 +1115,16 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup, boolean parentFlag) throws GroupOperationsException, InternalErrorException;
+
+	/**
+	 * Get list of group unions for specified group.
+	 * @param sess perun session
+	 * @param group group
+	 * @param reverseDirection if false get all operand groups of requested result group
+	 *                         if true get all result groups of requested operand group   
+	 * @return list of groups.
+	 * 
+	 * @throws InternalErrorException
+	 */
+	List<Group> getGroupUnions(PerunSession sess, Group group, boolean reverseDirection) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -209,7 +209,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 				// 1. remove all relations with group g as an operand group.
 				// this removes all relations that depend on this group
-				List<Integer> relations = groupsManagerImpl.getGroupRelations(sess, g.getId());
+				List<Integer> relations = groupsManagerImpl.getResultGroups(sess, g.getId());
 				for (Integer groupId : relations) {
 					removeGroupUnion(sess, groupsManagerImpl.getGroupById(sess, groupId), g, true);
 				}
@@ -290,7 +290,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		// 1. remove all relations with group g as an operand group.
 		// this removes all relations that depend on this group
-		List<Integer> relations = groupsManagerImpl.getGroupRelations(sess, group.getId());
+		List<Integer> relations = groupsManagerImpl.getResultGroups(sess, group.getId());
 		for (Integer groupId : relations) {
 			removeGroupUnion(sess, groupsManagerImpl.getGroupById(sess, groupId), group, true);
 		}
@@ -471,7 +471,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		//If member was indirect in group before, we don't need to change anything in other groups
 		if(memberWasIndirectInGroup) return;
 		// check all relations with this group and call processRelationMembers to reflect changes of adding member to group
-		List<Integer> relations = groupsManagerImpl.getGroupRelations(sess, group.getId());
+		List<Integer> relations = groupsManagerImpl.getResultGroups(sess, group.getId());
 		for (Integer groupId : relations) {
 			processRelationMembers(sess, groupsManagerImpl.getGroupById(sess, groupId), Collections.singletonList(member), group.getId(), true);
 		}
@@ -602,7 +602,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 
 		// check all relations with this group and call processRelationMembers to reflect changes of removing member from group
-		List<Integer> relations = groupsManagerImpl.getGroupRelations(sess, group.getId());
+		List<Integer> relations = groupsManagerImpl.getResultGroups(sess, group.getId());
 		for (Integer groupId : relations) {
 			processRelationMembers(sess, groupsManagerImpl.getGroupById(sess, groupId), Collections.singletonList(member), group.getId(), false);
 		}
@@ -2292,7 +2292,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				return;
 			}
 
-			List<Integer> relations = groupsManagerImpl.getGroupRelations(sess, resultGroup.getId());
+			List<Integer> relations = groupsManagerImpl.getResultGroups(sess, resultGroup.getId());
 			for (Integer groupId : relations) {
 				processRelationMembers(sess, groupsManagerImpl.getGroupById(sess, groupId), newMembers, resultGroup.getId(), addition);
 			}
@@ -2354,7 +2354,16 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		
 		groupsManagerImpl.removeGroupUnion(sess, resultGroup, operandGroup);
 	}
-
+	
+	@Override
+	public List<Group> getGroupUnions(PerunSession session, Group group, boolean reverseDirection) throws InternalErrorException {
+		if (reverseDirection) {
+			return groupsManagerImpl.getGroupsByIds(session, groupsManagerImpl.getResultGroups(session, group.getId()));
+		} else {
+			return groupsManagerImpl.getGroupsByIds(session, groupsManagerImpl.getOperandGroups(session, group.getId()));
+		}
+	}
+	
 	/**
 	 * Check if cycle would be created by adding union between these groups.
 	 *
@@ -2365,7 +2374,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	private boolean checkGroupsCycle(PerunSession sess, int resultGroupId, int operandGroupId) throws InternalErrorException {
-		List<Integer> groupsIds = groupsManagerImpl.getRelatedGroupsIds(sess, resultGroupId);
+		List<Integer> groupsIds = groupsManagerImpl.getResultGroups(sess, resultGroupId);
 
 		if (groupsIds.contains(operandGroupId)) {
 			return true;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -209,7 +209,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 				// 1. remove all relations with group g as an operand group.
 				// this removes all relations that depend on this group
-				List<Integer> relations = groupsManagerImpl.getResultGroups(sess, g.getId());
+				List<Integer> relations = groupsManagerImpl.getResultGroupsIds(sess, g.getId());
 				for (Integer groupId : relations) {
 					removeGroupUnion(sess, groupsManagerImpl.getGroupById(sess, groupId), g, true);
 				}
@@ -290,7 +290,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		// 1. remove all relations with group g as an operand group.
 		// this removes all relations that depend on this group
-		List<Integer> relations = groupsManagerImpl.getResultGroups(sess, group.getId());
+		List<Integer> relations = groupsManagerImpl.getResultGroupsIds(sess, group.getId());
 		for (Integer groupId : relations) {
 			removeGroupUnion(sess, groupsManagerImpl.getGroupById(sess, groupId), group, true);
 		}
@@ -471,7 +471,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		//If member was indirect in group before, we don't need to change anything in other groups
 		if(memberWasIndirectInGroup) return;
 		// check all relations with this group and call processRelationMembers to reflect changes of adding member to group
-		List<Integer> relations = groupsManagerImpl.getResultGroups(sess, group.getId());
+		List<Integer> relations = groupsManagerImpl.getResultGroupsIds(sess, group.getId());
 		for (Integer groupId : relations) {
 			processRelationMembers(sess, groupsManagerImpl.getGroupById(sess, groupId), Collections.singletonList(member), group.getId(), true);
 		}
@@ -602,7 +602,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 
 		// check all relations with this group and call processRelationMembers to reflect changes of removing member from group
-		List<Integer> relations = groupsManagerImpl.getResultGroups(sess, group.getId());
+		List<Integer> relations = groupsManagerImpl.getResultGroupsIds(sess, group.getId());
 		for (Integer groupId : relations) {
 			processRelationMembers(sess, groupsManagerImpl.getGroupById(sess, groupId), Collections.singletonList(member), group.getId(), false);
 		}
@@ -2292,7 +2292,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				return;
 			}
 
-			List<Integer> relations = groupsManagerImpl.getResultGroups(sess, resultGroup.getId());
+			List<Integer> relations = groupsManagerImpl.getResultGroupsIds(sess, resultGroup.getId());
 			for (Integer groupId : relations) {
 				processRelationMembers(sess, groupsManagerImpl.getGroupById(sess, groupId), newMembers, resultGroup.getId(), addition);
 			}
@@ -2358,9 +2358,9 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	@Override
 	public List<Group> getGroupUnions(PerunSession session, Group group, boolean reverseDirection) throws InternalErrorException {
 		if (reverseDirection) {
-			return groupsManagerImpl.getGroupsByIds(session, groupsManagerImpl.getResultGroups(session, group.getId()));
+			return groupsManagerImpl.getResultGroups(session, group.getId());
 		} else {
-			return groupsManagerImpl.getGroupsByIds(session, groupsManagerImpl.getOperandGroups(session, group.getId()));
+			return groupsManagerImpl.getOperandGroups(session, group.getId());
 		}
 	}
 	
@@ -2374,7 +2374,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	private boolean checkGroupsCycle(PerunSession sess, int resultGroupId, int operandGroupId) throws InternalErrorException {
-		List<Integer> groupsIds = groupsManagerImpl.getResultGroups(sess, resultGroupId);
+		List<Integer> groupsIds = groupsManagerImpl.getResultGroupsIds(sess, resultGroupId);
 
 		if (groupsIds.contains(operandGroupId)) {
 			return true;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1058,4 +1058,17 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		getGroupsManagerBl().removeGroupUnion(sess, resultGroup, operandGroup, false);
 	}
+
+	@Override
+	public List<Group> getGroupUnions(PerunSession sess, Group group, boolean reverseDirection) throws InternalErrorException, GroupNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		getGroupsManagerBl().checkGroupExists(sess, group);
+
+		// Authorization
+		if ( !AuthzResolver.isAuthorized(sess, Role.VOADMIN, group) && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) { 
+			throw new PrivilegeException(sess, "getGroupUnions");
+		}
+		
+		return groupsManagerBl.getGroupUnions(sess, group, reverseDirection);
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -719,18 +719,29 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
-	public List<Integer> getResultGroups(PerunSession sess, int groupId) throws InternalErrorException {
+	public List<Group> getResultGroups(PerunSession sess, int groupId) throws InternalErrorException {
 		try {
-			return jdbc.queryForList("SELECT result_gid FROM groups_groups WHERE operand_gid=?", Integer.class, groupId);
+			return jdbc.query("SELECT " + groupMappingSelectQuery + " FROM groups_groups JOIN groups " +
+					"ON groups.id = groups_groups.result_gid WHERE operand_gid=?", GROUP_MAPPER, groupId);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public List<Integer> getOperandGroups(PerunSession sess, int groupId) throws InternalErrorException {
+	public List<Group> getOperandGroups(PerunSession sess, int groupId) throws InternalErrorException {
 		try {
-			return jdbc.queryForList("SELECT operand_gid FROM groups_groups WHERE result_gid=?", Integer.class, groupId);
+			return jdbc.query("SELECT " + groupMappingSelectQuery + " FROM groups_groups JOIN groups " +
+					"ON groups.id = groups_groups.operand_gid WHERE result_gid=?", GROUP_MAPPER, groupId);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Integer> getResultGroupsIds(PerunSession sess, int groupId) throws InternalErrorException {
+		try {
+			return jdbc.queryForList("SELECT result_gid FROM groups_groups WHERE operand_gid=?", Integer.class, groupId);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -658,17 +658,6 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
-	public List<Integer> getRelatedGroupsIds(PerunSession sess, int groupId) throws InternalErrorException {
-		try {
-			return jdbc.queryForList("SELECT result_gid FROM groups_groups WHERE operand_gid=" + groupId, Integer.class);
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<Integer>();
-		} catch (RuntimeException e) {
-			throw new InternalErrorException(e);
-		}
-	}
-
-	@Override
 	public void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException {
 		try {
 			if (0 == jdbc.update("DELETE FROM groups_groups WHERE result_gid = ? AND operand_gid = ?",
@@ -730,9 +719,18 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
-	public List<Integer> getGroupRelations(PerunSession sess, int groupId) throws InternalErrorException {
+	public List<Integer> getResultGroups(PerunSession sess, int groupId) throws InternalErrorException {
 		try {
 			return jdbc.queryForList("SELECT result_gid FROM groups_groups WHERE operand_gid=?", Integer.class, groupId);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Integer> getOperandGroups(PerunSession sess, int groupId) throws InternalErrorException {
+		try {
+			return jdbc.queryForList("SELECT operand_gid FROM groups_groups WHERE result_gid=?", Integer.class, groupId);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -563,18 +563,28 @@ public interface GroupsManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param groupId group id
-	 * @return list of group ids
+	 * @return list of Group objects
 	 * 
 	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
-	List<Integer> getResultGroups(PerunSession sess, int groupId) throws InternalErrorException;
+	List<Group> getResultGroups(PerunSession sess, int groupId) throws InternalErrorException;
 
 	/**
 	 * Return all operand groups of requested result group.
 	 * 
 	 * @param sess perun session
 	 * @param groupId group id
-	 * @return list of group ids
+	 * @return list of Group objects
 	 */
-	List<Integer> getOperandGroups(PerunSession sess, int groupId) throws InternalErrorException;
+	List<Group> getOperandGroups(PerunSession sess, int groupId) throws InternalErrorException;
+
+	/**
+	 * Return list of all result groups ids of requested operand group.
+	 * 
+	 * @param sess perun session
+	 * @param groupId group id
+	 * @return list of group ids
+	 * @throws InternalErrorException
+	 */
+	List<Integer> getResultGroupsIds(PerunSession sess, int groupId) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -490,17 +490,6 @@ public interface GroupsManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getGroupsWithAssignedExtSourceInVo(PerunSession sess, ExtSource source, Vo vo) throws InternalErrorException;
-	
-	/**
-	 * Returns all result groups ids of the given operand group.
-	 *
-	 * @param sess perun session
-	 * @param groupId operand group id
-	 * @return related groups ids
-	 *
-	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
-	 */
-	List<Integer> getRelatedGroupsIds(PerunSession sess, int groupId) throws InternalErrorException;
 
 	/**
 	 * Removes a relation between two groups.
@@ -570,7 +559,7 @@ public interface GroupsManagerImplApi {
 	boolean isOneWayRelationBetweenGroups(Group resultGroup, Group operandGroup) throws InternalErrorException;
 
 	/**
-	 * Return all group relations.
+	 * Return all result groups of requested operand group.
 	 *
 	 * @param sess perun session
 	 * @param groupId group id
@@ -578,5 +567,14 @@ public interface GroupsManagerImplApi {
 	 * 
 	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 */
-	List<Integer> getGroupRelations(PerunSession sess, int groupId) throws InternalErrorException;
+	List<Integer> getResultGroups(PerunSession sess, int groupId) throws InternalErrorException;
+
+	/**
+	 * Return all operand groups of requested result group.
+	 * 
+	 * @param sess perun session
+	 * @param groupId group id
+	 * @return list of group ids
+	 */
+	List<Integer> getOperandGroups(PerunSession sess, int groupId) throws InternalErrorException;
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -384,6 +384,14 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		groupsManager.createGroupUnion(sess, group, group2);
 
 		assertTrue(groupsManager.getGroupMembers(sess, group).size() == 1);
+		Member returnMember = groupsManager.getGroupMembers(sess, group).get(0);
+		assertEquals(returnMember.getMembershipType(), MembershipType.INDIRECT);
+		assertEquals(returnMember.getSourceGroupId(), Integer.valueOf(group2.getId()));
+
+		assertTrue(groupsManagerBl.getGroupUnions(sess, group, false).size() == 1);
+		assertTrue(groupsManagerBl.getGroupUnions(sess, group2, true).size() == 1);
+		assertTrue(groupsManagerBl.getGroupUnions(sess, group, false).get(0).getId() == group2.getId());
+		assertTrue(groupsManagerBl.getGroupUnions(sess, group2, true).get(0).getId() == group.getId());
 	}
 
 	@Test
@@ -404,6 +412,8 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		groupsManager.removeGroupUnion(sess, group, group2);
 
 		assertTrue(groupsManager.getGroupMembers(sess, group).size() == 0);
+		assertTrue(groupsManagerBl.getGroupUnions(sess, group, false).size() == 0);
+		assertTrue(groupsManagerBl.getGroupUnions(sess, group2, true).size() == 0);
 	}
 
 	@Test(expected=InternalErrorException.class)

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -531,19 +531,19 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 			if (Objects.equals(group.getName(), "D")) {
 				topLevel = group;
 				//perun.getGroupsManager().addMember(sess, group, member);
-				//System.out.println(perun.getGroupsManagerBl().getGroupRelations(sess, group.getId()));
+				//System.out.println(perun.getGroupsManagerBl().getResultGroups(sess, group.getId()));
 			} else if (Objects.equals(group.getName(), "D:C")) {
 				//perun.getGroupsManager().addMember(sess, group, member);
 				secondLevel = group;
-				//System.out.println(perun.getGroupsManagerBl().getGroupRelations(sess, group.getId()));
+				//System.out.println(perun.getGroupsManagerBl().getResultGroups(sess, group.getId()));
 			} else if (Objects.equals(group.getName(), "D:C:E")) {
 				//perun.getGroupsManager().addMember(sess, group, member);
 				thirdLevel = group;
-				//System.out.println(perun.getGroupsManagerBl().getGroupRelations(sess, group.getId()));
+				//System.out.println(perun.getGroupsManagerBl().getResultGroups(sess, group.getId()));
 			} else if (Objects.equals(group.getName(), "D:C:E:F")) {
 				fourthLevel = group;
 				//perun.getGroupsManager().addMember(sess, group, member);
-				//System.out.println(perun.getGroupsManagerBl().getGroupRelations(sess, group.getId()));
+				//System.out.println(perun.getGroupsManagerBl().getResultGroups(sess, group.getId()));
 			}
 		}
 
@@ -651,6 +651,26 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	}
 
+	@Test
+	public void getGroupUnions() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupUnions");
+
+		vo = setUpVo();
+		groupsManager.createGroup(sess, vo, group);
+		groupsManager.createGroup(sess, group, group2);
+		groupsManager.createGroup(sess, vo, group3);
+		groupsManager.createGroup(sess, vo, group4);
+		groupsManager.createGroup(sess, group4, group5);
+
+		groupsManager.createGroupUnion(sess, group3, group);
+		groupsManager.createGroupUnion(sess, group3, group2);
+		groupsManager.createGroupUnion(sess, group4, group3);
+		groupsManager.createGroupUnion(sess, group5, group3);
+		
+		assertEquals("Wrong number of operand groups.", 2, groupsManagerBl.getGroupUnions(sess, group3, false).size());
+		assertEquals("Wrong number of result groups.", 2, groupsManagerBl.getGroupUnions(sess, group3, true).size());
+	}
+	
 	@Test (expected=RelationExistsException.class)
 	public void deleteGroupWhenContainsMember() throws Exception {
 		System.out.println(CLASS_NAME + "deleteGroupWhenContainsMember");


### PR DESCRIPTION
- removed duplicit method (getRelatedGroupsIds) which returns all result groups ids which have relation with given group.
- now there are two new methods on Impl which returns result groups or operand groups of given group
- created new method in Bl and Entry (getGroupUnions) which returns operand or result groups based on reverseDirection parameter
- test for new method