### PR TITLE
Retrieve also member_group attributes from getDataWithGroups()

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2070,9 +2070,9 @@ public interface AttributesManagerBl {
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException;
 
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException;
 
 	/**
 	 * Get memner, user, member-resource, user-facility attributes which are required by the service.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2359,12 +2359,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws InternalErrorException {
 		return getAttributesManagerImpl().getRequiredAttributes(sess, service, member, group);
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException {
 		if(!workWithUserAttributes) return getAttributesManagerImpl().getRequiredAttributes(sess, service, member, group);
 
 		User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -2052,7 +2052,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		return result;
 	}
 
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Group group) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -2267,7 +2267,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		try {
 			return jdbc.query("select " + getAttributeMappingSelectQuery("mem_gr") + " from attr_names " +
 							"join service_required_attrs on id=service_required_attrs.attr_id and service_required_attrs.service_id=? " +
-							"left join member_group_attr_values mem_gr on id=mem.attr_id and mem_gr.group_id=? and member_id=? " +
+							"left join member_group_attr_values mem_gr on id=mem_gr.attr_id and mem_gr.group_id=? and member_id=? " +
 							"where namespace in (?,?,?)",
 					new AttributeRowMapper(sess, this, member), service.getId(), group.getId(), member.getId(), AttributesManager.NS_MEMBER_GROUP_ATTR_DEF, AttributesManager.NS_MEMBER_GROUP_ATTR_OPT, AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
 		} catch(RuntimeException ex) {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -240,10 +240,10 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *         Group second chi is abstract structure which children are members.
 	 <pre>
 	 Facility
-	 +---Attrs                              ...................................................
-	 +---ChildNodes                         |                                                 .
+	 +---Attrs                       ...................................................
+	 +---ChildNodes                  |                                                 .
 	 +------Resource                 |                                                 .
-	 |       +---Attrs
+	 |       +---Attrs               |                                                 .
 	 |       +---ChildNodes          |                                                 .
 	 |              +------()        V                                                 .
 	 |              |       +------Group                                               .
@@ -318,7 +318,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
-	 * @return attributes in special structure. 
+	 * @return attributes in special structure.
 	 *        Facility is in the root, facility children are vos.
 	 *        Vo first child is abstract structure which children are resources.
 	 *        Resource first child is abstract structure which children are groups.
@@ -327,12 +327,12 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *        Group second chi is abstract structure which children are members.
 	 <pre>
 	 Facility
-	 +---Attrs                              
-	 +---ChildNodes               
-	        +-----Vo 
+	 +---Attrs
+	 +---ChildNodes
+	        +-----Vo
 	        |      +---Attrs
 	        |      +---ChildNodes
-	        |             +-------Resource                                                               
+	        |             +-------Resource
 	        |             |       +---Attrs               |-------------------------------------------------.
 	        |             |       +---ChildNodes          |                                                 .
 	        |             |              +------()        V                                                 .


### PR DESCRIPTION
- Add also member_group attribute to services export in getDataWithGroups()
  method. They are available only when getting member from a group and not
  getting member from resource in generated structure.
- Removed unused exception from method signature, updated javadoc.
- Whitespace changes.
- Fixed SQL in member_group required attributes retrieval.