### PR TITLE
Created attribute module for apacheAuthzFile attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFile.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFile.java
@@ -1,0 +1,51 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Attribute module for apacheAuthzFile attribute. Module checks that
+ * attribute is not empty and it also contains unix-like file path.
+ *
+ * @author Vladimir Mecko vladimir.mecko@gmail.com
+ */
+public class urn_perun_resource_attribute_def_def_apacheAuthzFile extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+	private Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		if (attribute.getValue() == null) {
+			throw new WrongAttributeValueException(attribute, resource, null, "Attribute value can not be null.");
+		}
+
+		//checks for valid unix file path in attribute based on pattern
+		Matcher match = pattern.matcher((String) attribute.getValue());
+
+		if(!match.matches()) {
+			throw new WrongAttributeValueException(attribute, resource, null, "Wrong file path format in attribute (should be like '/dir1/dir2').");
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("apacheAuthzFile");
+		attr.setDisplayName("Apache authz file");
+		attr.setType(String.class.getName());
+		attr.setDescription("File containing authz entries for Apache.");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFileTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFileTest.java
@@ -1,0 +1,47 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Vladimir Mecko vladimir.mecko@gmail.com
+ */
+public class urn_perun_resource_attribute_def_def_apacheAuthzFileTest {
+	private static urn_perun_resource_attribute_def_def_apacheAuthzFile authzFileAttr;
+	private static PerunSessionImpl ps;
+
+	@Before
+	public void setUp() {
+		authzFileAttr = new urn_perun_resource_attribute_def_def_apacheAuthzFile();
+		ps = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void checkAttributeWithoutValue() throws Exception {
+		System.out.println("checkAttributeWithoutValue()");
+		authzFileAttr.checkAttributeValue(ps, new Resource(), new Attribute());
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void checkAttributeWithWrongSlashInFilePath() throws Exception {
+		System.out.println("checkAttributeWithWrongValue()");
+		final Attribute attr = new Attribute();
+		attr.setValue("bad/file/path");
+		authzFileAttr.checkAttributeValue(ps, new Resource(), attr);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void checkAttributeWithNoSlashInFilePath() throws Exception {
+		System.out.println("checkAttributeWithNoSlashInFilePath()");
+		final Attribute attr = new Attribute();
+		attr.setValue("pathToFile");
+		authzFileAttr.checkAttributeValue(ps, new Resource(), attr);
+	}
+}


### PR DESCRIPTION
Created attribute module with tests. Tests are aimed mostly on correctly filled unix-like file path in attribute.

This is the continuation of the pull request #1579 .

I tried to amend changed indents to previous commit but I failed and it messed up my commits completely. Sorry for trouble!

This pull request is fix for all things mentioned in pull request 1579:
1) files now have good intends.
2) urn_perun_resource_attribute_def_def_apacheAuthzFile now has brief JavaDoc overview.
3) variable 'pattern' in urn_..._apacheAuthzFile is now part of class rather than just a local variable of
checkAttributeValue method.

V. Mečko