### PR TITLE
UTILS: Added systemd service units for perun components

### DIFF
--- a/perun-utils/systemd/perun-engine.service
+++ b/perun-utils/systemd/perun-engine.service
@@ -1,0 +1,19 @@
+# Systemd unit file for perun-engine
+#
+#
+
+[Unit]
+Description=Perun-engine
+After=perun.service
+
+[Service]
+Type=forking
+ExecStart=/bin/bash /home/perun/perun-engine/start_engine.sh
+ExecStop=/bin/bash /home/perun/perun-engine/stop_engine.sh
+#SuccessExitStatus=143
+User=perun
+Group=perun
+
+[Install]
+WantedBy=multi-user.target
+

--- a/perun-utils/systemd/perun.service
+++ b/perun-utils/systemd/perun.service
@@ -1,0 +1,30 @@
+# Systemd unit file for Perun tomcat instance.
+#
+# You must first create it like:
+# mkdir /var/lib/tomcats/perun
+# mkdir /var/lib/tomcats/perun/bin /var/lib/tomcats/perun/logs /var/lib/tomcats/perun/webapps /var/lib/tomcats/perun/work
+# cp -r /usr/share/tomcat/conf /var/lib/tomcats/perun/
+# chown -R perun:perun /var/lib/tomcats/perun/
+#
+# You can configure JAVA_OPTS in
+# /usr/share/tomcat/conf/tomcat.conf
+#
+
+[Unit]
+Description=Apache Tomcat Web Application for Perun
+After=syslog.target network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/tomcat/tomcat.conf
+# Fake environment to be like tomcat@instance service.
+Environment="NAME=perun"
+ExecStart=/usr/libexec/tomcat/server start
+ExecStop=/usr/libexec/tomcat/server stop
+SuccessExitStatus=143
+User=perun
+Group=tomcat
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
- perun.service start/stop own instance of tomcat like tomcat@perun.service would.
- perun-engine.service start/stop engine java app (start/stop scripts are required
  to be deployed at engine folder).