### PR TITLE
DB: Added unique constraint on Tasks

### DIFF
--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -4,6 +4,11 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 -- this update is not supported on hsql since its used only as in-memory db
+
+3.1.41
+alter table tasks add constraint task_u unique (exec_service_id, facility_id);
+update configurations set value='3.1.41' where property='DATABASE VERSION';
+
 3.1.40
 alter table tasks alter column engine_id type integer;
 update configurations set value='3.1.40' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -3,7 +3,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
-3.1.40 
+3.1.41
+alter table tasks add ( constraint TASK_U unique (exec_service_id, facility_id) );
+update configurations set value='3.1.41' where property='DATABASE VERSION';
+
+3.1.40
 alter table tasks modify engine_id integer;
 update configurations set value='3.1.40' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -2,6 +2,11 @@
 -- Versions must be separated by empty lines, version number should consist of three numbers with dots between, f.e. 3.0.1 is ok, 3.1 or 3.1.1.1 is not.
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
+
+3.1.41
+alter table tasks add constraint task_u unique (exec_service_id, facility_id);
+update configurations set value='3.1.41' where property='DATABASE VERSION';
+
 3.1.40
 alter table tasks alter column engine_id type integer;
 update configurations set value='3.1.40' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/schema.sql
+++ b/perun-core/src/main/resources/schema.sql
@@ -1006,7 +1006,7 @@ create table groups_groups (
 	created_by varchar(1300) default user not null,
 	modified_at timestamp default now not null,
 	modified_by varchar(1300) default user not null,
-	parent_flag boolean default false 
+	parent_flag boolean default false
 );
 
 create table res_tags (
@@ -1606,6 +1606,7 @@ alter table tags_resources add constraint tags_res_tags_fk foreign key (tag_id) 
 alter table tags_resources add constraint tags_res_res_fk foreign key (resource_id) references resources(id);
 
 alter table tasks add constraint task_pk primary key (id);
+alter table tasks add constraint task_u unique (exec_service_id,facility_id);
 alter table tasks add constraint task_exsrv_fk foreign key (exec_service_id) references exec_services(id);
 alter table tasks add constraint task_fac_fk foreign key (facility_id) references facilities(id);
 alter table tasks add constraint task_eng_fk foreign key (engine_id) references engines(id);

--- a/perun-core/src/main/resources/test-data.sql
+++ b/perun-core/src/main/resources/test-data.sql
@@ -2089,7 +2089,7 @@ insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routin
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,2,timestamp '2011-11-15 14:43:13.3','PERUNV3',timestamp '2011-11-15 14:43:13.3','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6071,timestamp '2015-01-21 13:05:00.4',timestamp '2015-01-16 14:29:29.6','PERUNV3',timestamp '2015-01-16 14:29:29.6','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6060,timestamp '2015-01-16 14:25:00.6',timestamp '2015-01-16 09:39:07.6','PERUNV3',timestamp '2015-01-16 09:39:07.6','PERUNV3','0');
-insert into configurations (property,value) values ('DATABASE VERSION','3.1.40');
+insert into configurations (property,value) values ('DATABASE VERSION','3.1.41');
 
 drop sequence service_principals_id_seq;
 create sequence service_principals_id_seq start with 1;

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1460,6 +1460,7 @@ alter table engines add (constraint ENG_PK primary key (id)
 );
 alter table tasks add (
 constraint TASK_PK primary key (id),
+constraint TASK_U unique (exec_service_id, facility_id),
 constraint TASK_EXSRV_FK foreign key (exec_service_id) references exec_services(id),
 constraint TASK_FAC_FK foreign key (facility_id) references facilities(id),
 constraint TASK_ENG_FK foreign key (engine_id) references engines (id),

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1202,15 +1202,15 @@ create table "facilities_bans" (
 );
 
 create table "user_ext_source_attr_values" (
-	user_ext_source_id integer not null, 
-	attr_id integer not null, 
-	attr_value varchar(4000), 
+	user_ext_source_id integer not null,
+	attr_id integer not null,
+	attr_value varchar(4000),
 	created_at timestamp default now() not null,
 	created_by varchar(1300) default user not null,
 	modified_at timestamp default now() not null,
 	modified_by varchar(1300) default user not null,
 	status char(1) default '0' not null,
-	attr_value_text text, 
+	attr_value_text text,
 	created_by_uid integer,
 	modified_by_uid integer
 );
@@ -1694,6 +1694,7 @@ alter table tags_resources add constraint tags_res_tags_fk foreign key (tag_id) 
 alter table tags_resources add constraint tags_res_res_fk foreign key (resource_id) references resources(id);
 
 alter table tasks add constraint task_pk primary key (id);
+alter table tasks add constraint task_u unique (exec_service_id, facility_id);
 alter table tasks add constraint task_exsrv_fk foreign key (exec_service_id) references exec_services(id);
 alter table tasks add constraint task_fac_fk foreign key (facility_id) references facilities(id);
 alter table tasks add constraint task_eng_fk foreign key (engine_id) references engines (id);


### PR DESCRIPTION
- For each ExecService and Facility there should be only single Task.
- Added constraint in DB and updated DB version.
- Removed trailing whitespace.