### PR TITLE
DISPATCHER: Do not wait on reading JMS messages

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueReceiver.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueReceiver.java
@@ -29,7 +29,6 @@ public class SystemQueueReceiver implements Runnable {
 	private Queue queue = null;
 	private boolean running = true;
 	private int timeout = 5000; // ms
-	private int periodicity = 1000; // ms
 	private Session session = null;
 	private String queueName = null;
 
@@ -89,7 +88,6 @@ public class SystemQueueReceiver implements Runnable {
 						log.debug("No message available...");
 					}
 				}
-				Thread.sleep(periodicity);
 			} catch (JMSException e) {
 				log.error(e.toString(), e);
 				systemQueueProcessor.stopProcessingSystemMessages();
@@ -100,9 +98,6 @@ public class SystemQueueReceiver implements Runnable {
 					log.error(ex.toString(), ex);
 					stop();
 				}
-			} catch (InterruptedException e) {
-				log.error(e.toString(), e);
-				stop();
 			} catch (Exception e) {
 				log.error(e.toString(), e);
 				stop();


### PR DESCRIPTION
- When we read JMS message, we wait 1s to read another. This is
  a bottleneck, when hundreds of messages are waiting to be read.
  Lets read next message when we finish processing current message.
  If no message is in a queue, we wait 5s, which prevents "while(true)".