### PR TITLE
Cleaned 3.1.44 DB changelog to meet our standard

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1338,8 +1338,8 @@ create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
 create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
 create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (user_ext_source_id);
 create index idx_fk_ues_attr_values_attr on user_ext_source_attr_values (attr_id);
-CREATE INDEX idx_members_sponsored_sponsor ON members_sponsored(sponsor_id);
-CREATE INDEX idx_members_sponsored_sponsored ON members_sponsored(sponsored_id);
+create index idx_fk_memspons_mem ON members_sponsored(sponsored_id);
+create index idx_fk_memspons_usr ON members_sponsored(sponsor_id);
 
 
 alter table auditer_log add constraint audlog_pk primary key (id);
@@ -1683,5 +1683,5 @@ alter table user_ext_source_attr_values add constraint uesattrval_pk primary key
 alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (user_ext_source_id) references user_ext_sources(id);
 alter table user_ext_source_attr_values add constraint uesattrval_attr_fk foreign key (attr_id) references attr_names(id);
 
-alter table members_sponsored add constraint members_sponsored_fk1 foreign key (sponsored_id) references members(id);
-alter table members_sponsored add constraint members_sponsored_fk2 foreign key (sponsor_id) references users(id);
+alter table members_sponsored add constraint memspons_mem_fk foreign key (sponsored_id) references members(id);
+alter table members_sponsored add constraint memspons_usr_fk foreign key (sponsor_id) references users(id);

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -7,10 +7,10 @@
 
 3.1.44
 CREATE TABLE members_sponsored (active char(1) default '1' not null, sponsored_id INTEGER NOT NULL, sponsor_id INTEGER NOT NULL,created_at timestamp default now not null, created_by varchar(1300) default user not null,created_by_uid integer,modified_at timestamp default now not null, modified_by varchar(1300) default user not null, modified_by_uid integer);
-CREATE INDEX ON members_sponsored(sponsor_id);
-CREATE INDEX ON members_sponsored(sponsored_id);
-alter table members_sponsored add constraint members_sponsored_fk1 foreign key (sponsored_id) references members(id);
-alter table members_sponsored add constraint members_sponsored_fk2 foreign key (sponsor_id) references users(id);
+create index idx_fk_memspons_mem ON members_sponsored(sponsored_id);
+create index idx_fk_memspons_usr ON members_sponsored(sponsor_id);
+alter table members_sponsored add constraint memspons_mem_fk foreign key (sponsored_id) references members(id);
+alter table members_sponsored add constraint memspons_usr_fk foreign key (sponsor_id) references users(id);
 ALTER TABLE members ADD COLUMN sponsored BOOLEAN DEFAULT FALSE NOT NULL;
 update configurations set value='3.1.44' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -4,9 +4,10 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 3.1.44
-CREATE TABLE members_sponsored (active char(1) default '1' not null,sponsored_id INTEGER NOT NULL REFERENCES members(id),sponsor_id INTEGER NOT NULL REFERENCES users(id),created_at date default sysdate not null,created_by nvarchar2(1300) default user not null,created_by_uid integer,modified_at date default sysdate not null,modified_by nvarchar2(1300) default user not null,modified_by_uid integer);
-CREATE INDEX ON members_sponsored(sponsor_id);
-CREATE INDEX ON members_sponsored(sponsored_id);
+CREATE TABLE members_sponsored (active char(1) default '1' not null,sponsored_id INTEGER NOT NULL,sponsor_id INTEGER NOT NULL,created_at date default sysdate not null,created_by nvarchar2(1300) default user not null,created_by_uid integer,modified_at date default sysdate not null,modified_by nvarchar2(1300) default user not null,modified_by_uid integer);
+alter table members_sponsored add ( constraint MEMSPONS_MEM_FK foreign key (sponsored_id) references members(id), constraint MEMSPONS_USR_FK foreign key (sponsor_id) references users(id));
+create index IDX_FK_MEMSPONS_USR ON members_sponsored(sponsor_id);
+create index IDX_FK_MEMSPONS_MEM ON members_sponsored(sponsored_id);
 alter table members add column sponsored char(1) default '0' not null;
 update configurations set value='3.1.44' where property='DATABASE VERSION';
 

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -4,9 +4,11 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 3.1.44
-CREATE TABLE members_sponsored (active char(1) default '1' not null, sponsored_id INTEGER NOT NULL REFERENCES members(id), sponsor_id INTEGER NOT NULL REFERENCES users(id),created_at timestamp default now() not null, created_by varchar(1024) default user not null,created_by_uid integer,modified_at timestamp default now() not null, modified_by varchar(1024) default user not null, modified_by_uid integer);
-CREATE INDEX ON members_sponsored(sponsor_id);
-CREATE INDEX ON members_sponsored(sponsored_id);
+CREATE TABLE members_sponsored (active char(1) default '1' not null, sponsored_id INTEGER NOT NULL, sponsor_id INTEGER NOT NULL,created_at timestamp default now() not null, created_by varchar(1024) default user not null,created_by_uid integer,modified_at timestamp default now() not null, modified_by varchar(1024) default user not null, modified_by_uid integer);
+alter table members_sponsored add constraint memspons_mem_fk foreign key (sponsored_id) references members(id);
+alter table members_sponsored add constraint memspons_usr_fk foreign key (sponsor_id) references users(id);
+create index idx_fk_memspons_mem ON members_sponsored(sponsored_id);
+create index idx_fk_memspons_usr ON members_sponsored(sponsor_id);
 ALTER TABLE members ADD COLUMN sponsored BOOLEAN DEFAULT FALSE NOT NULL;
 update configurations set value='3.1.44' where property='DATABASE VERSION';
 

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.43 (don't forget to update insert statement at the end of file)
+-- database version 3.1.44 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1136,8 +1136,8 @@ create table user_ext_source_attr_values (
 
 CREATE TABLE members_sponsored (
 	active char(1) default '1' not null,
-	sponsored_id INTEGER NOT NULL REFERENCES members(id),
-	sponsor_id INTEGER NOT NULL REFERENCES users(id),
+	sponsored_id INTEGER NOT NULL,
+	sponsor_id INTEGER NOT NULL,
 	created_at date default sysdate not null,
 	created_by nvarchar2(1300) default user not null,
 	created_by_uid integer,
@@ -1337,8 +1337,8 @@ create index IDX_FK_FAC_BAN_USER on facilities_bans (user_id);
 create index IDX_FK_FAC_BAN_FAC on facilities_bans (facility_id);
 create index IDX_FK_UES_ATTR_VALUES_UES on user_ext_source_attr_values (user_ext_source_id);
 create index IDX_FK_UES_ATTR_VALUES_ATTR on user_ext_source_attr_values (attr_id);
-CREATE INDEX idx_members_sponsored_sponsor ON members_sponsored(sponsor_id);
-CREATE INDEX idx_members_sponsored_sponsored ON members_sponsored(sponsored_id);
+create index IDX_FK_MEMSPONS_USR ON members_sponsored(sponsor_id);
+create index IDX_FK_MEMSPONS_MEM ON members_sponsored(sponsored_id);
 
 alter table auditer_log add (constraint AUDLOG_PK primary key (id));
 alter table auditer_consumers add (constraint AUDCON_PK primary key (id),
@@ -1817,8 +1817,13 @@ constraint UESATTRVAL_UES_FK foreign key (user_ext_source_id) references user_ex
 constraint UESATTRVAL_ATTR_FK foreign key (attr_id) references attr_names(id)
 );
 
+alter table members_sponsored add (
+	constraint MEMSPONS_MEM_FK foreign key (sponsored_id) references members(id),
+	constraint MEMSPONS_USR_FK foreign key (sponsor_id) references users(id)
+);
+
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.43');
+insert into configurations values ('DATABASE VERSION','3.1.44');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.43 (don't forget to update insert statement at the end of file)
+-- database version 3.1.44 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table "vos" (
@@ -1217,8 +1217,8 @@ create table "user_ext_source_attr_values" (
 
 CREATE TABLE members_sponsored (
 	active char(1) default '1' not null,
-	sponsored_id INTEGER NOT NULL REFERENCES members(id),
-	sponsor_id INTEGER NOT NULL REFERENCES users(id),
+	sponsored_id INTEGER NOT NULL,
+	sponsor_id INTEGER NOT NULL,
 	created_at timestamp default now() not null,
 	created_by varchar(1024) default user not null,
 	created_by_uid integer,
@@ -1425,8 +1425,8 @@ create index idx_fk_fac_ban_fac on facilities_bans (facility_id);
 create index idx_fk_fac_ban_user_fac on facilities_bans (user_id, facility_id);
 create index idx_fk_ues_attr_values_ues on user_ext_source_attr_values (user_ext_source_id);
 create index idx_fk_ues_attr_values_attr on user_ext_source_attr_values (attr_id);
-CREATE INDEX idx_members_sponsored_sponsor ON members_sponsored(sponsor_id);
-CREATE INDEX idx_members_sponsored_sponsored ON members_sponsored(sponsored_id);
+create index idx_fk_memspons_mem ON members_sponsored(sponsored_id);
+create index idx_fk_memspons_usr ON members_sponsored(sponsor_id);
 
 alter table auditer_log add constraint audlog_pk primary key (id);
 
@@ -1769,6 +1769,9 @@ alter table user_ext_source_attr_values add constraint uesattrval_pk primary key
 alter table user_ext_source_attr_values add constraint uesattrval_ues_fk foreign key (user_ext_source_id) references user_ext_sources(id);
 alter table user_ext_source_attr_values add constraint uesattrval_attr_fk foreign key (attr_id) references attr_names(id);
 
+alter table members_sponsored add constraint memspons_mem_fk foreign key (sponsored_id) references members(id);
+alter table members_sponsored add constraint memspons_usr_fk foreign key (sponsor_id) references users(id);
+
 grant all on users to perun;
 grant all on vos to perun;
 grant all on ext_sources to perun;
@@ -1862,6 +1865,7 @@ grant all on resources_bans to perun;
 grant all on facilities_bans to perun;
 grant all on membership_types to perun;
 grant all on user_ext_source_attr_values to perun;
+grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
 insert into configurations values ('DATABASE VERSION','3.1.44');

--- a/perun-db/table_order
+++ b/perun-db/table_order
@@ -13,6 +13,7 @@ facility_owners
 groups
 facility_contacts
 members
+members_sponsored
 routing_rules
 dispatcher_settings
 engines


### PR DESCRIPTION
- Use specific names for indexes and constraints.
- Added far-key constraint after table creation.
- Table members_sponsored added to table_order file.