### PR TITLE
Fix nullPointer exception in lightweight synchronization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1614,6 +1614,8 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
 				if(!idsOfUsersInGroup.containsKey(user.getId())) {
 					candidate = new Candidate(user, userExtSource);
+					//for lightweight synchronization we want to skip all update of attributes
+					candidate.setAttributes(new HashMap<String, String>());
 				}
 			} catch (UserExtSourceNotExistsException | UserNotExistsException ex) {
 				//If not find, get more information about him from member extSource


### PR DESCRIPTION
 - if new candidate is already user in perun and also member in vo,
   but not member of synchronized group, it create a new candidate
   without any attributes. After that this will throw null pointer
   exception when trying to resolve candidates attributes. For this
   reason we need to set empty array there instead of null.