### PR TITLE
CORE: Attribute modules for FS replica service

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -399,4 +399,15 @@ public interface ModulesUtilsBl {
 	 * @return counted user facility quotas
 	 */
 	Map<String, Pair<BigDecimal, BigDecimal>> countUserFacilityQuotas(List<Map<String, Pair<BigDecimal, BigDecimal>>> allUserQuotas);
+
+	/**
+	 * Checks fully qualified domain name and returns true, if it is valid.
+	 *
+	 * @param sess
+	 * @param fqdn fully qualified domain name
+	 *
+	 * @return true if the fqdn is valid
+	 */
+	boolean isFQDNValid(PerunSessionImpl sess, String fqdn);
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -65,6 +65,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	public static final Pattern quotaWithoutMetricsPattern = Pattern.compile("^([0-9]+)(:)([0-9]+)$");
 	public static final Pattern numberPattern = Pattern.compile("[0-9]+([.][0-9]+)?");
 	public static final Pattern letterPattern = Pattern.compile("[A-Z]");
+	public static final Pattern fqdnPattern = Pattern.compile("^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}\\.?$");
 
 	public final static List<String> reservedNamesForUnixGroups = Arrays.asList("root", "daemon", "tty", "bin", "sys", "sudo", "nogroup",
 	          "hadoop", "hdfs", "mapred", "yarn", "hsqldb", "derby", "jetty", "hbase", "zookeeper", "users");
@@ -934,6 +935,13 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		}
 		//return result map
 		return resultTransferredQuotas;
+	}
+
+	@Override
+	public boolean isFQDNValid(PerunSessionImpl sess, String fqdn) {
+		if (fqdn == null) return false;
+		Matcher fqdnMatcher = fqdnPattern.matcher(fqdn);
+		return fqdnMatcher.find();
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestination.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestination.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+
+/**
+ * @author Simona Kruppova, Oliver Mrazik
+ */
+public class urn_perun_resource_attribute_def_def_replicaDestination extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+
+		if(attribute.getValue() == null) {
+			throw new WrongAttributeValueException(attribute, resource, "Destination for FS replica can't be empty.");
+		}
+
+		if (!perunSession.getPerunBl().getModulesUtilsBl().isFQDNValid(perunSession, (String) attribute.getValue())) {
+			throw new WrongAttributeValueException(attribute, resource, "Bad replicaDestination attribute format " + attribute.getValue() + ". It should be " +
+					"fully qualified domain name.");
+		}
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("replicaDestination");
+		attr.setDisplayName("Replica destination");
+		attr.setType(String.class.getName());
+		attr.setDescription("Fully qualified domain name (FQDN) of the target storage.");
+		return attr;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPath.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPath.java
@@ -1,0 +1,45 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Simona Kruppova, Oliver Mrazik
+ */
+public class urn_perun_resource_attribute_def_def_replicaDestinationPath extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+
+		if(attribute.getValue() == null) {
+			throw new WrongAttributeValueException(attribute, resource, "Destination path for FS replica can't be empty");
+		}
+
+		Matcher match = pattern.matcher((String) attribute.getValue());
+		if (!match.matches()) {
+			throw new WrongAttributeValueException(attribute, resource, "Bad replicaDestinationPath attribute format " + attribute.getValue());
+		}
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("replicaDestinationPath");
+		attr.setDisplayName("Replica destination path");
+		attr.setType(String.class.getName());
+		attr.setDescription("Absolute path in the target storage to copy to.");
+		return attr;
+	}
+
+}


### PR DESCRIPTION
- Added method for checking FQDN format to ModulesUtilsBl.
- Added modules for attributes:
  res:def:replicaDestination - not empty, is FQDN
  res:def:replicaDestinationPath - not empty, unix path
- res:def:replicaSourcePath is still TBD.
- Original authors are Simona Kruppova and Oliver Mrazik,
  I fixed only pattern usage and rebase it to master.