### PR TITLE
REGISTRAR: Send also original IdP in proxyIdp ext source name

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
@@ -523,6 +523,10 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 							// FIXME - hack Social IdP to let us know proper identity source
 							String type = ues.getLogin().split("@")[1].split("\\.")[0];
 							ues.getExtSource().setName("https://extidp.cesnet.cz/idp/shibboleth&authnContextClassRef=urn:cesnet:extidp:authn:"+type);
+						} else if (ues.getExtSource().getName().equals("https://login.elixir-czech.org/idp/")) {
+							// FIXME - hack Elixir proxy IdP to let us know proper identity source
+							String type = ues.getLogin().split("@")[1];
+							ues.getExtSource().setName("https://login.elixir-czech.org/idp/@"+type);
 						}
 						es.add(ues.getExtSource());
 					} else if (ues.getExtSource().getType().equals(ExtSourcesManagerEntry.EXTSOURCE_KERBEROS)) {


### PR DESCRIPTION
- When searching for similar users, when external identity is returned,
  put original IdP to ExtSource name in case of Elixir proxy IdP.
  It can be then used by GUI for meaningful translation of user identities
  when offering identity joining.