### PR TITLE
CORE: Extend correct class in res:def:vomsRoles attribute module

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_vomsRoles.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_vomsRoles.java
@@ -9,8 +9,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
  *
  * @author Vojtech Sassmann &lt;vojtech.sassmann@gmail.com&gt;
  */
-public class urn_perun_resource_attribute_def_def_vomsRoles extends ResourceVirtualAttributesModuleAbstract implements ResourceVirtualAttributesModuleImplApi {
+public class urn_perun_resource_attribute_def_def_vomsRoles extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private final Pattern pattern = Pattern.compile("^[^<>&]*$");
 


### PR DESCRIPTION
- It would probably work, but since attribute is not "virtual", we shouldn't
  extend ResourceVirtualAttributesModuleAbstract but rather
  ResourceAttributesModuleAbstract, same goes for interface class.