### PR TITLE
CORE: Do not log BLOB values in SQL import

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -204,7 +204,12 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 							log.error("Unknown attribute type '{}' for user {} {}, attributeRaw {}", new Object[] {attributeRaw[1], map.get("firstName"), map.get("lastName"), attributeRaw});
 						} else {
 							attributeName = attributeNameMapping.get(attributeRaw[0]) + attributeNameMapping.get(attributeRaw[1]) + attributeRaw[2];
-							log.trace("Adding attribute {} with value {}", attributeName, rs.getString(i));
+							if (!Objects.equals(rs.getMetaData().getColumnTypeName(i), "BLOB")) {
+								// trace only string data
+								log.trace("Adding attribute {} with value {}", attributeName, rs.getString(i));
+							} else {
+								log.trace("Adding attribute {} with BLOB value", attributeName);
+							}
 						}
 
 						String attributeValue = null;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
@@ -215,7 +215,12 @@ public class ExtSourceSqlComplex extends ExtSource implements ExtSourceApi {
 							log.error("Unknown attribute type '{}' for user {} {}, attributeRaw {}", new Object[] {attributeRaw[1], map.get("firstName"), map.get("lastName"), attributeRaw});
 						} else {
 							attributeName = attributeNameMapping.get(attributeRaw[0]) + attributeNameMapping.get(attributeRaw[1]) + attributeRaw[2];
-							log.trace("Adding attribute {} with value {}", attributeName, rs.getString(i));
+							if (!Objects.equals(rs.getMetaData().getColumnTypeName(i), "BLOB")) {
+								// trace only string data
+								log.trace("Adding attribute {} with value {}", attributeName, rs.getString(i));
+							} else {
+								log.trace("Adding attribute {} with BLOB value", attributeName);
+							}
 						}
 
 						String attributeValue = null;


### PR DESCRIPTION
- When using SQL ExtSource, do not trace log "rs.getString(i)" when
  value is a BLOB type. We should do full convert, but its most probably
  not necessary, so we just log "value was BLOB".