### PR TITLE
Extend rules for ExtSource to replacing regular expressions

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -242,7 +242,6 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		String ldapAttrName;
 		String rule = null;
 		Matcher matcher = null;
-		Pattern pattern = null;
 		String attrValue = "";;
 
 		// Check if the ldapAttrName contains regex
@@ -250,7 +249,6 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 			int splitter = ldapAttrNameRaw.indexOf('|');
 			ldapAttrName = ldapAttrNameRaw.substring(0,splitter);
 			rule = ldapAttrNameRaw.substring(splitter+1, ldapAttrNameRaw.length());
-			pattern =  Pattern.compile(rule);
 		} else {
 			ldapAttrName = ldapAttrNameRaw;
 		}
@@ -294,11 +292,20 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 				}
 
 				if (rule != null) {
-					// Rules are in place, so apply them
-					matcher = pattern.matcher(tmpAttrValue);
-					// Get the first group which matched
-					if (matcher.matches()) {
-						tmpAttrValue = matcher.group(1);
+					if(rule.contains("#")) {
+						// Rules are in place, so apply them
+						String regex = rule.substring(0, rule.indexOf('#'));
+						String replacement = rule.substring(rule.indexOf('#')+1);
+						tmpAttrValue = tmpAttrValue.replaceAll(regex, replacement);
+					//DEPRECATED way
+					} else {
+						// Rules are in place, so apply them
+						Pattern pattern = Pattern.compile(rule);
+						matcher = pattern.matcher(tmpAttrValue);
+						// Get the first group which matched
+						if (matcher.matches()) {
+							tmpAttrValue = matcher.group(1);
+						}
 					}
 				}
 				if (i == 0 || attributeValueIndex != -1) {


### PR DESCRIPTION
 - in rules there can be specific regular expression not just for
   selecting specific group, but also for replacing regex by specific
   string (group can be part of string). There need to be character '#'
   as delimiter of regex and replacement.
 - old rules are still active for rule without delimiter '#' but they
   are deprecated, because replacement can do the same work