### PR TITLE
Change behavior of threading for synchronization of groups

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -20,6 +20,7 @@ public class CoreConfig {
 	private boolean readOnlyPerun;
 	private int groupSynchronizationInterval;
 	private int groupSynchronizationTimeout;
+	private int groupMaxConcurentGroupsToSynchronize;
 	private int mailchangeValidationWindow;
 	private int pwdresetValidationWindow;
 	private List<String> admins;
@@ -48,6 +49,15 @@ public class CoreConfig {
 	private String rtUrl;
 	private String smsProgram;
 	private String userExtSourcesPersistent;
+
+	public int getGroupMaxConcurentGroupsToSynchronize() {
+		return groupMaxConcurentGroupsToSynchronize;
+	}
+
+	public void setGroupMaxConcurentGroupsToSynchronize(int groupMaxConcurentGroupsToSynchronize) {
+		this.groupMaxConcurentGroupsToSynchronize = groupMaxConcurentGroupsToSynchronize;
+	}
+
 	private Map<String, List<AttributeDefinition>> attributesForUpdate = new HashMap<>();
 
 

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -17,6 +17,7 @@
 		<property name="generatedLoginNamespaces" value="#{'${perun.loginNamespace.generated}'.split('\s*,\s*')}"/>
 		<property name="groupSynchronizationInterval" value="${perun.group.synchronization.interval}"/>
 		<property name="groupSynchronizationTimeout" value="${perun.group.synchronization.timeout}"/>
+		<property name="groupMaxConcurentGroupsToSynchronize" value="${perun.group.maxConcurentGroupsToSynchronize}"/>
 		<property name="instanceId" value="${perun.instanceId}"/>
 		<property name="instanceName" value="${perun.instanceName}"/>
 		<property name="mailchangeBackupFrom" value="${perun.mailchange.backupFrom}"/>
@@ -69,6 +70,7 @@
 				<prop key="perun.db.type">hsqldb</prop>
 				<prop key="perun.group.synchronization.interval">1</prop>
 				<prop key="perun.group.synchronization.timeout">10</prop>
+				<prop key="perun.group.maxConcurentGroupsToSynchronize">10</prop>
 				<prop key="perun.rpc.powerusers"/>
 				<prop key="perun.perun.db.name">perun</prop>
 				<prop key="perun.rt.url">https://rt3.cesnet.cz/rt/REST/1.0/ticket/new</prop>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -14,7 +14,7 @@ import java.util.TreeMap;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
-import cz.metacentrum.perun.core.api.exceptions.rt.WrongAttributeAssignmentRuntimeException;
+import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
@@ -43,8 +44,9 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 	private final GroupsManagerImplApi groupsManagerImpl;
 	private PerunBl perunBl;
-
-	private Map<Integer, GroupSynchronizerThread> groupSynchronizerThreads;
+	private Integer maxConcurentGroupsToSynchronize;
+	private ConcurrentLinkedDeque<Group> queueOfGroupsToBeSynchronized;
+	private Map<GroupSynchronizerThread, Integer> groupSynchronizerThreads;
 	private static final String A_G_D_AUTHORITATIVE_GROUP = AttributesManager.NS_GROUP_ATTR_DEF + ":authoritativeGroup";
 
 	/**
@@ -53,7 +55,10 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 */
 	public GroupsManagerBlImpl(GroupsManagerImplApi groupsManagerImpl) {
 		this.groupsManagerImpl = groupsManagerImpl;
-		this.groupSynchronizerThreads = new HashMap<Integer, GroupSynchronizerThread>();
+		this.groupSynchronizerThreads = new HashMap<>();
+		this.queueOfGroupsToBeSynchronized = new ConcurrentLinkedDeque<>();
+		//set maximum concurent groups to synchronize by property or if any problem, then use default
+		this.maxConcurentGroupsToSynchronize = BeansUtils.getCoreConfig().getGroupMaxConcurentGroupsToSynchronize();
 	}
 
 	public Group createGroup(PerunSession sess, Vo vo, Group group) throws GroupExistsException, InternalErrorException {
@@ -1083,72 +1088,86 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * Adds the group synchronization process in the groupSynchronizerThreads.
 	 *
 	 * @param group
+	 * @throws InternalErrorException when object group is null
 	 */
-	public void forceGroupSynchronization(PerunSession sess, Group group) throws GroupSynchronizationAlreadyRunningException {
+	public void forceGroupSynchronization(PerunSession sess, Group group) throws GroupSynchronizationAlreadyRunningException, InternalErrorException {
+		Utils.notNull(group, "group");
 		// First check if the group is not currently in synchronization process
-		if (groupSynchronizerThreads.containsKey(group.getId()) && groupSynchronizerThreads.get(group.getId()).getState() != Thread.State.TERMINATED) {
+		if (groupSynchronizerThreads.values().contains(group.getId())) {
 			throw new GroupSynchronizationAlreadyRunningException(group);
 		} else {
-			// Remove from groupSynchronizerThreads if the thread was terminated
-			if (groupSynchronizerThreads.containsKey(group.getId())) {
-				groupSynchronizerThreads.remove(group.getId());
-			}
-			// Start and run the new thread
-			GroupSynchronizerThread thread = new GroupSynchronizerThread(sess, group);
-			thread.start();
-			log.info("Group synchronization thread started for group {}.", group);
-
-			groupSynchronizerThreads.put(group.getId(), thread);
+			// Add this group as first to the queue (similar to LIFO)
+			putGroupToQueueToBeSynchronized(group, true);
+			log.info("Scheduling synchronization for the group {} by force!", group);
 		}
 	}
 
 	/**
-	 * Synchronize all groups which have enabled synchronization. This method is run by the scheduler every 5 minutes.
+	 * Start and check threads with synchronization of groups. (max threads is defined by constant)
+	 * It also add new groups to the queue.
+	 * This method is run by the scheduler every 5 minutes.
 	 *
 	 * @throws InternalErrorException
 	 */
 	public void synchronizeGroups(PerunSession sess) throws InternalErrorException {
-		Random rand = new Random();
-
-		// Firstly remove all terminated threads
-		List<Integer> threadsToRemove = new ArrayList<Integer>();
-		for (Integer groupId: groupSynchronizerThreads.keySet()) {
-			if (groupSynchronizerThreads.get(groupId).getState() == Thread.State.TERMINATED) {
-				threadsToRemove.add(groupId);
-			}
-		}
-		for (Integer groupId: threadsToRemove) {
-			groupSynchronizerThreads.remove(groupId);
-			log.debug("Removing terminated group synchronization thread for group id={}", groupId);
-		}
-
 		// Get the default synchronization interval and synchronization timeout from the configuration file
-		int intervalMultiplier = BeansUtils.getCoreConfig().getGroupSynchronizationInterval();
 		int timeout = BeansUtils.getCoreConfig().getGroupSynchronizationTimeout();
-
+		int defaultIntervalMultiplier = BeansUtils.getCoreConfig().getGroupSynchronizationInterval();
 		// Get the number of seconds from the epoch, so we can divide it by the synchronization interval value
 		long minutesFromEpoch = System.currentTimeMillis()/1000/60;
+
+		// Firstly remove all terminated and too old threads
+		for (GroupSynchronizerThread thread: groupSynchronizerThreads.keySet()) {
+			long threadStart = thread.getStartTime();
+			//If thread start is 0, skip this thread, it is waiting for another group to start synchronization
+			if(threadStart == 0) {
+				continue;
+			}
+
+			long timeDiff = System.currentTimeMillis() - threadStart;
+			//If group is in terminated state
+			if (thread.getState() == Thread.State.TERMINATED) {
+				int groupId = groupSynchronizerThreads.get(thread);
+				groupSynchronizerThreads.remove(thread);
+				log.debug("Removing terminated group synchronization thread for group id={}", groupId);
+			// If the time is greater than timeout set in the configuration file (in minutes)
+			} else if(timeDiff/1000/60 > timeout) {
+				thread.interrupt();
+				int groupId = groupSynchronizerThreads.get(thread);
+				groupSynchronizerThreads.remove(thread);
+				log.debug("Removing timouting group synchronization thread for group id={}", groupId);
+			}
+		}
+
+		// Start new threads if there is place for them
+		int countOfActiveThreads = groupSynchronizerThreads.size();
+		while(countOfActiveThreads < maxConcurentGroupsToSynchronize) {
+			GroupSynchronizerThread thread = new GroupSynchronizerThread(sess);
+			thread.start();
+			log.debug("New thread for synchronization started.");
+			countOfActiveThreads++;
+		}
 
 		// Get the groups with synchronization enabled
 		List<Group> groups = groupsManagerImpl.getGroupsToSynchronize(sess);
 
-		int numberOfNewSynchronizations = 0;
-		int numberOfActiveSynchronizations = 0;
-		int numberOfTerminatedSynchronizations = 0;
 		for (Group group: groups) {
-			// Get the synchronization interval
+			// Get the synchronization interval for the group
+			int intervalMultiplier;
 			try {
 				Attribute intervalAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
 				if (intervalAttribute.getValue() != null) {
 					intervalMultiplier = Integer.parseInt((String) intervalAttribute.getValue());
 				} else {
+					intervalMultiplier = defaultIntervalMultiplier;
 					log.warn("Group {} hasn't set synchronization interval, using default {} seconds", group, intervalMultiplier);
 				}
 			} catch (AttributeNotExistsException e) {
-				throw new ConsistencyErrorException("Required attribute " + GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME + " isn't defined in Perun!",e);
+				log.error("Required attribute {} isn't defined in Perun! Using default value from properties instead!", GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
+				intervalMultiplier = defaultIntervalMultiplier;
 			} catch (WrongAttributeAssignmentException e) {
-				log.error("Cannot synchronize group " + group +" due to exception:", e);
-				continue;
+				log.error("Cannot get attribute " + GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME + " for group " + group + " due to exception. Using default value from properties instead!",e);
+				intervalMultiplier = defaultIntervalMultiplier;
 			}
 
 			// Multiply with 5 to get real minutes
@@ -1156,49 +1175,20 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 			// If the minutesFromEpoch can be divided by the intervalMultiplier, then synchronize
 			if ((minutesFromEpoch % intervalMultiplier) == 0) {
-				// It's time to synchronize
-				log.info("Scheduling synchronization for the group {}. Interval {} minutes.", group, intervalMultiplier);
-
-				// Run each synchronization in separate thread, but do not start new one, if previous hasn't finished yet
-				if (groupSynchronizerThreads.containsKey(group.getId())) {
-					// Check the running time of the thread
-					long timeDiff = System.currentTimeMillis() - groupSynchronizerThreads.get(group.getId()).getStartTime();
-
-					// If the time is greater than timeout set in the configuration file (in minutes)
-					if (timeDiff/1000/60 > timeout) {
-						// Timeout reach, stop the thread
-						log.warn("Timeout {} minutes of the synchronization thread for the group {} reached.", timeout, group);
-						groupSynchronizerThreads.get(group.getId()).interrupt();
-						groupSynchronizerThreads.remove(group.getId());
-						numberOfTerminatedSynchronizations++;
-					} else {
-						numberOfActiveSynchronizations++;
-					}
+				if(groupSynchronizerThreads.values().contains(group.getId())) {
+					log.info("Group {} synchronzation is already running.", group);
 				} else {
-					// Start and run the new thread
-					try {
-						// Do not overload externalSource, run each synchronization in 0-30s steps
-						Thread.sleep(rand.nextInt(30000));
-					} catch (InterruptedException e) {
-						// Do nothing
+					if(putGroupToQueueToBeSynchronized(group, false)) {
+						log.info("Group {} was added to the queue of groups waiting for synchronization.", group);
+					} else {
+						log.info("Group {} is already in the queue of groups waiting for synchronization.", group);
 					}
-					GroupSynchronizerThread thread = new GroupSynchronizerThread(sess, group);
-					thread.start();
-					log.info("Group synchronization thread started for group {}.", group);
-
-					groupSynchronizerThreads.put(group.getId(), thread);
-					numberOfNewSynchronizations++;
 				}
 			}
 		}
-
-		if (groups.size() > 0) {
-			log.info("Synchronizing {} groups, active {}, new {}, terminated {}.",
-					new Object[] {groups.size(), numberOfActiveSynchronizations, numberOfNewSynchronizations, numberOfTerminatedSynchronizations});
-		}
 	}
 
-	private static class GroupSynchronizerThread extends Thread {
+	private class GroupSynchronizerThread extends Thread {
 
 		// all synchronization runs under synchronizer identity.
 		final PerunPrincipal pp = new PerunPrincipal("perunSynchronizer", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
@@ -1207,75 +1197,92 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		private Group group;
 		private long startTime;
 
-		public GroupSynchronizerThread(PerunSession sess, Group group) {
+		public GroupSynchronizerThread(PerunSession sess) {
 			// take only reference to perun
 			this.perunBl = (PerunBl) sess.getPerun();
-			this.group = group;
 			try {
 				// create own session
 				this.sess = perunBl.getPerunSession(pp, new PerunClient());
 			} catch (InternalErrorException ex) {
 				log.error("Unable to create internal session for Synchronizer with credentials {} because of exception {}", pp, ex);
 			}
+			//Default settings of not running thread (waiting for another group)
+			this.group = null;
+			this.startTime = 0;
 		}
 
 		public void run() {
-			//text of exception if was thrown, null in exceptionMessage means "no exception, it's ok"
-			String exceptionMessage = null;
-			//text with all skipped members and reasons of this skipping
-			String skippedMembersMessage = null;
-			//if exception which produce fail of whole synchronization was thrown
-			boolean failedDueToException = false;
+			while (true) {
+				//Set thread to default state (waiting for another group to synchronize)
+				this.setThreadToDefaultState();
+				//text of exception if was thrown, null in exceptionMessage means "no exception, it's ok"
+				String exceptionMessage = null;
+				//text with all skipped members and reasons of this skipping
+				String skippedMembersMessage = null;
+				//if exception which produce fail of whole synchronization was thrown
+				boolean failedDueToException = false;
 
-			try {
-				log.debug("Synchronization thread for group {} has started.", group);
-				// Set the start time, so we can check the timeout of the thread
-				startTime = System.currentTimeMillis();
-
-				//synchronize Group and get information about skipped Members
-				List<String> skippedMembers = perunBl.getGroupsManagerBl().synchronizeGroup(sess, group);
-
-				if(!skippedMembers.isEmpty()) {
-					skippedMembersMessage = "These members from extSource were skipped: { ";
-
-					for(String skippedMember: skippedMembers) {
-						if(skippedMember == null) continue;
-
-						skippedMembersMessage+= skippedMember + ", ";
-					}
-					skippedMembersMessage+= " }";
-					exceptionMessage = skippedMembersMessage;
-				}
-
-				log.debug("Synchronization thread for group {} has finished in {} ms.", group, System.currentTimeMillis()-startTime);
-			} catch (WrongAttributeValueException | WrongReferenceAttributeValueException | InternalErrorException |
-					WrongAttributeAssignmentException | MemberAlreadyRemovedException | GroupNotExistsException |
-					GroupOperationsException | AttributeNotExistsException | ExtSourceNotExistsException e) {
-				failedDueToException = true;
-				exceptionMessage = "Cannot synchronize group ";
-				log.error(exceptionMessage + group, e);
-				exceptionMessage+= "due to exception: " + e.getName() + " => " + e.getMessage();
-			} catch (Exception e) {
-				//If some other exception has been thrown, log it and throw again
-				failedDueToException = true;
-				exceptionMessage = "Cannot synchronize group ";
-				log.error(exceptionMessage + group, e);
-				exceptionMessage+= "due to unexpected exception: " + e.getClass().getName() + " => " + e.getMessage();
-				throw e;
-			} finally {
-				//Save information about group synchronization, this method run in new transaction
 				try {
-					perunBl.getGroupsManagerBl().saveInformationAboutGroupSynchronization(sess, group, failedDueToException, exceptionMessage);
-				} catch (Exception ex) {
-					log.error("When synchronization group " + group + ", exception was thrown.", ex);
-					log.info("Info about exception from synchronization: " + skippedMembersMessage);
+					//Take anouther group from the queue to synchronize it
+					this.group = GroupsManagerBlImpl.this.takeAnotherGroupFromQueueToBeSynchronized();
+					//Actualize group id in map of active threads
+					GroupsManagerBlImpl.this.groupSynchronizerThreads.put(this, this.group.getId());
+					// Set the start time, so we can check the timeout of the thread
+					startTime = System.currentTimeMillis();
+
+					log.debug("Synchronization thread started synchronization for group {}.", group);
+
+					//synchronize Group and get information about skipped Members
+					List<String> skippedMembers = perunBl.getGroupsManagerBl().synchronizeGroup(sess, group);
+
+					if (!skippedMembers.isEmpty()) {
+						skippedMembersMessage = "These members from extSource were skipped: { ";
+
+						for (String skippedMember : skippedMembers) {
+							if (skippedMember == null) continue;
+
+							skippedMembersMessage += skippedMember + ", ";
+						}
+						skippedMembersMessage += " }";
+						exceptionMessage = skippedMembersMessage;
+					}
+
+					log.debug("Synchronization thread for group {} has finished in {} ms.", group, System.currentTimeMillis() - startTime);
+				} catch (WrongAttributeValueException | WrongReferenceAttributeValueException | InternalErrorException |
+						WrongAttributeAssignmentException | MemberAlreadyRemovedException | GroupNotExistsException |
+						GroupOperationsException | AttributeNotExistsException | ExtSourceNotExistsException e) {
+					failedDueToException = true;
+					exceptionMessage = "Cannot synchronize group ";
+					log.error(exceptionMessage + group, e);
+					exceptionMessage += "due to exception: " + e.getName() + " => " + e.getMessage();
+				} catch (Exception e) {
+					//If some other exception has been thrown, log it and throw again
+					failedDueToException = true;
+					exceptionMessage = "Cannot synchronize group ";
+					log.error(exceptionMessage + group, e);
+					exceptionMessage += "due to unexpected exception: " + e.getClass().getName() + " => " + e.getMessage();
+				} finally {
+					//Save information about group synchronization, this method run in new transaction
+					try {
+						perunBl.getGroupsManagerBl().saveInformationAboutGroupSynchronization(sess, group, failedDueToException, exceptionMessage);
+					} catch (Exception ex) {
+						log.error("When synchronization group " + group + ", exception was thrown.", ex);
+						log.info("Info about exception from synchronization: " + skippedMembersMessage);
+					}
+					log.debug("GroupSynchronizerThread finished for group: {}", group);
 				}
-				log.debug("GroupSynchronizerThread finished for group: {}", group);
 			}
 		}
 
 		public long getStartTime() {
 			return startTime;
+		}
+
+		private void setThreadToDefaultState() {
+			this.group = null;
+			this.startTime = 0;
+			//Remove processed groupId from map (set it to 0 - waiting to process another group)
+			GroupsManagerBlImpl.this.groupSynchronizerThreads.put(this, 0);
 		}
 	}
 
@@ -2577,5 +2584,65 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Put Group to the queue defined as groups to be synchronized as soon as possible (FIFO)
+	 * One exception, if putAsFirst is set to true, this group will skip the order and will be added as first to
+	 * process (LIFO).
+	 *
+	 * WARNING:
+	 * - using putAsFirst set to true can in specific situation (group is already on first place in queue)
+	 * delayed processing of group
+	 * - method is synchronized so only one thread should add group to the queue at one time (this prevents
+	 * creating duplicities of groups in queue), but it also lasts more time if call at bulk
+	 *
+	 * @param group group to add to the queue
+	 * @param putAsFirst group will be put to the first place in queue (LIFO)
+	 * @return true if group was added, false if group was already in queue on any place, it always return true for synchronizeAsFirst
+	 * @throws InternalErrorException if group is null
+	 */
+	private synchronized boolean putGroupToQueueToBeSynchronized(Group group, boolean putAsFirst) throws InternalErrorException {
+		Utils.notNull(group, "group");
+		if(putAsFirst) {
+			//remove existence of group
+			queueOfGroupsToBeSynchronized.remove(group);
+			queueOfGroupsToBeSynchronized.addFirst(group);
+		} else {
+			if(!queueOfGroupsToBeSynchronized.contains(group)) {
+				queueOfGroupsToBeSynchronized.addLast(group);
+			} else {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Put list of groups to queue defined as groups to be synchronized as soon as possible (FIFO)
+	 *
+	 * @param groups list of groups to put to the queue
+	 * @return true if there is at least one group which was added to the queue (was not already in)
+	 * @throws InternalErrorException if one of the group is null
+	 */
+	private boolean putGroupsToQueueToBeSynchronized(List<Group> groups) throws InternalErrorException {
+		boolean wasAnyGroupAdded = false;
+		//Process them only if there is anything to proceed
+		if(groups != null && !groups.isEmpty()) {
+			for(Group group: groups) {
+				if(putGroupToQueueToBeSynchronized(group, false)) wasAnyGroupAdded = true;
+			}
+		}
+		return wasAnyGroupAdded;
+	}
+
+	/**
+	 * Retrieve and remove first group from the queue.
+	 *
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	private Group takeAnotherGroupFromQueueToBeSynchronized() throws InternalErrorException {
+		return queueOfGroupsToBeSynchronized.pollFirst();
 	}
 }


### PR DESCRIPTION
 - new concurent double ended queue for purpose of preparing groups in
   order to be synchronized
 - add some methods to work with this dequeue (putting and removing
   groups) with checking of possible duplicity
 - change definition of thread pool, now keys are threads itself, values
   are actually processing groups (null if thread is waiting for another
   group)
 - now thread is still running except interupting or timeouting, from
   start it always set everything to default and take another group (or
   wait if no such is waiting) from head of the queue with waiting
   groups
 - number of active concurent threads is limited by new property
   perun.group.maxConcurentGroupsToSynchronize with default value=10,
   this property can be override in perun.properties file for every
   instance separate
 - force propagation now does not start new synchronization, instead it
   add forced group at the head of the queue so it will be processed as
   soon as possible and skip other groups in the queue (it also means
   that can be outrun by another forcing different group)
 - there is still process synchronizeGroups running by cron tool every 5
   minutes but behavior of this process is now little different. It
   remove all interrupted or timeouted threads from threadpool and then
   it creates a new threads and starts them (maximum defined by property
   menationed above). After restarting threads it also add new groups to
   the queue (groups where is already time to run defined by interval)