### PR TITLE
OIDC: Fix header vulnerability

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -79,15 +79,8 @@ public class Api extends HttpServlet {
 	protected String getExtSourceName(HttpServletRequest req, Deserializer des) throws RpcException {
 		if (req.getHeader("Shib-Identity-Provider") != null && !req.getHeader("Shib-Identity-Provider").isEmpty()) {
 			return (String) req.getHeader("Shib-Identity-Provider");
-		} else if (req.getHeader("OIDC_CLAIM_principal") != null && !req.getHeader("OIDC_CLAIM_principal").isEmpty()) {
-			try {
-				ObjectMapper mapper = new ObjectMapper();
-				ObjectNode jsonPrincipal = (ObjectNode) mapper.readTree(req.getHeader("OIDC_CLAIM_principal"));
-				ObjectNode jsonAttributes = (ObjectNode) jsonPrincipal.get("attributes");
-				return jsonAttributes.get("extSourceName").getTextValue();
-			} catch (IOException e) {
-				throw new RpcException(RpcException.Type.NO_REMOTE_USER_SPECIFIED, "Cannot read OAuth2 principal", e);
-			}
+		} else if (req.getHeader("OIDC_CLAIM_sub") != null && !req.getHeader("OIDC_CLAIM_sub").isEmpty()) {
+			return req.getHeader("OIDC_CLAIM_extSourceName");
 		} else if (req.getAttribute("SSL_CLIENT_VERIFY") != null && ((String) req.getAttribute("SSL_CLIENT_VERIFY")).equals("SUCCESS")){
 			return (String) req.getAttribute("SSL_CLIENT_I_DN");
 		} else if (req.getAttribute("EXTSOURCE") != null) {
@@ -106,7 +99,7 @@ public class Api extends HttpServlet {
 				actor = (String) req.getRemoteUser();
 			}
 		} else if (req.getHeader("OIDC_CLAIM_sub") != null && !req.getHeader("OIDC_CLAIM_sub").isEmpty()) {
-			actor = req.getHeader("OIDC_CLAIM_userExtSourceLogin");
+			actor = req.getRemoteUser();
 		} else if (req.getAttribute("SSL_CLIENT_VERIFY") != null && ((String) req.getAttribute("SSL_CLIENT_VERIFY")).equals("SUCCESS")){
 			actor = (String) req.getAttribute("SSL_CLIENT_S_DN");
 		} else if (req.getAttribute("EXTSOURCE") != null) {
@@ -169,7 +162,7 @@ public class Api extends HttpServlet {
 		// If OIDC_CLAIM_sub header is present, it means user authenticated via OAuth2 with MITRE.
 		else if (req.getHeader("OIDC_CLAIM_sub") != null && !req.getHeader("OIDC_CLAIM_sub").isEmpty()) {
 
-				extLogin = req.getHeader("OIDC_CLAIM_userExtSourceLogin");
+				extLogin = req.getRemoteUser();
 				extSourceName = req.getHeader("OIDC_CLAIM_extSourceName");
 				extSourceType = req.getHeader("OIDC_CLAIM_extSourceType");
 				extSourceLoaString = req.getHeader("OIDC_CLAIM_extSourceLoa");


### PR DESCRIPTION
Client could 'inject' header OIDC_CLAIM_userExtSourceLogin into request and perun could accept that value if apache wouldnt overwrite it. Now remoteUser is used instead.

plus:
getExtSourceName method was wrong and accepts old APIS headers. 
