### PR TITLE
add another destination type (DUMMY), that makes the whole propagatio…

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Destination.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Destination.java
@@ -19,6 +19,7 @@ public class Destination extends Auditable implements Comparable<PerunBean> {
 
 	public static final String PROPAGATIONTYPE_PARALLEL = "PARALLEL";
 	public static final String PROPAGATIONTYPE_SERIAL = "SERIAL";
+	public static final String PROPAGATIONTYPE_DUMMY = "DUMMY";
 
 	private String destination;
 	private String type;
@@ -79,7 +80,7 @@ public class Destination extends Auditable implements Comparable<PerunBean> {
 	/**
 	 * 	Gets the propagation type for this instance.
 	 * 
-	 *  @return The propagation type, either "PARALLEL" or "SERIAL"
+	 *  @return The propagation type, either "PARALLEL", "SERIAL" or "DUMMY"
 	 */
 	public String getPropagationType() {
 		return this.propagationType;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -131,8 +131,11 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 			destination.setModifiedAt(rs.getString("destinations_modified_at"));
 			destination.setModifiedBy(rs.getString("destinations_modified_by"));
 			try { // do not mind if the column is not in the results
-				if(rs.getString("f_s_des_propagation_type").equals(Destination.PROPAGATIONTYPE_SERIAL)) {
-					destination.setPropagationType(Destination.PROPAGATIONTYPE_SERIAL);
+				String ptype = rs.getString("f_s_des_propagation_type");
+				if(ptype.equals(Destination.PROPAGATIONTYPE_SERIAL) ||
+				   ptype.equals(Destination.PROPAGATIONTYPE_PARALLEL) ||
+				   ptype.equals(Destination.PROPAGATIONTYPE_DUMMY)) {
+					destination.setPropagationType(ptype);
 				} else {
 					destination.setPropagationType(Destination.PROPAGATIONTYPE_PARALLEL);
 				}

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
@@ -621,6 +621,13 @@ public class TaskSchedulerImpl implements TaskScheduler {
 		}
 		log.debug("Fetched destinations: " + ( (destinations == null) ?  "[]" : destinations.toString()));
 		task.setDestinations(destinations);
+		if(task.getExecService().getExecServiceType().equals(ExecServiceType.SEND) && 
+		   (destinations == null || destinations.isEmpty())) {
+			log.info("Task [] has no destination, setting to error.");
+			task.setEndTime(new Date(System.currentTimeMillis()));
+			schedulingPool.setTaskStatus(task, TaskStatus.ERROR);
+			return;
+		}
 		StringBuilder destinations_s = new StringBuilder("Destinations [");
 		if (destinations != null) {
 			for (Destination destination : destinations) {

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/ExecutorEngineWorkerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/ExecutorEngineWorkerImpl.java
@@ -46,6 +46,28 @@ public class ExecutorEngineWorkerImpl implements ExecutorEngineWorker {
 	@Override
 	public void run() {
 
+		if(destination.getPropagationType().equals(Destination.PROPAGATIONTYPE_DUMMY)) {
+			log.info("EXECUTING(worker:" + this.hashCode() + "): Task ID:"
+					+ task.getId() + ", Facility ID:" + task.getFacilityId()
+					+ ", ExecService ID:" + task.getExecServiceId()
+					+ ", ExecServiceType:" + execService.getExecServiceType());
+
+
+			TaskResult taskResult = new TaskResult();
+			taskResult.setTaskId(task.getId());
+			taskResult.setDestinationId(destination.getId());
+			taskResult.setErrorMessage("");
+			taskResult.setStandardMessage("");
+			taskResult.setReturnCode(0);
+			taskResult.setStatus(TaskResultStatus.DONE);
+			taskResult.setTimestamp(new Date(System.currentTimeMillis()));
+			taskResult.setService(execService.getService());
+				
+			resultListener.onTaskDestinationDone(task, destination,	taskResult);
+			log.info("SEND task for dummy destination done. Task: " + task.getId());
+			return;
+		}
+		
 		log.info("EXECUTING(worker:" + this.hashCode() + "): Task ID:"
 				+ task.getId() + ", Facility ID:" + task.getFacilityId()
 				+ ", ExecService ID:" + task.getExecServiceId()

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskSchedulerImpl.java
@@ -49,9 +49,9 @@ public class TaskSchedulerImpl implements TaskScheduler {
 		List<Destination> destinations = task.getDestinations();
 		if (task.getExecService().getExecServiceType().equals(ExecServiceType.SEND)
 				&& (destinations == null || destinations.isEmpty())) {
-			log.info("No destinations found for SEND task {}, marking as DONE",
+			log.info("No destinations found for SEND task {}, marking as ERROR",
 					task.getId());
-			schedulingPool.setTaskStatus(task, TaskStatus.DONE);
+			schedulingPool.setTaskStatus(task, TaskStatus.ERROR);
 		} else {
 			if(task.getStatus() == TaskStatus.PROCESSING) {
 				log.warn("Attempt to schedule already processing task {}, ignoring this.", task.getId());

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskStatusImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/TaskStatusImpl.java
@@ -62,7 +62,7 @@ public class TaskStatusImpl implements TaskStatus {
 				if (destination.getPropagationType().equals("PARALLEL")) {
 					allDestinations.put(destination,
 							TaskDestinationStatus.WAITING);
-				} else {
+				} else { // propagation type SERIAL or DUMMY
 					oneOfAllDestinations.put(destination,
 							TaskDestinationStatus.WAITING);
 				}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -387,6 +387,14 @@ public class ApiCaller {
 		return d;
 	}
 
+	public Destination getDestination(String destination, String type, String propagationType) throws PerunException {
+		Destination d = new Destination();
+		d.setDestination(destination);
+		d.setType(type);
+		d.setPropagationType(propagationType);
+		return d;
+	}
+
 	public List<Object> convertGroupsWithHierarchy(Group group, Map<Group, Object> groups) {
 		if (group != null) {
 			List<Object> groupHierarchy = new ArrayList<Object>();

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -757,16 +757,24 @@ public enum ServicesManagerMethod implements ManagerMethod {
 		public Destination call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
+			Destination destination;
+			
+			if(parms.contains("propagationType")) {
+				destination = ac.getDestination(parms.readString("destination"), parms.readString("type"), 
+						parms.readString("propagationType"));
+			} else {
+				destination = ac.getDestination(parms.readString("destination"), parms.readString("type")); 
+			}
 			if(parms.contains("services")) {
 				return ac.getServicesManager().addDestination(ac.getSession(),
 						parms.readList("services", Service.class),
 						ac.getFacilityById(parms.readInt("facility")),
-						ac.getDestination(parms.readString("destination"), parms.readString("type")));
+						destination);
 			} else {
 				return ac.getServicesManager().addDestination(ac.getSession(),
 						ac.getServiceById(parms.readInt("service")),
 						ac.getFacilityById(parms.readInt("facility")),
-						ac.getDestination(parms.readString("destination"), parms.readString("type")));
+						destination);
 			}
 
 
@@ -787,9 +795,17 @@ public enum ServicesManagerMethod implements ManagerMethod {
 		public List<Destination> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
+			Destination destination;
+			
+			if(parms.contains("propagationType")) {
+				destination = ac.getDestination(parms.readString("destination"), parms.readString("type"), 
+						parms.readString("propagationType"));
+			} else {
+				destination = ac.getDestination(parms.readString("destination"), parms.readString("type")); 
+			}
 			return ac.getServicesManager().addDestinationsForAllServicesOnFacility(ac.getSession(),
 					ac.getFacilityById(parms.readInt("facility")),
-					ac.getDestination(parms.readString("destination"), parms.readString("type")));
+					destination);
 		}
 	},
 


### PR DESCRIPTION
…n sucessfull without actually running SEND task

* adds propagation type DUMMY to the Destination
* dispatcher now sets tasks with no destinations to the error state
* engine does not try to propagate tasks that have DUMMY destination, they are considered done
* engine sets tasks with no destinations to the error state

See RT#214867.