### PR TITLE
CORE, GUI: Allow per-vo RT queues for quota change requests

### DIFF
--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -40,6 +40,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<prop key="perun.rpc.powerusers"></prop>
 					<prop key="perun.perun.db.name">perun</prop>
 					<prop key="perun.rt.url">https://rt3.cesnet.cz/rt/REST/1.0/ticket/new</prop>
+					<prop key="perun.rt.defaultQueue">perun</prop>
 					<prop key="perun.rt.serviceuser.username">perunv3-rt</prop>
 					<prop key="perun.rt.serviceuser.password">password</prop>
 					<prop key="perun.passwordManager.program">/usr/local/bin/perun.passwordManager</prop>
@@ -74,6 +75,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<prop key="perun.rpc.powerusers"></prop>
 					<prop key="perun.perun.db.name">perun</prop>
 					<prop key="perun.rt.url">https://rt3.cesnet.cz/rt/REST/1.0/ticket/new</prop>
+					<prop key="perun.rt.defaultQueue">perun</prop>
 					<prop key="perun.rt.serviceuser.username">perunv3-rt</prop>
 					<prop key="perun.rt.serviceuser.password">password</prop>
 					<prop key="perun.passwordManager.program">/usr/local/bin/perun.passwordManager</prop>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/RTMessagesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/RTMessagesManagerBlImpl.java
@@ -43,11 +43,12 @@ import cz.metacentrum.perun.core.impl.Utils;
  *
  * @author Michal Stava <stavamichal@gmail.com>
  */
-public class RTMessagesManagerBlImpl implements RTMessagesManagerBl{
+public class RTMessagesManagerBlImpl implements RTMessagesManagerBl {
+
 	private String rtURL;
 	private PerunBl perunBl;
 	private final static org.slf4j.Logger log = LoggerFactory.getLogger(RTMessagesManagerBlImpl.class);
-	private final String defaultQueue = "perunv3";
+	private final String defaultQueue = BeansUtils.getPropertyFromConfiguration("perun.rt.defaultQueue");
 
 	private Pattern ticketNumberPattern = Pattern.compile("^# Ticket ([0-9]+) created.");
 
@@ -80,7 +81,7 @@ public class RTMessagesManagerBlImpl implements RTMessagesManagerBl{
 		//Get Email from User who get from session
 		String email = null;
 		User user = sess.getPerunPrincipal().getUser();
-		
+
 		//try to get user/member email from user in session
 		if(user != null) email = findUserPreferredEmail(sess, user);
 		else {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/RequestQuotaChangeTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/RequestQuotaChangeTabItem.java
@@ -195,7 +195,8 @@ public class RequestQuotaChangeTabItem implements TabItem {
 	protected void requestQuotaChange(String newQuota, String reason) {
 
 		SendMessageToRt rt = new SendMessageToRt(JsonCallbackEvents.closeTabEvents(session, this));
-		rt.sendMessage(SendMessageToRt.DEFAULT_QUEUE, RT_SUBJECT, getRequestText(newQuota, reason), resource.getVoId());
+		// quota change will use per-vo (or per-resource in a future) queue
+		rt.sendMessage("", RT_SUBJECT, getRequestText(newQuota, reason), resource.getVoId());
 
 	}
 


### PR DESCRIPTION
- Read default RT queue from perun.properties property "perun.rt.defaultQueue".
- Do not send default RT queue from gui, since it overrides per-vo settings in RPC api.