### PR TITLE
Wrong name for FK of table user_ext_source_attr_values fixed.

### DIFF
--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -6,11 +6,11 @@
 -- this update is not supported on hsql since its used only as in-memory db
 
 3.1.38
-create table user_ext_source_attr_values ( ues_id integer not null, attr_id integer not null, attr_value varchar(4000), created_at timestamp default now not null, created_by varchar(1024) default user not null, modified_at timestamp default now not null, modified_by varchar(1024) default user not null, status char(1) default '0' not null, attr_value_text text, created_by_uid integer, modified_by_uid integer );
-create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (ues_id);
+create table user_ext_source_attr_values ( user_ext_source_id integer not null, attr_id integer not null, attr_value varchar(4000), created_at timestamp default now not null, created_by varchar(1024) default user not null, modified_at timestamp default now not null, modified_by varchar(1024) default user not null, status char(1) default '0' not null, attr_value_text text, created_by_uid integer, modified_by_uid integer );
+create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (user_ext_source_id);
 create index idx_fk_ues_attr_values_attr on user_ext_source_attr_values (attr_id);
-alter table user_ext_source_attr_values add constraint uesattrval_pk primary key (ues_id, attr_id);
-alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (ues_id) references user_ext_sources(id);
+alter table user_ext_source_attr_values add constraint uesattrval_pk primary key (user_ext_source_id, attr_id);
+alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (user_ext_source_id) references user_ext_sources(id);
 alter table user_ext_source_attr_values add constraint uesattrval_attr_fk foreign key (attr_id) references attr_names(id);
 grant all on user_ext_source_attr_values to perun;
 update configurations set value='3.1.38' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -4,10 +4,10 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 3.1.38
-create table user_ext_source_attr_values ( ues_id integer not null, attr_id integer not null, attr_value nvarchar2(4000), created_at date default sysdate not null, created_by nvarchar2(1024) default user not null, modified_at date default sysdate not null, modified_by nvarchar2(1024) default user not null, status char(1) default '0' not null, attr_value_text clob, created_by_uid integer, modified_by_uid integer);
-create index IDX_FK_UES_ATTR_VALUES_UES on user_ext_source_attr_values (ues_id);
+create table user_ext_source_attr_values ( user_ext_source_id integer not null, attr_id integer not null, attr_value nvarchar2(4000), created_at date default sysdate not null, created_by nvarchar2(1024) default user not null, modified_at date default sysdate not null, modified_by nvarchar2(1024) default user not null, status char(1) default '0' not null, attr_value_text clob, created_by_uid integer, modified_by_uid integer);
+create index IDX_FK_UES_ATTR_VALUES_UES on user_ext_source_attr_values (user_ext_source_id);
 create index IDX_FK_UES_ATTR_VALUES_ATTR on user_ext_source_attr_values (attr_id);
-alter table user_ext_source_attr_values add ( constraint UESATTRVAL_PK primary key (ues_id, attr_id), constraint UESATTRVAL_UES_FK foreign key (ues_id) references user_ext_sources(id), constraint UESATTRVAL_ATTR_FK foreign key (attr_id) references attr_names(id) );
+alter table user_ext_source_attr_values add ( constraint UESATTRVAL_PK primary key (user_ext_source_id, attr_id), constraint UESATTRVAL_UES_FK foreign key (user_ext_source_id) references user_ext_sources(id), constraint UESATTRVAL_ATTR_FK foreign key (attr_id) references attr_names(id) );
 update configurations set value='3.1.38' where property='DATABASE VERSION';
 
 3.1.37

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -4,11 +4,11 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 3.1.38
-create table "user_ext_source_attr_values" ( ues_id integer not null, attr_id integer not null, attr_value varchar(4000), created_at timestamp default now() not null, created_by varchar(1024) default user not null, modified_at timestamp default now() not null, modified_by varchar(1024) default user not null, status char(1) default '0' not null, attr_value_text text, created_by_uid integer, modified_by_uid integer );
-create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (ues_id);
+create table "user_ext_source_attr_values" ( user_ext_source_id integer not null, attr_id integer not null, attr_value varchar(4000), created_at timestamp default now() not null, created_by varchar(1024) default user not null, modified_at timestamp default now() not null, modified_by varchar(1024) default user not null, status char(1) default '0' not null, attr_value_text text, created_by_uid integer, modified_by_uid integer );
+create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (user_ext_source_id);
 create index idx_fk_ues_attr_values_attr on user_ext_source_attr_values (attr_id);
-alter table user_ext_source_attr_values add constraint uesattrval_pk primary key (ues_id, attr_id);
-alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (ues_id) references user_ext_sources(id);
+alter table user_ext_source_attr_values add constraint uesattrval_pk primary key (user_ext_source_id, attr_id);
+alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (user_ext_source_id) references user_ext_sources(id);
 alter table user_ext_source_attr_values add constraint uesattrval_attr_fk foreign key (attr_id) references attr_names(id);
 grant all on user_ext_source_attr_values to perun;
 update configurations set value='3.1.38' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/schema.sql
+++ b/perun-core/src/main/resources/schema.sql
@@ -1113,7 +1113,7 @@ create table facilities_bans (
 );
 
 create table user_ext_source_attr_values (
-	ues_id integer not null,
+	user_ext_source_id integer not null,
 	attr_id integer not null,
 	attr_value varchar(4000),
 	created_at timestamp default now not null,
@@ -1323,7 +1323,7 @@ create index idx_fk_res_ban_member_res on resources_bans (member_id, resource_id
 create index idx_fk_fac_ban_user on facilities_bans (user_id);
 create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
 create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
-create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (ues_id);
+create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (user_ext_source_id);
 create index idx_fk_ues_attr_values_attr on user_ext_source_attr_values (attr_id);
 
 alter table auditer_log add constraint audlog_pk primary key (id);
@@ -1661,6 +1661,6 @@ alter table mailchange add constraint mailchange_u_fk foreign key (user_id) refe
 alter table pwdreset add constraint pwdreset_pk primary key (id);
 alter table pwdreset add constraint pwdreset_u_fk foreign key (user_id) references users(id);
 
-alter table user_ext_source_attr_values add constraint uesattrval_pk primary key (ues_id, attr_id);
-alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (ues_id) references user_ext_sources(id);
+alter table user_ext_source_attr_values add constraint uesattrval_pk primary key (user_ext_source_id, attr_id);
+alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (user_ext_source_id) references user_ext_sources(id);
 alter table user_ext_source_attr_values add constraint uesattrval_attr_fk foreign key (attr_id) references attr_names(id);

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1120,7 +1120,7 @@ create table facilities_bans (
 );
 
 create table user_ext_source_attr_values (
-	ues_id integer not null,
+	user_ext_source_id integer not null,
 	attr_id integer not null,
 	attr_value nvarchar2(4000),
 	created_at date default sysdate not null,
@@ -1321,7 +1321,7 @@ create index IDX_FK_RES_BAN_MEMBER on resources_bans (member_id);
 create index IDX_FK_RES_BAN_RES on resources_bans (resource_id);
 create index IDX_FK_FAC_BAN_USER on facilities_bans (user_id);
 create index IDX_FK_FAC_BAN_FAC on facilities_bans (facility_id);
-create index IDX_FK_UES_ATTR_VALUES_UES on user_ext_source_attr_values (ues_id);
+create index IDX_FK_UES_ATTR_VALUES_UES on user_ext_source_attr_values (user_ext_source_id);
 create index IDX_FK_UES_ATTR_VALUES_ATTR on user_ext_source_attr_values (attr_id);
 
 alter table auditer_log add (constraint AUDLOG_PK primary key (id));
@@ -1794,8 +1794,8 @@ constraint pwdreset_u_fk foreign key (user_id) references users(id)
 );
 
 alter table user_ext_source_attr_values add (
-constraint UESATTRVAL_PK primary key (ues_id, attr_id),
-constraint UESATTRVAL_UES_FK foreign key (ues_id) references user_ext_sources(id),
+constraint UESATTRVAL_PK primary key (user_ext_source_id, attr_id),
+constraint UESATTRVAL_UES_FK foreign key (user_ext_source_id) references user_ext_sources(id),
 constraint UESATTRVAL_ATTR_FK foreign key (attr_id) references attr_names(id)
 );
 

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1202,7 +1202,7 @@ create table "facilities_bans" (
 );
 
 create table "user_ext_source_attr_values" (
-	ues_id integer not null, 
+	user_ext_source_id integer not null, 
 	attr_id integer not null, 
 	attr_value varchar(4000), 
 	created_at timestamp default now() not null,
@@ -1411,7 +1411,7 @@ create index idx_fk_res_ban_member_res on resources_bans (member_id, resource_id
 create index idx_fk_fac_ban_user on facilities_bans (user_id);
 create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
 create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
-create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (ues_id);
+create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (user_ext_source_id);
 create index idx_fk_ues_attr_values_attr on user_ext_source_attr_values (attr_id);
 
 alter table auditer_log add constraint audlog_pk primary key (id);
@@ -1749,8 +1749,8 @@ alter table facility_contacts add constraint faccont_own_fk foreign key (owner_i
 alter table facility_contacts add constraint faccont_grp_fk foreign key (group_id) references groups(id);
 alter table facility_contacts add constraint faccont_usr_own_grp_chk check ((user_id is not null and owner_id is null and group_id is null) or (user_id is null and owner_id is not null and group_id is null) or (user_id is null and owner_id is null and group_id is not null));
 
-alter table user_ext_source_attr_values add constraint uesattrval_pk primary key (ues_id, attr_id);
-alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (ues_id) references user_ext_sources(id);
+alter table user_ext_source_attr_values add constraint uesattrval_pk primary key (user_ext_source_id, attr_id);
+alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (user_ext_source_id) references user_ext_sources(id);
 alter table user_ext_source_attr_values add constraint uesattrval_attr_fk foreign key (attr_id) references attr_names(id);
 
 grant all on users to perun;


### PR DESCRIPTION
Name of FK for user_ext_source changed from ues_id to user_external_source_id.