### PR TITLE
CORE: Fix reading of null "core" attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -344,7 +344,9 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					//
 					// Try to automatically convert object returned from bean method call to required data type
 					//
-					if(attribute.getType().equals(String.class.getName()) && !(value instanceof String)) {
+					if (value == null) {
+						// No need to convert NULL value (for String it caused NULL->"null" conversion)
+					} else if(attribute.getType().equals(String.class.getName()) && !(value instanceof String)) {
 						//TODO check exceptions
 						value = String.valueOf(value);
 					} else if(attribute.getType().equals(Integer.class.getName()) && !(value instanceof Integer)) {


### PR DESCRIPTION
- When reading values for core attributes (retrieved from object)
  we wrongly converted NULL strings to "null" by String.valueOf(value).
  Now we simply check, if value object is NULL if so, no action is performed.