### PR TITLE
Fix typo for javadoc in RPC

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -574,7 +574,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * Attributes are filtered by rights of user in session. User get only those selected attributes he has rights to read.
 	 *
 	 * @param resource int Resource <code>id</code>
-	 * @param List<String> names of attributes
+	 * @param attrNames List<String> names of attributes
 	 * @return List<RichGroup> groups with attributes
 	 *
 	 */


### PR DESCRIPTION
 - there need to be also name of parameter, not just type and
   description