### PR TITLE
CLI tools for collective managing of host attributes

### DIFF
--- a/perun-rpc/src/main/perl/getHostNumCores
+++ b/perun-rpc/src/main/perl/getHostNumCores
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Text::ASCIITable;
+use Perun::Agent;
+use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+
+sub help {
+	return qq{
+	Gets attribute determining number of cores on Host. Host name is required field.
+	---------------------------------------------------
+	Available options:
+	--hostName    | -H  host name
+	--batch       | -b  batch
+	--help        | -h  prints this help
+	};
+}
+
+my ($hostName, $batch);
+GetOptions("help|h" => sub { print help; exit 0;} ,
+	"hostName|H=s" => \$hostName,
+"batch|b" => \$batch) || die help;
+
+#options check
+unless(defined $hostName) { die "ERROR: hostName is required\n";}
+
+my $attrName="urn:perun:host:attribute-def:def:coresNumber";
+
+my $agent = Perun::Agent->new();
+
+my $attributesAgent = $agent->getAttributesAgent;
+my $facilitiesAgent = $agent->getFacilitiesAgent;
+
+my $table = Text::ASCIITable->new();
+$table->setCols('Id','Host name', 'Number of cores','Facility name');
+
+my @hosts=$facilitiesAgent->getHostsByHostname(hostname => $hostName);
+while (@hosts) {
+    my $host=shift(@hosts);
+    my $hostId=$host->getId;
+    my $attribute = $attributesAgent->getAttribute(attributeName => $attrName,host => $hostId);
+    my $numCores;
+    $numCores=$attribute->getValueAsScalar; 
+    unless(defined $numCores) { $numCores = "undefined";}
+    
+    my $facility = $facilitiesAgent->getFacilityForHost(host => $hostId);
+    my $facilityName;
+    unless($facility) {$facilityName=" ";}
+    $facilityName=$facility->getName;
+
+    $table->addRow($hostId,$hostName,$numCores,$facilityName);
+}
+
+print tableToPrint($table, $batch);

--- a/perun-rpc/src/main/perl/listOfHostNumCores
+++ b/perun-rpc/src/main/perl/listOfHostNumCores
@@ -1,0 +1,81 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Text::ASCIITable;
+use Perun::Agent;
+use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+
+sub help {
+	return qq{
+	Lists hostnames and their number of cores.
+	---------------------------------------------------
+	Available options:
+	--facilityName | -F  facility name
+	--facilityId   | -f  facility Id
+	--orderById    | -i  order by ID
+	--orderByName  | -n  order by name
+	--batch        | -b  batch
+	--help         | -h  prints this help
+        
+        If no facility is entered, list for all facilities is displayed.
+	};
+}
+
+my ($facilityName, $facilityId, $all, $sortingFunction, $batch, @facilities, @hosts);
+GetOptions("help|h" => sub { print help; exit 0;} ,
+"facilityId|f=i" => \$facilityId,
+"facilityName|F=s" => \$facilityName,
+"orderByName|n" =>  sub {$sortingFunction = getSortingFunction("getHostname", 1)},
+"orderById|i" => sub { $sortingFunction = getSortingFunction("getId")},
+"batch|b" => \$batch) || die help;
+
+#options check
+unless(defined $facilityId or (defined $facilityName)) { $all=1;} else {$all=0;} 
+unless(defined $sortingFunction) { $sortingFunction = getSortingFunction("getHostname", 1); }
+
+my $sortingFunction2 = getSortingFunction("getName",1); 
+my $attrName="urn:perun:host:attribute-def:def:coresNumber";
+
+my $agent = Perun::Agent->new();
+
+my $attributesAgent = $agent->getAttributesAgent;
+my $facilitiesAgent = $agent->getFacilitiesAgent;
+
+my $table = Text::ASCIITable->new();
+$table->setCols('Facility name','Host name', 'Number of cores');
+
+if ($all>0) {
+    @facilities = $facilitiesAgent->getFacilities;
+    unless(@facilities) { printMessage "No Facilities found", $batch; exit 0;}
+} else {
+    my $facility;
+    if ($facilityId) {
+        $facility = $facilitiesAgent->getFacilityById(id => $facilityId);
+    }
+    if ($facilityName) {
+        $facility = $facilitiesAgent->getFacilityByName(name => $facilityName);
+    }
+    $facilities[0]=$facility;
+} 
+
+foreach my $facility (sort $sortingFunction2 @facilities) {
+    my $facilityId=$facility->getId;
+    my $facilityName=$facility->getName;
+
+    @hosts = $facilitiesAgent->getHosts(facility => $facilityId);
+    unless(@hosts) {printMessage "No Host found for facility $facilityName", $batch; next;}
+    foreach my $host (sort $sortingFunction @hosts) {
+        my $hostId=$host->getId;
+        my $hostName=$host->getHostname;
+        my $attribute = $attributesAgent->getAttribute(attributeName => $attrName,host => $hostId);
+        my $numCores;
+        $numCores=$attribute->getValueAsScalar; 
+        unless(defined $numCores) { $numCores = "undefined";}
+    
+        $table->addRow($facilityName,$hostName,$numCores);
+    }
+}
+
+print tableToPrint($table, $batch);

--- a/perun-rpc/src/main/perl/setAllFacilityHostAttribute
+++ b/perun-rpc/src/main/perl/setAllFacilityHostAttribute
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Text::ASCIITable;
+use Perun::Agent;
+use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+
+sub help {
+	return qq{
+	Sets Host attribute on each Host on Facility. 
+	Facility Id or Name required.
+	Attribute Id or Name required.
+	Attribute value required.
+	---------------------------------------------------
+	Available options:
+	--facilityName   | -F  facility name
+	--faclityId      | -f  facility Id
+	--attributeId    | -a attribute id
+	--attributeName  | -A attribute name including namespace
+	--attributeValue | -w attribute value  
+	--batch          | -b  batch
+	--help           | -h  prints this help
+	};
+}
+
+my ($facilityId, $facilityName, $attributeId, $attributeName, @attributeValue);
+our $batch;
+GetOptions ("help|h" => sub { print help(); exit 0;} ,"batch|b" => \$batch,
+"facilityId|f=i" => \$facilityId,
+"facilityName|F=s" => \$facilityName,
+"attributeId|a=i" => \$attributeId,
+"attributeName|A=s" => \$attributeName,
+'attributeValue|w=s@{1,}' => \@attributeValue) || die help();
+
+#options check
+# Check options
+unless (defined($facilityId) or (defined($facilityName))) { die "ERROR: facilityId or facilityName is required \n";}
+unless (defined($attributeId) or defined($attributeName)) { die "ERROR: attributeId or attributeName is required \n";}
+unless (@attributeValue) { die "ERROR: attributeValue is required \n";}
+
+my $agent = Perun::Agent->new();
+my $facilitiesAgent = $agent->getFacilitiesAgent;
+my $attributesAgent = $agent->getAttributesAgent;
+
+unless($facilityId) {
+        my $facility = $facilitiesAgent->getFacilityByName(name => $facilityName);
+        $facilityId=$facility->getId;
+}
+
+my $attributeDefinition;
+if (!defined($attributeId)) {
+        $attributeDefinition =  $attributesAgent->getAttributeDefinition(attributeName => $attributeName);
+} else {
+        $attributeDefinition =  $attributesAgent->getAttributeDefinitionById(id => $attributeId);
+}
+# Get the attribute definition and create the attribute
+my $attribute = Perun::beans::Attribute->fromAttributeDefinition($attributeDefinition);
+
+$attribute->setValueFromArray(@attributeValue);
+
+my @hosts=$facilitiesAgent->getHosts(facility => $facilityId);
+unless (@hosts) { printMessage "No host found", $batch; exit 0;}
+
+while (@hosts) {
+    my $host=shift(@hosts);
+    my $hostId=$host->getId;
+    
+    $attributesAgent->setAttribute(host => $hostId, attribute => $attribute );
+    printMessage("Attribute ".$attribute->getFriendlyName." set for host ".$host->getHostname." on the facility ".($facilityName ? $facilityName : $facilityId), $batch);    
+}
+

--- a/perun-rpc/src/main/perl/setHostNumCores
+++ b/perun-rpc/src/main/perl/setHostNumCores
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Text::ASCIITable;
+use Perun::Agent;
+use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+
+sub help {
+	return qq{
+	Sets attribute determining number of cores on Host. Host name and number of cores are required field.
+	---------------------------------------------------
+	Available options:
+	--hostName    | -H  host name
+        --numCores    | -n  number of cores
+	--batch       | -b  batch
+	--help        | -h  prints this help
+	};
+}
+
+my ($hostName, $numCores, $facilityName, $batch);
+GetOptions("help|h" => sub { print help; exit 0;} ,
+"hostName|H=s" => \$hostName,
+"numCores|n=i" => \$numCores,
+"batch|b" => \$batch) || die help;
+
+#options check
+unless(defined $hostName) { die "ERROR: hostName is required\n";}
+unless(defined $numCores) { die "ERROR: number of Cores is required\n";}
+
+my $attrName="urn:perun:host:attribute-def:def:coresNumber";
+
+my $agent = Perun::Agent->new();
+
+my $attributesAgent = $agent->getAttributesAgent;
+my $facilitiesAgent = $agent->getFacilitiesAgent;
+
+my $attributeDefinition =  $attributesAgent->getAttributeDefinition(attributeName => $attrName);
+my $attribute = Perun::beans::Attribute->fromAttributeDefinition($attributeDefinition);
+$attribute->setValue($numCores);
+
+
+my @hosts=$facilitiesAgent->getHostsByHostname(hostname => $hostName);
+while (@hosts) {
+    my $host=shift(@hosts);
+    my $hostId=$host->getId;
+    
+    $attributesAgent->setAttribute(host => $hostId, attribute => $attribute );
+    
+    my $facility = $facilitiesAgent->getFacilityForHost(host => $hostId);
+    unless($facility) {$facilityName="undefined";}
+    $facilityName=$facility->getName;
+}
+
+printMessage ("Number of Cores $numCores set for Host $hostName on $facilityName Facility",$batch);


### PR DESCRIPTION
- Tools for managing number of cores on facility hosts. 
- Tool 'setAllFacilityHostAttribute' allow to set the same value of attribute (cores,isManaged,isMonitored...) for all Hosts on whole Facility.