### PR TITLE
CORE: Fixed javadoc for PerunLogbackConfigurator

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/logging/PerunLogbackConfigurator.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/logging/PerunLogbackConfigurator.java
@@ -16,10 +16,10 @@ import java.nio.file.Paths;
  * Configurator for logback logging framework. The loading sequence is as follows:
  * <p>
  * <ol>
- * <li>if <b>logback-test.xml</b> is found in classpath, it is used (this happens only during tests)</li>
  * <li>if <b>-Dlogback.configurationFile=/somedir/logback.xml</b> is set, it is used</li>
+ * <li>if <b>logback-test.xml</b> is found in classpath, it is used (this happens only during tests)</li>
  * <li>if logback.xml is found anywhere on the classpath, it is used (like perun-engine)</li>
- * <li>if system property<b>perun.conf.custom</b> defines a directory wioth logback.xml, it is used</li>
+ * <li>if system property<b>perun.conf.custom</b> defines a directory with logback.xml, it is used</li>
  * <li>if file /etc/perun/logback.xml exists, it is used</li>
  * <li>file logback-default.xml from perun-base is loaded</li>
  * <li>if everything else fails, logback's BasicConfigurator is used</li>

--- a/perun-utils/init.d-scripts/perun-engine.debian
+++ b/perun-utils/init.d-scripts/perun-engine.debian
@@ -25,7 +25,7 @@ JAR=/home/perun/perun-engine/perun-engine-3.0.1-SNAPSHOT-production.jar
 NAME=perun-engine
 SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid
-LOG4J_CONF=/etc/perun/log4j-engine.xml
+LOG_CONF=/etc/perun/logback-engine.xml
 PERUN_ENGINE_CONF_DIR=/etc/perun/
 DAEMON_USER=perun
 JAVA=`which java`
@@ -44,7 +44,7 @@ EXEC_DIR=/home/perun/perun-engine/
 # Read configuration if it is present.
 [ -r /etc/perun/$NAME ] && . /etc/perun/$NAME
 
-DAEMON_OPTS="-Dlog4j.debug -Djava.util.logging.config.file=$LOG4J_CONF -Dlog4j.configuration=file:$LOG4J_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR $JAVA_OPTS -Dspring.profiles.default=production -jar $JAR"
+DAEMON_OPTS="-Dlogback.configurationFile=$LOG_CONF -Dperun.conf.custom=$PERUN_ENGINE_CONF_DIR $JAVA_OPTS -Dspring.profiles.default=production -jar $JAR"
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh


### PR DESCRIPTION
- Fixed order in javadoc of PerunLogbackConfigurator, configuration
  param passed on commandline take precedence every time.
- Updated init.d script for perun-engine to use new logback configuration.

On deployment must be uploaded to perun instance first !