### PR TITLE
Fix task end time

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueProcessor.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/jms/SystemQueueProcessor.java
@@ -226,8 +226,8 @@ public class SystemQueueProcessor {
 				propagationMaintainer.closeTasksForEngine(clientID);
 				dispatcherQueuePool.removeDispatcherQueue(clientID);
 			} else if (clientIDsplitter[0].equalsIgnoreCase("task")) {
-				clientIDsplitter = systemMessagetext.split(":", 5);
-				if(clientIDsplitter.length < 5) {
+				clientIDsplitter = systemMessagetext.split(":", 6);
+				if(clientIDsplitter.length < 6) {
 					throw new MessageFormatException(
 							"Client (Perun-Engine) sent a malformed message ["
 									+ systemMessagetext + "]");
@@ -236,7 +236,7 @@ public class SystemQueueProcessor {
 				// task complete...
 				propagationMaintainer.onTaskComplete(
 						Integer.parseInt(clientIDsplitter[2]), clientID,
-						clientIDsplitter[3], clientIDsplitter[4]);
+						clientIDsplitter[3], clientIDsplitter[4], clientIDsplitter[5]);
 			} else if (clientIDsplitter[0].equalsIgnoreCase("taskresult")) {
 				//clientIDsplitter = systemMessagetext.split(":", 3);
 				// destination complete for task

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
@@ -22,7 +22,7 @@ public interface PropagationMaintainer {
 
 	void closeTasksForEngine(int clientID);
 
-	void onTaskComplete(int parseInt, int clientID, String status, String string);
+	void onTaskComplete(int parseInt, int clientID, String status, String endTimestamp, String string);
 
 	void onTaskDestinationComplete(int clientID, String string);
 

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
@@ -522,7 +522,14 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 			status = TaskStatus.ERROR;
 		}
 
-		completedTask.setEndTime(new Date(System.currentTimeMillis()));
+		try {
+			Date endTime = new Date(Long.parseLong(endTimestamp));
+			completedTask.setEndTime(endTime);
+		} catch(NumberFormatException e) {
+			log.error("Engine reported unparsable end time {} for task id {}, setting to current time",
+					endTimestamp, taskId);
+			completedTask.setEndTime(new Date(System.currentTimeMillis()));
+		}
 
 		// if we are going to run this task again, make sure to generate up to
 		// date data

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
@@ -502,7 +502,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 
 	@Override
 	public void onTaskComplete(int taskId, int clientID, String status_s,
-			String string) {
+			String endTimestamp, String string) {
 		Task completedTask = schedulingPool.getTaskById(taskId);
 
 		if (completedTask == null) {

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
@@ -169,7 +169,7 @@ public class JMSQueueManager {
 		TextMessage message = session.createTextMessage("task:"
 				+ propertiesBean.getProperty("engine.unique.id") + ":"
 				+ task.getId() + ":" + task.getStatus().toString() + ":"
-				+ destinations);
+				+ task.getEndTime() + ":" + destinations);
 		// + ":" + task.getId() + ":DONE:Destinations []");
 		//message.setJMSPriority(6);
 		producer.send(message, DeliveryMode.PERSISTENT, 6, 0);

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
@@ -169,7 +169,7 @@ public class JMSQueueManager {
 		TextMessage message = session.createTextMessage("task:"
 				+ propertiesBean.getProperty("engine.unique.id") + ":"
 				+ task.getId() + ":" + task.getStatus().toString() + ":"
-				+ task.getEndTime() + ":" + destinations);
+				+ task.getEndTime().getTime() + ":" + destinations);
 		// + ":" + task.getId() + ":DONE:Destinations []");
 		//message.setJMSPriority(6);
 		producer.send(message, DeliveryMode.PERSISTENT, 6, 0);

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/ExecutorEngineWorkerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/ExecutorEngineWorkerImpl.java
@@ -83,7 +83,6 @@ public class ExecutorEngineWorkerImpl implements ExecutorEngineWorker {
 
 				// task.setStatus(returnCode == 0 ? TaskStatus.DONE :
 				// TaskStatus.ERROR);
-				task.setEndTime(new Date(System.currentTimeMillis()));
 				if (returnCode != 0) {
 					log.info("GEN task failed. Ret code " + returnCode
 							+ ". STDOUT: {}  STDERR: {}. Task: " + task.getId(),
@@ -99,12 +98,10 @@ public class ExecutorEngineWorkerImpl implements ExecutorEngineWorker {
 			} catch (IOException e) {
 				log.error(e.toString(), e);
 				// task.setStatus(TaskStatus.ERROR);
-				task.setEndTime(new Date(System.currentTimeMillis()));
 				resultListener.onTaskDestinationError(task, destination, null);
 			} catch (Exception e) {
 				log.error(e.toString(), e);
 				// task.setStatus(TaskStatus.ERROR);
-				task.setEndTime(new Date(System.currentTimeMillis()));
 				resultListener.onTaskDestinationError(task, destination, null);
 			} finally {
 				String ret = returnCode == -1 ? "unknown" : String
@@ -149,7 +146,6 @@ public class ExecutorEngineWorkerImpl implements ExecutorEngineWorker {
 				taskResult.setTimestamp(new Date(System.currentTimeMillis()));
 				taskResult.setService(execService.getService());
 				
-				task.setEndTime(new Date(System.currentTimeMillis()));
 				if (taskResult.getStatus().equals(TaskResultStatus.ERROR)) {
 					resultListener.onTaskDestinationError(task, destination,
 							taskResult);

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskStatusManagerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskStatusManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.engine.scheduling.impl;
 
+import java.util.Date;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -72,6 +73,7 @@ public class TaskStatusManagerImpl implements TaskStatusManager,
 			}
 		}
 		if(task.getExecService().getExecServiceType().equals(ExecServiceType.GENERATE)) {
+			task.setEndTime(new Date(System.currentTimeMillis()));
 			schedulingPool.setTaskStatus(task, cz.metacentrum.perun.taskslib.model.Task.TaskStatus.DONE);
 		} else {
 			TaskStatus taskStatus = this.getTaskStatus(task);
@@ -84,6 +86,7 @@ public class TaskStatusManagerImpl implements TaskStatusManager,
 						+ ": " + e.getMessage());
 			}
 			if (taskStatus.isTaskFinished()) {
+				task.setEndTime(new Date(System.currentTimeMillis()));
 				schedulingPool.setTaskStatus(task, taskStatus.getTaskStatus());
 			}
 		}
@@ -115,6 +118,7 @@ public class TaskStatusManagerImpl implements TaskStatusManager,
 			}
 		}
 		if(task.getExecService().getExecServiceType().equals(ExecServiceType.GENERATE)) {
+			task.setEndTime(new Date(System.currentTimeMillis()));
 			schedulingPool.setTaskStatus(task, cz.metacentrum.perun.taskslib.model.Task.TaskStatus.ERROR);
 		} else {
 			TaskStatus taskStatus = this.getTaskStatus(task);
@@ -127,6 +131,7 @@ public class TaskStatusManagerImpl implements TaskStatusManager,
 						+ ": " + e.getMessage());
 			}
 			if (taskStatus.isTaskFinished()) {
+				task.setEndTime(new Date(System.currentTimeMillis()));
 				schedulingPool.setTaskStatus(task, taskStatus.getTaskStatus());
 			}
 		}


### PR DESCRIPTION
In engine:
* move setting of task end time from ExecutorEngineWorker to TaskStatusManager, ie. set end time only after all destinations are complete
* pack the task end time to the jms message sent to the dispatcher

In dispatcher:
* read the task end time from jms message and store that value into database