### PR TITLE
rerun GEN tasks if data are modified before it (or the SEND) finishes

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/PropagationMaintainerImpl.java
@@ -549,14 +549,11 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 			schedulingPool.setTaskStatus(completedTask, TaskStatus.DONE);
 			completedTask.setRecurrence(0);
 			log.debug("TASK {} reported as DONE", completedTask.toString());
-			// for GEN tasks, signal SENDs that source data are updated
+			// for forced and completed GEN tasks, schedule SENDs immediately
 			if(completedTask.getExecService().getExecServiceType().equals(ExecServiceType.GENERATE)) {
 				List<ExecService> dependantServices = dependenciesResolver.listDependantServices(completedTask.getExecService());
 				for (ExecService dependantService : dependantServices) {
 					Task dependantTask = schedulingPool.getTask(dependantService, completedTask.getFacility());
-					if (dependantTask != null && dependantService.getExecServiceType().equals(ExecServiceType.SEND)) {
-						dependantTask.setSourceUpdated(false);
-					}
 					if(completedTask.isPropagationForced() && dependantTask.isPropagationForced()) {
 						log.debug("Going to force schedule dependant task " + dependantTask.getId());
 						taskScheduler.scheduleTask(dependantTask);

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
@@ -476,6 +476,14 @@ public class TaskSchedulerImpl implements TaskScheduler {
 						+ "] facility [" + facility.getId() + "] as PLANNED.");
 				task.setSchedule(time);
 				schedulingPool.setTaskStatus(task, TaskStatus.PLANNED);
+				// we are going to run the GEN task, so reset the source updated flag to
+				// allow rerunning the GEN when data changes before the GEN is complete
+				for (ExecService dependantService : dependantServices) {
+					Task dependantServiceTask = schedulingPool.getTask(dependantService, facility);
+					if (dependantServiceTask != null && dependantServiceTask.isSourceUpdated()) {
+						dependantServiceTask.setSourceUpdated(false);
+					}
+				}
 				sendToEngine(task);
 				// manipulateTasks(execService, facility, task);
 			} else {


### PR DESCRIPTION
This patch moves the code resetting the sourceUpdated task flag from after the GEN task is completed
to before the GEN task is sent to engine. The SEND task has already been scheduled, so it is safe to reset the flag earlier nad be ready when new data arrives.