### PR TITLE
 Refresh of all attributes in setRequiredAttributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1400,15 +1400,15 @@ public interface AttributesManagerBl {
 	void setRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException;
 
 	/**
-	 * Get and set required attributes from arrayList for member, resource, user and facility.
+	 * Take list of required attributes and set those which are empty and can be filled, then check them all.
 	 *
-	 * IMPORTANT: set all attrs from arrayList, set not required attrs too if they are in arrayList
+	 * Important: this method DO NOT set non-empty attributes in list, just refresh their values and check them
 	 *
 	 * Procedure:
-	 * 1] Get all attrs from arrayList
-	 * 2] Fill attributes and store those which were really filled. (value changed)
+	 * 1] Get all attrs from arrayList (they should be required attributes)
+	 * 2] Fill empty attributes and store those which were really filled. (value changed)
 	 * 3] Set filled attributes.
-	 * 4] Refresh value in all virtual attributes.
+	 * 4] Refresh value in all attributes (not only in virtual ones - because of possible change by changeAttributeHook in other filledAttributes)
 	 * 5] Check all attributes and their dependencies.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1694,9 +1694,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//Join all attributes and filled attributes together
 		attributes.addAll(filledAttributes);
 
-		//refresh all virtual attributes with new value
-		for (Attribute attr : attributes) {
-			if (this.isVirtAttribute(sess, attr)) {
+		//refresh all attributes with new value (not just virtual attributes)
+		//Reason: there could be an attribute (def one) which value was set meantime by changeAttributeHook process
+		for(Attribute attr: attributes) {
+			if(!this.isCoreAttribute(sess, attr)) {
 				if (getAttributesManagerImpl().isFromNamespace(attr, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
 					attr.setValue(this.getAttribute(sess, member, resource, attr.getName()).getValue());
 				} else if (getAttributesManagerImpl().isFromNamespace(attr, AttributesManager.NS_USER_FACILITY_ATTR)) {


### PR DESCRIPTION
Problem:
 If some attribute module alters values of other attributes inside
 changedAttributeHook() method and it happens to be non-virtual
 attribute, which is also required by the same service/facility,
 then setRequiredAttributes() method might fail on checkAttributeValue()
 call if you don't allow null value or check itself permits old value.

Solution:
 - we need to refresh all attributes in setRequiredAttributes method,
   not just virtual ones
 - javadoc for this method was changed too (to be more correct)