### PR TITLE
GUI: Updated description of allowed chars in group name

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
@@ -188,7 +188,7 @@ public class CreateGroupTabItem implements TabItem {
 				if (groupNameTextBox.getTextBox().getText().trim().isEmpty()) {
 					groupNameTextBox.setError("Name can't be empty.");
 				} else if (!groupNameTextBox.getTextBox().getText().trim().matches(Utils.GROUP_SHORT_NAME_MATCHER)) {
-					groupNameTextBox.setError("Name can contain only letters, numbers, spaces, dots, '_' and '-'.");
+					groupNameTextBox.setError("Name can contain only a-z, A-Z, numbers, spaces, dots, '_' and '-'.");
 				} else {
 					groupNameTextBox.setOk();
 					return true;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/EditGroupDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/EditGroupDetailsTabItem.java
@@ -99,7 +99,7 @@ public class EditGroupDetailsTabItem implements TabItem {
 				if (nameTextBox.getTextBox().getText().trim().isEmpty()) {
 					nameTextBox.setError("Name can't be empty.");
 				} else if (!nameTextBox.getTextBox().getText().trim().matches(Utils.GROUP_SHORT_NAME_MATCHER)) {
-					nameTextBox.setError("Name can contain only letters, numbers, spaces, dots, '_' and '-'.");
+					nameTextBox.setError("Name can contain only a-z, A-Z, numbers, spaces, dots, '_' and '-'.");
 				} else {
 					nameTextBox.setOk();
 					return true;


### PR DESCRIPTION
- When creating/editing groups, changed description list of
  allowed chars ("letters" -> "a-z,A-Z"), because we don't allow accents.