### PR TITLE
CORE,RPC: Added changePassword for login/namespace combination

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -633,7 +633,26 @@ public interface UsersManager {
 	boolean isUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException, PrivilegeException, UserNotExistsException;
 
 	/**
-	 * Changes user password in defined login-namespace. If checkOldPassword is true, then ask autnetication system if old password is correct.
+	 * Changes user password in defined login-namespace. If checkOldPassword is true, then ask authentication system if old password is correct.
+	 *
+	 * @param sess
+	 * @param login
+	 * @param loginNamespace
+	 * @param oldPassword
+	 * @param newPassword
+	 * @param checkOldPassword
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws LoginNotExistsException
+	 * @throws PasswordDoesntMatchException
+	 * @throws PasswordChangeFailedException
+	 */
+	void changePassword(PerunSession sess, String login, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword)
+		throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException;
+
+	/**
+	 * Changes user password in defined login-namespace. If checkOldPassword is true, then ask authentication system if old password is correct.
 	 *
 	 * @param sess
 	 * @param user
@@ -649,7 +668,8 @@ public interface UsersManager {
 	 * @throws PasswordChangeFailedException
 	 */
 	void changePassword(PerunSession sess, User user, String loginNamespace, String oldPassword, String newPassword, boolean checkOldPassword)
-		throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException;
+			throws InternalErrorException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException;
+
 
 	/**
 	 * Changes user password in defined login-namespace using encrypted parameters.

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -821,6 +821,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	makeUserPerunAdmin {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
 			User user = ac.getUserById(parms.readInt("user"));
 			ac.getUsersManager().makeUserPerunAdmin(ac.getSession(), user);
 			return null;
@@ -828,6 +829,24 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 
+	/*#
+	 * Changes user password in defined login-namespace.
+	 *
+	 * @param login String Users login
+	 * @param loginNamespace String Namespace
+	 * @param newPassword String New password
+	 * @param checkOldPassword boolean Must be false
+	 */
+	/*#
+	 * Changes user password in defined login-namespace.
+	 * You must send the old password, which will be checked
+	 *
+	 * @param login String Users login
+	 * @param loginNamespace String Namespace
+	 * @param oldPassword String Old password which will be checked.
+	 * @param newPassword String New password
+	 * @param checkOldPassword boolean Must be true
+	 */
 	/*#
 	 * Changes user password in defined login-namespace.
 	 *
@@ -849,12 +868,22 @@ public enum UsersManagerMethod implements ManagerMethod {
 	changePassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			User user = ac.getUserById(parms.readInt("user"));
+			ac.stateChangingCheck();
 
-			if (parms.readBoolean("checkOldPassword")) {
-				ac.getUsersManager().changePassword(ac.getSession(), user, parms.readString("loginNamespace"), parms.readString("oldPassword"), parms.readString("newPassword"), true);
+			if (parms.contains("login")) {
+				String login = parms.readString("login");
+				if (parms.readBoolean("checkOldPassword")) {
+					ac.getUsersManager().changePassword(ac.getSession(), login, parms.readString("loginNamespace"), parms.readString("oldPassword"), parms.readString("newPassword"), true);
+				} else {
+					ac.getUsersManager().changePassword(ac.getSession(), login, parms.readString("loginNamespace"), parms.readString("oldPassword"), parms.readString("newPassword"), false);
+				}
 			} else {
-				ac.getUsersManager().changePassword(ac.getSession(), user, parms.readString("loginNamespace"), parms.readString("oldPassword"), parms.readString("newPassword"), false);
+				User user = ac.getUserById(parms.readInt("user"));
+				if (parms.readBoolean("checkOldPassword")) {
+					ac.getUsersManager().changePassword(ac.getSession(), user, parms.readString("loginNamespace"), parms.readString("oldPassword"), parms.readString("newPassword"), true);
+				} else {
+					ac.getUsersManager().changePassword(ac.getSession(), user, parms.readString("loginNamespace"), parms.readString("oldPassword"), parms.readString("newPassword"), false);
+				}
 			}
 			return null;
 		}
@@ -869,6 +898,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	changeNonAuthzPassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
 
 			ac.getUsersManager().changeNonAuthzPassword(ac.getSession(), parms.readString("i"), parms.readString("m"), parms.readString("password"));
 


### PR DESCRIPTION
- We allow to change/reset password for login/namespace combination
  and not just userId/namespace combination.
  Proper user is searched by login value and authz is performed too.
- Marked changePassword and some others methods in RPC api to
  require POST/PUT and not allow GET.
- Fixed javadoc.