### PR TITLE
CORE: Handle null BLOBs in SQL ExtSource

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -217,14 +217,16 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 							// source column is binary
 							try {
 								InputStream inputStream = rs.getBinaryStream(i);
-								ByteArrayOutputStream result = new ByteArrayOutputStream();
-								byte[] buffer = new byte[1024];
-								int length;
-								while ((length = inputStream.read(buffer)) != -1) {
-									result.write(buffer, 0, length);
+								if (inputStream != null) {
+									ByteArrayOutputStream result = new ByteArrayOutputStream();
+									byte[] buffer = new byte[1024];
+									int length;
+									while ((length = inputStream.read(buffer)) != -1) {
+										result.write(buffer, 0, length);
+									}
+									byte[] bytes = Base64.encodeBase64(result.toByteArray());
+									attributeValue = new String(bytes, "UTF-8");
 								}
-								byte[] bytes = Base64.encodeBase64(result.toByteArray());
-								attributeValue = new String(bytes, "UTF-8");
 							} catch (IOException ex) {
 								log.error("Unable to read BLOB for column {}", columnName);
 								throw new InternalErrorException("Unable to read BLOB data for column: "+columnName, ex);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
@@ -228,14 +228,16 @@ public class ExtSourceSqlComplex extends ExtSource implements ExtSourceApi {
 							// source column is binary
 							try {
 								InputStream inputStream = rs.getBinaryStream(i);
-								ByteArrayOutputStream result = new ByteArrayOutputStream();
-								byte[] buffer = new byte[1024];
-								int length;
-								while ((length = inputStream.read(buffer)) != -1) {
-									result.write(buffer, 0, length);
+								if (inputStream != null) {
+									ByteArrayOutputStream result = new ByteArrayOutputStream();
+									byte[] buffer = new byte[1024];
+									int length;
+									while ((length = inputStream.read(buffer)) != -1) {
+										result.write(buffer, 0, length);
+									}
+									byte[] bytes = Base64.encodeBase64(result.toByteArray());
+									attributeValue = new String(bytes, "UTF-8");
 								}
-								byte[] bytes = Base64.encodeBase64(result.toByteArray());
-								attributeValue = new String(bytes, "UTF-8");
 							} catch (IOException ex) {
 								log.error("Unable to read BLOB for column {}", columnName);
 								throw new InternalErrorException("Unable to read BLOB data for column: "+columnName, ex);


### PR DESCRIPTION
- When BLOB is null, InputStream is null too, so skip processing
  and let attribute value to be null.