### PR TITLE
[Perun - Feature #3648] Vytvorit atributovy modul pro urn:perun:resource:attribute-def:def:sshkeysTargetUser

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUser.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUser.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Module for names of target users (to whose accounts are sshkeys stored).
+ *
+ * @author Zdenek Strmiska <zdenek.strm@gmail.com>
+ * @date 27.7.2017
+ */
+
+
+public class urn_perun_resource_attribute_def_def_sshkeysTargetUser {
+
+	Pattern pattern = Pattern.compile("^(?!-)[-_.a-zA-Z0-9]+$");
+
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		String key = (String) attribute.getValue();
+		if (key == null) {
+			throw new WrongAttributeValueException(attribute, resource, "Name of the user can't be empty");
+		}
+
+		Matcher match = pattern.matcher(key);
+
+		if (!match.matches()) {
+			throw new WrongAttributeValueException(attribute, resource, "Bad format of attribute sshkeysTargetUser (only letters, numbers and '.' '_' '-' are allowed. Cannot begin with '-').");
+		}
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("sshkeysTargetUser");
+		attr.setDisplayName("Target user for ssh keys");
+		attr.setType(String.class.getName());
+		attr.setDescription("Target user for ssh keys");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUserTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUserTest.java
@@ -1,0 +1,71 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_sshkeysTargetUserTest {
+
+	private static PerunSessionImpl session;
+	private static urn_perun_resource_attribute_def_def_sshkeysTargetUser classInstance;
+	private static Resource resource;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_resource_attribute_def_def_sshkeysTargetUser();
+		resource = new Resource();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+	}
+
+	@Test
+	public void testCheckAttributeValue() throws Exception {
+		System.out.println("testCheckAttributeValue()");
+
+		Attribute attributeToCheck = new Attribute();
+
+		attributeToCheck.setValue("Jan_Nepomucky");
+		classInstance.checkAttributeValue(session, resource, attributeToCheck);
+
+		attributeToCheck.setValue(".John_Dale.");
+		classInstance.checkAttributeValue(session, resource, attributeToCheck);
+
+		attributeToCheck.setValue("_Adele-Frank");
+		classInstance.checkAttributeValue(session, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeValueWithWrongValueHyphen() throws Exception {
+		System.out.println("testCheckAttributeValueWithWrongValueHyphen()");
+
+		Attribute attributeToCheck = new Attribute();
+
+		attributeToCheck.setValue("-Adam");
+		classInstance.checkAttributeValue(session, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeValueWithWrongValueWhitespace() throws Exception {
+		System.out.println("testCheckAttributeValueWithWrongValueWhitespace()");
+
+		Attribute attributeToCheck = new Attribute();
+
+		attributeToCheck.setValue("Elena Fuente");
+		classInstance.checkAttributeValue(session, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeValueWithWrongValueDiacritic() throws Exception {
+		System.out.println("testCheckAttributeValueWithWrongValueDiacritic()");
+
+		Attribute attributeToCheck = new Attribute();
+
+		attributeToCheck.setValue("Jan_Veselý");
+		classInstance.checkAttributeValue(session, resource, attributeToCheck);
+	}
+}


### PR DESCRIPTION
Attribute module for urn: perun: resource: attribute-def: def: sshkeysTargetUser.

The module checks that the attribute is not empty and also checks the syntax. Allowed characters are: letters, numbers, hyphens, underlines, and numbers. Value cannot begin with a dash.