### PR TITLE
RPC: Store Shib-Identity-Provider param to "originIdentityProvider"

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -197,6 +197,11 @@ public class Api extends HttpServlet {
 				// Remove scope from the eppn attribute
 				additionalInformations.put("eppnwoscope", StringUtils.substringBefore(eppn, "@"));
 			}
+
+			// Store IdP used by user to session, since for IdentityConsolidator and Registrar we need to know,
+			// if user logged in through proxy or not - we provide different links etc.
+			additionalInformations.put("originIdentityProvider", shibIdentityProvider);
+
 			if (isNotEmpty(remoteUser)) {
 				extLogin = remoteUser;
 			}


### PR DESCRIPTION
- When perun is accessed using proxyIdP, we store only source IdP.
  For purpose of identity consolidation and proper links offering
  on registration page (where similar users are found) we need to know,
  if user used proxy or not. If proxy is in use, we need to send user through
  proxy again, if not, use original IdPs.