### PR TITLE
CORE: Fixed sync on group members, which are in VO

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -2102,6 +2102,19 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			try {
 				// Check if the member is already in the VO (just not in the group)
 				member = getPerunBl().getMembersManagerBl().getMemberByUserExtSources(sess, getPerunBl().getGroupsManagerBl().getVo(sess, group), candidate.getUserExtSources());
+
+				// member exists - update attributes
+				Map<Candidate,RichMember> memberMap = new HashMap<>();
+				memberMap.put(candidate, getPerunBl().getMembersManagerBl().getRichMember(sess, member));
+				try {
+					updateExistingMembersWhileSynchronization(sess, group, memberMap, overwriteUserAttributesList);
+				} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+					// if update fails, skip him
+					log.warn("Can't update member from candidate {} due to attribute value exception {}.", candidate, e);
+					skippedMembers.add("MemberEntry:[" + candidate + "] was skipped because there was problem when updating member from candidate: Exception: " + e.getName() + " => '" + e.getMessage() + "'");
+					continue;
+				}
+
 			} catch (MemberNotExistsException e) {
 				try {
 					// We have new member (candidate), so create him using synchronous createMember (and overwrite chosed user attributes)


### PR DESCRIPTION
- When member is in vo but not in synced group, his attributes are
  not updated from candidate object. He is just added to the group
  and then fill/check is called. If fails (due to transitive membership
  and required services) then it took down whole sync process.

- Group arithmetic introduced problem, when all exception on adding
  member to the group in relation are wrapped to GroupOperationException,
  since synchronizer was catching attribute exceptions and put such member
  between "skipped". Right now it is not yet solved and still kill whole sync.