### PR TITLE
DISPATCHER: Temporary revert back property resolving

### DIFF
--- a/perun-dispatcher/src/main/resources/perun-dispatcher.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher.xml
@@ -120,35 +120,54 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 
 	<!-- Dispatcher properties per-profile -->
 
-	<!-- default values -->
-	<bean id="dispatcherPropertiesBean" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-		<property name="properties">
-			<props>
-				<prop key="perun.principal.name">perunDispatcher</prop>
-				<prop key="perun.principal.extSourceName">INTERNAL</prop>
-				<prop key="perun.principal.extSourceType">cz.metacentrum.perun.core.impl.ExtSourceInternal</prop>
-				<prop key="dispatcher.cron.propagation">45 0/2 * * * ?</prop>
-				<prop key="dispatcher.cron.processpool">0 0/1 * * * ?</prop>
-				<prop key="dispatcher.cron.cleantaskresults">0 0 1 * * ?</prop>
-				<prop key="dispatcher.cron.maintenance">0 0 0/2 * * ?</prop>
-				<prop key="dispatcher.datadir">/tmp/perun-dispatcher-data</prop>
-			</props>
-		</property>
+	<!-- import properties -->
+	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="ignoreUnresolvablePlaceholders" value="true" />
+		<property name="properties" ref="dispatcherPropertiesBean" />
 	</bean>
 
 	<beans profile="devel,production">
-		<context:property-placeholder
-				ignore-resource-not-found="true" ignore-unresolvable="true"
-				properties-ref="dispatcherPropertiesBean"
-				location="file:@perun.conf@perun-dispatcher.properties, file:${perun.conf.custom}perun-dispatcher.properties"
-		/>
+		<bean id="dispatcherPropertiesBean" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+			<property name="locations">
+				<list>
+					<value>file:@{perun.conf@perun-dispatcher.properties</value>
+					<value>file:${perun.conf.custom}perun-dispatcher.properties</value>
+				</list>
+			</property>
+			<property name="ignoreResourceNotFound">
+				<value>true</value>
+			</property>
+			<property name="properties">
+				<props>
+					<!-- we still want properties to have default (backup) in production -->
+					<prop key="perun.principal.name">perunDispatcher</prop>
+					<prop key="perun.principal.extSourceName">INTERNAL</prop>
+					<prop key="perun.principal.extSourceType">cz.metacentrum.perun.core.impl.ExtSourceInternal</prop>
+					<prop key="dispatcher.cron.propagation">45 0/2 * * * ?</prop>
+					<prop key="dispatcher.cron.processpool">0 0/1 * * * ?</prop>
+					<prop key="dispatcher.cron.cleantaskresults">0 0 1 * * ?</prop>
+					<prop key="dispatcher.cron.maintenance">0 0 0/2 * * ?</prop>
+					<prop key="dispatcher.datadir">/tmp/perun-dispatcher-data</prop>
+				</props>
+			</property>
+		</bean>
 	</beans>
 
 	<beans profile="default">
-		<context:property-placeholder
-				ignore-resource-not-found="true" ignore-unresolvable="true"
-				properties-ref="dispatcherPropertiesBean"
-		/>
+		<bean id="dispatcherPropertiesBean" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+			<property name="properties">
+				<props>
+					<prop key="perun.principal.name">perunDispatcher</prop>
+					<prop key="perun.principal.extSourceName">INTERNAL</prop>
+					<prop key="perun.principal.extSourceType">cz.metacentrum.perun.core.impl.ExtSourceInternal</prop>
+					<prop key="dispatcher.cron.propagation">45 0/2 * * * ?</prop>
+					<prop key="dispatcher.cron.processpool">0 0/1 * * * ?</prop>
+					<prop key="dispatcher.cron.cleantaskresults">0 0 1 * * ?</prop>
+					<prop key="dispatcher.cron.maintenance">0 0 0/2 * * ?</prop>
+					<prop key="dispatcher.datadir">/tmp/perun-dispatcher-data</prop>
+				</props>
+			</property>
+		</bean>
 	</beans>
 
 </beans>


### PR DESCRIPTION
Merge or re-use if original spring context solution is not fixed soon and
there will be need to deploy production.

- With current config, devel and production spring profiles ignored properties
   which were stored in a file /etc/perun/perun-dispatcher.properties even if they
   were correctly referenced in location tag. Only properties from xml bean definition
   were visible to application.
- This fix restore previous behavior in properties handling and allows HornetQ server to start.