### PR TITLE
replaced maven.test.skip with skipTests to fix production builds

### DIFF
--- a/perun-auditer-exporter/pom.xml
+++ b/perun-auditer-exporter/pom.xml
@@ -153,7 +153,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-auditparser/pom.xml
+++ b/perun-auditparser/pom.xml
@@ -140,7 +140,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -173,7 +173,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests >
 			</properties>
 
 		</profile>

--- a/perun-cabinet/pom.xml
+++ b/perun-cabinet/pom.xml
@@ -157,7 +157,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-controller/pom.xml
+++ b/perun-controller/pom.xml
@@ -138,7 +138,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -292,7 +292,7 @@
 			</activation>
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 			<dependencies>
 				<!-- DBs -->

--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -227,7 +227,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -222,7 +222,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-ldapc-initializer/pom.xml
+++ b/perun-ldapc-initializer/pom.xml
@@ -145,7 +145,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -189,7 +189,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -214,7 +214,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-oidc/pom.xml
+++ b/perun-oidc/pom.xml
@@ -123,7 +123,7 @@
 
             <properties>
                 <perun.build.type>production</perun.build.type>
-                <maven.test.skip>true</maven.test.skip>
+                <skipTests>true</skipTests>
             </properties>
 
         </profile>

--- a/perun-registrar-lib/pom.xml
+++ b/perun-registrar-lib/pom.xml
@@ -156,7 +156,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 		</profile>

--- a/perun-rpc-lib/pom.xml
+++ b/perun-rpc-lib/pom.xml
@@ -126,7 +126,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 			<build>

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -18,7 +18,7 @@
 	<description>RPC interface provided by Perun to communicate with GUI,CLI and any other external system (maven webapp 8081)</description>
 
 	<properties>
-		<maven.test.skip>true</maven.test.skip>
+		<skipTests>true</skipTests>
 		<tomcat7.plugin.tomcat.version>7.0.56</tomcat7.plugin.tomcat.version>
 	</properties>
 
@@ -302,7 +302,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 				<spring.profiles.default>production</spring.profiles.default>
 			</properties>
 

--- a/perun-tasks-lib/pom.xml
+++ b/perun-tasks-lib/pom.xml
@@ -128,7 +128,7 @@
 			</activation>
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 		</profile>
 	</profiles>

--- a/perun-voot/pom.xml
+++ b/perun-voot/pom.xml
@@ -138,7 +138,7 @@
 			</activation>
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 		</profile>
 	</profiles>

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -224,7 +224,7 @@
 
 			<properties>
 				<perun.build.type>production</perun.build.type>
-				<maven.test.skip>true</maven.test.skip>
+				<skipTests>true</skipTests>
 			</properties>
 
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
 		<!-- by default we build devel version of perun and do tests -->
 		<perun.build.type>default</perun.build.type>
-		<maven.test.skip>false</maven.test.skip>
+		<skipTests>false</skipTests>
 
 		<!-- macros @perun.conf@ @perun.jdbc@ etc replaced in all filtered resources in /src/main/resources during maven build-->
 		<perun.conf>/etc/perun/</perun.conf> 


### PR DESCRIPTION
Property maven.test.skip suppresses test compilation, while SkipTests suppresses just test execution. Production build needs to create perun-base-version-tests.jar file used in other modules, so test compilation must not be suppressed. 