### PR TITLE
Add attribute module for phone in Perun

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_phone.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_phone.java
@@ -15,12 +15,37 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.MemberAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.MemberAttributesModuleImplApi;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * @author Simona Kruppova
  */
 public class urn_perun_member_attribute_def_def_phone extends MemberAttributesModuleAbstract implements MemberAttributesModuleImplApi {
 
 	private static final String A_U_phone = AttributesManager.NS_USER_ATTR_DEF + ":phone";
+	//This regular expression requires international form of phone number starting with '+' without spaces
+	//Due to technical reasons we support only numbers longer than 3 characters and shorter than 17 characters [4,16]
+	//Example of correct number "+420123456789"
+	private static final Pattern pattern = Pattern.compile("^[+][0-9]{4,16}$");
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		String phone = null;
+
+		// null attribute
+		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "User attribute phone cannot be null.");
+
+		// wrong type of the attribute
+		if (!(attribute.getValue() instanceof String)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: String");
+
+		phone = (String) attribute.getValue();
+
+		Matcher matcher = pattern.matcher(phone);
+		if (!matcher.matches()) {
+			throw new WrongAttributeValueException(attribute, "Phone is not in correct format!");
+		}
+	}
 
 	@Override
 	public void changedAttributeHook(PerunSessionImpl session, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_phone.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_phone.java
@@ -1,0 +1,55 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Michal Stava &lt;stavamichal@gmail.com&gt;
+ */
+public class urn_perun_user_attribute_def_def_phone extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
+
+	//This regular expression requires international form of phone number starting with '+' without spaces
+	//Due to technical reasons we support only numbers longer than 3 characters and shorter than 17 characters [4,16]
+	//Example of correct number "+420123456789"
+	private static final Pattern pattern = Pattern.compile("^[+][0-9]{4,16}$");
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		String phone = null;
+
+		// null attribute
+		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "User attribute phone cannot be null.");
+
+		// wrong type of the attribute
+		if (!(attribute.getValue() instanceof String)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: String");
+
+		phone = (String) attribute.getValue();
+
+		Matcher matcher = pattern.matcher(phone);
+		if (!matcher.matches()) {
+			throw new WrongAttributeValueException(attribute, "Phone is not in correct format!");
+		}
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName("phone");
+		attr.setDisplayName("Phone");
+		attr.setType(String.class.getName());
+		attr.setDescription("Phone number provided by IDP.");
+		return attr;
+	}
+}


### PR DESCRIPTION
 - add check to existing member attribute module for phone
 - create a new module for user attribute module for phone
 - only international numbers starting with '+' are correct
 - min length of number is 4 and max 16 (we want to create some
   reasonoble technical limitation)