### PR TITLE
replaced 'now' with statement_timestamp() for postgres

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Compatibility.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Compatibility.java
@@ -29,7 +29,7 @@ public class Compatibility {
 			case "oracle":
 				return "sysdate";
 			case "postgresql":
-				return "'now'";
+				return "statement_timestamp()";
 			case "hsqldb":
 				return "current_date";
 			default:


### PR DESCRIPTION
In the Compatibility class, replaced the 'now' string which returns time of transaction start with statement_timestamp() function that returns time of statement execution