### PR TITLE
CORE,RPC,GUI: Manage also member-group attributes from GUI

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/MemberGroupMismatchException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/MemberGroupMismatchException.java
@@ -1,0 +1,25 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * Member and Group are not in the same VO
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class MemberGroupMismatchException extends PerunException {
+
+	public MemberGroupMismatchException(Throwable cause) {
+		super(cause);
+	}
+
+	public MemberGroupMismatchException(String message, Throwable cause) {
+		super(message,cause);
+	}
+
+	public MemberGroupMismatchException(String message) {
+		super(message);
+	}
+
+	public MemberGroupMismatchException() {
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -847,6 +847,32 @@ public interface AttributesManager {
 	void setAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
+	 * Store the member, user, member-group, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 *
+	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
+	 *
+	 * @param sess perun session
+	 * @param facility facility to set on
+	 * @param resource resource to set on
+	 * @param group group to set on
+	 * @param user user to set on
+	 * @param member member to set on
+	 * @param attributes Attributes to be stored
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws ResourceNotExistsException if the resource doesn't exists in the underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in the underlying data source
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
+	 * @throws UserNotExistsException
+	 * @throws FacilityNotExistsException
+	 * @throws GroupNotExistsException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException;
+
+	/**
 	 * Store the attributes associated with the resource. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
 	 *
 	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
@@ -2086,6 +2112,33 @@ public interface AttributesManager {
 	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group, boolean workWithGroupAttributes) throws WrongAttributeAssignmentException, PrivilegeException, InternalErrorException, ConsistencyErrorException, ResourceNotExistsException, GroupNotExistsException, GroupResourceMismatchException;
 
 	/**
+	 * Get member-group and member-resource attributes required by the services specified on resource
+	 * Get user, member, user-facility attributes, if workWithUserAttributes is true.
+	 *
+	 * PRIVILEGE: Get only those required attributes principal has access to.
+	 *
+	 * @param sess
+	 * @param resourceToGetServicesFrom getRequired attributes from services which are assigned on this resource
+	 * @param resource
+	 * @param group
+	 * @param member
+	 * @param workWithUserAttributes if true, get also user required attributes
+	 *
+	 * @return List of required attributes (member-group, member-resource). Return also user, member, user-facility attributes, if workWithUserAttributes is true.
+	 *
+	 * @throws PrivilegeException
+	 * @throws InternalErrorException
+	 * @throws ConsistencyErrorException
+	 * @throws ResourceNotExistsException
+	 * @throws MemberNotExistsException
+	 * @throws GroupNotExistsException
+	 * @throws GroupResourceMismatchException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws MemberGroupMismatchException
+	 */
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws WrongAttributeAssignmentException, PrivilegeException, InternalErrorException, ConsistencyErrorException, ResourceNotExistsException, GroupNotExistsException, GroupResourceMismatchException, MemberNotExistsException, MemberGroupMismatchException, UserNotExistsException, FacilityNotExistsException;
+
+	/**
 	 * Get member-resource attributes which are required by services which are relater to this member-resource.
 	 *
 	 * PRIVILEGE: Get only those required attributes principal has access to.
@@ -2158,6 +2211,24 @@ public interface AttributesManager {
 	 * @throws MemberNotExistsException
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException;
+
+	/**
+	 * Get member, member-group attributes which are required by services which are relater to this member.
+	 * If workWithUserAttributes = true, then user attributes are returned too.
+	 *
+	 * PRIVILEGE: Get only those required attributes principal has access to.
+	 *
+	 * @param sess perun session
+	 * @param member you get attributes for this member
+	 * @param workWithUserAttributes if TRUE, return also member and user attributes
+	 * @return list of member, member-group and user attributes which are required by services which are related to this member
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws MemberNotExistsException
+	 * @throws GroupNotExistsException
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get user attributes which are required by services which are relater to this user.
@@ -2318,6 +2389,33 @@ public interface AttributesManager {
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException;
+
+	/**
+	 * Get member, member-resource and member-group attributes required by the specified service.
+	 * if workWithUserAttributes == TRUE return also user and user-facility attributes
+	 *
+	 * PRIVILEGE: Get only those required attributes principal has access to.
+	 *
+	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
+	 *
+	 * @param sess perun session
+	 * @param resource you get attributes for this resource and the member and group
+	 * @param group you get attributes for this group and resource and member
+	 * @param member you get attributes for this member and the resource and group
+	 * @param service attributes required by this services you'll get
+	 * @param workWithUserAttributes if TRUE return also user and user-facility attributes
+	 * @return list of attributes which are required by the service.
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws ResourceNotExistsException if the resource doesn't exists in underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in underlying data source
+	 * @throws ServiceNotExistsException if the service doesn't exists in underlying data source
+	 * @throws MemberNotExistsException if the member doesn't have access to this resource
+	 * @throws GroupNotExistsException if the group doesn't exists in underlying data source
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException;
 
 	/**
 	 * Get member-resource, member, user-facility and user attributes which are required by service for each member in list of members.
@@ -3453,6 +3551,31 @@ public interface AttributesManager {
 	 */
 	void removeAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
+	/**
+	 * Unset the member, user, member-group, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't unset (It's skipped without any notification).
+	 *
+	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
+	 *
+	 * @param sess perun session
+	 * @param facility
+	 * @param resource resource to set on
+	 * @param group
+	 * @param user
+	 * @param member member to set on
+	 * @param attributes
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws PrivilegeException if privileges are not given
+	 * @throws ResourceNotExistsException if the resource doesn't exists in the underlying data source
+	 * @throws MemberNotExistsException if the member doesn't exists in the underlying data source
+	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource, user, member or user-facility attribute
+	 * @throws UserNotExistsException
+	 * @throws GroupNotExistsException
+	 * @throws FacilityNotExistsException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException;
 
 	/**
 	 * Unset all attributes for the resource.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -847,9 +847,12 @@ public interface AttributesManager {
 	void setAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
-	 * Store the member, user, member-group, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 * Store the member, user, member-group, member-resource and user-facility attributes.
+	 * If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
 	 *
 	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
+	 *
+	 * Group and group-resource attributes are not supported in this context.
 	 *
 	 * @param sess perun session
 	 * @param facility facility to set on
@@ -858,13 +861,13 @@ public interface AttributesManager {
 	 * @param user user to set on
 	 * @param member member to set on
 	 * @param attributes Attributes to be stored
-	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws InternalErrorException if an exception raise in concrete implementation
 	 * @throws PrivilegeException if privileges are not given
 	 * @throws ResourceNotExistsException if the resource doesn't exists in the underlying data source
 	 * @throws MemberNotExistsException if the member doesn't exists in the underlying data source
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlying data source
 	 * @throws WrongAttributeValueException if the attribute value is illegal
-	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
+	 * @throws WrongAttributeAssignmentException if attribute is not one of user, member, user-facility, member-group, member-resource
 	 * @throws UserNotExistsException
 	 * @throws FacilityNotExistsException
 	 * @throws GroupNotExistsException
@@ -2107,22 +2110,23 @@ public interface AttributesManager {
 	 * @throws GroupNotExistsException
 	 * @throws GroupResourceMismatchException
 	 * @throws WrongAttributeAssignmentException
-	 *
 	 */
 	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group, boolean workWithGroupAttributes) throws WrongAttributeAssignmentException, PrivilegeException, InternalErrorException, ConsistencyErrorException, ResourceNotExistsException, GroupNotExistsException, GroupResourceMismatchException;
 
 	/**
 	 * Get member-group and member-resource attributes required by the services specified on resource
-	 * Get user, member, user-facility attributes, if workWithUserAttributes is true.
+	 * Get also user, member, user-facility attributes, if workWithUserAttributes is true.
 	 *
 	 * PRIVILEGE: Get only those required attributes principal has access to.
+	 *
+	 * Group and group-resource attributes are not supported in this context !!
 	 *
 	 * @param sess
 	 * @param resourceToGetServicesFrom getRequired attributes from services which are assigned on this resource
 	 * @param resource
 	 * @param group
 	 * @param member
-	 * @param workWithUserAttributes if true, get also user required attributes
+	 * @param workWithUserAttributes if true, get also user, member and user-facility required attributes
 	 *
 	 * @return List of required attributes (member-group, member-resource). Return also user, member, user-facility attributes, if workWithUserAttributes is true.
 	 *
@@ -2220,8 +2224,9 @@ public interface AttributesManager {
 	 *
 	 * @param sess perun session
 	 * @param member you get attributes for this member
-	 * @param workWithUserAttributes if TRUE, return also member and user attributes
-	 * @return list of member, member-group and user attributes which are required by services which are related to this member
+	 * @param group you get attributes for this group
+	 * @param workWithUserAttributes if TRUE, return also user attributes
+	 * @return list of member, member-group and optionally user attributes which are required by services which are related to this member
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException if privileges are not given
@@ -2398,11 +2403,13 @@ public interface AttributesManager {
 	 *
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 *
+	 * Group and group-resource attributes are not supported in this context !!
+	 *
 	 * @param sess perun session
 	 * @param resource you get attributes for this resource and the member and group
 	 * @param group you get attributes for this group and resource and member
 	 * @param member you get attributes for this member and the resource and group
-	 * @param service attributes required by this services you'll get
+	 * @param service you'll get attributes required by this service
 	 * @param workWithUserAttributes if TRUE return also user and user-facility attributes
 	 * @return list of attributes which are required by the service.
 	 *
@@ -3552,9 +3559,12 @@ public interface AttributesManager {
 	void removeAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
-	 * Unset the member, user, member-group, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't unset (It's skipped without any notification).
+	 * Unset the member, user, member-group, member-resource and user-facility attributes.
+	 * If an attribute is core attribute then the attribute isn't unset (It's skipped without any notification).
 	 *
-	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
+	 * PRIVILEGE: Remove attributes only when principal has write access on all of them.
+	 *
+	 * Group and group-resource attributes are not supported in this context !!
 	 *
 	 * @param sess perun session
 	 * @param facility

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -873,7 +873,7 @@ public interface AttributesManager {
 	 * @throws GroupNotExistsException
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException;
+	void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException;
 
 	/**
 	 * Store the attributes associated with the resource. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -2140,7 +2140,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws MemberGroupMismatchException
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws WrongAttributeAssignmentException, PrivilegeException, InternalErrorException, ConsistencyErrorException, ResourceNotExistsException, GroupNotExistsException, GroupResourceMismatchException, MemberNotExistsException, MemberGroupMismatchException, UserNotExistsException, FacilityNotExistsException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws WrongAttributeAssignmentException, PrivilegeException, InternalErrorException, ConsistencyErrorException, ResourceNotExistsException, GroupNotExistsException, GroupResourceMismatchException, MemberNotExistsException, MemberGroupMismatchException, UserNotExistsException, FacilityNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * Get member-resource attributes which are required by services which are relater to this member-resource.
@@ -2422,7 +2422,7 @@ public interface AttributesManager {
 	 * @throws GroupNotExistsException if the group doesn't exists in underlying data source
 	 * @throws WrongAttributeAssignmentException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException;
 
 	/**
 	 * Get member-resource, member, user-facility and user attributes which are required by service for each member in list of members.
@@ -3585,7 +3585,7 @@ public interface AttributesManager {
 	 * @throws FacilityNotExistsException
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException;
+	void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException;
 
 	/**
 	 * Unset all attributes for the resource.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -277,6 +277,21 @@ public interface ResourcesManager {
 	List<Group> getAssignedGroups(PerunSession perunSession, Resource resource) throws InternalErrorException, PrivilegeException, ResourceNotExistsException;
 
 	/**
+	 * List all groups associated with the resource and member
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @param member
+	 *
+	 * @return list of assigned groups
+	 *
+	 * @throws InternalErrorException
+	 * @throws ResourceNotExistsException
+	 * @throws PrivilegeException
+	 */
+	List<Group> getAssignedGroups(PerunSession perunSession, Resource resource, Member member) throws InternalErrorException, PrivilegeException, ResourceNotExistsException;
+
+	/**
 	 * List all resources associated with the group.
 	 *
 	 * @param perunSession
@@ -444,7 +459,7 @@ public interface ResourcesManager {
 	 *
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
-	 * 
+	 *
 	 * @return count of all resources
 	 */
 	int getResourcesCount(PerunSession perunSession) throws InternalErrorException, PrivilegeException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -283,7 +283,7 @@ public interface ResourcesManager {
 	 * @param resource
 	 * @param member
 	 *
-	 * @return list of assigned groups
+	 * @return list of assigned groups associated with the resource and member
 	 *
 	 * @throws InternalErrorException
 	 * @throws ResourceNotExistsException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.ActionType;
@@ -26,13 +23,11 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.ModuleNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
-import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -805,6 +800,22 @@ public interface AttributesManagerBl {
 	 * @throws MemberResourceMismatchException
 	 */
 	void setAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+
+	/**
+	 * Store the member, user, member-group, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 *
+	 * @param sess perun session
+	 * @param facility
+	 * @param resource
+	 * @param group
+	 * @param user
+	 * @param member
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException;
 
 	/**
 	 * Store the attributes associated with the resource. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -1967,13 +1978,24 @@ public interface AttributesManagerBl {
 	 *
 	 * @param sess perun session
 	 * @param member you get attributes for this member
-	 *
-	 * @return list of member, user attributes which are required by services which are related to this member
 	 * @param workWithUserAttributes method can process also user and user-facility attributes (user is automatically get from member a facility is get from resource)
+	 * @return list of member, user attributes which are required by services which are related to this member
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, boolean workWithUserAttributes) throws InternalErrorException;
 
+	/**
+	 * Get member, member-group attributes which are required by services which are relater to this member and
+	 * if is workWithUserAttributes = true, then also user required attributes
+	 *
+	 * @param sess perun session
+	 * @param member you get attributes for this member
+	 * @param group you get attribute for this group
+	 * @param workWithUserAttributes method can process also user if this is TRUE
+	 * @return list of member, user attributes which are required by services which are related to this member
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all attributes which are required by service.
@@ -2039,6 +2061,23 @@ public interface AttributesManagerBl {
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws InternalErrorException, MemberResourceMismatchException;
 
 	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
+
+	/**
+	 * Get member, member-resource and member-group attributes which are required by the service.
+	 * if workWithUserAttributes == TRUE return also user and user-facility attributes
+	 *
+	 * @param sess perun session
+	 * @param resource you get attributes for this resource and the member and group
+	 * @param group you get attributes for this group and resource and member
+	 * @param member you get attributes for this member and the resource and group
+	 * @param service attribute required by this service you'll get
+	 * @param workWithUserAttributes if TRUE also user and user-facility attributes
+	 * @return list of attributes which are required by the service.
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException, GroupResourceMismatchException;
 
 	/**
 	 * Get member-resource, member, user-facility and user attributes which are required by service for each member in list of members.
@@ -2592,7 +2631,7 @@ public interface AttributesManagerBl {
 	void checkAttributesValue(PerunSession sess, Member member, Group group, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
-	 * Check if value of attributes is valied. Attributes can be from namespace: member, user, member-resource and user-facility.
+	 * Check if value of attributes is valid. Attributes can be from namespace: member, user, member-resource and user-facility.
 	 *
 	 * @param sess
 	 * @param facility
@@ -2608,6 +2647,24 @@ public interface AttributesManagerBl {
 	 * @throws MemberResourceMismatchException
 	 */
 	void checkAttributesValue(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+
+	/**
+	 * Check if value of attributes is valid. Attributes can be from namespace: member, user, member-group, member-resource and user-facility.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param resource
+	 * @param group
+	 * @param user
+	 * @param member
+	 * @param attributes
+	 *
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeValueException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void checkAttributesValue(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException;
 
 	/**
 	 * Check if value of this member attribute is valid.
@@ -2875,6 +2932,23 @@ public interface AttributesManagerBl {
 	 * @throws MemberResourceMismatchException
 	 */
 	void removeAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+
+	/**
+	 * Unset the member, user, member-group, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't unseted (It's skipped without any notification).
+	 *
+	 * @param sess perun session
+	 * @param facility
+	 * @param resource resource to set on
+	 * @param group group to set on
+	 * @param user
+	 * @param member member to set on
+	 * @param attributes
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-resource, user, member or user-facility attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException;
 
 	/**
 	 * Unset all attributes for the facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -802,7 +802,8 @@ public interface AttributesManagerBl {
 	void setAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
-	 * Store the member, user, member-group, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
+	 * Store the member, user, member-group, member-resource and user-facility attributes.
+	 * If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
 	 *
 	 * @param sess perun session
 	 * @param facility
@@ -810,6 +811,7 @@ public interface AttributesManagerBl {
 	 * @param group
 	 * @param user
 	 * @param member
+	 * @param attributes
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeValueException if the attribute value is illegal
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute
@@ -1985,14 +1987,14 @@ public interface AttributesManagerBl {
 	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, boolean workWithUserAttributes) throws InternalErrorException;
 
 	/**
-	 * Get member, member-group attributes which are required by services which are relater to this member and
-	 * if is workWithUserAttributes = true, then also user required attributes
+	 * Get member, member-group attributes which are required by services which are related to this member and group.
+	 * If workWithUserAttributes = TRUE, then also user attributes are returned.
 	 *
 	 * @param sess perun session
 	 * @param member you get attributes for this member
 	 * @param group you get attribute for this group
 	 * @param workWithUserAttributes method can process also user if this is TRUE
-	 * @return list of member, user attributes which are required by services which are related to this member
+	 * @return list of attributes which are required by services which are related to this member and group
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
 	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
@@ -2934,7 +2936,8 @@ public interface AttributesManagerBl {
 	void removeAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
-	 * Unset the member, user, member-group, member-resource and user-facility attributes. If an attribute is core attribute then the attribute isn't unseted (It's skipped without any notification).
+	 * Unset the member, user, member-group, member-resource and user-facility attributes.
+	 * If an attribute is core attribute then the attribute isn't unseted (It's skipped without any notification).
 	 *
 	 * @param sess perun session
 	 * @param facility

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -267,6 +267,20 @@ public interface GroupsManagerBl {
 	 */
 	List<Group> getAssignedGroupsToResource(PerunSession perunSession, Resource resource) throws InternalErrorException;
 
+	/**
+	 * Return list of assigned groups on the resource (without subgroups unless they are assigned too),
+	 * which contain specific member
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @param member
+	 *
+	 * @return list of groups, which are assigned on the resource and contain specific member
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssignedGroupsToResource(PerunSession perunSession, Resource resource, Member member) throws InternalErrorException;
+
 	/** Return list of assigned groups on the resource.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -287,6 +287,19 @@ public interface ResourcesManagerBl {
 	List<Group> getAssignedGroups(PerunSession perunSession, Resource resource) throws InternalErrorException;
 
 	/**
+	 * List all groups associated with the resource where Member is a member.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @param member
+	 *
+	 * @return list of assigned groups
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssignedGroups(PerunSession perunSession, Resource resource, Member member) throws InternalErrorException;
+
+	/**
 	 * List all resources associated with the group.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -868,6 +868,44 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		this.checkAttributesDependencies(sess, resource, member, user, facility, attributesToSet);
 	}
 
+	public void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException {
+		// clasification of attributes to attributes to remove and attributes to set
+		List<Attribute> attributesToRemove = new ArrayList<Attribute>();
+		List<Attribute> attributesToSet = new ArrayList<Attribute>();
+		convertEmptyAttrValueToNull(attributes);
+		for(Attribute attribute : attributes) {
+			if (attribute.getValue() == null) {
+				attributesToRemove.add(attribute);
+			} else {
+				attributesToSet.add(attribute);
+			}
+		}
+		removeAttributes(sess, facility, resource, group, user, member, attributesToRemove);
+		for(Attribute attribute : attributesToSet) {
+			//skip core attributes
+			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
+
+				if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
+					setAttributeWithoutCheck(sess, resource, member, attribute, false);
+				} else if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
+					setAttributeWithoutCheck(sess, facility, user, attribute);
+				} else if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_ATTR)) {
+					setAttributeWithoutCheck(sess, user, attribute);
+				} else if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR)) {
+					setAttributeWithoutCheck(sess, member, attribute);
+				} else if (getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_GROUP_ATTR)) {
+					setAttributeWithoutCheck(sess, member, group, attribute, false);
+				} else {
+					throw new WrongAttributeAssignmentException(attribute);
+				}
+			}
+		}
+
+		//if checkAttributesValue fails it causes rollback so no attribute will be stored
+		checkAttributesValue(sess, facility, resource, group, user, member, attributesToSet);
+		this.checkAttributesDependencies(sess, resource, group, member, user, facility, attributesToSet);
+	}
+
 	public void setAttributes(PerunSession sess, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		// clasification of attributes to attributes to remove and attributes to set
 		List<Attribute> attributesToRemove = new ArrayList<Attribute>();
@@ -2238,6 +2276,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		return new ArrayList<Attribute>(attributes);
 	}
 
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException {
+		List<Resource> resources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, member);
+		Set<Attribute> attributes = new HashSet<Attribute>();
+
+		for(Resource resource : resources) {
+			attributes.addAll(this.getResourceRequiredAttributes(sess, resource, member, group));
+		}
+
+		attributes.addAll(this.getRequiredAttributes(sess, member, workWithUserAttributes));
+
+		return new ArrayList<Attribute>(attributes);
+	}
+
 	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		List<Attribute> attributes = new ArrayList<Attribute>();
@@ -2311,6 +2362,30 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		List<Attribute> attributes = new ArrayList<Attribute>();
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, member));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, user));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, user));
+		return attributes;
+	}
+
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException, GroupResourceMismatchException {
+		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
+		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
+
+		if(!workWithUserAttributes) {
+			List<Attribute> attributes = new ArrayList<Attribute>();
+			attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member));
+			attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member, group));
+			attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, member));
+			return attributes;
+		}
+
+		User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+
+		List<Attribute> attributes = new ArrayList<Attribute>();
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, member));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member, group));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, user));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, user));
@@ -3022,6 +3097,31 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 	}
 
+	public void checkAttributesValue(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException {
+		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
+		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
+		for(Attribute attribute : attributes) {
+			if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
+				if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, resource, member, attribute)) continue;
+				getAttributesManagerImpl().checkAttributeValue(sess, resource, member, attribute);
+			} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
+				if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, facility, user, attribute)) continue;
+				getAttributesManagerImpl().checkAttributeValue(sess, facility, user, attribute);
+			} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_ATTR)) {
+				if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, user, attribute)) continue;
+				getAttributesManagerImpl().checkAttributeValue(sess, user, attribute);
+			} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR)) {
+				if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, attribute)) continue;
+				getAttributesManagerImpl().checkAttributeValue(sess, member, attribute);
+			} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_GROUP_ATTR)) {
+				if(attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, group, attribute)) continue;
+				getAttributesManagerImpl().checkAttributeValue(sess, member, group, attribute);
+			} else {
+				throw new WrongAttributeAssignmentException(attribute);
+			}
+		}
+	}
+
 	public void checkAttributeValue(PerunSession sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_ATTR);
 
@@ -3279,6 +3379,33 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		this.checkAttributesValue(sess, facility, resource, user, member, attributesFromDefinitions(attributesToCheck));
 		this.checkAttributesDependencies(sess, resource, member, user, facility, attributesFromDefinitions(attributesToCheck));
+	}
+
+	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException {
+		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
+		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
+		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
+		for(AttributeDefinition attribute : attributes) {
+			//skip core attributes
+			if(!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
+
+				if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_ATTR)) {
+					if (removeAttributeWithoutCheck(sess, member, attribute)) attributesToCheck.add(attribute);
+				} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_ATTR)) {
+					if (removeAttributeWithoutCheck(sess, user, attribute)) attributesToCheck.add(attribute);
+				} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)){
+					if (removeAttributeWithoutCheck(sess, resource, member, attribute)) attributesToCheck.add(attribute);
+				} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_USER_FACILITY_ATTR)){
+					if (removeAttributeWithoutCheck(sess, facility, user, attribute)) attributesToCheck.add(attribute);
+				} else if(getAttributesManagerImpl().isFromNamespace(sess, attribute, AttributesManager.NS_MEMBER_GROUP_ATTR)){
+					if (removeAttributeWithoutCheck(sess, member, group, attribute)) attributesToCheck.add(attribute);
+				} else {
+					throw new WrongAttributeAssignmentException(attribute);
+				}
+			}
+		}
+		this.checkAttributesValue(sess, facility, resource, group, user, member, attributesFromDefinitions(attributesToCheck));
+		this.checkAttributesDependencies(sess, resource, group, member, user, facility, attributesFromDefinitions(attributesToCheck));
 	}
 
 	public void removeAllAttributes(PerunSession sess, Facility facility) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
@@ -4658,6 +4785,34 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		checkAttributesDependencies(sess, user, null, userAttributes);
 		checkAttributesDependencies(sess, facility, user, userFacilityAttributes);
 		checkAttributesDependencies(sess, resource, member, memberResourceAttributes);
+	}
+
+	private void checkAttributesDependencies(PerunSession sess, Resource resource, Group group, Member member, User user, Facility facility, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		List<Attribute> userAttributes = new ArrayList<Attribute>();
+		List<Attribute> memberAttributes = new ArrayList<Attribute>();
+		List<Attribute> memberResourceAttributes = new ArrayList<Attribute>();
+		List<Attribute> userFacilityAttributes = new ArrayList<Attribute>();
+		List<Attribute> memberGroupAttributes = new ArrayList<Attribute>();
+		for(Attribute attr: attributes) {
+			if(getAttributesManagerImpl().isFromNamespace(sess, attr, NS_USER_ATTR)) {
+				userAttributes.add(attr);
+			} else if(getAttributesManagerImpl().isFromNamespace(sess, attr, NS_MEMBER_ATTR)) {
+				memberAttributes.add(attr);
+			} else if(getAttributesManagerImpl().isFromNamespace(sess, attr, NS_MEMBER_RESOURCE_ATTR)) {
+				memberResourceAttributes.add(attr);
+			} else if(getAttributesManagerImpl().isFromNamespace(sess, attr, NS_USER_FACILITY_ATTR)) {
+				userFacilityAttributes.add(attr);
+			} else if(getAttributesManagerImpl().isFromNamespace(sess, attr, NS_MEMBER_GROUP_ATTR)) {
+				memberGroupAttributes.add(attr);
+			} else {
+				throw new WrongAttributeAssignmentException(attr);
+			}
+		}
+		checkAttributesDependencies(sess, member, null, memberAttributes);
+		checkAttributesDependencies(sess, user, null, userAttributes);
+		checkAttributesDependencies(sess, facility, user, userFacilityAttributes);
+		checkAttributesDependencies(sess, resource, member, memberResourceAttributes);
+		checkAttributesDependencies(sess, member, group, memberGroupAttributes);
 	}
 
 	private void checkAttributesDependencies(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
@@ -6560,6 +6715,17 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if(member.getVoId() != resource.getVoId()) throw new MemberResourceMismatchException("Member is not from the same vo like Resource: " + member + " " + resource);
 	}
 
+	/**
+	 * Check if group is assigned on resource. If not, throw WrongAttributeAssignment Exception
+	 *
+	 * @param sess
+	 * @param group
+	 * @param resource
+	 * @throws WrongAttributeAssignmentException
+	 * @throws InternalErrorException
+	 * @throws GroupNotExistsException
+	 * @throws ResourceNotExistsException
+	 */
 	public void checkGroupIsFromTheSameVoLikeResource(PerunSession sess, Group group, Resource resource) throws GroupResourceMismatchException, InternalErrorException {
 		Utils.notNull(sess, "sess");
 		Utils.notNull(group, "group");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -798,6 +798,10 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		return getAssignedGroupsToResource(sess, resource, false);
 	}
 
+	public List<Group> getAssignedGroupsToResource(PerunSession sess, Resource resource, Member member) throws InternalErrorException {
+		return getGroupsManagerImpl().getAssignedGroupsToResource(sess, resource, member);
+	}
+
 	public List<Group> getAssignedGroupsToResource(PerunSession sess, Resource resource, boolean withSubGroups) throws InternalErrorException {
 		List<Group> assignedGroups = getGroupsManagerImpl().getAssignedGroupsToResource(sess, resource);
 		if(!withSubGroups) return assignedGroups;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -365,6 +365,10 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		return getPerunBl().getGroupsManagerBl().getAssignedGroupsToResource(sess, resource);
 	}
 
+	public List<Group> getAssignedGroups(PerunSession sess, Resource resource, Member member) throws InternalErrorException {
+		return getPerunBl().getGroupsManagerBl().getAssignedGroupsToResource(sess, resource, member);
+	}
+
 	public List<Resource> getAssignedResources(PerunSession sess, Group group) throws InternalErrorException {
 		Vo vo = getPerunBl().getGroupsManagerBl().getVo(sess, group);
 		return getResourcesManagerImpl().getAssignedResources(sess, vo, group);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -753,7 +753,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().setAttributes(sess, facility, resource, user, member, attributes);
 	}
 
-	public void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException {
+	public void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -1561,7 +1561,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attributes;
 	}
 
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, GroupNotExistsException, GroupResourceMismatchException, WrongAttributeAssignmentException, MemberNotExistsException, MemberGroupMismatchException, UserNotExistsException, FacilityNotExistsException {
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, GroupNotExistsException, GroupResourceMismatchException, WrongAttributeAssignmentException, MemberNotExistsException, MemberGroupMismatchException, UserNotExistsException, FacilityNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
@@ -1933,7 +1933,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attributes;
 	}
 
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
@@ -3108,7 +3108,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().removeAttributes(sess, facility, resource, user, member, attributes);
 	}
 
-	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException {
+	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException, GroupResourceMismatchException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -1705,7 +1705,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, member, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
-		User u = null;
+		User user = null;
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
 			Attribute attrNext = attrIter.next();
@@ -1713,9 +1713,9 @@ public class AttributesManagerEntry implements AttributesManager {
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
-				if (u == null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, null)) attrIter.remove();
-				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, null));
+				if (user == null) user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, null));
 			} else {
 				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
 			}
@@ -1730,7 +1730,7 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, member, group, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
-		User u = null;
+		User user = null;
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
 			Attribute attrNext = attrIter.next();
@@ -1738,9 +1738,9 @@ public class AttributesManagerEntry implements AttributesManager {
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
-				if (u == null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, null)) attrIter.remove();
-				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, null));
+				if (user == null) user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_GROUP_ATTR)) {
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
@@ -1906,8 +1906,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, resource, member, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
-		User u = null;
-		Facility f = null;
+		User user = null;
+		Facility facility = null;
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
 			Attribute attrNext = attrIter.next();
@@ -1918,14 +1918,14 @@ public class AttributesManagerEntry implements AttributesManager {
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
-				if (u==null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, null)) attrIter.remove();
-				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, null));
+				if (user==null) user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_FACILITY_ATTR)){
-				if (u==null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-				if (f==null) f = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
-				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, f)) attrIter.remove();
-				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, f));
+				if (user==null) user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if (facility==null) facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, facility)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, facility));
 			} else {
 				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
 			}
@@ -1942,8 +1942,8 @@ public class AttributesManagerEntry implements AttributesManager {
 
 		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, resource, group, member, workWithUserAttributes);
 
-		User u = null;
-		Facility f = null;
+		User user = null;
+		Facility facility = null;
 
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
@@ -1959,14 +1959,14 @@ public class AttributesManagerEntry implements AttributesManager {
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
-				if (u==null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, null)) attrIter.remove();
-				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, null));
+				if (user==null) user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_FACILITY_ATTR)){
-				if (u==null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-				if (f==null) f = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
-				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, f)) attrIter.remove();
-				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, f));
+				if (user==null) user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if (facility==null) facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, facility)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, facility));
 			} else {
 				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
 			}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -753,6 +753,33 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().setAttributes(sess, facility, resource, user, member, attributes);
 	}
 
+	public void setAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		//Choose to which attributes has the principal access
+		for(Attribute attr: attributes) {
+			if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_MEMBER_ATTR_DEF)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), member, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_MEMBER_RESOURCE_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), resource , member)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_MEMBER_GROUP_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), member , group)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_USER_FACILITY_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), user , facility)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attr, NS_USER_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), user, null)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
+			} else {
+				throw new WrongAttributeAssignmentException("One of setting attribute has not correct type : " + new AttributeDefinition(attr));
+			}
+		}
+		getAttributesManagerBl().setAttributes(sess, facility, resource, group, user, member, attributes);
+	}
+
 	public void setAttributes(PerunSession sess, Member member, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -1534,6 +1561,52 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attributes;
 	}
 
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, GroupNotExistsException, GroupResourceMismatchException, WrongAttributeAssignmentException, MemberNotExistsException, MemberGroupMismatchException, UserNotExistsException, FacilityNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
+		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+
+		if(group.getVoId() != resource.getVoId()) {
+			throw new GroupResourceMismatchException("Group and resource are not in the same VO.");
+		}
+		if(member.getVoId() != group.getVoId()) {
+			throw new MemberGroupMismatchException("Member and Group are not in the same VO.");
+		}
+
+		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, resource, member, workWithUserAttributes);
+		attributes.addAll(getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, group));
+
+		User user = getPerunBl().getUsersManagerBl().getUserById(sess, member.getUserId());
+		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityById(sess, resource.getFacilityId());
+
+		Iterator<Attribute> attrIter = attributes.iterator();
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, null));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_GROUP_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_RESOURCE_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, resource)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, resource));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_FACILITY_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, user, facility)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, user, facility));
+			} else {
+				throw new ConsistencyErrorException("There is some attribute which is not of expected type (member, user, user_facility, member_group, member_resource).");
+			}
+		}
+		return attributes;
+	}
+
 	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Group group) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
@@ -1549,7 +1622,6 @@ public class AttributesManagerEntry implements AttributesManager {
 		}
 		return attributes;
 	}
-
 
 	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Group group) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, GroupNotExistsException {
 		Utils.checkPerunSession(sess);
@@ -1633,6 +1705,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, member, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
+		User u = null;
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
 			Attribute attrNext = attrIter.next();
@@ -1640,9 +1713,37 @@ public class AttributesManagerEntry implements AttributesManager {
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
-				User u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if (u == null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, null)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, null));
+			} else {
+				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
+			}
+		}
+		return attributes;
+	}
+
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Group group, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+
+		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, member, group, workWithUserAttributes);
+		Iterator<Attribute> attrIter = attributes.iterator();
+		User u = null;
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
+				if (u == null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, null));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_GROUP_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
 			} else {
 				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
 			}
@@ -1805,6 +1906,8 @@ public class AttributesManagerEntry implements AttributesManager {
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, resource, member, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
+		User u = null;
+		Facility f = null;
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
 			Attribute attrNext = attrIter.next();
@@ -1815,12 +1918,53 @@ public class AttributesManagerEntry implements AttributesManager {
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
-				User u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if (u==null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, null)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, null));
 			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_FACILITY_ATTR)){
-				User u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-				Facility f = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+				if (u==null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if (f==null) f = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, f)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, f));
+			} else {
+				throw new ConsistencyErrorException("There is some attribute which is not type of any possible choice.");
+			}
+		}
+		return attributes;
+	}
+
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Group group, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
+		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+
+		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, resource, group, member, workWithUserAttributes);
+
+		User u = null;
+		Facility f = null;
+
+		Iterator<Attribute> attrIter = attributes.iterator();
+		//Choose to which attributes has the principal access
+		while(attrIter.hasNext()) {
+			Attribute attrNext = attrIter.next();
+			if(getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_RESOURCE_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, resource, member)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, resource, member));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, null));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_MEMBER_GROUP_ATTR)){
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, member, group)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, member, group));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_ATTR)) {
+				if (u==null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, null)) attrIter.remove();
+				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, null));
+			} else if (getAttributesManagerBl().isFromNamespace(sess, attrNext, NS_USER_FACILITY_ATTR)){
+				if (u==null) u = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				if (f==null) f = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attrNext, u, f)) attrIter.remove();
 				else attrNext.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrNext, u, f));
 			} else {
@@ -2964,6 +3108,32 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().removeAttributes(sess, facility, resource, user, member, attributes);
 	}
 
+	public void removeAttributes(PerunSession sess, Facility facility, Resource resource, Group group, User user, Member member, List<? extends AttributeDefinition> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, FacilityNotExistsException, UserNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+		getAttributesManagerBl().checkAttributesExists(sess, attributes);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
+		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
+		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
+		//Choose to which attributes has the principal access
+		for(AttributeDefinition attrDef: attributes) {
+			if(getAttributesManagerBl().isFromNamespace(sess, attrDef, NS_MEMBER_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrDef, member , null)) throw new PrivilegeException("Principal has no access to remove attribute = " + attrDef);
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attrDef, NS_MEMBER_RESOURCE_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrDef, resource , member)) throw new PrivilegeException("Principal has no access to remove attribute = " + attrDef);
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attrDef, NS_USER_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrDef, user , null)) throw new PrivilegeException("Principal has no access to remove attribute = " + attrDef);
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attrDef, NS_USER_FACILITY_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrDef, user , facility)) throw new PrivilegeException("Principal has no access to remove attribute = " + attrDef);
+			} else if(getAttributesManagerBl().isFromNamespace(sess, attrDef, NS_MEMBER_GROUP_ATTR)) {
+				if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrDef, member, group)) throw new PrivilegeException("Principal has no access to remove attribute = " + attrDef);
+			} else {
+				throw new WrongAttributeAssignmentException("There is some attribute which is not type of any possible choice.");
+			}
+		}
+		getAttributesManagerBl().removeAttributes(sess, facility, resource, group, user, member, attributes);
+	}
 
 	public void removeAttributes(PerunSession sess, Member member, boolean workWithUserAttributes, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -349,12 +349,10 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		Utils.checkPerunSession(sess);
 		getResourcesManagerBl().checkResourceExists(sess, resource);
 
-		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
-
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, resource) &&
-				!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+				!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, resource)) {
 			throw new PrivilegeException(sess, "getAssignedGroups");
 				}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -361,6 +361,22 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		return getResourcesManagerBl().getAssignedGroups(sess, resource);
 	}
 
+	public List<Group> getAssignedGroups(PerunSession sess, Resource resource, Member member) throws InternalErrorException, PrivilegeException, ResourceNotExistsException {
+		Utils.checkPerunSession(sess);
+		getResourcesManagerBl().checkResourceExists(sess, resource);
+
+		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) &&
+				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, resource) &&
+				!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "getAssignedGroups");
+		}
+
+		return getResourcesManagerBl().getAssignedGroups(sess, resource, member);
+	}
+
 	public List<Resource> getAssignedResources(PerunSession sess, Group group) throws InternalErrorException, GroupNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -349,6 +349,19 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 		}
 	}
 
+	public List<Group> getAssignedGroupsToResource(PerunSession perunSession, Resource resource, Member member) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + groupMappingSelectQuery + " from groups join " +
+							" groups_resources on groups.id=groups_resources.group_id and groups_resources.resource_id=?" +
+							" join groups_members on groups_members.group_id=groups.id and groups_members.member_id=?",
+					GROUP_MAPPER, resource.getId(), member.getId());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<Group>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
 	public List<Group> getAssignedGroupsToFacility(PerunSession perunSession, Facility facility) throws InternalErrorException {
 		try {
 			return jdbc.query("select distinct " + groupMappingSelectQuery + " from groups join " +
@@ -719,7 +732,7 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 			throw new InternalErrorException(e);
 		}
 	}
-	
+
 	public boolean isRelationRemovable(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException {
 		try {
 			return 1 > jdbc.queryForInt("SELECT parent_flag"+Compatibility.castToInteger()+" FROM groups_groups WHERE result_gid=? AND operand_gid=?",

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -173,7 +173,8 @@ public interface GroupsManagerImplApi {
 	 */
 	void removeMember(PerunSession perunSession, Group group, Member member) throws InternalErrorException, NotGroupMemberException;
 
-	/** Return groups by theirs id.
+	/**
+	 * Return groups by theirs id.
 	 *
 	 * @param perunSession
 	 * @param groupsIds list of group ids
@@ -184,7 +185,8 @@ public interface GroupsManagerImplApi {
 	 */
 	List<Group> getGroupsByIds(PerunSession perunSession, List<Integer> groupsIds) throws InternalErrorException;
 
-	/** Return list of assigned groups on the resource.
+	/**
+	 * Return list of assigned groups on the resource.
 	 *
 	 * @param perunSession
 	 * @param resource
@@ -195,7 +197,21 @@ public interface GroupsManagerImplApi {
 	 */
 	List<Group> getAssignedGroupsToResource(PerunSession perunSession, Resource resource) throws InternalErrorException;
 
-	/** Return list of assigned groups from all facility resources
+	/**
+	 * Return list of assigned groups on the resource with specified member.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @param member
+	 *
+	 * @return list of groups, which are assigned on the resource with specified member
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAssignedGroupsToResource(PerunSession perunSession, Resource resource, Member member) throws InternalErrorException;
+
+	/**
+	 * Return list of assigned groups from all facility resources
 	 *
 	 * @param perunSession
 	 * @param facility
@@ -206,7 +222,8 @@ public interface GroupsManagerImplApi {
 	 */
 	List<Group> getAssignedGroupsToFacility(PerunSession perunSession, Facility facility) throws InternalErrorException;
 
-	/** Return group users sorted by name.
+	/**
+	 * Return group users sorted by name.
 	 *
 	 * @param sess
 	 * @param group

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -361,7 +361,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							parms.readList("attrNames", String.class));
 				} else {
 					return ac.getAttributesManager().getAttributes(ac.getSession(),
-						ac.getGroupById(parms.readInt("group")));
+							ac.getGroupById(parms.readInt("group")));
 				}
 			} else if (parms.contains("host")) {
 				return ac.getAttributesManager().getAttributes(ac.getSession(),
@@ -1456,8 +1456,8 @@ public enum AttributesManagerMethod implements ManagerMethod {
 		public List<Attribute> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if (parms.contains("service")) {
 				if (parms.contains("resource")) {
-					if (parms.contains("member")) {
-						if (parms.contains("group")) {
+					if (parms.contains("group")) {
+						if (parms.contains("member")) {
 							if (parms.contains("workWithUserAttributes")) {
 								return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 										ac.getServiceById(parms.readInt("service")),
@@ -1474,24 +1474,24 @@ public enum AttributesManagerMethod implements ManagerMethod {
 										false);
 							}
 						} else {
-							if (parms.contains("workWithUserAttributes")) {
-								return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-										ac.getServiceById(parms.readInt("service")),
-										ac.getResourceById(parms.readInt("resource")),
-										ac.getMemberById(parms.readInt("member")),
-										parms.readBoolean("workWithUserAttributes"));
-							} else {
-								return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-										ac.getServiceById(parms.readInt("service")),
-										ac.getResourceById(parms.readInt("resource")),
-										ac.getMemberById(parms.readInt("member")));
-							}
+							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+									ac.getServiceById(parms.readInt("service")),
+									ac.getResourceById(parms.readInt("resource")),
+									ac.getGroupById(parms.readInt("group")));
 						}
-					} else if (parms.contains("group")) {
-						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-								ac.getServiceById(parms.readInt("service")),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getGroupById(parms.readInt("group")));
+					} else if (parms.contains("member")) {
+						if (parms.contains("workWithUserAttributes")) {
+							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+									ac.getServiceById(parms.readInt("service")),
+									ac.getResourceById(parms.readInt("resource")),
+									ac.getMemberById(parms.readInt("member")),
+									parms.readBoolean("workWithUserAttributes"));
+						} else {
+							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+									ac.getServiceById(parms.readInt("service")),
+									ac.getResourceById(parms.readInt("resource")),
+									ac.getMemberById(parms.readInt("member")));
+						}
 					} else {
 						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 								ac.getServiceById(parms.readInt("service")),
@@ -1976,10 +1976,10 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							ac.getAttributeById(member, parms.readInt("attribute")));
 				}
 			} else if (parms.contains("group")) {
-					Group group = ac.getGroupById(parms.readInt("group"));
-					return ac.getAttributesManager().fillAttribute(ac.getSession(),
-							group,
-							ac.getAttributeById(group, parms.readInt("attribute")));
+				Group group = ac.getGroupById(parms.readInt("group"));
+				return ac.getAttributesManager().fillAttribute(ac.getSession(),
+						group,
+						ac.getAttributeById(group, parms.readInt("attribute")));
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "host, resource, user, member or group");
 			}
@@ -2500,7 +2500,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, resource, member, host, user or userExtSource");
 			}
-		return null;
+			return null;
 		}
 	},
 
@@ -2658,26 +2658,22 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				attributes.add(ac.getAttributeDefinitionById(i));
 			}
 			if (parms.contains("facility")) {
-				if (parms.contains("resource")) {
-					if (parms.contains("member")) {
-						if (parms.contains("user")) {
-							if (parms.contains("group")) {
-								ac.getAttributesManager().removeAttributes(ac.getSession(),
-										ac.getFacilityById(parms.readInt("facility")),
-										ac.getResourceById(parms.readInt("resource")),
-										ac.getGroupById(parms.readInt("group")),
-										ac.getUserById(parms.readInt("user")),
-										ac.getMemberById(parms.readInt("member")),
-										attributes);
-							} else {
-								ac.getAttributesManager().removeAttributes(ac.getSession(),
-										ac.getFacilityById(parms.readInt("facility")),
-										ac.getResourceById(parms.readInt("resource")),
-										ac.getUserById(parms.readInt("user")),
-										ac.getMemberById(parms.readInt("member")),
-										attributes);
-							}
-						}
+				if (parms.contains("resource") && parms.contains("member") && parms.contains("user")) {
+					if (parms.contains("group")) {
+						ac.getAttributesManager().removeAttributes(ac.getSession(),
+								ac.getFacilityById(parms.readInt("facility")),
+								ac.getResourceById(parms.readInt("resource")),
+								ac.getGroupById(parms.readInt("group")),
+								ac.getUserById(parms.readInt("user")),
+								ac.getMemberById(parms.readInt("member")),
+								attributes);
+					} else {
+						ac.getAttributesManager().removeAttributes(ac.getSession(),
+								ac.getFacilityById(parms.readInt("facility")),
+								ac.getResourceById(parms.readInt("resource")),
+								ac.getUserById(parms.readInt("user")),
+								ac.getMemberById(parms.readInt("member")),
+								attributes);
 					}
 				} else if (parms.contains("user")) {
 					ac.getAttributesManager().removeAttributes(ac.getSession(),
@@ -2924,7 +2920,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else {
 				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo, group, resource, member, host, user or userExtSource");
 			}
-		return null;
+			return null;
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -413,6 +413,16 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 *
 	 * @param facility int Facility <code>id</code>
 	 * @param user int User <code>id</code>
+	 * @param member int Member <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @param group in Group <code>id</code>
+	 * @param attributes List<Attribute> List of attributes
+	 */
+	/*#
+	 * Sets the attributes.
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param user int User <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
 	 */
 	/*#
@@ -523,7 +533,15 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 			if (parms.contains("facility")) {
 				if (parms.contains("user")) {
-					if (parms.contains("member") && parms.contains("resource")) {
+					if (parms.contains("member") && parms.contains("resource") && parms.contains("group")) {
+						ac.getAttributesManager().setAttributes(ac.getSession(),
+								ac.getFacilityById(parms.readInt("facility")),
+								ac.getResourceById(parms.readInt("resource")),
+								ac.getGroupById(parms.readInt("group")),
+								ac.getUserById(parms.readInt("user")),
+								ac.getMemberById(parms.readInt("member")),
+								parms.readList("attributes", Attribute.class));
+					} else if (parms.contains("member") && parms.contains("resource")) {
 						ac.getAttributesManager().setAttributes(ac.getSession(),
 								ac.getFacilityById(parms.readInt("facility")),
 								ac.getResourceById(parms.readInt("resource")),
@@ -1268,7 +1286,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns required attributes.
+	 * Returns member and member-resource attributes required by the specified service.
 	 *
 	 * @param member int Member <code>id</code>
 	 * @param service int Service <code>id</code>
@@ -1276,7 +1294,8 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns member and member-resource attributes required by the specified service.
+	 * If workWithUserAttributes == TRUE, then returns also user attributes.
 	 *
 	 * @param member int Member <code>id</code>
 	 * @param service int Service <code>id</code>
@@ -1285,7 +1304,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns group-resource attributes required by specified service.
 	 *
 	 * @param group int Group <code>id</code>
 	 * @param service int Service <code>id</code>
@@ -1293,14 +1312,35 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns resource attributes required by specified service.
 	 *
 	 * @param service int Service <code>id</code>
 	 * @param resource int Resource <code>id</code>
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns member, member-group and member-resource attributes required by specified service.
+	 * If workWithUserAttributes == TRUE, then returns also user and user-facility attributes.
+	 *
+	 * @param service int Service <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @param member int Member <code>id</code>
+	 * @param workWithUserAttributes boolean If <code>true</code>, return also User and User-facility attributes. <code>False</code> is default.
+	 * @return List<Attribute> Required Attributes
+	 */
+	/*#
+	 * Returns member, member-group and member-resource attributes required by specified service.
+	 *
+	 * @param service int Service <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @param member int Member <code>id</code>
+	 * @return List<Attribute> Required Attributes
+	 */
+	/*#
+	 * Returns member-group attributes required by specified service.
+	 * If workWithUserAttributes == TRUE, then returns also member and user attributes.
 	 *
 	 * @param service int Service <code>id</code>
 	 * @param member int Member <code>id</code>
@@ -1309,7 +1349,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns member-group attributes required by specified service.
 	 *
 	 * @param service int Service <code>id</code>
 	 * @param member int Member <code>id</code>
@@ -1317,35 +1357,36 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns facility attributes required by specified service.
 	 *
 	 * @param facility int Facility <code>id</code>
 	 * @param service int Service <code>id</code>
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns facility attributes required by specified list of services.
 	 *
 	 * @param facility int Facility <code>id</code>
 	 * @param services List<int> list of Service IDs
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns required host attributes.
 	 *
 	 * @param host int Host <code>id</code>
 	 * @param service int Service <code>id</code>
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns required member and member-resource attributes.
 	 *
 	 * @param member int Member <code>id</code>
 	 * @param resource int Resource <code>id</code>
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns required member and member-resource attributes.
+	 * If workWithUserAttributes == TRUE, then returns also user attributes.
 	 *
 	 * @param member int Member <code>id</code>
 	 * @param resource int Resource <code>id</code>
@@ -1353,39 +1394,56 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns required resource attributes.
 	 *
 	 * @param resource int Resource <code>id</code>
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns required user-facility attributes.
 	 *
 	 * @param facility int Facility <code>id</code>
 	 * @param user int User <code>id</code>
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns required facility attributes.
 	 *
 	 * @param facility int Facility <code>id</code>
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns required member attributes.
 	 *
 	 * @param member int Member <code>id</code>
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns required member attributes.
+	 * If workWithUserAttributes == TRUE, then returns also user attributes.
 	 *
 	 * @param member int Member <code>id</code>
 	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
 	 * @return List<Attribute> Required Attributes
 	 */
 	/*#
-	 * Returns required attributes.
+	 * Returns member and member-group required attributes.
+	 *
+	 * @param member int Member <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @return List<Attribute> Required Attributes
+	 */
+	/*#
+	 * Returns member and member-group required attributes.
+	 * If workWithUserAttributes == TRUE, then returns also user attributes.
+	 *
+	 * @param member int Member <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @param workWithUserAttributes boolean Work with user attributes. False is default value.
+	 * @return List<Attribute> Required Attributes
+	 */
+	/*#
+	 * Returns required user attributes.
 	 *
 	 * @param user int User <code>id</code>
 	 * @return List<Attribute> Required Attributes
@@ -1396,7 +1454,23 @@ public enum AttributesManagerMethod implements ManagerMethod {
 		public List<Attribute> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if (parms.contains("service")) {
 				if (parms.contains("resource")) {
-					if (parms.contains("member")) {
+					if (parms.contains("member") && parms.contains("group")) {
+						if (parms.contains("workWithUserAttributes")) {
+							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+									ac.getServiceById(parms.readInt("service")),
+									ac.getResourceById(parms.readInt("resource")),
+									ac.getGroupById(parms.readInt("group")),
+									ac.getMemberById(parms.readInt("member")),
+									parms.readBoolean("workWithUserAttributes"));
+						} else {
+							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+									ac.getServiceById(parms.readInt("service")),
+									ac.getResourceById(parms.readInt("resource")),
+									ac.getGroupById(parms.readInt("group")),
+									ac.getMemberById(parms.readInt("member")),
+									false);
+						}
+					} else if (parms.contains("member")) {
 						if (parms.contains("workWithUserAttributes")) {
 							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 									ac.getServiceById(parms.readInt("service")),
@@ -1495,12 +1569,26 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							ac.getFacilityById(parms.readInt("facility")));
 				}
 			} else if (parms.contains("member")) {
-				if (parms.contains("workWithUserAttributes")) {
-					return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-							ac.getMemberById(parms.readInt("member")), parms.readBoolean("workWithUserAttributes"));
+				if (parms.contains("group")) {
+					if (parms.contains("workWithUserAttributes")) {
+						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+								ac.getMemberById(parms.readInt("member")),
+								ac.getGroupById(parms.readInt("group")),
+								parms.readBoolean("workWithUserAttributes"));
+					} else {
+						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+								ac.getMemberById(parms.readInt("member")),
+								ac.getGroupById(parms.readInt("group")),
+								false);
+					}
 				} else {
-					return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-							ac.getMemberById(parms.readInt("member")), false);
+					if (parms.contains("workWithUserAttributes")) {
+						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+								ac.getMemberById(parms.readInt("member")), parms.readBoolean("workWithUserAttributes"));
+					} else {
+						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+								ac.getMemberById(parms.readInt("member")), false);
+					}
 				}
 			} else if (parms.contains("user")) {
 				return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
@@ -1620,6 +1708,28 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @return List<Attribute> Group-resource attributes
 	 */
 	/*#
+	 * Gets member-group and member-resource attributes.
+	 * If workWithUserAttributes == TRUE then return also member, user, user-facility attributes.
+	 * It returns attributes required by all services assigned to specified resource. Both empty and non-empty attributes are returned.
+	 *
+	 * @param resourceToGetServicesFrom int Resource to get services from <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @param member int Member <code>id</code>
+	 * @param workWithUserAttributes boolean Work with member, user, user-facility attributes. False is default value.
+	 * @return List<Attribute> Member-group and member-resource attributes, if workWithUserAttributes == TRUE, member, user and user-facility attributes are returned too.
+	 */
+	/*#
+	 * Gets member-group and member-resource attributes.
+	 * It returns attributes required by all services assigned to specified resource. Both empty and non-empty attributes are returned.
+	 *
+	 * @param resourceToGetServicesFrom int Resource to get services from <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @param member int Member <code>id</code>
+	 * @return List<Attribute> Member-group and member-resource attributes
+	 */
+	/*#
 	 * Gets group attributes.
 	 * It returns attributes required by all services assigned to specified resource. Both empty and non-empty attributes are returned.
 	 *
@@ -1649,6 +1759,22 @@ public enum AttributesManagerMethod implements ManagerMethod {
 									ac.getResourceById(parms.readInt("resource")),
 									ac.getUserById(parms.readInt("user")),
 									ac.getMemberById(parms.readInt("member")));
+						} else if (parms.contains("group")) {
+							if (parms.contains("workWithUserAttributes")) {
+								return ac.getAttributesManager().getResourceRequiredAttributes(ac.getSession(),
+										ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
+										ac.getResourceById(parms.readInt("resource")),
+										ac.getGroupById(parms.readInt("group")),
+										ac.getMemberById(parms.readInt("member")),
+										parms.readBoolean("workWithUserAttributes"));
+							} else {
+								return ac.getAttributesManager().getResourceRequiredAttributes(ac.getSession(),
+										ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
+										ac.getResourceById(parms.readInt("resource")),
+										ac.getGroupById(parms.readInt("group")),
+										ac.getMemberById(parms.readInt("member")),
+										false);
+							}
 						} else if (parms.contains("workWithUserAttributes")) {
 							return ac.getAttributesManager().getResourceRequiredAttributes(ac.getSession(),
 									ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
@@ -2388,6 +2514,18 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	/*#
 	 * Remove attributes of namespace:
 	 *
+	 * user, user-facility, member, member-resource, member-group
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param user int User <code>id</code>
+	 * @param member int Member <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @param attributes List<Integer> List of attributes IDs to remove
+	 */
+	/*#
+	 * Remove attributes of namespace:
+	 *
 	 * user-facility
 	 *
 	 * @param facility int Facility <code>id</code>
@@ -2517,7 +2655,15 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			}
 
 			if (parms.contains("facility")) {
-				if (parms.contains("resource") && parms.contains("user") && parms.contains("member")) {
+				if (parms.contains("resource") && parms.contains("group") && parms.contains("user") && parms.contains("member")) {
+					ac.getAttributesManager().removeAttributes(ac.getSession(),
+							ac.getFacilityById(parms.readInt("facility")),
+							ac.getResourceById(parms.readInt("resource")),
+							ac.getGroupById(parms.readInt("group")),
+							ac.getUserById(parms.readInt("user")),
+							ac.getMemberById(parms.readInt("member")),
+							attributes);
+				} else if (parms.contains("resource") && parms.contains("user") && parms.contains("member")) {
 					ac.getAttributesManager().removeAttributes(ac.getSession(),
 							ac.getFacilityById(parms.readInt("facility")),
 							ac.getResourceById(parms.readInt("resource")),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -533,21 +533,23 @@ public enum AttributesManagerMethod implements ManagerMethod {
 
 			if (parms.contains("facility")) {
 				if (parms.contains("user")) {
-					if (parms.contains("member") && parms.contains("resource") && parms.contains("group")) {
-						ac.getAttributesManager().setAttributes(ac.getSession(),
-								ac.getFacilityById(parms.readInt("facility")),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getGroupById(parms.readInt("group")),
-								ac.getUserById(parms.readInt("user")),
-								ac.getMemberById(parms.readInt("member")),
-								parms.readList("attributes", Attribute.class));
-					} else if (parms.contains("member") && parms.contains("resource")) {
-						ac.getAttributesManager().setAttributes(ac.getSession(),
-								ac.getFacilityById(parms.readInt("facility")),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getUserById(parms.readInt("user")),
-								ac.getMemberById(parms.readInt("member")),
-								parms.readList("attributes", Attribute.class));
+					if (parms.contains("member") && parms.contains("resource")) {
+						if (parms.contains("group")) {
+							ac.getAttributesManager().setAttributes(ac.getSession(),
+									ac.getFacilityById(parms.readInt("facility")),
+									ac.getResourceById(parms.readInt("resource")),
+									ac.getGroupById(parms.readInt("group")),
+									ac.getUserById(parms.readInt("user")),
+									ac.getMemberById(parms.readInt("member")),
+									parms.readList("attributes", Attribute.class));
+						} else {
+							ac.getAttributesManager().setAttributes(ac.getSession(),
+									ac.getFacilityById(parms.readInt("facility")),
+									ac.getResourceById(parms.readInt("resource")),
+									ac.getUserById(parms.readInt("user")),
+									ac.getMemberById(parms.readInt("member")),
+									parms.readList("attributes", Attribute.class));
+						}
 					} else {
 						ac.getAttributesManager().setAttributes(ac.getSession(),
 								ac.getFacilityById(parms.readInt("facility")),
@@ -1454,34 +1456,36 @@ public enum AttributesManagerMethod implements ManagerMethod {
 		public List<Attribute> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if (parms.contains("service")) {
 				if (parms.contains("resource")) {
-					if (parms.contains("member") && parms.contains("group")) {
-						if (parms.contains("workWithUserAttributes")) {
-							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-									ac.getServiceById(parms.readInt("service")),
-									ac.getResourceById(parms.readInt("resource")),
-									ac.getGroupById(parms.readInt("group")),
-									ac.getMemberById(parms.readInt("member")),
-									parms.readBoolean("workWithUserAttributes"));
+					if (parms.contains("member")) {
+						if (parms.contains("group")) {
+							if (parms.contains("workWithUserAttributes")) {
+								return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+										ac.getServiceById(parms.readInt("service")),
+										ac.getResourceById(parms.readInt("resource")),
+										ac.getGroupById(parms.readInt("group")),
+										ac.getMemberById(parms.readInt("member")),
+										parms.readBoolean("workWithUserAttributes"));
+							} else {
+								return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+										ac.getServiceById(parms.readInt("service")),
+										ac.getResourceById(parms.readInt("resource")),
+										ac.getGroupById(parms.readInt("group")),
+										ac.getMemberById(parms.readInt("member")),
+										false);
+							}
 						} else {
-							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-									ac.getServiceById(parms.readInt("service")),
-									ac.getResourceById(parms.readInt("resource")),
-									ac.getGroupById(parms.readInt("group")),
-									ac.getMemberById(parms.readInt("member")),
-									false);
-						}
-					} else if (parms.contains("member")) {
-						if (parms.contains("workWithUserAttributes")) {
-							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-									ac.getServiceById(parms.readInt("service")),
-									ac.getResourceById(parms.readInt("resource")),
-									ac.getMemberById(parms.readInt("member")),
-									parms.readBoolean("workWithUserAttributes"));
-						} else {
-							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-									ac.getServiceById(parms.readInt("service")),
-									ac.getResourceById(parms.readInt("resource")),
-									ac.getMemberById(parms.readInt("member")));
+							if (parms.contains("workWithUserAttributes")) {
+								return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+										ac.getServiceById(parms.readInt("service")),
+										ac.getResourceById(parms.readInt("resource")),
+										ac.getMemberById(parms.readInt("member")),
+										parms.readBoolean("workWithUserAttributes"));
+							} else {
+								return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
+										ac.getServiceById(parms.readInt("service")),
+										ac.getResourceById(parms.readInt("resource")),
+										ac.getMemberById(parms.readInt("member")));
+							}
 						}
 					} else if (parms.contains("group")) {
 						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
@@ -2653,23 +2657,28 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			for(int i : ids) {
 				attributes.add(ac.getAttributeDefinitionById(i));
 			}
-
 			if (parms.contains("facility")) {
-				if (parms.contains("resource") && parms.contains("group") && parms.contains("user") && parms.contains("member")) {
-					ac.getAttributesManager().removeAttributes(ac.getSession(),
-							ac.getFacilityById(parms.readInt("facility")),
-							ac.getResourceById(parms.readInt("resource")),
-							ac.getGroupById(parms.readInt("group")),
-							ac.getUserById(parms.readInt("user")),
-							ac.getMemberById(parms.readInt("member")),
-							attributes);
-				} else if (parms.contains("resource") && parms.contains("user") && parms.contains("member")) {
-					ac.getAttributesManager().removeAttributes(ac.getSession(),
-							ac.getFacilityById(parms.readInt("facility")),
-							ac.getResourceById(parms.readInt("resource")),
-							ac.getUserById(parms.readInt("user")),
-							ac.getMemberById(parms.readInt("member")),
-							attributes);
+				if (parms.contains("resource")) {
+					if (parms.contains("member")) {
+						if (parms.contains("user")) {
+							if (parms.contains("group")) {
+								ac.getAttributesManager().removeAttributes(ac.getSession(),
+										ac.getFacilityById(parms.readInt("facility")),
+										ac.getResourceById(parms.readInt("resource")),
+										ac.getGroupById(parms.readInt("group")),
+										ac.getUserById(parms.readInt("user")),
+										ac.getMemberById(parms.readInt("member")),
+										attributes);
+							} else {
+								ac.getAttributesManager().removeAttributes(ac.getSession(),
+										ac.getFacilityById(parms.readInt("facility")),
+										ac.getResourceById(parms.readInt("resource")),
+										ac.getUserById(parms.readInt("user")),
+										ac.getMemberById(parms.readInt("member")),
+										attributes);
+							}
+						}
+					}
 				} else if (parms.contains("user")) {
 					ac.getAttributesManager().removeAttributes(ac.getSession(),
 							ac.getFacilityById(parms.readInt("facility")),

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -335,12 +335,24 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	 * @param resource int Resource <code>id</code>
 	 * @return List<Group> Resource groups
 	 */
+	/*#
+	 * List all groups associated with the resource and member
+	 *
+	 * @param resource int Resource <code>id</code>
+	 * @param member int Member <code>id</code>
+	 * @return List<Group> Resource groups with specified member
+	 */
 	getAssignedGroups {
 
 		@Override
 		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getResourcesManager().getAssignedGroups(ac.getSession(),
-					ac.getResourceById(parms.readInt("resource")));
+			if (parms.contains("member")) {
+				return ac.getResourcesManager().getAssignedGroups(ac.getSession(),
+						ac.getResourceById(parms.readInt("resource")), ac.getMemberById(parms.readInt("member")));
+			} else {
+				return ac.getResourcesManager().getAssignedGroups(ac.getSession(),
+						ac.getResourceById(parms.readInt("resource")));
+			}
 		}
 	},
 
@@ -998,7 +1010,7 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 		@Override
 		public BanOnResource call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
-			
+
 			return ac.getResourcesManager().updateBan(ac.getSession(),
 					parms.read("banOnResource", BanOnResource.class));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/resourcesManager/GetAssignedGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/resourcesManager/GetAssignedGroups.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 
 /**
  * Ajax query to get assigned groups for specified resource
+ * or specified resource and member
  *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
@@ -37,6 +38,7 @@ public class GetAssignedGroups implements JsonCallback, JsonCallbackTable<Group>
 	private PerunWebSession session = PerunWebSession.getInstance();
 	// resource id
 	private int resourceId;
+	private int memberId = 0;
 	// JSON URL
 	static private final String JSON_URL = "resourcesManager/getAssignedGroups";
 	// Selection model
@@ -73,11 +75,35 @@ public class GetAssignedGroups implements JsonCallback, JsonCallbackTable<Group>
 	/**
 	 * Creates a new callback instance
 	 *
+	 * @param resourceId resource ID
+	 * @param memberId member ID
+	 */
+	public GetAssignedGroups(int resourceId, int memberId) {
+		this.resourceId = resourceId;
+		this.memberId = memberId;
+	}
+
+	/**
+	 * Creates a new callback instance
+	 *
 	 * @param id resource ID
 	 * @param events Custom events
 	 */
 	public GetAssignedGroups(int id, JsonCallbackEvents events) {
 		this.resourceId = id;
+		this.events = events;
+	}
+
+	/**
+	 * Creates a new callback instance
+	 *
+	 * @param id resource ID
+	 * @param memberId member ID
+	 * @param events Custom events
+	 */
+	public GetAssignedGroups(int id, int memberId, JsonCallbackEvents events) {
+		this.resourceId = id;
+		this.memberId = memberId;
 		this.events = events;
 	}
 
@@ -189,7 +215,10 @@ public class GetAssignedGroups implements JsonCallback, JsonCallbackTable<Group>
 	 * Retrieve data from RPC
 	 */
 	public void retrieveData() {
-		final String param = "resource=" + this.resourceId;
+		String param = "resource=" + this.resourceId;
+		if (memberId != 0) {
+			param = param+"&member=" + this.memberId;
+		}
 		JsonClient js = new JsonClient();
 		js.retrieveData(JSON_URL, param, this);
 	}
@@ -380,6 +409,10 @@ public class GetAssignedGroups implements JsonCallback, JsonCallbackTable<Group>
 
 	public void setOracle(UnaccentMultiWordSuggestOracle oracle) {
 		this.oracle = oracle;
+	}
+
+	public void setMemberId(int memberId) {
+		this.memberId = memberId;
 	}
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/SetNewAttributeTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/SetNewAttributeTabItem.java
@@ -211,7 +211,19 @@ public class SetNewAttributeTabItem implements TabItem {
 
 					SetAttributes request = new SetAttributes(events);
 
-					if (ids.size() == 4 && ids.containsKey("facility") && ids.containsKey("user") && ids.containsKey("member") && ids.containsKey("resource")) {
+					if (ids.size() == 5 && ids.containsKey("facility") && ids.containsKey("user") && ids.containsKey("member") && ids.containsKey("resource") && ids.containsKey("group")) {
+
+						ArrayList sendList = new ArrayList();
+						sendList.addAll(memberList);
+						sendList.addAll(userList);
+						sendList.addAll(memberResourceList);
+						sendList.addAll(userFacilityList);
+						sendList.addAll(memberGroupList);
+
+						request.setAttributes(ids, sendList);
+
+
+					} else if (ids.size() == 4 && ids.containsKey("facility") && ids.containsKey("user") && ids.containsKey("member") && ids.containsKey("resource")) {
 
 						ArrayList sendList = new ArrayList();
 						sendList.addAll(memberList);
@@ -221,6 +233,17 @@ public class SetNewAttributeTabItem implements TabItem {
 
 						request.setAttributes(ids, sendList);
 
+
+					} else if (ids.size() == 3 && ids.containsKey("member") && ids.containsKey("user") && ids.containsKey("group")) {
+
+						ArrayList sendList = new ArrayList();
+						sendList.addAll(memberList);
+						sendList.addAll(userList);
+						sendList.addAll(memberGroupList);
+						// call proper method in RPC
+						ids.put("workWithUserAttributes", 1);
+						request.setAttributes(ids, sendList);
+						ids.remove("workWithUserAttributes");
 
 					} else if (ids.size() == 2 &&ids.containsKey("facility") && ids.containsKey("user")) {
 
@@ -393,8 +416,14 @@ public class SetNewAttributeTabItem implements TabItem {
 		// resource relative
 		if (ids.contains("resource")) {
 			if (ids.contains("member")) {
-				namespaces.add("member");
-				namespaces.add("member_resource");
+				if (ids.contains("group")) {
+					namespaces.add("member");
+					namespaces.add("member_resource");
+					namespaces.add("member_group");
+				} else {
+					namespaces.add("member");
+					namespaces.add("member_resource");
+				}
 			} else if (ids.contains("group")) {
 				namespaces.add("group");
 				namespaces.add("group_resource");
@@ -416,6 +445,7 @@ public class SetNewAttributeTabItem implements TabItem {
 		}
 		if (ids.contains("member")) {
 			if (ids.contains("group")) {
+				namespaces.add("member");
 				namespaces.add("member_group");
 			} else {
 				namespaces.add("member");
@@ -430,7 +460,8 @@ public class SetNewAttributeTabItem implements TabItem {
 		if (ids.contains("vo")) {
 			namespaces.add("vo");
 		}
-		if (ids.contains("group")) {
+		// we never set member-group and group attributes together !!
+		if (ids.contains("group") && !ids.contains("member")) {
 			namespaces.add("group");
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberSettingsTabItem.java
@@ -103,6 +103,7 @@ public class MemberSettingsTabItem implements TabItem {
 		final Map<String, Integer> ids = new HashMap<String, Integer>();
 		ids.put("member", member.getId());
 		ids.put("workWithUserAttributes", 1); // work with user
+		if (groupId != 0) ids.put("group", groupId);
 		final GetResourceRequiredAttributesV2 resourceRequired = new GetResourceRequiredAttributesV2(ids, JsonCallbackEvents.passDataToAnotherCallback(callback));
 		final GetRequiredAttributes required = new GetRequiredAttributes(ids, JsonCallbackEvents.passDataToAnotherCallback(callback));
 
@@ -133,6 +134,10 @@ public class MemberSettingsTabItem implements TabItem {
 						callback.retrieveData();
 						callback.getUserFacilityAttributes(listbox.getSelectedObject().getFacilityId(), member.getUser().getId());
 						callback.retrieveData();
+						if (groupId != 0) {
+							callback.getMemberGroupAttributes(member.getId(), groupId);
+							callback.retrieveData();
+						}
 						// if required attributes
 					} else if (filter.getSelectedIndex() == 1) {
 						callback.clearTable();
@@ -142,6 +147,7 @@ public class MemberSettingsTabItem implements TabItem {
 						lastSelectedFilterIndex = 2;
 						ids.put("member", member.getId());
 						ids.put("resource", listbox.getSelectedObject().getId());
+						if (groupId != 0) ids.put("group", groupId);
 						ids.put("resourceToGetServicesFrom", listbox.getSelectedObject().getId());
 						ids.put("workWithUserAttributes",1);
 						resourceRequired.retrieveData();
@@ -151,6 +157,7 @@ public class MemberSettingsTabItem implements TabItem {
 						ids.clear();
 						ids.put("member", member.getId());
 						ids.put("resource", listbox.getSelectedObject().getId());
+						if (groupId != 0) ids.put("group", groupId);
 						ids.put("resourceToGetServicesFrom", listbox.getSelectedObject().getId());
 						ids.put("workWithUserAttributes",1);
 						resourceRequired.retrieveData();
@@ -162,12 +169,17 @@ public class MemberSettingsTabItem implements TabItem {
 						callback.clearTable();
 						callback.getMemberAttributes(member.getId(), 1);
 						callback.retrieveData();
+						if (groupId != 0) {
+							callback.getMemberGroupAttributes(member.getId(), groupId);
+							callback.retrieveData();
+						}
 						// if required attributes
 					} else if (filter.getSelectedIndex() == 1) {
 						callback.clearTable();
 						ids.clear();
 						ids.put("member", member.getId());
 						ids.put("workWithUserAttributes", 1);
+						if (groupId != 0) ids.put("group", groupId);
 						required.retrieveData();
 						// if resource required
 					} else if (filter.getSelectedIndex() == 2) {
@@ -283,6 +295,10 @@ public class MemberSettingsTabItem implements TabItem {
 									callback.retrieveData();
 									callback.getUserFacilityAttributes(listbox.getSelectedObject().getFacilityId(), member.getUser().getId());
 									callback.retrieveData();
+									if (groupId != 0) {
+										callback.getMemberGroupAttributes(member.getId(), groupId);
+										callback.retrieveData();
+									}
 								}
 							}));
 						} else {
@@ -293,6 +309,7 @@ public class MemberSettingsTabItem implements TabItem {
 									ids.clear();
 									ids.put("member", member.getId());
 									ids.put("resource", listbox.getSelectedObject().getId());
+									if (groupId != 0) ids.put("group", groupId);
 									ids.put("resourceToGetServicesFrom", listbox.getSelectedObject().getId());
 									ids.put("workWithUserAttributes", 1);
 									resourceRequired.retrieveData();
@@ -305,6 +322,7 @@ public class MemberSettingsTabItem implements TabItem {
 						ids.put("resource", listbox.getSelectedObject().getId());
 						ids.put("facility", listbox.getSelectedObject().getFacilityId());
 						ids.put("user", member.getUserId());
+						if (groupId != 0) ids.put("group", groupId);
 						request.setAttributes(ids, callback.getTableSelectedList());
 					} else {
 						// if resource not selected
@@ -321,13 +339,19 @@ public class MemberSettingsTabItem implements TabItem {
 							request = new SetAttributes(JsonCallbackEvents.disableButtonEvents(saveChangesButton, new JsonCallbackEvents() {
 								public void onFinished(JavaScriptObject jso) {
 									callback.clearTable();
+									callback.getMemberAttributes(memberId, 1);
 									callback.retrieveData();
+									if (groupId != 0) {
+										callback.getMemberGroupAttributes(memberId, groupId);
+										callback.retrieveData();
+									}
 								}
 							}));
 						}
 						// make setAttributes call
 						ids.clear();
 						ids.put("member", member.getId());
+						if (groupId != 0) ids.put("group", groupId);
 						ids.put("workWithUserAttributes", 1);
 						request.setAttributes(ids, callback.getTableSelectedList());
 					}
@@ -344,6 +368,7 @@ public class MemberSettingsTabItem implements TabItem {
 				Map<String, Integer> ids = new HashMap<String,Integer>();
 				ids.put("member", member.getId());
 				ids.put("user", member.getUser().getId());
+				if (groupId != 0) ids.put("group", groupId);
 				if (listbox.getSelectedIndex() > 0) {
 					ids.put("resource", listbox.getSelectedObject().getId());
 					ids.put("facility", listbox.getSelectedObject().getFacilityId());
@@ -376,6 +401,10 @@ public class MemberSettingsTabItem implements TabItem {
 									callback.retrieveData();
 									callback.getUserFacilityAttributes(listbox.getSelectedObject().getFacilityId(), member.getUser().getId());
 									callback.retrieveData();
+									if (groupId != 0) {
+										callback.getMemberGroupAttributes(member.getId(), groupId);
+										callback.retrieveData();
+									}
 								}
 							}));
 						} else {
@@ -386,6 +415,7 @@ public class MemberSettingsTabItem implements TabItem {
 									ids.clear();
 									ids.put("member", member.getId());
 									ids.put("resource", listbox.getSelectedObject().getId());
+									if (groupId != 0) ids.put("group", groupId);
 									ids.put("resourceToGetServicesFrom", listbox.getSelectedObject().getId());
 									ids.put("workWithUserAttributes",1);
 									resourceRequired.retrieveData();
@@ -398,6 +428,7 @@ public class MemberSettingsTabItem implements TabItem {
 						ids.put("resource", listbox.getSelectedObject().getId());
 						ids.put("facility",listbox.getSelectedObject().getFacilityId());
 						ids.put("user", member.getUserId());
+						if (groupId != 0) ids.put("group", groupId);
 						request.removeAttributes(ids, callback.getTableSelectedList());
 					} else {
 						// if resource not selected
@@ -414,13 +445,19 @@ public class MemberSettingsTabItem implements TabItem {
 							request = new RemoveAttributes(JsonCallbackEvents.disableButtonEvents(removeButton, new JsonCallbackEvents(){
 								public void onFinished(JavaScriptObject jso) {
 									callback.clearTable();
+									callback.getMemberAttributes(memberId, 1);
 									callback.retrieveData();
+									if (groupId != 0) {
+										callback.getMemberGroupAttributes(memberId, groupId);
+										callback.retrieveData();
+									}
 								}
 							}));
 						}
 						// make removeAttributes call
 						ids.clear();
 						ids.put("member", member.getId());
+						if (groupId != 0) ids.put("group", groupId);
 						ids.put("workWithUserAttributes", 1);
 						request.removeAttributes(ids, callback.getTableSelectedList());
 					}


### PR DESCRIPTION
CORE/RPC:
- Added methods for necessary member-group attributes management
  to Api/Entry layer:
  setAttributes(sess, facility,resource,group,user,member,attributes)
  getResourceRequiredAttributes(sess, resource, resource, group, member, workWithUserAttrs)
  getRequiredAttributes(sess, member, group, workWithUserAttrs)
  getRequiredAttributes(sess, service, resource, group, member, workWithUserAttrs)
  removeAttributes(sess, facility, resource, group, user, member, attributes)
  getAssignedGroups(sess, resource, member)
- Added also to Bl/Impl layer:
  checkAttributesValue(sess, facility, resource, group, user, member, attributes)
  checkAttributesDependencies(sess, resource, group, member, user, facility, attributes);
- Necessary methods added to RPC.
- Fixed core and rpc javadoc.

GUI:
- New type of attributes can be get/set/removed from standard attributes tabs.
- Allow to manage member-group attributes along with others from members details
  "settings" page if opened from Group details, "Members" tab.
- Same for "Members settings" on Resource detail page, where list of members groups
  assigned to resource is provided for each member.