### PR TITLE
handle multiple values of affiliation

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
@@ -12,10 +12,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
  * All affiliations collected from UserExtSources attributes.
+ * Afilliation is a multi-valued attribute, but Apache joins multiple values using ';',
+ * thus we must split it up here.
  *
  * @author Martin Kuba makub@ics.muni.cz
  */
@@ -36,7 +39,14 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations exten
 				Attribute a = am.getAttribute(sess, userExtSource, "urn:perun:ues:attribute-def:def:affiliation");
 				Object value = a.getValue();
 				if(value!=null && value instanceof String) {
-					values.add(String.valueOf(value));
+					String affiliation = (String) value;
+					if(affiliation.contains(";")) {
+						//multiple values
+						values.addAll(Arrays.asList(affiliation.split(";")));
+					} else {
+						//just one value
+						values.add(affiliation);
+					}
 				}
 			} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
 				log.error("cannot read affiliation from userExtSource "+userExtSource.getId()+" of user "+user.getId(),e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_epuids.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_epuids.java
@@ -27,7 +27,7 @@ public class urn_perun_user_attribute_def_virt_epuids extends UserVirtualAttribu
 	public Attribute getAttributeValue(PerunSessionImpl sess, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
 
 		Attribute attribute = new Attribute(attributeDefinition);
-		List<String> epuids = new ArrayList<>();
+		List<String> values = new ArrayList<>();
 
 		List<UserExtSource> userExtSources = sess.getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
 		AttributesManagerBl am = sess.getPerunBl().getAttributesManagerBl();
@@ -36,13 +36,13 @@ public class urn_perun_user_attribute_def_virt_epuids extends UserVirtualAttribu
 				Attribute a = am.getAttribute(sess, userExtSource, "urn:perun:ues:attribute-def:def:epuid");
 				Object value = a.getValue();
 				if(value!=null && value instanceof String) {
-					epuids.add(String.valueOf(value));
+					values.add((String)value);
 				}
 			} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
 				log.error("cannot read epuid from userExtSource "+userExtSource.getId()+" of user "+user.getId(),e);
 			}
 		}
-		attribute.setValue(epuids);
+		attribute.setValue(values);
 		return attribute;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_schacHomeOrganizations.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_schacHomeOrganizations.java
@@ -36,7 +36,7 @@ public class urn_perun_user_attribute_def_virt_schacHomeOrganizations extends Us
 				Attribute a = am.getAttribute(sess, userExtSource, "urn:perun:ues:attribute-def:def:schacHomeOrganization");
 				Object value = a.getValue();
 				if(value!=null && value instanceof String) {
-					values.add(String.valueOf(value));
+					values.add((String)value);
 				}
 			} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
 				log.error("cannot read schacHomeOrganization from userExtSource "+userExtSource.getId()+" of user "+user.getId(),e);


### PR DESCRIPTION
Afilliation is a multi-valued attribute, but Apache joins multiple values using ';', so they must be split again when collecting all  values.