### PR TITLE
DISPATCHER: Don't reschedule forced dependent Task on each pool processing

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
@@ -256,6 +256,7 @@ public class TaskSchedulerImpl implements TaskScheduler {
 								dispatcherQueue, time);
 						proceed = false;
 					} else {
+						boolean wasDependencyServiceTaskForced = dependencyServiceTask.isPropagationForced();
 						dependencyServiceTask.setPropagationForced(task.isPropagationForced());
 						switch (dependencyServiceTask.getStatus()) {
 						case DONE:
@@ -362,7 +363,8 @@ public class TaskSchedulerImpl implements TaskScheduler {
 									log.error("Could not get queue for task {}", dependencyServiceTask.getId());
 								}
 							}
-							if(dependencyServiceTask.isPropagationForced()) {
+							if(dependencyServiceTask.isPropagationForced() && !wasDependencyServiceTaskForced) {
+								// reschedule dependant only if originally was not forced !!!
 								rescheduleTask(dependencyServiceTask, execService, dispatcherQueue);
 								// XXX - should we proceed here?
 							}


### PR DESCRIPTION
- On each attempt to plan SEND Task processing, dependent processing GEN
  was forcefully re-scheduled (meaning it had 1 minute to generate data
  for forced Task). Gladly multiple re-schedules were ignored by engine.
  Now processing dependent GEN Task is re-scheduled only if previously
  whole Task was not forced.