### PR TITLE
Fix synchronization of (key-value) attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -4050,7 +4050,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	public Object stringToAttributeValue(String value, String type) throws InternalErrorException {
 		if (type.equals(ArrayList.class.getName()) || type.equals(LinkedHashMap.class.getName())) {
-			if (value != null && !value.endsWith(String.valueOf(AttributesManagerImpl.LIST_DELIMITER))) {
+			if (value != null && !value.isEmpty() && !value.endsWith(String.valueOf(AttributesManagerImpl.LIST_DELIMITER))) {
 				value = value.concat(String.valueOf(AttributesManagerImpl.LIST_DELIMITER));
 			}
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -280,7 +280,8 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 				try {
 					if(attr.get() instanceof byte[]) {
 						// It can be byte array with cert or binary file
-						tmpAttrValue = Base64Coder.encodeLines((byte[]) attr.get());
+						char[] encodedValue = Base64Coder.encode((byte[]) attr.get());
+						tmpAttrValue = new String(encodedValue);
 					} else if (((String) attr.get()).startsWith(": ")) {
 						// Base64 encoded attribute starts with ": "
 						tmpAttrValue = String.valueOf(Base64Coder.decodeString((String) attr.get(i)));


### PR DESCRIPTION
 - if key-value attribute has empty string representation, do not
   add delimiter on the end this representation. We want to work with
   him same like with null value.
 - do not use encoding on lines, because it add '\n' to the string
   representation of attribute, we want to raw base64 encoded text
   without new lines there