### PR TITLE
UserExtSource attributes for AttributesManager - task #3034

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -82,6 +82,12 @@ public interface AttributesManager {
 	public static final String NS_ENTITYLESS_ATTR_DEF = "urn:perun:entityless:attribute-def:def";
 	public static final String NS_ENTITYLESS_ATTR_OPT = "urn:perun:entityless:attribute-def:opt";
 
+	public static final String NS_UES_ATTR = "urn:perun:ues:attribute-def";
+	public static final String NS_UES_ATTR_CORE = "urn:perun:ues:attribute-def:core";
+	public static final String NS_UES_ATTR_DEF = "urn:perun:ues:attribute-def:def";
+	public static final String NS_UES_ATTR_OPT = "urn:perun:ues:attribute-def:opt";
+	public static final String NS_UES_ATTR_VIRT = "urn:perun:ues:attribute-def:virt";
+
 	public static final String ENTITY_MEMBER = "member";
 	public static final String ENTITY_USER = "user";
 
@@ -538,6 +544,21 @@ public interface AttributesManager {
 	List<String> getEntitylessKeys(PerunSession sess, AttributeDefinition attributeDefinition) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
+	 * Get all <b>non-empty</b> attributes associated with the UserExtSource.
+	 *
+	 * PRIVILEGE: Get only those attributes the principal has access to.
+	 *
+	 * @param sess perun session
+	 * @param ues to get the attributes from
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws UserExtSourceNotExistsException if the user external source doesn't exists
+	 */
+	List<Attribute> getAttributes(PerunSession sess, UserExtSource ues) throws PrivilegeException, InternalErrorException, UserExtSourceNotExistsException;
+
+	/**
 	 * Returns all attributes with not-null value which fits the attributeDefinition. Can't proscess core or virtual attributes.
 	 *
 	 * PRIVILEGE: Only PerunAdmin has access to get Attributes by AttributeDefinition
@@ -880,6 +901,25 @@ public interface AttributesManager {
 	void setAttributes(PerunSession sess, Resource resource, Group group, List<Attribute> attributes, boolean workWithGroupAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, GroupNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException,GroupResourceMismatchException,AttributeNotExistsException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Store the attributes associated with the user external source. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 *
+	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
+	 *
+	 * @param sess perun session
+	 * @param ues user external source to set on
+	 * @param attributes attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws UserExtSourceNotExistsException if the user external source doesn't exists in the underlying data source
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not user external source attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributes(PerunSession sess, UserExtSource ues, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, UserExtSourceNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
 	 * Get particular attribute for the facility.
 	 *
 	 * PRIVILEGE: Principal need to have access to attribute which wants to get.
@@ -1098,6 +1138,24 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException if attribute isn't entityless attribute
 	 */
 	Attribute getAttribute(PerunSession sess, String key, String attributeName) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get particular attribute for the user external source.
+	 *
+	 * PRIVILEGE: Principal need to have access to attribute which wants to get.
+	 *
+	 * @param sess
+	 * @param ues to get attribute from
+	 * @param attributeName attribute name defined in the particular manager
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws UserExtSourceNotExistsException if the user external source doesn't exists in the underlying data source
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 */
+	Attribute getAttribute(PerunSession sess, UserExtSource ues, String attributeName) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, UserExtSourceNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get attribute definition (attribute without defined value).
@@ -1385,6 +1443,23 @@ public interface AttributesManager {
 	Attribute getAttributeById(PerunSession sess, Group group, int id) throws PrivilegeException, InternalErrorException, AttributeNotExistsException,GroupNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException;
 
 	/**
+	 * Get particular attribute for user external source
+	 *
+	 * PRIVILEGE: Principal need to have access to attribute which wants to get.
+	 *
+	 * @param sess
+	 * @param ues
+	 * @param id
+	 * @return
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws InternalErrorException  if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws UserExtSourceNotExistsException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	Attribute getAttributeById(PerunSession sess, UserExtSource ues, int id) throws PrivilegeException, InternalErrorException, AttributeNotExistsException,UserExtSourceNotExistsException, WrongAttributeAssignmentException;
+
+	/**
 	 * Store the particular attribute associated with the facility. Core attributes can't be set this way.
 	 *
 	 * PRIVILEGE: Principal need to have access to all attribute which wants to set.
@@ -1617,6 +1692,24 @@ public interface AttributesManager {
 	 */
 	void setAttribute(PerunSession sess, String key, Attribute attribute) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
+	/**
+	 * Store the attribute associated with the user external source.
+	 *
+	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
+	 *
+	 * @param sess perun session
+	 * @param ues user external source to set on
+	 * @param attribute attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws UserExtSourceNotExistsException if the user external source doesn't exists in the underlying data source
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not user external source attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttribute(PerunSession sess, UserExtSource ues, Attribute attribute) throws PrivilegeException, InternalErrorException, UserExtSourceNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Creates an attribute, the attribute is stored into the appropriate DB table according to the namespace
@@ -2639,6 +2732,32 @@ public interface AttributesManager {
 	List<Attribute> fillAttributes(PerunSession sess, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
+	 * This method tries to fill value of the user external source attribute. This value is automatically generated, but not all attributes can be filled this way.
+	 *
+	 * PRIVILEGE: Fill attribute only when principal has access to write on it.
+	 *
+	 * @param sess perun session
+	 * @param ues user external source which will be filled with attribute
+	 * @param attribute attribute to fill. If attributes already have set value, this value won't be overwritten. This means the attribute value must be empty otherwise this method won't fill it.
+	 * @return attribute which may have filled value
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws UserExtSourceNotExistsException if user external source doesn't exists in underlying data source
+	 * @throws WrongAttributeAssignmentException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in underlying data source
+	 */
+	Attribute fillAttribute(PerunSession sess, UserExtSource ues, Attribute attribute) throws PrivilegeException, InternalErrorException, UserExtSourceNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * PRIVILEGE: Fill attributes only when principal has access to write on them.
+	 *
+	 * Batch version of fillAttribute.
+	 * @see AttributesManager#fillAttribute(PerunSession, UserExtSouce, Attribute)
+	 */
+	List<Attribute> fillAttributes(PerunSession sess, UserExtSource ues, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, UserExtSourceNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
 	 * Check if value of this facility attribute is valid.
 	 *
 	 * PRIVILEGE: Check attribute only when principal has access to write on it.
@@ -2974,6 +3093,33 @@ public interface AttributesManager {
 	 * @see AttributesManager#checkAttributeValue(PerunSession, Resource, Group, Attribute)
 	 */
 	void checkAttributesValue(PerunSession sess, Resource resource, Group group, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, ResourceNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException,GroupResourceMismatchException, WrongReferenceAttributeValueException;
+	
+	/**
+	 * Checks if value of this user external source attribute is valid
+	 *
+	 * PRIVILEGE: Check attribute only when principal has access to write on it.
+	 *
+	 * @param sess perun session
+	 * @param ues user external source for which attribute validity is checked
+	 * @param attribute
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongAttributeAssignmentException if the attribute isn't UserExtSource attribute
+	 * @throws AttributeNotExistsException if given attribute doesn't exist
+	 * @throws UserExtSourceNotExistsException if specified user external source doesn't exist
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void checkAttributeValue(PerunSession sess, UserExtSource ues, Attribute attribute) throws PrivilegeException, InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException,AttributeNotExistsException, UserExtSourceNotExistsException, WrongReferenceAttributeValueException;
+
+	/**
+	 * PRIVILEGE: Check attributes only when principal has access to write on them.
+	 *
+	 * batch version of checkAttributeValue
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession, UserExtSource, Attribute)
+	 */
+	void checkAttributesValue(PerunSession sess, UserExtSource ues, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, UserExtSourceNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException,  WrongReferenceAttributeValueException;
+
 	/**
 	 * Unset particular attribute for the facility. Core attributes can't be removed this way.
 	 *
@@ -3588,6 +3734,49 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException
 	 */
 	void removeAllAttributes(PerunSession sess, Resource resource, Group group) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, GroupNotExistsException,GroupResourceMismatchException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	
+	/**
+	 * Unset particular attribute for the user external source.
+	 *
+	 * PRIVILEGE: Remove attribute only when principal has access to write on it.
+	 *
+	 * @param sess perun session
+	 * @param ues remove attribute from this user external source
+	 * @param attribute attribute to remove
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in underlying data source
+	 * @throws UserExtSourceNotExistsException if the user external source doesn't exists in underlying data source
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongAttributeAssignmentException if attribute isn't user external source attribute or if it is core attribute
+	 */
+	void removeAttribute(PerunSession sess, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, UserExtSourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
+	 *
+	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
+	 * @throws AttributeNotExistsException if the any of attributes doesn't exists in underlying data source
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, UserExtSource, AttributeDefinition)
+	 */
+	void removeAttributes(PerunSession sess, UserExtSource ues, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, UserExtSourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Unset all attributes for the user external source.
+	 *
+	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
+	 *
+	 * @param sess perun session
+	 * @param ues remove attributes from this user external source
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 * @throws UserExtSourceNotExistsException if the user external source doesn't exists in underlying data source
+	 */
+	void removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException, PrivilegeException, UserExtSourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
 	/**
 	 * Determine if attribute is core attribute.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -449,6 +449,22 @@ public interface AttributesManager {
 	List<Attribute> getAttributes(PerunSession sess, User user, List<String> attrNames) throws PrivilegeException, InternalErrorException, UserNotExistsException;
 
 	/**
+	 * Get all attributes associated with the userExtSource which have name in list attrNames (empty too).
+	 *
+	 * PRIVILEGE: Get only those attributes the principal has access to.
+	 *
+	 * @param sess perun session
+	 * @param ues to get the attributes from
+	 * @param attrNames list of attributes' names
+	 * @return list of attributes
+	 *
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws UserExtSourceNotExistsException if the UserExtSource doesn't have access to this resource
+	 */
+	List<Attribute> getAttributes(PerunSession sess, UserExtSource ues, List<String> attrNames) throws PrivilegeException, InternalErrorException, UserExtSourceNotExistsException;
+
+	/**
 	 * Get all <b>non-empty</b> attributes associated with the user on the facility.
 	 *
 	 * PRIVILEGE: Get only those attributes the principal has access to.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -310,6 +310,17 @@ public interface AttributesManagerBl {
 	 */
 	List<Attribute> getAttributes(PerunSession sess, User user, List<String> attrNames) throws InternalErrorException;
 
+	/**
+	 * Get all attributes associated with the UserExtSource which have name in list attrNames (empty and virtual too).
+	 *
+	 * @param sess perun session
+	 * @param ues to get the attributes from
+	 * @param attrNames list of attributes' names
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wraped in InternalErrorException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, UserExtSource ues, List<String> attrNames) throws InternalErrorException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the user on the facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -48,6 +48,7 @@ import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeExistsException;
@@ -415,6 +416,17 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, facility, user));
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, user));
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, member));
+		return attributes;
+	}
+
+	public List<Attribute> getAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException {
+		//get virtual attributes
+		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, ues);
+		//filter out virtual attributes with null value
+		Iterator<Attribute> attributeIterator = attributes.iterator();
+		while(attributeIterator.hasNext()) if(attributeIterator.next().getValue() == null) attributeIterator.remove();
+
+		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, ues));
 		return attributes;
 	}
 
@@ -904,6 +916,36 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 	}
 
+	public void setAttributes(PerunSession sess, UserExtSource ues, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		// clasification of attributes to attributes to remove and attributes to set
+		List<Attribute> attributesToRemove = new ArrayList<Attribute>();
+		List<Attribute> attributesToSet = new ArrayList<Attribute>();
+		for(Attribute attribute : attributes) {
+			if (attribute.getValue() == null) {
+				attributesToRemove.add(attribute);
+			} else {
+				attributesToSet.add(attribute);
+			}
+		}
+		removeAttributes(sess, ues, attributesToRemove);
+		//fist we have to store attributes into DB because checkAttributesValue can be preformed only on stored attributes.
+		for(Attribute attribute : attributesToSet) {
+			//skip core attributes
+			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
+				if(isVirtAttribute(sess, attribute)) {
+					//TODO
+					throw new InternalErrorException("Virtual attribute can't be set this way yet. Please set physical attribute.");
+				} else {
+					setAttributeWithoutCheck(sess, ues, attribute);
+				}
+			}
+		}
+
+		//if checkAttributesValue fails it causes rollback so no attribute will be stored
+		checkAttributesValue(sess, ues, attributesToSet);
+		this.checkAttributesDependencies(sess, ues, null, attributesToSet);
+	}
+
 	public void setCoreAttributeWithoutCheck(PerunSession sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 
 		if(!attribute.getName().equals("urn:perun:member:attribute-def:core:status")) {
@@ -1031,6 +1073,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public Attribute getAttribute(PerunSession sess, String key, String attributeName) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		if(!attributeName.startsWith(AttributesManager.NS_ENTITYLESS_ATTR)) throw new WrongAttributeAssignmentException("Attribute name= " + attributeName);
 		return getAttributesManagerImpl().getAttribute(sess, key, attributeName);
+	}
+
+	public Attribute getAttribute(PerunSession sess, UserExtSource ues, String attributeName) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException {
+		//check namespace
+		if(!attributeName.startsWith(AttributesManager.NS_UES_ATTR)) throw new WrongAttributeAssignmentException("Attribute name=" + attributeName);
+
+		return getAttributesManagerImpl().getAttribute(sess, ues, attributeName);
 	}
 
 	public AttributeDefinition getAttributeDefinition(PerunSession sess, String attributeName) throws InternalErrorException, AttributeNotExistsException {
@@ -1263,6 +1312,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public Attribute getAttributeById(PerunSession sess, Group group, int id) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException {
 		Attribute attribute = getAttributesManagerImpl().getAttributeById(sess, group, id);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_GROUP_ATTR);
+		return attribute;
+	}
+
+	public Attribute getAttributeById(PerunSession sess, UserExtSource ues, int id) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException {
+		Attribute attribute = getAttributesManagerImpl().getAttributeById(sess, ues, id);
+		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_UES_ATTR);
 		return attribute;
 	}
 
@@ -1796,6 +1851,25 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		return changed;
 	}
 
+	public boolean setAttributeWithoutCheck(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_UES_ATTR);
+		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
+
+		boolean changed = true;
+		if(isVirtAttribute(sess, attribute)) {
+			return getAttributesManagerImpl().setVirtualAttribute(sess, ues, attribute);
+		} else {
+			changed = getAttributesManagerImpl().setAttribute(sess, ues, attribute);
+		}
+
+		if(changed) {
+			getPerunBl().getAuditer().log(sess, "{} set for {}.", attribute, ues);
+			getAttributesManagerImpl().changedAttributeHook(sess, ues, attribute);
+		}
+
+		return changed;
+	}
+
 	public boolean setAttributeWithoutCheck(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_ENTITYLESS_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
@@ -1824,6 +1898,17 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if(setAttributeWithoutCheck(sess, key, attribute)) {
 			checkAttributeValue(sess, key, attribute);
 			this.checkAttributeDependencies(sess, new RichAttribute(key, null, attribute));
+		}
+	}
+
+	public void setAttribute(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			removeAttribute(sess, ues, attribute);
+			return;
+		}
+		if(setAttributeWithoutCheck(sess, ues, attribute)) {
+			checkAttributeValue(sess, ues, attribute);
+			this.checkAttributeDependencies(sess, new RichAttribute(ues, null, attribute));
 		}
 	}
 
@@ -2558,6 +2643,26 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		return filledAttributes;
 	}
 
+	public Attribute fillAttribute(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_UES_ATTR);
+		return getAttributesManagerImpl().fillAttribute(sess, ues, attribute);
+	}
+
+	public List<Attribute> fillAttributes(PerunSession sess, UserExtSource ues, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException {
+		getAttributesManagerImpl().checkNamespace(sess, attributes, AttributesManager.NS_UES_ATTR);
+		List<Attribute> filledAttributes = new ArrayList<Attribute>();
+
+		for(Attribute attribute : attributes) {
+			if(attribute.getValue() == null) {
+				filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, ues, attribute));
+			} else {
+				//skip non-empty attribute
+				filledAttributes.add(attribute);
+			}
+		}
+		return filledAttributes;
+	}
+
 	public void checkAttributeValue(PerunSession sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_FACILITY_ATTR);
 
@@ -2576,7 +2681,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void checkAttributeValue(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_VO_ATTR);
 
-                if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, vo, attribute)) return;
+		if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, vo, attribute)) return;
 		getAttributesManagerImpl().checkAttributeValue(sess, vo, attribute);
 	}
 
@@ -2846,6 +2951,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		getAttributesManagerImpl().checkAttributeValue(sess, host, attribute);
 	}
 
+	public void checkAttributesValue(PerunSession sess, UserExtSource ues, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException{
+		getAttributesManagerImpl().checkNamespace(sess, attributes, AttributesManager.NS_UES_ATTR);
+
+		for(Attribute attribute : attributes) {
+			getAttributesManagerImpl().checkAttributeValue(sess, ues, attribute);
+		}
+	}
+
+	public void checkAttributeValue(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_UES_ATTR);
+
+		getAttributesManagerImpl().checkAttributeValue(sess, ues, attribute);
+	}
 
 	public void checkAttributeValue(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_ENTITYLESS_ATTR);
@@ -3873,6 +3991,72 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for(Attribute attribute: attributes) {
 			try {
 				getAttributesManagerImpl().changedAttributeHook(sess, resource, group, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+		}
+	}
+
+	public void removeAttribute(PerunSession sess, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		if (removeAttributeWithoutCheck(sess, ues, attribute)) {
+			checkAttributeValue(sess, ues, new Attribute(attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute(ues, null, new Attribute(attribute)));
+		}
+	}
+
+	public boolean removeAttributeWithoutCheck(PerunSession sess, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_UES_ATTR);
+
+		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
+
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, ues, attribute);
+		if (changed) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, ues, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+				//TODO better exception here
+				throw new InternalErrorException(ex);
+			}
+			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, ues);
+		}
+		return changed;
+	}
+
+	public void removeAttributes(PerunSession sess, UserExtSource ues, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		getAttributesManagerImpl().checkNamespace(sess, attributes, AttributesManager.NS_UES_ATTR);
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
+		for(AttributeDefinition attribute : attributes) {
+			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
+				if (removeAttributeWithoutCheck(sess, ues, attribute)) attributesToCheck.add(attribute);
+			}
+		}
+		checkAttributesValue(sess, ues, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, ues, null, attributesFromDefinitions(attributesToCheck));
+	}
+
+	public void removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		List<Attribute> attributes = getAttributes(sess, ues);
+		getAttributesManagerImpl().removeAllAttributes(sess, ues);
+		getPerunBl().getAuditer().log(sess, "All attributes removed for {}", ues);
+
+		for(Attribute attribute : attributes) attribute.setValue(null);
+		try {
+			checkAttributesValue(sess, ues, attributes);
+			this.checkAttributesDependencies(sess, ues, null, attributes);
+		} catch(WrongAttributeAssignmentException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		for(Attribute attribute: attributes) {
+			try {
+				getAttributesManagerImpl().changedAttributeHook(sess, ues, new Attribute(attribute));
 			} catch (WrongAttributeValueException ex) {
 				//TODO better exception here
 				throw new InternalErrorException(ex);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -295,6 +295,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		return getAttributesManagerImpl().getAttributes(sess, vo, attrNames);
 	}
 
+	public List<Attribute> getAttributes(PerunSession sess, UserExtSource ues, List<String> attrNames) throws InternalErrorException {
+		if(attrNames.isEmpty()) return new ArrayList<Attribute>();
+
+		return getAttributesManagerImpl().getAttributes(sess, ues, attrNames);
+	}
+
 	public List<Attribute> getUserFacilityAttributesForAnyUser(PerunSession sess, Facility facility) throws InternalErrorException {
 		List<Attribute> attributes =  getAttributesManagerImpl().getUserFacilityAttributesForAnyUser(sess, facility);
 		List<User> facilityUsers = perunBl.getFacilitiesManagerBl().getAllowedUsers(sess, facility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -22,6 +22,7 @@ import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -230,6 +231,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		User user = null;
 		Host host = null;
 		Resource resource = null;
+		UserExtSource ues = null;
 
 		//Get object for primaryHolder
 		if(primaryHolder != null) {
@@ -240,6 +242,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			else if(primaryHolder instanceof User) user = (User) primaryHolder;
 			else if(primaryHolder instanceof Host) host = (Host) primaryHolder;
 			else if(primaryHolder instanceof Resource) resource = (Resource) primaryHolder;
+			else if(primaryHolder instanceof UserExtSource) ues = (UserExtSource) primaryHolder;
 			else {
 				throw new InternalErrorException("There is unrecognized object in primaryHolder.");
 			}
@@ -256,6 +259,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			else if(secondaryHolder instanceof User) user = (User) secondaryHolder;
 			else if(secondaryHolder instanceof Host) host = (Host) secondaryHolder;
 			else if(secondaryHolder instanceof Resource) resource = (Resource) secondaryHolder;
+			else if(secondaryHolder instanceof UserExtSource) ues = (UserExtSource) secondaryHolder;
 			else {
 				throw new InternalErrorException("There is unrecognized perunBean in secondaryHolder.");
 			}
@@ -471,6 +475,34 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				if(isAuthorized(sess, Role.FACILITYADMIN, f)) return true;
 			}
 			if(roles.contains(Role.SELF)); //Not allowed
+		} else if(ues != null) {
+			User sessUser = sess.getPerunPrincipal().getUser();
+			User uesUser;
+			try {
+				uesUser = getPerunBlImpl().getUsersManagerBl().getUserById(sess, ues.getUserId());
+			} catch (UserNotExistsException ex) {
+				return false;
+			}
+			if(ues.getUserId() == sessUser.getId() ) return true;
+			if(roles.contains(Role.FACILITYADMIN)) {
+				List<Facility> facilities = getPerunBlImpl().getFacilitiesManagerBl().getAssignedFacilities(sess, uesUser);
+				for(Facility f: facilities) {
+					if(isAuthorized(sess, Role.FACILITYADMIN, f)) return true;
+				}
+			}
+			if(roles.contains(Role.VOADMIN) || roles.contains(Role.VOOBSERVER)) {
+				List<Vo> vos = getPerunBlImpl().getUsersManagerBl().getVosWhereUserIsMember(sess, uesUser);
+				for(Vo v: vos) {
+					if(isAuthorized(sess, Role.VOADMIN, v)) return true;
+					if(isAuthorized(sess, Role.VOOBSERVER, v)) return true;
+				}
+			}
+			if(roles.contains(Role.GROUPADMIN)) {
+				List<Vo> vos = getPerunBlImpl().getUsersManagerBl().getVosWhereUserIsMember(sess, uesUser);
+				for(Vo v: vos) {
+					if(isAuthorized(sess, Role.GROUPADMIN, v)) return true;
+				}
+			}
 		} else {
 			throw new InternalErrorException("There is no other possible variants for now!");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -364,6 +364,20 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attributes;
 	}
 
+	public List<Attribute> getAttributes(PerunSession sess, UserExtSource ues, List<String> attrNames) throws PrivilegeException, InternalErrorException, UserExtSourceNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getUsersManagerBl().checkUserExtSourceExists(sess, ues);
+		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, ues, attrNames);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, new AttributeDefinition(attrNext), ues, null)) attrIter.remove();
+			else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, ues, null));
+		}
+		return attributes;
+	}
+
 	public List<Attribute> getAttributes(PerunSession sess, Facility facility, User user) throws PrivilegeException, FacilityNotExistsException, InternalErrorException, UserNotExistsException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -51,6 +51,7 @@ import static cz.metacentrum.perun.core.api.AttributesManager.NS_MEMBER_ATTR;
 import static cz.metacentrum.perun.core.api.AttributesManager.NS_MEMBER_GROUP_ATTR;
 import static cz.metacentrum.perun.core.api.AttributesManager.NS_MEMBER_RESOURCE_ATTR;
 import static cz.metacentrum.perun.core.api.AttributesManager.NS_RESOURCE_ATTR;
+import static cz.metacentrum.perun.core.api.AttributesManager.NS_UES_ATTR;
 import static cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR;
 import static cz.metacentrum.perun.core.api.AttributesManager.NS_USER_FACILITY_ATTR;
 import static cz.metacentrum.perun.core.api.AttributesManager.NS_VO_ATTR;
@@ -67,6 +68,7 @@ import cz.metacentrum.perun.core.api.RichAttribute;
 import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
 
@@ -103,6 +105,8 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttrib
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserExtSourceAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserExtSourceVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
@@ -152,6 +156,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		NAMESPACES_BEANS_MAP.put("member_group", NS_MEMBER_GROUP_ATTR);
 		NAMESPACES_BEANS_MAP.put("user_facility", NS_USER_FACILITY_ATTR);
 		NAMESPACES_BEANS_MAP.put("group_resource", NS_GROUP_RESOURCE_ATTR);
+		NAMESPACES_BEANS_MAP.put("user_ext_source", NS_UES_ATTR);
 	}
 
 	/**
@@ -483,6 +488,16 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					try {
 						ResourceMemberVirtualAttributesModuleImplApi attributeModule = this.attributesManagerImpl.getResourceMemberVirtualAttributeModule(sess, attribute);
 						return attributeModule.getAttributeValue((PerunSessionImpl) sess, (Resource) attributeHolder, (Member) attributeHolder2, attribute);
+					} catch (InternalErrorException ex) {
+						throw new InternalErrorRuntimeException(ex);
+					}
+
+				} else if(this.attributesManagerImpl.isFromNamespace(sess, attribute, AttributesManager.NS_UES_ATTR_VIRT)) {
+					if(!(attributeHolder instanceof UserExtSource)) throw new ConsistencyErrorRuntimeException("Attribute holder of UserExtSource attribute isn't UserExtSource");
+
+					try {
+						UserExtSourceVirtualAttributesModuleImplApi attributeModule = this.attributesManagerImpl.getUserExtSourceVirtualAttributeModule(sess, attribute);
+						return attributeModule.getAttributeValue((PerunSessionImpl) sess, (UserExtSource) attributeHolder, attribute);
 					} catch (InternalErrorException ex) {
 						throw new InternalErrorRuntimeException(ex);
 					}
@@ -1080,6 +1095,19 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	public List<Attribute> getVirtualAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + attributeDefinitionMappingSelectQuery + ", null as attr_value from attr_names " +
+					"where namespace=?",
+					new AttributeRowMapper(sess, this, ues), AttributesManager.NS_UES_ATTR_VIRT);
+		} catch(EmptyResultDataAccessException ex) {
+			log.debug("No virtual attribute for user external source exists.");
+			return new ArrayList<Attribute>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("grp_res") + " from attr_names " +
@@ -1102,6 +1130,21 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 					"where namespace in (?,?) and (enattr.attr_value is not null or enattr.attr_value_text is not null)",
 					new AttributeRowMapper(sess, this, null),key, AttributesManager.NS_ENTITYLESS_ATTR_DEF, AttributesManager.NS_ENTITYLESS_ATTR_OPT);
 		} catch(EmptyResultDataAccessException ex) {
+			return new ArrayList<Attribute>();
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public List<Attribute> getAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + getAttributeMappingSelectQuery("ues") + " from attr_names " +
+					"left join user_ext_source_attr_values ues on id=ues.attr_id and user_ext_source_id=? " +
+					"where namespace=? or (namespace in (?,?) and (ues.attr_value is not null or ues.attr_value_text is not null))",
+					new AttributeRowMapper(sess, this, ues), ues.getId(),
+					AttributesManager.NS_UES_ATTR_CORE, AttributesManager.NS_UES_ATTR_DEF, AttributesManager.NS_UES_ATTR_OPT);
+		} catch(EmptyResultDataAccessException ex) {
+			log.debug("No attribute for UserExtSource exists.");
 			return new ArrayList<Attribute>();
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
@@ -1335,6 +1378,19 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	public Attribute getAttribute(PerunSession sess, UserExtSource ues, String attributeName) throws InternalErrorException, AttributeNotExistsException {
+		try {
+			return jdbc.queryForObject("select " + getAttributeMappingSelectQuery("user_ext_source_attr_values") + " from attr_names " +
+					"left join user_ext_source_attr_values on id=attr_id and user_ext_source_id=? " +
+					"where attr_name=?",
+					new AttributeRowMapper(sess, this, ues), ues.getId(), attributeName);
+		} catch(EmptyResultDataAccessException ex) {
+			throw new AttributeNotExistsException("Attribute name: \"" + attributeName +"\"", ex);
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public AttributeDefinition getAttributeDefinition(PerunSession sess, String attributeName) throws InternalErrorException, AttributeNotExistsException {
 		try {
 			return jdbc.queryForObject("select " + attributeDefinitionMappingSelectQuery + " from attr_names where attr_name=?", ATTRIBUTE_DEFINITION_MAPPER, attributeName);
@@ -1514,6 +1570,16 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	public Attribute getAttributeById(PerunSession sess, UserExtSource ues, int id) throws InternalErrorException, AttributeNotExistsException {
+		try {
+			return jdbc.queryForObject("select " + getAttributeMappingSelectQuery("ues") + " from attr_names left join user_ext_source_attr_values ues on id=ues.attr_id and user_ext_source_id=? where id=?", new AttributeRowMapper(sess, this, ues), ues.getId(), id);
+		} catch(EmptyResultDataAccessException ex) {
+			throw new AttributeNotExistsException("Attribute id= \"" + id +"\"", ex);
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	@Override
 	public boolean setAttribute(final PerunSession sess, final Object object, final Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		String tableName;
@@ -1529,10 +1595,11 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			namespace = AttributesManager.NS_ENTITYLESS_ATTR;
 		} else if (object instanceof PerunBean) {
 			PerunBean bean = (PerunBean) object;
-			String name = bean.getBeanName().toLowerCase();
-			// same behaviour for rich objects as for the simple ones -> cut off "rich" prefix
+			// Add underscore between two letters where first is lowercase and second is uppercase, then lowercase BeanName
+			String name = bean.getBeanName().replaceAll("(\\p{Ll})(\\p{Lu})","$1_$2").toLowerCase();
+			// same behaviour for rich objects as for the simple ones -> cut off "rich_" prefix
 			if (name.startsWith("rich")) {
-				name = name.replaceFirst("rich", "");
+				name = name.replaceFirst("rich_", "");
 			}
 			// get namespace of the perun bean
 			namespace = NAMESPACES_BEANS_MAP.get(name);
@@ -1790,6 +1857,10 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	public boolean setVirtualAttribute(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongModuleTypeException, ModuleNotExistsException, WrongReferenceAttributeValueException {
 		return getUserVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, user, attribute);
+	}
+
+	public boolean setVirtualAttribute(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongModuleTypeException, ModuleNotExistsException, WrongReferenceAttributeValueException {
+		return getUserExtSourceVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, ues, attribute);
 	}
 
 	public AttributeDefinition createAttribute(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException, AttributeExistsException {
@@ -2544,6 +2615,19 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	public Attribute fillAttribute(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException {
+		UserExtSourceAttributesModuleImplApi attributeModule = getUserExtSourceAttributeModule(sess, attribute);
+		if(attributeModule == null) {
+			log.debug("fillAttribute - There's no rule for this attribute. Attribute wasn't filled. Attribute={}", attribute);
+			return attribute;
+		}
+		try {
+			return attributeModule.fillAttribute((PerunSessionImpl) sess, ues, attribute);
+		} catch (WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public void changedAttributeHook(PerunSession sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//Call attribute module
 		FacilityAttributesModuleImplApi facilityModule = getFacilityAttributeModule(sess, attribute);
@@ -2670,6 +2754,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	public void changedAttributeHook(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		//Call attribute module
+		UserExtSourceAttributesModuleImplApi uesModule = getUserExtSourceAttributeModule(sess, attribute);
+		if(uesModule == null) return;
+		try {
+			uesModule.changedAttributeHook((PerunSessionImpl) sess, ues, attribute);
+		} catch(WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public void checkAttributeValue(PerunSession sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//Call attribute module
 		FacilityAttributesModuleImplApi facilityModule = getFacilityAttributeModule(sess, attribute);
@@ -2768,6 +2863,16 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		if(attributeModule == null) return;
 		try {
 			attributeModule.checkAttributeValue((PerunSessionImpl) sess, member, attribute);
+		} catch (WrongAttributeAssignmentException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public void checkAttributeValue(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException {
+		UserExtSourceAttributesModuleImplApi attributeModule = getUserExtSourceAttributeModule(sess, attribute);
+		if(attributeModule == null) return;
+		try {
+			attributeModule.checkAttributeValue((PerunSessionImpl) sess, ues, attribute);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3094,12 +3199,33 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 	}
 
+	public boolean removeAttribute(PerunSession sess, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException {
+		try {
+			if(0 < jdbc.update("delete from user_ext_source_attr_values where attr_id=? and user_ext_source_id=?", attribute.getId(), ues.getId())) {
+				log.info("Attribute (its value) was removed from user external source. Attribute={}, UserExtSource={}", attribute, ues);
+				return true;
+			}
+			return false;
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	public void removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException {
+		try {
+			if(0 < jdbc.update("delete from user_ext_source_attr_values where user_ext_source_id=?", ues.getId())) {
+				log.info("All attributes (their values) were removed from user external source. UserExtSource={}", ues);
+			}
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
 	public boolean attributeExists(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Utils.notNull(attribute, "attribute");
 		Utils.notNull(attribute.getName(), "attribute.name");
 		Utils.notNull(attribute.getNamespace(), "attribute.namespace");
 		Utils.notNull(attribute.getType(), "attribute.type");
-
 
 		try {
 			return 1 == jdbc.queryForInt("select count('x') from attr_names where attr_name=? and friendly_name=? and namespace=? and id=? and type=?", attribute.getName(), attribute.getFriendlyName(), attribute.getNamespace(), attribute.getId(), attribute.getType());
@@ -3639,6 +3765,26 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	/**
+	 * Get user external source attribute module for the attribute.
+	 *
+	 * @param attribute attribute for which you get the module
+	 * @return instance user ext source attribute module
+	 *         null if the module doesn't exists
+	 *
+	 * @throws InternalErrorException
+	 */
+	private UserExtSourceAttributesModuleImplApi getUserExtSourceAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
+		Object attributeModule = getAttributesModule(sess, attribute);
+		if(attributeModule == null) return null;
+
+		if(attributeModule instanceof UserExtSourceAttributesModuleImplApi) {
+			return (UserExtSourceAttributesModuleImplApi) attributeModule;
+		} else {
+			throw new InternalErrorException("Required attribute module isn't UserExtSourceAttributesModule. " + attribute);
+		}
+	}
+
+	/**
 	 * Get group-resource attribute module for the attribute.
 	 *
 	 * @param attribute attribute for which you get the module
@@ -3694,6 +3840,26 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			return (MemberGroupVirtualAttributesModuleImplApi) attributeModule;
 		} else {
 			throw new InternalErrorException("Required attribute module isn't MemberGroupVirtualAttributesModuleImplApi");
+		}
+	}
+	
+	/**
+	 * Get UserExtSource attribute module for the attribute.
+	 *
+	 * @param attribute attribute for which you get the module
+	 * @return instance UserExtSource attribute module
+	 *         null if the module doesn't exists
+	 *
+	 * @throws InternalErrorException
+	 */
+	private UserExtSourceVirtualAttributesModuleImplApi getUserExtSourceVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
+		Object attributeModule = getAttributesModule(sess, attribute);
+		if(attributeModule == null) return null;
+
+		if(attributeModule instanceof UserExtSourceVirtualAttributesModuleImplApi) {
+			return (UserExtSourceVirtualAttributesModuleImplApi) attributeModule;
+		} else {
+			throw new InternalErrorException("Required attribute module isn't UserExtSourceVirtualAttributesModule. " + attribute);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -961,17 +961,9 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 	public boolean userExtSourceExists(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException {
 		Utils.notNull(userExtSource, "userExtSource");
-		Utils.notNull(userExtSource.getLogin(), "userExtSource.getLogin");
-		Utils.notNull(userExtSource.getExtSource(), "userExtSource.getExtSource");
 
 		try {
-			if (userExtSource.getUserId() >= 0) {
-				return 1 == jdbc.queryForInt("select 1 from user_ext_sources where login_ext=? and ext_sources_id=? and user_id=?",
-						userExtSource.getLogin(), userExtSource.getExtSource().getId(), userExtSource.getUserId());
-			} else {
-				return 1 == jdbc.queryForInt("select 1 from user_ext_sources where login_ext=? and ext_sources_id=?",
-						userExtSource.getLogin(), userExtSource.getExtSource().getId());
-			}
+			return 1==jdbc.queryForInt("select 1 from user_ext_sources where id=?", userExtSource.getId());
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichAttribute;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeExistsException;
@@ -412,9 +413,31 @@ public interface AttributesManagerImplApi {
 	 */
 	List<Attribute> getVirtualAttributes(PerunSession sess, User user) throws InternalErrorException;
 
+	/**
+	 * Get all virtual attributes associated with the UserExtSource.
+	 *
+	 * @param sess perun session
+	 * @param ues to get the attributes from
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getVirtualAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException;
+
 	List<Attribute> getAttributes(PerunSession sess, Host host) throws InternalErrorException;
 
 	List<Attribute> getAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException;
+
+	/**
+	 * Get all <b>non-empty</b> attributes associated with the UserExtSource.
+	 *
+	 * @param sess perun session
+	 * @param ues to get the attributes from
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the user on the all facilities.
@@ -553,6 +576,19 @@ public interface AttributesManagerImplApi {
 	 * @throws AttributeNotExistsException  if the attribute doesn't exists in the underlaying data source
 	 */
 	Attribute getAttribute(PerunSession sess, String key, String attributeName) throws InternalErrorException, AttributeNotExistsException;
+
+	/**
+	 * Get particular attribute for the User External Source.
+	 *
+	 * @param sess
+	 * @param ues
+	 * @param attributeName attribute name defined in the particular manager
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlaying data source
+	 */
+	Attribute getAttribute(PerunSession sess, UserExtSource ues, String attributeName) throws InternalErrorException, AttributeNotExistsException;
 
 	/**
 	 * Get attributes definition (attribute without defined value).
@@ -703,6 +739,19 @@ public interface AttributesManagerImplApi {
 	Attribute getAttributeById(PerunSession sess, Resource resource, Group group, int id) throws InternalErrorException, AttributeNotExistsException;
 
 	Attribute getAttributeById(PerunSession sess, Group group, int id) throws InternalErrorException, AttributeNotExistsException;
+
+	/**
+	 * Get particular attribute for the user external source.
+	 *
+	 * @param sess
+	 * @param ues
+	 * @param id attribute id
+	 * @return attribute
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlaying data source
+	 */	
+	Attribute getAttributeById(PerunSession sess, UserExtSource ues, int id) throws InternalErrorException, AttributeNotExistsException;
 
 	/**
 	 * Store the particular attribute associated with the given perun bean. If an attribute is core attribute then the attribute isn't stored (It's skkiped whithout any notification).
@@ -874,6 +923,20 @@ public interface AttributesManagerImplApi {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	boolean setVirtualAttribute(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongModuleTypeException, ModuleNotExistsException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Store the particular virtual attribute associated with the user external source.
+	 *
+	 * @param sess perun session
+	 * @param ues
+	 * @param attribute attribute to set
+	 * @return true if attribute was really changed
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ModuleNotExistsException
+	 * @throws WrongModuleTypeException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	boolean setVirtualAttribute(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongModuleTypeException, ModuleNotExistsException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Creates an attribute, the attribute is stored into the appropriate DB table according to the namespace.
@@ -1282,6 +1345,18 @@ public interface AttributesManagerImplApi {
 	Attribute fillAttribute(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException;
 
 	/**
+	 * This method try to fill value of the user external source attribute. This value is automatically generated, but not all atrributes can be filled this way.
+	 *
+	 * @param sess perun session
+	 * @param ues attribute of this user external source you want to fill
+	 * @param attribute attribute to fill. If attributes already have set value, this value won't be owerwriten. This means the attribute value must be empty otherwise this method won't fill it.
+	 * @return attribute which may have filled value
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	Attribute fillAttribute(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException;
+
+	/**
 	 * If you need to do some further work with other modules, this method do that
 	 *
 	 * @param sess perun session
@@ -1430,6 +1505,18 @@ public interface AttributesManagerImplApi {
 	void changedAttributeHook(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
+	 * If you need to do some further work with other modules, this method do that
+	 *
+	 * @param sess
+	 * @param ues
+	 * @param attribute
+	 * @throws InternalErrorException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 */
+	void changedAttributeHook(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
+	/**
 	 * Check if value of this facility attribute is valid.
 	 *
 	 * @param sess perun session
@@ -1568,6 +1655,20 @@ public interface AttributesManagerImplApi {
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	void checkAttributeValue(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException;
+
+	/**
+	 * Check if value of this user external source attribute is valid.
+	 *
+	 *
+	 * @param sess perun session
+	 * @param ues user external source for which you want to check validity of attribute
+	 * @param attribute attribute to check
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void checkAttributeValue(PerunSession sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException;
 
 	/**
 	 * Unset particular attribute for the facility.
@@ -1885,6 +1986,27 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	void removeAllAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException;
+
+	/**
+	 * Unset particular user external source attribute
+	 *
+	 * @param sess perun session
+	 * @param ues
+	 * @param attribute attribute to remove
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	boolean removeAttribute(PerunSession sess, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException;
+
+	/**
+	 * Unset all UserExtSource attributes for the user external source.
+	 *
+	 * @param sess perun session
+	 * @param ues
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	void removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException;
+
 	/**
 	 * Check if attribute exists in underlaying data source.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -277,6 +277,18 @@ public interface AttributesManagerImplApi {
 	List<Attribute> getAttributes(PerunSession sess, Group group, List<String> attrNames) throws InternalErrorException;
 
 	/**
+	 * Get all attributes associated with the UserExtSource which have name in list attrNames (empty and virtual too).
+	 *
+	 * @param sess perun session
+	 * @param ues to get the attributes from
+	 * @param attrNames list of attributes' names
+	 * @return list of attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getAttributes(PerunSession sess, UserExtSource ues, List<String> attrNames) throws InternalErrorException;
+
+	/**
 	 * Get all <b>non-empty</b> attributes associated with the user on the facility.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceAttributesModuleAbstract.java
@@ -1,0 +1,34 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * Abstract class for UserExtSource Attributes modules.
+ * -----------------------------------------------------------------------------
+ * Implements methods for modules to perform default function.
+ * In the function that the method in the module does nothing, it is not necessary to implement it, simply extend this abstract class.
+ *
+ * @author Jan Zvěřina <zverina.jan@email.cz>
+ *
+ */
+public abstract class UserExtSourceAttributesModuleAbstract extends AttributesModuleAbstract implements UserExtSourceAttributesModuleImplApi {
+
+	public void checkAttributeValue(PerunSessionImpl perunSession, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+
+	}
+
+	public Attribute fillAttribute(PerunSessionImpl session, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+		return new Attribute(attribute);
+	}
+
+	public void changedAttributeHook(PerunSessionImpl session, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceAttributesModuleImplApi.java
@@ -1,0 +1,63 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * This interface serves as a template for checking and fillind in attribute
+ * for a member at a specified UserExtSource.
+ *
+ * @author Jan Zvěřina <zverina.jan@email.cz>
+ */
+public interface UserExtSourceAttributesModuleImplApi extends AttributesModuleImplApi{
+
+	/**
+	 * This method checks UserExtSource attributes.
+	 *
+	 * @param perunSession Perun session
+	 * @param ues
+	 * @param attribute Attribute to be checked.
+	 *
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongReferenceAttributeValueException if an referenced attribute against
+	 *         the parameter is to be compared is not available
+	 * @throws WrongAttributeAssignmentException
+	 */
+	void checkAttributeValue(PerunSessionImpl perunSession, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+
+	/**
+	 * This method fill UserExtSource attributes.
+	 *
+	 * @param perunSession Perun session
+	 * @param ues
+	 * @param attribute Attribute to be filled in
+	 *
+	 * @return Attribute which MAY be filled in.
+	 *
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	Attribute fillAttribute(PerunSessionImpl perunSession, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * If you need to do some further work with other modules, this method do that
+	 *
+	 * @param session session
+	 * @param ues
+	 * @param attribute the attribute
+	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
+	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException
+	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException
+	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException
+	 */
+	void changedAttributeHook(PerunSessionImpl session, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceVirtualAttributesModuleAbstract.java
@@ -1,0 +1,44 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract class for UserExtSource Virtual Attributes modules.
+ * Implements methods for modules to perform default function.
+ * In the function that the method in the module does nothing, it is not necessary to implement it, simply extend this abstract class.
+ *
+ * @author Jan Zvěřina <zverina.jan@email.cz>
+ *
+ */
+public abstract class UserExtSourceVirtualAttributesModuleAbstract extends UserExtSourceAttributesModuleAbstract implements UserExtSourceVirtualAttributesModuleImplApi {
+
+	@Override
+	public Attribute getAttributeValue(PerunSessionImpl perunSession, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException {
+		return new Attribute(attribute);
+	}
+
+	@Override
+	public boolean setAttributeValue(PerunSessionImpl perunSession, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		return false;
+	}
+
+	@Override
+	public boolean removeAttributeValue(PerunSessionImpl perunSession, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		return false;
+	}
+
+	@Override
+	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		return new ArrayList<String>();
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceVirtualAttributesModuleImplApi.java
@@ -1,0 +1,55 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * This interface serves as a template for virtual attributes.
+ *
+ * @author Jan Zvěřina <zverina.jan@email.cz>
+ */
+public interface UserExtSourceVirtualAttributesModuleImplApi extends UserExtSourceAttributesModuleImplApi, VirtualAttributesModuleImplApi {
+
+	/**
+	 * This method will return computed value.
+	 *
+	 * @param sess PerunSession
+	 * @param ues UserExternalSource
+	 * @param attribute attribute to operate on
+	 * @return
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 */
+	Attribute getAttributeValue(PerunSessionImpl sess, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException;
+
+	/**
+	 * Method sets attributes' values which are dependent on this virtual attribute.
+	 *
+	 * @param sess PerunSession
+	 * @param ues UserExternalSource
+	 * @param attribute attribute to operate on
+	 * @return true if attribute was really changed
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 */
+	boolean setAttributeValue(PerunSessionImpl sess, UserExtSource ues, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Currently do nothing.
+	 *
+	 * @param sess PerunSession
+	 * @param ues UserExternalSource
+	 * @param attribute attribute to operate on
+	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
+	 */
+	boolean removeAttributeValue(PerunSessionImpl sess, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -345,6 +345,10 @@ public class ApiCaller {
 		return getAttributesManager().getAttributeById(session, facility, user, id);
 	}
 
+	public Attribute getAttributeById(UserExtSource ues, int id) throws PerunException {
+		return getAttributesManager().getAttributeById(session, ues, id);
+	}
+
 	public UserExtSource getUserExtSourceById(int id) throws PerunException {
 		return getUsersManager().getUserExtSourceById(rpcSession, id);
 	}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -45,6 +45,22 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @exampleParam attrNames [ "urn:perun:vo:attribute-def:def:contactEmail" , "urn:perun:vo:attribute-def:core:shortName" ]
 	 */
 	/*#
+	 * Returns all non-empty UserExtSource attributes for selected UserExtSource.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @return List<Attribute> All non-empty UserExtSource attributes
+	 * @throw UserExtSourceNotExistsException When Ues with <code>id</code> doesn't exist.
+	 */
+	/*#
+	 * Returns all specified UserExtSource attributes for selected UserExtSource.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @param attrNames List<String> Attribute names
+	 * @return List<Attribute> Specified UserExtSource attributes
+	 * @throw UserExtSourceNotExistsException When userExtSource with <code>id</code> doesn't exist.
+	 * @exampleParam attrNames [ "urn:perun:ues:attribute-def:opt:optionalAttribute" ]
+	 */
+	/*#
 	 * Returns all non-empty Member-Resource attributes for selected Member and Resource.
 	 *
 	 * @param member int Member <code>id</code>
@@ -312,12 +328,22 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("key")) {
 				return ac.getAttributesManager().getAttributes(ac.getSession(),
 						parms.readString("key"));
-			} else {
-				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, user, host, group or key");
+			} else if (parms.contains("userExtSource")) {
+				if (parms.contains("attrNames")) {
+					return ac.getAttributesManager().getAttributes(ac.getSession(),
+							ac.getUserExtSourceById(parms.readInt("userExtSource")),
+							parms.readList("attrNames", String.class));
+				} else {
+					return ac.getAttributesManager().getAttributes(ac.getSession(),
+							ac.getUserExtSourceById(parms.readInt("userExtSource")));
+				}
+			}
+			else {
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, user, host, group, userExtSource or key");
 			}
 		}
 	},
-	
+
 	/*#
 	 * Returns all entityless attributes with <code>attrName</code> (for all namespaces of same attribute).
 	 *
@@ -358,6 +384,11 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * Sets the attributes.
 	 *
 	 * @param vo int VO <code>id</code>
+	 * @param attributes List<Attribute> List of attributes
+	 */
+	/* Sets the attributes.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
 	 */
 	/*#
@@ -541,8 +572,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				ac.getAttributesManager().setAttributes(ac.getSession(),
 						ac.getHostById(parms.readInt("host")),
 						parms.readList("attributes", Attribute.class));
+			} else if (parms.contains("userExtSource")) {
+				ac.getAttributesManager().setAttributes(ac.getSession(),
+						ac.getUserExtSourceById(parms.readInt("userExtSource")),
+						parms.readList("attributes", Attribute.class));
 			} else {
-				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, user, host or group");
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, user, host, group or userExtSource");
 			}
 
 			return null;
@@ -620,6 +655,13 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * Returns an Attribute by its <code>id</code>. Returns only non-empty attributes.
 	 *
 	 * @param host int Host <code>id</code>
+	 * @param attributeId int Attribute <code>id</code>
+	 * @return Attribute Found Attribute
+	 */
+	/*#
+	 * Returns an Attribute by its <code>id</code>. Returns only non-empty attributes.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
 	 * @param attributeId int Attribute <code>id</code>
 	 * @return Attribute Found Attribute
 	 */
@@ -704,6 +746,13 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param attributeName String Attribute name
 	 * @return Attribute Found Attribute
 	 */
+	/*#
+	 * Returns an Attribute by its name. Returns only non-empty attributes.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @param attributeName String Attribute name
+	 * @return Attribute Found Attribute
+	 */
 	getAttribute {
 
 		@Override
@@ -769,8 +818,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							parms.readString("key"),
 							parms.readInt("attributeId"));
 							*/
+				} else if (parms.contains("userExtSource")) {
+					return ac.getAttributesManager().getAttributeById(ac.getSession(),
+							ac.getUserExtSourceById(parms.readInt("userExtSource")),
+							parms.readInt("attributeId"));
 				} else {
-					throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, user, host, key or group");
+					throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, user, host, key, group or userExtSource");
 				}
 			} else {
 				if (parms.contains("facility")) {
@@ -827,12 +880,16 @@ public enum AttributesManagerMethod implements ManagerMethod {
 					return ac.getAttributesManager().getAttribute(ac.getSession(),
 							ac.getHostById(parms.readInt("host")),
 							parms.readString("attributeName"));
+				} else if (parms.contains("userExtSource")) {
+					return ac.getAttributesManager().getAttribute(ac.getSession(),
+							ac.getUserExtSourceById(parms.readInt("userExtSource")),
+							parms.readString("attributeName"));
 				} else if (parms.contains("key")) {
 					return ac.getAttributesManager().getAttribute(ac.getSession(),
 							parms.readString("key"),
 							parms.readString("attributeName"));
 				} else {
-					throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, user, host, key or group");
+					throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, user, host, key, group or userExtSource");
 				}
 			}
 		}
@@ -907,6 +964,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param resource int <code>id</code> of Resource
 	 * @param facility int <code>id</code> of Facility
 	 * @param host int <code>id</code> of Host
+	 * @param userExtSource int <code>id</code> of UserExtSource
 	 *
 	 * @return List<AttributeDefinition> Definitions of Attributes for entities
 	 */
@@ -920,6 +978,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			Resource resource = null;
 			Facility facility = null;
 			Host host = null;
+			UserExtSource ues = null;
 			//Not supported entityless attirbutes now
 			//String entityless = null;
 			List<PerunBean> entities = new ArrayList<PerunBean>();
@@ -958,6 +1017,11 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			if (parms.contains("host")) {
 				host = ac.getHostById(parms.readInt("host"));
 				entities.add(host);
+			}
+			//If userExtSource exists in query
+			if (parms.contains("userExtSource")) {
+				ues = ac.getUserExtSourceById(parms.readInt("userExtSource"));
+				entities.add(ues);
 			}
 			//If entityless exists in query
 			/*if(parms.contains("entityless")) {
@@ -1041,6 +1105,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param host int Host <code>id</code>
 	 * @param attribute Attribute JSON object
 	 */
+	/*#
+	 * Sets an Attribute.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @param attribute Attribute JSON object
+	 */
 	setAttribute {
 
 		@Override
@@ -1101,12 +1171,16 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				ac.getAttributesManager().setAttribute(ac.getSession(),
 						ac.getHostById(parms.readInt("host")),
 						parms.read("attribute", Attribute.class));
+			} else if (parms.contains("userExtSource")) {
+				ac.getAttributesManager().setAttribute(ac.getSession(),
+						ac.getUserExtSourceById(parms.readInt("userExtSource")),
+						parms.read("attribute", Attribute.class));
 			} else if (parms.contains("key")) {
 				ac.getAttributesManager().setAttribute(ac.getSession(),
 						parms.readString("key"),
 						parms.read("attribute", Attribute.class));
 			} else {
-				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, user, member, host, key or group");
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, user, member, host, key, group or userExtSource");
 			}
 
 			return null;
@@ -1998,6 +2072,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param attribute int Attribute <code>id</code>
 	 */
+	/*#
+	 * Checks if this userExtSource attribute is valid.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @param attribute int Attribute <code>id</code>
+	 */
 	checkAttributeValue {
 
 		@Override
@@ -2056,8 +2136,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				ac.getAttributesManager().checkAttributeValue(ac.getSession(),
 						ac.getUserById(parms.readInt("user")),
 						parms.read("attribute", Attribute.class));
+			} else if (parms.contains("userExtSource")) {
+				ac.getAttributesManager().checkAttributeValue(ac.getSession(),
+						ac.getUserExtSourceById(parms.readInt("userExtSource")),
+						parms.read("attribute", Attribute.class));
 			} else {
-				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, group, host or user");
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, group, host, user or userExtSource");
 			}
 
 			return null;
@@ -2153,6 +2237,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param attributes List<Attribute> Attributes List
 	 */
+	/*#
+	 * Checks if these userExtSource attributes are valid.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @param attributes List<Attribute> Attributes List
+	 */
 	checkAttributesValue {
 
 		@Override
@@ -2232,8 +2322,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				ac.getAttributesManager().checkAttributesValue(ac.getSession(),
 						ac.getUserById(parms.readInt("user")),
 						parms.readList("attributes", Attribute.class));
+			} else if (parms.contains("userExtSource")) {
+				ac.getAttributesManager().checkAttributesValue(ac.getSession(),
+						ac.getUserExtSourceById(parms.readInt("userExtSource")),
+						parms.readList("attributes", Attribute.class));
 			} else {
-				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, host or user");
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, host, user or userExtSource");
 			}
 		return null;
 		}
@@ -2361,6 +2455,14 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param attributes List<Integer> List of attributes IDs to remove
 	 */
+	/*#
+	 * Remove attributes of namespace:
+	 *
+	 * userExtSource
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @param attributes List<Integer> List of attributes IDs to remove
+	 */
 	removeAttributes {
 
 		@Override
@@ -2447,8 +2549,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				ac.getAttributesManager().removeAttributes(ac.getSession(),
 						ac.getGroupById(parms.readInt("group")),
 						attributes);
+			} else if (parms.contains("userExtSource")) {
+				ac.getAttributesManager().removeAttributes(ac.getSession(),
+						ac.getUserExtSourceById(parms.readInt("userExtSource")),
+						attributes);
 			} else {
-				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, group, host, resource, member or user");
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, group, host, resource, member, user or userExtSource");
 			}
 
 			return null;
@@ -2547,6 +2653,14 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param attribute int <code>id</code> of attribute to remove
 	 */
+	/*#
+	 * Remove attribute of namespace:
+	 *
+	 * userExtSource
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @param attribute int <code>id</code> of attribute to remove
+	 */
 	removeAttribute {
 
 		@Override
@@ -2607,8 +2721,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				ac.getAttributesManager().removeAttribute(ac.getSession(),
 						ac.getHostById(parms.readInt("host")),
 						ac.getAttributeDefinitionById(parms.readInt("attribute")));
+			} else if (parms.contains("userExtSource")) {
+				ac.getAttributesManager().removeAttribute(ac.getSession(),
+						ac.getUserExtSourceById(parms.readInt("userExtSource")),
+						ac.getAttributeDefinitionById(parms.readInt("attribute")));
 			} else {
-				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, group, resource, member, host or user");
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, group, resource, member, host, user or userExtSource");
 			}
 		return null;
 		}
@@ -2686,6 +2804,11 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @param host int Host <code>id</code>
 	 */
+	/*#
+	 * Unset all attributes for the userExtSource.
+	 *
+	 * @param userExtSource int UserExtSource <code>id</code>
+	 */
 	removeAllAttributes {
 
 		@Override
@@ -2746,10 +2869,13 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("host")) {
 				ac.getAttributesManager().removeAllAttributes(ac.getSession(),
 						ac.getHostById(parms.readInt("host")));
+			} else if (parms.contains("userExtSource")) {
+				ac.getAttributesManager().removeAllAttributes(ac.getSession(),
+						ac.getUserExtSourceById(parms.readInt("userExtSource")));
 			} else {
-				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, resource, vo, group, member, host or user");
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, resource, vo, group, member, host, user or userExtSource");
 			}
-			
+
 			return null;
 		}
 	},


### PR DESCRIPTION
UserExtSource attributes added to AttributesManager.
DB changes were added in previous pull request (already merged to master).

UserExtSource attributes methods added to Perun-RPC/methods.
- I didn't do methods getRequiredAttribute(s) for UserExtSource with resource/service. Is it necessary to have?
- I didn't add userExtSource to fillAttributes(s) methods in Perun-RPC/methods/AttributesManagerMethod. I don't know where I should put it.
