### PR TITLE
specify priority for each message

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
@@ -170,8 +170,8 @@ public class JMSQueueManager {
 				+ task.getId() + ":" + task.getStatus().toString() + ":"
 				+ destinations);
 		// + ":" + task.getId() + ":DONE:Destinations []");
-		message.setJMSPriority(6);
-		producer.send(message);
+		//message.setJMSPriority(6);
+		producer.send(message, DeliveryMode.DEFAULT_DELIVERY_MODE, 6, 0);
 		log.debug("Task result message [" + message.getText()
 				+ "] has been sent...");
 	}
@@ -180,8 +180,8 @@ public class JMSQueueManager {
 		TextMessage message = session.createTextMessage("taskresult:"
 				+ propertiesBean.getProperty("engine.unique.id") + ":"
 				+ (result == null ? "" : result.serializeToString()));
-		message.setJMSPriority(2);
-		producer.send(message);
+		//message.setJMSPriority(2);
+		producer.send(message, DeliveryMode.DEFAULT_DELIVERY_MODE, 2, 0);
 		log.debug("Task destination result message [" + message.getText()
 				+ "] has been sent...");
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
 import javax.jms.JMSException;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
@@ -171,7 +172,7 @@ public class JMSQueueManager {
 				+ destinations);
 		// + ":" + task.getId() + ":DONE:Destinations []");
 		//message.setJMSPriority(6);
-		producer.send(message, DeliveryMode.DEFAULT_DELIVERY_MODE, 6, 0);
+		producer.send(message, DeliveryMode.PERSISTENT, 6, 0);
 		log.debug("Task result message [" + message.getText()
 				+ "] has been sent...");
 	}
@@ -181,7 +182,7 @@ public class JMSQueueManager {
 				+ propertiesBean.getProperty("engine.unique.id") + ":"
 				+ (result == null ? "" : result.serializeToString()));
 		//message.setJMSPriority(2);
-		producer.send(message, DeliveryMode.DEFAULT_DELIVERY_MODE, 2, 0);
+		producer.send(message, DeliveryMode.PERSISTENT, 2, 0);
 		log.debug("Task destination result message [" + message.getText()
 				+ "] has been sent...");
 	}


### PR DESCRIPTION
Instead of changing default producer priority, specify priority with each message sent.
This should avoid possible race conditions when setting message priority from different threads.
