### PR TITLE
REGISTRAR: Call canBeApproved() check in auto-approval case

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
@@ -61,7 +61,9 @@ public interface RegistrarModule {
 	Application beforeApprove(PerunSession session, Application app) throws PerunException;
 
 	/**
-	 * Custom logic for checking method before application approval from GUI
+	 * Custom logic for checking method before application approval from GUI.
+	 * Also called if application is set to auto-approval mode. In such case,
+	 * if CantBeApprovedException is thrown, approval is stopped.
 	 *
 	 * @param session who approves the application
 	 * @param app application

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2349,6 +2349,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			if (AppState.VERIFIED.equals(app.getState())) {
 				// with registrar session, since only VO admin can approve application
 
+				// check if can be approved (we normally call this manually from GUI before calling approve)
+				canBeApproved(registrarSession, app);
+
 				/*
 
 				FIXME - temporarily disabled checking

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/CeitecNcbr.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/CeitecNcbr.java
@@ -1,0 +1,69 @@
+package cz.metacentrum.perun.registrar.modules;
+
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.registrar.RegistrarManager;
+import cz.metacentrum.perun.registrar.RegistrarModule;
+import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
+import cz.metacentrum.perun.registrar.model.Application;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Module for CEITEC@MUNI and NCBR@MUNI VOs at CESNET instance of Perun.
+ *
+ * The module
+ * 1. Allows (auto)approval of applications with LoA = 2.
+ * 2. Enforce manual approval of applications with LoA = 0, 1.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class CeitecNcbr implements RegistrarModule {
+
+	final static Logger log = LoggerFactory.getLogger(CeitecNcbr.class);
+
+	private RegistrarManager registrar;
+
+	@Override
+	public void setRegistrar(RegistrarManager registrar) {
+		this.registrar = registrar;
+	}
+
+	@Override
+	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
+		return data;
+	}
+
+	@Override
+	public Application approveApplication(PerunSession session, Application app) throws PerunException {
+		return app;
+	}
+
+	@Override
+	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
+		return app;
+	}
+
+	@Override
+	public Application beforeApprove(PerunSession session, Application app) throws PerunException {
+		return app;
+	}
+
+	@Override
+	public void canBeApproved(PerunSession session, Application app) throws PerunException {
+
+		if (app.getExtSourceLoa() == 2) return;
+		throw new CantBeApprovedException("Application can't be approved automatically. LoA is: "+app.getExtSourceLoa()+". Please double check users identity before manual/force approval.", "", "", "", true);
+
+	}
+
+	@Override
+	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
+
+	}
+
+}


### PR DESCRIPTION
- When application form is set to auto-approval, there was missing check
  of attribute module, if application can be approved. It's called manually
  from GUI, if form is in manual approval mode.
- Now, if application can't be auto-approved exception is thrown and mail
  sent to VO manager.