### PR TITLE
CORE: Use new attribute for phone from DC2 in VŠUP

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_preferredPhone.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_preferredPhone.java
@@ -25,7 +25,7 @@ public class urn_perun_user_attribute_def_virt_preferredPhone extends UserVirtua
 
 		try {
 
-			Attribute sourceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, "urn:perun:user:attribute-def:def:phone");
+			Attribute sourceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, "urn:perun:user:attribute-def:def:phoneDc2");
 			if (sourceAttribute.getValue() != null) {
 				attribute.setValue(sourceAttribute.getValue());
 				return attribute;


### PR DESCRIPTION
- Updated user:virt:preferredPhone attribute module to load
  base work phone from new attribute. Standard phone attribute will
  have more strict rules and can't be used at VŠUP now.