### PR TITLE
Validate member when disabled in lightweight synchronization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1625,6 +1625,16 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			//If user is not null now, we found it so we can use it from perun, in other case he is not in perun at all
 			if(user != null && candidate == null) {
 				//we can skip this one, because he is already in group, and remove him from the map
+				//but first we need to also validate him if he was disabled before (invalidate and then validate)
+				RichMember richMember = idsOfUsersInGroup.get(user.getId());
+				if(richMember != null && Status.DISABLED.equals(richMember.getStatus())) {
+						getPerunBl().getMembersManagerBl().invalidateMember(sess, richMember);
+						try {
+							getPerunBl().getMembersManagerBl().validateMember(sess, richMember);
+						} catch (WrongAttributeValueException | WrongReferenceAttributeValueException e) {
+							log.info("Switching member id {} into INVALID state from DISABLED, because there was problem with attributes {}.", richMember.getId(), e);
+						}
+				}
 				idsOfUsersInGroup.remove(user.getId());
 			} else if (candidate != null) {
 				candidatesToAdd.add(candidate);


### PR DESCRIPTION
 - there was bug when member was Disabled in Vo (because of removing him
   from extSource data) and after that he was added to extSource data
   again. This member was skiped as actual group member without
   validation.
 - add validation to lightweight synchronization for already disabled
   members who should be members of the group again