### PR TITLE
REGISTRAR: Fix delivery fail for some app notifications

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -1300,6 +1300,7 @@ public class MailManagerImpl implements MailManager {
 
 		// set backup
 		message.setFrom(getPropertyFromConfiguration("backupFrom"));
+		message.setReplyTo(getPropertyFromConfiguration("backupFrom"));
 
 		// get proper value from attribute
 		try {
@@ -1318,7 +1319,7 @@ public class MailManagerImpl implements MailManager {
 			String senderEmail = "";
 			if (attrSenderEmail != null && attrSenderEmail.getValue() != null) {
 				senderEmail = BeansUtils.attributeValueToString(attrSenderEmail);
-				message.setFrom(senderEmail);
+				message.setReplyTo(senderEmail);
 			}
 		} catch (Exception ex) {
 			// we dont care about exceptions here - we have backup TO/FROM address


### PR DESCRIPTION
- When user provides email address for notifications, we might
  not be authorized to set it as sender (from), since receiving server
  might reject it (domain theirs, server ours).
  So now we set "from" as single address based on perun instance, which
  belongs to us and "reply-to" set to mail provided by user.