### PR TITLE
Hack for GID range in EINFRA

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -250,6 +250,13 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		if(maxGidAttribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, maxGidAttribute);
 		Integer maxGid = (Integer) maxGidAttribute.getValue();
 
+		//FIXME HACK: there are some artefact in 'einfra' from the past we need to skip
+		if(gidNamespace.equals("einfra")) {
+			List<Integer> artefactGIDs = new ArrayList<>(Arrays.asList(221,223,226,228,230,236,1185,1186,2001,2004));
+			if(artefactGIDs.contains(gid)) return;
+		}
+		//END OF HACK (need to be remove after solving the problem with EINFRA GID range)
+
 		if ( gid < minGid || gid > maxGid ) {
 			throw new WrongAttributeValueException(attribute,"GID number is not in allowed values min: "+minGid+", max:"+maxGid);
 		}


### PR DESCRIPTION
 - there are 10 groups with BAD GID not in range of EINFRA Namespace so
   we need to skip checking for these artefact gids
 - change is in method checkIfGIDIsWithinRange just for group_gid and
   for namespace einfra