### PR TITLE
Add member-group attributes to getRichMembersWithAttributesByNames

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -944,7 +944,7 @@ public interface AttributesManager {
 	 * @param group group to set on
 	 * @param resource resource to set on
 	 * @param attributes attribute to set
-	 * @param workWithUserAttributes true/false If true, we can use group attributes too
+	 * @param workWithGroupAttributes true/false If true, we can use group attributes too
 	 *
 	 * @throws PrivilegeException if privileges are not given
 	 * @throws GroupNotExistsException if the group doesn't exists in the underlying data source

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -536,8 +536,9 @@ public interface MembersManager {
 	 * @throws PrivilegeException
 	 * @throws AttributeNotExistsException
 	 * @throws GroupNotExistsException
+	 * @throws WrongAttributeAssignmentException
 	 */
-	List<RichMember> getRichMembersWithAttributesByNames(PerunSession sess, Group group, List<String> attrsNames) throws InternalErrorException, PrivilegeException, GroupNotExistsException, AttributeNotExistsException;
+	List<RichMember> getRichMembersWithAttributesByNames(PerunSession sess, Group group, List<String> attrsNames) throws InternalErrorException, PrivilegeException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all RichMembers with attrs specific for list of attrsNames from the vo.
@@ -590,7 +591,7 @@ public interface MembersManager {
 	 * @throws AttributeNotExistsException
 	 * @throws VoNotExistsException
 	 */
-	List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, boolean lookingInParentGroup) throws InternalErrorException, PrivilegeException, VoNotExistsException, GroupNotExistsException, AttributeNotExistsException, ParentGroupNotExistsException;
+	List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, boolean lookingInParentGroup) throws InternalErrorException, PrivilegeException, VoNotExistsException, GroupNotExistsException, AttributeNotExistsException, ParentGroupNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all RichMembers with attrs specific for list of attrsNames from the group and have only
@@ -612,8 +613,9 @@ public interface MembersManager {
 	 * @throws GroupNotExistsException
 	 * @throws AttributeNotExistsException
 	 * @throws VoNotExistsException
+	 * @throws WrongAttributeAssignmentException
 	 */
-	List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, List<String> allowedStatuses, boolean lookingInParentGroup) throws InternalErrorException, PrivilegeException, VoNotExistsException, GroupNotExistsException, AttributeNotExistsException, ParentGroupNotExistsException;
+	List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, List<String> allowedStatuses, boolean lookingInParentGroup) throws InternalErrorException, PrivilegeException, VoNotExistsException, GroupNotExistsException, AttributeNotExistsException, ParentGroupNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all RichMembers with attributes specific for list of attrNames.
@@ -753,8 +755,9 @@ public interface MembersManager {
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 * @throws GroupNotExistsException
+	 * @throws WrongAttributeAssignmentException
 	 */
-	List<RichMember> getRichMembersWithAttributes(PerunSession sess, Group group, List<AttributeDefinition> attrsDef) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
+	List<RichMember> getRichMembersWithAttributes(PerunSession sess, Group group, List<AttributeDefinition> attrsDef) throws InternalErrorException, PrivilegeException, GroupNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all rich members of VO. Rich member object contains user, member, userExtSources.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -175,6 +175,26 @@ public interface AttributesManagerBl {
 	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
+	 * Gets selected <b>non-empty</b> attributes associated with the member, group and the resource.
+	 * It returns member, member-resource and member-group attributes and also user and user-facility attributes if
+	 * workWithUserAttributes is true.
+	 * Attributes are selected by list of attr_names. Empty list means all attributes.
+	 *
+	 * @param sess perun session
+	 * @param group group to get the attributes from
+	 * @param resource to get the attributes from
+	 * @param member to get the attributes from
+	 * @param workWithUserAttributes if true returns also user and user-facility attributes (user is automatically get from member a facility is get from resource)
+	 * @return list of selected attributes
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 *
+	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
+	 */
+	List<Attribute> getAttributes(PerunSession sess, Group group, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
 	 * Get all <b>non-empty</b> attributes associated with the member in the group.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -175,10 +175,10 @@ public interface AttributesManagerBl {
 	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
-	 * Gets selected <b>non-empty</b> attributes associated with the member, group and the resource.
+	 * Gets selected attributes associated with the member, group and the resource.
 	 * It returns member, member-resource and member-group attributes and also user and user-facility attributes if
 	 * workWithUserAttributes is true.
-	 * Attributes are selected by list of attr_names. Empty list means all attributes.
+	 * Attributes are selected by list of attr_names. Empty list means all <b>non-empty</b> attributes.
 	 *
 	 * @param sess perun session
 	 * @param group group to get the attributes from

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -164,7 +164,7 @@ public interface AttributesManagerBl {
 	 * @param sess perun session
 	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
-	 * @param workWithUserAttributes if true returns also user and user-facility attributes (user is automatically get from member a facility is get from resource)
+	 * @param workWithUserAttributes if true returns also user and user-facility attributes (user is automatically get from member and facility is get from resource)
 	 * @return list of selected attributes
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
@@ -184,7 +184,7 @@ public interface AttributesManagerBl {
 	 * @param group group to get the attributes from
 	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
-	 * @param workWithUserAttributes if true returns also user and user-facility attributes (user is automatically get from member a facility is get from resource)
+	 * @param workWithUserAttributes if true returns also user and user-facility attributes (user is automatically get from member and facility is get from resource)
 	 * @return list of selected attributes
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -883,7 +883,6 @@ public interface MembersManagerBl {
 	 */
 	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, List<RichMember> richMembers, Resource resource, List<AttributeDefinition> attrsDef)  throws InternalErrorException, WrongAttributeAssignmentException;
 
-
 	/**
 	 * Get the VO members count.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -576,8 +576,9 @@ public interface MembersManagerBl {
 	 * @throws InternalErrorException
 	 * @throws AttributeNotExistsException
 	 * @throws ParentGroupNotExistsException
+	 * @throws WrongAttributeAssignmentException
 	 */
-	List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, boolean lookingInParentGroup) throws InternalErrorException, AttributeNotExistsException, ParentGroupNotExistsException;
+	List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, boolean lookingInParentGroup) throws InternalErrorException, AttributeNotExistsException, ParentGroupNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all RichMembers with attributes specific for list of attrsNames from the group and have only
@@ -597,8 +598,9 @@ public interface MembersManagerBl {
 	 * @throws InternalErrorException
 	 * @throws AttributeNotExistsException
 	 * @throws ParentGroupNotExistsException
+	 * @throws WrongAttributeAssignmentException
 	 */
-	List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, List<String> allowedStatuses, boolean lookingInParentGroup) throws InternalErrorException, AttributeNotExistsException, ParentGroupNotExistsException;
+	List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, List<String> allowedStatuses, boolean lookingInParentGroup) throws InternalErrorException, AttributeNotExistsException, ParentGroupNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get all RichMembers with attributes specific for list of attrNames.
@@ -729,8 +731,9 @@ public interface MembersManagerBl {
 	 * @return list of RichMembers
 	 * @throws AttributeNotExistsException
 	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
 	 */
-	List<RichMember> getRichMembersWithAttributesByNames(PerunSession sess, Group group, List<String> attrsNames) throws InternalErrorException, AttributeNotExistsException;
+	List<RichMember> getRichMembersWithAttributesByNames(PerunSession sess, Group group, List<String> attrsNames) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get RichMembers with Attributes but only with selected attributes from list attrsDef for group.
@@ -757,8 +760,9 @@ public interface MembersManagerBl {
 	 * @param attrsDef
 	 * @return
 	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
 	 */
-	List<RichMember> getRichMembersWithAttributes(PerunSession sess, Group group, List<AttributeDefinition> attrsDef) throws InternalErrorException;
+	List<RichMember> getRichMembersWithAttributes(PerunSession sess, Group group, List<AttributeDefinition> attrsDef) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get rich members for displaying on pages. Rich member object contains user, member, userExtSources.
@@ -878,6 +882,7 @@ public interface MembersManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 */
 	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, List<RichMember> richMembers, Resource resource, List<AttributeDefinition> attrsDef)  throws InternalErrorException, WrongAttributeAssignmentException;
+
 
 	/**
 	 * Get the VO members count.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -259,6 +259,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				memberResourceAttributeNames.add(attributeName);
 			} else if(attributeName.startsWith(AttributesManager.NS_USER_FACILITY_ATTR)) {
 				userFacilityAttirbuteNames.add(attributeName);
+			} else if(attributeName.startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) {
+
 			} else {
 				log.error("Attribute defined by " + attributeName + " is not in supported namespace. Skip it there!");
 			}
@@ -274,6 +276,31 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			attributes.addAll(getAttributesManagerImpl().getAttributes(sess, user, facility, userFacilityAttirbuteNames));
 		}
 
+		return attributes;
+	}
+
+	public List<Attribute> getAttributes(PerunSession sess, Group group, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException {
+		List<Attribute> attributes = getAttributes(sess, resource, member, attrNames, workWithUserAttributes);
+
+		if(attrNames.isEmpty()) {
+			attributes.addAll(getAttributes(sess, member, group));
+			return attributes;
+		}
+
+		List<String> memberGroupAttributeNames = new ArrayList<>();
+
+		//possible inefficiency - additional iteration over attrNames
+		for(String attributeName: attrNames) {
+			if(attributeName.startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) {
+				memberGroupAttributeNames.add(attributeName);
+			} else if (!(attributeName.startsWith(AttributesManager.NS_USER_ATTR) || attributeName.startsWith(AttributesManager.NS_MEMBER_ATTR) || attributeName.startsWith (AttributesManager.NS_MEMBER_RESOURCE_ATTR) || attributeName.startsWith(AttributesManager.NS_USER_FACILITY_ATTR)))
+			{
+				log.error("Attribute defined by " + attributeName + " is not in supported namespace. Skip it there!");
+			}
+		}
+		if(!memberGroupAttributeNames.isEmpty()){
+			attributes.addAll(getAttributesManagerImpl().getAttributes(sess, member, group, memberGroupAttributeNames));
+		}
 		return attributes;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -259,8 +259,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				memberResourceAttributeNames.add(attributeName);
 			} else if(attributeName.startsWith(AttributesManager.NS_USER_FACILITY_ATTR)) {
 				userFacilityAttirbuteNames.add(attributeName);
-			} else if(attributeName.startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) {
-
 			} else {
 				log.error("Attribute defined by " + attributeName + " is not in supported namespace. Skip it there!");
 			}
@@ -289,13 +287,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		List<String> memberGroupAttributeNames = new ArrayList<>();
 
-		//possible inefficiency - additional iteration over attrNames
 		for(String attributeName: attrNames) {
 			if(attributeName.startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) {
 				memberGroupAttributeNames.add(attributeName);
-			} else if (!(attributeName.startsWith(AttributesManager.NS_USER_ATTR) || attributeName.startsWith(AttributesManager.NS_MEMBER_ATTR) || attributeName.startsWith (AttributesManager.NS_MEMBER_RESOURCE_ATTR) || attributeName.startsWith(AttributesManager.NS_USER_FACILITY_ATTR)))
-			{
-				log.error("Attribute defined by " + attributeName + " is not in supported namespace. Skip it there!");
 			}
 		}
 		if(!memberGroupAttributeNames.isEmpty()){

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -847,7 +847,16 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return getOnlyRichMembersWithAllowedStatuses(sess, this.convertMembersToRichMembersWithAttributes(sess, richMembers), allowedStatuses);
 	}
 
-
+	/**
+	 * Converts members to rich members.
+	 * Rich member object contains user, member, userExtSources, userAttributes, memberAttributes.
+	 * The method returns list of rich members with user and userExtSources filled. UserAttributes and memberAttributes are set to null.
+	 *
+	 * @param sess
+	 * @param members
+	 * @return list of rich members, empty list if empty list of members is passed
+	 * @throws InternalErrorException
+	 */
 	public List<RichMember> convertMembersToRichMembers(PerunSession sess, List<Member> members) throws InternalErrorException {
 		List<RichMember> richMembers = new ArrayList<RichMember>();
 
@@ -862,6 +871,15 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return richMembers;
 	}
 
+	/**
+	 * Adds userAttributes and memberAttributes to rich members.
+	 * The method returns list of rich members with userAttributes and memberAttributes filled.
+	 *
+	 * @param sess
+	 * @param richMembers
+	 * @return list of rich members with userAttributes and memberAttributes filled
+	 * @throws InternalErrorException
+	 */
 	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, List<RichMember> richMembers)  throws InternalErrorException {
 		for (RichMember richMember: richMembers) {
 			List<Attribute> userAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, richMember.getUser());
@@ -874,6 +892,20 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return richMembers;
 	}
 
+	/**
+	 * Adds userAttributes and memberAttributes to rich members.
+	 * Specifically adds attributes that are associated with the members and the resource. Attributes are also limited by the list of attributes definitions.
+	 * Adds member and member-resource attributes to memberAttributes and user and user-facility attributes to userAttributes.
+	 * The method returns list of rich members with userAttributes and memberAttributes filled.
+	 *
+	 * @param sess
+	 * @param richMembers
+	 * @param resource
+	 * @param attrsDef
+	 * @return list of rich members with userAttributes and memberAttributes filled
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
 	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, List<RichMember> richMembers, Resource resource, List<AttributeDefinition> attrsDef)  throws InternalErrorException, WrongAttributeAssignmentException {
 		List<String> attrNames = new ArrayList<>();
 		for(AttributeDefinition attributeDefinition: attrsDef) {
@@ -903,7 +935,21 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return richMembers;
 	}
 
-	// works with RESOURCE and GROUP
+	/**
+	 * Adds userAttributes and memberAttributes to rich members.
+	 * Specifically adds attributes that are associated with the members, the group and the resource. Attributes are also limited by the list of attributes definitions.
+	 * Adds member, member-group and member-resource attributes to memberAttributes and user and user-facility attributes to userAttributes.
+	 * The method returns list of rich members with userAttributes and memberAttributes filled.
+	 *
+	 * @param sess
+	 * @param group
+	 * @param resource
+	 * @param richMembers
+	 * @param attrsDef
+	 * @return list of rich members with userAttributes and memberAttributes filled
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
 	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, Group group, Resource resource, List<RichMember> richMembers, List<AttributeDefinition> attrsDef)  throws InternalErrorException, WrongAttributeAssignmentException {
 		List<String> attrNames = new ArrayList<>();
 		for(AttributeDefinition attributeDefinition: attrsDef) {
@@ -934,6 +980,17 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return richMembers;
 	}
 
+	/**
+	 * Adds userAttributes and memberAttributes to rich members.
+	 * Attributes are limited by the list of attributes definitions.
+	 * The method returns list of rich members with userAttributes and memberAttributes filled.
+	 *
+	 * @param sess
+	 * @param richMembers
+	 * @param attrsDef
+	 * @return list of rich members with userAttributes and memberAttributes filled
+	 * @throws InternalErrorException
+	 */
 	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, List<RichMember> richMembers, List<AttributeDefinition> attrsDef)  throws InternalErrorException {
 		List<AttributeDefinition> usersAttributesDef = new ArrayList<AttributeDefinition>();
 		List<AttributeDefinition> membersAttributesDef = new ArrayList<AttributeDefinition>();
@@ -966,16 +1023,29 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return richMembers;
 	}
 
-	//also adds group-member attributes
+
+	/**
+	 * Adds userAttributes and memberAttributes to rich members.
+	 * Specifically adds attributes that are associated with the members and the group. Attributes are also limited by the list of attributes definitions.
+	 * Adds member and member-group attributes to memberAttributes and user attributes to userAttributes.
+	 * The method returns list of rich members with userAttributes and memberAttributes filled.
+	 *
+	 * @param sess
+	 * @param group
+	 * @param richMembers
+	 * @param attrsDef
+	 * @return list of rich members with userAttributes and memberAttributes filled
+	 * @throws InternalErrorException
+	 */
 	public List<RichMember> convertMembersToRichMembersWithAttributes(PerunSession sess, Group group, List<RichMember> richMembers, List<AttributeDefinition> attrsDef)  throws InternalErrorException, WrongAttributeAssignmentException {
 		List<AttributeDefinition> usersAttributesDef = new ArrayList<AttributeDefinition>();
 		List<AttributeDefinition> membersAttributesDef = new ArrayList<AttributeDefinition>();
-		List<AttributeDefinition> groupAttributesDef = new ArrayList<AttributeDefinition>();
+		List<AttributeDefinition> memberGroupAttributesDef = new ArrayList<AttributeDefinition>();
 
 		for(AttributeDefinition attrd: attrsDef) {
 			if(attrd.getName().startsWith(AttributesManager.NS_USER_ATTR)) usersAttributesDef.add(attrd);
 			else if(attrd.getName().startsWith(AttributesManager.NS_MEMBER_ATTR)) membersAttributesDef.add(attrd);
-			else if(attrd.getName().startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) groupAttributesDef.add(attrd);
+			else if(attrd.getName().startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) memberGroupAttributesDef.add(attrd);
 		}
 
 		for (RichMember richMember: richMembers) {
@@ -996,7 +1066,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 			//add group-member attributes
 			List<String> groupAttrNames = new ArrayList<String>();
-			for(AttributeDefinition ad: groupAttributesDef) {
+			for(AttributeDefinition ad: memberGroupAttributesDef) {
 				groupAttrNames.add(ad.getName());
 			}
 			memberAttributes.addAll(getPerunBl().getAttributesManagerBl().getAttributes(sess, richMember, group, groupAttrNames));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -780,7 +780,6 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		return richMembersWithAttributes;
 	}
 
-
 	public List<RichMember> getRichMembersWithAttributesByNames(PerunSession sess, Group group, Resource resource, List<String> attrsNames) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException {
 		List<Member> members = new ArrayList<Member>();
 		members.addAll(perunBl.getGroupsManagerBl().getGroupMembers(sess, group));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -488,7 +488,7 @@ public class MembersManagerEntry implements MembersManager {
 		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, vo, attrsNames, allowedStatuses), true);
 	}
 
-	public List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, boolean lookingInParentGroup) throws InternalErrorException, PrivilegeException, ParentGroupNotExistsException, GroupNotExistsException, VoNotExistsException, AttributeNotExistsException {
+	public List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, boolean lookingInParentGroup) throws InternalErrorException, PrivilegeException, ParentGroupNotExistsException, GroupNotExistsException, VoNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
@@ -519,7 +519,7 @@ public class MembersManagerEntry implements MembersManager {
 		return getMembersManagerBl().getCompleteRichMembers(sess, group, resource, attrsNames, allowedStatuses);
 	}
 
-	public List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, List<String> allowedStatuses, boolean lookingInParentGroup) throws InternalErrorException, PrivilegeException, ParentGroupNotExistsException, GroupNotExistsException, VoNotExistsException, AttributeNotExistsException {
+	public List<RichMember> getCompleteRichMembers(PerunSession sess, Group group, List<String> attrsNames, List<String> allowedStatuses, boolean lookingInParentGroup) throws InternalErrorException, PrivilegeException, ParentGroupNotExistsException, GroupNotExistsException, VoNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
@@ -634,7 +634,7 @@ public class MembersManagerEntry implements MembersManager {
 		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, group, attrsNames, allowedStatuses, searchString, lookingInParentGroup), true);
 	}
 
-	public List<RichMember> getRichMembersWithAttributesByNames(PerunSession sess, Group group, List<String> attrsNames) throws InternalErrorException, PrivilegeException, GroupNotExistsException, AttributeNotExistsException {
+	public List<RichMember> getRichMembersWithAttributesByNames(PerunSession sess, Group group, List<String> attrsNames) throws InternalErrorException, PrivilegeException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);
@@ -649,7 +649,7 @@ public class MembersManagerEntry implements MembersManager {
 		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributesByNames(sess, group, attrsNames), true);
 	}
 
-	public List<RichMember> getRichMembersWithAttributes(PerunSession sess, Group group, List<AttributeDefinition> attrsDef) throws InternalErrorException, PrivilegeException, GroupNotExistsException {
+	public List<RichMember> getRichMembersWithAttributes(PerunSession sess, Group group, List<AttributeDefinition> attrsDef) throws InternalErrorException, PrivilegeException, GroupNotExistsException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 
 		perunBl.getGroupsManagerBl().checkGroupExists(sess, group);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -214,6 +214,53 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	}
 
 	@Test
+	public void getRichMembersWithAttributesByNames() throws Exception {
+		System.out.println(CLASS_NAME + "getRichMembersWithAttributesByNames");
+
+		User user = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+		Facility facility = new Facility(0, "TESTING Facility", "TESTING Facility");
+		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
+		Resource resource = new Resource(0, "TESTING Resource", "TESTING Resource", facility.getId(), createdVo.getId());
+		resource = perun.getResourcesManagerBl().createResource(sess, resource, createdVo, facility);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, createdGroup, resource);
+		perun.getGroupsManagerBl().addMember(sess, createdGroup, createdMember);
+
+		Attribute userAttribute1 = setUpAttribute(String.class.getName(), "testUserAttribute1", AttributesManager.NS_USER_ATTR_DEF, "TEST VALUE");
+		Attribute userAttribute2 = setUpAttribute(String.class.getName(), "testUserAttribute2", AttributesManager.NS_USER_ATTR_DEF, "TEST VALUE");
+		perun.getAttributesManagerBl().setAttributes(sess, user, new ArrayList<>(Arrays.asList(userAttribute1, userAttribute1)));
+		Attribute memberAttribute1 = setUpAttribute(Integer.class.getName(), "testMemberAttribute1", AttributesManager.NS_MEMBER_ATTR_DEF, 15);
+		perun.getAttributesManagerBl().setAttributes(sess, createdMember, new ArrayList<>(Arrays.asList(memberAttribute1)));
+		Attribute userFacilityAttribute1 = setUpAttribute(ArrayList.class.getName(), "testUserFacilityAttribute1", AttributesManager.NS_USER_FACILITY_ATTR_DEF, new ArrayList<>(Arrays.asList("A", "B")));
+		perun.getAttributesManagerBl().setAttributes(sess, facility, user, new ArrayList<>(Arrays.asList(userFacilityAttribute1)));
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("A", "B");
+		map.put("C", "D");
+		Attribute memberResourceAttribute1 = setUpAttribute(LinkedHashMap.class.getName(), "testMemberResourceAttribute1", AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF, map);
+		//test of member-group attributes
+		perun.getAttributesManagerBl().setAttributes(sess, resource, createdMember, new ArrayList<>(Arrays.asList(memberResourceAttribute1)));
+		Map<String, String> groupMap = new LinkedHashMap<>();
+		groupMap.put("E", "F");
+		groupMap.put("G", "H");
+		Attribute memberGroupAttribute1 = setUpAttribute(LinkedHashMap.class.getName(), "testMemberGroupAttribute1", AttributesManager.NS_MEMBER_GROUP_ATTR_DEF, groupMap);
+		perun.getAttributesManagerBl().setAttributes(sess, createdMember, createdGroup, new ArrayList<>(Arrays.asList(memberGroupAttribute1)));
+
+		List<String> attrNames = new ArrayList<>(Arrays.asList(userAttribute1.getName(), memberAttribute1.getName(), userFacilityAttribute1.getName(), memberResourceAttribute1.getName(), memberGroupAttribute1.getName()));
+		List<RichMember> richMembers = perun.getMembersManagerBl().getRichMembersWithAttributesByNames(sess, createdGroup, resource, attrNames);
+
+		List<Attribute> userAttributes = richMembers.get(0).getUserAttributes();
+		List<Attribute> memberAttributes = richMembers.get(0).getMemberAttributes();
+
+		assertTrue(richMembers.size() == 1);
+		assertTrue(userAttributes.size() == 2);
+		assertTrue(memberAttributes.size() == 3);
+		assertTrue(userAttributes.contains(userAttribute1));
+		assertTrue(userAttributes.contains(userFacilityAttribute1));
+		assertTrue(memberAttributes.contains(memberAttribute1));
+		assertTrue(memberAttributes.contains(memberResourceAttribute1));
+		assertTrue(memberAttributes.contains(memberGroupAttribute1));
+	}
+
+	@Test
 	public void findCompleteRichMembers() throws Exception {
 		System.out.println(CLASS_NAME + "findCompleteRichMembers");
 


### PR DESCRIPTION
Cherry-picked changes by @zdenek-strm:

Updated two overloaded methods convertMembersToRichMembersWithAttributes, so they will work with member-group attributes.

The goal is to enable the methods listed below (that call the convertMembersToRichMembersWithAttributes) work with member group attributes:

getRichMembersWithAttributesByNames(PerunSession sess, Group group, Resource resource, List attrsNames)
getRichMembersWithAttributesByNames(PerunSession sess, Group group, List attrsNames)
getRichMembersWithAttributes(PerunSession sess, Group group, List attrsDef)