### PR TITLE
CORE: Attribute modules for DC2/KOS ids on VŠUP

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_osbIddc2.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_osbIddc2.java
@@ -1,0 +1,37 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
+
+/**
+ * Check if OSB_ID of person from DC2 system is not empty (ID of employee on VŠUP).
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class urn_perun_user_attribute_def_def_osbIddc2 extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
+
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+
+		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "ID from DC2 can't be null.");
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("osbIddc2");
+		attr.setDisplayName("OSB_ID DC2");
+		attr.setType(String.class.getName());
+		attr.setDescription("ID of person in DC2 system.");
+		return attr;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_osbIdkos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_osbIdkos.java
@@ -1,0 +1,37 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
+
+/**
+ * Check if OSB_ID of person from KOS system is not empty (ID of student on VŠUP).
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class urn_perun_user_attribute_def_def_osbIdkos extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
+
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+
+		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "ID from KOS can't be null.");
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("osbIdkos");
+		attr.setDisplayName("OSB_ID KOS");
+		attr.setType(String.class.getName());
+		attr.setDescription("ID of person in KOS system.");
+		return attr;
+	}
+
+}


### PR DESCRIPTION
- When required by service OSB_IDs from DC2 or KOS can't be empty
  (prevent pushing employees/students between systems if they are not both).