### PR TITLE
CORE: Converted some private methods to public to fix transactions

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcesManagerImpl.java
@@ -17,12 +17,12 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -46,6 +46,8 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourcesManagerImpl.class);
 	public final static String USEREXTSOURCEMAPPING = "additionalues_";
+
+	private ExtSourcesManagerImplApi self;
 
 	protected final static String extSourceMappingSelectQuery = "ext_sources.id as ext_sources_id, ext_sources.name as ext_sources_name, ext_sources.type as ext_sources_type, " +
 		"ext_sources.created_at as ext_sources_created_at, ext_sources.created_by as ext_sources_created_by, ext_sources.modified_by as ext_sources_modified_by, " +
@@ -100,6 +102,10 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 
 	public ExtSourcesManagerImpl(DataSource perunPool) throws InternalErrorException {
 		jdbc = new JdbcPerunTemplate(perunPool);
+	}
+
+	public void setSelf(ExtSourcesManagerImplApi self) {
+		this.self = self;
 	}
 
 	public ExtSource createExtSource(PerunSession sess, ExtSource extSource, Map<String, String> attributes) throws InternalErrorException, ExtSourceExistsException {
@@ -172,20 +178,13 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 		}
 	}
 
-	/**
-	 * Updates extSource definition. It is only private method, because extSources are defined in the external XML file.
-	 *
-	 * @param sess
-	 * @param extSource
-	 * @throws InternalErrorException
-	 */
-	private void updateExtSource(PerunSession sess, ExtSource extSource, Map<String, String> attributes) throws InternalErrorException {
+
+	@Override
+	public void updateExtSource(PerunSession sess, ExtSource extSource, Map<String, String> attributes) throws ExtSourceNotExistsException, InternalErrorException {
 		ExtSource extSourceDb;
-		try {
-			extSourceDb = this.getExtSourceById(sess, extSource.getId());
-		} catch (ExtSourceNotExistsException e) {
-			throw new InternalErrorException(e);
-		}
+
+		extSourceDb = this.getExtSourceById(sess, extSource.getId());
+
 
 		// Check the name
 		if (!extSourceDb.getName().equals(extSource.getName())) {
@@ -482,14 +481,14 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 							extSource.setType(extSourceType);
 
 							// ExtSource exists, so check values and potentionally update it
-							this.updateExtSource(sess, extSource, attributes);
+							self.updateExtSource(sess, extSource, attributes);
 
 						} catch (ExtSourceNotExistsException e) {
 							// ExtSource doesn't exist, so create it
 							extSource = new ExtSource();
 							extSource.setName(extSourceName);
 							extSource.setType(extSourceType);
-							extSource = this.createExtSource(sess, extSource, attributes);
+							extSource = self.createExtSource(sess, extSource, attributes);
 						}
 					} catch (RuntimeException e) {
 						throw new InternalErrorException(e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -320,20 +320,20 @@ public interface AttributesManagerImplApi {
 	 * Return value of entityless attribute by attr_id and key (subject).
 	 * Value is in the format from DB.
 	 * IMPORTANT: return only values in String (special format for Map or List)!
-	 * 
+	 *
 	 * If value is null, return null.
 	 * If attribute with subject=key not exists, create new one with null value and return null.
-	 * 
+	 *
 	 * @param sess
 	 * @param attrId
 	 * @param key
 	 * @return attr_value in string
-	 * 
+	 *
 	 * @throws InternalErrorException if runtime error exception has been thrown
 	 * @throws AttributeNotExistsException throw exception if attribute with value not exists in DB
 	 */
 	String getEntitylessAttrValueForUpdate(PerunSession sess, int attrId, String key) throws InternalErrorException, AttributeNotExistsException;
-	
+
 	/**
 	 * Returns list of Keys which fits the attributeDefinition.
 	 *
@@ -733,34 +733,47 @@ public interface AttributesManagerImplApi {
 
 	/**
 	 * Insert attribute value in DB.
-	 * 
+	 *
 	 * @param sess perun session
 	 * @param valueColName column, where the data will be stored, usually one of value or attr_value or attr_value_text
 	 * @param attribute that will be stored in the DB
-	 * @param tableName in the database in which the attribute will be inserted 
+	 * @param tableName in the database in which the attribute will be inserted
 	 * @param columnNames of the database table in which the attribute will be written
 	 * @param columnValues of the objects, for which the attribute will be written, corresponding to the columnNames
 	 * @return true if new value differs from old value (i.e. values changed)
 	 *         false otherwise (value do not change)
-	 * @throws InternalErrorException 
+	 * @throws InternalErrorException
 	 */
 	public boolean insertAttribute(PerunSession sess, String valueColName, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues) throws InternalErrorException;
-	
+
 	/**
 	 * Update attribute value in DB.
-	 * 
+	 *
 	 * @param sess perun session
 	 * @param valueColName column, where the data will be stored, usually one of value or attr_value or attr_value_text
 	 * @param attribute that will be stored in the DB
-	 * @param tableName in the database for updating 
+	 * @param tableName in the database for updating
 	 * @param columnNames of the database table in which the attribute will be written
 	 * @param columnValues of the objects, for which the attribute will be written, corresponding to the columnNames
 	 * @return true if new value differs from old value (i.e. values changed)
 	 *         false otherwise (value do not change)
-	 * @throws InternalErrorException 
+	 * @throws InternalErrorException
 	 */
 	public boolean updateAttribute(PerunSession sess, String valueColName, Attribute attribute, String tableName, List<String> columnNames, List<Object> columnValues) throws InternalErrorException;
-	
+
+	/**
+	 * Set entityless attribute with null value (for key and attribute). Shouldn't be called from upper layer !!!
+	 *
+	 * @param sess
+	 * @param key key for storing entityless attribute
+	 * @param attribute attribute to set
+	 *
+	 * @return true if insert is ok
+	 *
+	 * @throws InternalErrorException if runtimeException is thrown
+	 */
+	boolean setAttributeWithNullValue(final PerunSession sess, final String key, final Attribute attribute) throws InternalErrorException;
+
 	/**
 	 * Store the particular virtual attribute associated with the facility.
 	 *
@@ -923,7 +936,7 @@ public interface AttributesManagerImplApi {
 	 * @param resource
 	 * @param serviceIds
 	 * @return list of resource attributes which are required by services which are selceted
-	 * 
+	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, List<Integer> serviceIds) throws InternalErrorException;
@@ -1042,7 +1055,7 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Vo vo) throws InternalErrorException;
-	
+
 	/**
 	 * Get resource attributes which are required by the service.
 	 *
@@ -1589,10 +1602,10 @@ public interface AttributesManagerImplApi {
 
 	/**
 	 * Remove all non-virtual group-resource attribute on selected resource
-	 * 
+	 *
 	 * @param sess
 	 * @param resource
-	 * @throws InternalErrorException 
+	 * @throws InternalErrorException
 	 */
 	void removeAllGroupResourceAttributes(PerunSession sess, Resource resource) throws InternalErrorException;
 
@@ -2109,6 +2122,14 @@ public interface AttributesManagerImplApi {
 	 * @see cz.metacentrum.perun.core.impl.AttributesManagerImpl#getAttributesModule(PerunSession,String)
 	 */
 	Object getAttributesModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException;
+
+	/**
+	 * Creates attributes during initialization. Shouldn't be called from upper layers !!!
+	 *
+	 * @param attribute Attribute to create
+	 * @throws InternalErrorException
+	 */
+	void createAttributeExistsForInitialize(AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Updates AttributeDefinition.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourcesManagerImplApi.java
@@ -51,6 +51,16 @@ public interface ExtSourcesManagerImplApi {
 	void deleteExtSource(PerunSession perunSession, ExtSource extSource) throws InternalErrorException, ExtSourceAlreadyRemovedException;
 
 	/**
+	 * Updates extSource definition. It should be called only internally, because extSources are defined in the external XML file.
+	 * It shouldn't be called from upper layers !!!
+	 *
+	 * @param sess
+	 * @param extSource
+	 * @throws InternalErrorException
+	 */
+	void updateExtSource(PerunSession sess, ExtSource extSource, Map<String, String> attributes) throws ExtSourceNotExistsException, InternalErrorException;
+
+	/**
 	 * Searches for the external source with specified id.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -335,10 +335,11 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	</bean>
 	<bean id="extSourcesManagerImpl" class="cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl" scope="singleton" depends-on="databaseManagerBl">
 		<constructor-arg ref="dataSource" />
+		<property name="self" ref="extSourcesManagerImpl"/>
 	</bean>
 	<bean id="attributesManagerImpl" class="cz.metacentrum.perun.core.impl.AttributesManagerImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
 		<property name="perun" ref="perun"/>
-                <property name="self" ref="attributesManagerImpl"/>
+		<property name="self" ref="attributesManagerImpl"/>
 		<constructor-arg ref="dataSource" />
 	</bean>
 	<bean id="servicesManagerImpl" class="cz.metacentrum.perun.core.impl.ServicesManagerImpl" scope="singleton" depends-on="databaseManagerBl">


### PR DESCRIPTION
- We must call this private methods through interface in order to start
  nested transaction (by spring config). Changed from private to public
  and fixed call over the interface instance (not using this.method()).
- Automatic whitespace and source format.