### PR TITLE
Implementation of tests for AttributesManagerBlImpl private methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -3783,13 +3783,14 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws AttributeNotExistsException
 	 * @throws VoNotExistsException
+	 * @throws UserNotExistsException
 	 * @throws WrongAttributeAssignmentException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws MemberResourceMismatchException
 	 * @throws GroupResourceMismatchException
 	 */
-	List<RichAttribute> getRichAttributesWithHoldersForAttributeDefinition(PerunSession sess, AttributeDefinition attrDef, RichAttribute aidingAttr) throws InternalErrorException, AttributeNotExistsException, VoNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException;
+	List<RichAttribute> getRichAttributesWithHoldersForAttributeDefinition(PerunSession sess, AttributeDefinition attrDef, RichAttribute aidingAttr) throws InternalErrorException, AttributeNotExistsException, VoNotExistsException, UserNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException, MemberResourceMismatchException;
 
 	/**
 	 * Get All user_facility attributes for any existing user

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1061,6 +1061,16 @@ public interface MembersManagerBl {
 	void checkMemberExists(PerunSession sess, Member member) throws InternalErrorException, MemberNotExistsException;
 
 	/**
+	 * Return false if member has status INVALID or DISABLED. True in other cases.
+	 *
+	 * @param sess
+	 * @param member the member
+	 * @return false if member has INVALID or DISABLED status, true in other cases
+	 * @throws InternalErrorException
+	 */
+	boolean isMemberAllowed(PerunSession sess, Member member) throws InternalErrorException;
+
+	/**
 	 *  Set status of the member to specified status.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -67,6 +67,7 @@ import cz.metacentrum.perun.core.implApi.AttributesManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import static cz.metacentrum.perun.core.api.AttributesManager.*;
 
@@ -1209,7 +1210,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		//if there is no entities, so no attribute definition will be returned => empty array list of ADs
 		if(entities == null || entities.isEmpty()) return attributeDefinitions;
-		//or fill list by all attributeDefinitions
+			//or fill list by all attributeDefinitions
 		else attributeDefinitions = this.getAttributesDefinition(sess);
 
 		//Prepare possible objects
@@ -1232,7 +1233,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			else if(entity instanceof Facility) facility = (Facility) entity;
 			else if(entity instanceof Host) host = (Host) entity;
 			else if(entity instanceof UserExtSource) ues = (UserExtSource) entity;
-			//Else skip not identified entity (log it)
+				//Else skip not identified entity (log it)
 			else log.debug("In method GetAttributesDefinitionWithRights there are entity which is not identified correctly and will be skipped: " + entity);
 		}
 
@@ -1530,7 +1531,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, facility, attribute)) {
 			checkAttributeValue(sess, facility, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(facility, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(facility, null, attribute));
 		}
 	}
 
@@ -1561,7 +1562,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, vo, attribute)) {
 			checkAttributeValue(sess, vo, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(vo, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(vo, null, attribute));
 		}
 	}
 
@@ -1591,7 +1592,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, group, attribute)) {
 			checkAttributeValue(sess, group, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(group, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(group, null, attribute));
 		}
 	}
 
@@ -1603,7 +1604,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, resource, attribute)) {
 			checkAttributeValue(sess, resource, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(resource, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(resource, null, attribute));
 		}
 	}
 
@@ -1657,7 +1658,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, resource, member, attribute, false)) {
 			checkAttributeValue(sess, resource, member, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(resource, member, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(resource, member, attribute));
 		}
 	}
 
@@ -1670,7 +1671,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if (setAttributeWithoutCheck(sess, member, group, attribute, false)) {
 			checkAttributeValue(sess, member, group, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(member, group, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(member, group, attribute));
 		}
 	}
 
@@ -1682,7 +1683,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(!workWithUserAttributes) {
 			if(setAttributeWithoutCheck(sess, resource, member, attribute, false)) {
-				this.checkAttributeDependencies(sess, new RichAttribute(resource, member, attribute));
+				this.checkAttributeDependencies(sess, new RichAttribute<>(resource, member, attribute));
 				checkAttributeValue(sess, resource, member, attribute);
 			}
 		} else {
@@ -1818,7 +1819,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, member, attribute)) {
 			checkAttributeValue(sess, member, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(member, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(member, null, attribute));
 		}
 	}
 
@@ -1868,7 +1869,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, facility, user, attribute)) {
 			checkAttributeValue(sess, facility, user, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(facility, user, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(facility, user, attribute));
 		}
 	}
 
@@ -1880,7 +1881,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, user, attribute)) {
 			checkAttributeValue(sess, user, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(user, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(user, null, attribute));
 		}
 	}
 
@@ -1915,7 +1916,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, host, attribute)) {
 			checkAttributeValue(sess, host, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(host, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(host, null, attribute));
 		}
 	}
 
@@ -1946,7 +1947,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			return;
 		}
 		if(setAttributeWithoutCheck(sess, resource, group, attribute)) {
-			this.checkAttributeDependencies(sess, new RichAttribute(resource, group, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(resource, group, attribute));
 			checkAttributeValue(sess, resource, group, attribute);
 		}
 	}
@@ -2036,7 +2037,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, key, attribute)) {
 			checkAttributeValue(sess, key, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(key, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(key, null, attribute));
 		}
 	}
 
@@ -2048,7 +2049,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(setAttributeWithoutCheck(sess, ues, attribute)) {
 			checkAttributeValue(sess, ues, attribute);
-			this.checkAttributeDependencies(sess, new RichAttribute(ues, null, attribute));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(ues, null, attribute));
 		}
 	}
 
@@ -2066,7 +2067,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//check if attribute.type is valid class name
 		try {
 			if (!attribute.getType().equals(BeansUtils.largeStringClassName) &&
-					!attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
+						!attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
 				Class.forName(attribute.getType());
 			}
 		} catch(ClassNotFoundException ex) {
@@ -2663,7 +2664,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 					if(a.getValue() != null) attributesWithChangedValue.add(a);
 				}
 			}
-		return attributesWithChangedValue;
+			return attributesWithChangedValue;
 		}
 	}
 
@@ -3174,7 +3175,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, String key, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, key, attribute)) {
 			this.checkAttributeValue(sess, key, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(key, null, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(key, null, new Attribute(attribute)));
 		}
 	}
 
@@ -3200,7 +3201,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, facility, attribute)) {
 			this.checkAttributeValue(sess, facility, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(facility, null, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(facility, null, new Attribute(attribute)));
 		}
 	}
 
@@ -3340,7 +3341,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if (removeAttributeWithoutCheck(sess, host, attribute)) {
 			checkAttributeValue(sess, host, new Attribute(attribute));
 			try {
-				this.checkAttributeDependencies(sess, new RichAttribute(host, null, new Attribute(attribute)));
+				this.checkAttributeDependencies(sess, new RichAttribute<>(host, null, new Attribute(attribute)));
 			} catch (WrongReferenceAttributeValueException ex) {
 				throw new WrongAttributeValueException(ex);
 			}
@@ -3418,7 +3419,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, vo, attribute)) {
 			checkAttributeValue(sess, vo, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(vo, null, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(vo, null, new Attribute(attribute)));
 		}
 	}
 
@@ -3484,7 +3485,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, group, attribute)) {
 			checkAttributeValue(sess, group, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(group, null, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(group, null, new Attribute(attribute)));
 		}
 	}
 
@@ -3550,7 +3551,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		boolean changed = removeAttributeWithoutCheck(sess, resource, attribute);
 		if (changed) {
 			checkAttributeValue(sess, resource, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(resource, null, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(resource, null, new Attribute(attribute)));
 		}
 		return changed;
 	}
@@ -3627,7 +3628,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		if (removeAttributeWithoutCheck(sess, resource, member, attribute)) {
 			checkAttributeValue(sess, resource, member, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(resource, member, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(resource, member, new Attribute(attribute)));
 		}
 	}
 
@@ -3723,10 +3724,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, member, group, attribute)) {
 			checkAttributeValue(sess, member, group, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(member, group, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(member, group, new Attribute(attribute)));
 		}
 	}
-// s workWithUserAttr.
+	// s workWithUserAttr.
 	public boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_GROUP_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);
@@ -3815,7 +3816,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, member, attribute)) {
 			checkAttributeValue(sess, member, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(member, null, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(member, null, new Attribute(attribute)));
 		}
 	}
 
@@ -3884,7 +3885,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, facility, user, attribute)) {
 			checkAttributeValue(sess, facility, user, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(facility, user, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(facility, user, new Attribute(attribute)));
 		}
 	}
 
@@ -3998,7 +3999,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, user, attribute)) {
 			checkAttributeValue(sess, user, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(user, null, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(user, null, new Attribute(attribute)));
 		}
 	}
 
@@ -4064,7 +4065,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
 		if (removeAttributeWithoutCheck(sess, resource, group, attribute)) {
 			checkAttributeValue(sess, resource, group, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(resource, group, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(resource, group, new Attribute(attribute)));
 		}
 	}
 
@@ -4161,7 +4162,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAttribute(PerunSession sess, UserExtSource ues, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, ues, attribute)) {
 			checkAttributeValue(sess, ues, new Attribute(attribute));
-			this.checkAttributeDependencies(sess, new RichAttribute(ues, null, new Attribute(attribute)));
+			this.checkAttributeDependencies(sess, new RichAttribute<>(ues, null, new Attribute(attribute)));
 		}
 	}
 
@@ -4391,7 +4392,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	public Object stringToAttributeValue(String value, String type) throws InternalErrorException {
 		if (type.equals(ArrayList.class.getName()) || type.equals(LinkedHashMap.class.getName()) ||
-				type.equals(BeansUtils.largeArrayListClassName)) {
+					type.equals(BeansUtils.largeArrayListClassName)) {
 			if (value != null && !value.isEmpty() && !value.endsWith(String.valueOf(AttributesManagerImpl.LIST_DELIMITER))) {
 				value = value.concat(String.valueOf(AttributesManagerImpl.LIST_DELIMITER));
 			}
@@ -4710,7 +4711,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private void checkAttributesDependencies(PerunSession sess, Object primaryHolder, Object secondaryHolder, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		if(attributes != null && !attributes.isEmpty()) {
 			for(Attribute attr: attributes) {
-				checkAttributeDependencies(sess, new RichAttribute(primaryHolder, secondaryHolder, attr));
+				checkAttributeDependencies(sess, new RichAttribute<>(primaryHolder, secondaryHolder, attr));
 			}
 		}
 	}
@@ -4907,7 +4908,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if(aidingAttr == null) throw new InternalErrorException("Aiding attribute cant be null.");
 		if(attrDef == null) throw new InternalErrorException("attrDef cant be null.");
 
-		List<RichAttribute> listOfRichAttributes = new ArrayList<RichAttribute>();
+		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 
 		//All possible useful objects
 		Vo vo = null;
@@ -4958,17 +4959,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//Second on the fact what i really have in aidingAttr i try to find what i am looking for
 		//IMPORTANT: If member is not allowed on connected objects (INVALID or DISABLED status), we skip these objects
 
-		//RESULT -> VO attributes
 		if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_VO_ATTR)) {
 
 			if(resource != null && member != null) {
-				listOfRichAttributes.addAll(this.getVoAttributes(sess, member, resource, attrDef));
+				//we do not need object resource to resolve this case
+				listOfRichAttributes.addAll(this.getVoAttributes(sess, member, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getVoAttributes(sess, group, resource, attrDef));
+				//we do not need object resource to resolve this case
+				listOfRichAttributes.addAll(this.getVoAttributes(sess, group, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getVoAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
-				listOfRichAttributes.addAll(this.getVoAttributes(sess, member, group, attrDef));
+				//we do not need object group to resolve this case
+				listOfRichAttributes.addAll(this.getVoAttributes(sess, member, attrDef));
 			} else if(group != null) {
 				listOfRichAttributes.addAll(this.getVoAttributes(sess, group, attrDef));
 			} else if(member != null) {
@@ -4991,12 +4994,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> GROUP attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_GROUP_ATTR)) {
 			if(resource != null && member != null) {
 				listOfRichAttributes.addAll(this.getGroupAttributes(sess, member, resource, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getGroupAttributes(sess, group, resource, attrDef));
+				//we do not need to use the resource object here
+				listOfRichAttributes.addAll(this.getGroupAttributes(sess, group, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getGroupAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
@@ -5020,15 +5023,15 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			} else if(key != null) {
 				listOfRichAttributes.addAll(this.getGroupAttributes(sess, key, attrDef));
 			} else {
-			throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
+				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> FACILITY attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_FACILITY_ATTR)) {
 			if(resource != null && member != null) {
 				listOfRichAttributes.addAll(this.getFacilityAttributes(sess, member, resource, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getFacilityAttributes(sess, group, resource, attrDef));
+				//we do not need to use the group object here
+				listOfRichAttributes.addAll(this.getFacilityAttributes(sess, resource, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getFacilityAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
@@ -5055,16 +5058,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> MEMBER attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_MEMBER_ATTR)) {
 			if(resource != null && member != null) {
-				listOfRichAttributes.addAll(this.getMemberAttributes(sess, member, resource, attrDef));
+				//we do not need to use the resource object here
+				listOfRichAttributes.addAll(this.getMemberAttributes(sess, member, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getMemberAttributes(sess, group, resource, attrDef));
+				//we do not need to use the resource object here
+				listOfRichAttributes.addAll(this.getMemberAttributes(sess, group, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getMemberAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
-				listOfRichAttributes.addAll(this.getMemberAttributes(sess, member, group, attrDef));
+				//we do not need to use the group object here
+				listOfRichAttributes.addAll(this.getMemberAttributes(sess, member, attrDef));
 			} else if(group != null) {
 				listOfRichAttributes.addAll(this.getMemberAttributes(sess, group, attrDef));
 			} else if(member != null) {
@@ -5087,12 +5092,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> RESOURCE attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_RESOURCE_ATTR)) {
 			if(resource != null && member != null) {
 				listOfRichAttributes.addAll(this.getResourceAttributes(sess, member, resource, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getResourceAttributes(sess, group, resource, attrDef));
+				//we do not need to use the group object here
+				listOfRichAttributes.addAll(this.getResourceAttributes(sess, resource, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getResourceAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
@@ -5119,16 +5124,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> USER attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_USER_ATTR)) {
 			if(resource != null && member != null) {
-				listOfRichAttributes.addAll(this.getUserAttributes(sess, member, resource, attrDef));
+				//we do not need to use the resource object here
+				listOfRichAttributes.addAll(this.getUserAttributes(sess, member, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getUserAttributes(sess, group, resource, attrDef));
+				//we do not need to use the resource object here
+				listOfRichAttributes.addAll(this.getUserAttributes(sess, group, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getUserAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
-				listOfRichAttributes.addAll(this.getUserAttributes(sess, member, group, attrDef));
+				//we do not need to use the group object here
+				listOfRichAttributes.addAll(this.getUserAttributes(sess, member, attrDef));
 			} else if(group != null) {
 				listOfRichAttributes.addAll(this.getUserAttributes(sess, group, attrDef));
 			} else if(member != null) {
@@ -5151,12 +5158,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> HOST attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, AttributesManager.NS_HOST_ATTR)) {
 			if(resource != null && member != null) {
 				listOfRichAttributes.addAll(this.getHostAttributes(sess, member, resource, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getHostAttributes(sess, group, resource, attrDef));
+				//we do not need to user the group object here
+				listOfRichAttributes.addAll(this.getHostAttributes(sess, resource, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getHostAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
@@ -5183,7 +5190,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> GROUP-RESOURCE attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_GROUP_RESOURCE_ATTR)) {
 			if(resource != null && member != null) {
 				listOfRichAttributes.addAll(this.getGroupResourceAttributes(sess, member, resource, attrDef));
@@ -5215,12 +5221,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> MEMBER-GROUP attributes
 		} else if (getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_MEMBER_GROUP_ATTR)) {
 			if(resource != null && member != null) {
 				listOfRichAttributes.addAll(this.getMemberGroupAttributes(sess, member, resource, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getMemberGroupAttributes(sess, group, resource, attrDef));
+				//we do not need to use the resource object
+				listOfRichAttributes.addAll(this.getMemberGroupAttributes(sess, group, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getMemberGroupAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
@@ -5247,7 +5253,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> MEMBER-RESOURCE attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_MEMBER_RESOURCE_ATTR)) {
 			if(resource != null && member != null) {
 				listOfRichAttributes.addAll(this.getMemberResourceAttributes(sess, member, resource, attrDef));
@@ -5279,7 +5284,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> USER-FACILITY attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_USER_FACILITY_ATTR)) {
 			if(resource != null && member != null) {
 				listOfRichAttributes.addAll(this.getUserFacilityAttributes(sess, member, resource, attrDef));
@@ -5311,16 +5315,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-		//RESULT -> USEREXTSOURCE attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, NS_UES_ATTR)) {
 			if(resource != null && member != null) {
-				listOfRichAttributes.addAll(this.getUserExtSourceAttributes(sess, member, resource, attrDef));
+				//we do not need to use the resource object here
+				listOfRichAttributes.addAll(this.getUserExtSourceAttributes(sess, member, attrDef));
 			} else if(group != null && resource != null) {
-				listOfRichAttributes.addAll(this.getUserExtSourceAttributes(sess, group, resource, attrDef));
+				//we do not need to use the resource object here
+				listOfRichAttributes.addAll(this.getUserExtSourceAttributes(sess, group, attrDef));
 			} else if(user != null && facility != null) {
 				listOfRichAttributes.addAll(this.getUserExtSourceAttributes(sess, user, facility, attrDef));
 			} else if (member != null && group != null) {
-				listOfRichAttributes.addAll(this.getUserExtSourceAttributes(sess, member, group, attrDef));
+				//we do not need to use the group object here
+				listOfRichAttributes.addAll(this.getUserExtSourceAttributes(sess, member, attrDef));
 			} else if(group != null) {
 				listOfRichAttributes.addAll(this.getUserExtSourceAttributes(sess, group, attrDef));
 			} else if(member != null) {
@@ -5343,7 +5349,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				throw new InternalErrorException("Unknown combination of PerunBeans: " + aidingAttr );
 			}
 
-			//RESULT -> ENTITYLESS attributes
 		} else if(getAttributesManagerImpl().isFromNamespace(sess, attrDef, AttributesManager.NS_ENTITYLESS_ATTR)) {
 			if(key != null) {
 				listOfRichAttributes.addAll(getEntitylessAttributes(sess, key, attrDef));
@@ -5351,7 +5356,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				listOfRichAttributes.addAll(getEntitylessAttributes(sess, attrDef));
 			}
 
-		//RESULT -> UNKNOWN
 		} else {
 			throw new InternalErrorException("There is unrecognized namespace in attribute " + attrDef);
 		}
@@ -5882,7 +5886,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getVoAttributes(PerunSession sess, User user, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> membersFromUser = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		List<Vo> vosFromMembers = new ArrayList<Vo>();
+		List<Vo> vosFromMembers = new ArrayList<>();
 		for (Member memberElement : membersFromUser) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				vosFromMembers.add(getPerunBl().getMembersManagerBl().getMemberVo(sess, memberElement));
@@ -5890,7 +5894,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		for (Vo voElement : vosFromMembers) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, voElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(voElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(voElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -5900,7 +5904,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			Vo vo = getPerunBl().getMembersManagerBl().getMemberVo(sess, member);
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(vo, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(vo, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -5909,7 +5913,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Vo vo = getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId());
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(vo, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(vo, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -5917,14 +5921,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Vo vo = getPerunBl().getVosManagerBl().getVoById(sess, resource.getVoId());
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(vo, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(vo, null, attribute));
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getVoAttributes(PerunSession sess, Vo vo, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(vo, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(vo, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -5933,7 +5937,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Vo> vos = getPerunBl().getFacilitiesManagerBl().getAllowedVos(sess, facility);
 		for (Vo voElement : vos) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, voElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(voElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(voElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -5944,68 +5948,54 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Vo> vos = getPerunBl().getFacilitiesManagerBl().getAllowedVos(sess, facility);
 		for (Vo voElement : vos) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, voElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(voElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(voElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
 
-	private List<RichAttribute> getVoAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, UserNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<RichAttribute> getVoAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, UserNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, VoNotExistsException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		User user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
-		List<Vo> vosFromUser = getPerunBl().getUsersManagerBl().getVosWhereUserIsMember(sess, user);
-		for (Vo voElement : vosFromUser) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, voElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(voElement, null, attribute));
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getVoAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, VoNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		Vo vo = getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId());
-		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(vo, null, attribute));
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getVoAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, VoNotExistsException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			Vo vo = getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId());
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(vo, null, attribute));
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getVoAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, VoNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			Vo vo = getPerunBl().getVosManagerBl().getVoById(sess, member.getVoId());
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(vo, null, attribute));
+		List<Member> membersOfUser = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
+		for (Member memberElement : membersOfUser) {
+			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
+				Vo vo = getPerunBl().getVosManagerBl().getVoById(sess, memberElement.getVoId());
+				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, attrDef.getName());
+				listOfRichAttributes.add(new RichAttribute<>(vo, null, attribute));
+			}
 		}
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getVoAttributes(PerunSession sess, User user, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		List<Vo> vosFromUser = new ArrayList<Vo>();
+		List<Group> groupsFromUser = new ArrayList<>();
 		List<Member> membersFromUser = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		List<Resource> resourcesFromUser = new ArrayList<Resource>();
 		for (Member memberElement : membersFromUser) {
-			resourcesFromUser.addAll(getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement));
+			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
+				groupsFromUser.addAll(getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement));
+			}
 		}
-		for (Resource resourceElement : resourcesFromUser) {
-			vosFromUser.add(getPerunBl().getResourcesManagerBl().getVo(sess, resourceElement));
+		List<Resource> resourcesFromFacility = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
+		List<Group> groupsFromFacility = new ArrayList<>();
+		for (Resource resourceElement : resourcesFromFacility) {
+			groupsFromFacility.addAll(perunBl.getResourcesManagerBl().getAssignedGroups(sess, resourceElement));
 		}
-		List<Vo> vosFromFacility = getPerunBl().getFacilitiesManagerBl().getAllowedVos(sess, facility);
-		vosFromFacility.retainAll(vosFromUser);
-		vosFromFacility = new ArrayList<Vo>(new HashSet<Vo>(vosFromFacility));
-		for (Vo voElement : vosFromFacility) {
+		groupsFromUser.retainAll(groupsFromFacility);
+		groupsFromUser = new ArrayList<>(new HashSet<>(groupsFromUser));
+
+		List<Vo> vos = new ArrayList<>();
+		for (Group groupElement : groupsFromUser) {
+			vos.add(getPerunBl().getGroupsManagerBl().getVo(sess, groupElement));
+		}
+
+		vos = new ArrayList<>(new HashSet<>(vos));
+
+		for (Vo voElement : vos) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, voElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(voElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(voElement, null, attribute));
 		}
+
 		return listOfRichAttributes;
 	}
 
@@ -6014,7 +6004,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Vo> vos = getPerunBl().getVosManagerBl().getVos(sess);
 		for (Vo voElement : vos) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, voElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(voElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(voElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6024,7 +6014,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getUserAttributes(PerunSession sess, User user, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(user, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(user, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -6033,7 +6023,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(user, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(user, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6041,16 +6031,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getUserAttributes(PerunSession sess, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
-		List<User> usersFromGroup = new ArrayList<User>();
+		List<User> usersFromGroup = new ArrayList<>();
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				usersFromGroup.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
 			}
 		}
-		usersFromGroup = new ArrayList<User>(new HashSet<User>(usersFromGroup));
+		usersFromGroup = new ArrayList<>(new HashSet<>(usersFromGroup));
 		for (User userElement : usersFromGroup) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(userElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(userElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6060,7 +6050,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<User> usersFromResource = getPerunBl().getResourcesManagerBl().getAllowedUsers(sess, resource);
 		for (User userElement : usersFromResource) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(userElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(userElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6068,16 +6058,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getUserAttributes(PerunSession sess, Vo vo, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembers(sess, vo);
-		List<User> usersFromVo = new ArrayList<User>();
+		List<User> usersFromVo = new ArrayList<>();
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				usersFromVo.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
 			}
 		}
-		usersFromVo = new ArrayList<User>(new HashSet<User>(usersFromVo));
+		usersFromVo = new ArrayList<>(new HashSet<>(usersFromVo));
 		for (User userElement : usersFromVo) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(userElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(userElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6087,7 +6077,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<User> usersFromFacility = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility);
 		for (User userElement : usersFromFacility) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(userElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(userElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6098,7 +6088,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<User> usersFromHost = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility);
 		for (User userElement : usersFromHost) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(userElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(userElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6107,53 +6097,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		User user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(user, null, attribute));
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getUserAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		List<Member> members = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
-		List<Member> membersFromResource = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
-		members.retainAll(membersFromResource);
-		List<User> usersFromGroup = new ArrayList<User>();
-		for (Member memberElement : members) {
-			usersFromGroup.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
-		}
-		usersFromGroup = new ArrayList<User>(new HashSet<User>(usersFromGroup));
-		for (User userElement : usersFromGroup) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(userElement, null, attribute));
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getUserAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(user, null, attribute));
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getUserAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(user, null, attribute));
-		}
+		listOfRichAttributes.add(new RichAttribute<>(user, null, attribute));
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getUserAttributes(PerunSession sess, User user, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Facility> facilitiesFromUser = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
-		if (facilitiesFromUser.contains(user)) {
+		if (facilitiesFromUser.contains(facility)) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(user, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(user, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6163,7 +6116,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<User> allUsers = getPerunBl().getUsersManagerBl().getUsers(sess);
 		for (User userElement : allUsers) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(userElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(userElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6176,7 +6129,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Member memberElement : membersFromUser) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6186,7 +6139,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(member, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(member, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6197,7 +6150,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Member memberElement : membersFromGroup) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6208,7 +6161,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Member> membersFromResource = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		for (Member memberElement : membersFromResource) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6219,7 +6172,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Member memberElement : membersFromVo) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6230,7 +6183,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Member> membersFromFacility = getPerunBl().getFacilitiesManagerBl().getAllowedMembers(sess, facility);
 		for (Member memberElement : membersFromFacility) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6241,7 +6194,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Member> membersFromHost = getPerunBl().getFacilitiesManagerBl().getAllowedMembers(sess, facility);
 		for (Member memberElement : membersFromHost) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6253,39 +6206,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Member memberElement : membersFromUser) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 			}
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getMemberAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		List<Member> membersFromResource = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
-		List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
-		membersFromResource.retainAll(membersFromGroup);
-		membersFromResource = new ArrayList<Member>(new HashSet<Member>(membersFromResource));
-		for (Member memberElement : membersFromResource) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getMemberAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(member, null, attribute));
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getMemberAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(member, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6295,10 +6217,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Member> membersFromUser = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
 		List<Member> membersFromFacility = getPerunBl().getFacilitiesManagerBl().getAllowedMembers(sess, facility);
 		membersFromUser.retainAll(membersFromFacility);
-		membersFromUser = new ArrayList<Member>(new HashSet<Member>(membersFromUser));
+		membersFromUser = new ArrayList<>(new HashSet<>(membersFromUser));
 		for (Member memberElement : membersFromUser) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6306,14 +6228,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getMemberAttributes(PerunSession sess, String key, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Vo> vos = getPerunBl().getVosManagerBl().getVos(sess);
-		Set<Member> allMembers = new HashSet<Member>();
+		Set<Member> allMembers = new HashSet<>();
 		for (Vo voElement : vos) {
 			allMembers.addAll(getPerunBl().getMembersManagerBl().getMembers(sess, voElement));
 		}
 		for (Member memberElement : allMembers) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(memberElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(memberElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6324,16 +6246,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getGroupAttributes(PerunSession sess, User user, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		List<Group> groupsFromMembers = new ArrayList<Group>();
+		List<Group> groupsFromMembers = new ArrayList<>();
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				groupsFromMembers.addAll(getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement));
 			}
 		}
-		groupsFromMembers = new ArrayList<Group>(new HashSet<Group>(groupsFromMembers));
+		groupsFromMembers = new ArrayList<>(new HashSet<>(groupsFromMembers));
 		for (Group groupElement : groupsFromMembers) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6344,7 +6266,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Group> groupsFromMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, member);
 			for (Group groupElement : groupsFromMember) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6353,7 +6275,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getGroupAttributes(PerunSession sess, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(group, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(group, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -6362,7 +6284,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Group> groupsFromResource = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
 		for (Group groupElement : groupsFromResource) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6372,7 +6294,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Group> groups = getPerunBl().getGroupsManagerBl().getAllGroups(sess, vo);
 		for (Group groupElement : groups) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6382,7 +6304,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Group> groupsFromFacility = getPerunBl().getGroupsManagerBl().getAssignedGroupsToFacility(sess, facility);
 		for (Group groupElement : groupsFromFacility) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6393,7 +6315,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Group> groupsFromFacility = getPerunBl().getGroupsManagerBl().getAssignedGroupsToFacility(sess, facility);
 		for (Group groupElement : groupsFromFacility) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6411,22 +6333,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		groupsFromMembers = new ArrayList<>(new HashSet<>(groupsFromMembers));
 		for (Group groupElement : groupsFromMembers) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getGroupAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(group, null, attribute));
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getGroupAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(group, null, attribute));
+		if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
+			listOfRichAttributes = getGroupAttributes(sess, group, attrDef);
+		}
 		return listOfRichAttributes;
 	}
 
@@ -6436,10 +6352,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Group> groupsFromResource = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
 			List<Group> groupsFromMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, member);
 			groupsFromResource.retainAll(groupsFromMember);
-			groupsFromResource = new ArrayList<Group>(new HashSet<Group>(groupsFromResource));
+			groupsFromResource = new ArrayList<>(new HashSet<>(groupsFromResource));
 			for (Group groupElement : groupsFromResource) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6448,7 +6364,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getGroupAttributes(PerunSession sess, User user, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		Set<Group> groupsFromMembers = new HashSet<Group>();
+		Set<Group> groupsFromMembers = new HashSet<>();
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				groupsFromMembers.addAll(getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement));
@@ -6457,7 +6373,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		groupsFromMembers.retainAll(getPerunBl().getGroupsManagerBl().getAssignedGroupsToFacility(sess, facility));
 		for (Group groupElement : groupsFromMembers) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6465,14 +6381,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getGroupAttributes(PerunSession sess, String key, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Vo> vos = getPerunBl().getVosManagerBl().getVos(sess);
-		List<Group> groupsFromVos = new ArrayList<Group>();
+		List<Group> groupsFromVos = new ArrayList<>();
 		for (Vo voElement : vos) {
 			groupsFromVos.addAll(getPerunBl().getGroupsManagerBl().getAllGroups(sess, voElement));
 		}
-		groupsFromVos = new ArrayList<Group>(new HashSet<Group>(groupsFromVos));
+		groupsFromVos = new ArrayList<>(new HashSet<>(groupsFromVos));
 		for (Group groupElement : groupsFromVos) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(groupElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(groupElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6482,16 +6398,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getResourceAttributes(PerunSession sess, User user, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		List<Resource> resourcesFromUser = new ArrayList<Resource>();
+		List<Resource> resourcesFromUser = new ArrayList<>();
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				resourcesFromUser.addAll(getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement));
 			}
 		}
-		resourcesFromUser = new ArrayList<Resource>(new HashSet<Resource>(resourcesFromUser));
+		resourcesFromUser = new ArrayList<>(new HashSet<>(resourcesFromUser));
 		for (Resource resourceElement : resourcesFromUser) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6502,7 +6418,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Resource> resourcesFromMember = getPerunBl().getResourcesManagerBl().getAllowedResources(sess, member);
 			for (Resource resourceElement : resourcesFromMember) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6513,7 +6429,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Resource> resourcesFromGroup = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
 		for (Resource resourceElement : resourcesFromGroup) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6521,7 +6437,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getResourceAttributes(PerunSession sess, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(resource, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(resource, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -6530,7 +6446,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Resource> resourcesFromVo = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
 		for (Resource resourceElement : resourcesFromVo) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 		}
 
 		return listOfRichAttributes;
@@ -6541,7 +6457,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Resource> resourcesFromFacility = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 		for (Resource resourceElement : resourcesFromFacility) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6552,7 +6468,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Resource> resourcesFromFacility = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 		for (Resource resourceElement : resourcesFromFacility) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6561,24 +6477,17 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		User user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		List<Resource> resourcesFromUser = new ArrayList<Resource>();
+		List<Resource> resourcesFromUser = new ArrayList<>();
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				resourcesFromUser.addAll(getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement));
 			}
 		}
-		resourcesFromUser = new ArrayList<Resource>(new HashSet<Resource>(resourcesFromUser));
+		resourcesFromUser = new ArrayList<>(new HashSet<>(resourcesFromUser));
 		for (Resource resourceElement : resourcesFromUser) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getResourceAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(resource, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -6588,7 +6497,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Resource> resourcesFromGroup = new ArrayList<>(new HashSet<>(getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group)));
 			for (Resource resourceElement : resourcesFromGroup) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6598,7 +6507,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resource, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resource, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6606,7 +6515,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getResourceAttributes(PerunSession sess, User user, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		List<Resource> resourcesFromUser = new ArrayList<Resource>();
+		List<Resource> resourcesFromUser = new ArrayList<>();
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				resourcesFromUser.addAll(getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement));
@@ -6614,10 +6523,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		List<Resource> resourcesFromFacility = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 		resourcesFromUser.retainAll(resourcesFromFacility);
-		resourcesFromUser = new ArrayList<Resource>(new HashSet<Resource>(resourcesFromUser));
+		resourcesFromUser = new ArrayList<>(new HashSet<>(resourcesFromUser));
 		for (Resource resourceElement : resourcesFromUser) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6625,14 +6534,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getResourceAttributes(PerunSession sess, String key, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Vo> vos = getPerunBl().getVosManagerBl().getVos(sess);
-		List<Resource> allResources = new ArrayList<Resource>();
+		List<Resource> allResources = new ArrayList<>();
 		for (Vo voElement : vos) {
 			allResources.addAll(getPerunBl().getResourcesManagerBl().getResources(sess, voElement));
 		}
-		allResources = new ArrayList<Resource>(new HashSet<Resource>(allResources));
+		allResources = new ArrayList<>(new HashSet<>(allResources));
 		for (Resource resourceElement : allResources) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6644,7 +6553,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
 		for (Facility facilityElement : facilities) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facilityElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facilityElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6653,18 +6562,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			List<Group> groupsForMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, member);
-			List<Resource> resourcesFromMember = new ArrayList<Resource>();
+			List<Resource> resourcesFromMember = new ArrayList<>();
 			for (Group groupElement : groupsForMember) {
 				resourcesFromMember.addAll(getPerunBl().getResourcesManagerBl().getAssignedResources(sess, groupElement));
 			}
-			Set<Facility> facilitiesFromMember = new HashSet<Facility>();
+			Set<Facility> facilitiesFromMember = new HashSet<>();
 			for (Resource resourceElement : resourcesFromMember) {
 				facilitiesFromMember.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElement));
 
 			}
 			for (Facility facilityElement : facilitiesFromMember) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(facilityElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(facilityElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6673,14 +6582,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getFacilityAttributes(PerunSession sess, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Resource> resources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
-		List<Facility> facilitiesFromResources = new ArrayList<Facility>();
+		List<Facility> facilitiesFromResources = new ArrayList<>();
 		for (Resource resourceElemenet : resources) {
 			facilitiesFromResources.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElemenet));
 		}
-		facilitiesFromResources = new ArrayList<Facility>(new HashSet<Facility>(facilitiesFromResources));
+		facilitiesFromResources = new ArrayList<>(new HashSet<>(facilitiesFromResources));
 		for (Facility facilityElement : facilitiesFromResources) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facilityElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facilityElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6689,20 +6598,20 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(facility, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(facility, null, attribute));
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getFacilityAttributes(PerunSession sess, Vo vo, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Resource> resources = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
-		Set<Facility> facilitiesFromResources = new HashSet<Facility>();
+		Set<Facility> facilitiesFromResources = new HashSet<>();
 		for (Resource resourceElemenet : resources) {
 			facilitiesFromResources.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElemenet));
 		}
 		for (Facility facilityElement : facilitiesFromResources) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facilityElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facilityElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6710,7 +6619,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getFacilityAttributes(PerunSession sess, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(facility, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(facility, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -6718,7 +6627,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityForHost(sess, host);
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(facility, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(facility, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -6728,32 +6637,15 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Facility> facilitiesFromUser = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
 		for (Facility facilityElement : facilitiesFromUser) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facilityElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facilityElement, null, attribute));
 		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getFacilityAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
-		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(facility, null, attribute));
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getFacilityAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			List<Resource> resources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
-			List<Facility> facilitiesFromResources = new ArrayList<>();
-			for (Resource resourceElement : resources) {
-				facilitiesFromResources.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElement));
-			}
-			facilitiesFromResources = new ArrayList<>(new HashSet<>(facilitiesFromResources));
-			for (Facility facilityElement : facilitiesFromResources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(facilityElement, null, attribute));
-			}
+			listOfRichAttributes = getFacilityAttributes(sess, group, attrDef);
 		}
 		return listOfRichAttributes;
 	}
@@ -6761,9 +6653,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getFacilityAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facility, null, attribute));
+			listOfRichAttributes = getFacilityAttributes(sess, resource, attrDef);
 		}
 		return listOfRichAttributes;
 	}
@@ -6773,7 +6663,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Facility> facilitiesFromUser = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
 		if (facilitiesFromUser.contains(facility)) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facility, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facility, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6783,7 +6673,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getFacilities(sess);
 		for (Facility facilityElement : facilities) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facilityElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facilityElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6793,30 +6683,35 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getHostAttributes(PerunSession sess, User user, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
-		List<Host> hostsFromUser = new ArrayList<Host>();
+		List<Host> hostsFromUser = new ArrayList<>();
 		for (Facility facilityElement : facilities) {
 			hostsFromUser.addAll(getPerunBl().getFacilitiesManagerBl().getHosts(sess, facilityElement));
 		}
-		hostsFromUser = new ArrayList<Host>(new HashSet<Host>(hostsFromUser));
+		hostsFromUser = new ArrayList<>(new HashSet<>(hostsFromUser));
 		for (Host hostElement : hostsFromUser) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getHostAttributes(PerunSession sess, Member member, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
-		List<Host> hostsFromUser = new ArrayList<Host>();
-		for (Facility facilityElement : facilities) {
-			hostsFromUser.addAll(getPerunBl().getFacilitiesManagerBl().getHosts(sess, facilityElement));
-		}
-		hostsFromUser = new ArrayList<Host>(new HashSet<Host>(hostsFromUser));
-		for (Host hostElement : hostsFromUser) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+		if(perunBl.getMembersManagerBl().isMemberAllowed(sess, member)) {
+			List<Group> groupsForMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, member);
+			List<Facility> facilitiesForMemberGroups = new ArrayList<>();
+			List<Host> hostsForMemberGroups = new ArrayList<>();
+			for (Group groupElement : groupsForMember) {
+				facilitiesForMemberGroups.addAll(getPerunBl().getFacilitiesManagerBl().getAssignedFacilities(sess, groupElement));
+			}
+			for (Facility facilityElement : facilitiesForMemberGroups) {
+				hostsForMemberGroups.addAll(getPerunBl().getFacilitiesManagerBl().getHosts(sess, facilityElement));
+			}
+			hostsForMemberGroups = new ArrayList<>(new HashSet<>(hostsForMemberGroups));
+			for (Host hostElement : hostsForMemberGroups) {
+				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
+				listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
+			}
 		}
 		return listOfRichAttributes;
 	}
@@ -6824,18 +6719,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getHostAttributes(PerunSession sess, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Resource> resources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
-		List<Facility> facilities = new ArrayList<Facility>();
+		List<Facility> facilities = new ArrayList<>();
 		for (Resource resourceElement : resources) {
 			facilities.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElement));
 		}
-		List<Host> hostsFromGroup = new ArrayList<Host>();
+		List<Host> hostsFromGroup = new ArrayList<>();
 		for (Facility facilityElement : facilities) {
 			hostsFromGroup.addAll(getPerunBl().getFacilitiesManagerBl().getHosts(sess, facilityElement));
 		}
-		hostsFromGroup = new ArrayList<Host>(new HashSet<Host>(hostsFromGroup));
+		hostsFromGroup = new ArrayList<>(new HashSet<>(hostsFromGroup));
 		for (Host hostElement : hostsFromGroup) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6846,7 +6741,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Host> hostsFromResource = getPerunBl().getFacilitiesManagerBl().getHosts(sess, facility);
 		for (Host hostElement : hostsFromResource) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6854,18 +6749,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getHostAttributes(PerunSession sess, Vo vo, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Resource> resources = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
-		List<Facility> facilities = new ArrayList<Facility>();
+		List<Facility> facilities = new ArrayList<>();
 		for (Resource resourceElement : resources) {
 			facilities.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElement));
 		}
-		List<Host> hostsFromVo = new ArrayList<Host>();
+		List<Host> hostsFromVo = new ArrayList<>();
 		for (Facility facilityElement : facilities) {
 			hostsFromVo.addAll(getPerunBl().getFacilitiesManagerBl().getHosts(sess, facilityElement));
 		}
-		hostsFromVo = new ArrayList<Host>(new HashSet<Host>(hostsFromVo));
+		hostsFromVo = new ArrayList<>(new HashSet<>(hostsFromVo));
 		for (Host hostElement : hostsFromVo) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6875,7 +6770,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Host> hostsFromFacility = getPerunBl().getFacilitiesManagerBl().getHosts(sess, facility);
 		for (Host hostElement : hostsFromFacility) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6883,7 +6778,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getHostAttributes(PerunSession sess, Host host, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, host, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(host, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(host, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -6891,25 +6786,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		User user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
 		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
-		List<Host> hostsFromUser = new ArrayList<Host>();
+		List<Host> hostsFromUser = new ArrayList<>();
 		for (Facility facilityElement : facilities) {
 			hostsFromUser.addAll(getPerunBl().getFacilitiesManagerBl().getHosts(sess, facilityElement));
 		}
-		hostsFromUser = new ArrayList<Host>(new HashSet<Host>(hostsFromUser));
+		hostsFromUser = new ArrayList<>(new HashSet<>(hostsFromUser));
 		for (Host hostElement : hostsFromUser) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getHostAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
-		List<Host> hostsFromResource = getPerunBl().getFacilitiesManagerBl().getHosts(sess, facility);
-		for (Host hostElement : hostsFromResource) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6917,20 +6801,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getHostAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			List<Resource> resourcesFromGroup = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
-			List<Facility> facilitiesFromResources = new ArrayList<>();
-			for (Resource resourceElement : resourcesFromGroup) {
-				facilitiesFromResources.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElement));
-			}
-			facilitiesFromResources = new ArrayList<>(new HashSet<>(facilitiesFromResources));
-			List<Host> hostsFromFacilities = new ArrayList<>();
-			for (Facility facilityElement : facilitiesFromResources) {
-				hostsFromFacilities.addAll(getPerunBl().getFacilitiesManagerBl().getHosts(sess, facilityElement));
-			}
-			for (Host hostElement : hostsFromFacilities) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
-			}
+			listOfRichAttributes = getHostAttributes(sess, group, attrDef);
 		}
 		return listOfRichAttributes;
 	}
@@ -6938,12 +6809,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getHostAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
-			List<Host> hostsFromResource = getPerunBl().getFacilitiesManagerBl().getHosts(sess, facility);
-			for (Host hostElement : hostsFromResource) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
-			}
+			listOfRichAttributes = getHostAttributes(sess, resource, attrDef);
 		}
 		return listOfRichAttributes;
 	}
@@ -6954,7 +6820,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Host> hostsFromFacility = getPerunBl().getFacilitiesManagerBl().getHosts(sess, facility);
 			for (Host hostElement : hostsFromFacility) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -6963,14 +6829,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getHostAttributes(PerunSession sess, String key, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getFacilities(sess);
-		List<Host> hostsFromVo = new ArrayList<Host>();
+		List<Host> hostsFromVo = new ArrayList<>();
 		for (Facility facilityElement : facilities) {
 			hostsFromVo.addAll(getPerunBl().getFacilitiesManagerBl().getHosts(sess, facilityElement));
 		}
-		hostsFromVo = new ArrayList<Host>(new HashSet<Host>(hostsFromVo));
+		hostsFromVo = new ArrayList<>(new HashSet<>(hostsFromVo));
 		for (Host hostElement : hostsFromVo) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, hostElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(hostElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(hostElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6982,7 +6848,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
 		for(UserExtSource userExtSourceElement : userExtSources) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(userExtSourceElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -6991,11 +6857,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
-			for (UserExtSource userExtSourceElement : userExtSources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-			}
+			listOfRichAttributes = getUserExtSourceAttributes(sess, user, attrDef);
 		}
 		return listOfRichAttributes;
 	}
@@ -7004,14 +6866,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> groupMembers = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
 		for(Member memberElement: groupMembers) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement);
-				List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
-				for (UserExtSource userExtSourceElement : userExtSources) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-				}
-			}
+			listOfRichAttributes.addAll(getUserExtSourceAttributes(sess, memberElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7020,12 +6875,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> resourceMembers = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		for(Member memberElement: resourceMembers) {
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement);
-			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
-			for (UserExtSource userExtSourceElement : userExtSources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-			}
+			listOfRichAttributes.addAll(getUserExtSourceAttributes(sess, memberElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7034,14 +6884,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> voMembers = getPerunBl().getMembersManagerBl().getMembers(sess, vo);
 		for(Member memberElement: voMembers) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement);
-				List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
-				for (UserExtSource userExtSourceElement : userExtSources) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-				}
-			}
+			listOfRichAttributes.addAll(getUserExtSourceAttributes(sess, memberElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7050,12 +6893,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> facilityMembers = getPerunBl().getFacilitiesManagerBl().getAllowedMembers(sess, facility);
 		for(Member memberElement: facilityMembers) {
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement);
-			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
-			for (UserExtSource userExtSourceElement : userExtSources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-			}
+			listOfRichAttributes.addAll(getUserExtSourceAttributes(sess, memberElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7065,12 +6903,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityForHost(sess, host);
 		List<Member> facilityMembers = getPerunBl().getFacilitiesManagerBl().getAllowedMembers(sess, facility);
 		for(Member memberElement: facilityMembers) {
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement);
-			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
-			for (UserExtSource userExtSourceElement : userExtSources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-			}
+			listOfRichAttributes.addAll(getUserExtSourceAttributes(sess, memberElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7078,53 +6911,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getUserExtSourceAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSource, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(userExtSource, null, attribute));
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getUserExtSourceAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
-		List<User> usersFromGroup = new ArrayList<>();
-		for(Member memberElement: membersFromGroup) {
-			usersFromGroup.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
-		}
-		List<User> usersFromResource = getPerunBl().getResourcesManagerBl().getAllowedUsers(sess, resource);
-		usersFromResource.retainAll(usersFromGroup);
-		for(User userElement: usersFromResource) {
-			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, userElement);
-			for(UserExtSource userExtSourceElement: userExtSources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-			}
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getUserExtSourceAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
-			for(UserExtSource userExtSourceElement: userExtSources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-			}
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getUserExtSourceAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-		List<User> usersFromResource = getPerunBl().getResourcesManagerBl().getAllowedUsers(sess, resource);
-		if(usersFromResource.contains(user)) {
-			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
-			for(UserExtSource userExtSourceElement: userExtSources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
-			}
-		}
+		listOfRichAttributes.add(new RichAttribute<>(userExtSource, null, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -7135,7 +6922,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
 			for(UserExtSource userExtSourceElement: userExtSources) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(userExtSourceElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7152,7 +6939,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<UserExtSource> userExtSources = getPerunBl().getUsersManagerBl().getUserExtSources(sess, userElement);
 			for(UserExtSource userExtSourceElement: userExtSources) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, userExtSourceElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(userExtSourceElement, null, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(userExtSourceElement, null, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7164,19 +6951,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
 		for(Member memberElement: members) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				List<Group> groupsFromMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement);
-				List<Resource> resourcesFromMember = getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement);
-				for(Resource resourceElement: resourcesFromMember) {
-					List<Group> groupsFromResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
-					groupsFromResourceElement.retainAll(groupsFromMember);
-					groupsFromResourceElement = new ArrayList<Group>(new HashSet<Group>(groupsFromResourceElement));
-					for(Group groupElement: groupsFromResourceElement) {
-						Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, groupElement, attrDef.getName());
-						listOfRichAttributes.add(new RichAttribute(resourceElement, groupElement, attribute));
-					}
-				}
-			}
+			listOfRichAttributes.addAll(getGroupResourceAttributes(sess, memberElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7189,10 +6964,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			for(Resource resourceElement: resourcesFromMember) {
 				List<Group> groupsFromResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
 				groupsFromResourceElement.retainAll(groupsFromMember);
-				groupsFromResourceElement = new ArrayList<Group>(new HashSet<Group>(groupsFromResourceElement));
+				groupsFromResourceElement = new ArrayList<>(new HashSet<>(groupsFromResourceElement));
 				for(Group groupElement: groupsFromResourceElement) {
 					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(resourceElement, groupElement, attribute));
+					listOfRichAttributes.add(new RichAttribute<>(resourceElement, groupElement, attribute));
 				}
 			}
 		}
@@ -7204,7 +6979,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Resource> resourcesFromGroup = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
 		for(Resource resourceElement: resourcesFromGroup) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, group, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resourceElement, group, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resourceElement, group, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7214,7 +6989,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Group> groupsFromResource = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
 		for(Group groupElement: groupsFromResource) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resource, groupElement, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resource, groupElement, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7223,11 +6998,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Resource> resources = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
 		for(Resource resourceElement: resources) {
-			List<Group> groupsFromResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
-			for(Group groupElement: groupsFromResourceElement) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, groupElement, attribute));
-			}
+			listOfRichAttributes.addAll(getGroupResourceAttributes(sess, resourceElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7236,11 +7007,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Resource> resourcesFromHost = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 		for(Resource resourceElement: resourcesFromHost) {
-			List<Group> groupsFromResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
-			for(Group groupElement: groupsFromResourceElement) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, groupElement, attribute));
-			}
+			listOfRichAttributes.addAll(getGroupResourceAttributes(sess, resourceElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7248,43 +7015,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getGroupResourceAttributes(PerunSession sess, Host host, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityForHost(sess, host);
-		List<Resource> resourcesFromHost = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
-		for(Resource resourceElement: resourcesFromHost) {
-			List<Group> groupsFromResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
-			for(Group groupElement: groupsFromResourceElement) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, groupElement, attribute));
-			}
-		}
-		return listOfRichAttributes;
+		return getGroupResourceAttributes(sess, facility, attrDef);
 	}
 
 	private List<RichAttribute> getGroupResourceAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, UserNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		User user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
-		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		for(Member memberElement: members) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				List<Group> groupsFromMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement);
-				List<Resource> resourcesFromMember = getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement);
-				for(Resource resourceElement: resourcesFromMember) {
-					List<Group> groupsFromResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
-					groupsFromResourceElement.retainAll(groupsFromMember);
-					groupsFromResourceElement = new ArrayList<Group>(new HashSet<Group>(groupsFromResourceElement));
-					for(Group groupElement: groupsFromResourceElement) {
-						Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, groupElement, attrDef.getName());
-						listOfRichAttributes.add(new RichAttribute(resourceElement, groupElement, attribute));
-					}
-				}
-			}
-		}
-		return listOfRichAttributes;
+		return getGroupResourceAttributes(sess, user, attrDef);
 	}
 
 	private List<RichAttribute> getGroupResourceAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, group, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(resource, group, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(resource, group, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -7292,11 +7035,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		// there is no need to get Resources from Member because Members are only in those groups from which we already took Resources
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			List<Resource> resourcesFromGroup = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
-			for (Resource resourceElement : resourcesFromGroup) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, group, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, group, attribute));
-			}
+			listOfRichAttributes = getGroupResourceAttributes(sess, group, attrDef);
 		}
 		return listOfRichAttributes;
 	}
@@ -7307,10 +7046,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Group> groupsFromResource = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
 			List<Group> groupsFromMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, member);
 			groupsFromResource.retainAll(groupsFromMember);
-			groupsFromResource = new ArrayList<Group>(new HashSet<Group>(groupsFromResource));
+			groupsFromResource = new ArrayList<>(new HashSet<>(groupsFromResource));
 			for (Group groupElement : groupsFromResource) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resource, groupElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resource, groupElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7320,7 +7059,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		//Groups from User
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		List<Group> groupsFromUser = new ArrayList<Group>();
+		List<Group> groupsFromUser = new ArrayList<>();
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				groupsFromUser.addAll(getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement));
@@ -7331,7 +7070,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		groupsFromFacility.retainAll(groupsFromUser);
 		//Resources from user
 		List<Member> membersFromUser = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		List<Resource> resourcesFromUser = new ArrayList<Resource>();
+		List<Resource> resourcesFromUser = new ArrayList<>();
 		for (Member memberElement : membersFromUser) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				resourcesFromUser.addAll(getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement));
@@ -7342,14 +7081,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//Retain of Resources
 		resourcesFromFacility.retainAll(resourcesFromUser);
 		//All possibilities
-		resourcesFromFacility = new ArrayList<Resource>(new HashSet<Resource>(resourcesFromFacility));
+		resourcesFromFacility = new ArrayList<>(new HashSet<>(resourcesFromFacility));
 		for (Resource resourceElement : resourcesFromFacility) {
 			List<Group> groupsForResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
 			groupsForResourceElement.retainAll(groupsFromFacility);
-			groupsForResourceElement = new ArrayList<Group>(new HashSet<Group>(groupsForResourceElement));
+			groupsForResourceElement = new ArrayList<>(new HashSet<>(groupsForResourceElement));
 			for (Group groupElement : groupsForResourceElement) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, groupElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resourceElement, groupElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7358,16 +7097,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getGroupResourceAttributes(PerunSession sess, String key, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, GroupResourceMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getFacilities(sess);
-		List<Resource> resources = new ArrayList<Resource>();
+		List<Resource> resources = new ArrayList<>();
 		for(Facility facilityElement: facilities) {
 			resources.addAll(getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facilityElement));
 		}
-		resources = new ArrayList<Resource>(new HashSet<Resource>(resources));
+		resources = new ArrayList<>(new HashSet<>(resources));
 		for(Resource resourceElement: resources) {
 			List<Group> groupsFromResourceElement = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resourceElement);
 			for(Group groupElement: groupsFromResourceElement) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, groupElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resourceElement, groupElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7379,14 +7118,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> membersFromUser = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
 		for (Member memberElement: membersFromUser) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				// get all groups for 'memberElement' variable
-				List<Group> groupsFromMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement);
-				for (Group groupElement : groupsFromMember) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(memberElement, groupElement, attribute));
-				}
-			}
+			listOfRichAttributes.addAll(getMemberGroupAttributes(sess, memberElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7397,7 +7129,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Group> groupsFromMembers = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, member);
 			for(Group groupElement : groupsFromMembers) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, groupElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(member, groupElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(member, groupElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7409,7 +7141,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Member memberElement: membersFromGroups) {
 			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, group, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(memberElement, group, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(memberElement, group, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7419,16 +7151,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Group> groupsFromResources = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
 		for (Group groupElement : groupsFromResources) {
-			// get all members for 'groupElement' variable
-			List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, groupElement);
-			for (Member memberElement : membersFromGroup) {
-				if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(memberElement, groupElement, attribute));
-				}
-			}
+			listOfRichAttributes.addAll(getMemberGroupAttributes(sess, groupElement, attrDef));
 		}
-
 		return listOfRichAttributes;
 	}
 
@@ -7436,14 +7160,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Group> groupsFromVo = getPerunBl().getGroupsManagerBl().getAllGroups(sess, vo);
 		for (Group groupElement : groupsFromVo) {
-			// get all members for 'groupElement' variable
-			List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, groupElement);
-			for (Member memberElement : membersFromGroup) {
-				if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(memberElement, groupElement, attribute));
-				}
-			}
+			listOfRichAttributes.addAll(getMemberGroupAttributes(sess, groupElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7452,70 +7169,26 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Group> groupsFromFacility = getPerunBl().getGroupsManagerBl().getAssignedGroupsToFacility(sess, facility);
 		for (Group groupElement : groupsFromFacility) {
-			// get all members for 'groupElement' variable
-			List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, groupElement);
-			for (Member memberElement : membersFromGroup) {
-				if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(memberElement, groupElement, attribute));
-				}
-			}
+			listOfRichAttributes.addAll(getMemberGroupAttributes(sess, groupElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Host host, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityForHost(sess, host);
-		List<Group> groupsFromFacility = getPerunBl().getGroupsManagerBl().getAssignedGroupsToFacility(sess, facility);
-		for (Group groupElement : groupsFromFacility) {
-			// get all members for 'groupElement' variable
-			List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, groupElement);
-			for (Member memberElement : membersFromGroup) {
-				if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(memberElement, groupElement, attribute));
-				}
-			}
-		}
-		return listOfRichAttributes;
+		return getMemberGroupAttributes(sess, facility, attrDef);
 	}
 
 	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, UserNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		User user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
-		List<Member> membersFromUser = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		for (Member memberElement: membersFromUser) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				// get all groups for 'memberElement' variable
-				List<Group> groupsFromMember = getPerunBl().getGroupsManagerBl().getAllMemberGroups(sess, memberElement);
-				for (Group groupElement : groupsFromMember) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(memberElement, groupElement, attribute));
-				}
-			}
-		}
-		return listOfRichAttributes;
-	}
-
-	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		// Because group should be assigned to the resource, we can use allowed members of this group instead
-		List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
-		for (Member memberElement : membersFromGroup) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, group, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(memberElement, group, attribute));
-			}
-		}
-		return listOfRichAttributes;
+		return getMemberGroupAttributes(sess, user, attrDef);
 	}
 
 	private List<RichAttribute> getMemberGroupAttributes(PerunSession sess, Member member, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, group, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(member, group, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(member, group, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7533,7 +7206,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		groupsFromResources = new ArrayList<>(new HashSet<>(groupsFromResources));
 		for (Group groupElement : groupsFromResources) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, groupElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(member, groupElement, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(member, groupElement, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7555,11 +7228,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Group groupElement : retainedGroups) {
 			// get all members for 'groupElement' variable
 			List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, groupElement);
+			membersFromGroup.retainAll(membersFromUser);
 			// all possibilities
 			for (Member memberElement : membersFromGroup) {
 				if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(memberElement, groupElement, attribute));
+					listOfRichAttributes.add(new RichAttribute<>(memberElement, groupElement, attribute));
 				}
 			}
 		}
@@ -7580,7 +7254,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			for (Member memberElement : membersFromGroup) {
 				if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, groupElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(memberElement, groupElement, attribute));
+					listOfRichAttributes.add(new RichAttribute<>(memberElement, groupElement, attribute));
 				}
 			}
 		}
@@ -7593,13 +7267,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
 		for(Member memberElement: members) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				List<Resource> resourcesFromMember = getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement);
-				for(Resource resourceElement: resourcesFromMember) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(resourceElement, memberElement, attribute));
-				}
-			}
+			listOfRichAttributes.addAll(getMemberResourceAttributes(sess, memberElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7610,7 +7278,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Resource> resources = getPerunBl().getResourcesManagerBl().getAllowedResources(sess, member);
 			for(Resource resourceElement: resources) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, member, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, member, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resourceElement, member, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7623,11 +7291,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for(Resource resourceElement: resourcesFromGroup) {
 			List<Member> membersForResourceElement = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resourceElement);
 			membersForResourceElement.retainAll(membersFromGroup);
-			membersForResourceElement = new ArrayList<Member>(new HashSet<Member>(membersForResourceElement));
+			membersForResourceElement = new ArrayList<>(new HashSet<>(membersForResourceElement));
 			for(Member memberElement: membersForResourceElement) {
 				if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(resourceElement, memberElement, attribute));
+					listOfRichAttributes.add(new RichAttribute<>(resourceElement, memberElement, attribute));
 				}
 			}
 		}
@@ -7639,7 +7307,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Member> members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		for(Member memberElement: members) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, memberElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resource, memberElement, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resource, memberElement, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7648,11 +7316,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Resource> resources = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
 		for(Resource resourceElement: resources) {
-			List<Member> membersFromResource = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resourceElement);
-			for(Member memberElement: membersFromResource) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, memberElement, attribute));
-			}
+			listOfRichAttributes.addAll(getMemberResourceAttributes(sess, resourceElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7661,11 +7325,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Resource> resources = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 		for(Resource resourceElement: resources) {
-			List<Member> members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resourceElement);
-			for(Member memberElement: members) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, memberElement, attribute));
-			}
+			listOfRichAttributes.addAll(getMemberResourceAttributes(sess, resourceElement, attrDef));
 		}
 		return listOfRichAttributes;
 	}
@@ -7673,31 +7333,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getMemberResourceAttributes(PerunSession sess, Host host, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityForHost(sess, host);
-		List<Resource> resources = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
-		for(Resource resourceElement: resources) {
-			List<Member> members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resourceElement);
-			for(Member memberElement: members) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, memberElement, attribute));
-			}
-		}
-		return listOfRichAttributes;
+		return getMemberResourceAttributes(sess, facility, attrDef);
 	}
 
 	private List<RichAttribute> getMemberResourceAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, UserNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		User user = getPerunBl().getUsersManagerBl().getUserByUserExtSource(sess, userExtSource);
-		List<Member> members = getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
-		for (Member memberElement : members) {
-			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				List<Resource> resourcesFromMember = getPerunBl().getResourcesManagerBl().getAllowedResources(sess, memberElement);
-				for (Resource resourceElement : resourcesFromMember) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(resourceElement, memberElement, attribute));
-				}
-			}
-		}
-		return listOfRichAttributes;
+		return getMemberResourceAttributes(sess, user, attrDef);
 	}
 
 	private List<RichAttribute> getMemberResourceAttributes(PerunSession sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
@@ -7705,10 +7347,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Member> membersFromGroup = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
 		List<Member> membersFromResource = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		membersFromGroup.retainAll(membersFromResource);
-		membersFromGroup = new ArrayList<Member>(new HashSet<Member>(membersFromGroup));
+		membersFromGroup = new ArrayList<>(new HashSet<>(membersFromGroup));
 		for(Member memberElement: membersFromGroup) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, memberElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resource, memberElement, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resource, memberElement, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7720,7 +7362,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<Resource> resourcesFromGroup = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
 			for (Resource resourceElement : resourcesFromGroup) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, member, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, member, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resourceElement, member, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7730,7 +7372,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, member, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(resource, member, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(resource, member, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7743,14 +7385,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Resource> resourcesFromFacility = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 		List<Resource> resourcesFromUser =getPerunBl().getUsersManagerBl().getAllowedResources(sess, user);
 		resourcesFromUser.retainAll(resourcesFromFacility);
-		resourcesFromUser = new ArrayList<Resource>(new HashSet<Resource>(resourcesFromUser));
+		resourcesFromUser = new ArrayList<>(new HashSet<>(resourcesFromUser));
 		for(Resource resourceElement: resourcesFromUser) {
 			List<Member> membersForResourceElement = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resourceElement);
 			membersForResourceElement.retainAll(membersFromUser);
-			membersForResourceElement = new ArrayList<Member>(new HashSet<Member>(membersForResourceElement));
+			membersForResourceElement = new ArrayList<>(new HashSet<>(membersForResourceElement));
 			for(Member memberElement: membersForResourceElement) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, memberElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resourceElement, memberElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7759,16 +7401,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getMemberResourceAttributes(PerunSession sess, String key, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Vo> vos = getPerunBl().getVosManagerBl().getVos(sess);
-		List<Resource> resources = new ArrayList<Resource>();
+		List<Resource> resources = new ArrayList<>();
 		for(Vo voElement: vos) {
 			resources.addAll(getPerunBl().getResourcesManagerBl().getResources(sess, voElement));
 		}
-		resources = new ArrayList<Resource>(new HashSet<Resource>(resources));
+		resources = new ArrayList<>(new HashSet<>(resources));
 		for(Resource resourceElement: resources) {
 			List<Member> membersFromResource = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resourceElement);
 			for(Member memberElement: membersFromResource) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(resourceElement, memberElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(resourceElement, memberElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7781,7 +7423,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
 		for(Facility facilityElement: facilities) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, user, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facilityElement, user, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facilityElement, user, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7791,16 +7433,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 			List<Resource> memberResources = getPerunBl().getResourcesManagerBl().getAllowedResources(sess, member);
-			List<Facility> facilities = new ArrayList<Facility>();
+			List<Facility> facilities = new ArrayList<>();
 			for(Resource resourceElement: memberResources) {
 				facilities.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElement));
 			}
-			facilities = new ArrayList<Facility>(new HashSet<Facility>(facilities));
+			facilities = new ArrayList<>(new HashSet<>(facilities));
 			List<Facility> userAllowedFacilities = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
 			for(Facility facilityElement: facilities) {
 				if(userAllowedFacilities.contains(facilityElement)) {
 					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, user, attrDef.getName());
-					listOfRichAttributes.add(new RichAttribute(facilityElement, user, attribute));
+					listOfRichAttributes.add(new RichAttribute<>(facilityElement, user, attribute));
 				}
 			}
 		}
@@ -7810,25 +7452,25 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getUserFacilityAttributes(PerunSession sess, Group group, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		List<Member> members = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
-		List<User> users = new ArrayList<User>();
+		List<User> users = new ArrayList<>();
 		for(Member memberElement: members) {
 			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				users.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
 			}
 		}
 		List<Resource> resources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
-		List<Facility> facilities = new ArrayList<Facility>();
+		List<Facility> facilities = new ArrayList<>();
 		for(Resource resourceElement: resources) {
 			facilities.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElement));
 		}
-		users = new ArrayList<User>(new HashSet<User>(users));
+		users = new ArrayList<>(new HashSet<>(users));
 		for(User userElement: users) {
 			List<Facility> facilitiesFromUser = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, userElement);
 			facilities.retainAll(facilitiesFromUser);
-			facilities = new ArrayList<Facility>(new HashSet<Facility>(facilities));
+			facilities = new ArrayList<>(new HashSet<>(facilities));
 			for(Facility facilityElement: facilities) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, userElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(facilityElement, userElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(facilityElement, userElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7840,35 +7482,35 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<User> usersFromResource = getPerunBl().getResourcesManagerBl().getAllowedUsers(sess, resource);
 		for(User userElement: usersFromResource) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facility, userElement, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facility, userElement, attribute));
 		}
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getUserFacilityAttributes(PerunSession sess, Vo vo, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
-		List<Member> members = getPerunBl().getMembersManagerBl().getMembers(sess, vo);
-		List<User> users = new ArrayList<User>();
-		for(Member memberElement: members) {
-			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				users.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
+		List<Group> groupsFromVo = getPerunBl().getGroupsManagerBl().getGroups(sess, vo);
+		for (Group groupElement : groupsFromVo) {
+			List<Facility> groupFacilities = getPerunBl().getFacilitiesManagerBl().getAssignedFacilities(sess, groupElement);
+			List<Member> groupMembers = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, groupElement);
+			List<Member> allowedMembers = new ArrayList<>();
+			for(Member memberElement : groupMembers) {
+				if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
+					allowedMembers.add(memberElement);
+				}
+			}
+			List<User> groupUsers = new ArrayList<>();
+			for (Member memberElement : allowedMembers) {
+				groupUsers.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
+			}
+			for (Facility facilityElement : groupFacilities) {
+				for (User userElement : groupUsers) {
+					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, userElement, attrDef.getName());
+					listOfRichAttributes.add(new RichAttribute<>(facilityElement, userElement, attribute));
+				}
 			}
 		}
-		List<Resource> resourcesFromVo = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
-		List<Facility> facilitiesFromVo = new ArrayList<Facility>();
-		for(Resource resourceElement: resourcesFromVo) {
-			facilitiesFromVo.add(getPerunBl().getResourcesManagerBl().getFacility(sess, resourceElement));
-		}
-		users = new ArrayList<User>(new HashSet<User>(users));
-		for(User userElement: users) {
-			List<Facility> facilitiesFromUserElement = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, userElement);
-			facilitiesFromUserElement.retainAll(facilitiesFromVo);
-			facilitiesFromUserElement = new ArrayList<Facility>(new HashSet<Facility>(facilitiesFromUserElement));
-			for(Facility facilityElement: facilitiesFromUserElement) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, userElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(facilityElement, userElement, attribute));
-			}
-		}
+		listOfRichAttributes = new ArrayList<>(new HashSet<>(listOfRichAttributes));
 		return listOfRichAttributes;
 	}
 
@@ -7877,20 +7519,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<User> users = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility);
 		for(User userElement: users) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facility, userElement, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facility, userElement, attribute));
 		}
 		return listOfRichAttributes;
 	}
 
 	private List<RichAttribute> getUserFacilityAttributes(PerunSession sess, Host host, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Facility facility = getPerunBl().getFacilitiesManagerBl().getFacilityForHost(sess, host);
-		List<User> users = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility);
-		for(User userElement: users) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, userElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facility, userElement, attribute));
-		}
-		return listOfRichAttributes;
+		return getUserFacilityAttributes(sess, facility, attrDef);
 	}
 
 	private List<RichAttribute> getUserFacilityAttributes(PerunSession sess, UserExtSource userExtSource, AttributeDefinition attrDef) throws InternalErrorException, UserNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
@@ -7899,7 +7535,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Facility> facilities = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
 		for(Facility facilityElement: facilities) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, user, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facilityElement, user, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(facilityElement, user, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7909,7 +7545,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 		//get Users from Group
 		List<Member> members = getPerunBl().getGroupsManagerBl().getGroupMembers(sess, group);
-		List<User> usersFromGroup = new ArrayList<User>();
+		List<User> usersFromGroup = new ArrayList<>();
 		for(Member memberElement: members) {
 			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				usersFromGroup.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
@@ -7917,18 +7553,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		//get users from resource
 		List<Member> membersFromResource = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
-		List<User> usersFromResource = new ArrayList<User>();
+		List<User> usersFromResource = new ArrayList<>();
 		for(Member memberElement: membersFromResource) {
 			if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
 				usersFromResource.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, memberElement));
 			}
 		}
 		usersFromGroup.retainAll(usersFromResource);
-		usersFromGroup = new ArrayList<User>(new HashSet<User>(usersFromGroup));
+		usersFromGroup = new ArrayList<>(new HashSet<>(usersFromGroup));
 		for(User userElement: usersFromGroup) {
 			if(getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, userElement).contains(facility)) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, userElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(facility, userElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(facility, userElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7946,7 +7582,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			User userFromMember = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 			for (Facility facilityElement : facilitiesFromResources) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, userFromMember, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(facilityElement, userFromMember, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(facilityElement, userFromMember, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7956,9 +7592,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if(getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
-			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, user, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(facility, user, attribute));
+			List<Resource> memberResources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, member);
+			if(memberResources.contains(resource)) {
+				User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
+				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, user, attrDef.getName());
+				listOfRichAttributes.add(new RichAttribute<>(facility, user, attribute));
+			}
 		}
 		return listOfRichAttributes;
 	}
@@ -7966,7 +7605,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getUserFacilityAttributes(PerunSession sess, User user, Facility facility, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, user, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(facility, user, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(facility, user, attribute));
 		return listOfRichAttributes;
 	}
 
@@ -7977,7 +7616,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			List<User> users = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facilityElement);
 			for (User userElement : users) {
 				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facilityElement, userElement, attrDef.getName());
-				listOfRichAttributes.add(new RichAttribute(facilityElement, userElement, attribute));
+				listOfRichAttributes.add(new RichAttribute<>(facilityElement, userElement, attribute));
 			}
 		}
 		return listOfRichAttributes;
@@ -7990,7 +7629,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<String> keys = this.getEntitylessKeys(sess, attrDef);
 		for (String keyElement : keys) {
 			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, keyElement, attrDef.getName());
-			listOfRichAttributes.add(new RichAttribute(keyElement, null, attribute));
+			listOfRichAttributes.add(new RichAttribute<>(keyElement, null, attribute));
 		}
 		return listOfRichAttributes;
 	}
@@ -7998,7 +7637,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getEntitylessAttributes(PerunSession sess, String key, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, key, attrDef.getName());
-		listOfRichAttributes.add(new RichAttribute(key, null, attribute));
+		listOfRichAttributes.add(new RichAttribute<>(key, null, attribute));
 		return listOfRichAttributes;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1251,6 +1251,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		getMembersManagerImpl().checkMemberExists(sess, member);
 	}
 
+	public boolean isMemberAllowed(PerunSession sess, Member member) throws InternalErrorException {
+		if(member == null) throw new InternalErrorException("Member can't be null.");
+		if(this.haveStatus(sess, member, Status.INVALID)) return false;
+		else if (this.haveStatus(sess, member, Status.DISABLED)) return false;
+		else return true;
+	}
+
 	public Member setStatus(PerunSession sess, Member member, Status status) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberNotValidYetException {
 		switch(status) {
 			case VALID:

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -13289,19 +13289,23 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		//get impl object
 		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
 
-		entityless_test_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(
-				sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minUID");
+		entityless_test_atr_def = new AttributeDefinition();
+		entityless_test_atr_def.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+		entityless_test_atr_def.setDescription("entityless_test_atr_def");
+		entityless_test_atr_def.setFriendlyName("test-entityless-test-atr-def");
+		entityless_test_atr_def.setType(String.class.getName());
+		entityless_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, entityless_test_atr_def);
 
 		entityless_test_attribute1 = new Attribute(entityless_test_atr_def);
-		entityless_test_attribute1.setValue(154);
+		entityless_test_attribute1.setValue("154");
 		perun.getAttributesManagerBl().setAttribute(sess, "1", entityless_test_attribute1);
 
 		entityless_test_attribute2 = new Attribute(entityless_test_atr_def);
-		entityless_test_attribute2.setValue(202);
+		entityless_test_attribute2.setValue("202");
 		perun.getAttributesManagerBl().setAttribute(sess, "2", entityless_test_attribute2);
 
 		entityless_test_attribute3 = new Attribute(entityless_test_atr_def);
-		entityless_test_attribute3.setValue(362);
+		entityless_test_attribute3.setValue("362");
 		perun.getAttributesManagerBl().setAttribute(sess, "3", entityless_test_attribute3);
 	}
 
@@ -13320,8 +13324,8 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		userFacility_test_atr_def = new AttributeDefinition();
 		userFacility_test_atr_def.setNamespace(AttributesManager.NS_USER_FACILITY_ATTR_DEF);
-		userFacility_test_atr_def.setDescription("test userFacility attr");
-		userFacility_test_atr_def.setFriendlyName("test");
+		userFacility_test_atr_def.setDescription("userFacility_test_atr_def");
+		userFacility_test_atr_def.setFriendlyName("test-userFacility-test-atr-def");
 		userFacility_test_atr_def.setType(String.class.getName());
 		userFacility_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, userFacility_test_atr_def);
 
@@ -13369,8 +13373,8 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		memberResource_test_atr_def = new AttributeDefinition();
 		memberResource_test_atr_def.setNamespace(AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF);
-		memberResource_test_atr_def.setDescription("test memberResource attr");
-		memberResource_test_atr_def.setFriendlyName("test");
+		memberResource_test_atr_def.setDescription("memberResource_test_atr_def");
+		memberResource_test_atr_def.setFriendlyName("test-memberResource-test-atr-def");
 		memberResource_test_atr_def.setType(String.class.getName());
 		memberResource_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, memberResource_test_atr_def);
 
@@ -13422,8 +13426,8 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		memberGroup_test_atr_def = new AttributeDefinition();
 		memberGroup_test_atr_def.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_DEF);
-		memberGroup_test_atr_def.setDescription("test groupResource attr");
-		memberGroup_test_atr_def.setFriendlyName("test");
+		memberGroup_test_atr_def.setDescription("memberGroup_test_atr_def");
+		memberGroup_test_atr_def.setFriendlyName("test-memberGroup-test-atr-def");
 		memberGroup_test_atr_def.setType(String.class.getName());
 		memberGroup_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, memberGroup_test_atr_def);
 
@@ -13482,8 +13486,8 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		groupResource_test_atr_def = new AttributeDefinition();
 		groupResource_test_atr_def.setNamespace(AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF);
-		groupResource_test_atr_def.setDescription("test groupResource attr");
-		groupResource_test_atr_def.setFriendlyName("test");
+		groupResource_test_atr_def.setDescription("groupResource_test_atr_def");
+		groupResource_test_atr_def.setFriendlyName("test-groupResource-test-atr-def");
 		groupResource_test_atr_def.setType(String.class.getName());
 		groupResource_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, groupResource_test_atr_def);
 
@@ -13519,23 +13523,31 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 *
 	 */
 	private void setAttributesForVoAttributesTest() throws Exception {
-		String namespaceToEmail = "urn:perun:vo:attribute-def:def:toEmail";
-		String namespaceFromEmail = "urn:perun:vo:attribute-def:def:fromEmail";
-
 		//get Impl object
 		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
 
-		vo_toEmail_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, namespaceToEmail);
-		vo_fromEmail_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, namespaceFromEmail);
+		vo_toEmail_def = new AttributeDefinition();
+		vo_toEmail_def.setNamespace(AttributesManager.NS_VO_ATTR_DEF);
+		vo_toEmail_def.setDescription("vo_toEmail_def");
+		vo_toEmail_def.setFriendlyName("test-vo-toEmail-def");
+		vo_toEmail_def.setType(String.class.getName());
+		vo_toEmail_def = perun.getAttributesManagerBl().createAttribute(sess, vo_toEmail_def);
+
+		vo_fromEmail_def = new AttributeDefinition();
+		vo_fromEmail_def.setNamespace(AttributesManager.NS_VO_ATTR_DEF);
+		vo_fromEmail_def.setDescription("vo_fromEmail_def");
+		vo_fromEmail_def.setFriendlyName("test-vo-fromEmail-def");
+		vo_fromEmail_def.setType(String.class.getName());
+		vo_fromEmail_def = perun.getAttributesManagerBl().createAttribute(sess, vo_fromEmail_def);
 
 		//set vo_toEmail_def attribute to vo1
 		vo1_toEmail_attribute = new Attribute(vo_toEmail_def);
-		vo1_toEmail_attribute.setValue(new ArrayList<>(Collections.singletonList("vo1To@email.com")));
+		vo1_toEmail_attribute.setValue("vo1To@email.com");
 		perun.getAttributesManagerBl().setAttribute(sess, vo1, vo1_toEmail_attribute);
 
 		//set vo_toEmail_def attribute to vo2
 		vo2_toEmail_attribute = new Attribute(vo_toEmail_def);
-		vo2_toEmail_attribute.setValue(new ArrayList<>(Collections.singletonList("vo2To@email.com")));
+		vo2_toEmail_attribute.setValue("vo2To@email.com");
 		perun.getAttributesManagerBl().setAttribute(sess, vo2, vo2_toEmail_attribute);
 
 		//set vo_fromEmail_def attribute to vo2
@@ -13554,8 +13566,19 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		//get Impl object
 		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
 
-		user_phone_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:user:attribute-def:def:phone");
-		user_email_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:user:attribute-def:def:preferredMail");
+		user_phone_atr_def = new AttributeDefinition();
+		user_phone_atr_def.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		user_phone_atr_def.setDescription("user_phone_atr_def");
+		user_phone_atr_def.setFriendlyName("test-user-phone-atr-def");
+		user_phone_atr_def.setType(String.class.getName());
+		user_phone_atr_def = perun.getAttributesManagerBl().createAttribute(sess, user_phone_atr_def);
+
+		user_email_atr_def = new AttributeDefinition();
+		user_email_atr_def.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		user_email_atr_def.setDescription("user_email_atr_def");
+		user_email_atr_def.setFriendlyName("test-user-email-atr-def");
+		user_email_atr_def.setType(String.class.getName());
+		user_email_atr_def = perun.getAttributesManagerBl().createAttribute(sess, user_email_atr_def);
 
 		//set Phone attribute for user1
 		user1_phone_attribute = new Attribute(user_phone_atr_def);
@@ -13591,8 +13614,20 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		//get impl object
 		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
 
-		member_phone_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:member:attribute-def:def:phone");
-		member_email_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:member:attribute-def:def:mail");
+		member_phone_atr_def = new AttributeDefinition();
+		member_phone_atr_def.setNamespace(AttributesManager.NS_MEMBER_ATTR_DEF);
+		member_phone_atr_def.setDescription("member_phone_atr_def");
+		member_phone_atr_def.setFriendlyName("test-member-phone-atr-def");
+		member_phone_atr_def.setType(String.class.getName());
+		member_phone_atr_def = perun.getAttributesManagerBl().createAttribute(sess, member_phone_atr_def);
+
+		member_email_atr_def = new AttributeDefinition();
+		member_email_atr_def.setNamespace(AttributesManager.NS_MEMBER_ATTR_DEF);
+		member_email_atr_def.setDescription("member_email_atr_def");
+		member_email_atr_def.setFriendlyName("test-member-email-atr-def");
+		member_email_atr_def.setType(String.class.getName());
+		member_email_atr_def = perun.getAttributesManagerBl().createAttribute(sess, member_email_atr_def);
+
 
 		//set Phone attribute for member1OfUser1 and member2OfUser1
 		member1OfUser1_phone_attribute = new Attribute(member_phone_atr_def);
@@ -13643,7 +13678,12 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		//get impl object
 		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
 
-		group_fromEmail_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:group:attribute-def:def:fromEmail");
+		group_fromEmail_atr_def = new AttributeDefinition();
+		group_fromEmail_atr_def.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		group_fromEmail_atr_def.setDescription("group_fromEmail_atr_def");
+		group_fromEmail_atr_def.setFriendlyName("test-group-fromEmail-atr-def");
+		group_fromEmail_atr_def.setType(String.class.getName());
+		group_fromEmail_atr_def = perun.getAttributesManagerBl().createAttribute(sess, group_fromEmail_atr_def);
 
 		group1InVo1_email_atr = new Attribute(group_fromEmail_atr_def);
 		group1InVo1_email_atr.setValue("1@mail.com");
@@ -13680,7 +13720,12 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		//get impl object
 		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
 
-		resource_test_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:resource:attribute-def:def:defaultDataQuota");
+		resource_test_atr_def = new AttributeDefinition();
+		resource_test_atr_def.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		resource_test_atr_def.setDescription("resource_test_atr_def");
+		resource_test_atr_def.setFriendlyName("test-resource-test-atr-def");
+		resource_test_atr_def.setType(String.class.getName());
+		resource_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, resource_test_atr_def);
 
 		resource1InVo1_test_atr = new Attribute(resource_test_atr_def);
 		resource1InVo1_test_atr.setValue("1K");
@@ -13708,7 +13753,12 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		//get impl object
 		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
 
-		facility_test_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:facility:attribute-def:def:homeDirUmask");
+		facility_test_atr_def = new AttributeDefinition();
+		facility_test_atr_def.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
+		facility_test_atr_def.setDescription("facility_test_atr_def");
+		facility_test_atr_def.setFriendlyName("test-facility-test-atr-def");
+		facility_test_atr_def.setType(String.class.getName());
+		facility_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, facility_test_atr_def);
 
 		facility1_test_atr = new Attribute(facility_test_atr_def);
 		facility1_test_atr.setValue("756");
@@ -13737,8 +13787,8 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		host_test_atr_def = new AttributeDefinition();
 		host_test_atr_def.setNamespace(AttributesManager.NS_HOST_ATTR_DEF);
-		host_test_atr_def.setDescription("test host attr");
-		host_test_atr_def.setFriendlyName("host");
+		host_test_atr_def.setDescription("host_test_atr_def");
+		host_test_atr_def.setFriendlyName("test-host-test-atr-def");
 		host_test_atr_def.setType(String.class.getName());
 		host_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, host_test_atr_def);
 
@@ -13779,8 +13829,8 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 		ues_test_atr_def = new AttributeDefinition();
 		ues_test_atr_def.setNamespace(AttributesManager.NS_UES_ATTR_DEF);
-		ues_test_atr_def.setDescription("test ues attr");
-		ues_test_atr_def.setFriendlyName("ues");
+		ues_test_atr_def.setDescription("ues_test_atr_def");
+		ues_test_atr_def.setFriendlyName("test-ues-test-atr-def");
 		ues_test_atr_def.setType(String.class.getName());
 		ues_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, ues_test_atr_def);
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -1,16 +1,5 @@
 package cz.metacentrum.perun.core.entry;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.*;
-
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
@@ -26,6 +15,7 @@ import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MembershipType;
 import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.ResourcesManager;
 import cz.metacentrum.perun.core.api.RichAttribute;
@@ -49,6 +39,28 @@ import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Integration tests of AttributesManager
@@ -74,6 +86,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	 * 10. ==checkAttributeValue==
 	 * 11. removeAttribute/s / removeAllAttributes
 	 * 12. rest check methods
+	 * 13. private methods for attribute dependencies logic
 	 */
 
 	// these are in DB only when setUp"Type"() and must be used in correct (this) order
@@ -94,6 +107,9 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	private User user1;
 	private User user2;
 	private User user3;
+	private UserExtSource userExtSource1;
+	private UserExtSource userExtSource2;
+	private UserExtSource userExtSource3;
 	private Group membersGroupOfVo1;
 	private Group membersGroupOfVo2;
 	private Group group1InVo1;
@@ -120,6 +136,120 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	private Host host1OnFacility3;
 	private Host host2OnFacility3;
 	private String key;
+
+	//for testing attribute dependencies logic (no. 13) - VOs
+	private AttributeDefinition vo_toEmail_def;
+	private AttributeDefinition vo_fromEmail_def;
+	private Attribute vo1_toEmail_attribute;
+	private Attribute vo2_toEmail_attribute;
+	private Attribute vo2_fromEmail_attribute;
+	private AttributesManagerBlImpl attributesManagerBl;
+
+	//for testing attribute dependencies logic (no. 13) - USERs
+	private AttributeDefinition user_phone_atr_def;
+	private AttributeDefinition user_email_atr_def;
+	private Attribute user1_phone_attribute;
+	private Attribute user2_phone_attribute;
+	private Attribute user2_email_attribute;
+	private Attribute user3_email_attribute;
+
+	//for testing attribute dependencies logic (no. 13) - MEMBERs
+	private AttributeDefinition member_phone_atr_def;
+	private AttributeDefinition member_email_atr_def;
+	private Attribute member1OfUser1_phone_attribute;
+	private Attribute member1OfUser2_phone_attribute;
+	private Attribute member1OfUser2_mail_attribute;
+	private Attribute member1OfUser3_mail_attribute;
+	private Attribute member2OfUser1_phone_attribute;
+	private Attribute member2OfUser2_phone_attribute;
+	private Attribute member2OfUser2_mail_attribute;
+	private Attribute member2OfUser3_mail_attribute;
+
+	//for testing attribute dependencies logic (no. 13) - GROUPS
+	private AttributeDefinition group_fromEmail_atr_def;
+	private Attribute group1InVo1_email_atr;
+	private Attribute group2InVo1_email_atr;
+	private Attribute group1InVo2_email_atr;
+	private Attribute group2InVo2_email_atr;
+	private Attribute membersGroupOfVo1_email_atr;
+	private Attribute membersGroupOfVo2_email_atr;
+
+	//for testing attribute dependencies logic (no. 13) - RESOURCEs
+	private AttributeDefinition resource_test_atr_def;
+	private Attribute resource1InVo1_test_atr;
+	private Attribute resource2InVo1_test_atr;
+	private Attribute resource1InVo2_test_atr;
+	private Attribute resource2InVo2_test_atr;
+
+	//for testing attribute dependencies logic (no. 13) - FACILITIES
+	private AttributeDefinition facility_test_atr_def;
+	private Attribute facility1_test_atr;
+	private Attribute facility2_test_atr;
+	private Attribute facility3_test_atr;
+
+	//for testing attribute dependencies logic (no. 13) - HOSTS
+	private AttributeDefinition host_test_atr_def;
+	private Attribute host1F1_test_atr;
+	private Attribute host2F1_test_atr;
+	private Attribute host1F2_test_atr;
+	private Attribute host1F3_test_atr;
+	private Attribute host2F2_test_atr;
+	private Attribute host2F3_test_atr;
+
+	//for testing attribute dependencies logic (no. 13) - UESs
+	private AttributeDefinition ues_test_atr_def;
+	private Attribute ues1_test_atr;
+	private Attribute ues2_test_atr;
+	private Attribute ues3_test_atr;
+	private Attribute internal_ues_atr;
+
+	//for testing attribute dependencies logic (no. 13) - GROUP-RESOURCEs
+	private AttributeDefinition groupResource_test_atr_def;
+	private Attribute group1VO1Res1VO1_test_attribute;
+	private Attribute group2VO1Res1VO1_test_attribute;
+	private Attribute group2VO1Res2VO1_test_attribute;
+	private Attribute group1VO2Res1VO2_test_attribute;
+	private Attribute group2VO2Res2VO2_test_attribute;
+	private Attribute group2VO2Res1VO2_test_attribute;
+
+	//for testing attribute dependencies logic (no. 13) - MEMBER-GROUPs
+	private AttributeDefinition memberGroup_test_atr_def;
+	private Attribute member1U1Group1Vo1_test_attribute;
+	private Attribute member1U1Group2Vo1_test_attribute;
+	private Attribute member2U1Group1Vo2_test_attribute;
+	private Attribute member2U1Group2Vo2_test_attribute;
+	private Attribute member1U2Group1Vo2_test_attribute;
+	private Attribute member1U2Group2Vo2_test_attribute;
+	private Attribute member2U2Group1Vo1_test_attribute;
+	private Attribute member2U2Group2Vo1_test_attribute;
+	private Attribute member1U3Group1Vo1_test_attribute;
+	private Attribute member2U3Group2Vo2_test_attribute;
+
+	//for testing attribute dependencies logic (no. 13) - MEMBER-RESOURCEs
+	private AttributeDefinition memberResource_test_atr_def;
+	private Attribute member1U1Res1Vo1_test_attribute;
+	private Attribute member1U1Res2Vo1_test_attribute;
+	private Attribute member1U2Res1Vo2_test_attribute;
+	private Attribute member1U2Res2Vo2_test_attribute;
+	private Attribute member1U3Res1Vo1_test_attribute;
+	private Attribute member2U3Res1Vo2_test_attribute;
+	private Attribute member2U3Res2Vo2_test_attribute;
+
+	//for testing attribute dependencies logic (no. 13) - USER-FACILITYs
+	private AttributeDefinition userFacility_test_atr_def;
+	private Attribute user1Facility1_test_attribute;
+	private Attribute user1Facility2_test_attribute;
+	private Attribute user2Facility2_test_attribute;
+	private Attribute user2Facility3_test_attribute;
+	private Attribute user3Facility3_test_attribute;
+	private Attribute user3Facility1_test_attribute;
+	private Attribute user3Facility2_test_attribute;
+
+	//for testing attribute dependencies logic (no. 13) - ENTITYLESS
+	private AttributeDefinition entityless_test_atr_def;
+	private Attribute entityless_test_attribute1;
+	private Attribute entityless_test_attribute2;
+	private Attribute entityless_test_attribute3;
 
 	@Before
 	public void setUp() throws Exception {
@@ -174,11 +304,11 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		can1.setLastName("Test");
 		can1.setTitleBefore("");
 		can1.setTitleAfter("");
-		UserExtSource userExtSource1 = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), "user1TestLogin");
-		UserExtSource userExtSource2 = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), "user2TestLogin");
-		UserExtSource userExtSource3 = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), "user3TestLogin");
+		userExtSource1 = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), "user1TestLogin");
+		userExtSource2 = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), "user2TestLogin");
+		userExtSource3 = new UserExtSource(new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal"), "user3TestLogin");
 		can1.setUserExtSource(userExtSource1);
-		can1.setAttributes(new HashMap<String,String>());
+		can1.setAttributes(new HashMap<>());
 		member1OfUser1 = perun.getMembersManagerBl().createMemberSync(sess, vo1, can1);
 		user1 = perun.getUsersManagerBl().getUserByMember(sess, member1OfUser1);
 		member2OfUser1 = perun.getMembersManagerBl().createMember(sess, vo2, user1);
@@ -8744,10 +8874,4948 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 
 
 
+	// ============= 13. private methods for attribute dependencies logic ====================================
+	// In these methods are suppressed "unchecked" warnings because of casting the returned type of
+	// testedMethod.invoke() to a List<RichAttribute>
 
+
+//----------------------- VO attributes -------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByUser");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, user1, vo_toEmail_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_user1.size());
+		assertTrue(attrs_user1.contains(vo1_toEmail_attribute));
+
+		//get attributes for user2
+		List<RichAttribute> ra_user2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, user2, vo_fromEmail_def);
+		List<Attribute> attrs_user2 = new ArrayList<>();
+		ra_user2.forEach(ra -> attrs_user2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_user2.size());
+		assertTrue(attrs_user2.contains(vo2_fromEmail_attribute));
+
+		//get attributes for user3
+		List<RichAttribute> ra_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, user3, vo_toEmail_def);
+		List<Attribute> attrs_user3 = new ArrayList<>();
+		ra_user3.forEach(ra -> attrs_user3.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 2, attrs_user3.size());
+		assertTrue(attrs_user3.contains(vo2_toEmail_attribute));
+		assertTrue(attrs_user3.contains(vo1_toEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByMember");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for member1OfUser1
+		List<RichAttribute> ra_member1_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, member1OfUser1, vo_toEmail_def);
+		List<Attribute> attrs_member1_user1 = new ArrayList<>();
+		ra_member1_user1.forEach(ra -> attrs_member1_user1.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_member1_user1.size());
+		assertTrue(attrs_member1_user1.contains(vo1_toEmail_attribute));
+
+		//get vo_toEmail_def attributes for member member1OfUser2
+		List<RichAttribute> ra_member1_user2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, member1OfUser2, vo_toEmail_def);
+		List<Attribute> attrs_member1_user2 = new ArrayList<>();
+		ra_member1_user2.forEach(ra -> attrs_member1_user2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_member1_user2.size());
+		assertTrue(attrs_member1_user2.contains(vo2_toEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByGroup");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for group1InVo1
+		List<RichAttribute> ra_group1_invo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, group1InVo1, vo_toEmail_def);
+		List<Attribute> attrs_group1_invo1 = new ArrayList<>();
+		ra_group1_invo1.forEach(ra -> attrs_group1_invo1.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_group1_invo1.size());
+		assertTrue(attrs_group1_invo1.contains(vo1_toEmail_attribute));
+
+		//get vo_fromEmail_def attributes for group1InVo2
+		List<RichAttribute> ra_group1_invo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, group1InVo2, vo_fromEmail_def);
+		List<Attribute> attrs_group1_invo2 = new ArrayList<>();
+		ra_group1_invo2.forEach(ra -> attrs_group1_invo2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_group1_invo2.size());
+		assertTrue(attrs_group1_invo2.contains(vo2_fromEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByResource");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for resource1InVo1
+		List<RichAttribute> ra_res1_invo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, resource1InVo1, vo_toEmail_def);
+		List<Attribute> attrs_res1_invo1 = new ArrayList<>();
+		ra_res1_invo1.forEach(ra -> attrs_res1_invo1.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_res1_invo1.size());
+		assertTrue(attrs_res1_invo1.contains(vo1_toEmail_attribute));
+
+		//get vo_fromEmail_def attributes for resource1InVo2
+		List<RichAttribute> ra_res1_invo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, resource1InVo2, vo_fromEmail_def);
+		List<Attribute> attrs_res1_invo2 = new ArrayList<>();
+		ra_res1_invo2.forEach(ra -> attrs_res1_invo2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_res1_invo2.size());
+		assertTrue(attrs_res1_invo2.contains(vo2_fromEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByResource");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for Vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, vo1, vo_toEmail_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(vo1_toEmail_attribute));
+
+		//get vo_fromEmail_def attributes for Vo1
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, vo2, vo_fromEmail_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+		ra_vo2.forEach(ra -> attrs_vo2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(vo2_fromEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByFacility");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, facility2, vo_toEmail_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 2, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(vo1_toEmail_attribute));
+		assertTrue(attrs_facility2.contains(vo2_toEmail_attribute));
+
+		//get vo_fromEmail_def attributes for facility3
+		List<RichAttribute> ra_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, facility3, vo_fromEmail_def);
+		List<Attribute> attrs_facility3 = new ArrayList<>();
+		ra_facility3.forEach(ra -> attrs_facility3.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_facility3.size());
+		assertTrue(attrs_facility3.contains(vo2_fromEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByHost");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for host2OnFacility2
+		List<RichAttribute> ra_host2_onfac2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, host2OnFacility2, vo_toEmail_def);
+		List<Attribute> attrs_host2_onfac2 = new ArrayList<>();
+		ra_host2_onfac2.forEach(ra -> attrs_host2_onfac2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 2, attrs_host2_onfac2.size());
+		assertTrue(attrs_host2_onfac2.contains(vo1_toEmail_attribute));
+		assertTrue(attrs_host2_onfac2.contains(vo2_toEmail_attribute));
+
+		//get vo_fromEmail_def attributes for host1OnFacility3
+		List<RichAttribute> ra_host1_onfac3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, host1OnFacility3, vo_fromEmail_def);
+		List<Attribute> attrs_host1_onfac3 = new ArrayList<>();
+		ra_host1_onfac3.forEach(ra -> attrs_host1_onfac3.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_host1_onfac3.size());
+		assertTrue(attrs_host1_onfac3.contains(vo2_fromEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByUserExtSource");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for userExtSource1
+		List<RichAttribute> ra_userExtSrc1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, userExtSource1, vo_toEmail_def);
+		List<Attribute> attrs_userExtSrc1 = new ArrayList<>();
+		ra_userExtSrc1.forEach(ra -> attrs_userExtSrc1.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_userExtSrc1.size());
+		assertTrue(attrs_userExtSrc1.contains(vo1_toEmail_attribute));
+
+		//get vo_fromEmail_def attributes for userExtSource2
+		List<RichAttribute> ra_userExtSrc2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, userExtSource2, vo_fromEmail_def);
+		List<Attribute> attrs_userExtSrc2 = new ArrayList<>();
+		ra_userExtSrc2.forEach(ra -> attrs_userExtSrc2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes",1, attrs_userExtSrc2.size());
+		assertTrue(attrs_userExtSrc2.contains(vo2_fromEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByUserFacility");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//get vo_toEmail_def attributes for user3 and facility2
+		List<RichAttribute> ra_user3_fac2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility2, vo_toEmail_def);
+		List<Attribute> attrs_user3_fac2 = new ArrayList<>();
+		ra_user3_fac2.forEach(ra -> attrs_user3_fac2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_user3_fac2.size());
+		assertTrue(attrs_user3_fac2.contains(vo2_toEmail_attribute));
+
+		List<RichAttribute> ra_user2_fac2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user2, facility2, vo_toEmail_def);
+		List<Attribute> attrs_user2_fac2 = new ArrayList<>();
+		ra_user2_fac2.forEach(ra -> attrs_user2_fac2.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 1, attrs_user2_fac2.size());
+		assertTrue(attrs_user2_fac2.contains(vo2_toEmail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getVoAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getVoAttributesByKey");
+
+		setAttributesForVoAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getVoAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//get all vo_toEmail_def attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl, sess, null, vo_toEmail_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Found invalid number of attributes", 2, attrs_all.size());
+		assertTrue(attrs_all.contains(vo1_toEmail_attribute));
+		assertTrue(attrs_all.contains(vo2_toEmail_attribute));
+	}
+
+	//----------------------- USER attributes -------------------------//
+
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByUser");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find phone attributes for user1
+		List<RichAttribute> ra_phone_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, user_phone_atr_def);
+		List<Attribute> attrs_phone_user1 = new ArrayList<>();
+		ra_phone_user1.forEach(ra -> attrs_phone_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_phone_user1.size());
+		assertTrue(attrs_phone_user1.contains(user1_phone_attribute));
+
+		//find email attribute for user2
+		List<RichAttribute> ra_email_user2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user2, user_email_atr_def);
+		List<Attribute> attrs_email_user2 = new ArrayList<>();
+		ra_email_user2.forEach(ra -> attrs_email_user2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_email_user2.size());
+		assertTrue(attrs_email_user2.contains(user2_email_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByMember");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find phone attributes for member2OfUser1 - disallowed member
+		List<RichAttribute> ra_phone_member2U1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, user_phone_atr_def);
+		List<Attribute> attrs_phone_member2U1 = new ArrayList<>();
+		ra_phone_member2U1.forEach(ra -> attrs_phone_member2U1.add(ra.getAttribute()));
+
+		assertTrue(attrs_phone_member2U1.isEmpty());
+
+		//find email attributes for member1OfUser3
+		List<RichAttribute> ra_phone_member1U3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser3, user_email_atr_def);
+		List<Attribute> attrs_phone_member1U3 = new ArrayList<>();
+		ra_phone_member1U3.forEach(ra -> attrs_phone_member1U3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_phone_member1U3.size());
+		assertTrue(attrs_phone_member1U3.contains(user3_email_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByGroup");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find user preferred email attributes in group1InVo1
+		List<RichAttribute> ra_email_group1VO1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo1, user_email_atr_def);
+		List<Attribute> attrs_email_group1VO1 = new ArrayList<>();
+		ra_email_group1VO1.forEach(ra -> attrs_email_group1VO1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_email_group1VO1.size());
+		assertTrue(attrs_email_group1VO1.contains(user3_email_attribute));
+		//contains empty value from user1 who does not have email set
+		assertTrue(attrs_email_group1VO1.contains(new Attribute(user_email_atr_def)));
+
+		//find user preferred email attributes in group2InVo2
+		List<RichAttribute> ra_email_group2VO2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo2, user_email_atr_def);
+		List<Attribute> attrs_email_group2VO2 = new ArrayList<>();
+		ra_email_group2VO2.forEach(ra -> attrs_email_group2VO2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_email_group2VO2.size());
+		assertTrue(attrs_email_group2VO2.contains(user3_email_attribute));
+		assertTrue(attrs_email_group2VO2.contains(user2_email_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByResource");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find user phone attributes by resource2InVo1
+		List<RichAttribute> ra_phone_res2VO1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource2InVo1, user_phone_atr_def);
+		List<Attribute> attrs_phone_res2VO1 = new ArrayList<>();
+		ra_phone_res2VO1.forEach(ra -> attrs_phone_res2VO1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_phone_res2VO1.size());
+		assertTrue(attrs_phone_res2VO1.contains(user1_phone_attribute));
+
+		//find user preffered email attributes by resource1InVo2
+		List<RichAttribute> ra_phone_res1VO2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo2, user_email_atr_def);
+		List<Attribute> attrs_phone_res1VO2 = new ArrayList<>();
+		ra_phone_res1VO2.forEach(ra -> attrs_phone_res1VO2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_res1VO2.size());
+		assertTrue(attrs_phone_res1VO2.contains(user2_email_attribute));
+		assertTrue(attrs_phone_res1VO2.contains(user3_email_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByVo");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find user phone attributes by vo1
+		List<RichAttribute> ra_phone_VO1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, user_phone_atr_def);
+		List<Attribute> attrs_phone_VO1 = new ArrayList<>();
+		ra_phone_VO1.forEach(ra -> attrs_phone_VO1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_VO1.size());
+		assertTrue(attrs_phone_VO1.contains(user1_phone_attribute));
+		//contains empty attribute value from user3 who does not have phone set
+		assertTrue(attrs_phone_VO1.contains(new Attribute(user_phone_atr_def)));
+
+		//find user preferred email attributes by vo2
+		List<RichAttribute> ra_email_VO2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, user_email_atr_def);
+		List<Attribute> attrs_email_VO2 = new ArrayList<>();
+		ra_email_VO2.forEach(ra -> attrs_email_VO2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_email_VO2.size());
+		assertTrue(attrs_email_VO2.contains(user2_email_attribute));
+		assertTrue(attrs_email_VO2.contains(user3_email_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByFacility");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find user phone attributes by facility2
+		List<RichAttribute> ra_phone_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, user_phone_atr_def);
+		List<Attribute> attrs_phone_facility2 = new ArrayList<>();
+		ra_phone_facility2.forEach(ra -> attrs_phone_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_phone_facility2.size());
+		assertTrue(attrs_phone_facility2.contains(user1_phone_attribute));
+		assertTrue(attrs_phone_facility2.contains(user2_phone_attribute));
+		//contains empty attribute value from user3 who does not have phone set
+		assertTrue(attrs_phone_facility2.contains(new Attribute(user_phone_atr_def)));
+
+		//find user preferred email attributes by facility3
+		List<RichAttribute> ra_email_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility3, user_email_atr_def);
+		List<Attribute> attrs_email_facility3 = new ArrayList<>();
+		ra_email_facility3.forEach(ra -> attrs_email_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_email_facility3.size());
+		assertTrue(attrs_email_facility3.contains(user2_email_attribute));
+		assertTrue(attrs_email_facility3.contains(user3_email_attribute	));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByHost");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find user phone attributes by host1OnFacility2
+		List<RichAttribute> ra_phone_host1_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, user_phone_atr_def);
+		List<Attribute> attrs_phone_host1_facility2 = new ArrayList<>();
+		ra_phone_host1_facility2.forEach(ra -> attrs_phone_host1_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_phone_host1_facility2.size());
+		assertTrue(attrs_phone_host1_facility2.contains(user1_phone_attribute));
+		assertTrue(attrs_phone_host1_facility2.contains(user2_phone_attribute));
+		//contains empty attribute value from user3 who does not have phone set
+		assertTrue(attrs_phone_host1_facility2.contains(new Attribute(user_phone_atr_def)));
+
+		//find user preferred email attributes by host1OnFacility3
+		List<RichAttribute> ra_email_host1_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility3, user_email_atr_def);
+		List<Attribute> attrs_email_facility3 = new ArrayList<>();
+		ra_email_host1_facility3.forEach(ra -> attrs_email_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_email_facility3.size());
+		assertTrue(attrs_email_facility3.contains(user2_email_attribute));
+		assertTrue(attrs_email_facility3.contains(user3_email_attribute	));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByUserExtSource");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find phone attributes for userExtSource1
+		List<RichAttribute> ra_phone_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, user_phone_atr_def);
+		List<Attribute> attrs_phone_userExtSource1 = new ArrayList<>();
+		ra_phone_userExtSource1.forEach(ra -> attrs_phone_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_phone_userExtSource1.size());
+		assertTrue(attrs_phone_userExtSource1.contains(user1_phone_attribute));
+
+		//find email attribute for userExtSource2
+		List<RichAttribute> ra_email_userExtSource2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource2, user_email_atr_def);
+		List<Attribute> attrs_email_userExtSource2 = new ArrayList<>();
+		ra_email_userExtSource2.forEach(ra -> attrs_email_userExtSource2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_email_userExtSource2.size());
+		assertTrue(attrs_email_userExtSource2.contains(user2_email_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByKey");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all phone user attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, user_phone_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		//actually contains 4 user attributes because of test user John Doe
+		assertEquals("Invalid number of attributes found", 4, attrs_all.size());
+		assertTrue(attrs_all.contains(user1_phone_attribute));
+		assertTrue(attrs_all.contains(user2_phone_attribute));
+		//contains empty user3 attribute
+		assertTrue(attrs_all.contains(new Attribute(user_phone_atr_def)));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getUserAttributesByUserFacility");
+
+		setAttributesForUserAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find phone user attributes for user1 and facility1
+		List<RichAttribute> ra_user1_fac1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility1, user_phone_atr_def);
+		List<Attribute> attrs_user1_fac1 = new ArrayList<>();
+		ra_user1_fac1.forEach(ra -> attrs_user1_fac1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user1_fac1.size());
+		assertTrue(attrs_user1_fac1.contains(user1_phone_attribute));
+
+		//find phone user attributes for user2 and facility1
+		List<RichAttribute> ra_user2_fac1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user2, facility1, user_phone_atr_def);
+		List<Attribute> attrs_user2_fac1 = new ArrayList<>();
+		ra_user2_fac1.forEach(ra -> attrs_user2_fac1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_user2_fac1.size());
+	}
+
+	//----------------------- MEMBER attributes -------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByUser");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find phone member attributes for user1
+		List<RichAttribute> ra_phone_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, member_phone_atr_def);
+		List<Attribute> attrs_phone_user1 = new ArrayList<>();
+		ra_phone_user1.forEach(ra -> attrs_phone_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_phone_user1.size());
+		assertTrue(attrs_phone_user1.contains(member1OfUser1_phone_attribute));
+
+		//find email member attributes for user3
+		List<RichAttribute> ra_email_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, member_email_atr_def);
+		List<Attribute> attrs_email_user3 = new ArrayList<>();
+		ra_email_user3.forEach(ra -> attrs_email_user3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_email_user3.size());
+		assertTrue(attrs_email_user3.contains(member1OfUser3_mail_attribute));
+		assertTrue(attrs_email_user3.contains(member2OfUser3_mail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByMember");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find phone member attributes for member1OfUser1
+		List<RichAttribute> ra_phone_member1U1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, member_phone_atr_def);
+		List<Attribute> attrs_phone_member1U1 = new ArrayList<>();
+		ra_phone_member1U1.forEach(ra -> attrs_phone_member1U1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_phone_member1U1.size());
+		assertTrue(attrs_phone_member1U1.contains(member1OfUser1_phone_attribute));
+
+		//find email member attributes for member2OfUser1
+		List<RichAttribute> ra_email_member2U1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, member_email_atr_def);
+		List<Attribute> attrs_email_user3 = new ArrayList<>();
+		ra_email_member2U1.forEach(ra -> attrs_email_user3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_email_user3.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByGroup");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find phone member attributes for group1InVo1
+		List<RichAttribute> ra_phone_group1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo1, member_phone_atr_def);
+		List<Attribute> attrs_phone_group1Vo1 = new ArrayList<>();
+		ra_phone_group1Vo1.forEach(ra -> attrs_phone_group1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_group1Vo1.size());
+		assertTrue(attrs_phone_group1Vo1.contains(member1OfUser1_phone_attribute));
+		//contains an empty attribute from member1OfUser3
+		assertTrue(attrs_phone_group1Vo1.contains(new Attribute(member_phone_atr_def)));
+
+		//find email member attributes for group2InVo2
+		List<RichAttribute> ra_phone_group2Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo2, member_email_atr_def);
+		List<Attribute> attrs_phone_group2Vo2 = new ArrayList<>();
+		ra_phone_group2Vo2.forEach(ra -> attrs_phone_group2Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_group2Vo2.size());
+		assertTrue(attrs_phone_group2Vo2.contains(member1OfUser2_mail_attribute));
+		assertTrue(attrs_phone_group2Vo2.contains(member2OfUser3_mail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByResource");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find phone member attributes for resource1InVo1
+		List<RichAttribute> ra_phone_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo1, member_phone_atr_def);
+		List<Attribute> attrs_phone_res1Vo1 = new ArrayList<>();
+		ra_phone_res1Vo1.forEach(ra -> attrs_phone_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_res1Vo1.size());
+		assertTrue(attrs_phone_res1Vo1.contains(member1OfUser1_phone_attribute));
+		//contains an empty attribute from member1OfUser3
+		assertTrue(attrs_phone_res1Vo1.contains(new Attribute(member_phone_atr_def)));
+
+		//find email member attributes for resource1InVo2
+		List<RichAttribute> ra_phone_res1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo2, member_email_atr_def);
+		List<Attribute> attrs_phone_res1Vo2 = new ArrayList<>();
+		ra_phone_res1Vo2.forEach(ra -> attrs_phone_res1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_res1Vo2.size());
+		assertTrue(attrs_phone_res1Vo2.contains(member1OfUser2_mail_attribute));
+		assertTrue(attrs_phone_res1Vo2.contains(member2OfUser3_mail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByVo");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find phone member attributes for vo1
+		List<RichAttribute> ra_phone_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, member_phone_atr_def);
+		List<Attribute> attrs_phone_vo1 = new ArrayList<>();
+		ra_phone_vo1.forEach(ra -> attrs_phone_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_vo1.size());
+		assertTrue(attrs_phone_vo1.contains(member1OfUser1_phone_attribute));
+		//contains an empty attribute from member1OfUser3
+		assertTrue(attrs_phone_vo1.contains(new Attribute(member_phone_atr_def)));
+
+		//find email member attributes for vo2
+		List<RichAttribute> ra_phone_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, member_email_atr_def);
+		List<Attribute> attrs_phone_vo2 = new ArrayList<>();
+		ra_phone_vo2.forEach(ra -> attrs_phone_vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_vo2.size());
+		assertTrue(attrs_phone_vo2.contains(member1OfUser2_mail_attribute));
+		assertTrue(attrs_phone_vo2.contains(member2OfUser3_mail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByFacility");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find phone member attributes for facility1
+		List<RichAttribute> ra_phone_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, member_phone_atr_def);
+		List<Attribute> attrs_phone_facility1 = new ArrayList<>();
+		ra_phone_facility1.forEach(ra -> attrs_phone_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_facility1.size());
+		assertTrue(attrs_phone_facility1.contains(member1OfUser1_phone_attribute));
+		//contains an empty attribute from member1OfUser3
+		assertTrue(attrs_phone_facility1.contains(new Attribute(member_phone_atr_def)));
+
+		//find email member attributes for facility2
+		List<RichAttribute> ra_phone_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, member_email_atr_def);
+		List<Attribute> attrs_phone_facility2 = new ArrayList<>();
+		ra_phone_facility2.forEach(ra -> attrs_phone_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_phone_facility2.size());
+		assertTrue(attrs_phone_facility2.contains(member1OfUser2_mail_attribute));
+		assertTrue(attrs_phone_facility2.contains(member2OfUser3_mail_attribute));
+		//contains an empty attribute from member1OfUser1
+		assertTrue(attrs_phone_facility2.contains(new Attribute(member_email_atr_def)));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByHost");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find phone member attributes for host1OnFacility1
+		List<RichAttribute> ra_phone_host1F1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, member_phone_atr_def);
+		List<Attribute> attrs_phone_host1F1 = new ArrayList<>();
+		ra_phone_host1F1.forEach(ra -> attrs_phone_host1F1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_phone_host1F1.size());
+		assertTrue(attrs_phone_host1F1.contains(member1OfUser1_phone_attribute));
+		//contains an empty attribute from member1OfUser3
+		assertTrue(attrs_phone_host1F1.contains(new Attribute(member_phone_atr_def)));
+
+		//find email member attributes for host1OnFacility2
+		List<RichAttribute> ra_phone_host1F2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, member_email_atr_def);
+		List<Attribute> attrs_phone_host1F2 = new ArrayList<>();
+		ra_phone_host1F2.forEach(ra -> attrs_phone_host1F2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_phone_host1F2.size());
+		assertTrue(attrs_phone_host1F2.contains(member1OfUser2_mail_attribute));
+		assertTrue(attrs_phone_host1F2.contains(member2OfUser3_mail_attribute));
+		//contains an empty attribute from member1OfUser1
+		assertTrue(attrs_phone_host1F2.contains(new Attribute(member_email_atr_def)));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByUserExtSource");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find phone member attributes for userExtSource1
+		List<RichAttribute> ra_phone_userExtSrc1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, member_phone_atr_def);
+		List<Attribute> attrs_phone_userExtSrc1 = new ArrayList<>();
+		ra_phone_userExtSrc1.forEach(ra -> attrs_phone_userExtSrc1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_phone_userExtSrc1.size());
+		assertTrue(attrs_phone_userExtSrc1.contains(member1OfUser1_phone_attribute));
+
+		//find email member attributes for userExtSource3
+		List<RichAttribute> ra_email_userExtSrc3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource3, member_email_atr_def);
+		List<Attribute> attrs_email_userExtSrc3 = new ArrayList<>();
+		ra_email_userExtSrc3.forEach(ra -> attrs_email_userExtSrc3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_email_userExtSrc3.size());
+		assertTrue(attrs_email_userExtSrc3.contains(member1OfUser3_mail_attribute));
+		assertTrue(attrs_email_userExtSrc3.contains(member2OfUser3_mail_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByKey");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all phone member attributes
+		List<RichAttribute> ra_phone_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, member_phone_atr_def);
+		List<Attribute> attrs_phone_all = new ArrayList<>();
+		ra_phone_all.forEach(ra -> attrs_phone_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_phone_all.size());
+		assertTrue(attrs_phone_all.contains(member1OfUser1_phone_attribute));
+		assertTrue(attrs_phone_all.contains(member1OfUser2_phone_attribute));
+		//contains 2 empty attributes from member1OfUser3 and member2OfUser3
+		assertTrue(attrs_phone_all.contains(new Attribute(member_phone_atr_def)));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberAttributesByUserFacility");
+
+		setAttributesForMemberAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find email member attributes for user3 and facility1
+		List<RichAttribute> ra_user3_fac1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility1, member_email_atr_def);
+		List<Attribute> attrs_user3_fac1 = new ArrayList<>();
+		ra_user3_fac1.forEach(ra -> attrs_user3_fac1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user3_fac1.size());
+		assertTrue(attrs_user3_fac1.contains(member1OfUser3_mail_attribute));
+
+		//find phone member attributes for user1 and facility2
+		List<RichAttribute> ra_user1_fac2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility2, member_phone_atr_def);
+		List<Attribute> attrs_user1_fac2 = new ArrayList<>();
+		ra_user1_fac2.forEach(ra -> attrs_user1_fac2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user1_fac2.size());
+		assertTrue(attrs_user1_fac2.contains(member1OfUser1_phone_attribute));
+	}
+
+	//----------------------- GROUP attributes -------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByUser");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find email group attributes by user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, group_fromEmail_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_user1.size());
+		assertTrue(attrs_user1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_user1.contains(group2InVo1_email_atr));
+		assertTrue(attrs_user1.contains(membersGroupOfVo1_email_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByUser");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find email group attributes by member1OfUser1
+		List<RichAttribute> ra_member1OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, group_fromEmail_atr_def);
+		List<Attribute> attrs_member1OfUser1 = new ArrayList<>();
+		ra_member1OfUser1.forEach(ra -> attrs_member1OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_member1OfUser1.size());
+		assertTrue(attrs_member1OfUser1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_member1OfUser1.contains(group2InVo1_email_atr));
+		assertTrue(attrs_member1OfUser1.contains(membersGroupOfVo1_email_atr));
+
+		//find email group attributes by member2OfUser1
+		List<RichAttribute> ra_member2OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, group_fromEmail_atr_def);
+		List<Attribute> attrs_member2OfUser1 = new ArrayList<>();
+		ra_member2OfUser1.forEach(ra -> attrs_member2OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2OfUser1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByGroup");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find email group attributes by group1InVo1
+		List<RichAttribute> ra_group1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo1, group_fromEmail_atr_def);
+		List<Attribute> attrs_group1InVo1 = new ArrayList<>();
+		ra_group1InVo1.forEach(ra -> attrs_group1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group1InVo1.size());
+		assertTrue(attrs_group1InVo1.contains(group1InVo1_email_atr));
+
+		//find email group attributes by group1InVo2
+		List<RichAttribute> ra_group1InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo2, group_fromEmail_atr_def);
+		List<Attribute> attrs_group1InVo2 = new ArrayList<>();
+		ra_group1InVo2.forEach(ra -> attrs_group1InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group1InVo2.size());
+		assertTrue(attrs_group1InVo2.contains(group1InVo2_email_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByResource");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find email group attributes by resource1InVo1
+		List<RichAttribute> ra_resource1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo1, group_fromEmail_atr_def);
+		List<Attribute> attrs_resource1InVo1 = new ArrayList<>();
+		ra_resource1InVo1.forEach(ra -> attrs_resource1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_resource1InVo1.size());
+		assertTrue(attrs_resource1InVo1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_resource1InVo1.contains(group2InVo1_email_atr));
+
+		//find email group attributes by resource2InVo2
+		List<RichAttribute> ra_resource2InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource2InVo2, group_fromEmail_atr_def);
+		List<Attribute> attrs_resource2InVo2 = new ArrayList<>();
+		ra_resource2InVo2.forEach(ra -> attrs_resource2InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_resource2InVo2.size());
+		assertTrue(attrs_resource2InVo2.contains(group2InVo2_email_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByVo");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find email group attributes by vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, group_fromEmail_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_vo1.contains(group2InVo1_email_atr));
+		assertTrue(attrs_vo1.contains(membersGroupOfVo1_email_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByFacility");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find email group attributes by facility1
+		List<RichAttribute> ra_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, group_fromEmail_atr_def);
+		List<Attribute> attrs_facility1 = new ArrayList<>();
+		ra_facility1.forEach(ra -> attrs_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility1.size());
+		assertTrue(attrs_facility1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_facility1.contains(group2InVo1_email_atr));
+
+		//find email group attributes by facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, group_fromEmail_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(group2InVo1_email_atr));
+		assertTrue(attrs_facility2.contains(group1InVo2_email_atr));
+		assertTrue(attrs_facility2.contains(group2InVo2_email_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByHost");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find email group attributes by host1OnFacility1
+		List<RichAttribute> ra_host1OnFacility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, group_fromEmail_atr_def);
+		List<Attribute> attrs_host1OnFacility1 = new ArrayList<>();
+		ra_host1OnFacility1.forEach(ra -> attrs_host1OnFacility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_host1OnFacility1.size());
+		assertTrue(attrs_host1OnFacility1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_host1OnFacility1.contains(group2InVo1_email_atr));
+
+		//find email group attributes by host1OnFacility2
+		List<RichAttribute> ra_host1OnFacility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, group_fromEmail_atr_def);
+		List<Attribute> attrs_host1OnFacility2 = new ArrayList<>();
+		ra_host1OnFacility2.forEach(ra -> attrs_host1OnFacility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_host1OnFacility2.size());
+		assertTrue(attrs_host1OnFacility2.contains(group2InVo1_email_atr));
+		assertTrue(attrs_host1OnFacility2.contains(group1InVo2_email_atr));
+		assertTrue(attrs_host1OnFacility2.contains(group2InVo2_email_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByUserExtSource");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find email group attributes by userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, group_fromEmail_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+		ra_userExtSource1.forEach(ra -> attrs_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_userExtSource1.contains(group2InVo1_email_atr));
+		assertTrue(attrs_userExtSource1.contains(membersGroupOfVo1_email_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByKey");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all email group attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, group_fromEmail_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue(attrs_all.contains(group1InVo1_email_atr));
+		assertTrue(attrs_all.contains(group2InVo1_email_atr));
+		assertTrue(attrs_all.contains(group1InVo2_email_atr));
+		assertTrue(attrs_all.contains(group2InVo2_email_atr));
+		assertTrue(attrs_all.contains(membersGroupOfVo1_email_atr));
+		assertTrue(attrs_all.contains(membersGroupOfVo2_email_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByMemberGroup");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, Member.class, Group.class, AttributeDefinition.class);
+
+		//find email group attributes by group1InVo1 and member1OfUser1
+		List<RichAttribute> ra_group1Vo1_mem1U1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, group1InVo1, group_fromEmail_atr_def);
+		List<Attribute> attrs_group1Vo1_mem1U1 = new ArrayList<>();
+		ra_group1Vo1_mem1U1.forEach(ra -> attrs_group1Vo1_mem1U1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group1Vo1_mem1U1.size());
+		assertTrue(attrs_group1Vo1_mem1U1.contains(group1InVo1_email_atr));
+
+		//find email group attributes by group1InVo2 and member2OfUser1
+		List<RichAttribute> ra_group1Vo2_mem2U1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, group1InVo2, group_fromEmail_atr_def);
+		List<Attribute> attrs_group1Vo2_mem2U1 = new ArrayList<>();
+		ra_group1Vo2_mem2U1.forEach(ra -> attrs_group1Vo2_mem2U1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_group1Vo2_mem2U1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByMemberGroup");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, Member.class, Resource.class, AttributeDefinition.class);
+
+		//find email group attributes by member1OfUser1 and resource1InVo1
+		List<RichAttribute> ra_member1U1_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, resource1InVo1, group_fromEmail_atr_def);
+		List<Attribute> attrs_member1U1_res1Vo1 = new ArrayList<>();
+		ra_member1U1_res1Vo1.forEach(ra -> attrs_member1U1_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1U1_res1Vo1.size());
+		assertTrue(attrs_member1U1_res1Vo1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_member1U1_res1Vo1.contains(group2InVo1_email_atr));
+
+		//find email group attributes by member1OfUser3 and resource1InVo1
+		List<RichAttribute> ra_member1U3_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser3, resource1InVo1, group_fromEmail_atr_def);
+		List<Attribute> attrs_member1U3_res1Vo1 = new ArrayList<>();
+		ra_member1U3_res1Vo1.forEach(ra -> attrs_member1U3_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U3_res1Vo1.size());
+		assertTrue(attrs_member1U3_res1Vo1.contains(group1InVo1_email_atr));
+
+		//find email group attributes by member2OfUser2 and resource1InVo1
+		List<RichAttribute> ra_member2U2_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser2, resource1InVo1, group_fromEmail_atr_def);
+		List<Attribute> attrs_member2U2_res1Vo1 = new ArrayList<>();
+		ra_member2U2_res1Vo1.forEach(ra -> attrs_member2U2_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U2_res1Vo1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupAttributesByUserFacility");
+
+		setAttributesForGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find email group attributes by user1 and facility2
+		List<RichAttribute> ra_user1_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility2, group_fromEmail_atr_def);
+		List<Attribute> attrs_user1_facility2 = new ArrayList<>();
+		ra_user1_facility2.forEach(ra -> attrs_user1_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user1_facility2.size());
+		assertTrue(attrs_user1_facility2.contains(group2InVo1_email_atr));
+
+		//find email group attributes by user2 and facility3
+		List<RichAttribute> ra_user2_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user2, facility3, group_fromEmail_atr_def);
+		List<Attribute> attrs_user2_facility3 = new ArrayList<>();
+		ra_user2_facility3.forEach(ra -> attrs_user2_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user2_facility3.size());
+		assertTrue(attrs_user2_facility3.contains(group2InVo2_email_atr));
+
+		//find email group attributes by user1 and facility1
+		List<RichAttribute> ra_user1_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility1, group_fromEmail_atr_def);
+		List<Attribute> attrs_user1_facility1 = new ArrayList<>();
+		ra_user1_facility1.forEach(ra -> attrs_user1_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user1_facility1.size());
+		assertTrue(attrs_user1_facility1.contains(group1InVo1_email_atr));
+		assertTrue(attrs_user1_facility1.contains(group2InVo1_email_atr));
+	}
+
+	//----------------------- RESOURCEs attributes -------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByUser");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find test resource attributes for user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, resource_test_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user1.size());
+		assertTrue(attrs_user1.contains(resource1InVo1_test_atr));
+		assertTrue(attrs_user1.contains(resource2InVo1_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByMember");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find test resource attributes for member1OfUser1
+		List<RichAttribute> ra_member1OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, resource_test_atr_def);
+		List<Attribute> attrs_member1OfUser1 = new ArrayList<>();
+		ra_member1OfUser1.forEach(ra -> attrs_member1OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1OfUser1.size());
+		assertTrue(attrs_member1OfUser1.contains(resource1InVo1_test_atr));
+		assertTrue(attrs_member1OfUser1.contains(resource2InVo1_test_atr));
+
+		//find test resource attributes for member1OfUser3
+		List<RichAttribute> ra_member1OfUser3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser3, resource_test_atr_def);
+		List<Attribute> attrs_member1OfUser3 = new ArrayList<>();
+		ra_member1OfUser3.forEach(ra -> attrs_member1OfUser3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1OfUser3.size());
+		assertTrue(attrs_member1OfUser3.contains(resource1InVo1_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByGroup");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find test resource attributes for group2InVo1
+		List<RichAttribute> ra_group2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, resource_test_atr_def);
+		List<Attribute> attrs_group2InVo1 = new ArrayList<>();
+		ra_group2InVo1.forEach(ra -> attrs_group2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2InVo1.size());
+		assertTrue(attrs_group2InVo1.contains(resource1InVo1_test_atr));
+		assertTrue(attrs_group2InVo1.contains(resource2InVo1_test_atr));
+
+		//find test resource attributes for membersGroupOfVo1
+		List<RichAttribute> ra_membersGroupOfVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, membersGroupOfVo1, resource_test_atr_def);
+		List<Attribute> attrs_membersGroupOfVo1 = new ArrayList<>();
+		ra_membersGroupOfVo1.forEach(ra -> attrs_membersGroupOfVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_membersGroupOfVo1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByResource");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find test resource attributes for resource1InVo1
+		List<RichAttribute> ra_resource1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo1, resource_test_atr_def);
+		List<Attribute> attrs_resource1InVo1 = new ArrayList<>();
+		ra_resource1InVo1.forEach(ra -> attrs_resource1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_resource1InVo1.size());
+		assertTrue(attrs_resource1InVo1.contains(resource1InVo1_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByVo");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find test resource attributes for vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, resource_test_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(resource1InVo1_test_atr));
+		assertTrue(attrs_vo1.contains(resource2InVo1_test_atr));
+
+		//find test resource attributes for vo2
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, resource_test_atr_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+		ra_vo2.forEach(ra -> attrs_vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(resource1InVo2_test_atr));
+		assertTrue(attrs_vo2.contains(resource2InVo2_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByFacility");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find test resource attributes for facility1
+		List<RichAttribute> ra_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, resource_test_atr_def);
+		List<Attribute> attrs_facility1 = new ArrayList<>();
+		ra_facility1.forEach(ra -> attrs_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_facility1.size());
+		assertTrue(attrs_facility1.contains(resource1InVo1_test_atr));
+
+		//find test resource attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, resource_test_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(resource2InVo1_test_atr));
+		assertTrue(attrs_facility2.contains(resource1InVo2_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByHost");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find test resource attributes for host1OnFacility1
+		List<RichAttribute> ra_host1OnFacility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, resource_test_atr_def);
+		List<Attribute> attrs_host1OnFacility1 = new ArrayList<>();
+		ra_host1OnFacility1.forEach(ra -> attrs_host1OnFacility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_host1OnFacility1.size());
+		assertTrue(attrs_host1OnFacility1.contains(resource1InVo1_test_atr));
+
+		//find test resource attributes for host1OnFacility2
+		List<RichAttribute> ra_host1OnFacility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, resource_test_atr_def);
+		List<Attribute> attrs_host1OnFacility2 = new ArrayList<>();
+		ra_host1OnFacility2.forEach(ra -> attrs_host1OnFacility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_host1OnFacility2.size());
+		assertTrue(attrs_host1OnFacility2.contains(resource2InVo1_test_atr));
+		assertTrue(attrs_host1OnFacility2.contains(resource1InVo2_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByUserExtSource");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find test resource attributes for userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, resource_test_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+		ra_userExtSource1.forEach(ra -> attrs_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(resource1InVo1_test_atr));
+		assertTrue(attrs_userExtSource1.contains(resource2InVo1_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByKey");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all test resource attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, resource_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_all.size());
+		assertTrue(attrs_all.contains(resource1InVo1_test_atr));
+		assertTrue(attrs_all.contains(resource2InVo1_test_atr));
+		assertTrue(attrs_all.contains(resource1InVo2_test_atr));
+		assertTrue(attrs_all.contains(resource2InVo2_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByMemberGroup");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, Member.class, Group.class, AttributeDefinition.class);
+
+		//find test resource attributes for member2OfUser3 and group2InVo2
+		List<RichAttribute> ra_mem2U3_group2Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser3, group2InVo2, resource_test_atr_def);
+		List<Attribute> attrs_mem2U3_group2Vo2 = new ArrayList<>();
+		ra_mem2U3_group2Vo2.forEach(ra -> attrs_mem2U3_group2Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_mem2U3_group2Vo2.size());
+		assertTrue(attrs_mem2U3_group2Vo2.contains(resource1InVo2_test_atr));
+		assertTrue(attrs_mem2U3_group2Vo2.contains(resource2InVo2_test_atr));
+
+		//find test resource attributes for member2OfUser1 and group1InVo1
+		List<RichAttribute> ra_mem2U1_group1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, group1InVo1, resource_test_atr_def);
+		List<Attribute> attrs_mem2U1_group1Vo1 = new ArrayList<>();
+		ra_mem2U1_group1Vo1.forEach(ra -> attrs_mem2U1_group1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_mem2U1_group1Vo1.size());
+
+		//find test resource attributes for member1OfUser1 and group1InVo1
+		List<RichAttribute> ra_mem1U1_group1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, group1InVo1, resource_test_atr_def);
+		List<Attribute> attrs_mem1U1_group1Vo1 = new ArrayList<>();
+		ra_mem1U1_group1Vo1.forEach(ra -> attrs_mem1U1_group1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_mem1U1_group1Vo1.size());
+		assertTrue(attrs_mem1U1_group1Vo1.contains(resource1InVo1_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByMemberResource");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, Member.class, Resource.class, AttributeDefinition.class);
+
+		//find test resource attributes for member2OfUser3 and resource2InVo2
+		List<RichAttribute> ra_mem2U3_res2Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser3, resource2InVo2, resource_test_atr_def);
+		List<Attribute> attrs_mem2U3_res2Vo2 = new ArrayList<>();
+		ra_mem2U3_res2Vo2.forEach(ra -> attrs_mem2U3_res2Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_mem2U3_res2Vo2.size());
+		assertTrue(attrs_mem2U3_res2Vo2.contains(resource2InVo2_test_atr));
+
+		//find test resource attributes for member2OfUser1 and resource1InVo1
+		List<RichAttribute> ra_mem2U1_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, resource1InVo1, resource_test_atr_def);
+		List<Attribute> attrs_mem2U1_res1Vo1 = new ArrayList<>();
+		ra_mem2U1_res1Vo1.forEach(ra -> attrs_mem2U1_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_mem2U1_res1Vo1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getResourceAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getResourceAttributesByUserFacility");
+
+		setAttributesForResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getResourceAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find test resource attributes for user3 and facility3
+		List<RichAttribute> ra_user3_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility3, resource_test_atr_def);
+		List<Attribute> attrs_user3_facility3 = new ArrayList<>();
+		ra_user3_facility3.forEach(ra -> attrs_user3_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user3_facility3.size());
+		assertTrue(attrs_user3_facility3.contains(resource2InVo2_test_atr));
+
+		//find test resource attributes for user2 and facility2
+		List<RichAttribute> ra_user2_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user2, facility2, resource_test_atr_def);
+		List<Attribute> attrs_user2_facility2 = new ArrayList<>();
+		ra_user2_facility2.forEach(ra -> attrs_user2_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user2_facility2.size());
+		assertTrue(attrs_user2_facility2.contains(resource1InVo2_test_atr));
+	}
+
+	//----------------------- FACILITIES attributes -------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByUser");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find test resource attributes for user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility_test_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user1.size());
+		assertTrue(attrs_user1.contains(facility1_test_atr));
+		assertTrue(attrs_user1.contains(facility2_test_atr));
+
+		//find test resource attributes for user3
+		List<RichAttribute> ra_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility_test_atr_def);
+		List<Attribute> attrs_user3 = new ArrayList<>();
+		ra_user3.forEach(ra -> attrs_user3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_user3.size());
+		assertTrue(attrs_user3.contains(facility1_test_atr));
+		assertTrue(attrs_user3.contains(facility2_test_atr));
+		assertTrue(attrs_user3.contains(facility3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByMember");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find test resource attributes for member1OfUser1
+		List<RichAttribute> ra_member1OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, facility_test_atr_def);
+		List<Attribute> attrs_member1OfUser1 = new ArrayList<>();
+		ra_member1OfUser1.forEach(ra -> attrs_member1OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1OfUser1.size());
+		assertTrue(attrs_member1OfUser1.contains(facility1_test_atr));
+		assertTrue(attrs_member1OfUser1.contains(facility2_test_atr));
+
+		//find test resource attributes for member2OfUser2
+		List<RichAttribute> ra_member2OfUser2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser2, facility_test_atr_def);
+		List<Attribute> attrs_member2OfUser2 = new ArrayList<>();
+		ra_member2OfUser2.forEach(ra -> attrs_member2OfUser2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2OfUser2.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByGroup");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find test resource attributes for group2InVo1
+		List<RichAttribute> ra_group2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, facility_test_atr_def);
+		List<Attribute> attrs_group2InVo1 = new ArrayList<>();
+		ra_group2InVo1.forEach(ra -> attrs_group2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2InVo1.size());
+		assertTrue(attrs_group2InVo1.contains(facility1_test_atr));
+		assertTrue(attrs_group2InVo1.contains(facility2_test_atr));
+
+		//find test resource attributes for group1InVo2
+		List<RichAttribute> ra_group1InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo2, facility_test_atr_def);
+		List<Attribute> attrs_group1InVo2 = new ArrayList<>();
+		ra_group1InVo2.forEach(ra -> attrs_group1InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group1InVo2.size());
+		assertTrue(attrs_group1InVo2.contains(facility2_test_atr));
+
+		//find test resource attributes for membersGroupOfVo1
+		List<RichAttribute> ra_membersGroupOfVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, membersGroupOfVo1, facility_test_atr_def);
+		List<Attribute> attrs_membersGroupOfVo1 = new ArrayList<>();
+		ra_membersGroupOfVo1.forEach(ra -> attrs_membersGroupOfVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_membersGroupOfVo1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByResource");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find test resource attributes for resource1InVo1
+		List<RichAttribute> ra_resource1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo1, facility_test_atr_def);
+		List<Attribute> attrs_resource1InVo1 = new ArrayList<>();
+		ra_resource1InVo1.forEach(ra -> attrs_resource1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_resource1InVo1.size());
+		assertTrue(attrs_resource1InVo1.contains(facility1_test_atr));
+
+		//find test resource attributes for resource2InVo2
+		List<RichAttribute> ra_resource2InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource2InVo2, facility_test_atr_def);
+		List<Attribute> attrs_resource2InVo2 = new ArrayList<>();
+		ra_resource2InVo2.forEach(ra -> attrs_resource2InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_resource2InVo2.size());
+		assertTrue(attrs_resource2InVo2.contains(facility3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByVo");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find test resource attributes for vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, facility_test_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(facility1_test_atr));
+		assertTrue(attrs_vo1.contains(facility2_test_atr));
+
+		//find test resource attributes for vo2
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, facility_test_atr_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+		ra_vo2.forEach(ra -> attrs_vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(facility2_test_atr));
+		assertTrue(attrs_vo2.contains(facility3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByFacility");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find test resource attributes for facility1
+		List<RichAttribute> ra_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, facility_test_atr_def);
+		List<Attribute> attrs_facility1 = new ArrayList<>();
+		ra_facility1.forEach(ra -> attrs_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_facility1.size());
+		assertTrue(attrs_facility1.contains(facility1_test_atr));
+
+		//find test resource attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, facility_test_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(facility2_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByHost");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find test resource attributes for host1OnFacility1
+		List<RichAttribute> ra_host1OnFacility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, facility_test_atr_def);
+		List<Attribute> attrs_host1OnFacility1 = new ArrayList<>();
+		ra_host1OnFacility1.forEach(ra -> attrs_host1OnFacility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_host1OnFacility1.size());
+		assertTrue(attrs_host1OnFacility1.contains(facility1_test_atr));
+
+		//find test resource attributes for host1OnFacility2
+		List<RichAttribute> ra_host1OnFacility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, facility_test_atr_def);
+		List<Attribute> attrs_host1OnFacility2 = new ArrayList<>();
+		ra_host1OnFacility2.forEach(ra -> attrs_host1OnFacility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_host1OnFacility2.size());
+		assertTrue(attrs_host1OnFacility2.contains(facility2_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByUserExtSource");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find test resource attributes for userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, facility_test_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+		ra_userExtSource1.forEach(ra -> attrs_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(facility1_test_atr));
+		assertTrue(attrs_userExtSource1.contains(facility2_test_atr));
+
+		//find test resource attributes for userExtSource3
+		List<RichAttribute> ra_userExtSource3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource3, facility_test_atr_def);
+		List<Attribute> attrs_userExtSource3 = new ArrayList<>();
+		ra_userExtSource3.forEach(ra -> attrs_userExtSource3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_userExtSource3.size());
+		assertTrue(attrs_userExtSource3.contains(facility1_test_atr));
+		assertTrue(attrs_userExtSource3.contains(facility2_test_atr));
+		assertTrue(attrs_userExtSource3.contains(facility3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByKey");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all test resource attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, facility_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_all.size());
+		assertTrue(attrs_all.contains(facility1_test_atr));
+		assertTrue(attrs_all.contains(facility2_test_atr));
+		assertTrue(attrs_all.contains(facility3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByMemberGroup");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, Member.class, Group.class, AttributeDefinition.class);
+
+		//find test resource attributes for member1OfUser1 group2InVo1
+		List<RichAttribute> ra_member1U1_group2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, group2InVo1, facility_test_atr_def);
+		List<Attribute> attrs_member1U1_group2Vo1 = new ArrayList<>();
+		ra_member1U1_group2Vo1.forEach(ra -> attrs_member1U1_group2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1U1_group2Vo1.size());
+		assertTrue(attrs_member1U1_group2Vo1.contains(facility1_test_atr));
+		assertTrue(attrs_member1U1_group2Vo1.contains(facility2_test_atr));
+
+		//find test resource attributes for member1OfUser2 group1InVo2
+		List<RichAttribute> ra_member1U2_group1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser2, group1InVo2, facility_test_atr_def);
+		List<Attribute> attrs_member1U2_group1Vo2 = new ArrayList<>();
+		ra_member1U2_group1Vo2.forEach(ra -> attrs_member1U2_group1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U2_group1Vo2.size());
+		assertTrue(attrs_member1U2_group1Vo2.contains(facility2_test_atr));
+
+		//find test resource attributes for member2OfUser1 group1InVo2
+		List<RichAttribute> ra_member2U1_group1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, group1InVo2, facility_test_atr_def);
+		List<Attribute> attrs_member2U1_group1Vo2 = new ArrayList<>();
+		ra_member2U1_group1Vo2.forEach(ra -> attrs_member2U1_group1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U1_group1Vo2.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByMemberResource");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, Member.class, Resource.class, AttributeDefinition.class);
+
+		//find test resource attributes for member1OfUser1 resource2InVo1
+		List<RichAttribute> ra_member1U1_res2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, resource2InVo1, facility_test_atr_def);
+		List<Attribute> attrs_member1U1_res2Vo1 = new ArrayList<>();
+		ra_member1U1_res2Vo1.forEach(ra -> attrs_member1U1_res2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U1_res2Vo1.size());
+		assertTrue(attrs_member1U1_res2Vo1.contains(facility2_test_atr));
+
+		//find test resource attributes for member1OfUser2 resource2InVo2
+		List<RichAttribute> ra_member1U2_res2Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser2, resource2InVo2, facility_test_atr_def);
+		List<Attribute> attrs_member1U2_res2Vo2 = new ArrayList<>();
+		ra_member1U2_res2Vo2.forEach(ra -> attrs_member1U2_res2Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U2_res2Vo2.size());
+		assertTrue(attrs_member1U2_res2Vo2.contains(facility3_test_atr));
+
+		//find test resource attributes for member2OfUser1 resource1InVo2
+		List<RichAttribute> ra_member2U1_res1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, resource1InVo2, facility_test_atr_def);
+		List<Attribute> attrs_member2U1_res1Vo2 = new ArrayList<>();
+		ra_member2U1_res1Vo2.forEach(ra -> attrs_member2U1_res1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U1_res1Vo2.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getFacilityAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getFacilityAttributesByUserFacility");
+
+		setAttributesForFacilityAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getFacilityAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find test resource attributes for user2 facility2
+		List<RichAttribute> ra_user2_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user2, facility2, facility_test_atr_def);
+		List<Attribute> attrs_user2_facility2 = new ArrayList<>();
+		ra_user2_facility2.forEach(ra -> attrs_user2_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user2_facility2.size());
+		assertTrue(attrs_user2_facility2.contains(facility2_test_atr));
+
+		//find test resource attributes for user2 facility1
+		List<RichAttribute> ra_user2_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user2, facility1, facility_test_atr_def);
+		List<Attribute> attrs_user2_facility1 = new ArrayList<>();
+		ra_user2_facility1.forEach(ra -> attrs_user2_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_user2_facility1.size());
+	}
+
+	//---------------------HOSTS------------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByUser");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find test host attributes for user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, host_test_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_user1.size());
+		assertTrue(attrs_user1.contains(host1F1_test_atr));
+		assertTrue(attrs_user1.contains(host2F1_test_atr));
+		assertTrue(attrs_user1.contains(host1F2_test_atr));
+		assertTrue(attrs_user1.contains(host2F2_test_atr));
+
+		//find test host attributes for user3
+		List<RichAttribute> ra_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, host_test_atr_def);
+		List<Attribute> attrs_user3 = new ArrayList<>();
+		ra_user3.forEach(ra -> attrs_user3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 6, attrs_user3.size());
+		assertTrue(attrs_user3.contains(host1F1_test_atr));
+		assertTrue(attrs_user3.contains(host2F1_test_atr));
+		assertTrue(attrs_user3.contains(host1F2_test_atr));
+		assertTrue(attrs_user3.contains(host2F2_test_atr));
+		assertTrue(attrs_user3.contains(host1F3_test_atr));
+		assertTrue(attrs_user3.contains(host2F3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByMember");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find test host attributes for member1OfUser1
+		List<RichAttribute> ra_member1OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, host_test_atr_def);
+		List<Attribute> attrs_member1OfUser1 = new ArrayList<>();
+		ra_member1OfUser1.forEach(ra -> attrs_member1OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_member1OfUser1.size());
+		assertTrue(attrs_member1OfUser1.contains(host1F1_test_atr));
+		assertTrue(attrs_member1OfUser1.contains(host2F1_test_atr));
+		assertTrue(attrs_member1OfUser1.contains(host1F2_test_atr));
+		assertTrue(attrs_member1OfUser1.contains(host2F2_test_atr));
+
+		//find test host attributes for member2OfUser2
+		List<RichAttribute> ra_member2OfUser2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser2, host_test_atr_def);
+		List<Attribute> attrs_member2OfUser2 = new ArrayList<>();
+		ra_member2OfUser2.forEach(ra -> attrs_member2OfUser2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2OfUser2.size());
+
+		//find test host attributes for member2OfUser3
+		List<RichAttribute> ra_member2OfUser3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser3, host_test_atr_def);
+		List<Attribute> attrs_member2OfUser3 = new ArrayList<>();
+		ra_member2OfUser3.forEach(ra -> attrs_member2OfUser3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_member2OfUser3.size());
+		assertTrue(attrs_member2OfUser3.contains(host1F2_test_atr));
+		assertTrue(attrs_member2OfUser3.contains(host2F2_test_atr));
+		assertTrue(attrs_member2OfUser3.contains(host1F3_test_atr));
+		assertTrue(attrs_member2OfUser3.contains(host2F3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByGroup");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find test host attributes for group1InVo2
+		List<RichAttribute> ra_group1InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo2, host_test_atr_def);
+		List<Attribute> attrs_group1InVo2 = new ArrayList<>();
+		ra_group1InVo2.forEach(ra -> attrs_group1InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group1InVo2.size());
+		assertTrue(attrs_group1InVo2.contains(host1F2_test_atr));
+		assertTrue(attrs_group1InVo2.contains(host2F2_test_atr));
+
+		//find test host attributes for group2InVo2
+		List<RichAttribute> ra_group2InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo2, host_test_atr_def);
+		List<Attribute> attrs_group2InVo2 = new ArrayList<>();
+		ra_group2InVo2.forEach(ra -> attrs_group2InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_group2InVo2.size());
+		assertTrue(attrs_group2InVo2.contains(host1F2_test_atr));
+		assertTrue(attrs_group2InVo2.contains(host2F2_test_atr));
+		assertTrue(attrs_group2InVo2.contains(host1F3_test_atr));
+		assertTrue(attrs_group2InVo2.contains(host2F3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByResource");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find test host attributes for resource1InVo1
+		List<RichAttribute> ra_resource1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo1, host_test_atr_def);
+		List<Attribute> attrs_resource1InVo1 = new ArrayList<>();
+		ra_resource1InVo1.forEach(ra -> attrs_resource1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_resource1InVo1.size());
+		assertTrue(attrs_resource1InVo1.contains(host1F1_test_atr));
+		assertTrue(attrs_resource1InVo1.contains(host2F1_test_atr));
+
+		//find test host attributes for resource2InVo1
+		List<RichAttribute> ra_resource2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource2InVo1, host_test_atr_def);
+		List<Attribute> attrs_resource2InVo1 = new ArrayList<>();
+		ra_resource2InVo1.forEach(ra -> attrs_resource2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_resource2InVo1.size());
+		assertTrue(attrs_resource2InVo1.contains(host1F2_test_atr));
+		assertTrue(attrs_resource2InVo1.contains(host2F2_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByVo");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find test host attributes for vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, host_test_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(host1F1_test_atr));
+		assertTrue(attrs_vo1.contains(host2F1_test_atr));
+		assertTrue(attrs_vo1.contains(host1F2_test_atr));
+		assertTrue(attrs_vo1.contains(host2F2_test_atr));
+
+		//find test host attributes for vo2
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, host_test_atr_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+		ra_vo2.forEach(ra -> attrs_vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(host1F2_test_atr));
+		assertTrue(attrs_vo2.contains(host2F2_test_atr));
+		assertTrue(attrs_vo2.contains(host1F3_test_atr));
+		assertTrue(attrs_vo2.contains(host2F3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByFacility");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find test host attributes for facility1
+		List<RichAttribute> ra_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, host_test_atr_def);
+		List<Attribute> attrs_facility1 = new ArrayList<>();
+		ra_facility1.forEach(ra -> attrs_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility1.size());
+		assertTrue(attrs_facility1.contains(host1F1_test_atr));
+		assertTrue(attrs_facility1.contains(host2F1_test_atr));
+
+		//find test host attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, host_test_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(host1F2_test_atr));
+		assertTrue(attrs_facility2.contains(host2F2_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByHost");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find test host attributes for host1OnFacility1
+		List<RichAttribute> ra_host1OnFacility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, host_test_atr_def);
+		List<Attribute> attrs_host1OnFacility1 = new ArrayList<>();
+		ra_host1OnFacility1.forEach(ra -> attrs_host1OnFacility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_host1OnFacility1.size());
+		assertTrue(attrs_host1OnFacility1.contains(host1F1_test_atr));
+
+		//find test host attributes for host2OnFacility3
+		List<RichAttribute> ra_host2OnFacility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host2OnFacility3, host_test_atr_def);
+		List<Attribute> attrs_host2OnFacility3 = new ArrayList<>();
+		ra_host2OnFacility3.forEach(ra -> attrs_host2OnFacility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_host2OnFacility3.size());
+		assertTrue(attrs_host2OnFacility3.contains(host2F3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByUserExtSource");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find test host attributes for userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, host_test_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+		ra_userExtSource1.forEach(ra -> attrs_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(host1F1_test_atr));
+		assertTrue(attrs_userExtSource1.contains(host2F1_test_atr));
+		assertTrue(attrs_userExtSource1.contains(host1F2_test_atr));
+		assertTrue(attrs_userExtSource1.contains(host2F2_test_atr));
+
+		//find test host attributes for userExtSource3
+		List<RichAttribute> ra_userExtSource3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource3, host_test_atr_def);
+		List<Attribute> attrs_userExtSource3 = new ArrayList<>();
+		ra_userExtSource3.forEach(ra -> attrs_userExtSource3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 6, attrs_userExtSource3.size());
+		assertTrue(attrs_userExtSource3.contains(host1F1_test_atr));
+		assertTrue(attrs_userExtSource3.contains(host2F1_test_atr));
+		assertTrue(attrs_userExtSource3.contains(host1F2_test_atr));
+		assertTrue(attrs_userExtSource3.contains(host2F2_test_atr));
+		assertTrue(attrs_userExtSource3.contains(host1F3_test_atr));
+		assertTrue(attrs_userExtSource3.contains(host2F3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByKey");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all test host attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, host_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue(attrs_all.contains(host1F1_test_atr));
+		assertTrue(attrs_all.contains(host2F1_test_atr));
+		assertTrue(attrs_all.contains(host1F2_test_atr));
+		assertTrue(attrs_all.contains(host2F2_test_atr));
+		assertTrue(attrs_all.contains(host1F3_test_atr));
+		assertTrue(attrs_all.contains(host2F3_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByMemberGroup");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, Member.class, Group.class, AttributeDefinition.class);
+
+		//find test host attributes for member1OfUser2 and group1InVo2
+		List<RichAttribute> ra_member1U2_group1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser2, group1InVo2, host_test_atr_def);
+		List<Attribute> attrs_member1U2_group1Vo2 = new ArrayList<>();
+		ra_member1U2_group1Vo2.forEach(ra -> attrs_member1U2_group1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1U2_group1Vo2.size());
+		assertTrue(attrs_member1U2_group1Vo2.contains(host1F2_test_atr));
+		assertTrue(attrs_member1U2_group1Vo2.contains(host2F2_test_atr));
+
+		//find test host attributes for member2OfUser3 and group2InVo2
+		List<RichAttribute> ra_member2U3_group2Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess,  member2OfUser3, group2InVo2, host_test_atr_def);
+		List<Attribute> attrs_member2U3_group2Vo2 = new ArrayList<>();
+		ra_member2U3_group2Vo2.forEach(ra -> attrs_member2U3_group2Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_member2U3_group2Vo2.size());
+		assertTrue(attrs_member2U3_group2Vo2.contains(host1F2_test_atr));
+		assertTrue(attrs_member2U3_group2Vo2.contains(host2F2_test_atr));
+		assertTrue(attrs_member2U3_group2Vo2.contains(host1F3_test_atr));
+		assertTrue(attrs_member2U3_group2Vo2.contains(host2F3_test_atr));
+
+		//find test host attributes for member2OfUser1 and group2InVo2
+		List<RichAttribute> ra_member2U1_group2Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess,  member2OfUser1, group2InVo2, host_test_atr_def);
+		List<Attribute> attrs_member2U1_group2Vo2 = new ArrayList<>();
+		ra_member2U1_group2Vo2.forEach(ra -> attrs_member2U1_group2Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U1_group2Vo2.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getHostAttributesByMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "getHostAttributesByMemberResource");
+
+		setAttributesForHostAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getHostAttributes",
+				PerunSession.class, Member.class, Resource.class, AttributeDefinition.class);
+
+		//find test host attributes for member1OfUser1 and resource1InVo1
+		List<RichAttribute> ra_mem1U1_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, resource1InVo1, host_test_atr_def);
+		List<Attribute> attrs_mem1U1_res1Vo1 = new ArrayList<>();
+		ra_mem1U1_res1Vo1.forEach(ra -> attrs_mem1U1_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_mem1U1_res1Vo1.size());
+		assertTrue(attrs_mem1U1_res1Vo1.contains(host1F1_test_atr));
+		assertTrue(attrs_mem1U1_res1Vo1.contains(host2F1_test_atr));
+
+		//find test host attributes for member2OfUser2 and resource2InVo1
+		List<RichAttribute> ra_mem2U2_res2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser2, resource2InVo1, host_test_atr_def);
+		List<Attribute> attrs_mem2U2_res2Vo1 = new ArrayList<>();
+		ra_mem2U2_res2Vo1.forEach(ra -> attrs_mem2U2_res2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_mem2U2_res2Vo1.size());
+	}
+
+	//----------------------UESs--------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByUser");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find test UES attributes for user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, ues_test_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user1.size());
+		assertTrue(attrs_user1.contains(ues1_test_atr));
+		assertTrue(attrs_user1.contains(internal_ues_atr));
+
+		//find test UES attributes for user3
+		List<RichAttribute> ra_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, ues_test_atr_def);
+		List<Attribute> attrs_user3 = new ArrayList<>();
+		ra_user3.forEach(ra -> attrs_user3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user3.size());
+		assertTrue(attrs_user3.contains(ues3_test_atr));
+		assertTrue(attrs_user3.contains(internal_ues_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByMember");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find test UES attributes for member1OfUser1
+		List<RichAttribute> ra_member1OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, ues_test_atr_def);
+		List<Attribute> attrs_member1OfUser1 = new ArrayList<>();
+		ra_member1OfUser1.forEach(ra -> attrs_member1OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1OfUser1.size());
+		assertTrue(attrs_member1OfUser1.contains(ues1_test_atr));
+		assertTrue(attrs_member1OfUser1.contains(internal_ues_atr));
+
+		//find test UES attributes for member2OfUser1
+		List<RichAttribute> ra_member2OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, ues_test_atr_def);
+		List<Attribute> attrs_member2OfUser1 = new ArrayList<>();
+		ra_member2OfUser1.forEach(ra -> attrs_member2OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2OfUser1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByGroup");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find test UES attributes for group1InVo1
+		List<RichAttribute> ra_group1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo1, ues_test_atr_def);
+		List<Attribute> attrs_group1InVo1 = new ArrayList<>();
+		ra_group1InVo1.forEach(ra -> attrs_group1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_group1InVo1.size());
+		//contains two internal_ues_atr
+		assertTrue(attrs_group1InVo1.contains(ues1_test_atr));
+		assertTrue(attrs_group1InVo1.contains(ues3_test_atr));
+		assertTrue(attrs_group1InVo1.contains(internal_ues_atr));
+
+		//find test UES attributes for group2InVo1
+		List<RichAttribute> ra_group2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, ues_test_atr_def);
+		List<Attribute> attrs_group2InVo1 = new ArrayList<>();
+		ra_group2InVo1.forEach(ra -> attrs_group2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2InVo1.size());
+		assertTrue(attrs_group2InVo1.contains(ues1_test_atr));
+		assertTrue(attrs_group2InVo1.contains(internal_ues_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByResource");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find test UES attributes for resource1InVo2
+		List<RichAttribute> ra_resource1InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo2, ues_test_atr_def);
+		List<Attribute> attrs_resource1InVo2 = new ArrayList<>();
+		ra_resource1InVo2.forEach(ra -> attrs_resource1InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_resource1InVo2.size());
+		//contains two internal_ues_atr
+		assertTrue(attrs_resource1InVo2.contains(ues2_test_atr));
+		assertTrue(attrs_resource1InVo2.contains(ues3_test_atr));
+		assertTrue(attrs_resource1InVo2.contains(internal_ues_atr));
+
+		//find test UES attributes for resource2InVo1
+		List<RichAttribute> ra_resource2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource2InVo1, ues_test_atr_def);
+		List<Attribute> attrs_resource2InVo1 = new ArrayList<>();
+		ra_resource2InVo1.forEach(ra -> attrs_resource2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_resource2InVo1.size());
+		assertTrue(attrs_resource2InVo1.contains(ues1_test_atr));
+		assertTrue(attrs_resource2InVo1.contains(internal_ues_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByVo");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find test UES attributes for vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, ues_test_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_vo1.size());
+		//contains two internal_ues_atr
+		assertTrue(attrs_vo1.contains(ues1_test_atr));
+		assertTrue(attrs_vo1.contains(ues3_test_atr));
+		assertTrue(attrs_vo1.contains(internal_ues_atr));
+
+		//find test UES attributes for vo2
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, ues_test_atr_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+		ra_vo2.forEach(ra -> attrs_vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(ues2_test_atr));
+		assertTrue(attrs_vo2.contains(ues3_test_atr));
+		assertTrue(attrs_vo2.contains(internal_ues_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByFacility");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find test UES attributes for facility1
+		List<RichAttribute> ra_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, ues_test_atr_def);
+		List<Attribute> attrs_facility1 = new ArrayList<>();
+		ra_facility1.forEach(ra -> attrs_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_facility1.size());
+		//contains two internal_ues_atr
+		assertTrue(attrs_facility1.contains(ues1_test_atr));
+		assertTrue(attrs_facility1.contains(ues3_test_atr));
+		assertTrue(attrs_facility1.contains(internal_ues_atr));
+
+		//find test UES attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, ues_test_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 6, attrs_facility2.size());
+		//contains three internal_ues_atr
+		assertTrue(attrs_facility2.contains(ues1_test_atr));
+		assertTrue(attrs_facility2.contains(ues2_test_atr));
+		assertTrue(attrs_facility2.contains(ues3_test_atr));
+		assertTrue(attrs_facility2.contains(internal_ues_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByHost");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find test UES attributes for host1OnFacility1
+		List<RichAttribute> ra_host1OnFacility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, ues_test_atr_def);
+		List<Attribute> attrs_host1OnFacility1 = new ArrayList<>();
+		ra_host1OnFacility1.forEach(ra -> attrs_host1OnFacility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_host1OnFacility1.size());
+		//contains two internal_ues_atr
+		assertTrue(attrs_host1OnFacility1.contains(ues1_test_atr));
+		assertTrue(attrs_host1OnFacility1.contains(ues3_test_atr));
+		assertTrue(attrs_host1OnFacility1.contains(internal_ues_atr));
+
+		//find test UES attributes for host1OnFacility2
+		List<RichAttribute> ra_host1OnFacility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, ues_test_atr_def);
+		List<Attribute> attrs_host1OnFacility2 = new ArrayList<>();
+		ra_host1OnFacility2.forEach(ra -> attrs_host1OnFacility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 6, attrs_host1OnFacility2.size());
+		//contains three internal_ues_atr
+		assertTrue(attrs_host1OnFacility2.contains(ues1_test_atr));
+		assertTrue(attrs_host1OnFacility2.contains(ues2_test_atr));
+		assertTrue(attrs_host1OnFacility2.contains(ues3_test_atr));
+		assertTrue(attrs_host1OnFacility2.contains(internal_ues_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByUserExtSource");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find test UES attributes for userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, ues_test_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+		ra_userExtSource1.forEach(ra -> attrs_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(ues1_test_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByKey");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all test UES attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, ues_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue(attrs_all.contains(ues1_test_atr));
+		assertTrue(attrs_all.contains(ues2_test_atr));
+		assertTrue(attrs_all.contains(ues3_test_atr));
+		//contains three internal ues attributes
+		assertTrue(attrs_all.contains(internal_ues_atr));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserExtSourceAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByUserFacility");
+
+		setAttributesForUESAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserExtSourceAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find test UES attributes for user1 facility1
+		List<RichAttribute> ra_user1_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility1, ues_test_atr_def);
+		List<Attribute> attrs_user1_facility1 = new ArrayList<>();
+		ra_user1_facility1.forEach(ra -> attrs_user1_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user1_facility1.size());
+		assertTrue(attrs_user1_facility1.contains(ues1_test_atr));
+		assertTrue(attrs_user1_facility1.contains(internal_ues_atr));
+
+		//find test UES attributes for user1 and facility3
+		List<RichAttribute> ra_user1_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility3, ues_test_atr_def);
+		List<Attribute> attrs_user1_facility3 = new ArrayList<>();
+		ra_user1_facility3.forEach(ra -> attrs_user1_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_user1_facility3.size());
+	}
+
+	//-----------------------GROUP-RESOURCE--------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByUser");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, groupResource_test_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_user1.size());
+		assertTrue(attrs_user1.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_user1.contains(group2VO1Res1VO1_test_attribute));
+		assertTrue(attrs_user1.contains(group2VO1Res2VO1_test_attribute));
+
+		//find test group-resource attributes for user3
+		List<RichAttribute> ra_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, groupResource_test_atr_def);
+		List<Attribute> attrs_user3 = new ArrayList<>();
+		ra_user3.forEach(ra -> attrs_user3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_user3.size());
+		assertTrue(attrs_user3.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_user3.contains(group2VO2Res1VO2_test_attribute));
+		assertTrue(attrs_user3.contains(group2VO2Res2VO2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByMember");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for member2OfUser3
+		List<RichAttribute> ra_member2OfUser3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser3, groupResource_test_atr_def);
+		List<Attribute> attrs_member2OfUser3 = new ArrayList<>();
+		ra_member2OfUser3.forEach(ra -> attrs_member2OfUser3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member2OfUser3.size());
+		assertTrue(attrs_member2OfUser3.contains(group2VO2Res1VO2_test_attribute));
+		assertTrue(attrs_member2OfUser3.contains(group2VO2Res2VO2_test_attribute));
+
+		//find test group-resource attributes for member1OfUser2
+		List<RichAttribute> ra_member1OfUser2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser2, groupResource_test_atr_def);
+		List<Attribute> attrs_member1OfUser2 = new ArrayList<>();
+		ra_member1OfUser2.forEach(ra -> attrs_member1OfUser2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_member1OfUser2.size());
+		assertTrue(attrs_member1OfUser2.contains(group1VO2Res1VO2_test_attribute));
+		assertTrue(attrs_member1OfUser2.contains(group2VO2Res1VO2_test_attribute));
+		assertTrue(attrs_member1OfUser2.contains(group2VO2Res2VO2_test_attribute));
+
+		//find test group-resource attributes for member2OfUser1
+		List<RichAttribute> ra_member2OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, groupResource_test_atr_def);
+		List<Attribute> attrs_member2OfUser1 = new ArrayList<>();
+		ra_member2OfUser1.forEach(ra -> attrs_member2OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2OfUser1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByGroup");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for group2InVo1
+		List<RichAttribute> ra_group2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, groupResource_test_atr_def);
+		List<Attribute> attrs_group2InVo1 = new ArrayList<>();
+		ra_group2InVo1.forEach(ra -> attrs_group2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2InVo1.size());
+		assertTrue(attrs_group2InVo1.contains(group2VO1Res1VO1_test_attribute));
+		assertTrue(attrs_group2InVo1.contains(group2VO1Res2VO1_test_attribute));
+
+		//find test group-resource attributes for group1InVo2
+		List<RichAttribute> ra_group1InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo2, groupResource_test_atr_def);
+		List<Attribute> attrs_group1InVo2 = new ArrayList<>();
+		ra_group1InVo2.forEach(ra -> attrs_group1InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group1InVo2.size());
+		assertTrue(attrs_group1InVo2.contains(group1VO2Res1VO2_test_attribute));
+
+		//find test group-resource attributes for membersGroupOfVo1
+		List<RichAttribute> ra_membersGroupOfVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, membersGroupOfVo1, groupResource_test_atr_def);
+		List<Attribute> attrs_membersGroupOfVo1 = new ArrayList<>();
+		ra_membersGroupOfVo1.forEach(ra -> attrs_membersGroupOfVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_membersGroupOfVo1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByResource");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for resource1InVo1
+		List<RichAttribute> ra_resource1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo1, groupResource_test_atr_def);
+		List<Attribute> attrs_resource1InVo1 = new ArrayList<>();
+		ra_resource1InVo1.forEach(ra -> attrs_resource1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_resource1InVo1.size());
+		assertTrue(attrs_resource1InVo1.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_resource1InVo1.contains(group2VO1Res1VO1_test_attribute));
+
+		//find test group-resource attributes for resource2InVo2
+		List<RichAttribute> ra_resource2InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource2InVo2, groupResource_test_atr_def);
+		List<Attribute> attrs_resource2InVo2 = new ArrayList<>();
+		ra_resource2InVo2.forEach(ra -> attrs_resource2InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_resource2InVo2.size());
+		assertTrue(attrs_resource2InVo2.contains(group2VO2Res2VO2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByVo");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, groupResource_test_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_vo1.contains(group2VO1Res1VO1_test_attribute));
+		assertTrue(attrs_vo1.contains(group2VO1Res2VO1_test_attribute));
+
+		//find test group-resource attributes for vo2
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, groupResource_test_atr_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+		ra_vo2.forEach(ra -> attrs_vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(group1VO2Res1VO2_test_attribute));
+		assertTrue(attrs_vo2.contains(group2VO2Res1VO2_test_attribute));
+		assertTrue(attrs_vo2.contains(group2VO2Res2VO2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByFacility");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, groupResource_test_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(group1VO2Res1VO2_test_attribute));
+		assertTrue(attrs_facility2.contains(group2VO2Res1VO2_test_attribute));
+		assertTrue(attrs_facility2.contains(group2VO1Res2VO1_test_attribute));
+
+		//find test group-resource attributes for facility1
+		List<RichAttribute> ra_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, groupResource_test_atr_def);
+		List<Attribute> attrs_facility1 = new ArrayList<>();
+		ra_facility1.forEach(ra -> attrs_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility1.size());
+		assertTrue(attrs_facility1.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_facility1.contains(group2VO1Res1VO1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByHost");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for host1OnFacility2
+		List<RichAttribute> ra_host1OnFacility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, groupResource_test_atr_def);
+		List<Attribute> attrs_host1OnFacility2 = new ArrayList<>();
+		ra_host1OnFacility2.forEach(ra -> attrs_host1OnFacility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_host1OnFacility2.size());
+		assertTrue(attrs_host1OnFacility2.contains(group1VO2Res1VO2_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(group2VO2Res1VO2_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(group2VO1Res2VO1_test_attribute));
+
+		//find test group-resource attributes for host1OnFacility1
+		List<RichAttribute> ra_host1OnFacility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, groupResource_test_atr_def);
+		List<Attribute> attrs_host1OnFacility1 = new ArrayList<>();
+		ra_host1OnFacility1.forEach(ra -> attrs_host1OnFacility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_host1OnFacility1.size());
+		assertTrue(attrs_host1OnFacility1.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_host1OnFacility1.contains(group2VO1Res1VO1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByUserExtSource");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, groupResource_test_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+		ra_userExtSource1.forEach(ra -> attrs_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_userExtSource1.contains(group2VO1Res1VO1_test_attribute));
+		assertTrue(attrs_userExtSource1.contains(group2VO1Res2VO1_test_attribute));
+
+		//find test group-resource attributes for userExtSource3
+		List<RichAttribute> ra_userExtSource3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource3, groupResource_test_atr_def);
+		List<Attribute> attrs_userExtSource3 = new ArrayList<>();
+		ra_userExtSource3.forEach(ra -> attrs_userExtSource3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_userExtSource3.size());
+		assertTrue(attrs_userExtSource3.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_userExtSource3.contains(group2VO2Res1VO2_test_attribute));
+		assertTrue(attrs_userExtSource3.contains(group2VO2Res2VO2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByGroupResource() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByGroupResource");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Group.class, Resource.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for group1InVo1 and resource1InVo1
+		List<RichAttribute> ra_group1Vo1_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo1, resource1InVo1, groupResource_test_atr_def);
+		List<Attribute> attrs_group1Vo1_res1Vo1 = new ArrayList<>();
+		ra_group1Vo1_res1Vo1.forEach(ra -> attrs_group1Vo1_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group1Vo1_res1Vo1.size());
+		assertTrue(attrs_group1Vo1_res1Vo1.contains(group1VO1Res1VO1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByMemberGroup");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Member.class, Group.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for member1OfUser1 and group2InVo1
+		List<RichAttribute> ra_member1U1_group2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, group2InVo1, groupResource_test_atr_def);
+		List<Attribute> attrs_member1U1_group2Vo1 = new ArrayList<>();
+		ra_member1U1_group2Vo1.forEach(ra -> attrs_member1U1_group2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1U1_group2Vo1.size());
+		assertTrue(attrs_member1U1_group2Vo1.contains(group2VO1Res1VO1_test_attribute));
+		assertTrue(attrs_member1U1_group2Vo1.contains(group2VO1Res2VO1_test_attribute));
+
+		//find test group-resource attributes for member2OfUser1 group1InVo2
+		List<RichAttribute> ra_member2U1_group2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, group1InVo2, groupResource_test_atr_def);
+		List<Attribute> attrs_member2U1_group2Vo1 = new ArrayList<>();
+		ra_member2U1_group2Vo1.forEach(ra -> attrs_member2U1_group2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U1_group2Vo1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByMemberResource");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, Member.class, Resource.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for member1OfUser1 and resource1InVo1
+		List<RichAttribute> ra_member1U1_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, resource1InVo1, groupResource_test_atr_def);
+		List<Attribute> attrs_member1U1_res1Vo1 = new ArrayList<>();
+		ra_member1U1_res1Vo1.forEach(ra -> attrs_member1U1_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1U1_res1Vo1.size());
+		assertTrue(attrs_member1U1_res1Vo1.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_member1U1_res1Vo1.contains(group2VO1Res1VO1_test_attribute));
+
+		//find test group-resource attributes for member2OfUser1 and resource1InVo2
+		List<RichAttribute> ra_member2U1_res1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, resource1InVo2, groupResource_test_atr_def);
+		List<Attribute> attrs_member2U1_res1Vo2 = new ArrayList<>();
+		ra_member2U1_res1Vo2.forEach(ra -> attrs_member2U1_res1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U1_res1Vo2.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByUserFacility");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find test group-resource attributes for user1 and facility2
+		List<RichAttribute> ra_user1_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility2, groupResource_test_atr_def);
+		List<Attribute> attrs_user1_facility2 = new ArrayList<>();
+		ra_user1_facility2.forEach(ra -> attrs_user1_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user1_facility2.size());
+		assertTrue(attrs_user1_facility2.contains(group2VO1Res2VO1_test_attribute));
+
+		//find test group-resource attributes for user3 and facility1
+		List<RichAttribute> ra_user3_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility1, groupResource_test_atr_def);
+		List<Attribute> attrs_user3_facility1 = new ArrayList<>();
+		ra_user3_facility1.forEach(ra -> attrs_user3_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user3_facility1.size());
+		assertTrue(attrs_user3_facility1.contains(group1VO1Res1VO1_test_attribute));
+
+		//find test group-resource attributes for user3 and facility2
+		List<RichAttribute> ra_user3_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility2, groupResource_test_atr_def);
+		List<Attribute> attrs_user3_facility2 = new ArrayList<>();
+		ra_user3_facility2.forEach(ra -> attrs_user3_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user3_facility2.size());
+		assertTrue(attrs_user3_facility2.contains(group2VO2Res1VO2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getGroupResourceAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupResourceAttributesByKey");
+
+		setAttributesForGroupResourceAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getGroupResourceAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all test group-resource attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, groupResource_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue(attrs_all.contains(group1VO1Res1VO1_test_attribute));
+		assertTrue(attrs_all.contains(group2VO1Res1VO1_test_attribute));
+		assertTrue(attrs_all.contains(group2VO1Res2VO1_test_attribute));
+		assertTrue(attrs_all.contains(group1VO2Res1VO2_test_attribute));
+		assertTrue(attrs_all.contains(group2VO2Res1VO2_test_attribute));
+		assertTrue(attrs_all.contains(group2VO2Res2VO2_test_attribute));
+	}
+
+	//-------------------------MEMBER-GROUP------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByUser");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find all test member-group attributes user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, memberGroup_test_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+
+		//remove empty attributes which are not tested
+		List<Attribute> finalAttrs_user1 = attrs_user1;
+		ra_user1.forEach(ra -> finalAttrs_user1.add(ra.getAttribute()));
+		attrs_user1 = attrs_user1.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user1.size());
+		assertTrue(attrs_user1.contains(member1U1Group1Vo1_test_attribute));
+		assertTrue(attrs_user1.contains(member1U1Group2Vo1_test_attribute));
+
+		//find all test member-group attributes user3
+		List<RichAttribute> ra_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, memberGroup_test_atr_def);
+		List<Attribute> attrs_user3 = new ArrayList<>();
+
+		//remove empty attributes which are not tested
+		List<Attribute> finalAttrs_user3 = attrs_user3;
+		ra_user3.forEach(ra -> finalAttrs_user3.add(ra.getAttribute()));
+		attrs_user3 = attrs_user3.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user3.size());
+		assertTrue(attrs_user3.contains(member1U3Group1Vo1_test_attribute));
+		assertTrue(attrs_user3.contains(member2U3Group2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByMember");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for member1OfUser1
+		List<RichAttribute> ra_member1OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, memberGroup_test_atr_def);
+		List<Attribute> attrs_member1OfUser1 = new ArrayList<>();
+
+		//remove empty attributes which are not tested
+		List<Attribute> finalAttrs_member1U1 = attrs_member1OfUser1;
+		ra_member1OfUser1.forEach(ra -> finalAttrs_member1U1.add(ra.getAttribute()));
+		attrs_member1OfUser1 = attrs_member1OfUser1.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1OfUser1.size());
+		assertTrue(attrs_member1OfUser1.contains(member1U1Group1Vo1_test_attribute));
+		assertTrue(attrs_member1OfUser1.contains(member1U1Group2Vo1_test_attribute));
+
+		//find all test member-group attributes for member2OfUser1
+		List<RichAttribute> ra_member2OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, memberGroup_test_atr_def);
+		List<Attribute> attrs_member2OfUser1 = new ArrayList<>();
+
+		//remove empty attributes which are not tested
+		List<Attribute> finalAttrs_member2U1 = attrs_member2OfUser1;
+		ra_member2OfUser1.forEach(ra -> finalAttrs_member2U1.add(ra.getAttribute()));
+		attrs_member2OfUser1 = attrs_member2OfUser1.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2OfUser1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByGroup");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for group2InVo2
+		List<RichAttribute> ra_group2InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo2, memberGroup_test_atr_def);
+		List<Attribute> attrs_group2InVo2 = new ArrayList<>();
+		ra_group2InVo2.forEach(ra -> attrs_group2InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2InVo2.size());
+		assertTrue(attrs_group2InVo2.contains(member1U2Group2Vo2_test_attribute));
+		assertTrue(attrs_group2InVo2.contains(member2U3Group2Vo2_test_attribute));
+
+		//find all test member-group attributes for group2InVo1
+		List<RichAttribute> ra_group2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, memberGroup_test_atr_def);
+		List<Attribute> attrs_group2InVo1 = new ArrayList<>();
+		ra_group2InVo1.forEach(ra -> attrs_group2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group2InVo1.size());
+		assertTrue(attrs_group2InVo1.contains(member1U1Group2Vo1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByResource");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for resource1InVo2
+		List<RichAttribute> ra_resource1InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo2, memberGroup_test_atr_def);
+		List<Attribute> attrs_resource1InVo2 = new ArrayList<>();
+		ra_resource1InVo2.forEach(ra -> attrs_resource1InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_resource1InVo2.size());
+		assertTrue(attrs_resource1InVo2.contains(member1U2Group2Vo2_test_attribute));
+		assertTrue(attrs_resource1InVo2.contains(member1U2Group1Vo2_test_attribute));
+		assertTrue(attrs_resource1InVo2.contains(member2U3Group2Vo2_test_attribute));
+
+		//find all test member-group attributes for resource1InVo1
+		List<RichAttribute> ra_resource1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo1, memberGroup_test_atr_def);
+		List<Attribute> attrs_resource1InVo1 = new ArrayList<>();
+		ra_resource1InVo1.forEach(ra -> attrs_resource1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_resource1InVo1.size());
+		assertTrue(attrs_resource1InVo1.contains(member1U1Group1Vo1_test_attribute));
+		assertTrue(attrs_resource1InVo1.contains(member1U1Group2Vo1_test_attribute));
+		assertTrue(attrs_resource1InVo1.contains(member1U3Group1Vo1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByVo");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, memberGroup_test_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+
+		//remove empty attributes which are not used in test
+		List<Attribute> finalAttrs_vo1 = attrs_vo1;
+		ra_vo1.forEach(ra -> finalAttrs_vo1.add(ra.getAttribute()));
+		attrs_vo1 = attrs_vo1.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 3, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(member1U1Group1Vo1_test_attribute));
+		assertTrue(attrs_vo1.contains(member1U1Group2Vo1_test_attribute));
+		assertTrue(attrs_vo1.contains(member1U3Group1Vo1_test_attribute));
+
+		//find all test member-group attributes for vo2
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, memberGroup_test_atr_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+
+		//remove empty attributes which are not used in test
+		List<Attribute> finalAttrs_vo2 = attrs_vo2;
+		ra_vo2.forEach(ra -> finalAttrs_vo2.add(ra.getAttribute()));
+		attrs_vo2 = attrs_vo2.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 3, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(member1U2Group1Vo2_test_attribute));
+		assertTrue(attrs_vo2.contains(member1U2Group2Vo2_test_attribute));
+		assertTrue(attrs_vo2.contains(member2U3Group2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByFacility");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, memberGroup_test_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(member1U1Group2Vo1_test_attribute));
+		assertTrue(attrs_facility2.contains(member1U2Group1Vo2_test_attribute));
+		assertTrue(attrs_facility2.contains(member1U2Group2Vo2_test_attribute));
+		assertTrue(attrs_facility2.contains(member2U3Group2Vo2_test_attribute));
+
+		//find all test member-group attributes for facility3
+		List<RichAttribute> ra_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility3, memberGroup_test_atr_def);
+		List<Attribute> attrs_facility3 = new ArrayList<>();
+		ra_facility3.forEach(ra -> attrs_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility3.size());
+		assertTrue(attrs_facility3.contains(member1U2Group2Vo2_test_attribute));
+		assertTrue(attrs_facility3.contains(member2U3Group2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByHost");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for host1OnFacility2
+		List<RichAttribute> ra_host1OnFacility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, memberGroup_test_atr_def);
+		List<Attribute> attrs_host1OnFacility2 = new ArrayList<>();
+		ra_host1OnFacility2.forEach(ra -> attrs_host1OnFacility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_host1OnFacility2.size());
+		assertTrue(attrs_host1OnFacility2.contains(member1U1Group2Vo1_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(member1U2Group1Vo2_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(member1U2Group2Vo2_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(member2U3Group2Vo2_test_attribute));
+
+		//find all test member-group attributes for host2OnFacility3
+		List<RichAttribute> ra_host2OnFacility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host2OnFacility3, memberGroup_test_atr_def);
+		List<Attribute> attrs_host2OnFacility3 = new ArrayList<>();
+		ra_host2OnFacility3.forEach(ra -> attrs_host2OnFacility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_host2OnFacility3.size());
+		assertTrue(attrs_host2OnFacility3.contains(member1U2Group2Vo2_test_attribute));
+		assertTrue(attrs_host2OnFacility3.contains(member2U3Group2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByUserExtSource");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find all test member-group attributes userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, memberGroup_test_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+
+		//remove empty attributes which are not tested
+		List<Attribute> finalAttrs_userExtSource1 = attrs_userExtSource1;
+		ra_userExtSource1.forEach(ra -> finalAttrs_userExtSource1.add(ra.getAttribute()));
+		attrs_userExtSource1 = attrs_userExtSource1.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 2, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(member1U1Group1Vo1_test_attribute));
+		assertTrue(attrs_userExtSource1.contains(member1U1Group2Vo1_test_attribute));
+
+		//find all test member-group attributes userExtSource3
+		List<RichAttribute> ra_userExtSource3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource3, memberGroup_test_atr_def);
+		List<Attribute> attrs_userExtSource3 = new ArrayList<>();
+
+		//remove empty attributes which are not tested
+		List<Attribute> finalAttrs_userExtSource3 = attrs_userExtSource3;
+		ra_userExtSource3.forEach(ra -> finalAttrs_userExtSource3.add(ra.getAttribute()));
+		attrs_userExtSource3 = attrs_userExtSource3.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 2, attrs_userExtSource3.size());
+		assertTrue(attrs_userExtSource3.contains(member1U3Group1Vo1_test_attribute));
+		assertTrue(attrs_userExtSource3.contains(member2U3Group2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByMemberGroup");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, Member.class, Group.class, AttributeDefinition.class);
+
+		//find all test member-group attributesmember1OfUser1 and group1InVo1
+		List<RichAttribute> ra_member1U1_group1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, group1InVo1, memberGroup_test_atr_def);
+		List<Attribute> attrs_member1U1_group1Vo1 = new ArrayList<>();
+		ra_member1U1_group1Vo1.forEach(ra -> attrs_member1U1_group1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U1_group1Vo1.size());
+		assertTrue(attrs_member1U1_group1Vo1.contains(member1U1Group1Vo1_test_attribute));
+
+		//find all test member-group attributes member2OfUser1 and group1InVo2
+		List<RichAttribute> ra_member2U1_group1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, group1InVo2, memberGroup_test_atr_def);
+		List<Attribute> attrs_member2U1_group1Vo2 = new ArrayList<>();
+		ra_member2U1_group1Vo2.forEach(ra -> attrs_member2U1_group1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U1_group1Vo2.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByMemberResource");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, Member.class, Resource.class, AttributeDefinition.class);
+
+		//find all test member-group attributes member1OfUser1 and resource2InVo1
+		List<RichAttribute> ra_member1U1_res2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, resource2InVo1, memberGroup_test_atr_def);
+		List<Attribute> attrs_member1U1_res2Vo1 = new ArrayList<>();
+		ra_member1U1_res2Vo1.forEach(ra -> attrs_member1U1_res2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U1_res2Vo1.size());
+		assertTrue(attrs_member1U1_res2Vo1.contains(member1U1Group2Vo1_test_attribute));
+
+		//find all test member-group attributes member1OfUser1 and resource1InVo1
+		List<RichAttribute> ra_member1U1_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, resource1InVo1, memberGroup_test_atr_def);
+		List<Attribute> attrs_member1U1_res1Vo1 = new ArrayList<>();
+		ra_member1U1_res1Vo1.forEach(ra -> attrs_member1U1_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1U1_res1Vo1.size());
+		assertTrue(attrs_member1U1_res1Vo1.contains(member1U1Group1Vo1_test_attribute));
+		assertTrue(attrs_member1U1_res1Vo1.contains(member1U1Group2Vo1_test_attribute));
+
+		//find all test member-group attributes member2OfUser2 and resource2InVo1
+		List<RichAttribute> ra_member2U2_res2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser2, resource2InVo1, memberGroup_test_atr_def);
+		List<Attribute> attrs_member2U2_res2Vo1 = new ArrayList<>();
+		ra_member2U2_res2Vo1.forEach(ra -> attrs_member2U2_res2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U2_res2Vo1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByUserFacility");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for user3 and facility2
+		List<RichAttribute> ra_user3_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility2, memberGroup_test_atr_def);
+		List<Attribute> attrs_user3_facility2 = new ArrayList<>();
+
+		//remove attributes which are not used in test
+		List<Attribute> finalAttrs_user3_facility2 = attrs_user3_facility2;
+		ra_user3_facility2.forEach(ra -> finalAttrs_user3_facility2.add(ra.getAttribute()));
+		attrs_user3_facility2 = attrs_user3_facility2.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		System.out.println(attrs_user3_facility2);
+		assertEquals("Invalid number of attributes found", 1, attrs_user3_facility2.size());
+		assertTrue(attrs_user3_facility2.contains(member2U3Group2Vo2_test_attribute));
+
+		//find all test member-group attributes for user1 and facility2
+		List<RichAttribute> ra_user1_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility2, memberGroup_test_atr_def);
+		List<Attribute> attrs_user1_facility2 = new ArrayList<>();
+
+		//remove attributes which are not used in test
+		List<Attribute> finalAttrs_user1_facility2 = attrs_user1_facility2;
+		ra_user1_facility2.forEach(ra -> finalAttrs_user1_facility2.add(ra.getAttribute()));
+		attrs_user1_facility2 = attrs_user1_facility2.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user1_facility2.size());
+		assertTrue(attrs_user1_facility2.contains(member1U1Group2Vo1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberGroupAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberGroupAttributesByKey");
+
+		setAttributesForMemberGroupAttributesTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberGroupAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all test member-group attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, memberGroup_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+
+		//remove attributes which are not used in test
+		List<Attribute> finalAttrs_all = attrs_all;
+		ra_all.forEach(ra -> finalAttrs_all.add(ra.getAttribute()));
+		attrs_all = attrs_all.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
+
+		System.out.println(attrs_all);
+		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue(attrs_all.contains(member1U1Group1Vo1_test_attribute));
+		assertTrue(attrs_all.contains(member1U1Group2Vo1_test_attribute));
+		assertTrue(attrs_all.contains(member1U2Group1Vo2_test_attribute));
+		assertTrue(attrs_all.contains(member1U2Group2Vo2_test_attribute));
+		assertTrue(attrs_all.contains(member1U3Group1Vo1_test_attribute));
+		assertTrue(attrs_all.contains(member2U3Group2Vo2_test_attribute));
+	}
+
+	//----------------------------MEMBER-RESOURCE-----------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByUser");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find all test member-group attributes user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, memberResource_test_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user1.size());
+		assertTrue(attrs_user1.contains(member1U1Res1Vo1_test_attribute));
+		assertTrue(attrs_user1.contains(member1U1Res2Vo1_test_attribute));
+
+		//find all test member-group attributes user3
+		List<RichAttribute> ra_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, memberResource_test_atr_def);
+		List<Attribute> attrs_user3 = new ArrayList<>();
+		ra_user3.forEach(ra -> attrs_user3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_user3.size());
+		assertTrue(attrs_user3.contains(member1U3Res1Vo1_test_attribute));
+		assertTrue(attrs_user3.contains(member2U3Res1Vo2_test_attribute));
+		assertTrue(attrs_user3.contains(member2U3Res2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByMember");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for member2OfUser3
+		List<RichAttribute> ra_member2OfUser3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser3, memberResource_test_atr_def);
+		List<Attribute> attrs_member2OfUser3 = new ArrayList<>();
+		ra_member2OfUser3.forEach(ra -> attrs_member2OfUser3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member2OfUser3.size());
+		assertTrue(attrs_member2OfUser3.contains(member2U3Res1Vo2_test_attribute));
+		assertTrue(attrs_member2OfUser3.contains(member2U3Res2Vo2_test_attribute));
+
+		//find all test member-group attributes for member2OfUser3
+		List<RichAttribute> ra_member2OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, memberResource_test_atr_def);
+		List<Attribute> attrs_member2OfUser1 = new ArrayList<>();
+		ra_member2OfUser1.forEach(ra -> attrs_member2OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2OfUser1.size());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByGroup");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for group2InVo2
+		List<RichAttribute> ra_group2InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo2, memberResource_test_atr_def);
+		List<Attribute> attrs_group2InVo2 = new ArrayList<>();
+		ra_group2InVo2.forEach(ra -> attrs_group2InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_group2InVo2.size());
+		assertTrue(attrs_group2InVo2.contains(member1U2Res1Vo2_test_attribute));
+		assertTrue(attrs_group2InVo2.contains(member1U2Res2Vo2_test_attribute));
+		assertTrue(attrs_group2InVo2.contains(member2U3Res1Vo2_test_attribute));
+		assertTrue(attrs_group2InVo2.contains(member2U3Res2Vo2_test_attribute));
+
+		//find all test member-group attributes for group2InVo1
+		List<RichAttribute> ra_group2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, memberResource_test_atr_def);
+		List<Attribute> attrs_group2InVo1 = new ArrayList<>();
+		ra_group2InVo1.forEach(ra -> attrs_group2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2InVo1.size());
+		assertTrue(attrs_group2InVo1.contains(member1U1Res1Vo1_test_attribute));
+		assertTrue(attrs_group2InVo1.contains(member1U1Res2Vo1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByResource");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for resource2InVo1
+		List<RichAttribute> ra_resource2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource2InVo1, memberResource_test_atr_def);
+		List<Attribute> attrs_resource2InVo1 = new ArrayList<>();
+		ra_resource2InVo1.forEach(ra -> attrs_resource2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_resource2InVo1.size());
+		assertTrue(attrs_resource2InVo1.contains(member1U1Res2Vo1_test_attribute));
+
+		//find all test member-group attributes for resource1InVo2
+		List<RichAttribute> ra_resource1InVo21 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo2, memberResource_test_atr_def);
+		List<Attribute> attrs_resource1InVo2 = new ArrayList<>();
+		ra_resource1InVo21.forEach(ra -> attrs_resource1InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_resource1InVo2.size());
+		assertTrue(attrs_resource1InVo2.contains(member1U2Res1Vo2_test_attribute));
+		assertTrue(attrs_resource1InVo2.contains(member2U3Res1Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByVo");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, memberResource_test_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(member1U1Res2Vo1_test_attribute));
+		assertTrue(attrs_vo1.contains(member1U1Res1Vo1_test_attribute));
+		assertTrue(attrs_vo1.contains(member1U3Res1Vo1_test_attribute));
+
+		//find all test member-group attributes for vo2
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, memberResource_test_atr_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+		ra_vo2.forEach(ra -> attrs_vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(member1U2Res1Vo2_test_attribute));
+		assertTrue(attrs_vo2.contains(member1U2Res2Vo2_test_attribute));
+		assertTrue(attrs_vo2.contains(member2U3Res1Vo2_test_attribute));
+		assertTrue(attrs_vo2.contains(member2U3Res2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByFacility");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for facility1
+		List<RichAttribute> ra_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, memberResource_test_atr_def);
+		List<Attribute> attrs_facility1 = new ArrayList<>();
+		ra_facility1.forEach(ra -> attrs_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility1.size());
+		assertTrue(attrs_facility1.contains(member1U1Res1Vo1_test_attribute));
+		assertTrue(attrs_facility1.contains(member1U3Res1Vo1_test_attribute));
+
+		//find all test member-group attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, memberResource_test_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(member1U1Res2Vo1_test_attribute));
+		assertTrue(attrs_facility2.contains(member1U2Res1Vo2_test_attribute));
+		assertTrue(attrs_facility2.contains(member2U3Res1Vo2_test_attribute));
+
+		//find all test member-group attributes for facility3
+		List<RichAttribute> ra_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility3, memberResource_test_atr_def);
+		List<Attribute> attrs_facility3 = new ArrayList<>();
+		ra_facility3.forEach(ra -> attrs_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility3.size());
+		assertTrue(attrs_facility3.contains(member1U2Res2Vo2_test_attribute));
+		assertTrue(attrs_facility3.contains(member2U3Res2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByHost");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find all test member-group attributes for host1OnFacility1
+		List<RichAttribute> ra_host1OnFacility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, memberResource_test_atr_def);
+		List<Attribute> attrs_host1OnFacility1 = new ArrayList<>();
+		ra_host1OnFacility1.forEach(ra -> attrs_host1OnFacility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_host1OnFacility1.size());
+		assertTrue(attrs_host1OnFacility1.contains(member1U1Res1Vo1_test_attribute));
+		assertTrue(attrs_host1OnFacility1.contains(member1U3Res1Vo1_test_attribute));
+
+		//find all test member-group attributes for host1OnFacility2
+		List<RichAttribute> ra_host1OnFacility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, memberResource_test_atr_def);
+		List<Attribute> attrs_host1OnFacility2 = new ArrayList<>();
+		ra_host1OnFacility2.forEach(ra -> attrs_host1OnFacility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_host1OnFacility2.size());
+		assertTrue(attrs_host1OnFacility2.contains(member1U1Res2Vo1_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(member1U2Res1Vo2_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(member2U3Res1Vo2_test_attribute));
+
+		//find all test member-group attributes for host2OnFacility3
+		List<RichAttribute> ra_host2OnFacility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host2OnFacility3, memberResource_test_atr_def);
+		List<Attribute> attrs_host2OnFacility3 = new ArrayList<>();
+		ra_host2OnFacility3.forEach(ra -> attrs_host2OnFacility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_host2OnFacility3.size());
+		assertTrue(attrs_host2OnFacility3.contains(member1U2Res2Vo2_test_attribute));
+		assertTrue(attrs_host2OnFacility3.contains(member2U3Res2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByUserExtSource");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find all test member-group attributes userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, memberResource_test_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+		ra_userExtSource1.forEach(ra -> attrs_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(member1U1Res1Vo1_test_attribute));
+		assertTrue(attrs_userExtSource1.contains(member1U1Res2Vo1_test_attribute));
+
+		//find all test member-group attributes userExtSource3
+		List<RichAttribute> ra_userExtSource3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource3, memberResource_test_atr_def);
+		List<Attribute> attrs_userExtSource3 = new ArrayList<>();
+		ra_userExtSource3.forEach(ra -> attrs_userExtSource3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_userExtSource3.size());
+		assertTrue(attrs_userExtSource3.contains(member1U3Res1Vo1_test_attribute));
+		assertTrue(attrs_userExtSource3.contains(member2U3Res1Vo2_test_attribute));
+		assertTrue(attrs_userExtSource3.contains(member2U3Res2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByGroupResource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByUserExtSource");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Group.class, Resource.class, AttributeDefinition.class);
+
+		//find all test member-group attributes group2InVo1 and resource1InVo1
+		List<RichAttribute> ra_group2Vo1_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, resource1InVo1, memberResource_test_atr_def);
+		List<Attribute> attrs_group2Vo1_res1Vo1 = new ArrayList<>();
+		ra_group2Vo1_res1Vo1.forEach(ra -> attrs_group2Vo1_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group2Vo1_res1Vo1.size());
+		assertTrue(attrs_group2Vo1_res1Vo1.contains(member1U1Res1Vo1_test_attribute));
+
+		//find all test member-group attributes group2InVo2 and resource1InVo2
+		List<RichAttribute> ra_group2Vo2_res1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo2, resource1InVo2, memberResource_test_atr_def);
+		List<Attribute> attrs_group2Vo2_res1Vo2 = new ArrayList<>();
+		ra_group2Vo2_res1Vo2.forEach(ra -> attrs_group2Vo2_res1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2Vo2_res1Vo2.size());
+		assertTrue(attrs_group2Vo2_res1Vo2.contains(member1U2Res1Vo2_test_attribute));
+		assertTrue(attrs_group2Vo2_res1Vo2.contains(member2U3Res1Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByMemberGroup");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Member.class, Group.class, AttributeDefinition.class);
+
+		//find all test member-group attributes member1OfUser1 and group1InVo1
+		List<RichAttribute> ra_member1U1_group1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, group1InVo1, memberResource_test_atr_def);
+		List<Attribute> attrs_member1U1_group1Vo1 = new ArrayList<>();
+		ra_member1U1_group1Vo1.forEach(ra -> attrs_member1U1_group1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U1_group1Vo1.size());
+		assertTrue(attrs_member1U1_group1Vo1.contains(member1U1Res1Vo1_test_attribute));
+
+		//find all test member-group for attributes member1OfUser2 and group2InVo2
+		List<RichAttribute> ra_member1U2_group2Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser2, group2InVo2, memberResource_test_atr_def);
+		List<Attribute> attrs_member1U2_group2Vo2 = new ArrayList<>();
+		ra_member1U2_group2Vo2.forEach(ra -> attrs_member1U2_group2Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1U2_group2Vo2.size());
+		assertTrue(attrs_member1U2_group2Vo2.contains(member1U2Res1Vo2_test_attribute));
+		assertTrue(attrs_member1U2_group2Vo2.contains(member1U2Res2Vo2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByMemberResource");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, Member.class, Resource.class, AttributeDefinition.class);
+
+		//find all test member-group attributes member1OfUser1 and resource1InVo1
+		List<RichAttribute> ra_member1U1_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, resource1InVo1, memberResource_test_atr_def);
+		List<Attribute> attrs_member1U1_res1Vo1 = new ArrayList<>();
+		ra_member1U1_res1Vo1.forEach(ra -> attrs_member1U1_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U1_res1Vo1.size());
+		assertTrue(attrs_member1U1_res1Vo1.contains(member1U1Res1Vo1_test_attribute));
+
+		//find all test member-group attributes member1OfUser3 and resource1InVo1
+		List<RichAttribute> ra_member1U3_res1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser3, resource1InVo1, memberResource_test_atr_def);
+		List<Attribute> attrs_member1U3_res1Vo1 = new ArrayList<>();
+		ra_member1U3_res1Vo1.forEach(ra -> attrs_member1U3_res1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U3_res1Vo1.size());
+		assertTrue(attrs_member1U3_res1Vo1.contains(member1U3Res1Vo1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByUserFacility");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find all test member-group attributes user3 and facility2
+		List<RichAttribute> ra_user3_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility2, memberResource_test_atr_def);
+		List<Attribute> attrs_user3_facility2 = new ArrayList<>();
+		ra_user3_facility2.forEach(ra -> attrs_user3_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user3_facility2.size());
+		assertTrue(attrs_user3_facility2.contains(member2U3Res1Vo2_test_attribute));
+
+		//find all test member-group attributes user1 and facility3
+		List<RichAttribute> ra_user1_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility3, memberResource_test_atr_def);
+		List<Attribute> attrs_user1_facility3 = new ArrayList<>();
+		ra_user1_facility3.forEach(ra -> attrs_user1_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_user1_facility3.size());
+
+		//find all test member-group attributes user1 and facility1
+		List<RichAttribute> ra_user1_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility1, memberResource_test_atr_def);
+		List<Attribute> attrs_user1_facility1 = new ArrayList<>();
+		ra_user1_facility1.forEach(ra -> attrs_user1_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user1_facility1.size());
+		assertTrue(attrs_user1_facility1.contains(member1U1Res1Vo1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getMemberResourceAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getMemberResourceAttributesByKey");
+
+		setAttributesForMemberResourceTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getMemberResourceAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all test member-group attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, memberResource_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 7, attrs_all.size());
+		assertTrue(attrs_all.contains(member1U1Res1Vo1_test_attribute));
+		assertTrue(attrs_all.contains(member1U1Res2Vo1_test_attribute));
+		assertTrue(attrs_all.contains(member1U2Res1Vo2_test_attribute));
+		assertTrue(attrs_all.contains(member1U2Res2Vo2_test_attribute));
+		assertTrue(attrs_all.contains(member1U3Res1Vo1_test_attribute));
+		assertTrue(attrs_all.contains(member2U3Res1Vo2_test_attribute));
+		assertTrue(attrs_all.contains(member2U3Res2Vo2_test_attribute));
+	}
+
+	//--------------------------USER-FACILITY-------------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByUser() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByUser");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, User.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for user1
+		List<RichAttribute> ra_user1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, userFacility_test_atr_def);
+		List<Attribute> attrs_user1 = new ArrayList<>();
+		ra_user1.forEach(ra -> attrs_user1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_user1.size());
+		assertTrue(attrs_user1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_user1.contains(user1Facility2_test_attribute));
+
+		//find all test user-facility attributes for user3
+		List<RichAttribute> ra_user3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, userFacility_test_atr_def);
+		List<Attribute> attrs_user3 = new ArrayList<>();
+		ra_user3.forEach(ra -> attrs_user3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_user3.size());
+		assertTrue(attrs_user3.contains(user3Facility3_test_attribute));
+		assertTrue(attrs_user3.contains(user3Facility2_test_attribute));
+		assertTrue(attrs_user3.contains(user3Facility1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByMember() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByMember");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Member.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for member2OfUser3
+		List<RichAttribute> ra_member2OfUser3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser3, userFacility_test_atr_def);
+		List<Attribute> attrs_member2OfUser3 = new ArrayList<>();
+		ra_member2OfUser3.forEach(ra -> attrs_member2OfUser3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member2OfUser3.size());
+		assertTrue(attrs_member2OfUser3.contains(user3Facility2_test_attribute));
+		assertTrue(attrs_member2OfUser3.contains(user3Facility3_test_attribute));
+
+		//find all test user-facility attributes for member2OfUser1
+		List<RichAttribute> ra_member2OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, userFacility_test_atr_def);
+		List<Attribute> attrs_member2OfUser1 = new ArrayList<>();
+		ra_member2OfUser1.forEach(ra -> attrs_member2OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2OfUser1.size());
+
+		//find all test user-facility attributes for member1OfUser1
+		List<RichAttribute> ra_member1OfUser1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, userFacility_test_atr_def);
+		List<Attribute> attrs_member1OfUser1 = new ArrayList<>();
+		ra_member1OfUser1.forEach(ra -> attrs_member1OfUser1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1OfUser1.size());
+		assertTrue(attrs_member1OfUser1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_member1OfUser1.contains(user1Facility2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByGroup");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Group.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for group2InVo2
+		List<RichAttribute> ra_group2InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo2, userFacility_test_atr_def);
+		List<Attribute> attrs_group2InVo2 = new ArrayList<>();
+		ra_group2InVo2.forEach(ra -> attrs_group2InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_group2InVo2.size());
+		assertTrue(attrs_group2InVo2.contains(user2Facility2_test_attribute));
+		assertTrue(attrs_group2InVo2.contains(user2Facility3_test_attribute));
+		assertTrue(attrs_group2InVo2.contains(user3Facility2_test_attribute));
+		assertTrue(attrs_group2InVo2.contains(user3Facility3_test_attribute));
+
+		//find all test user-facility attributes for group1InVo1
+		List<RichAttribute> ra_group1InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo1, userFacility_test_atr_def);
+		List<Attribute> attrs_group1InVo1 = new ArrayList<>();
+		ra_group1InVo1.forEach(ra -> attrs_group1InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group1InVo1.size());
+		assertTrue(attrs_group1InVo1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_group1InVo1.contains(user3Facility1_test_attribute));
+
+		//find all test user-facility attributes for group2InVo1
+		List<RichAttribute> ra_group2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, userFacility_test_atr_def);
+		List<Attribute> attrs_group2InVo1 = new ArrayList<>();
+		ra_group2InVo1.forEach(ra -> attrs_group2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2InVo1.size());
+		assertTrue(attrs_group2InVo1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_group2InVo1.contains(user1Facility2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByResource() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByResource");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Resource.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for resource2InVo1
+		List<RichAttribute> ra_resource2InVo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource2InVo1, userFacility_test_atr_def);
+		List<Attribute> attrs_resource2InVo1 = new ArrayList<>();
+		ra_resource2InVo1.forEach(ra -> attrs_resource2InVo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_resource2InVo1.size());
+		assertTrue(attrs_resource2InVo1.contains(user1Facility2_test_attribute));
+
+		//find all test user-facility attributes for resource1InVo2
+		List<RichAttribute> ra_resource1InVo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, resource1InVo2, userFacility_test_atr_def);
+		List<Attribute> attrs_resource1InVo2 = new ArrayList<>();
+		ra_resource1InVo2.forEach(ra -> attrs_resource1InVo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_resource1InVo2.size());
+		assertTrue(attrs_resource1InVo2.contains(user2Facility2_test_attribute));
+		assertTrue(attrs_resource1InVo2.contains(user3Facility2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByVo() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByVo");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Vo.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for vo1
+		List<RichAttribute> ra_vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo1, userFacility_test_atr_def);
+		List<Attribute> attrs_vo1 = new ArrayList<>();
+		ra_vo1.forEach(ra -> attrs_vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_vo1.size());
+		assertTrue(attrs_vo1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_vo1.contains(user1Facility2_test_attribute));
+		assertTrue(attrs_vo1.contains(user3Facility1_test_attribute));
+
+		//find all test user-facility attributes for vo2
+		List<RichAttribute> ra_vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, vo2, userFacility_test_atr_def);
+		List<Attribute> attrs_vo2 = new ArrayList<>();
+		ra_vo2.forEach(ra -> attrs_vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 4, attrs_vo2.size());
+		assertTrue(attrs_vo2.contains(user2Facility2_test_attribute));
+		assertTrue(attrs_vo2.contains(user2Facility3_test_attribute));
+		assertTrue(attrs_vo2.contains(user3Facility2_test_attribute));
+		assertTrue(attrs_vo2.contains(user3Facility3_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByFacility");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Facility.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for facility1
+		List<RichAttribute> ra_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility1, userFacility_test_atr_def);
+		List<Attribute> attrs_facility1 = new ArrayList<>();
+		ra_facility1.forEach(ra -> attrs_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility1.size());
+		assertTrue(attrs_facility1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_facility1.contains(user3Facility1_test_attribute));
+
+		//find all test user-facility attributes for facility2
+		List<RichAttribute> ra_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility2, userFacility_test_atr_def);
+		List<Attribute> attrs_facility2 = new ArrayList<>();
+		ra_facility2.forEach(ra -> attrs_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_facility2.size());
+		assertTrue(attrs_facility2.contains(user1Facility2_test_attribute));
+		assertTrue(attrs_facility2.contains(user2Facility2_test_attribute));
+		assertTrue(attrs_facility2.contains(user3Facility2_test_attribute));
+
+		//find all test user-facility attributes for facility3
+		List<RichAttribute> ra_facility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, facility3, userFacility_test_atr_def);
+		List<Attribute> attrs_facility3 = new ArrayList<>();
+		ra_facility3.forEach(ra -> attrs_facility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_facility3.size());
+		assertTrue(attrs_facility3.contains(user2Facility3_test_attribute));
+		assertTrue(attrs_facility3.contains(user3Facility3_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByHost() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByHost");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Host.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for host1OnFacility1
+		List<RichAttribute> ra_host1OnFacility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility1, userFacility_test_atr_def);
+		List<Attribute> attrs_host1OnFacility1 = new ArrayList<>();
+		ra_host1OnFacility1.forEach(ra -> attrs_host1OnFacility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_host1OnFacility1.size());
+		assertTrue(attrs_host1OnFacility1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_host1OnFacility1.contains(user3Facility1_test_attribute));
+
+		//find all test user-facility attributes for host1OnFacility2
+		List<RichAttribute> ra_host1OnFacility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host1OnFacility2, userFacility_test_atr_def);
+		List<Attribute> attrs_host1OnFacility2 = new ArrayList<>();
+		ra_host1OnFacility2.forEach(ra -> attrs_host1OnFacility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_host1OnFacility2.size());
+		assertTrue(attrs_host1OnFacility2.contains(user1Facility2_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(user2Facility2_test_attribute));
+		assertTrue(attrs_host1OnFacility2.contains(user3Facility2_test_attribute));
+
+		//find all test user-facility attributes for host2OnFacility3
+		List<RichAttribute> ra_host2OnFacility3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, host2OnFacility3, userFacility_test_atr_def);
+		List<Attribute> attrs_host2OnFacility3 = new ArrayList<>();
+		ra_host2OnFacility3.forEach(ra -> attrs_host2OnFacility3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_host2OnFacility3.size());
+		assertTrue(attrs_host2OnFacility3.contains(user2Facility3_test_attribute));
+		assertTrue(attrs_host2OnFacility3.contains(user3Facility3_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByUserExtSource");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, UserExtSource.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for userExtSource1
+		List<RichAttribute> ra_userExtSource1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource1, userFacility_test_atr_def);
+		List<Attribute> attrs_userExtSource1 = new ArrayList<>();
+		ra_userExtSource1.forEach(ra -> attrs_userExtSource1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_userExtSource1.size());
+		assertTrue(attrs_userExtSource1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_userExtSource1.contains(user1Facility2_test_attribute));
+
+		//find all test user-facility attributes for userExtSource3
+		List<RichAttribute> ra_userExtSource3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, userExtSource3, userFacility_test_atr_def);
+		List<Attribute> attrs_userExtSource3 = new ArrayList<>();
+		ra_userExtSource3.forEach(ra -> attrs_userExtSource3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_userExtSource3.size());
+		assertTrue(attrs_userExtSource3.contains(user3Facility3_test_attribute));
+		assertTrue(attrs_userExtSource3.contains(user3Facility2_test_attribute));
+		assertTrue(attrs_userExtSource3.contains(user3Facility1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByGroupResource() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByGroupResource");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Group.class, Resource.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for group2InVo1 and resource2InVo1
+		List<RichAttribute> ra_group2Vo1_resource2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo1, resource2InVo1, userFacility_test_atr_def);
+		List<Attribute> attrs_group2Vo1_resource2Vo1 = new ArrayList<>();
+		ra_group2Vo1_resource2Vo1.forEach(ra -> attrs_group2Vo1_resource2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_group2Vo1_resource2Vo1.size());
+		assertTrue(attrs_group2Vo1_resource2Vo1.contains(user1Facility2_test_attribute));
+
+		//find all test user-facility attributes for group1InVo1 and resource1InVo1
+		List<RichAttribute> ra_group1Vo1_resource1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group1InVo1, resource1InVo1, userFacility_test_atr_def);
+		List<Attribute> attrs_group1Vo1_resource1Vo1 = new ArrayList<>();
+		ra_group1Vo1_resource1Vo1.forEach(ra -> attrs_group1Vo1_resource1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group1Vo1_resource1Vo1.size());
+		assertTrue(attrs_group1Vo1_resource1Vo1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_group1Vo1_resource1Vo1.contains(user3Facility1_test_attribute));
+
+		//find all test user-facility attributes for group2InVo2 and resource1InVo2
+		List<RichAttribute> ra_group2Vo2_resource1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, group2InVo2, resource1InVo2, userFacility_test_atr_def);
+		List<Attribute> attrs_group2Vo2_resource1Vo2 = new ArrayList<>();
+		ra_group2Vo2_resource1Vo2.forEach(ra -> attrs_group2Vo2_resource1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_group2Vo2_resource1Vo2.size());
+		assertTrue(attrs_group2Vo2_resource1Vo2.contains(user2Facility2_test_attribute));
+		assertTrue(attrs_group2Vo2_resource1Vo2.contains(user3Facility2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByMemberGroup() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByMemberGroup");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Member.class, Group.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for member1OfUser1 and group2InVo1
+		List<RichAttribute> ra_member1U1_group2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser1, group2InVo1, userFacility_test_atr_def);
+		List<Attribute> attrs_member1U1_group2Vo1 = new ArrayList<>();
+		ra_member1U1_group2Vo1.forEach(ra -> attrs_member1U1_group2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 2, attrs_member1U1_group2Vo1.size());
+		assertTrue(attrs_member1U1_group2Vo1.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_member1U1_group2Vo1.contains(user1Facility2_test_attribute));
+
+		//find all test user-facility attributes for member2OfUser1 and group1InVo2
+		List<RichAttribute> ra_member2U1_group1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser1, group1InVo2, userFacility_test_atr_def);
+		List<Attribute> attrs_member2U1_group1Vo2 = new ArrayList<>();
+		ra_member2U1_group1Vo2.forEach(ra -> attrs_member2U1_group1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member2U1_group1Vo2.size());
+
+		//find all test user-facility attributes for member1OfUser3 and group1InVo1
+		List<RichAttribute> ra_member1U3_group1Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser3, group1InVo1, userFacility_test_atr_def);
+		List<Attribute> attrs_member1U3_group1Vo1 = new ArrayList<>();
+		ra_member1U3_group1Vo1.forEach(ra -> attrs_member1U3_group1Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U3_group1Vo1.size());
+		assertTrue(attrs_member1U3_group1Vo1.contains(user3Facility1_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByMemberResource() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByMemberResource");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, Member.class, Resource.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for member1OfUser3 and resource2InVo1
+		List<RichAttribute> ra_member1U1_res2Vo1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser3, resource2InVo1, userFacility_test_atr_def);
+		List<Attribute> attrs_member1U1_res2Vo1 = new ArrayList<>();
+		ra_member1U1_res2Vo1.forEach(ra -> attrs_member1U1_res2Vo1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 0, attrs_member1U1_res2Vo1.size());
+
+		//find all test user-facility attributes for member2OfUser3 and resource1InVo2
+		List<RichAttribute> ra_member2U3_res1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member2OfUser3, resource1InVo2, userFacility_test_atr_def);
+		List<Attribute> attrs_member2U3_res1Vo2 = new ArrayList<>();
+		ra_member2U3_res1Vo2.forEach(ra -> attrs_member2U3_res1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member2U3_res1Vo2.size());
+		assertTrue(attrs_member2U3_res1Vo2.contains(user3Facility2_test_attribute));
+
+		//find all test user-facility attributes for member1OfUser2 and resource1InVo2
+		List<RichAttribute> ra_member1U2_res1Vo2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, member1OfUser2, resource1InVo2, userFacility_test_atr_def);
+		List<Attribute> attrs_member1U2_res1Vo2 = new ArrayList<>();
+		ra_member1U2_res1Vo2.forEach(ra -> attrs_member1U2_res1Vo2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_member1U2_res1Vo2.size());
+		assertTrue(attrs_member1U2_res1Vo2.contains(user2Facility2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByUserFacility() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByUserFacility");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, User.class, Facility.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes for user1 and facility1
+		List<RichAttribute> ra_user1_facility1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user1, facility1, userFacility_test_atr_def);
+		List<Attribute> attrs_user1_facility1 = new ArrayList<>();
+		ra_user1_facility1.forEach(ra -> attrs_user1_facility1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user1_facility1.size());
+		assertTrue(attrs_user1_facility1.contains(user1Facility1_test_attribute));
+
+		//find all test user-facility attributes for user3 and facilty2
+		List<RichAttribute> ra_user3_facility2 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, user3, facility2, userFacility_test_atr_def);
+		List<Attribute> attrs_user3_facility2 = new ArrayList<>();
+		ra_user3_facility2.forEach(ra -> attrs_user3_facility2.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_user3_facility2.size());
+		assertTrue(attrs_user3_facility2.contains(user3Facility2_test_attribute));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getUserFacilityAttributesByKey() throws Exception {
+		System.out.println(CLASS_NAME + "getUserFacilityAttributesByKey");
+
+		setAttributesForUserFacilityTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getUserFacilityAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		//find all test user-facility attributes
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, null, userFacility_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 7, attrs_all.size());
+		assertTrue(attrs_all.contains(user1Facility1_test_attribute));
+		assertTrue(attrs_all.contains(user1Facility2_test_attribute));
+		assertTrue(attrs_all.contains(user2Facility2_test_attribute));
+		assertTrue(attrs_all.contains(user2Facility3_test_attribute));
+		assertTrue(attrs_all.contains(user3Facility3_test_attribute));
+		assertTrue(attrs_all.contains(user3Facility2_test_attribute));
+		assertTrue(attrs_all.contains(user3Facility1_test_attribute));
+	}
+
+	//-------------------------ENTITYLESS----------------------------//
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getEntitylessAttributesAll() throws Exception {
+		setAttributesForEntitylessTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getEntitylessAttributes",
+				PerunSession.class, AttributeDefinition.class);
+
+		List<RichAttribute> ra_all = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, entityless_test_atr_def);
+		List<Attribute> attrs_all = new ArrayList<>();
+		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 3, attrs_all.size());
+		assertTrue(attrs_all.contains(entityless_test_attribute1));
+		assertTrue(attrs_all.contains(entityless_test_attribute2));
+		assertTrue(attrs_all.contains(entityless_test_attribute3));
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void getEntitylessAttributesByKey() throws Exception {
+		setAttributesForEntitylessTest();
+
+		Method testedMethod = getPrivateMethodFromAtrManager("getEntitylessAttributes",
+				PerunSession.class, String.class, AttributeDefinition.class);
+
+		List<RichAttribute> ra_key1 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, "1", entityless_test_atr_def);
+		List<Attribute> attrs_key1 = new ArrayList<>();
+		ra_key1.forEach(ra -> attrs_key1.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_key1.size());
+		assertTrue(attrs_key1.contains(entityless_test_attribute1));
+
+		List<RichAttribute> ra_key3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
+				sess, "3", entityless_test_atr_def);
+		List<Attribute> attrs_key3 = new ArrayList<>();
+		ra_key3.forEach(ra -> attrs_key3.add(ra.getAttribute()));
+
+		assertEquals("Invalid number of attributes found", 1, attrs_key3.size());
+		assertTrue(attrs_key3.contains(entityless_test_attribute3));
+	}
 
 
 // PRIVATE METHODS ----------------------------------------------
+
+	/**
+	 * entityless_test_attribute1 -> key:1
+	 * entityless_test_attribute2 -> key:2
+	 * entityless_test_attribute3 -> key:3
+	 */
+	private void setAttributesForEntitylessTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		entityless_test_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(
+				sess, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minUID");
+
+		entityless_test_attribute1 = new Attribute(entityless_test_atr_def);
+		entityless_test_attribute1.setValue(154);
+		perun.getAttributesManagerBl().setAttribute(sess, "1", entityless_test_attribute1);
+
+		entityless_test_attribute2 = new Attribute(entityless_test_atr_def);
+		entityless_test_attribute2.setValue(202);
+		perun.getAttributesManagerBl().setAttribute(sess, "2", entityless_test_attribute2);
+
+		entityless_test_attribute3 = new Attribute(entityless_test_atr_def);
+		entityless_test_attribute3.setValue(362);
+		perun.getAttributesManagerBl().setAttribute(sess, "3", entityless_test_attribute3);
+	}
+
+	/**
+	 * user1Facility1_test_attribute -> facility1, user1
+	 * user1Facility2_test_attribute -> facility2, user1
+	 * user2Facility2_test_attribute -> facility2, user2
+	 * user2Facility3_test_attribute -> facility3, user2
+	 * user3Facility3_test_attribute -> facility3, user3
+	 * user3Facility2_test_attribute -> facility2, user3
+	 * user3Facility1_test_attribute -> facility1, user3
+	 */
+	private void setAttributesForUserFacilityTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		userFacility_test_atr_def = new AttributeDefinition();
+		userFacility_test_atr_def.setNamespace(AttributesManager.NS_USER_FACILITY_ATTR_DEF);
+		userFacility_test_atr_def.setDescription("test userFacility attr");
+		userFacility_test_atr_def.setFriendlyName("test");
+		userFacility_test_atr_def.setType(String.class.getName());
+		userFacility_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, userFacility_test_atr_def);
+
+		user1Facility1_test_attribute = new Attribute(userFacility_test_atr_def);
+		user1Facility1_test_attribute.setValue("user1Facility1");
+		perun.getAttributesManagerBl().setAttribute(sess, facility1, user1, user1Facility1_test_attribute);
+
+		user1Facility2_test_attribute = new Attribute(userFacility_test_atr_def);
+		user1Facility2_test_attribute.setValue("user1Facility2");
+		perun.getAttributesManagerBl().setAttribute(sess, facility2, user1, user1Facility2_test_attribute);
+
+		user2Facility2_test_attribute = new Attribute(userFacility_test_atr_def);
+		user2Facility2_test_attribute.setValue("user2Facility2");
+		perun.getAttributesManagerBl().setAttribute(sess, facility2, user2, user2Facility2_test_attribute);
+
+		user2Facility3_test_attribute = new Attribute(userFacility_test_atr_def);
+		user2Facility3_test_attribute.setValue("user2Facility3");
+		perun.getAttributesManagerBl().setAttribute(sess, facility3, user2, user2Facility3_test_attribute);
+
+		user3Facility3_test_attribute = new Attribute(userFacility_test_atr_def);
+		user3Facility3_test_attribute.setValue("user3Facility3");
+		perun.getAttributesManagerBl().setAttribute(sess, facility3, user3, user3Facility3_test_attribute);
+
+		user3Facility2_test_attribute = new Attribute(userFacility_test_atr_def);
+		user3Facility2_test_attribute.setValue("user3Facility2");
+		perun.getAttributesManagerBl().setAttribute(sess, facility2, user3, user3Facility2_test_attribute);
+
+		user3Facility1_test_attribute = new Attribute(userFacility_test_atr_def);
+		user3Facility1_test_attribute.setValue("user3Facility1");
+		perun.getAttributesManagerBl().setAttribute(sess, facility1, user3, user3Facility1_test_attribute);
+	}
+
+	/**
+	 * member1U1Res1Vo1_test_attribute -> member1OfUser1, resource1InVo1
+	 * member1U1Res2Vo1_test_attribute -> member1OfUser1, resource2InVo1
+	 * member1U2Res1Vo2_test_attribute -> member1OfUser2, resource1InVo2
+	 * member1U2Res2Vo2_test_attribute -> member1OfUser2, resource2InVo2
+	 * member1U3Res1Vo1_test_attribute -> member1OfUser3, resource1InVo1
+	 * member2U3Res1Vo2_test_attribute -> member2OfUser3, resource1InVo2
+	 * member2U3Res2Vo2_test_attribute -> member2OfUser3, resource2InVo2
+	 */
+	private void setAttributesForMemberResourceTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		memberResource_test_atr_def = new AttributeDefinition();
+		memberResource_test_atr_def.setNamespace(AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF);
+		memberResource_test_atr_def.setDescription("test memberResource attr");
+		memberResource_test_atr_def.setFriendlyName("test");
+		memberResource_test_atr_def.setType(String.class.getName());
+		memberResource_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, memberResource_test_atr_def);
+
+		member1U1Res1Vo1_test_attribute = new Attribute(memberResource_test_atr_def);
+		member1U1Res1Vo1_test_attribute.setValue("member1U1Res1Vo1");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo1, member1OfUser1, member1U1Res1Vo1_test_attribute);
+
+		member1U1Res2Vo1_test_attribute = new Attribute(memberResource_test_atr_def);
+		member1U1Res2Vo1_test_attribute.setValue("member1U1Res2Vo1");
+		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo1, member1OfUser1, member1U1Res2Vo1_test_attribute);
+
+		member1U2Res1Vo2_test_attribute = new Attribute(memberResource_test_atr_def);
+		member1U2Res1Vo2_test_attribute.setValue("member1U2Res1Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo2, member1OfUser2, member1U2Res1Vo2_test_attribute);
+
+		member1U2Res2Vo2_test_attribute = new Attribute(memberResource_test_atr_def);
+		member1U2Res2Vo2_test_attribute.setValue("member1U2Res2Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo2, member1OfUser2, member1U2Res2Vo2_test_attribute);
+
+		member1U3Res1Vo1_test_attribute = new Attribute(memberResource_test_atr_def);
+		member1U3Res1Vo1_test_attribute.setValue("member1U3Res1Vo1");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo1, member1OfUser3, member1U3Res1Vo1_test_attribute);
+
+		member2U3Res1Vo2_test_attribute = new Attribute(memberResource_test_atr_def);
+		member2U3Res1Vo2_test_attribute.setValue("member2U3Res1Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo2, member2OfUser3, member2U3Res1Vo2_test_attribute);
+
+		member2U3Res2Vo2_test_attribute = new Attribute(memberResource_test_atr_def);
+		member2U3Res2Vo2_test_attribute.setValue("member2U3Res2Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo2, member2OfUser3, member2U3Res2Vo2_test_attribute);
+	}
+
+	/**
+	 * member1U1Group1Vo1_test_attribute -> member1OfUser1, group1InVo1
+	 * member1U1Group2Vo1_test_attribute -> member1OfUser1, group2InVo1
+	 * member2U1Group1Vo2_test_attribute -> member2OfUser1, group1InVo2
+	 * member2U1Group2Vo2_test_attribute -> member2OfUser1, group2InVo2
+	 * member1U2Group1Vo2_test_attribute -> member1OfUser2, group1InVo2
+	 * member1U2Group2Vo2_test_attribute -> member1OfUser2, group2InVo2
+	 * member2U2Group1Vo1_test_attribute -> member2OfUser2, group1InVo1
+	 * member2U2Group2Vo1_test_attribute -> member2OfUser2, group2InVo1
+	 * member1U3Group1Vo1_test_attribute -> member1OfUser3, group1InVo1
+	 * member2U3Group2Vo2_test_attribute -> member2OfUser3, group2InVo2
+	 *
+	 */
+	private void setAttributesForMemberGroupAttributesTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		memberGroup_test_atr_def = new AttributeDefinition();
+		memberGroup_test_atr_def.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_DEF);
+		memberGroup_test_atr_def.setDescription("test groupResource attr");
+		memberGroup_test_atr_def.setFriendlyName("test");
+		memberGroup_test_atr_def.setType(String.class.getName());
+		memberGroup_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, memberGroup_test_atr_def);
+
+		member1U1Group1Vo1_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member1U1Group1Vo1_test_attribute.setValue("member1U1Group1Vo1");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser1, group1InVo1, member1U1Group1Vo1_test_attribute);
+
+		member1U1Group2Vo1_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member1U1Group2Vo1_test_attribute.setValue("member1U1Group2Vo1");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser1, group2InVo1, member1U1Group2Vo1_test_attribute);
+
+		member2U1Group1Vo2_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member2U1Group1Vo2_test_attribute.setValue("member2U1Group1Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser1, group1InVo2, member2U1Group1Vo2_test_attribute);
+
+		member2U1Group2Vo2_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member2U1Group2Vo2_test_attribute.setValue("member2U1Group2Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser1, group2InVo2, member2U1Group2Vo2_test_attribute);
+
+		member1U2Group1Vo2_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member1U2Group1Vo2_test_attribute.setValue("member1U2Group1Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser2, group1InVo2, member1U2Group1Vo2_test_attribute);
+
+		member1U2Group2Vo2_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member1U2Group2Vo2_test_attribute.setValue("member1U2Group2Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser2, group2InVo2, member1U2Group2Vo2_test_attribute);
+
+		member2U2Group1Vo1_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member2U2Group1Vo1_test_attribute.setValue("member2U2Group1Vo1");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser2, group1InVo1, member2U2Group1Vo1_test_attribute);
+
+		member2U2Group2Vo1_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member2U2Group2Vo1_test_attribute.setValue("member2U2Group2Vo1");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser2, group2InVo1, member2U2Group2Vo1_test_attribute);
+
+		member1U3Group1Vo1_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member1U3Group1Vo1_test_attribute.setValue("member1U3Group1Vo1");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser3, group1InVo1, member1U3Group1Vo1_test_attribute);
+
+		member2U3Group2Vo2_test_attribute = new Attribute(memberGroup_test_atr_def);
+		member2U3Group2Vo2_test_attribute.setValue("member2U3Group2Vo2");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser3, group2InVo2, member2U3Group2Vo2_test_attribute);
+	}
+
+	/**
+	 * group1VO1Res1VO1_test_attribute -> resource1InVo1, group1InVo1
+	 * group2VO1Res1VO1_test_attribute -> resource1InVo1, group2InVo1
+	 * group2VO1Res2VO1_test_attribute -> resource2InVo1, group2InVo1
+	 * group1VO2Res1VO2_test_attribute -> resource1InVo2, group1InVo2
+	 * group2VO2Res1VO2_test_attribute -> resource1InVo2, group2InVo2
+	 * group2VO2Res2VO2_test_attribute -> resource2InVo2, group2InVo2
+	 */
+	private void setAttributesForGroupResourceAttributesTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		groupResource_test_atr_def = new AttributeDefinition();
+		groupResource_test_atr_def.setNamespace(AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF);
+		groupResource_test_atr_def.setDescription("test groupResource attr");
+		groupResource_test_atr_def.setFriendlyName("test");
+		groupResource_test_atr_def.setType(String.class.getName());
+		groupResource_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, groupResource_test_atr_def);
+
+		group1VO1Res1VO1_test_attribute = new Attribute(groupResource_test_atr_def);
+		group1VO1Res1VO1_test_attribute.setValue("G1VO1_RES1VO1");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo1, group1InVo1, group1VO1Res1VO1_test_attribute);
+
+		group2VO1Res1VO1_test_attribute = new Attribute(groupResource_test_atr_def);
+		group2VO1Res1VO1_test_attribute.setValue("G2VO1_RES1VO1");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo1, group2InVo1, group2VO1Res1VO1_test_attribute);
+
+		group2VO1Res2VO1_test_attribute = new Attribute(groupResource_test_atr_def);
+		group2VO1Res2VO1_test_attribute.setValue("G2VO1_RES2VO1");
+		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo1, group2InVo1, group2VO1Res2VO1_test_attribute);
+
+		group1VO2Res1VO2_test_attribute = new Attribute(groupResource_test_atr_def);
+		group1VO2Res1VO2_test_attribute.setValue("G1VO2_RES1VO2");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo2, group1InVo2, group1VO2Res1VO2_test_attribute);
+
+		group2VO2Res1VO2_test_attribute = new Attribute(groupResource_test_atr_def);
+		group2VO2Res1VO2_test_attribute.setValue("G2VO2_RES1VO2");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo2, group2InVo2, group2VO2Res1VO2_test_attribute);
+
+		group2VO2Res2VO2_test_attribute = new Attribute(groupResource_test_atr_def);
+		group2VO2Res2VO2_test_attribute.setValue("G2VO2_RES2VO2");
+		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo2, group2InVo2, group2VO2Res2VO2_test_attribute);
+	}
+
+	/**
+	 * Attribute def types: vo_toEmail_def, vo_fromEmail_def
+	 * vo1 -> vo1_toEmail_attribute
+	 * vo2 -> vo2_toEmail_attribute, vo2_fromEmail_attribute
+	 *
+	 */
+	private void setAttributesForVoAttributesTest() throws Exception {
+		String namespaceToEmail = "urn:perun:vo:attribute-def:def:toEmail";
+		String namespaceFromEmail = "urn:perun:vo:attribute-def:def:fromEmail";
+
+		//get Impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		vo_toEmail_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, namespaceToEmail);
+		vo_fromEmail_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, namespaceFromEmail);
+
+		//set vo_toEmail_def attribute to vo1
+		vo1_toEmail_attribute = new Attribute(vo_toEmail_def);
+		vo1_toEmail_attribute.setValue(new ArrayList<>(Collections.singletonList("vo1To@email.com")));
+		perun.getAttributesManagerBl().setAttribute(sess, vo1, vo1_toEmail_attribute);
+
+		//set vo_toEmail_def attribute to vo2
+		vo2_toEmail_attribute = new Attribute(vo_toEmail_def);
+		vo2_toEmail_attribute.setValue(new ArrayList<>(Collections.singletonList("vo2To@email.com")));
+		perun.getAttributesManagerBl().setAttribute(sess, vo2, vo2_toEmail_attribute);
+
+		//set vo_fromEmail_def attribute to vo2
+		vo2_fromEmail_attribute = new Attribute(vo_fromEmail_def);
+		vo2_fromEmail_attribute.setValue("vo2From@email.com");
+		perun.getAttributesManagerBl().setAttribute(sess, vo2, vo2_fromEmail_attribute);
+	}
+
+	/**
+	 * Sets user attributes like this:
+	 * user1 - user1_phone_attribute
+	 * user2 - user2_phone_attribute, user2_email_attribute
+	 * user3 - user3_email_attribute
+	 */
+	private void setAttributesForUserAttributesTest() throws Exception {
+		//get Impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		user_phone_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:user:attribute-def:def:phone");
+		user_email_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:user:attribute-def:def:preferredMail");
+
+		//set Phone attribute for user1
+		user1_phone_attribute = new Attribute(user_phone_atr_def);
+		user1_phone_attribute.setValue("+420555444222");
+		perun.getAttributesManagerBl().setAttribute(sess, user1, user1_phone_attribute);
+
+		//set Phone attribute for user2
+		user2_phone_attribute = new Attribute(user_phone_atr_def);
+		user2_phone_attribute.setValue("+420888555444");
+		perun.getAttributesManagerBl().setAttribute(sess, user2, user2_phone_attribute);
+
+		//set Prefferred mail attribute for user2
+		user2_email_attribute = new Attribute(user_email_atr_def);
+		user2_email_attribute.setValue("user2@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, user2, user2_email_attribute);
+
+		//set Preferred mail attribute for user3
+		user3_email_attribute = new Attribute(user_email_atr_def);
+		user3_email_attribute.setValue("user3@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, user3, user3_email_attribute);
+	}
+
+	/**
+	 * Sets member attributes like this:
+	 * member1OfUser1: member1OfUser1_phone_attribute
+	 * member2OfUser1: member2OfUser1_phone_attribute - disallowed
+	 * member1OfUser2: member1OfUser2_phone_attribute, member1OfUser2_mail_attribute
+	 * member2OfUser2: member2OfUser2_phone_attribute, member2OfUser2_mail_attribute - disallowed
+	 * member1OfUser3: member1OfUser3_mail_attribute
+	 * member2OfUser3: member2OfUser3_mail_attribute
+	 */
+	private void setAttributesForMemberAttributesTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		member_phone_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:member:attribute-def:def:phone");
+		member_email_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:member:attribute-def:def:mail");
+
+		//set Phone attribute for member1OfUser1 and member2OfUser1
+		member1OfUser1_phone_attribute = new Attribute(member_phone_atr_def);
+		member1OfUser1_phone_attribute.setValue("+420555444222");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser1, member1OfUser1_phone_attribute);
+
+		member2OfUser1_phone_attribute = new Attribute(member_phone_atr_def);
+		member2OfUser1_phone_attribute.setValue("+420555444111");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser1, member2OfUser1_phone_attribute);
+
+		//set Phone attribute for member1OfUser2 and member2OfUser2
+		member1OfUser2_phone_attribute = new Attribute(member_phone_atr_def);
+		member1OfUser2_phone_attribute.setValue("+420888555444");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser2, member1OfUser2_phone_attribute);
+
+		member2OfUser2_phone_attribute = new Attribute(member_phone_atr_def);
+		member2OfUser2_phone_attribute.setValue("+420888555898");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser2, member2OfUser2_phone_attribute);
+
+		//set email attribute for member1OfUser2 and member2OfUser2
+		member1OfUser2_mail_attribute = new Attribute(member_email_atr_def);
+		member1OfUser2_mail_attribute.setValue("user2@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser2, member1OfUser2_mail_attribute);
+
+		member2OfUser2_mail_attribute = new Attribute(member_email_atr_def);
+		member2OfUser2_mail_attribute.setValue("user22@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser2, member2OfUser2_mail_attribute);
+
+		//set email attribute for member1OfUser3 and member2OfUser3
+		member1OfUser3_mail_attribute = new Attribute(member_email_atr_def);
+		member1OfUser3_mail_attribute.setValue("user3@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser3, member1OfUser3_mail_attribute);
+
+		member2OfUser3_mail_attribute = new Attribute(member_email_atr_def);
+		member2OfUser3_mail_attribute.setValue("user32@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser3, member2OfUser3_mail_attribute);
+	}
+
+	/**
+	 * group1InVo1:           group1InVo1_email_atr
+	 * group2InVo1:           group2InVo1_email_atr
+	 * group1InVo2:           group1InVo2_email_atr
+	 * group2InVo2:           group2InVo2_email_atr
+	 * membersGroupOfVo1:     membersGroupOfVo1_email_atr
+	 * membersGroupOfVo2:     membersGroupOfVo2_email_atr
+	 */
+	private void setAttributesForGroupAttributesTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		group_fromEmail_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:group:attribute-def:def:fromEmail");
+
+		group1InVo1_email_atr = new Attribute(group_fromEmail_atr_def);
+		group1InVo1_email_atr.setValue("1@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, group1InVo1, group1InVo1_email_atr);
+
+		group2InVo1_email_atr = new Attribute(group_fromEmail_atr_def);
+		group2InVo1_email_atr.setValue("2@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, group2InVo1, group2InVo1_email_atr);
+
+		group1InVo2_email_atr = new Attribute(group_fromEmail_atr_def);
+		group1InVo2_email_atr.setValue("3@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, group1InVo2, group1InVo2_email_atr);
+
+		group2InVo2_email_atr = new Attribute(group_fromEmail_atr_def);
+		group2InVo2_email_atr.setValue("4@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, group2InVo2, group2InVo2_email_atr);
+
+		membersGroupOfVo1_email_atr = new Attribute(group_fromEmail_atr_def);
+		membersGroupOfVo1_email_atr.setValue("5@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, membersGroupOfVo1, membersGroupOfVo1_email_atr);
+
+		membersGroupOfVo2_email_atr = new Attribute(group_fromEmail_atr_def);
+		membersGroupOfVo2_email_atr.setValue("6@mail.com");
+		perun.getAttributesManagerBl().setAttribute(sess, membersGroupOfVo2, membersGroupOfVo2_email_atr);
+	}
+
+	/**
+	 * resource1InVo1: resource1InVo1_test_atr
+	 * resource2InVo1: resource2InVo1_test_atr
+	 * resource1InVo2: resource1InVo2_test_atr
+	 * resource2InVo2: resource2InVo2_test_atr
+	 */
+	private void setAttributesForResourceAttributesTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		resource_test_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:resource:attribute-def:def:defaultDataQuota");
+
+		resource1InVo1_test_atr = new Attribute(resource_test_atr_def);
+		resource1InVo1_test_atr.setValue("1K");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo1, resource1InVo1_test_atr);
+
+		resource2InVo1_test_atr = new Attribute(resource_test_atr_def);
+		resource2InVo1_test_atr.setValue("2K");
+		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo1, resource2InVo1_test_atr);
+
+		resource1InVo2_test_atr = new Attribute(resource_test_atr_def);
+		resource1InVo2_test_atr.setValue("3K");
+		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo2, resource1InVo2_test_atr);
+
+		resource2InVo2_test_atr = new Attribute(resource_test_atr_def);
+		resource2InVo2_test_atr.setValue("4K");
+		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo2, resource2InVo2_test_atr);
+	}
+
+	/**
+	 * facility1: facility1_test_atr
+	 * facility2: facility2_test_atr
+	 * facility3: facility3_test_atr
+	 */
+	private void setAttributesForFacilityAttributesTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		facility_test_atr_def = perun.getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:facility:attribute-def:def:homeDirUmask");
+
+		facility1_test_atr = new Attribute(facility_test_atr_def);
+		facility1_test_atr.setValue("756");
+		perun.getAttributesManagerBl().setAttribute(sess, facility1, facility1_test_atr);
+
+		facility2_test_atr = new Attribute(facility_test_atr_def);
+		facility2_test_atr.setValue("0475");
+		perun.getAttributesManagerBl().setAttribute(sess, facility2, facility2_test_atr);
+
+		facility3_test_atr = new Attribute(facility_test_atr_def);
+		facility3_test_atr.setValue("0000");
+		perun.getAttributesManagerBl().setAttribute(sess, facility3, facility3_test_atr);
+	}
+
+	/**
+	 * host1OnFacility1: host1F1_test_atr
+	 * host2OnFacility1: host2F1_test_atr
+	 * host1OnFacility2: host1F2_test_atr
+	 * host2OnFacility2: host2F2_test_atr
+	 * host1OnFacility3: host1F3_test_atr
+	 * host2OnFacility3: host2F3_test_atr
+	 */
+	private void setAttributesForHostAttributesTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+		host_test_atr_def = new AttributeDefinition();
+		host_test_atr_def.setNamespace(AttributesManager.NS_HOST_ATTR_DEF);
+		host_test_atr_def.setDescription("test host attr");
+		host_test_atr_def.setFriendlyName("host");
+		host_test_atr_def.setType(String.class.getName());
+		host_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, host_test_atr_def);
+
+		host1F1_test_atr = new Attribute(host_test_atr_def);
+		host1F1_test_atr.setValue("host1F1");
+		perun.getAttributesManagerBl().setAttribute(sess, host1OnFacility1, host1F1_test_atr);
+
+		host2F1_test_atr = new Attribute(host_test_atr_def);
+		host2F1_test_atr.setValue("host2F1");
+		perun.getAttributesManagerBl().setAttribute(sess, host2OnFacility1, host2F1_test_atr);
+
+		host1F2_test_atr = new Attribute(host_test_atr_def);
+		host1F2_test_atr.setValue("host1F2");
+		perun.getAttributesManagerBl().setAttribute(sess, host1OnFacility2, host1F2_test_atr);
+
+		host2F2_test_atr = new Attribute(host_test_atr_def);
+		host2F2_test_atr.setValue("host2F2");
+		perun.getAttributesManagerBl().setAttribute(sess, host2OnFacility2, host2F2_test_atr);
+
+		host1F3_test_atr = new Attribute(host_test_atr_def);
+		host1F3_test_atr.setValue("host1F3");
+		perun.getAttributesManagerBl().setAttribute(sess, host1OnFacility3, host1F3_test_atr);
+
+		host2F3_test_atr = new Attribute(host_test_atr_def);
+		host2F3_test_atr.setValue("host2F3");
+		perun.getAttributesManagerBl().setAttribute(sess, host2OnFacility3, host2F3_test_atr);
+	}
+
+	/**
+	 * userExtSource1: ues1_test_atr
+	 * userExtSource2: ues2_test_atr
+	 * userExtSource3: ues3_test_atr
+	 */
+	private void setAttributesForUESAttributesTest() throws Exception {
+		//get impl object
+		attributesManagerBl = getTargetObject(perun.getAttributesManagerBl());
+
+
+		ues_test_atr_def = new AttributeDefinition();
+		ues_test_atr_def.setNamespace(AttributesManager.NS_UES_ATTR_DEF);
+		ues_test_atr_def.setDescription("test ues attr");
+		ues_test_atr_def.setFriendlyName("ues");
+		ues_test_atr_def.setType(String.class.getName());
+		ues_test_atr_def = perun.getAttributesManagerBl().createAttribute(sess, ues_test_atr_def);
+
+		//create sample of internal attribute
+		internal_ues_atr = new Attribute(ues_test_atr_def);
+
+		ues1_test_atr = new Attribute(ues_test_atr_def);
+		ues1_test_atr.setValue("ues1");
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource1, ues1_test_atr);
+
+		ues2_test_atr = new Attribute(ues_test_atr_def);
+		ues2_test_atr.setValue("ues2");
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource2, ues2_test_atr);
+
+		ues3_test_atr = new Attribute(ues_test_atr_def);
+		ues3_test_atr.setValue("ues3");
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource3, ues3_test_atr);
+	}
+
+	/**
+	 * cast spring proxy type to regular impl type
+	 */
+	@SuppressWarnings({"unchecked"})
+	private <T> T getTargetObject(Object proxy) throws Exception {
+		if (AopUtils.isJdkDynamicProxy(proxy)) {
+			return (T) getTargetObject(((Advised)proxy).getTargetSource().getTarget());
+		}
+		return (T) proxy; // expected to be cglib proxy then, which is simply a specialized class
+	}
+
+	private Method getPrivateMethodFromAtrManager(String methodName, Class<?>... argClasses) throws Exception {
+		Method method = AttributesManagerBlImpl.class.getDeclaredMethod(methodName, argClasses);
+		method.setAccessible(true);
+		return method;
+	}
 
 	private Vo setUpVo() throws Exception {
 


### PR DESCRIPTION
 Refactoring of attribute dependencies logic
 - instead one big method use a bulk of special private methods where
   every method takes care about specific way how to obtain
   richAttributes from input parameters
 - this is easier for adding new funcionality and testing existing one
   (lost of small tests than one big)
 - add all missing logic for dependencies and perunBean UserExtSource
   (newly also userExtSources can have attributes and these attributes
   of course can have dependencies to other attributes)
 - add new public method to MembersManagerBl and BlImpl to be able to
   say if some member is allowed or not (has status DISABLED or INVALID)

Implementation of tests for AttributesManagerBlImpl private methods
 - Implemented tests for private methods that should find certain object
attributes by given objects. Those methods are obtained by method
"getPrivateMethodFromAtrManager" so they can remain private.
 - Each part of tests is focused on certain entities, eg. "VOs" and has
a private method that creates attributes which are then used in tests.
 - Some of the private methods where changed because they usually returned
more objects than were supposed to.
 -Some methods now use other private methods to reduce duplicity of code
and increase readability.
 - Removed unnecessary generic type declaration and replaced only with
"<>".
 - Changed the declaration of RichAttribute to its generic version ->
"RichAttribute<>". The previous version caused "unchecked" warnings and
should not be used.
- Some versions of private methods were completely removed because other
they were unnecessary.