### PR TITLE
removed tomcat7 dependency

### DIFF
--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -104,8 +104,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.tomcat</groupId>
-			<artifactId>tomcat-dbcp</artifactId>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-dbcp2</artifactId>
 		</dependency>
 
 		<!-- SPRING -->
@@ -294,14 +294,6 @@
 				<maven.test.skip>true</maven.test.skip>
 			</properties>
 			<dependencies>
-				<!-- FIXME - re-define "provided" scope, so it won't be in final production jar/war -->
-				<!-- FIXME - it's provided by devel/production tomcat instance -->
-				<dependency>
-					<groupId>org.apache.tomcat</groupId>
-					<artifactId>tomcat-dbcp</artifactId>
-					<scope>provided</scope>
-				</dependency>
-
 				<!-- DBs -->
 
 				<!-- PostgreSQL driver -->

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/DatabaseManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/DatabaseManagerImpl.java
@@ -9,20 +9,17 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.sql.DataSource;
-import org.apache.tomcat.dbcp.dbcp.BasicDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
-import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 
 /**
  * Database manager can work with database version and upgraded state of perun DB.
@@ -53,11 +50,7 @@ public class DatabaseManagerImpl implements DatabaseManagerImplApi {
 		try {
 			Connection con;
 			// for tests
-			if (Compatibility.isHSQLDB()) {
-				con = ((SimpleDriverDataSource) jdbc.getDataSource()).getConnection();
-			} else {
-				con = ((BasicDataSource) jdbc.getDataSource()).getConnection();
-			}
+			con = jdbc.getDataSource().getConnection();
 			String driverVersion = con.getMetaData().getDriverVersion();
 			String driverName = con.getMetaData().getDriverName();
 			con.close();
@@ -71,11 +64,7 @@ public class DatabaseManagerImpl implements DatabaseManagerImplApi {
 		try {
 			Connection con;
 			// for tests
-			if (Compatibility.isHSQLDB()) {
-				con = ((SimpleDriverDataSource) jdbc.getDataSource()).getConnection();
-			} else {
-				con = ((BasicDataSource) jdbc.getDataSource()).getConnection();
-			}
+			con = jdbc.getDataSource().getConnection();
 			String dbName = con.getMetaData().getDatabaseProductName();
 			String dbVersion = con.getMetaData().getDatabaseProductVersion();
 			con.close();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.tomcat.dbcp.dbcp.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.tomcat.dbcp.dbcp.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunBasicDataSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunBasicDataSource.java
@@ -1,9 +1,10 @@
 package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.BeansUtils;
+import org.apache.commons.dbcp2.BasicDataSource;
+
 import java.sql.Connection;
 import java.sql.SQLException;
-import org.apache.tomcat.dbcp.dbcp.BasicDataSource;
 
 /**
  * BasicDataSource used instead of BasicDataSource in Perun to override getConnection.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -4,7 +4,7 @@ import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
 import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.tomcat.dbcp.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -87,13 +87,6 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- DB -->
-
-		<!--<dependency>-->
-			<!--<groupId>commons-dbcp</groupId>-->
-			<!--<artifactId>commons-dbcp</artifactId>-->
-		<!--</dependency>-->
-
 		<!-- TESTS -->
 
 		<dependency>

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -19,6 +19,7 @@
 
 	<properties>
 		<maven.test.skip>true</maven.test.skip>
+		<tomcat7.plugin.tomcat.version>7.0.56</tomcat7.plugin.tomcat.version>
 	</properties>
 
 	<!-- common module build settings used by all profiles -->
@@ -89,88 +90,88 @@
 					<dependency>
 						<groupId>org.apache.tomcat.embed</groupId>
 						<artifactId>tomcat-embed-core</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-util</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-coyote</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-api</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-jdbc</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-dbcp</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-servlet-api</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-jsp-api</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-jasper</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-jasper-el</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-el-api</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-catalina</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-tribes</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-catalina-ha</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-annotations-api</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<!-- tomcat i18n too ?? -->
@@ -179,18 +180,18 @@
 					<dependency>
 						<groupId>org.apache.tomcat</groupId>
 						<artifactId>tomcat-juli</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 					<dependency>
 						<groupId>org.apache.tomcat.embed</groupId>
 						<artifactId>tomcat-embed-logging-juli</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.tomcat.embed</groupId>
 						<artifactId>tomcat-embed-logging-log4j</artifactId>
-						<version>${tomcat.version}</version>
+						<version>${tomcat7.plugin.tomcat.version}</version>
 					</dependency>
 
 				</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
 
 		<!-- redefine versions of some libraries defined by Spring platform -->
 		<postgresql.version>42.0.0</postgresql.version>
-		<tomcat.version>7.0.56</tomcat.version>
 		<hsqldb.version>2.3.2</hsqldb.version> <!-- 2.3.3 fails GroupsManagerEntryIntegrationTest.addAdminWhenAlreadyAdmin test -->
 		<javax-validation.version>1.0.0.GA</javax-validation.version>
 


### PR DESCRIPTION
Just replaced Tomcat DBCP with Commons DBCP (the same code, just repackaged by Tomcat).

The Tomcat DBCP version in Tomcat 7 is repackaged Commons DBCP 1, while in Tomcat 8 it is repackaged Commons DBCP 2. Between Tomcat 7 and 8, the package name has changed, so using classes from Tomcat DBCP caused dependency on a particular version of Tomcat.

By using specifically using Commons DBCP 2, the Perun code is now independent of Tomcat version.