### PR TITLE
Fix bug in methods working with getting commonGID

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -78,13 +78,16 @@ public interface ModulesUtilsBl {
 	int haveTheSameAttributeWithTheSameNamespace(PerunSessionImpl sess, Group group, Attribute attr) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
-	 * If there are commong GID in the list of resources, get it.
-	 * If there is some collision (more than one have the other GID in the same namespace) throw exception
+	 * This method is looking for exactly one commonGID for all objects in list.
+	 * If commonGID in parameter is not null, it checks that all objects in list have this one set as gid.
+	 *
+	 * If list of groups is empty, return always commonGID from parameter (it can be null).
+	 * If there are more than one different commonGIDs, throw ConsistencyErrorException
 	 *
 	 * @param sess
 	 * @param resourcesWithSameGroupNameInSameNamespace
 	 * @param nameOfAttribute
-	 * @param commonGID can be null if no commonGID exists
+	 * @param commonGID if any common gid already exists (for example from Resources) use it to compare, null in other case
 	 * @return common GID, if no exists return null
 	 *
 	 * @throws InternalErrorException
@@ -108,13 +111,16 @@ public interface ModulesUtilsBl {
 	void checkIfListOfGIDIsWithinRange(PerunSessionImpl sess,User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongAttributeValueException;
 
 	/**
-	 * If there are commong GID in the list of groups, get it.
-	 * If there is some collision (more than one have the other GID in the same namespace) throw exception
+	 * This method is looking for exactly one commonGID for all objects in list.
+	 * If commonGID in parameter is not null, it checks that all objects in list have this one set as gid.
+	 *
+	 * If list of groups is empty, return always commonGID from parameter (it can be null).
+	 * If there are more than one different commonGIDs, throw ConsistencyErrorException
 	 *
 	 * @param sess
 	 * @param groupsWithSameGroupNameInSameNamespace
 	 * @param nameOfAttribute
-	 * @param commonGID can bu null if no commonGID exists
+	 * @param commonGID if any common gid already exists (for example from Resources) use it to compare, null in other case
 	 * @return common GID, if no exists return null
 	 *
 	 * @throws InternalErrorException
@@ -236,10 +242,10 @@ public interface ModulesUtilsBl {
 	 * If attribute is null, then it's ok.
 	 * For unpermitted user logins this method firstly tries to read perun-namespaces.properties file.
 	 * If there is no property in this file, it reads the default hardcoded values.
-	 * 
+	 *
 	 * @param loginAttribute login-namespace
 	 * @throws InternalErrorException
-	 * @throws WrongAttributeValueException 
+	 * @throws WrongAttributeValueException
 	 */
 	void checkUnpermittedUserLogins(Attribute loginAttribute) throws InternalErrorException, WrongAttributeValueException;
 
@@ -385,9 +391,9 @@ public interface ModulesUtilsBl {
 	 * Every record in list is merged quotas map with value from resource attribute and resource-member attribute where user has allowed member.
 	 *
 	 * Quotas for same paths are sum together. If value is '0' then result is also '0', because 0 means unlimited.
-	 * 
+	 *
 	 * Example: /path/to/volume 30G:50G , /path/to/volume 40G:0 => /path/to/volume 70G:0
-	 * 
+	 *
 	 * @param allUserQuotas list
 	 *
 	 * @return counted user facility quotas

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -301,23 +301,24 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		else {
 			Map<String,String> usedGidsValue = (Map<String, String>) usedGids.getValue();
 			Set<String> keys = usedGidsValue.keySet();
-			
+
 			for(String key: keys) {
 				allGids.add(Integer.parseInt(usedGidsValue.get(key)));
 			}
 		}
-		
+
 		for(int i = minGid; i < maxGid; i++) {
 			if(!allGids.contains(i)) {
 				return i;
 			}
 		}
-		
+
 		return null;
 	}
 
 	public Integer getCommonGIDOfGroupsWithSameNameInSameNamespace(PerunSessionImpl sess, List<Group> groupsWithSameGroupNameInSameNamespace, String gidNamespace, Integer commonGID) throws InternalErrorException, WrongAttributeAssignmentException {
-		if(groupsWithSameGroupNameInSameNamespace == null || groupsWithSameGroupNameInSameNamespace.isEmpty()) return null;
+		//If there are no groups, return commonGID from param (it can be null)
+		if(groupsWithSameGroupNameInSameNamespace == null || groupsWithSameGroupNameInSameNamespace.isEmpty()) return commonGID;
 		Utils.notNull(gidNamespace, "gidNamespace");
 
 		Group commonGIDGroup = null;  //only for more verbose exception messages
@@ -341,7 +342,8 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	}
 
 	public Integer getCommonGIDOfResourcesWithSameNameInSameNamespace(PerunSessionImpl sess, List<Resource> resourcesWithSameGroupNameInSameNamespace, String gidNamespace, Integer commonGID) throws InternalErrorException, WrongAttributeAssignmentException {
-		if(resourcesWithSameGroupNameInSameNamespace == null || resourcesWithSameGroupNameInSameNamespace.isEmpty()) return null;
+		//If there are no resources, return commonGID from param (it can be null)
+		if(resourcesWithSameGroupNameInSameNamespace == null || resourcesWithSameGroupNameInSameNamespace.isEmpty()) return commonGID;
 		Utils.notNull(gidNamespace,"gidNamespace");
 
 		Resource commonGIDResource = null;   //only for more verbose exception messages
@@ -674,7 +676,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		if(firstPlaceholder == null) throw new InternalErrorException("Missing first mandatory placeHolder (PerunBean).");
 		//Quotas attribute must exists with not null value
 		if(quotasAttribute == null || quotasAttribute.getValue() == null) throw new InternalErrorException("Attribute quotas for checking and transfering can't be null.");
-		
+
 		//Prepare result container and value of attribute
 		Map<String, Pair<BigDecimal, BigDecimal>> transferedQuotas = new HashMap<>();
 		Map<String, String> defaultQuotasMap = (Map<String, String>) quotasAttribute.getValue();


### PR DESCRIPTION
 - both affected methods (for Groups and Resources) should return
   commonGID from parameter of method, when list of objects in other
   parameter is empty or null
 - add this information also to javadoc of both methods