### PR TITLE
fixed resource filtering in log4j.properties in perun-ldapc module

### DIFF
--- a/perun-ldapc/src/main/resources/log4j.properties
+++ b/perun-ldapc/src/main/resources/log4j.properties
@@ -7,7 +7,7 @@
 
 # Perun log
 log4j.appender.perun_auditparser_log         = org.apache.log4j.RollingFileAppender
-log4j.appender.perun_auditparser_log.File        = ${perun.log}perun-auditparser.log
+log4j.appender.perun_auditparser_log.File        = @perun.log@perun-auditparser.log
 log4j.appender.perun_auditparser_log.MaxFileSize     = 50000KB
 log4j.appender.perun_auditparser_log.MaxBackupIndex      = 50
 log4j.appender.perun_auditparser_log.layout        = org.apache.log4j.PatternLayout
@@ -15,7 +15,7 @@ log4j.appender.perun_auditparser_log.layout.ConversionPattern    = %d %-5p %c - 
 
 # RPC lib
 log4j.appender.perun_rpc_lib_log					= org.apache.log4j.RollingFileAppender
-log4j.appender.perun_rpc_lib_log.File				= ${perun.log}perun-rpc-lib.log
+log4j.appender.perun_rpc_lib_log.File				= @perun.log@perun-rpc-lib.log
 log4j.appender.perun_rpc_lib_log.MaxFileSize			= 30000KB
 log4j.appender.perun_rpc_lib_log.MaxBackupIndex			= 30
 log4j.appender.perun_rpc_lib_log.layout				= org.apache.log4j.PatternLayout
@@ -23,7 +23,7 @@ log4j.appender.perun_rpc_lib_log.layout.ConversionPattern		= %d %-5p %c - %m%n
 
 # RPC lib
 log4j.appender.perun_ldapc_log					= org.apache.log4j.RollingFileAppender
-log4j.appender.perun_ldapc_log.File				= ${perun.log}perun-ldapc.log
+log4j.appender.perun_ldapc_log.File				= @perun.log@perun-ldapc.log
 log4j.appender.perun_ldapc_log.MaxFileSize			= 30000KB
 log4j.appender.perun_ldapc_log.MaxBackupIndex			= 30
 log4j.appender.perun_ldapc_log.layout				= org.apache.log4j.PatternLayout


### PR DESCRIPTION
The file log4j.properties still used the ${perun.log} placeholders instead of @perun.log@, thus resource filtering did not replace them and log file were put into actual working directory instead of /var/log/perun/. Fixed by changing the placeholder delimiters from ${} to @@.
