### PR TITLE
Add limit of concurent active synchronization

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -20,6 +20,7 @@ public class CoreConfig {
 	private boolean readOnlyPerun;
 	private int groupSynchronizationInterval;
 	private int groupSynchronizationTimeout;
+	private int groupMaxConcurentGroupsToSynchronize;
 	private int mailchangeValidationWindow;
 	private int pwdresetValidationWindow;
 	private List<String> admins;
@@ -48,6 +49,15 @@ public class CoreConfig {
 	private String rtUrl;
 	private String smsProgram;
 	private String userExtSourcesPersistent;
+
+	public int getGroupMaxConcurentGroupsToSynchronize() {
+		return groupMaxConcurentGroupsToSynchronize;
+	}
+
+	public void setGroupMaxConcurentGroupsToSynchronize(int groupMaxConcurentGroupsToSynchronize) {
+		this.groupMaxConcurentGroupsToSynchronize = groupMaxConcurentGroupsToSynchronize;
+	}
+
 	private Map<String, List<AttributeDefinition>> attributesForUpdate = new HashMap<>();
 
 

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -17,6 +17,7 @@
 		<property name="generatedLoginNamespaces" value="#{'${perun.loginNamespace.generated}'.split('\s*,\s*')}"/>
 		<property name="groupSynchronizationInterval" value="${perun.group.synchronization.interval}"/>
 		<property name="groupSynchronizationTimeout" value="${perun.group.synchronization.timeout}"/>
+		<property name="groupMaxConcurentGroupsToSynchronize" value="${perun.group.maxConcurentGroupsToSynchronize}"/>
 		<property name="instanceId" value="${perun.instanceId}"/>
 		<property name="instanceName" value="${perun.instanceName}"/>
 		<property name="mailchangeBackupFrom" value="${perun.mailchange.backupFrom}"/>
@@ -69,6 +70,7 @@
 				<prop key="perun.db.type">hsqldb</prop>
 				<prop key="perun.group.synchronization.interval">1</prop>
 				<prop key="perun.group.synchronization.timeout">10</prop>
+				<prop key="perun.group.maxConcurentGroupsToSynchronize">10</prop>
 				<prop key="perun.rpc.powerusers"/>
 				<prop key="perun.perun.db.name">perun</prop>
 				<prop key="perun.rt.url">https://rt3.cesnet.cz/rt/REST/1.0/ticket/new</prop>


### PR DESCRIPTION
 - limit by default with value 10, can be changed by property
   perun.group.maxConcurentGroupsToSynchronize in perun.properties file
 - instead of execute all not-already running groups, add them to the
   queue and they will be executed as soon as there will be place for
   them (less running threads than current maximum)
 - forcing group adds group at the first place of the queue (it means
   it can be outrun by another forcing of group)
 - add some methods to work with this concurent queue of waiting groups