### PR TITLE
Fix path in script for generating NRPE Commands

### DIFF
--- a/perun-cli/listOfNRPECommands
+++ b/perun-cli/listOfNRPECommands
@@ -13,7 +13,7 @@ my $servicesAgent = $agent->getServicesAgent;
 my $resourcesAgent = $agent->getResourcesAgent;
 
 # CONSTANTS
-my $PERUN_CLI_PATH = '/opt/perun-cli/lib';
+my $PERUN_CLI_PATH = '/opt/perun-cli/bin';
 my $CHECK_COMMAND = 'checkLastTaskResult';
 
 # HELP


### PR DESCRIPTION
 - perun-cli scripts are in directory 'bin' not 'lib'