### PR TITLE
removed adding lib/ dir to classpath for perun-engine

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -60,7 +60,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.6</version>
 				<executions>
 					<execution>
 						<goals>

--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -57,50 +57,6 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 			</plugin>
 
-			<!-- Package JAR with Main class -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<archive>
-						<index>true</index>
-						<manifest>
-							<mainClass>cz.metacentrum.perun.dispatcher.main.DispatcherStarter</mainClass>
-							<addClasspath>true</addClasspath>
-							<classpathPrefix>lib/</classpathPrefix>
-							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-						</manifest>
-						<manifestEntries>
-							<SplashScreen-Image>perun-dispatcher-splash.png</SplashScreen-Image>
-						</manifestEntries>
-					</archive>
-				</configuration>
-			</plugin>
-
-			<!-- Copy dependencies plug-in -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<configuration>
-					<outputDirectory>
-						target/lib
-					</outputDirectory>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>java</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 
 		<resources>

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -16,6 +16,7 @@
 
 	<name>perun-engine</name>
 	<description>Execution module for Perun propagation sub-system</description>
+	<url>https://perun.cesnet.cz/web/</url>
 
 	<properties>
 		<start-class>cz.metacentrum.perun.engine.main.EngineStarter</start-class>
@@ -58,19 +59,13 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 			</plugin>
 
-			<!-- Package JAR with Main class -->
+			<!-- Prepare META-INF/MANIFEST.MF entries for JAR file -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>
 						<index>true</index>
-						<manifest>
-							<mainClass>cz.metacentrum.perun.engine.main.EngineStarter</mainClass>
-							<addClasspath>true</addClasspath>
-							<classpathPrefix>lib/</classpathPrefix>
-							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-						</manifest>
 						<manifestEntries>
 							<SplashScreen-Image>perun-engine-splash.png</SplashScreen-Image>
 						</manifestEntries>

--- a/perun-engine/src/main/resources/logback.xml
+++ b/perun-engine/src/main/resources/logback.xml
@@ -10,6 +10,7 @@
 
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-engine">
+		<file>${LOGDIR}perun-engine.log</file>
 		<!-- see https://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy -->
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
 			<fileNamePattern>${LOGDIR}perun-engine.log.%d.%i</fileNamePattern>

--- a/pom.xml
+++ b/pom.xml
@@ -463,13 +463,12 @@
 
 	<inceptionYear>2010</inceptionYear>
 
-	<url>http://perun.cesnet.cz/web/</url>
+	<url>https://perun.cesnet.cz/web/</url>
 
 	<scm>
 		<connection>scm:git:https://github.com/CESNET/perun.git</connection>
-		<url>scm:git:https://github.com/CESNET/perun.git</url>
+		<url>https://github.com/CESNET/perun</url>
 		<developerConnection>scm:git:https://github.com/CESNET/perun.git</developerConnection>
-		<tag>HEAD</tag>
 	</scm>
 
 </project>


### PR DESCRIPTION
The shade maven plugin already packs all needed libraries into the resulting jar file, thus there is no need to add lib/ dir to classpath  in jar's manifest file anymore.

Also dispatcher is not packaged as a separate executable jar, so there is no need for jar plugin in its pom.xml.