### PR TITLE
There is no need for restriction on role PerunAdmin for SpecificUsers

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -664,7 +664,6 @@ public class UsersManagerEntry implements UsersManager {
 
 		getUsersManagerBl().checkUserExists(sess, user);
 
-		if(user.isServiceUser() || user.isSponsoredUser()) throw new NotSpecificUserExpectedException(user);
 		// Authorization
 		if(!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
 			throw new PrivilegeException(sess, "makeUserPerunAdmin");


### PR DESCRIPTION
 - remove restriction for specificUsers to get role PerunAdmin
 - we have some use-case where specific system has service-user and need
   to have PerunAdmin in Perun