### PR TITLE
Display also VOs ID and shortName on resource tab detail

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceDetailTabItem.java
@@ -154,6 +154,16 @@ public class ResourceDetailTabItem implements TabItem, TabItemWithUrl {
 			menu.getFlexCellFormatter().setWidth(0, column, "25px");
 			column++;
 		}
+
+		if (facilityId > 0) {
+			// facility admin view
+			menu.setHTML(0, column, "<strong>VO:</strong><br/><span class=\"inputFormInlineComment\">"+resource.getVoId()+" / "+resource.getVo().getShortName()+"</span>");
+			column++;
+			menu.setHTML(0, column, "&nbsp;");
+			menu.getFlexCellFormatter().setWidth(0, column, "25px");
+			column++;
+		}
+
 		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+resource.getDescription()+"&nbsp;</span>");
 
 		if (session.isFacilityAdmin(resource.getFacilityId())) {


### PR DESCRIPTION
- Only when opened from facility admin section.
- We might consider same logic as click-through to facility detail?