### PR TITLE
CABINET: Reworking locking in cabinet

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/bl/impl/AuthorshipManagerBlImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/bl/impl/AuthorshipManagerBlImpl.java
@@ -110,12 +110,16 @@ public class AuthorshipManagerBlImpl implements AuthorshipManagerBl {
 			throw new CabinetException(ErrorCodes.USER_NOT_EXISTS, e);
 		}
 		log.debug("{} created.", authorship);
+
+		synchronized (CabinetManagerBlImpl.class) {
+			getCabinetManagerBl().updatePriorityCoefficient(sess, authorship.getUserId(), calculateNewRank(authorship.getUserId()));
+		}
+		synchronized (ThanksManagerBlImpl.class) {
+			getCabinetManagerBl().setThanksAttribute(authorship.getUserId());
+		}
+
 		// log
 		perun.getAuditer().log(sess, "Authorship {} created.", authorship);
-
-		getCabinetManagerBl().updatePriorityCoefficient(sess, authorship.getUserId(), calculateNewRank(authorship.getUserId()));
-
-		getCabinetManagerBl().setThanksAttribute(authorship.getUserId());
 
 		return authorship;
 
@@ -151,11 +155,15 @@ public class AuthorshipManagerBlImpl implements AuthorshipManagerBl {
 		log.debug("{} deleted.", authorship);
 
 		int userId = authorship.getUserId();
-		getCabinetManagerBl().updatePriorityCoefficient(sess, userId, calculateNewRank(userId));
+
+		synchronized (CabinetManagerBlImpl.class) {
+			getCabinetManagerBl().updatePriorityCoefficient(sess, userId, calculateNewRank(userId));
+		}
+		synchronized (ThanksManagerBlImpl.class) {
+			getCabinetManagerBl().setThanksAttribute(authorship.getUserId());
+		}
 
 		perun.getAuditer().log(sess, "Authorship {} deleted.", authorship);
-
-		getCabinetManagerBl().setThanksAttribute(authorship.getUserId());
 
 	}
 

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/bl/impl/CabinetManagerBlImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/bl/impl/CabinetManagerBlImpl.java
@@ -189,13 +189,13 @@ public class CabinetManagerBlImpl implements CabinetManagerBl {
 			// assign or update user's attribute
 			perun.getAttributesManager().setAttribute(cabinetSession, user, attr);
 		} catch (PerunException e) {
-			throw new CabinetException("Failed to update priority coeficient in Perun.",ErrorCodes.PERUN_EXCEPTION, e);
+			throw new CabinetException("Failed to update priority coefficient in Perun.",ErrorCodes.PERUN_EXCEPTION, e);
 		}
 
 	}
 
 	@Override
-	public synchronized void setThanksAttribute(int userId) throws CabinetException, InternalErrorException {
+	public void setThanksAttribute(int userId) throws CabinetException, InternalErrorException {
 
 		List<ThanksForGUI> thanks = getThanksManagerBl().getRichThanksByUserId(userId);
 
@@ -203,7 +203,7 @@ public class CabinetManagerBlImpl implements CabinetManagerBl {
 			// get user
 			User u = perun.getUsersManager().getUserById(cabinetSession, userId);
 			// get attribute
-			AttributeDefinition attrDef = perun.getAttributesManager().getAttributeDefinition(cabinetSession, ATTR_PUBS_NAMESPACE+":"+ATTR_PUBS_FRIENDLY_NAME);
+			AttributeDefinition attrDef = perun.getAttributesManager().getAttributeDefinition(cabinetSession, ATTR_PUBS_NAMESPACE + ":" + ATTR_PUBS_FRIENDLY_NAME);
 			Attribute attr = new Attribute(attrDef);
 			// if there are thanks to set
 			if (thanks != null && !thanks.isEmpty()) {
@@ -227,9 +227,8 @@ public class CabinetManagerBlImpl implements CabinetManagerBl {
 			}
 
 		} catch (PerunException e) {
-			throw new CabinetException("Failed to update "+ATTR_PUBS_NAMESPACE+":"+ATTR_PUBS_FRIENDLY_NAME+" in Perun.",ErrorCodes.PERUN_EXCEPTION, e);
+			throw new CabinetException("Failed to update " + ATTR_PUBS_NAMESPACE + ":" + ATTR_PUBS_FRIENDLY_NAME + " in Perun.", ErrorCodes.PERUN_EXCEPTION, e);
 		}
-
 
 	}
 

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/bl/impl/CategoryManagerBlImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/bl/impl/CategoryManagerBlImpl.java
@@ -91,16 +91,19 @@ public class CategoryManagerBlImpl implements CategoryManagerBl {
 		Category result = getCategoryManagerDao().updateCategory(sess, category);
 		// was rank changed ?
 		if (!Objects.equals(cat.getRank(), category.getRank())) {
-			// yes
-			List<Publication> pubs = getPublicationManagerBl().getPublicationsByCategoryId(category.getId());
+			synchronized (CabinetManagerBlImpl.class) {
+				// yes
+				List<Publication> pubs = getPublicationManagerBl().getPublicationsByCategoryId(category.getId());
 
-			// update coef for all authors of all publications in updated category
-			Set<Author> authors = new HashSet<Author>();
-			for (Publication p : pubs) {
-				authors.addAll(getAuthorshipManagerBl().getAuthorsByPublicationId(p.getId()));
-			}
-			for (Author a : authors) {
-				getCabinetManagerBl().updatePriorityCoefficient(sess, a.getId(), getAuthorshipManagerBl().calculateNewRank(a.getAuthorships()));
+				// update coef for all authors of all publications in updated category
+				Set<Author> authors = new HashSet<Author>();
+				for (Publication p : pubs) {
+					authors.addAll(getAuthorshipManagerBl().getAuthorsByPublicationId(p.getId()));
+				}
+
+				for (Author a : authors) {
+					getCabinetManagerBl().updatePriorityCoefficient(sess, a.getId(), getAuthorshipManagerBl().calculateNewRank(a.getAuthorships()));
+				}
 			}
 			log.debug("Category: [{}] updated to Category: [{}]", cat, category);
 		}

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/bl/impl/PublicationManagerBlImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/bl/impl/PublicationManagerBlImpl.java
@@ -162,10 +162,12 @@ public class PublicationManagerBlImpl implements PublicationManagerBl {
 
 		// if updated and rank or category was changed
 		if ((oldPub.getRank() != publication.getRank()) || (oldPub.getCategoryId() != publication.getCategoryId())) {
-			// update coefficient for all it's authors
-			List<Author> authors = getAuthorshipManagerBl().getAuthorsByPublicationId(oldPub.getId());
-			for (Author a : authors) {
-				getCabinetManagerBl().updatePriorityCoefficient(sess, a.getId(), getAuthorshipManagerBl().calculateNewRank(a.getAuthorships()));
+			synchronized (CabinetManagerBlImpl.class) {
+				// update coefficient for all it's authors
+				List<Author> authors = getAuthorshipManagerBl().getAuthorsByPublicationId(oldPub.getId());
+				for (Author a : authors) {
+					getCabinetManagerBl().updatePriorityCoefficient(sess, a.getId(), getAuthorshipManagerBl().calculateNewRank(a.getAuthorships()));
+				}
 			}
 		}
 


### PR DESCRIPTION
- Fixed deleteThanks() processing order.

- Previous fix didn't work. Synchronized on method level still
  causes deadlock, even when items are sorted.
  Synchronized inside method (on manager class/instance) didn't help either.
  Working solution is synchronized on manager class outside
  the deadlocking method -> create/deleteThanks().

- Same solution used for create/deleteAuthorship(), updatePublication()
  and updateCategory() when we recalculate priority coefficient.

- It should work also for concurrent calls of createThanks() and createAuthorship()
  for same user since we lock on manager class and always use same order of locks,
  so first come first served.