### PR TITLE
changes for Spring platform

### DIFF
--- a/perun-auditer-exporter/pom.xml
+++ b/perun-auditer-exporter/pom.xml
@@ -133,7 +133,7 @@
 		<!-- DBs -->
 		<!-- PostgreSQL driver -->
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
 		<!-- Oracle jdbc driver -->
@@ -162,7 +162,6 @@
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
-			<version>1.2</version>
 		</dependency>
 
 		<!-- SPRING -->
@@ -182,6 +181,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- LOGGING -->

--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -73,10 +73,6 @@
 	<!-- Dependencies for all profiles -->
 	<dependencies>
 
-		<!-- PERUN -->
-
-		<!-- DB -->
-
 		<!-- SPRING -->
 
 		<dependency>
@@ -88,8 +84,6 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context-support</artifactId>
 		</dependency>
-
-		<!-- TEST -->
 
 		<!-- LOGGING -->
 
@@ -103,12 +97,11 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
+		<!-- OTHER -->
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-core-asl</artifactId>
 		</dependency>
-
-		<!-- OTHER -->
 
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
@@ -116,9 +109,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-servlet-api</artifactId>
+			<version>${tomcat.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Attribute.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Attribute.java
@@ -3,10 +3,8 @@ package cz.metacentrum.perun.core.api;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
-import cz.metacentrum.perun.core.api.AttributeDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 
 /**
@@ -15,6 +13,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
  *
  * @author Slavek Licehammer <glory@ics.muni.cz>
  */
+@SuppressWarnings({"RedundantIfStatement", "SimplifiableIfStatement"})
 public class Attribute extends AttributeDefinition {
 
 	private final static Logger log = LoggerFactory.getLogger(Attribute.class);
@@ -107,9 +106,10 @@ public class Attribute extends AttributeDefinition {
 	/**
 	 * Check if the attribute value contains value. In case of list, it uses method contains. In case of array it searches in both keys and values.
 	 *
-	 * @param value
+	 * @param value value
 	 * @return true if the attribute value contains value.
 	 */
+	@SuppressWarnings("unchecked")
 	public boolean valueContains(String value) {
 		if (this.getType().equals(String.class.getName()) || this.getType().equals(BeansUtils.largeStringClassName)) {
 			return value == null ? this.getValue() == null : value.equals(this.getValue());
@@ -168,14 +168,12 @@ public class Attribute extends AttributeDefinition {
 
 	@Override
 	public String toString() {
-		StringBuilder str = new StringBuilder();
-
-		return str.append(this.getClass().getSimpleName()).append(":[").append(
-				"id='").append(getId()).append('\'').append(
-				", friendlyName='").append(getFriendlyName()).append('\'').append(
-				", namespace='").append(getNamespace()).append('\'').append(
-				", type='").append(getType()).append('\'').append(
-				", value='").append(getValue()).append('\'').append(
-				']').toString();
+		return this.getClass().getSimpleName() + ":[" +
+				"id='" + getId() + '\'' +
+				", friendlyName='" + getFriendlyName() + '\'' +
+				", namespace='" + getNamespace() + '\'' +
+				", type='" + getType() + '\'' +
+				", value='" + getValue() + '\'' +
+				']';
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -197,6 +197,7 @@ public class BeansUtils {
 	 *
 	 * @throws InternalErrorException
 	 */
+	@SuppressWarnings("unchecked")
 	public static String attributeValueToString(Attribute attribute) throws InternalErrorException {
 		if(attribute == null) throw new InternalErrorException(new NullPointerException("attribute is null"));
 		if(attribute.getValue() == null) return null;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/User.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/User.java
@@ -12,7 +12,6 @@ import cz.metacentrum.perun.core.api.BeansUtils;
  */
 public class User extends Auditable implements Comparable<PerunBean> {
 
-	protected int id;
 	protected String firstName;
 	protected String lastName;
 	protected String middleName;

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -35,6 +35,7 @@ import javax.servlet.http.HttpServletRequest;
  * @author Jan Klos <ddd@mail.muni.cz>
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
+@SuppressWarnings("Duplicates")
 public class JsonDeserializer extends Deserializer {
 
 	@JsonIgnoreProperties({"name","baseFriendlyName", "friendlyNameParameter", "entity", "beanName"})
@@ -67,6 +68,7 @@ public class JsonDeserializer extends Deserializer {
 	@JsonIgnoreProperties({"persistent","beanName"})
 	private interface UserExtSourceMixIn {}
 
+	@SuppressWarnings("unused")
 	private interface MemberMixIn {
 		@JsonIgnore
 		void setStatus(String status);
@@ -147,11 +149,7 @@ public class JsonDeserializer extends Deserializer {
 
 	@Override
 	public boolean contains(String name) {
-		if (root.get(name) != null) {
-			return true;
-		} else {
-			return false;
-		}
+		return root.get(name) != null;
 	}
 
 	@Override
@@ -168,7 +166,7 @@ public class JsonDeserializer extends Deserializer {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as String");
 		}
 
-		return node.getValueAsText();
+		return node.asText();
 	}
 
 	@Override
@@ -185,7 +183,7 @@ public class JsonDeserializer extends Deserializer {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as Boolean");
 		}
 
-		return node.getValueAsBoolean();
+		return node.asBoolean();
 	}
 
 	@Override
@@ -264,8 +262,7 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			T obj = mapper.readValue(node, valueType);
-			return obj;
+			return mapper.readValue(node, valueType);
 		} catch (IOException ex) {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as " + valueType.getSimpleName(), ex);
 		}
@@ -294,7 +291,7 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			List<T> list = new ArrayList<T>(node.size());
+			List<T> list = new ArrayList<>(node.size());
 			for (JsonNode e : node) {
 				list.add(mapper.readValue(e, valueType));
 			}
@@ -319,13 +316,11 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			String beanName = "cz.metacentrum.perun.core.api." + node.get("beanName").getTextValue();
-
+			String beanName = node.get("beanName").getTextValue();
 			if(beanName == null) {
 				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - missing beanName info");
 			}
-			PerunBean obj = (PerunBean) mapper.readValue(node, Class.forName(beanName));
-			return obj;
+			return (PerunBean) mapper.readValue(node, Class.forName("cz.metacentrum.perun.core.api." + beanName));
 		} catch (ClassNotFoundException ex) {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - class not found");
 		} catch (IOException ex) {
@@ -355,14 +350,14 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			List<PerunBean> list = new ArrayList<PerunBean>(node.size());
+			List<PerunBean> list = new ArrayList<>(node.size());
 			for (JsonNode e : node) {
-				String beanName = "cz.metacentrum.perun.core.api." + e.get("beanName").getTextValue();
+				String beanName = e.get("beanName").getTextValue();
 
 				if(beanName == null) {
 					throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - missing beanName info");
 				}
-				list.add((PerunBean) mapper.readValue(e, Class.forName(beanName)));
+				list.add((PerunBean) mapper.readValue(e, Class.forName("cz.metacentrum.perun.core.api." + beanName)));
 			}
 			return list;
 		} catch (ClassNotFoundException ex) {

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.taskslib.model.ExecService;
  * @author Jan Klos <ddd@mail.muni.cz>
  * @since 0.1
  */
+@SuppressWarnings("WeakerAccess")
 public class JsonDeserializer extends Deserializer {
 
 	@JsonIgnoreProperties({"name", "baseFriendlyName", "friendlyNameParameter", "entity", "beanName"})
@@ -57,7 +58,7 @@ public class JsonDeserializer extends Deserializer {
 
 	private interface MemberMixIn {
 		@JsonIgnore
-		public void setStatus(String status);
+		void setStatus(String status);
 	}
 
 	private static final ObjectMapper mapper = new ObjectMapper();
@@ -98,11 +99,7 @@ public class JsonDeserializer extends Deserializer {
 
 	@Override
 	public boolean contains(String name) {
-		if (root.get(name) != null) {
-			return true;
-		} else {
-			return false;
-		}
+		return root.get(name) != null;
 	}
 
 	@Override
@@ -112,7 +109,6 @@ public class JsonDeserializer extends Deserializer {
 		if (name == null) {
 			// The object is not under root, but directly in the response
 			node = root;
-			name = "root";
 		} else {
 			node = root.get(name);
 		}
@@ -124,7 +120,7 @@ public class JsonDeserializer extends Deserializer {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as String");
 		}
 
-		return node.getValueAsText();
+		return node.asText();
 	}
 
 	@Override
@@ -176,7 +172,6 @@ public class JsonDeserializer extends Deserializer {
 		if (name == null) {
 			// The object is not under root, but directly in the response
 			node = root;
-			name = "root";
 		} else {
 			node = root.get(name);
 		}
@@ -228,8 +223,7 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			T obj = mapper.readValue(node, valueType);
-			return obj;
+			return mapper.readValue(node, valueType);
 		} catch (IOException ex) {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as " + valueType.getSimpleName(), ex);
 		}
@@ -263,7 +257,7 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			List<T> list = new ArrayList<T>(node.size());
+			List<T> list = new ArrayList<>(node.size());
 			for (JsonNode e : node) {
 				list.add(mapper.readValue(e, valueType));
 			}

--- a/perun-cabinet/pom.xml
+++ b/perun-cabinet/pom.xml
@@ -117,19 +117,16 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.4.5</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.5.2</version>
 		</dependency>
 
 	</dependencies>

--- a/perun-controller/pom.xml
+++ b/perun-controller/pom.xml
@@ -91,19 +91,21 @@
 
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
 			<artifactId>spring-context-support</artifactId>
 		</dependency>
 
 		<!-- TESTS -->
 
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- LOGGING -->

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -19,7 +19,7 @@
 
 	<!-- module properties and versions -->
 	<properties>
-		<powermock.version>1.4.8</powermock.version>
+		<start-class>cz.metacentrum.perun.core.impl.Main</start-class>
 	</properties>
 
 	<!-- Build settings for all profiles -->
@@ -60,7 +60,6 @@
 			<plugin>
 				<groupId>eu.somatik.serviceloader-maven-plugin</groupId>
 				<artifactId>serviceloader-maven-plugin</artifactId>
-				<version>1.0.7</version>
 				<configuration>
 					<services>
 						<param>cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi</param>
@@ -75,39 +74,11 @@
 				</executions>
 			</plugin>
 
-			<!-- JAR with Main class, needed to join the Spring 3 separate JARs with separate schemas and handlers into one JAR -->
+			<!-- JAR with Main class -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<!-- which class should be run when the JAR is executed -->
-									<mainClass>cz.metacentrum.perun.core.impl.Main</mainClass>
-								</transformer>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/spring.handlers</resource>
-								</transformer>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/spring.schemas</resource>
-								</transformer>
-							</transformers>
-							<artifactSet>
-								<excludes>
-									<!-- test artifacts are excluded by default -->
-									<!-- we don't need maven build plugins in our application -->
-									<exclude>org.apache.maven*</exclude>
-								</excludes>
-							</artifactSet>
-						</configuration>
-					</execution>
-				</executions>
+				<!-- Main-Class taken from property ${start-class} -->
 			</plugin>
 
 		</plugins>
@@ -143,9 +114,10 @@
 		<!-- DBs -->
 		<!-- PostgreSQL driver -->
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
+		
 		<!-- Oracle jdbc driver -->
 		<dependency>
 			<groupId>com.oracle</groupId>
@@ -156,11 +128,13 @@
 			<groupId>com.oracle</groupId>
 			<artifactId>orai18n</artifactId>
 		</dependency>
+
 		<!-- SQL Lite -->
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
 		</dependency>
+
 		<!-- Mysql -->
 		<dependency>
 			<groupId>mysql</groupId>
@@ -178,13 +152,6 @@
 		</dependency>
 
 		<!-- SPRING -->
-
-		<!-- spring -->
-		<!-- see  http://blog.springsource.com/2009/12/02/obtaining-spring-3-artifacts-with-maven/ -->
-		<!--
-		  Application Context (depends on spring-core, spring-expression, spring-aop, spring-beans)
-		  This is the central artifact for Spring's Dependency Injection Container and is generally always defined
-		-->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
@@ -195,36 +162,23 @@
 			<artifactId>spring-context-support</artifactId>
 		</dependency>
 
-		<!--
-		  JDBC Data Access Library (depends on spring-core, spring-beans, spring-context, spring-tx)
-		  Define this if you use Spring's JdbcTemplate API (org.springframework.jdbc.*)
-		-->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 		</dependency>
 
-		<!--
-		  Web application development utilities applicable to both Servlet and Portlet Environments
-		  (depends on spring-core, spring-beans, spring-context)
-		  Define this if you use Spring MVC, or wish to use Struts, JSF, or another web framework with Spring (org.springframework.web.*)
-
-		  Perun-core does not require this dependency. However, it is required by the all perun-api-driven web applications, so we define it here rather than elsewhere.
-		-->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
 		</dependency>
-		<!--
-			Support for testing Spring applications with tools such as JUnit and TestNG
-			This artifact is generally always defined with a 'test' scope for the integration testing framework and unit testing stubs
-		-->
+
+		<!-- TEST -->
+
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
 		</dependency>
-
-		<!-- TEST -->
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -242,7 +196,7 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
-
+		
 		<!-- OTHERS -->
 
 		<dependency>
@@ -251,121 +205,101 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
-			<version>1.4.2</version>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
-			<version>1.8.5</version>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>${powermock.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>
-			<version>${powermock.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>jdom</groupId>
 			<artifactId>jdom</artifactId>
-			<version>1.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.4.5</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.5.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
 		</dependency>
 
 		<dependency>
 			<groupId>commons-httpclient</groupId>
 			<artifactId>commons-httpclient</artifactId>
-			<version>3.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>cglib</groupId>
 			<artifactId>cglib-nodep</artifactId>
-			<version>2.2.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>net.jcip</groupId>
 			<artifactId>jcip-annotations</artifactId>
-			<version>1.0</version>
 		</dependency>
 
 		<dependency>
-			<groupId>eu.somatik.serviceloader-maven-plugin</groupId>
-			<artifactId>serviceloader-maven-plugin</artifactId>
-			<version>1.0.7</version>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-servlet-api</artifactId>
+			<version>${tomcat.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
-			<version>3.3</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.apis</groupId>
 			<artifactId>google-api-services-admin-directory</artifactId>
-			<version>directory_v1-rev54-1.20.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.http-client</groupId>
 			<artifactId>google-http-client-jackson2</artifactId>
-			<version>1.18.0-rc</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.api-client</groupId>
 			<artifactId>google-api-client</artifactId>
-			<version>1.18.0-rc</version>
 		</dependency>
-                <dependency>
+
+        <dependency>
  			<groupId>org.json</groupId>
  			<artifactId>json</artifactId>
- 			<version>20160212</version>
  		</dependency>
+		
 	</dependencies>
 
 	<profiles>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -242,7 +242,7 @@ public class Auditer {
 		Object[] objects = new Object[2];
 		objects[0] = serializeObject(arg1);
 		objects[1] = serializeObject(arg2);
-		String formatedMessage = MessageFormatter.arrayFormat(message, objects);
+		String formatedMessage = MessageFormatter.arrayFormat(message, objects).getMessage();
 		storeMessageToDb(sess, formatedMessage);
 	}
 
@@ -256,7 +256,7 @@ public class Auditer {
 	 */
 	public void log(PerunSession sess, String message, Object arg1, Object arg2) throws InternalErrorException {
 		message = BeansUtils.createEscaping(message);
-		String formatedMessage = MessageFormatter.format(message, this.serializeObject(arg1), this.serializeObject(arg2));
+		String formatedMessage = MessageFormatter.format(message, this.serializeObject(arg1), this.serializeObject(arg2)).getMessage();
 		log(sess, formatedMessage);
 	}
 
@@ -266,7 +266,7 @@ public class Auditer {
 		objects[0] = serializeObject(arg1);
 		objects[1] = serializeObject(arg2);
 		objects[2] = serializeObject(arg3);
-		String formatedMessage = MessageFormatter.arrayFormat(message, objects);
+		String formatedMessage = MessageFormatter.arrayFormat(message, objects).getMessage();
 		log(sess, formatedMessage);
 	}
 
@@ -277,7 +277,7 @@ public class Auditer {
 		objects[1] = serializeObject(arg2);
 		objects[2] = serializeObject(arg3);
 		objects[3] = serializeObject(arg4);
-		String formatedMessage = MessageFormatter.arrayFormat(message, objects);
+		String formatedMessage = MessageFormatter.arrayFormat(message, objects).getMessage();
 		log(sess, formatedMessage);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzRole.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzRole.java
@@ -65,7 +65,7 @@ public class AuthzRole {
 
 	public String toString() {
 		return getClass().getSimpleName() +
-			"role='" + role == null ? "null" : role + "', " +
-			"complementaryObject='" + complementaryObject == null ? "null" : complementaryObject + "']";
+			"role='" + ((role == null) ? "null" : role) + "', " +
+			"complementaryObject='" + ((complementaryObject == null) ? "null" : complementaryObject + "']");
 	}
 }

--- a/perun-core/src/main/java/org/springframework/jdbc/core/JdbcPerunTemplate.java
+++ b/perun-core/src/main/java/org/springframework/jdbc/core/JdbcPerunTemplate.java
@@ -8,6 +8,7 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
 
 /**
  * Class JdbcPerunTemplate extends JdbcTemplate from spring. - it has 1
@@ -26,19 +27,26 @@ public class JdbcPerunTemplate extends JdbcTemplate {
 	 * Returns one object from the query, else throws an exception.
 	 *
 	 * @param sql sql query
-	 * @param rse result set extractor
+	 * @param rse result set extractor that returns List of objects
 	 * @param args arguments for the query
 	 *
-	 * @return 1 object obtained from the query
+	 * @return the single object obtained from the query
 	 *
-	 * @throws IncorrectResultSizeDataAccessException if more than one
-	 * element has been found in the given Collection
-	 * @throws EmptyResultDataAccessException if no element at all
-	 * has been found in the given Collection
+	 * @throws IncorrectResultSizeDataAccessException if more than one element has been found in the given Collection
+	 * @throws EmptyResultDataAccessException if no element at all has been found in the given Collection
 	 */
-	public <T> T queryForObject(String sql, ResultSetExtractor<T> rse, Object... args) throws DataAccessException {
-		List<T> results = (List<T>) this.query(sql, rse, args);
-		return DataAccessUtils.requiredSingleResult(results);
+	public <T> T queryForObject(String sql, ResultSetExtractor<? extends List<T>> rse, Object... args) throws DataAccessException {
+		return DataAccessUtils.requiredSingleResult(this.query(sql, rse, args));
 	}
 
+	/**
+	 * Implements a method removed from spring-jdbc
+	 * @param sql SQL query
+	 * @param args arguments for the SQL query
+	 * @return result of the query or zero if null
+	 */
+	public int queryForInt(String sql,Object... args) {
+		Integer i = this.queryForObject(sql, Integer.class, args);
+		return i==null?0:i;
+	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/AbstractPerunIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/AbstractPerunIntegrationTest.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.core.api.PerunClient;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.transaction.TransactionConfiguration;
@@ -30,16 +31,13 @@ import cz.metacentrum.perun.core.bl.PerunBl;
  * <ul>
  * <li>Reference for Perun instance from Spring's application context.</li>
  * <li>Automatical transaction support (via Spring ContextTest Framework) with
- * default rollback feature. If you don't wish the rollback to be performed, use
- * @Rollback(false).</li>
+ * default rollback feature.
  * </ul>
  *
  * Your class can provide/overwrite it's own configuration of Spring's
  * application context
  *
- * @see http
- *      ://static.springsource.org/spring/docs/current/spring-framework-reference
- *      /html/testing.html#testcontext-framework
+ * @see <a href="http://static.springsource.org/spring/docs/current/spring-framework-reference/html/testing.html#testcontext-framework">testing</a>
  *
  *      You can use Mockito and PowerMock testing frameworks as well.
  *
@@ -52,8 +50,8 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:perun-core.xml", "classpath:perun-core-jdbc.xml" })
-@TransactionConfiguration(transactionManager = "springTransactionManager", defaultRollback = true)
-@Transactional
+@Rollback
+@Transactional(transactionManager = "springTransactionManager")
 public abstract class AbstractPerunIntegrationTest {
 
 	@Autowired

--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -101,24 +101,6 @@
 				</executions>
 			</plugin>
 
-			<!-- Executing plug-in:  mvn exec:java -->
-			<!--<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<version>1.1</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>java</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<mainClass>cz.metacentrum.perun.dispatcher.main.DispatcherStarter</mainClass>
-				</configuration>
-			</plugin>
-			-->
-
 		</plugins>
 
 		<resources>
@@ -160,14 +142,6 @@
 
 		<!-- DB -->
 
-		<!-- use tomcat dbcp instead
-		<dependency>
-			<groupId>commons-dbcp</groupId>
-			<artifactId>commons-dbcp</artifactId>
-			<version>1.4</version>
-		</dependency>
- 		-->
-
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-dbcp</artifactId>
@@ -186,33 +160,28 @@
 
 
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
 
 		<!-- SPRING -->
 
-		<!--
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-			<version>${org.springframework.version}</version>
-		</dependency>
-		-->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context-support</artifactId>
 		</dependency>
 
+		<!-- TESTS -->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 
-		<!-- TESTS -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- LOGGING -->
@@ -229,9 +198,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>quartz</groupId>
+			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz</artifactId>
-			<version>1.5.2</version>
 		</dependency>
 
 		<!-- HORNET-Q  -->
@@ -239,31 +207,26 @@
 		<dependency>
 			<groupId>org.hornetq</groupId>
 			<artifactId>hornetq-core</artifactId>
-			<version>2.2.21.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.hornetq</groupId>
 			<artifactId>hornetq-jms</artifactId>
-			<version>2.2.21.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.hornetq</groupId>
 			<artifactId>hornetq-logging</artifactId>
-			<version>2.2.21.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jboss.netty</groupId>
 			<artifactId>netty</artifactId>
-			<version>3.2.1.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jboss.javaee</groupId>
 			<artifactId>jboss-jms-api</artifactId>
-			<version>1.1.0.GA</version>
 		</dependency>
 
 	</dependencies>

--- a/perun-dispatcher/src/main/resources/perun-dispatcher.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher.xml
@@ -60,7 +60,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 
 	<!-- Quartz jobs definition - they are not started unless perun-dispatcher-scheduler.xml is imported to context -->
 
-	<bean id="maintenanceJob" class="org.springframework.scheduling.quartz.JobDetailBean">
+	<bean id="maintenanceJob" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
 		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.MaintenanceJob" />
 		<property name="jobDataAsMap">
 			<map>
@@ -69,12 +69,12 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 		</property>
 	</bean>
 
-	<bean id="maintenanceJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="maintenanceJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="maintenanceJob" />
 		<property name="cronExpression" value="${dispatcher.cron.maintenance}" />
 	</bean>
 
-	<bean id="propagationMaintainerJob" class="org.springframework.scheduling.quartz.JobDetailBean">
+	<bean id="propagationMaintainerJob" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
 		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.PropagationMaintainerJob" />
 		<property name="jobDataAsMap">
 			<map>
@@ -83,12 +83,12 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 		</property>
 	</bean>
 
-	<bean id="propagationMaintainerJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="propagationMaintainerJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="propagationMaintainerJob" />
 		<property name="cronExpression" value="${dispatcher.cron.propagation}" />
 	</bean>
 
-	<bean id="processPoolJob" class="org.springframework.scheduling.quartz.JobDetailBean">
+	<bean id="processPoolJob" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
 		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.ProcessPoolJob" />
 		<property name="jobDataAsMap">
 			<map>
@@ -97,12 +97,12 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 		</property>
 	</bean>
 
-	<bean id="processPoolJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="processPoolJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="processPoolJob" />
 		<property name="cronExpression" value="${dispatcher.cron.processpool}" />
 	</bean>
 
-	<bean id="cleanTaskResultsJob" class="org.springframework.scheduling.quartz.JobDetailBean">
+	<bean id="cleanTaskResultsJob" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
 		<property name="jobClass" value="cz.metacentrum.perun.dispatcher.job.CleanTaskResultsJob" />
 		<property name="jobDataAsMap">
 			<map>
@@ -111,7 +111,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 		</property>
 	</bean>
 
-	<bean id="cleanTaskResultsJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="cleanTaskResultsJobTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="cleanTaskResultsJob" />
 		<property name="cronExpression" value="${dispatcher.cron.cleantaskresults}" />
 	</bean>

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -154,15 +154,17 @@
 			<artifactId>spring-context</artifactId>
 		</dependency>
 
+		<!-- TESTS -->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 
-		<!-- TESTS -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- LOGGING -->
@@ -175,25 +177,21 @@
 		<dependency>
 			<groupId>org.hornetq</groupId>
 			<artifactId>hornetq-core-client</artifactId>
-			<version>2.2.16.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.hornetq</groupId>
 			<artifactId>hornetq-jms-client</artifactId>
-			<version>2.2.16.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jboss.netty</groupId>
 			<artifactId>netty</artifactId>
-			<version>3.2.1.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jboss.javaee</groupId>
 			<artifactId>jboss-jms-api</artifactId>
-			<version>1.1.0.GA</version>
 		</dependency>
 
 	</dependencies>

--- a/perun-ldapc-initializer/pom.xml
+++ b/perun-ldapc-initializer/pom.xml
@@ -18,8 +18,7 @@
 	<description>LDAP connector initialization script</description>
 
 	<properties>
-		<!-- common module settings used by all profiles -->
-		<org.springframework.ldap.version>1.3.2.RELEASE</org.springframework.ldap.version>
+		<start-class>cz.metacentrum.perun.ldapc.initializer.main.Main</start-class>
 	</properties>
 
 	<!-- common build settings used by all profiles -->
@@ -60,35 +59,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<!-- which class should be run when the JAR is executed -->
-									<mainClass>cz.metacentrum.perun.ldapc.initializer.main.Main</mainClass>
-								</transformer>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/spring.handlers</resource>
-								</transformer>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/spring.schemas</resource>
-								</transformer>
-							</transformers>
-							<artifactSet>
-								<excludes>
-									<!-- test artifacts are excluded by default -->
-									<!-- we don't need maven build plugins in our application -->
-									<exclude>org.apache.maven*</exclude>
-								</excludes>
-							</artifactSet>
-						</configuration>
-					</execution>
-				</executions>
+				<!-- Main-Class taken from property ${start-class} -->
 			</plugin>
 
 			<!-- Copy dependencies plug-in -->

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -18,8 +18,6 @@
 	<description>LDAP connector which immediately pushes changes in Perun to LDAP</description>
 
 	<properties>
-		<!-- common module settings used by all profiles -->
-		<org.springframework.ldap.version>1.3.2.RELEASE</org.springframework.ldap.version>
 	</properties>
 
 	<!-- common build settings used by all profiles -->
@@ -144,7 +142,7 @@
 		<!-- DBs -->
 		<!-- PostgreSQL driver -->
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
 		<!-- Oracle jdbc driver -->
@@ -185,50 +183,31 @@
 			<artifactId>spring-test</artifactId>
 		</dependency>
 
-		<!--
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-aop</artifactId>
-			<version>${org.springframework.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		-->
-
 		<!-- SPRING - LDAP -->
 
 		<dependency>
 			<groupId>org.springframework.ldap</groupId>
 			<artifactId>spring-ldap-core</artifactId>
-			<version>${org.springframework.ldap.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ldap</groupId>
 			<artifactId>spring-ldap-core-tiger</artifactId>
-			<version>${org.springframework.ldap.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ldap</groupId>
 			<artifactId>spring-ldap-odm</artifactId>
-			<version>${org.springframework.ldap.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ldap</groupId>
 			<artifactId>spring-ldap-ldif-core</artifactId>
-			<version>${org.springframework.ldap.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ldap</groupId>
 			<artifactId>spring-ldap-ldif-batch</artifactId>
-			<version>${org.springframework.ldap.version}</version>
 		</dependency>
 
 		<!-- TESTS -->
@@ -236,6 +215,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- LOGGING -->

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -98,7 +98,6 @@
 		<dependency>
 			<groupId>commons-dbcp</groupId>
 			<artifactId>commons-dbcp</artifactId>
-			<version>1.4</version>
 		</dependency>
 
 		<!-- Commented for testing on perun-dev.meta.zcu.cz -->
@@ -106,7 +105,7 @@
 		<!-- DBs -->
 		<!-- PostgreSQL driver -->
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
 		<!-- Oracle jdbc driver -->
@@ -144,29 +143,20 @@
 
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>${org.springframework.version}</version>
+			<artifactId>spring-jdbc</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-		</dependency>
-
-		<!--
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-			<version>${org.springframework.version}</version>
-		</dependency>
-		-->
 
 		<!-- TESTS -->
 
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>dumbster</groupId>
 			<artifactId>dumbster</artifactId>
-			<version>1.6</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -183,13 +173,13 @@
 		<dependency>
 			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
-			<version>1.1.1</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- LOGGING -->
@@ -197,65 +187,46 @@
 		<!-- OTHERS -->
 
 		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
-			<version>1.4</version>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>2.3.14</version>
 		</dependency>
 
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>1.5.2</version>
 		</dependency>
 
 		<dependency>
-			<groupId>org.opensymphony.quartz</groupId>
+			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz</artifactId>
-			<version>1.6.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>javax.transaction</groupId>
-			<artifactId>jta</artifactId>
-			<version>1.1</version>
+			<artifactId>javax.transaction-api</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>jstl</artifactId>
-			<version>1.2</version>
-		</dependency>
-
+		
 		<dependency>
 			<groupId>jivesoftware</groupId>
 			<artifactId>smack</artifactId>
-			<version>3.1.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>jivesoftware</groupId>
 			<artifactId>smackx</artifactId>
-			<version>3.1.0</version>
 		</dependency>
+		
+		
 
 	</dependencies>
 

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/jdbc/PerunNotifPoolMessageDaoImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/jdbc/PerunNotifPoolMessageDaoImpl.java
@@ -7,23 +7,18 @@ import cz.metacentrum.perun.notif.dao.PerunNotifPoolMessageDao;
 import cz.metacentrum.perun.notif.dto.PoolMessage;
 import cz.metacentrum.perun.notif.entities.PerunNotifPoolMessage;
 import org.joda.time.DateTime;
+import org.joda.time.Days;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.joda.time.Days;
-import org.springframework.jdbc.support.rowset.SqlRowSet;
+import java.util.*;
 
 @Repository("perunNotifPoolMessageDao")
 @Transactional(propagation = Propagation.REQUIRED)
@@ -51,9 +46,9 @@ public class PerunNotifPoolMessageDaoImpl extends JdbcDaoSupport implements Peru
 			message.setCreated(new DateTime());
 		}
 		this.getJdbcTemplate().update(
-			"insert into pn_pool_message" + "(id, regex_id, template_id, key_attributes, notif_message, created) " + "values (?,?,?,?,?,?)",
-			newMessageId, message.getRegexId(), message.getTemplateId(), serializedKeyAttributes, message.getNotifMessage(),
-			new Timestamp(message.getCreated().getMillis()));
+				"insert into pn_pool_message" + "(id, regex_id, template_id, key_attributes, notif_message, created) " + "values (?,?,?,?,?,?)",
+				newMessageId, message.getRegexId(), message.getTemplateId(), serializedKeyAttributes, message.getNotifMessage(),
+				new Timestamp(message.getCreated().getMillis()));
 
 		message.setId(newMessageId);
 

--- a/perun-notification/src/main/resources/perun-notification-scheduler.xml
+++ b/perun-notification/src/main/resources/perun-notification-scheduler.xml
@@ -22,7 +22,7 @@
 
 	</bean>
 
-	<bean id="doNotificationTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+	<bean id="doNotificationTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
 		<property name="jobDetail" ref="doNotificationJobDetail" />
 		<!-- start every day at 2:00 AM -->
 		<!--detailed options could be find at http://quartz.sourceforge.net/javadoc/org/quartz/CronTrigger.html -->

--- a/perun-registrar-lib/pom.xml
+++ b/perun-registrar-lib/pom.xml
@@ -89,7 +89,7 @@
 		<!-- DBs -->
 		<!-- PostgreSQL driver -->
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
 		<!-- Oracle jdbc driver -->
@@ -130,24 +130,15 @@
 			<artifactId>spring-test</artifactId>
 		</dependency>
 
-		<!-- JavaMail
-		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
-			<version>1.4.1</version>
-			<scope>provided</scope>
-		</dependency>
-		-->
-
 		<!-- TESTS -->
 
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- LOGGING -->
-
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
@@ -157,7 +148,6 @@
 		<dependency>
 			<groupId>net.jodah</groupId>
 			<artifactId>expiringmap</artifactId>
-			<version>0.4.3</version>
 		</dependency>
 
 	</dependencies>

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -162,13 +162,12 @@
 		<dependency>
 			<groupId>net.tanesha.recaptcha4j</groupId>
 			<artifactId>recaptcha4j</artifactId>
-			<version>0.0.7</version>
 		</dependency>
 
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-servlet-api</artifactId>
+			<version>${tomcat.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/perun-tasks-lib/pom.xml
+++ b/perun-tasks-lib/pom.xml
@@ -87,7 +87,7 @@
         </dependency>
 
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
 
@@ -101,12 +101,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
-			<version>${org.springframework.version}</version>
 		</dependency>
 
 		<!-- TESTS -->

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/ExecServiceDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/ExecServiceDaoJdbc.java
@@ -4,6 +4,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
@@ -91,9 +92,14 @@ public class ExecServiceDaoJdbc extends JdbcDaoSupport implements ExecServiceDao
 				new Integer[] { serviceId }, ExecServiceDaoJdbc.EXEC_SERVICE_ROWMAPPER);
 	}
 
+	private int queryForInt(String sql, Object... args) throws DataAccessException {
+		Integer i = getJdbcTemplate().queryForObject(sql, args, Integer.class);
+		return (i != null ? i : 0);
+	}
+
 	@Override
 	public int countExecServices() {
-		return this.getJdbcTemplate().queryForInt("select count(*) from exec_services");
+		return queryForInt("select count(*) from exec_services");
 	}
 
 	@Override

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/ExecServiceDenialDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/ExecServiceDenialDaoJdbc.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.taskslib.dao.jdbc;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,26 +61,21 @@ public class ExecServiceDenialDaoJdbc extends JdbcDaoSupport implements ExecServ
 		}
 	}
 
+	private int queryForInt(String sql, Object... args) throws DataAccessException {
+		Integer i = getJdbcTemplate().queryForObject(sql, args, Integer.class);
+		return (i != null ? i : 0);
+	}
+
 	@Override
 	public boolean isExecServiceDeniedOnFacility(int execServiceId, int facilityId) {
-		int denials = 0;
-		denials = this.getJdbcTemplate().queryForInt("select count(*) from service_denials where exec_service_id = ? and facility_id = ?",
-				new Object[] { execServiceId, facilityId });
-		if (denials > 0) {
-			return true;
-		}
-		return false;
+		int denials = queryForInt("select count(*) from service_denials where exec_service_id = ? and facility_id = ?",	execServiceId, facilityId );
+		return denials > 0;
 	}
 
 	@Override
 	public boolean isExecServiceDeniedOnDestination(int execServiceId, int destinationId) {
-		int denials = 0;
-		denials = this.getJdbcTemplate().queryForInt("select count(*) from service_denials where exec_service_id = ? and destination_id = ?",
-				new Object[] { execServiceId, destinationId });
-		if (denials > 0) {
-			return true;
-		}
-		return false;
+		int denials = queryForInt("select count(*) from service_denials where exec_service_id = ? and destination_id = ?", execServiceId, destinationId );
+		return denials > 0;
 	}
 
 	@Override

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/ExecServiceDependencyDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/ExecServiceDependencyDaoJdbc.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,11 @@ import cz.metacentrum.perun.taskslib.model.ExecService.ExecServiceType;
 @Transactional
 public class ExecServiceDependencyDaoJdbc extends JdbcDaoSupport implements ExecServiceDependencyDao {
 	private final static Logger log = LoggerFactory.getLogger(ExecServiceDependencyDaoJdbc.class);
+
+	private int queryForInt(String sql, Object... args) throws DataAccessException {
+		Integer i = getJdbcTemplate().queryForObject(sql, args, Integer.class);
+		return (i != null ? i : 0);
+	}
 
 	private static final String scopeMappingSelectQuery = " service_dependencies.type as service_dependencies_type ";
 
@@ -58,8 +64,7 @@ public class ExecServiceDependencyDaoJdbc extends JdbcDaoSupport implements Exec
 	@Override
 	public boolean isThereDependency(int dependantExecServiceId, int execServiceId) {
 		int dependency = 0;
-		dependency = this.getJdbcTemplate().queryForInt("select count(*) from service_dependencies where dependency_id = ? and exec_service_id = ?",
-				new Object[] { execServiceId, dependantExecServiceId });
+		dependency = queryForInt("select count(*) from service_dependencies where dependency_id = ? and exec_service_id = ?", execServiceId, dependantExecServiceId );
 		if (dependency > 0) {
 			return true;
 		}

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskDaoJdbc.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
@@ -449,18 +450,23 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		this.getJdbcTemplate().update("delete from tasks where id = ?", id);
 	}
 
+	private int queryForInt(String sql, Object... args) throws DataAccessException {
+		Integer i = getJdbcTemplate().queryForObject(sql, args, Integer.class);
+		return (i != null ? i : 0);
+	}
+
 	@Override
 	public int countTasks(int engineID) {
 		if(engineID < 0) {
-			return this.getJdbcTemplate().queryForInt("select count(*) from tasks where engine_id is null");
+			return queryForInt("select count(*) from tasks where engine_id is null");
 		} else {
-			return this.getJdbcTemplate().queryForInt("select count(*) from tasks where engine_id = ?", engineID );
+			return queryForInt("select count(*) from tasks where engine_id = ?", engineID );
 		}
 	}
 
 	@Override
 	public int countTasks() {
-		return this.getJdbcTemplate().queryForInt("select count(*) from tasks");
+		return queryForInt("select count(*) from tasks");
 
 	}
 }

--- a/perun-voot/pom.xml
+++ b/perun-voot/pom.xml
@@ -91,7 +91,7 @@
 		-->
 
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
 
@@ -102,6 +102,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -27,11 +27,13 @@
 		<!-- Convenience property to set the GWT version -->
 		<gwtVersion>2.7.0</gwtVersion>
 		<webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
-		<gui.url.modifier></gui.url.modifier>
+		<gui.url.modifier/>
+		<maven.compiler.source>1.7</maven.compiler.source>
 	</properties>
 
 	<!-- common build settings used by all profiles -->
 	<build>
+		<finalName>perun-web-gui-${perun.build.type}</finalName>
 		<plugins>
 
 			<plugin>
@@ -99,7 +101,6 @@
 				</executions>
 				<configuration>
 					<webappDirectory>${webappDirectory}</webappDirectory>
-					<warName>perun-web-gui-${perun.build.type}</warName>
 				</configuration>
 			</plugin>
 
@@ -163,19 +164,19 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
-			<version>1.0.0.GA</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
-			<version>1.0.0.GA</version>
+			<version>${javax-validation.version}</version>
 			<classifier>sources</classifier>
 			<scope>provided</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -8,6 +9,16 @@
 	<artifactId>perun</artifactId>
 	<version>3.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
+
+	<!-- Spring Platform as parent project - this project inherits versions of dependencies and plugins -->
+	<!-- see http://docs.spring.io/platform/docs/current/reference/htmlsingle/#getting-started-using-spring-io-platform-maven -->
+	<!-- update Spring by changing the version here to the current release displayed at http://platform.spring.io/platform/ -->
+	<parent>
+		<groupId>io.spring.platform</groupId>
+		<artifactId>platform-bom</artifactId>
+		<version>Brussels-SR1</version>
+		<relativePath/>
+	</parent>
 
 	<!-- PERUN MODULES -->
 	<modules>
@@ -24,11 +35,11 @@
 		<module>perun-notification</module>
 		<module>perun-dispatcher</module>
 		<module>perun-engine</module>
-		<module>perun-web-gui</module>
 		<module>perun-voot</module>
 		<module>perun-auditer-exporter</module>
 		<module>perun-ldapc-initializer</module>
 		<module>perun-oidc</module>
+		<module>perun-web-gui</module>
 	</modules>
 
 	<!-- common environmental and version properties-->
@@ -48,12 +59,30 @@
 		<perun.ldapc>file:${perun.conf}perun-ldapc.properties</perun.ldapc>
 		<perun.log>/var/log/perun/</perun.log>
 
-		<!-- libraries versions -->
-		<org.springframework.version>3.2.17.RELEASE</org.springframework.version>
-		<junit.version>4.11</junit.version>
-		<log4j.version>1.5.8</log4j.version>
 		<!-- by default we run perun in memory -->
 		<spring.profiles.default>default</spring.profiles.default>
+
+		<!-- redefine versions of some libraries defined by Spring platform -->
+		<postgresql.version>42.0.0</postgresql.version>
+		<tomcat.version>7.0.77</tomcat.version>
+		<hsqldb.version>2.3.2</hsqldb.version> <!-- 2.3.3 fails GroupsManagerEntryIntegrationTest.addAdminWhenAlreadyAdmin test -->
+
+		<!-- versions of libraries not defined by the Spring platform-->
+		<cglib-nodep.version>2.2.2</cglib-nodep.version>
+		<dumbster.version>1.6</dumbster.version>
+		<expiringmap.version>0.4.3</expiringmap.version>
+		<google-api-services-admin-directory.version>directory_v1-rev78-1.22.0</google-api-services-admin-directory.version>
+		<google-client.version>1.22.0</google-client.version>
+		<hornetq.version>2.2.21.Final</hornetq.version>
+		<jboss-jms-api.version>1.1.0.GA</jboss-jms-api.version>
+		<jcip.version>1.0</jcip.version>
+		<jdom.version>1.0</jdom.version>
+		<netty.version>3.2.1.Final</netty.version>
+		<opencsv.version>3.3</opencsv.version>
+		<oracle.version>12.1.0.2.0</oracle.version>
+		<powermock.version>1.4.8</powermock.version>
+		<recaptcha4j.version>0.0.7</recaptcha4j.version>
+		<smack.version>3.1.0</smack.version>
 	</properties>
 
 	<!-- DEFAULT MAVEN BUILD SETTINGS
@@ -79,19 +108,17 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>3.0.0</version>
 				</plugin>
 
 				<!-- mvn compile - compile as Java 8 app in UTF-8 -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.6.1</version>
 					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
+						<source>8</source>
+						<target>8</target>
 						<verbose>false</verbose>
-						<encoding>UTF-8</encoding>
+						<!--<compilerArgument>-Xlint:unchecked,deprecation</compilerArgument>-->
 					</configuration>
 				</plugin>
 
@@ -99,21 +126,18 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-install-plugin</artifactId>
-					<version>2.5.2</version>
 				</plugin>
-
 
 				<!-- mvn javadoc - creates javadoc from source (we do append spring javadoc if found) -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.4</version>
 					<configuration>
 						<!-- disable hard errors when generating javadoc -->
 						<additionalparam>-Xdoclint:none</additionalparam>
 						<detectLinks/>
 						<links>
-							<link>http://static.springsource.org/spring/docs/3.0.x/javadoc-api/</link>
+							<link>http://docs.spring.io/spring/docs/current/javadoc-api/</link>
 						</links>
 					</configuration>
 				</plugin>
@@ -122,35 +146,33 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>3.0.1</version>
 				</plugin>
 
 				<!-- mvn jar:jar - creates final jar -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.0.2</version>
 				</plugin>
 
 				<!-- mvn jar:jar - creates final war -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>3.0.0</version>
 				</plugin>
 
 				<!-- mvn shade - creates shaded jar (1 jar containing e.g. core + spring) -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.0.0</version>
+					<configuration>
+						<createDependencyReducedPom>false</createDependencyReducedPom>
+					</configuration>
 				</plugin>
 
 				<!-- plugin used to apply jUnit tests settings in maven and to generate report (target/surefire-reports)-->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.19.1</version>
 					<configuration>
 						<!-- disable logging for maven's tests / Test in you IDE will log normally -->
 						<argLine>-Dlog4j.configuration=</argLine>
@@ -163,16 +185,20 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.0.0</version>
 				</plugin>
 
 				<!-- Executing plug-in: mvn exec:java -->
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
-					<version>1.5.0</version>
 				</plugin>
 
+				<plugin>
+					<groupId>eu.somatik.serviceloader-maven-plugin</groupId>
+					<artifactId>serviceloader-maven-plugin</artifactId>
+					<version>1.0.7</version>
+				</plugin>
+				
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -197,7 +223,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore/>
 									</action>
 								</pluginExecution>
 								<pluginExecution>
@@ -216,7 +242,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore/>
 									</action>
 								</pluginExecution>
 								<pluginExecution>
@@ -235,7 +261,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore/>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>
@@ -283,149 +309,154 @@
 
 	<!-- DEFAULT MAVEN DEPENDENCY SETTINGS
 
+     - most dependency versions are inherited from platform-bom, specify only those that are not defined by the platform
 	 - child modules inherits settings (e.g. version, scope), not dependency itself
 	 - to explicitly use one of listed dependencies in module just specify groupId and artifactId in it's dependencies section
 	 - child module can override any setting by defining value in child module (or it's profile)
 	 - beware, that default action on dependency configuration is MERGE !!
-	 - if merged values are defined in both (parent and child module), than module value if used
+	 - if merged values are defined in both (parent and child module), than module value is used
 
 	-->
 	<dependencyManagement>
 		<dependencies>
-			<!-- FIXME - needed in compile scope for running in local tomcat (mvn jetty:run on perun-rpc) and tests, so include it  -->
-			<!-- FIXME - production profile overrides it by setting scope to "provided" -->
-			<dependency>
-				<groupId>org.apache.tomcat</groupId>
-				<artifactId>tomcat-dbcp</artifactId>
-				<version>7.0.28</version>
-			</dependency>
 
-			<!-- DBs -->
-			<!-- PostgreSQL driver -->
-			<dependency>
-				<groupId>postgresql</groupId>
-				<artifactId>postgresql</artifactId>
-				<version>9.1-901.jdbc4</version>
-			</dependency>
 			<!-- Oracle jdbc driver -->
 			<dependency>
 				<groupId>com.oracle</groupId>
 				<artifactId>ojdbc7</artifactId>
-				<version>12.1.0.2.0</version>
+				<version>${oracle.version}</version>
 			</dependency>
 			<!-- Oracle internationalization -->
 			<dependency>
 				<groupId>com.oracle</groupId>
 				<artifactId>orai18n</artifactId>
-				<version>12.1.0.2.0</version>
-			</dependency>
-			<!-- SQL Lite -->
-			<dependency>
-				<groupId>org.xerial</groupId>
-				<artifactId>sqlite-jdbc</artifactId>
-				<version>3.7.2</version>
-			</dependency>
-			<!-- Mysql -->
-			<dependency>
-				<groupId>mysql</groupId>
-				<artifactId>mysql-connector-java</artifactId>
-				<version>5.1.31</version>
-			</dependency>
-			<!--HSQL-->
-			<dependency>
-				<groupId>org.hsqldb</groupId>
-				<artifactId>hsqldb</artifactId>
-				<version>2.3.2</version>
-			</dependency>
-
-			<!-- SPRING -->
-
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-context</artifactId>
-				<version>${org.springframework.version}</version>
-				<exclusions>
-					<!-- Exclude Commons Logging in favor of SLF4j -->
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-				</exclusions>
+				<version>${oracle.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-context-support</artifactId>
-				<version>${org.springframework.version}</version>
-				<exclusions>
-					<!-- Exclude Commons Logging in favor of SLF4j -->
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-				</exclusions>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-module-junit4</artifactId>
+				<version>${powermock.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-jdbc</artifactId>
-				<version>${org.springframework.version}</version>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-api-mockito</artifactId>
+				<version>${powermock.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-web</artifactId>
-				<version>${org.springframework.version}</version>
+				<groupId>cglib</groupId>
+				<artifactId>cglib-nodep</artifactId>
+				<version>${cglib-nodep.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-test</artifactId>
-				<version>${org.springframework.version}</version>
-				<scope>test</scope>
-			</dependency>
-
-			<!-- TESTS -->
-
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>${junit.version}</version>
-				<scope>test</scope>
-			</dependency>
-
-			<!-- LOGGING -->
-
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-log4j12</artifactId>
-				<version>${log4j.version}</version>
+				<groupId>net.jcip</groupId>
+				<artifactId>jcip-annotations</artifactId>
+				<version>${jcip.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-api</artifactId>
-				<version>${log4j.version}</version>
-			</dependency>
-
-			<!-- OTHERS -->
-
-			<dependency>
-				<groupId>org.aspectj</groupId>
-				<artifactId>aspectjweaver</artifactId>
-				<version>1.6.9</version>
+				<groupId>com.opencsv</groupId>
+				<artifactId>opencsv</artifactId>
+				<version>${opencsv.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.codehaus.jackson</groupId>
-				<artifactId>jackson-core-asl</artifactId>
-				<version>1.7.4</version>
+				<groupId>com.google.apis</groupId>
+				<artifactId>google-api-services-admin-directory</artifactId>
+				<version>${google-api-services-admin-directory.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.codehaus.jackson</groupId>
-				<artifactId>jackson-mapper-asl</artifactId>
-				<version>1.7.4</version>
+				<groupId>com.google.http-client</groupId>
+				<artifactId>google-http-client-jackson2</artifactId>
+				<version>${google-client.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.google.api-client</groupId>
+				<artifactId>google-api-client</artifactId>
+				<version>${google-client.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>jdom</groupId>
+				<artifactId>jdom</artifactId>
+				<version>${jdom.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>net.jodah</groupId>
+				<artifactId>expiringmap</artifactId>
+				<version>${expiringmap.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>net.tanesha.recaptcha4j</groupId>
+				<artifactId>recaptcha4j</artifactId>
+				<version>${recaptcha4j.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>dumbster</groupId>
+				<artifactId>dumbster</artifactId>
+				<version>${dumbster.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>jivesoftware</groupId>
+				<artifactId>smack</artifactId>
+				<version>${smack.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>jivesoftware</groupId>
+				<artifactId>smackx</artifactId>
+				<version>${smack.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.hornetq</groupId>
+				<artifactId>hornetq-core</artifactId>
+				<version>${hornetq.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.hornetq</groupId>
+				<artifactId>hornetq-jms</artifactId>
+				<version>${hornetq.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.hornetq</groupId>
+				<artifactId>hornetq-logging</artifactId>
+				<version>${hornetq.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.hornetq</groupId>
+				<artifactId>hornetq-core-client</artifactId>
+				<version>${hornetq.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.hornetq</groupId>
+				<artifactId>hornetq-jms-client</artifactId>
+				<version>${hornetq.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.jboss.netty</groupId>
+				<artifactId>netty</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.jboss.javaee</groupId>
+				<artifactId>jboss-jms-api</artifactId>
+				<version>${jboss-jms-api.version}</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
The main pom.xml and most of the modules' pom.xml were modified to use the Spring Platform. All libraries' versions are now either inherited from Spring Platform or defined by properties in the main pom.xml. No more version hell.

This change pushed Spring version to the latest 4.3.7 and versions of many libraries from old obsolete ones to current ones. Three Quartz versions were replaced by a single one. Some code changes were needed to handle some non-backward-compatible changes in libraries.