### PR TITLE
Updated tools to export DB

### DIFF
--- a/perun-db/delete_tables.pl
+++ b/perun-db/delete_tables.pl
@@ -19,6 +19,7 @@ $ENV{NLS_LANG} = "american_america.utf8";
 
 my $user="perun";                    # PostgreSQL user
 my $tableOrderFile="table_order";    # Defined list of tables and their order
+my $tablesToDelete="ADD_tablesToDelete";
 my $filename="DB_tables_delete.sql";
 
 sub help {
@@ -39,6 +40,13 @@ GetOptions ("help|h" => sub { print help(); exit 0;}, "user|u=s" => \$user, "fil
 
 my @tables = ();
 open POR,$tableOrderFile or die "[ERROR] Cannot open $tableOrderFile: $! \n";
+while (my $lin=<POR>) {
+	chomp($lin);
+	unshift (@tables,$lin);
+}
+close POR;
+
+open POR,$tablesToDelete or die "[ERROR] Cannot open $tablesToDelete: $! \n";
 while (my $lin=<POR>) {
 	chomp($lin);
 	unshift (@tables,$lin);

--- a/perun-db/export_oracle_to_postgres.pl
+++ b/perun-db/export_oracle_to_postgres.pl
@@ -21,6 +21,7 @@ my $pwd;                             # Oracle DB password
 my $newuser="perun";                 # PostgreSQL user
 my $tableOrderFile="table_order";    # Defined list of tables and their order
 my $tab;                             # Single table to export if preferred
+my $allTables = undef;               # Tag for exporting all tables
 
 sub help {
 	return qq{
@@ -28,12 +29,13 @@ sub help {
 	--------------------------------------------------------------
 	Available options:
 
-	--user     | -u Username for Oracle DB (required)
-	--password | -w Password for Oracle DB (required)
-	--newUser  | -n Username for Postgres DB (if not set, use "perun")
-	--file     | -f File with list of tables to export (if not set, use "table_order")
-	--table    | -t Name of single table to export (if set, ignore --file|-f option)
-	--help     | -h prints this help
+	--user      | -u Username for Oracle DB (required)
+	--password  | -w Password for Oracle DB (required)
+	--newUser   | -n Username for Postgres DB (if not set, use "perun")
+	--file      | -f File with list of tables to export (if not set, use "table_order")
+	--table     | -t Name of single table to export (if set, ignore --file|-f option)
+        --allTables | -a exports all tables incuding tables usually don't exported
+	--help      | -h prints this help
 
 	Usage:
 
@@ -41,10 +43,17 @@ sub help {
 	Export base tables: -u [login] -w [pass] -f table_order_base
 	Export single table: -u [login] -w [pass] -t [table_name]
 	Export custom tables: -u [login] -w [pass] -f [file_with_table_names]
+        Export all tables: -u [login] -w [pass] -f [file_with_table_names] -a
 	};
 }
 
-GetOptions ("help|h" => sub { print help(); exit 0;},"user|u=s" => \$user, "password|w=s" => \$pwd, "newUser|n=s" => \$newuser, "file|f=s" => \$tableOrderFile, "table|t=s" => \$tab) || die help();
+GetOptions ("help|h" => sub { print help(); exit 0;},
+"user|u=s" => \$user, 
+"password|w=s" => \$pwd, 
+"newUser|n=s" => \$newuser, 
+"file|f=s" => \$tableOrderFile, 
+"allTables|a" => \$allTables,
+"table|t=s" => \$tab) || die help();
 
 if (!defined $user) { print "[ERROR] Username for Oracle DB is required! Use --help | -h to print help.\n"; exit 1; }
 if (!defined $pwd) { print "[ERROR] Password for Oracle DB is required! Use --help | -h to print help.\n"; exit 1; }
@@ -53,72 +62,85 @@ my $dbh = DBI->connect('dbi:Oracle:',$user,$pwd,{RaiseError=>1,AutoCommit=>0,Lon
 
 my $filename;
 my @tabulky = ();
+my %tabs;
+my $tabstodelete="ADD_tablesToDelete";
+
 if (defined($tab)) {
 	push (@tabulky, $tab);
 	$filename=$tab."_data.sql";
 } else {
+        open (DEL,">$tabstodelete");
+	binmode DEL,":utf8";
+
 	open POR,$tableOrderFile or die "[ERROR] Cannot open $tableOrderFile: $! \n";
 	while (my $lin=<POR>) {
 		chomp($lin);
 		push (@tabulky,$lin);
+                $tabs{$lin}=1;
 	}
 	close POR;
 	$filename="DB_data.sql";
 
-	# Commented old way of exporting all tables without exact order
-
-	#my $tablename = $dbh->prepare(qq{
-	#select lower(table_name) from all_tables where lower(owner)=?});
-	#$tablename->execute($user);
-	#my $tbn;
-	#while ($tbn = $tablename->fetch) {
-	#push (@tabulky, $$tbn[0]);
-	#}
-
+	# all tables 
+	my $tablename = $dbh->prepare(qq{
+	    select lower(table_name) from all_tables where lower(owner)=?});
+	$tablename->execute($user);
+	my $tbn;
+	while ($tbn = $tablename->fetch) {
+	    if (not exists($tabs{$$tbn[0]})) {
+	        push (@tabulky, $$tbn[0]) if defined $allTables;
+	        print DEL $$tbn[0]."\n";
+	    }
+        }
+       close DEL;
 }
 
 open (DBD,">$filename");
 binmode DBD,":utf8";
 
-my $tabcolumn = $dbh->prepare(qq{select lower(column_name),data_type from all_tab_columns where lower(table_name)=? and lower(owner)=?});
+my $tabcolumn = $dbh->prepare(qq{select lower(column_name),data_type,data_scale from all_tab_columns where lower(table_name)=? and lower(owner)=?});
 
 while (@tabulky) {
 	my $tbl=shift(@tabulky);
+	my @instext=();
 	$tabcolumn->execute($tbl,$user);
 	my $textinsert='insert into "'.$newuser.'"."'.$tbl.'" (';
 	my $tcol;
 	my %columns;
+	my %precisions;
 	my $textcols="";
 	my @cols=();
-	my @savecols=();
 	while ($tcol=$tabcolumn->fetch) {
 		$columns{$$tcol[0]}=$$tcol[1];
+		$precisions{$$tcol[0]}=$$tcol[2];
 		push (@cols,$$tcol[0]);
-		push (@savecols,$$tcol[0]);
-		$textcols=$textcols.$$tcol[0].",";
 	}
 	if (@cols == 0) {warn "[WARN] Non-existing table name $tbl\n"; next;}
+	# order columns by Perl
+	foreach my $col (sort @cols) {
+	     $textcols=$textcols.$col.",";
+	}     
 	$textcols=substr($textcols,0,-1);
 	$textinsert=$textinsert.$textcols.") values (";
 	my $tsel="select ";
 	my $tsel2;
-	@cols=@savecols;
-	while (@cols) {
-		my $column=shift(@cols);
+	foreach my $column (sort @cols) {
 		if ($columns{$column} eq "DATE") {$tsel=$tsel."to_char($column,'YYYY-MM-DD HH24:MI:SS.D'),";
+		} elsif ($columns{$column} eq "NUMBER" and $precisions{$column} == 1) {
+		    $tsel=$tsel."ltrim(to_char($column,'0.9')),";
 		} else {
 			$tsel=$tsel.$column.",";
 		}
 	}
 	$tsel=substr($tsel,0,-1)." from $tbl";
 	if ($tbl eq "groups") {
-		$tsel2=$tsel." where parent_group_id is not null order by id";
-		$tsel=$tsel." where parent_group_id is null order by id";
+		$tsel2=$tsel." where parent_group_id is not null";
+		$tsel=$tsel." where parent_group_id is null";
 	}
 
-	# Keep only last 10 days of table auditer_log
+	# Keep only last month of table auditer_log
 	if ($tbl eq "auditer_log") {
-		$tsel=$tsel." where created_at>sysdate-10 order by created_at";
+	         $tsel=$tsel."  where created_at>to_date(to_char(sysdate-10,'YYYY-MM-DD'),'YYYY-MM-DD')";
 	}
 	SEL:  my $colval = $dbh->prepare($tsel);
 	$colval->execute();
@@ -126,9 +148,7 @@ while (@tabulky) {
 	while ($val=$colval->fetch) {
 		my $tval="";
 		my $ii=0;
-		@cols=@savecols;
-		while (@cols) {
-			my $column=shift(@cols);
+		foreach my $column (sort @cols) {
 			if (not defined($$val[$ii])) {
 				$tval=$tval."null,";
 			} else {
@@ -141,10 +161,12 @@ while (@tabulky) {
 			$ii++;
 		}
 		$tval=substr($tval,0,-1).");";
-		print DBD $textinsert;
-		print DBD $tval."\n";
+		push (@instext,$textinsert.$tval."\n");
 	}
-	if (defined $tsel2) {$tsel=$tsel2; undef($tsel2); goto SEL; }
+	foreach my $textrow (sort @instext) {
+	     print DBD $textrow;
+	}     
+	if (defined $tsel2) {$tsel=$tsel2; undef($tsel2); @instext=(); goto SEL; }
 }
 
 print DBD "\n\n";
@@ -154,6 +176,7 @@ my $seqname = $dbh->prepare(qq{select sequence_name from all_sequences where seq
 
 if (defined($tab)) {
 	my $seq=$dbh->selectrow_array($seqname,{},uc($tab));
+	unless (defined $seq) { warn "[WARN] No sequence found for table: $tab \n"; close DBD; commit $dbh; exit;}
 	$sequences{$seq}=$tab;
 } else {
 	my $tablename = $dbh->prepare(qq{select table_name from all_tables where lower(owner)=? order by table_name});

--- a/perun-db/export_postgres_to_postgres.pl
+++ b/perun-db/export_postgres_to_postgres.pl
@@ -2,7 +2,7 @@
 
 ########################
 #
-#  Script for exporting data from Oracle to Oracle compliant insert syntax.
+#  Script for exporting data from Postgres to PostgreSQL compliant insert syntax.
 #
 ########################
 
@@ -11,30 +11,29 @@ use strict;
 use POSIX qw(:errno_h);
 use Getopt::Long qw(:config no_ignore_case);
 
-my $perun_root = $ENV{PERUN_ROOT};
 $ENV{NLS_LANG} = "american_america.utf8";
 
 # IMPORTANT: these arguments must be set before using script or provided on commandline
 
 my $user;                            # Oracle DB user
 my $pwd;                             # Oracle DB password
-my $newuser="perunv3";               # PostgreSQL user
+my $newuser="perun";                 # PostgreSQL user
 my $tableOrderFile="table_order";    # Defined list of tables and their order
 my $tab;                             # Single table to export if preferred
 my $allTables = undef;               # Tag for exporting all tables
 
 sub help {
 	return qq{
-	Export data from Oracle and create Oracle compliant inserts
+	Export data from Oracle and create Postgres compliant inserts
 	--------------------------------------------------------------
 	Available options:
 
 	--user      | -u Username for Oracle DB (required)
 	--password  | -w Password for Oracle DB (required)
-	--newUser   | -n Username for new Oracle DB (if not set, use "perunv3")
+	--newUser   | -n Username for Postgres DB (if not set, use "perun")
 	--file      | -f File with list of tables to export (if not set, use "table_order")
 	--table     | -t Name of single table to export (if set, ignore --file|-f option)
-	--allTables | -a exports all tables incuding tables usually don't exported
+        --allTables | -a exports all tables incuding tables usually don't exported
 	--help      | -h prints this help
 
 	Usage:
@@ -43,7 +42,7 @@ sub help {
 	Export base tables: -u [login] -w [pass] -f table_order_base
 	Export single table: -u [login] -w [pass] -t [table_name]
 	Export custom tables: -u [login] -w [pass] -f [file_with_table_names]
-	Export all tables: -u [login] -w [pass] -f [file_with_table_names] -a
+        Export all tables: -u [login] -w [pass] -f [file_with_table_names] -a
 	};
 }
 
@@ -58,149 +57,140 @@ GetOptions ("help|h" => sub { print help(); exit 0;},
 if (!defined $user) { print "[ERROR] Username for Oracle DB is required! Use --help | -h to print help.\n"; exit 1; }
 if (!defined $pwd) { print "[ERROR] Password for Oracle DB is required! Use --help | -h to print help.\n"; exit 1; }
 
-my $dbh = DBI->connect('dbi:Oracle:',$user,$pwd,{RaiseError=>1,AutoCommit=>0,LongReadLen=>65530, ora_charset => 'AL32UTF8'}) or die EPERM," Connect";
+my $dbh = DBI->connect('dbi:Pg:dbname=perun',$user,$pwd,{RaiseError=>1,AutoCommit=>0,pg_enable_utf8=>1}) or die EPERM," Connect";
 
 my $filename;
 my @tabulky = ();
-my @tabulkys = ();
 my %tabs;
-my $tabstodelete="ADD_tablesToDelete";
+my $tabstodelete="ADD_tablesToDeletePR";
 
 if (defined($tab)) {
 	push (@tabulky, $tab);
-	$filename=$tab."_data.ora.sql";
+	$filename=$tab."_data.sql.PR";
 } else {
         open (DEL,">$tabstodelete");
 	binmode DEL,":utf8";
 
-	open POR,$tableOrderFile or die "Cannot open $tableOrderFile: $! \n";
+	open POR,$tableOrderFile or die "[ERROR] Cannot open $tableOrderFile: $! \n";
 	while (my $lin=<POR>) {
 		chomp($lin);
 		push (@tabulky,$lin);
-		push (@tabulkys,uc($lin));
-		$tabs{$lin}=1;
+                $tabs{$lin}=1;
 	}
 	close POR;
-	$filename="DB_data.ora.sql";
-        
+	$filename="DB_data.PR.sql";
+
 	# all tables 
-        my $tablename = $dbh->prepare(qq{
-           select lower(table_name) from all_tables where lower(owner)=?});
-        $tablename->execute($user);
-        my $tbn;
+	my $tablename = $dbh->prepare(qq{
+	    select table_name from INFORMATION_SCHEMA.TABLES where table_schema=? and table_name not like 'scim%'});
+	$tablename->execute($user);
+	my $tbn;
 	while ($tbn = $tablename->fetch) {
 	    if (not exists($tabs{$$tbn[0]})) {
-		if (defined $allTables) {    
-		    push (@tabulky, $$tbn[0]);
-		    push (@tabulkys, uc($$tbn[0]));
-		}
-		print DEL $$tbn[0]."\n";
+	        push (@tabulky, $$tbn[0]) if defined $allTables;
+	        print DEL $$tbn[0]."\n";
 	    }
-	}
-	close DEL;
+        }
+       close DEL;
 }
 
 open (DBD,">$filename");
 binmode DBD,":utf8";
 
-my $tabcolumn = $dbh->prepare(qq{select lower(column_name),data_type from all_tab_columns where lower(table_name)=? and lower(owner)=?});
+my $tabcolumn = $dbh->prepare(qq{select column_name, data_type from INFORMATION_SCHEMA.COLUMNS where table_name =? and table_schema=? order by column_name});
 
 while (@tabulky) {
 	my $tbl=shift(@tabulky);
+        my @instext=();
 	$tabcolumn->execute($tbl,$user);
-	my $textinsert='insert into '.$newuser.'.'.$tbl.' (';
+	my $textinsert='insert into "'.$newuser.'"."'.$tbl.'" (';
 	my $tcol;
 	my %columns;
 	my $textcols="";
 	my @cols=();
-	my @savecols=();
 	while ($tcol=$tabcolumn->fetch) {
 		$columns{$$tcol[0]}=$$tcol[1];
 		push (@cols,$$tcol[0]);
-		push (@savecols,$$tcol[0]);
-		$textcols=$textcols.$$tcol[0].",";
 	}
 	if (@cols == 0) {warn "[WARN] Non-existing table name $tbl\n"; next;}
+        # order columns by Perl
+        foreach my $col (sort @cols) {
+             $textcols=$textcols.$col.",";
+        }
 	$textcols=substr($textcols,0,-1);
 	$textinsert=$textinsert.$textcols.") values (";
 	my $tsel="select ";
 	my $tsel2;
-	@cols=@savecols;
-	while (@cols) {
-		my $column=shift(@cols);
-		if ($columns{$column} eq "DATE") {$tsel=$tsel."to_char($column,'YYYY-MM-DD HH24:MI:SS.D'),";
-		} else {
-			$tsel=$tsel.$column.",";
-		}
+	foreach my $column (sort @cols) {
+	    $tsel=$tsel.$column.",";
 	}
 	$tsel=substr($tsel,0,-1)." from $tbl";
 	if ($tbl eq "groups") {
-		$tsel2=$tsel." where parent_group_id is not null order by id";
-		$tsel=$tsel." where parent_group_id is null order by id";
+		$tsel2=$tsel." where parent_group_id is not null";
+		$tsel=$tsel." where parent_group_id is null";
 	}
 
 	# Keep only last 10 days of table auditer_log
 	if ($tbl eq "auditer_log") {
-		$tsel=$tsel." where created_at>sysdate-10 order by created_at";
+		$tsel=$tsel." where created_at > to_date(to_char(now() - interval '10 days','YYYY-MM-DD'),'YYYY-MM-DD')";
 	}
-
 	SEL:  my $colval = $dbh->prepare($tsel);
 	$colval->execute();
 	my $val;
 	while ($val=$colval->fetch) {
-
 		my $tval="";
 		my $ii=0;
-		@cols=@savecols;
-		while (@cols) {
-			my $column=shift(@cols);
+		foreach my $column ( sort @cols) {
 			if (not defined($$val[$ii])) {
 				$tval=$tval."null,";
 			} else {
-				if ($columns{$column} eq "NUMBER") {$tval=$tval.$$val[$ii].",";}
-				if ($columns{$column} eq "VARCHAR2" or $columns{$column} eq "NVARCHAR2") {$$val[$ii] =~ s/'/''/g; $tval=$tval."'".$$val[$ii]."',";}
-				if ($columns{$column} eq "CHAR") {$$val[$ii] =~ s/'/''/g; $tval=$tval."'".$$val[$ii]."',";}
-				if ($columns{$column} eq "CLOB") {$$val[$ii] =~ s/'/''/g; $tval=$tval."'".$$val[$ii]."',";}
-				if ($columns{$column} eq "DATE") {$tval=$tval."to_date('".$$val[$ii]."','YYYY-MM-DD HH24:MI:SS.D'),";}
+				if ($columns{$column} eq "integer" or $columns{$column} eq "numeric" or $columns{$column} eq "bigint" or $columns{$column} eq "boolean") {$tval=$tval.$$val[$ii].",";}
+				if ($columns{$column} =~ /character/) {$$val[$ii] =~ s/'/''/g; $tval=$tval."'".$$val[$ii]."',";}
+				if ($columns{$column} eq "text") {$$val[$ii] =~ s/'/''/g; $tval=$tval."'".$$val[$ii]."',";}
+				if ($columns{$column} =~ /timestamp/) {$tval=$tval."timestamp '".$$val[$ii]."',";}
 			}
 			$ii++;
 		}
 		$tval=substr($tval,0,-1).");";
-		print DBD $textinsert;
-		print DBD $tval."\n";
+                push (@instext,$textinsert.$tval."\n");
 	}
-	if (defined $tsel2) {$tsel=$tsel2; undef($tsel2); goto SEL; }
+        foreach my $textrow (sort @instext) {
+             print DBD $textrow;
+        }
+	if (defined $tsel2) {$tsel=$tsel2; undef($tsel2); @instext=(); goto SEL; }
 }
 
 print DBD "\n\n";
 
 my %sequences;
-my $seqname = $dbh->prepare(qq{select sequence_name from all_sequences where sequence_name like ?||'%'});
+my $seqname = $dbh->prepare(qq{select sequence_name from INFORMATION_SCHEMA.SEQUENCES  where sequence_name like ?||'%'});
 
 if (defined($tab)) {
-	my $seq=$dbh->selectrow_array($seqname,{},uc($tab));
+	my $seq=$dbh->selectrow_array($seqname,{},$tab);
+        unless (defined $seq) { warn "[WARN] No sequence found for table: $tab \n"; close DBD; commit $dbh; exit;}
 	$sequences{$seq}=$tab;
 } else {
-	while (@tabulkys) {
-		my $tbn=shift(@tabulkys);
-		$seqname->execute($tbn);
+	my $tablename = $dbh->prepare(qq{select table_name from INFORMATION_SCHEMA.TABLES where table_schema=? and table_name not like 'scim%' order by table_name});
+	$tablename->execute($user);
+
+	while (my $tbn = $tablename->fetch) {
+		$seqname->execute($$tbn[0]);
+
 		while (my $seqn = $seqname->fetch) {
-			$sequences{$$seqn[0]}=$tbn;
+			$sequences{$$seqn[0]}=$$tbn[0];
 		}
 		# Manually match this sequence, since it's name is not standardized as for others
-		if ($tbn eq "CABINET_PUBLICATION_SYSTEMS") {
-			$sequences{"CABINET_PUB_SYS_ID_SEQ"}="CABINET_PUBLICATION_SYSTEMS";
-		}
+		$sequences{"cabinet_pub_sys_id_seq"}="cabinet_publication_systems";
 	}
 }
 
 while (my ($seq,$tbl) = each(%sequences)) {
 	$seq=lc($seq);
 	unless (defined($tbl)) { warn "[WARN] No table found for sequence: $seq \n"; next;}
-	my $max=$dbh->selectrow_array("select nvl(max(id),0)+1 from $tbl",{});
+	my $max=$dbh->selectrow_array("select coalesce(max(id),0)+1 from $tbl",{});
 	unless (defined($max)) { warn "[WARN] No maxvalue found for sequence: $seq and table: $tbl\n"; next;}
-	print DBD "drop sequence ".$seq.";\n";
-	print DBD "create sequence ".$seq." start with ".$max." maxvalue 9223372036854775807;\n";
+	print DBD "drop sequence \"".$seq."\";\n";
+	print DBD "create sequence \"".$seq."\" start with ".$max." maxvalue 9223372036854775807;\n";
 }
 
 close DBD;

--- a/perun-db/tasksResultClear.ora
+++ b/perun-db/tasksResultClear.ora
@@ -1,0 +1,92 @@
+#!/usr/bin/perl -w
+
+use DBI;
+use strict;
+use POSIX qw(:errno_h);
+use Getopt::Long qw(:config no_ignore_case);
+
+use constant BACK => 4;
+
+sub help {
+        return qq{
+        Deletes older data from tasks_results
+        --------------------------------------
+        Available options:
+
+        --user      | -u Username for Oracle DB (required)
+        --password  | -w Password for Oracle DB (required)
+        --olderthan | -o Number of days to keep
+        };
+}
+
+my ($user,$pwd,$numkeep);
+
+GetOptions ("help|h" => sub { print help(); exit 0;},"user|u=s" => \$user, "password|w=s" => \$pwd, "olderthan|o=s" => \$numkeep) || die help();
+
+if (!defined $user) { print "[ERROR] Username for Oracle DB is required! Use --help | -h to print help.\n"; exit 1; }
+if (!defined $pwd) { print "[ERROR] Password for Oracle DB is required! Use --help | -h to print help.\n"; exit 1; }
+
+if (!defined $numkeep) {$numkeep=BACK;}
+
+my $dbh = DBI->connect('dbi:Oracle:',$user,$pwd,{ RaiseError=>1, AutoCommit=>0 })
+        or die EPERM," Connect";
+
+my $dst = $dbh->prepare(q{
+          select distinct r.destination_id,s.service_id from tasks_results r,tasks t,exec_services s where r.task_id=t.id and t.exec_service_id=s.id order by 1,2
+});
+
+my $maxts = $dbh->prepare(q{
+          select to_char(max(r.timestamp),'DD-MON-YYYY HH24:MI:SS') from tasks_results r,tasks t,exec_services s where r.task_id=t.id and t.exec_service_id=s.id and r.destination_id=? and s.service_id=?
+});
+
+my $fsd   = $dbh->prepare(q{
+            select count('x') from facility_service_destinations where service_id=? and destination_id=?
+});	    
+
+my $fd  = $dbh->prepare(q{
+          select count('x') from facility_service_destinations where destination_id=?
+});
+
+my $tr  = $dbh->prepare(q{
+          select count('x') from tasks_results where destination_id=?
+});	  
+
+my $del = $dbh->prepare(q{
+          delete from tasks_results where timestamp < (sysdate - ?) and timestamp != to_date(?,'DD-MON-YYYY HH24:MI:SS') and destination_id=? and task_id in (select id from tasks where exec_service_id in (select id from exec_services where service_id=?))
+}); 
+
+my $fdel = $dbh->prepare(q{
+           delete from tasks_results where destination_id=? and task_id in (select id from tasks where exec_service_id in (select id from exec_services where service_id=?))
+});	   
+
+my $ddel = $dbh->prepare(q{
+           delete from destinations where id=?
+});	   
+
+$dst->execute();
+while (my $dst = $dst->fetch) {
+     my $dest=$$dst[0];
+     my $serv=$$dst[1];
+     
+     #otestovat, zda existuje ve facility_service_destinations, 
+     #kdyz ne, zrusit z tasks_results i kdyz je posledni
+     my $fsdexist = $dbh->selectrow_array ($fsd,{},($serv,$dest));
+     if ($fsdexist != 0) {
+         my $maxtime = $dbh->selectrow_array ($maxts,{},($dest,$serv));
+     
+         print "$dest,$serv,$maxtime \n";
+         execute $del $numkeep,$maxtime,$dest,$serv;
+         commit $dbh;
+     } else {
+	 execute $fdel $dest,$serv;
+         print "$dest,$serv,FACSERVDEST DELETED \n";
+	 my $fdexist = $dbh->selectrow_array ($fd,{},($dest));
+	 my $trexist  = $dbh->selectrow_array ($tr,{},($dest));
+	 if ($fdexist == 0 && $trexist == 0) {
+	    execute $ddel $dest;
+	    print "$dest DESTINATION DELETED \n";
+	 }
+	 commit $dbh;
+     }	 
+}
+disconnect $dbh;

--- a/perun-db/tasksResultsClear.pgr
+++ b/perun-db/tasksResultsClear.pgr
@@ -1,0 +1,92 @@
+#!/usr/bin/perl -w
+
+use DBI;
+use strict;
+use POSIX qw(:errno_h);
+use Getopt::Long qw(:config no_ignore_case);
+
+use constant BACK => 4;
+
+sub help {
+        return qq{
+        Deletes older data from tasks_results
+        --------------------------------------
+        Available options:
+
+        --user      | -u Username for Oracle DB (required)
+        --password  | -w Password for Oracle DB (required)
+        --olderthan | -o Number of days to keep
+        };
+}
+
+my ($user,$pwd,$numkeep);
+
+GetOptions ("help|h" => sub { print help(); exit 0;},"user|u=s" => \$user, "password|w=s" => \$pwd, "olderthan|o=s" => \$numkeep) || die help();
+
+if (!defined $user) { print "[ERROR] Username for Oracle DB is required! Use --help | -h to print help.\n"; exit 1; }
+if (!defined $pwd) { print "[ERROR] Password for Oracle DB is required! Use --help | -h to print help.\n"; exit 1; }
+
+if (!defined $numkeep) {$numkeep=BACK;}
+
+my $dbh = DBI->connect('dbi:Pg:dbname=perun',$user,$pwd,{RaiseError=>1,AutoCommit=>0,pg_enable_utf8=>1}) or die EPERM," Connect";
+
+my $dst = $dbh->prepare(q{
+          select distinct r.destination_id,s.service_id from tasks_results r,tasks t,exec_services s where r.task_id=t.id and t.exec_service_id=s.id order by 1,2
+});
+
+my $maxts = $dbh->prepare(q{
+          select to_char(max(r.timestamp),'DD-MON-YYYY HH24:MI:SS') from tasks_results r,tasks t,exec_services s where r.task_id=t.id and t.exec_service_id=s.id and r.destination_id=? and s.service_id=?
+});
+
+my $fsd   = $dbh->prepare(q{
+            select count('x') from facility_service_destinations where service_id=? and destination_id=?
+});	    
+
+my $fd  = $dbh->prepare(q{
+          select count('x') from facility_service_destinations where destination_id=?
+});
+
+my $tr  = $dbh->prepare(q{
+          select count('x') from tasks_results where destination_id=?
+});	  
+
+my $tdel="delete from tasks_results where timestamp < (now() - interval '".$numkeep." days') and timestamp != to_date(?,'DD-MON-YYYY HH24:MI:SS') and destination_id=? and task_id in (select id from tasks where exec_service_id in (select id from exec_services where service_id=?))"; 
+print $tdel."\n";
+
+my $del = $dbh->prepare($tdel);
+
+my $fdel = $dbh->prepare(q{
+           delete from tasks_results where destination_id=? and task_id in (select id from tasks where exec_service_id in (select id from exec_services where service_id=?))
+});	   
+
+my $ddel = $dbh->prepare(q{
+           delete from destinations where id=?
+});	   
+
+$dst->execute();
+while (my $dst = $dst->fetch) {
+     my $dest=$$dst[0];
+     my $serv=$$dst[1];
+     
+     #otestovat, zda existuje ve facility_service_destinations, 
+     #kdyz ne, zrusit z tasks_results i kdyz je posledni
+     my $fsdexist = $dbh->selectrow_array ($fsd,{},($serv,$dest));
+     if ($fsdexist != 0) {
+         my $maxtime = $dbh->selectrow_array ($maxts,{},($dest,$serv));
+     
+         print "$dest,$serv,$maxtime \n";
+         execute $del $maxtime,$dest,$serv;
+         commit $dbh;
+     } else {
+	 execute $fdel $dest,$serv;
+         print "$dest,$serv,FACSERVDEST DELETED \n";
+	 my $fdexist = $dbh->selectrow_array ($fd,{},($dest));
+	 my $trexist  = $dbh->selectrow_array ($tr,{},($dest));
+	 if ($fdexist == 0 && $trexist == 0) {
+	    execute $ddel $dest;
+	    print "$dest DESTINATION DELETED \n";
+	 }
+	 commit $dbh;
+     }	 
+}
+disconnect $dbh;


### PR DESCRIPTION
- Added printing of tables, which are not exported by usual way (not included in table_order file). This list (in file ADD_tablesToDelete) is used for deleting of tables in delete_tables.pl tool.
- New tool for clearing of tasks_results table in version for oracle and for postgres.
- Updated export tool oracle_to_postgres and added postgres_to_postgres.