### PR TITLE
Optimization of group sychronization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -824,6 +824,17 @@ public interface MembersManagerBl {
 	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, List<RichMember> richMembers)  throws InternalErrorException;
 
 	/**
+	 * Fill the RichMember object with data from Member and corresponding User and user/member attributes defined by list of attribute definition.
+	 * 
+	 * @param sess
+	 * @param richMembers
+	 * @param attrsDef
+	 * @return
+	 * @throws InternalErrorException 
+	 */
+	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, List<RichMember> richMembers, List<AttributeDefinition> attrsDef)  throws InternalErrorException;
+
+	/**
 	 * Get the VO members count.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1903,6 +1903,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * @throws WrongAttributeAssignmentException if some attribute is updated in bad way (bad assignment)
 	 */
 	private void updateExistingMembersWhileSynchronization(PerunSession sess, Group group, Map<Candidate, RichMember> membersToUpdate, List<String> overwriteUserAttributesList) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		List<AttributeDefinition> attrDefs = new ArrayList<>();
 		//Iterate through all subject attributes
 		for(Candidate candidate: membersToUpdate.keySet()) {
 			RichMember richMember = membersToUpdate.get(candidate);
@@ -1916,10 +1917,22 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				continue;
 			}
 
-			for (String attributeName : candidate.getAttributes().keySet()) {
-				//get RichMember with attributes
-				richMember = getPerunBl().getMembersManagerBl().convertMembersToRichMembersWithAttributes(sess, Arrays.asList(richMember)).get(0);
+			//load attrDefinitions just once for first candidate
+			if(attrDefs.isEmpty()) {
+				for(String attrName : candidate.getAttributes().keySet()) {
+					try {
+						AttributeDefinition attrDef = getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, attrName);
+						attrDefs.add(attrDef);
+					} catch (AttributeNotExistsException ex) {
+						log.error("Can't synchronize attribute " + attrName + " for candidate " + candidate + " and for group " + group);
+						//skip this attribute at all
+					}
+				}
+			}
 
+			//get RichMember with attributes
+			richMember = getPerunBl().getMembersManagerBl().convertMembersToRichMembersWithAttributes(sess, Arrays.asList(richMember), attrDefs).get(0);
+			for (String attributeName : candidate.getAttributes().keySet()) {
 				//update member attribute
 				if(attributeName.startsWith(AttributesManager.NS_MEMBER_ATTR)) {
 					boolean attributeFound = false;


### PR DESCRIPTION
 - do not call converting to richMember with attributes for every
   attribute of candidate from extSource (do it just once for one
   candidate)
 - do not get all member and user attributes for richMember, just list
   of ext source specific attributes