### PR TITLE
Encode binary data from LDAP extSource to Base64

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -280,7 +280,10 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 
 				String tmpAttrValue = "";
 				try {
-					if (((String) attr.get()).startsWith(": ")) {
+					if(attr.get() instanceof byte[]) {
+						// It can be byte array with cert or binary file
+						tmpAttrValue = Base64Coder.encodeLines((byte[]) attr.get());
+					} else if (((String) attr.get()).startsWith(": ")) {
 						// Base64 encoded attribute starts with ": "
 						tmpAttrValue = String.valueOf(Base64Coder.decodeString((String) attr.get(i)));
 					} else {


### PR DESCRIPTION
 - when some sort of binary file comes from LDAP ExtSource, we need to
   encode them to base64 encoding