### PR TITLE
Updated Spring framework to version to 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 		<perun.log>/var/log/perun/</perun.log>
 
 		<!-- libraries versions -->
-		<org.springframework.version>3.1.4.RELEASE</org.springframework.version>
+		<org.springframework.version>3.2.17.RELEASE</org.springframework.version>
 		<junit.version>4.11</junit.version>
 		<log4j.version>1.5.8</log4j.version>
 		<!-- by default we run perun in memory -->


### PR DESCRIPTION
- Spring 3.1 support ended long time ago.
- Update to 3.2, which seems not to require change in a code.
  Yet its support ends on Dec 2016, so next year we should move
  to Spring 4.