### PR TITLE
Do not allow null value in facility uid namespace module

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_uid_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_uid_namespace.java
@@ -30,6 +30,8 @@ public class urn_perun_facility_attribute_def_def_uid_namespace extends Facility
 	 * Checks if the corresponding attribute u:uid-namespace:[namespace] exists.
 	 */
 	public void checkAttributeValue(PerunSessionImpl session, Facility facility, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
+		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, facility, "Missing uid namespace for facility.");
+
 		String userFacilityUidNamespaceAttributeName =
 			AttributesManager.NS_USER_ATTR_DEF + ":" + attribute.getFriendlyName() + ":" + (String) attribute.getValue();
 


### PR DESCRIPTION
 - throw wrongAttributeValueException if uid namespace is null in
   facility uid namespace module (better than ConsistencyException for
   not existing attribute definition)