### PR TITLE
CORE: user:virt:eppn must provide only correctly formatted values

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonPrincipalNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonPrincipalNames.java
@@ -6,11 +6,8 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
-import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 import java.util.ArrayList;
@@ -35,7 +32,8 @@ public class urn_perun_user_attribute_def_virt_eduPersonPrincipalNames extends U
 				String type = uES.getExtSource().getType();
 
 				if(type != null && login != null) {
-					if(type.equals(ExtSourcesManager.EXTSOURCE_IDP)) {
+					// insert only EPPN formatted data
+					if(type.equals(ExtSourcesManager.EXTSOURCE_IDP) && login.matches("[^@]+@[^@]+")) {
 						idpLogins.add(login);
 					}
 				}


### PR DESCRIPTION
- Resulting attribute should contain only values, which conform EPPN format
  "user@domain". Currently we provided also targetedID values and it caused
  problems to external systems using their own ServiceProvider (user gets new
  targetedID for them which is not same as stored in Perun).