### PR TITLE
update engine ID in database when assigned in dispatcher

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -293,6 +293,7 @@ public class SchedulingPoolImpl implements SchedulingPool {
 		} else {
 			tasksById.get(task.getId()).put(task, queueForTask);
 		}
+		taskManager.updateTaskEngine(task, queueForTask.getClientID());
 	}
 
 	@Override

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/TaskDao.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/TaskDao.java
@@ -76,7 +76,7 @@ public interface TaskDao {
 
 	void updateTask(Task task, int engineID);
 
-	void updateTaskEngine(Task task, int engineID);
+	void updateTaskEngine(Task task, int engineID) throws InternalErrorException;
 
 	boolean isThereSuchTask(ExecService execService, Facility facility, int engineID);
 

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/TaskDao.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/TaskDao.java
@@ -76,6 +76,8 @@ public interface TaskDao {
 
 	void updateTask(Task task, int engineID);
 
+	void updateTaskEngine(Task task, int engineID);
+
 	boolean isThereSuchTask(ExecService execService, Facility facility, int engineID);
 
 	void removeTask(ExecService execService, Facility facility, int engineID);

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskDaoJdbc.java
@@ -374,6 +374,12 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 	}
 
 	@Override
+	public void updateTaskEngine(Task task, int engineID) {
+		this.getJdbcTemplate().update(
+				"update tasks set engine_id = ? where id = ?", engineID, task.getId());
+	}
+
+	@Override
 	public boolean isThereSuchTask(ExecService execService, Facility facility, int engineID) {
 		this.getJdbcTemplate().update("select id from exec_services where id = ?", execService.getId());
 

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskDaoJdbc.java
@@ -374,9 +374,13 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 	}
 
 	@Override
-	public void updateTaskEngine(Task task, int engineID) {
-		this.getJdbcTemplate().update(
+	public void updateTaskEngine(Task task, int engineID) throws InternalErrorException {
+		try {
+			this.getJdbcTemplate().update(
 				"update tasks set engine_id = ? where id = ?", engineID, task.getId());
+		} catch(Exception e) {
+			throw new InternalErrorException("Error updating engine id", e);
+		}
 	}
 
 	@Override

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/TaskManager.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/TaskManager.java
@@ -47,6 +47,8 @@ public interface TaskManager {
 	void updateTask(Task task, int engineID);
 
 	void updateTask(Task task);
+	
+	void updateTaskEngine(Task task, int engineID);
 
 	boolean isThereSuchTask(ExecService execService, Facility facility, int engineID);
 

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/TaskManager.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/TaskManager.java
@@ -48,7 +48,7 @@ public interface TaskManager {
 
 	void updateTask(Task task);
 	
-	void updateTaskEngine(Task task, int engineID);
+	void updateTaskEngine(Task task, int engineID) throws InternalErrorException;
 
 	boolean isThereSuchTask(ExecService execService, Facility facility, int engineID);
 

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/impl/TaskManagerImpl.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/impl/TaskManagerImpl.java
@@ -110,6 +110,11 @@ public class TaskManagerImpl implements TaskManager {
 	}
 
 	@Override
+	public void updateTaskEngine(Task task, int engineID) {
+		taskDao.updateTaskEngine(task, engineID);
+	}
+
+	@Override
 	public boolean isThereSuchTask(ExecService execService, Facility facility, int engineID) {
 		return taskDao.isThereSuchTask(execService, facility, engineID);
 	}

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/impl/TaskManagerImpl.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/service/impl/TaskManagerImpl.java
@@ -110,7 +110,7 @@ public class TaskManagerImpl implements TaskManager {
 	}
 
 	@Override
-	public void updateTaskEngine(Task task, int engineID) {
+	public void updateTaskEngine(Task task, int engineID) throws InternalErrorException {
 		taskDao.updateTaskEngine(task, engineID);
 	}
 


### PR DESCRIPTION
* adds a method to TaskManager (and TaskDao) to update engine id in database
* updates the engine id database column when calling setQueueForTask() in dispatcher