### PR TITLE
CORE: Fix read only connection for SQLite

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import org.apache.commons.codec.binary.Base64;
@@ -35,6 +36,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 	private static final Map<String, String> attributeNameMapping = new HashMap<>();
 	private Connection con;
 	private boolean isOracle = false;
+	private boolean isSQLite = false;
 
 	private static PerunBlImpl perunBl;
 
@@ -122,9 +124,9 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 		}
 
 		try {
-		  // Check if we have existing connection. In case of Oracle also checks the connection validity
-		  if (this.con == null || (this.isOracle && !this.con.isValid(0))) {
-					this.createConnection();
+			// Check if we have existing connection. In case of Oracle also checks the connection validity
+			if (this.con == null || (this.isOracle && !this.con.isValid(0))) {
+				this.createConnection();
 			}
 
 			st = this.con.prepareStatement(query);
@@ -267,25 +269,43 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 	}
 
 	protected void createConnection() throws SQLException, InternalErrorException {
-    try {
-      if (getAttributes().get("user") != null && getAttributes().get("password") != null) {
-        this.con = (new DriverManagerConnectionFactory((String) getAttributes().get("url"),
-            (String) getAttributes().get("user"), (String) getAttributes().get("password"))).createConnection();
-      } else {
-        this.con = (new DriverManagerConnectionFactory((String) getAttributes().get("url"), null)).createConnection();
-      }
+		try {
 
-      // Set connection to read-only mode
-      this.con.setReadOnly(true);
+			String connectionUrl = getAttributes().get("url");
+			String user = getAttributes().get("user");
+			String pass = getAttributes().get("password");
+			Properties connectionProperties = new Properties();
 
-      if (this.con.getMetaData().getDriverName().toLowerCase().contains("oracle")) {
-        this.isOracle = true;
-      }
-    } catch (SQLException e) {
-      log.error("SQL exception during creating the connection to URL", (String) getAttributes().get("url"));
-      throw new InternalErrorRuntimeException(e);
-    }
-  }
+			// set user/pass to properties if present
+			if (user != null && pass != null) {
+				connectionProperties.put("user", user);
+				connectionProperties.put("password", pass);
+			}
+
+			// set connection read_only for SQLite (doesn't follow JDBC standard)
+			if (connectionUrl.startsWith("jdbc:sqlite:")) {
+				isSQLite = true;
+				connectionProperties.put("open_mode","1");
+			}
+
+			// create connection
+			this.con = (new DriverManagerConnectionFactory(connectionUrl, connectionProperties)).createConnection();
+
+			// Set connection to read-only mode for standard JDBC drivers
+			if (!isSQLite) {
+				this.con.setReadOnly(true);
+			}
+
+			if (this.con.getMetaData().getDriverName().toLowerCase().contains("oracle")) {
+				this.isOracle = true;
+				this.isSQLite = false;
+			}
+
+		} catch (SQLException e) {
+			log.error("SQL exception during creating the connection to URL", (String) getAttributes().get("url"));
+			throw new InternalErrorRuntimeException(e);
+		}
+	}
 
 	public void close() throws InternalErrorException {
 		if (this.con != null) {


### PR DESCRIPTION
- SQLite doesn't support standard JDBC interface to set connection
  to read only mode. Hence we check DB type based on connection URL.
  If SQLite, we set connection properties, before creating actual connection.
  Otherwise we use standard API.
- Switch to using DriverManagerConnectionFactory constructor with properties.
- Fix indentation of createConnection() method.