### PR TITLE
Fix null pointer exception in group synchronization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1939,6 +1939,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 					boolean attributeFound = false;
 					for (Attribute memberAttribute: richMember.getMemberAttributes()) {
 						if(memberAttribute.getName().equals(attributeName)) {
+							if(memberAttribute.getValue() == null) break;
 							attributeFound = true;
 							Object subjectAttributeValue = getPerunBl().getAttributesManagerBl().stringToAttributeValue(candidate.getAttributes().get(attributeName), memberAttribute.getType());
 							if (subjectAttributeValue != null && !memberAttribute.getValue().equals(subjectAttributeValue)) {
@@ -1977,6 +1978,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 					boolean attributeFound = false;
 					for (Attribute userAttribute: richMember.getUserAttributes()) {
 						if(userAttribute.getName().equals(attributeName)) {
+							if(userAttribute.getValue() == null) break;
 							attributeFound = true;
 							Object subjectAttributeValue = getPerunBl().getAttributesManagerBl().stringToAttributeValue(candidate.getAttributes().get(attributeName), userAttribute.getType());
 							if (!userAttribute.getValue().equals(subjectAttributeValue)) {


### PR DESCRIPTION
 - there were always a list of user and member attributes with setted
   value (without unset attributes with null value), now there are also
   these attributes so we need to skip searching for them to not find