### PR TITLE
Proxy idp conf

### DIFF
--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -93,6 +93,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<prop key="perun.readOnlyPerun">false</prop>
 					<prop key="perun.DBInitializatorEnabled">false</prop>
 					<prop key="perun.userExtSources.persistent">PERUN,[\w\d]*</prop>
+					<prop key="perun.proxyIdPs"></prop>
 				</props>
 			</property>
 		</bean>

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -78,7 +78,13 @@ public class Api extends HttpServlet {
 
 	protected String getExtSourceName(HttpServletRequest req, Deserializer des) throws RpcException {
 		if (req.getHeader("Shib-Identity-Provider") != null && !req.getHeader("Shib-Identity-Provider").isEmpty()) {
-			return (String) req.getHeader("Shib-Identity-Provider");
+			// If IdP is proxy and we want to save original source IdP behind Proxy.
+			if (req.getHeader("sourceIdPEntityID") != null
+					&& !req.getHeader("sourceIdPEntityID").isEmpty()) {
+				return req.getHeader("sourceIdPEntityID");
+			} else {
+				return req.getHeader("Shib-Identity-Provider");
+			}
 		} else if (req.getHeader("OIDC_CLAIM_sub") != null && !req.getHeader("OIDC_CLAIM_sub").isEmpty()) {
 			return req.getHeader("OIDC_CLAIM_extSourceName");
 		} else if (req.getAttribute("SSL_CLIENT_VERIFY") != null && ((String) req.getAttribute("SSL_CLIENT_VERIFY")).equals("SUCCESS")){
@@ -136,7 +142,13 @@ public class Api extends HttpServlet {
 
 		// If we have header Shib-Identity-Provider, then the user uses identity federation to authenticate
 		if (req.getHeader("Shib-Identity-Provider") != null && !req.getHeader("Shib-Identity-Provider").isEmpty()) {
-			extSourceName = (String) req.getHeader("Shib-Identity-Provider");
+			// If IdP is proxy and we want to save original source IdP behind Proxy.
+			if (req.getHeader("sourceIdPEntityID") != null
+					&& !req.getHeader("sourceIdPEntityID").isEmpty()) {
+				extSourceName = req.getHeader("sourceIdPEntityID");
+			} else {
+				extSourceName = req.getHeader("Shib-Identity-Provider");
+			}
 			extSourceType = ExtSourcesManager.EXTSOURCE_IDP;
 			if (req.getHeader("loa") != null && ! req.getHeader("loa").isEmpty()) {
 				extSourceLoaString = req.getHeader("loa");


### PR DESCRIPTION
extract extSourceName from sourceIdPEntityID attribute if it is present instead of standard Shib-Identity-Provider in case of SAML2 authentication behind proxy IdP so we will obtain original identity

add configuration option 'perun.proxyIdPs' which contains entityIDs of proxyIdPs delimited by ',' (comma) and check if attribute sourceIdPEntityID is from this list. Otherwise use classic entityID from a SAML AuthResponse.

Before it is deployed need to add configuration option 'perun.proxyIdPs' to /etc/perun/perun.conf file. e.g.
\# Comma separated list of entityIDs of proxy IdPs which is infront of Perun. So Perun can work with them differently.
perun.proxyIdPs=https://login.ceitec.cz/idp/,https://login.elixir-czech.org/idp/,https://elixir-idp-dev.ics.muni.cz/proxy/

I've done it on devel and elixir instances