### PR TITLE
CORE: Updated module for UCO at VŠUP

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_ucoVsup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_ucoVsup.java
@@ -3,8 +3,14 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
@@ -15,6 +21,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
 
 /**
  * Attribute module for generating unique UČO for every person in VŠUP.
+ * When UCO is set, UserExtSource is added too.
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
@@ -34,6 +41,43 @@ public class urn_perun_user_attribute_def_def_ucoVsup extends UserAttributesModu
 		int uco = Utils.getNewId(sess.getPerunBl().getDatabaseManagerBl().getJdbcPerunTemplate(), "vsup_uco_seq");
 		attr.setValue(uco);
 		return attr;
+
+	}
+
+	/**
+	 * When UCO changes: add UserExtSource, since UCOs are generated in Perun.
+	 *
+	 * @param session
+	 * @param user
+	 * @param attribute
+	 * @throws InternalErrorException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+
+		if (attribute.getValue() != null) {
+
+			// add UES
+			ExtSource es = null;
+
+			try {
+				es = session.getPerunBl().getExtSourcesManagerBl().getExtSourceByName(session, "UCO");
+			} catch (ExtSourceNotExistsException ex) {
+				throw new InternalErrorException("UCO ext source on VŠUP doesn't exists.", ex);
+			}
+			try {
+				session.getPerunBl().getUsersManagerBl().getUserExtSourceByExtLogin(session, es, (String) attribute.getValue());
+			} catch (UserExtSourceNotExistsException ex) {
+				// add UES
+				UserExtSource ues = new UserExtSource(es, 2, (String) attribute.getValue());
+				try {
+					session.getPerunBl().getUsersManagerBl().addUserExtSource(session, user, ues);
+				} catch (UserExtSourceExistsException ex2) {
+					throw new ConsistencyErrorException(ex2);
+				}
+			}
+		}
 
 	}
 


### PR DESCRIPTION
- Add new UCO user ext source every time uco is changed/set.

  We will use this ext source instead of IFIS/IFIST/IFIST2 for backward
  import form services managed by perun (like IFIS). This will prevent false
  user joining when RČ is changed or internal identifier moved between users.