### PR TITLE
Modify group locks - add timeout, use group/member locks in Perun

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunLocksUtils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunLocksUtils.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 
 import org.slf4j.Logger;
@@ -16,6 +18,8 @@ import java.util.Set;
 import java.util.Random;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -31,7 +35,7 @@ public class PerunLocksUtils {
 	private final static Logger log = LoggerFactory.getLogger(PerunLocksUtils.class);
 
 	//This empty object is used just for purpose of saving and identifying all locks for separate transaction
-	public static Object uniqueKey = new Object();
+	public static ThreadLocal<Object> uniqueKey = ThreadLocal.withInitial(Object::new);
 
 	//Maps for saving and working with specific locks
 	private static ConcurrentHashMap<Group, ReadWriteLock> groupsLocks = new ConcurrentHashMap<>();
@@ -46,7 +50,7 @@ public class PerunLocksUtils {
 	 * @throws InternalErrorException
 	 * @throws InterruptedException
 	 */
-	public static void lockGroupMembership(Group group, List<Member> members) throws InternalErrorException, InterruptedException {
+	public static void lockGroupMembership(Group group, List<Member> members) throws InternalErrorException {
 		if(group == null) throw new InternalErrorException("Group can't be null when creating lock for group and list of members.");
 		if(members == null) throw new InternalErrorException("Members can't be null or empty when creating lock for group and list of members.");
 
@@ -56,46 +60,42 @@ public class PerunLocksUtils {
 		List<Lock> returnedLocks = new ArrayList<>();
 
 		try {
-			//TODO - On java8 use computeIfAbsent instead
-			//try to lock all needed locks there
-			ReadWriteLock groupReadWriteLock = groupsLocks.get(group);
-			if(groupReadWriteLock == null) {
-				groupsLocks.putIfAbsent(group, new ReentrantReadWriteLock(true));
-				groupReadWriteLock = groupsLocks.get(group);
+			try {
+				//try to lock all needed locks there
+				ReadWriteLock groupReadWriteLock = groupsLocks.computeIfAbsent(group, f -> new ReentrantReadWriteLock(true));
 
-			}
-			groupReadWriteLock.readLock().lock();
-			returnedLocks.add(groupReadWriteLock.readLock());
-			for (Member member : members) {
-				//Get members lock map by group if exists or create a new one
-				ConcurrentHashMap<Member, Lock> membersLocks = groupsMembersLocks.get(group);
-				if(membersLocks == null) {
-					groupsMembersLocks.putIfAbsent(group, new ConcurrentHashMap<Member, Lock>());
-					membersLocks = groupsMembersLocks.get(group);
+				if (!groupReadWriteLock.readLock().tryLock(4, TimeUnit.HOURS)) {
+					throw new InternalErrorException("Can't acquire a lock in expected time.");
 				}
 
-				//TODO - On java8 use computeIfAbsent instead
-				//Get concrete member lock from members lock map or create a new one if not exists
-				Lock memberLock = membersLocks.get(member);
-				if(memberLock == null) {
-					membersLocks.putIfAbsent(member, new ReentrantLock(true));
-					memberLock = membersLocks.get(member);
+				returnedLocks.add(groupReadWriteLock.readLock());
+				for (Member member : members) {
+					//Get members lock map by group if exists or create a new one
+					ConcurrentHashMap<Member, Lock> membersLocks = groupsMembersLocks.get(group);
+					if (membersLocks == null) {
+						groupsMembersLocks.putIfAbsent(group, new ConcurrentHashMap<Member, Lock>());
+						membersLocks = groupsMembersLocks.get(group);
+					}
+
+					//Get concrete member lock from members lock map or create a new one if not exists
+					Lock memberLock = membersLocks.computeIfAbsent(member, f -> new ReentrantLock(true));
+
+					//Lock the lock and return it
+					if (!memberLock.tryLock(4, TimeUnit.HOURS)) {
+						throw new InternalErrorException("Can't acquire a lock in expected time.");
+					}
+					returnedLocks.add(memberLock);
 				}
 
-				//Lock the lock and return it
-				memberLock.lock();
-				returnedLocks.add(memberLock);
+				//bind these locks like transaction resource
+				if (TransactionSynchronizationManager.getResource(uniqueKey.get()) == null) {
+					TransactionSynchronizationManager.bindResource(uniqueKey.get(), returnedLocks);
+				} else {
+					((List<Lock>) TransactionSynchronizationManager.getResource(uniqueKey.get())).addAll(returnedLocks);
+				}
+			} catch (InterruptedException ex) {
+				throw new InternalErrorException("Interrupted exception has been thrown while locking group " + group + " and list of members " + members, ex);
 			}
-
-			//bind these locks like transaction resource
-			if(TransactionSynchronizationManager.getResource(uniqueKey) == null) {
-				TransactionSynchronizationManager.bindResource(uniqueKey, returnedLocks);
-			} else {
-				((List<Lock>) TransactionSynchronizationManager.getResource(uniqueKey)).addAll(returnedLocks);
-			}
-
-
-
 		} catch (Exception ex) {
 			//if some exception has been thrown, unlock all already locked locks
 			unlockAll(returnedLocks);
@@ -110,32 +110,47 @@ public class PerunLocksUtils {
 	 * @throws InternalErrorException
 	 * @throws InterruptedException
 	 */
-	public static void lockGroupMembership(Group group) throws InternalErrorException, InterruptedException {
+	public static void lockGroupMembership(Group group) throws InternalErrorException {
 		if(group == null) throw new InternalErrorException("Group can't be null when creating lock for group.");
 
 		List<Lock> returnedLocks = new ArrayList<>();
 		try {
-			//TODO - On java8 use computeIfAbsent instead
-			//Need to investigate if we have all needed locks already in the structure or we need to create them
-			ReadWriteLock groupReadWriteLock = groupsLocks.get(group);
-			if(groupReadWriteLock == null) {
-				groupsLocks.putIfAbsent(group, new ReentrantReadWriteLock(true));
-				groupReadWriteLock = groupsLocks.get(group);
-			}
-			groupReadWriteLock.writeLock().lock();
-			returnedLocks.add(groupReadWriteLock.writeLock());
+			try {
+				//Need to investigate if we have all needed locks already in the structure or we need to create them
+				ReadWriteLock groupReadWriteLock = groupsLocks.computeIfAbsent(group, f -> new ReentrantReadWriteLock(true));
 
-			//bind these locks like transaction resource
-			if(TransactionSynchronizationManager.getResource(uniqueKey) == null) {
-				TransactionSynchronizationManager.bindResource(uniqueKey, returnedLocks);
-			} else {
-				((List<Lock>) TransactionSynchronizationManager.getResource(uniqueKey)).addAll(returnedLocks);
-			}
+				if (!groupReadWriteLock.writeLock().tryLock(4, TimeUnit.HOURS)) {
+					throw new InternalErrorException("Can't acquire a lock in expected time.");
+				}
+				returnedLocks.add(groupReadWriteLock.writeLock());
 
+				//bind these locks like transaction resource
+				if (TransactionSynchronizationManager.getResource(uniqueKey.get()) == null) {
+					TransactionSynchronizationManager.bindResource(uniqueKey.get(), returnedLocks);
+				} else {
+					((List<Lock>) TransactionSynchronizationManager.getResource(uniqueKey.get())).addAll(returnedLocks);
+				}
+			} catch (InterruptedException ex) {
+				throw new InternalErrorException("Interrupted exception has been thrown while locking group " + group, ex);
+			}
 		} catch (Exception ex) {
 			//if some exception has been thrown, unlock all already locked locks
 			unlockAll(returnedLocks);
 			throw ex;
+		}
+	}
+
+	/**
+	 * Create transaction locks for list of Groups and bind them to the transaction (as resource by Object uniqueKey)
+	 *
+	 * @param groups list of groups
+	 * @throws InternalErrorException
+	 */
+	public static void lockGroupMembership(List<Group> groups) throws InternalErrorException {
+		if(groups != null) {
+			for(Group group: groups) {
+				lockGroupMembership(group);
+			}
 		}
 	}
 


### PR DESCRIPTION
 - modify locks for Group, GroupMember - add timeout (4 hours)
 - add locks to the code in Perun where is any manipulation with
   groups (creating, deleting, adding and removing) and manipulation
   with members (adding to Group, remove from Group)
 - add better thread local variable for purpose of seeing only locks for
   current thread
 - unbind all already used locks from ending thread