### PR TITLE
GUI: Do not allow selection on indirect group members

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityHostsSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityHostsSettingsTabItem.java
@@ -246,7 +246,7 @@ public class FacilityHostsSettingsTabItem implements TabItem, TabItemWithUrl {
 	public int hashCode() {
 		final int prime = 739;
 		int result = 1;
-		result = prime * result + facilityId;
+		result = prime * result + facilityId + lastSelectedHostId;
 		return result;
 	}
 
@@ -260,6 +260,8 @@ public class FacilityHostsSettingsTabItem implements TabItem, TabItemWithUrl {
 			return false;
 		FacilityHostsSettingsTabItem other = (FacilityHostsSettingsTabItem) obj;
 		if (facilityId != other.facilityId)
+			return false;
+		if (lastSelectedHostId != other.lastSelectedHostId)
 			return false;
 		return true;
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
@@ -130,6 +130,8 @@ public class GroupMembersTabItem implements TabItem, TabItemWithUrl {
 		final GetCompleteRichMembers members = new GetCompleteRichMembers(PerunEntity.GROUP, groupId, null);
 		final FindCompleteRichMembers findMembers = new FindCompleteRichMembers(PerunEntity.GROUP, groupId, "", null);
 		members.excludeDisabled(!wasDisabled);
+		members.setIndirectCheckable(false);
+		findMembers.setIndirectCheckable(false);
 
 		final CustomButton searchButton = TabMenu.getPredefinedButton(ButtonType.SEARCH, ButtonTranslation.INSTANCE.searchMemberInGroup());
 		final CustomButton listAllButton = TabMenu.getPredefinedButton(ButtonType.LIST_ALL_MEMBERS, ButtonTranslation.INSTANCE.listAllMembersInGroup());


### PR DESCRIPTION
- If member is indirect in a group, prevent selection, since member
  can't be removed from a group anyway.
- Fixed hosts settings page -> open new for each host.