### PR TITLE
Change behavior of threading for synchronization of groups

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -32,6 +32,7 @@ public class CoreConfig {
 	private boolean readOnlyPerun;
 	private int groupSynchronizationInterval;
 	private int groupSynchronizationTimeout;
+	private int groupMaxConcurentGroupsToSynchronize;
 	private int mailchangeValidationWindow;
 	private int pwdresetValidationWindow;
 	private List<String> admins;
@@ -60,6 +61,15 @@ public class CoreConfig {
 	private String rtUrl;
 	private String smsProgram;
 	private String userExtSourcesPersistent;
+
+	public int getGroupMaxConcurentGroupsToSynchronize() {
+		return groupMaxConcurentGroupsToSynchronize;
+	}
+
+	public void setGroupMaxConcurentGroupsToSynchronize(int groupMaxConcurentGroupsToSynchronize) {
+		this.groupMaxConcurentGroupsToSynchronize = groupMaxConcurentGroupsToSynchronize;
+	}
+
 	private Map<String, List<AttributeDefinition>> attributesForUpdate = new HashMap<>();
 	private Map<String, String> oidcIssuersExtsourceNames = new HashMap<>();
 	private Map<String, String> oidcIssuersExtsourceTypes = new HashMap<>();

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunBeanProcessingPool.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunBeanProcessingPool.java
@@ -1,0 +1,197 @@
+package cz.metacentrum.perun.core.api;
+
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Processing pool for processing PerunBeans as jobs.
+ *
+ * This implementation is thread-safe.
+ *
+ * You can put new waiting jobs in it and take waiting jobs to set them as running,
+ * and then remove them after work with them is finished.
+ * Jobs in processing pool are unique and can't be added if they are already
+ * in list of waiting jobs or in set of running jobs.
+ * New waiting job can skip order and be putted as first in the list of waiting jobs.
+ *
+ * Note: this class doesn't run any task scheduler, it just provides structures and functionality to manipulate
+ * with these structures used for processing job from the pool of waiting jobs.
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
+public class PerunBeanProcessingPool<T extends PerunBean> {
+
+	//List of waiting jobs (they should be process as soon as possible), there is FIFO order
+	private final LinkedList<T> waitingJobs = new LinkedList<>();
+	//Set of already running jobs (we need to track them until they are finished)
+	private final HashSet<T> runningJobs = new HashSet<>();
+	//Semaphore which takes care about emptiness of list of waiting jobs (threads will wait for another job)
+	//Counter in this semaphore counts number of waiting jobs in the pool (0 means no jobs are waiting to be processed)
+	private final Semaphore notEmptyPoolSemaphore = new Semaphore(0, true);
+	//Access lock to create concurrent access by any operation to any structure of this processing pool
+	private final Lock jobsAccessLock = new ReentrantLock(true);
+
+	/**
+	 * Put new unique job to the list of waiting jobs.
+	 *
+	 * If job is already running, return false because there would be no change.
+	 * If job is already waiting, check if asFirst is true. If yes, move it (remove and add) to
+	 * the first place and return true. If not, return false.
+	 * If there is no such job, add it and return true.
+	 *
+	 * Uniqueness of the job in pool is mandatory and it is no difference between waiting and running status of job in
+	 * this case.
+	 *
+	 * @param job perunBean object which defines job
+	 * @param asFirst true if job will skip order and will be placed to the list as first (LIFO)
+	 *
+	 * @return true if unique job was added or job was added to the beginning of the queue (asFirst is true), false if job exists and
+	 * was not added to the beginning of the queue (asFirst is false) or it is already running
+	 *
+	 * @throws InternalErrorException if job in parameter is null
+	 */
+	public boolean putJobIfAbsent(T job, boolean asFirst) throws InternalErrorException {
+		if(job == null) throw new InternalErrorException("Can't put null job to list of waiting jobs.");
+
+		try {
+			//get lock for any operation with structures of jobs
+			jobsAccessLock.lock();
+
+			//put only jobs which are not running yet
+			if (runningJobs.contains(job)) return false;
+
+			//If the job is already in waiting queue, we don't have to plan it again unless we want to move it
+			// to the begging of the queue which is indicated by asFirst variable.
+			if (waitingJobs.contains(job)) {
+				if (!asFirst) {
+					return false;
+				} else {
+					//remove it from the waiting queue before putting it back as first waiting job
+					waitingJobs.remove(job);
+				}
+			}
+
+			//add it as first or at last defined by parameter of method
+			if (asFirst) {
+				waitingJobs.addFirst(job);
+			} else {
+				waitingJobs.addLast(job);
+			}
+
+			//increase number of waiting jobs by one
+			notEmptyPoolSemaphore.release();
+
+		} finally {
+			//unlock access lock
+			jobsAccessLock.unlock();
+		}
+
+		//return true (new waiting job in list of waiting jobs)
+		return true;
+	}
+
+	/**
+	 * Take job from list of waiting jobs and add it to the list of running jobs.
+	 *
+	 * @return first waiting job from the list of waiting jobs
+	 *
+	 * @throws InterruptedException if acquiring of permit on semaphore was interrupted
+	 */
+	public T takeJob() throws InterruptedException {
+		//I can take only if there is not empty list of waiting jobs
+		notEmptyPoolSemaphore.acquire();
+
+		T job;
+		try {
+			//If there is at least one job in the list of waiting jobs, get access to manipulate with it
+			jobsAccessLock.lock();
+
+			//We should always get not null job, because semaphore pool was not empty
+			job = waitingJobs.pollFirst();
+
+			runningJobs.add(job);
+		} finally {
+			//unlock access lock
+			jobsAccessLock.unlock();
+
+		}
+
+		return job;
+	}
+
+	/**
+	 * Remove jobs from set of running jobs. It means that we are done with this job.
+	 *
+	 * @param job perunBean object which defines job
+	 *
+	 * @return true if removing was successful, false if not (structure not contained the job)
+	 */
+	public boolean removeJob(T job) {
+		//Can't remove null job
+		if (job == null) return false;
+
+		boolean removedSuccessfully;
+		try {
+			//get lock for any operation with structures of jobs
+			jobsAccessLock.lock();
+
+			//try to remove running job (because it should be done)
+			removedSuccessfully = runningJobs.remove(job);
+		} finally {
+			//in any case unlock access lock
+			jobsAccessLock.unlock();
+		}
+
+		return removedSuccessfully;
+	}
+
+	/**
+	 * Get set of running jobs at this moment.
+	 *
+	 * @return set of running jobs at this moment
+	 */
+	public Set<T> getRunningJobs() {
+		Set<T> runningJobs;
+		try {
+			//get lock for any operation with structures of jobs
+			jobsAccessLock.lock();
+
+			runningJobs = Collections.unmodifiableSet(this.runningJobs);
+
+		} finally {
+			//in any case unlock access lock
+			jobsAccessLock.unlock();
+		}
+
+		return runningJobs;
+	}
+
+	/**
+	 * Get ordered list of waiting jobs at this moment.
+	 *
+	 * @return ordered list of waiting jobs at this moment
+	 */
+	public List<T> getWaitingJobs() {
+		List<T> waitingJobs;
+		try {
+			//get lock for any operation with structures of jobs
+			jobsAccessLock.lock();
+
+			waitingJobs = Collections.unmodifiableList(this.waitingJobs);
+		} finally {
+			//in any case unlock access lock
+			jobsAccessLock.unlock();
+		}
+
+		return waitingJobs;
+	}
+}

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -18,6 +18,7 @@
 		<property name="generatedLoginNamespaces" value="#{'${perun.loginNamespace.generated}'.split('\s*,\s*')}"/>
 		<property name="groupSynchronizationInterval" value="${perun.group.synchronization.interval}"/>
 		<property name="groupSynchronizationTimeout" value="${perun.group.synchronization.timeout}"/>
+		<property name="groupMaxConcurentGroupsToSynchronize" value="${perun.group.maxConcurentGroupsToSynchronize}"/>
 		<property name="instanceId" value="${perun.instanceId}"/>
 		<property name="instanceName" value="${perun.instanceName}"/>
 		<property name="mailchangeBackupFrom" value="${perun.mailchange.backupFrom}"/>
@@ -71,6 +72,7 @@
 				<prop key="perun.db.type">hsqldb</prop>
 				<prop key="perun.group.synchronization.interval">1</prop>
 				<prop key="perun.group.synchronization.timeout">10</prop>
+				<prop key="perun.group.maxConcurentGroupsToSynchronize">10</prop>
 				<prop key="perun.rpc.powerusers"/>
 				<prop key="perun.perun.db.name">perun</prop>
 				<prop key="perun.rt.url">https://rt3.cesnet.cz/rt/REST/1.0/ticket/new</prop>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -9,12 +9,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.TreeMap;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
-import cz.metacentrum.perun.core.api.exceptions.rt.WrongAttributeAssignmentRuntimeException;
+import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,8 +42,9 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 	private final GroupsManagerImplApi groupsManagerImpl;
 	private PerunBl perunBl;
-
-	private Map<Integer, GroupSynchronizerThread> groupSynchronizerThreads;
+	private Integer maxConcurentGroupsToSynchronize;
+	private final PerunBeanProcessingPool<Group> poolOfGroupsToBeSynchronized;
+	private final ArrayList<GroupSynchronizerThread> groupSynchronizerThreads;
 	private static final String A_G_D_AUTHORITATIVE_GROUP = AttributesManager.NS_GROUP_ATTR_DEF + ":authoritativeGroup";
 
 	/**
@@ -53,7 +53,10 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 */
 	public GroupsManagerBlImpl(GroupsManagerImplApi groupsManagerImpl) {
 		this.groupsManagerImpl = groupsManagerImpl;
-		this.groupSynchronizerThreads = new HashMap<Integer, GroupSynchronizerThread>();
+		this.groupSynchronizerThreads = new ArrayList<>();
+		this.poolOfGroupsToBeSynchronized = new PerunBeanProcessingPool<>();
+		//set maximum concurrent groups to synchronize by property
+		this.maxConcurentGroupsToSynchronize = BeansUtils.getCoreConfig().getGroupMaxConcurentGroupsToSynchronize();
 	}
 
 	public Group createGroup(PerunSession sess, Vo vo, Group group) throws GroupExistsException, InternalErrorException {
@@ -1251,77 +1254,91 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	/**
-	 * Force group synchronization.
+	 * Adds the group on the first place to the queue of groups waiting for synchronization.
 	 *
-	 * Adds the group synchronization process in the groupSynchronizerThreads.
+	 * @param group the group to be forced this way
 	 *
-	 * @param group
+	 * @throws GroupSynchronizationAlreadyRunningException when group synchronization is already running at this moment
 	 */
-	public void forceGroupSynchronization(PerunSession sess, Group group) throws GroupSynchronizationAlreadyRunningException {
-		// First check if the group is not currently in synchronization process
-		if (groupSynchronizerThreads.containsKey(group.getId()) && groupSynchronizerThreads.get(group.getId()).getState() != Thread.State.TERMINATED) {
-			throw new GroupSynchronizationAlreadyRunningException(group);
+	public void forceGroupSynchronization(PerunSession sess, Group group) throws GroupSynchronizationAlreadyRunningException, InternalErrorException {
+		//Check if the group is not currently in synchronization process
+		if(poolOfGroupsToBeSynchronized.putJobIfAbsent(group, true)) {
+			log.info("Scheduling synchronization for the group {} by force!", group);
 		} else {
-			// Remove from groupSynchronizerThreads if the thread was terminated
-			if (groupSynchronizerThreads.containsKey(group.getId())) {
-				groupSynchronizerThreads.remove(group.getId());
-			}
-			// Start and run the new thread
-			GroupSynchronizerThread thread = new GroupSynchronizerThread(sess, group);
-			thread.start();
-			log.info("Group synchronization thread started for group {}.", group);
-
-			groupSynchronizerThreads.put(group.getId(), thread);
+			throw new GroupSynchronizationAlreadyRunningException(group);
 		}
 	}
 
 	/**
-	 * Synchronize all groups which have enabled synchronization. This method is run by the scheduler every 5 minutes.
+	 * Start and check threads with synchronization of groups. (max threads is defined by constant)
+	 * It also add new groups to the queue.
+	 * This method is run by the scheduler every 5 minutes.
+	 *
+	 * Note: this method is synchronized
 	 *
 	 * @throws InternalErrorException
 	 */
-	public void synchronizeGroups(PerunSession sess) throws InternalErrorException {
-		Random rand = new Random();
-
-		// Firstly remove all terminated threads
-		List<Integer> threadsToRemove = new ArrayList<Integer>();
-		for (Integer groupId: groupSynchronizerThreads.keySet()) {
-			if (groupSynchronizerThreads.get(groupId).getState() == Thread.State.TERMINATED) {
-				threadsToRemove.add(groupId);
-			}
-		}
-		for (Integer groupId: threadsToRemove) {
-			groupSynchronizerThreads.remove(groupId);
-			log.debug("Removing terminated group synchronization thread for group id={}", groupId);
-		}
-
+	public synchronized void synchronizeGroups(PerunSession sess) throws InternalErrorException {
 		// Get the default synchronization interval and synchronization timeout from the configuration file
-		int intervalMultiplier = BeansUtils.getCoreConfig().getGroupSynchronizationInterval();
 		int timeout = BeansUtils.getCoreConfig().getGroupSynchronizationTimeout();
-
+		int defaultIntervalMultiplier = BeansUtils.getCoreConfig().getGroupSynchronizationInterval();
 		// Get the number of seconds from the epoch, so we can divide it by the synchronization interval value
 		long minutesFromEpoch = System.currentTimeMillis()/1000/60;
+
+		int numberOfNewlyRemovedThreads = 0;
+		// Firstly interrupt threads after timeout, then remove all interrupted threads
+		Iterator<GroupSynchronizerThread> threadIterator = groupSynchronizerThreads.iterator();
+		while(threadIterator.hasNext()) {
+			GroupSynchronizerThread thread = threadIterator.next();
+			long threadStart = thread.getStartTime();
+			//If thread start time is 0, this thread is waiting for another job, skip it
+			if(threadStart == 0) continue;
+
+			long timeDiff = System.currentTimeMillis() - threadStart;
+			//If thread was interrupted by anything, remove it from the pool of active threads
+			if (thread.isInterrupted()) {
+				numberOfNewlyRemovedThreads++;
+				threadIterator.remove();
+			} else if(timeDiff/1000/60 > timeout) {
+				// If the time is greater than timeout set in the configuration file (in minutes), interrupt and remove this thread from pool
+				log.error("One of threads was interrupted because of timeout!");
+				thread.interrupt();
+				threadIterator.remove();
+				numberOfNewlyRemovedThreads++;
+			}
+		}
+
+		int numberOfNewlyCreatedThreads = 0;
+		// Start new threads if there is place for them
+		while(groupSynchronizerThreads.size() < maxConcurentGroupsToSynchronize) {
+			GroupSynchronizerThread thread = new GroupSynchronizerThread(sess);
+			thread.start();
+			groupSynchronizerThreads.add(thread);
+			numberOfNewlyCreatedThreads++;
+			log.debug("New thread for synchronization started.");
+		}
 
 		// Get the groups with synchronization enabled
 		List<Group> groups = groupsManagerImpl.getGroupsToSynchronize(sess);
 
-		int numberOfNewSynchronizations = 0;
-		int numberOfActiveSynchronizations = 0;
-		int numberOfTerminatedSynchronizations = 0;
+		int numberOfNewlyAddedGroups = 0;
 		for (Group group: groups) {
-			// Get the synchronization interval
+			// Get the synchronization interval for the group
+			int intervalMultiplier;
 			try {
 				Attribute intervalAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
 				if (intervalAttribute.getValue() != null) {
 					intervalMultiplier = Integer.parseInt((String) intervalAttribute.getValue());
 				} else {
+					intervalMultiplier = defaultIntervalMultiplier;
 					log.warn("Group {} hasn't set synchronization interval, using default {} seconds", group, intervalMultiplier);
 				}
 			} catch (AttributeNotExistsException e) {
-				throw new ConsistencyErrorException("Required attribute " + GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME + " isn't defined in Perun!",e);
+				log.error("Required attribute {} isn't defined in Perun! Using default value from properties instead!", GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
+				intervalMultiplier = defaultIntervalMultiplier;
 			} catch (WrongAttributeAssignmentException e) {
-				log.error("Cannot synchronize group " + group +" due to exception:", e);
-				continue;
+				log.error("Cannot get attribute " + GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME + " for group " + group + " due to exception. Using default value from properties instead!",e);
+				intervalMultiplier = defaultIntervalMultiplier;
 			}
 
 			// Multiply with 5 to get real minutes
@@ -1329,126 +1346,123 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 			// If the minutesFromEpoch can be divided by the intervalMultiplier, then synchronize
 			if ((minutesFromEpoch % intervalMultiplier) == 0) {
-				// It's time to synchronize
-				log.info("Scheduling synchronization for the group {}. Interval {} minutes.", group, intervalMultiplier);
-
-				// Run each synchronization in separate thread, but do not start new one, if previous hasn't finished yet
-				if (groupSynchronizerThreads.containsKey(group.getId())) {
-					// Check the running time of the thread
-					long timeDiff = System.currentTimeMillis() - groupSynchronizerThreads.get(group.getId()).getStartTime();
-
-					// If the time is greater than timeout set in the configuration file (in minutes)
-					if (timeDiff/1000/60 > timeout) {
-						// Timeout reach, stop the thread
-						log.warn("Timeout {} minutes of the synchronization thread for the group {} reached.", timeout, group);
-						groupSynchronizerThreads.get(group.getId()).interrupt();
-						groupSynchronizerThreads.remove(group.getId());
-						numberOfTerminatedSynchronizations++;
-					} else {
-						numberOfActiveSynchronizations++;
-					}
+				if (poolOfGroupsToBeSynchronized.putJobIfAbsent(group, false)) {
+					numberOfNewlyAddedGroups++;
+					log.info("Group {} was added to the pool of groups waiting for synchronization.", group);
 				} else {
-					// Start and run the new thread
-					try {
-						// Do not overload externalSource, run each synchronization in 0-30s steps
-						Thread.sleep(rand.nextInt(30000));
-					} catch (InterruptedException e) {
-						// Do nothing
-					}
-					GroupSynchronizerThread thread = new GroupSynchronizerThread(sess, group);
-					thread.start();
-					log.info("Group synchronization thread started for group {}.", group);
-
-					groupSynchronizerThreads.put(group.getId(), thread);
-					numberOfNewSynchronizations++;
+					log.info("Group {} synchronzation is already running.", group);
 				}
 			}
 		}
 
-		if (groups.size() > 0) {
-			log.info("Synchronizing {} groups, active {}, new {}, terminated {}.",
-					new Object[] {groups.size(), numberOfActiveSynchronizations, numberOfNewSynchronizations, numberOfTerminatedSynchronizations});
-		}
+		// Save state of synchronization to the info log
+		log.info("SynchronizeGroups method ends with these states: " +
+				"'number of newly removed threads'='" + numberOfNewlyRemovedThreads + "', " +
+				"'number of newly created threads'='" + numberOfNewlyCreatedThreads + "', " +
+				"'number of newly added groups to the pool'='" + numberOfNewlyAddedGroups + "', " +
+				"'right now synchronized groups'='" + poolOfGroupsToBeSynchronized.getRunningJobs() + "', " +
+				"'right now waiting groups'='" + poolOfGroupsToBeSynchronized.getWaitingJobs() + "'.");
 	}
 
-	private static class GroupSynchronizerThread extends Thread {
+	private class GroupSynchronizerThread extends Thread {
 
 		// all synchronization runs under synchronizer identity.
-		final PerunPrincipal pp = new PerunPrincipal("perunSynchronizer", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
-		private PerunBl perunBl;
-		private PerunSession sess;
-		private Group group;
-		private long startTime;
+		private final PerunPrincipal pp = new PerunPrincipal("perunSynchronizer", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
+		private final PerunBl perunBl;
+		private final PerunSession sess;
+		private volatile long startTime;
 
-		public GroupSynchronizerThread(PerunSession sess, Group group) {
+		public GroupSynchronizerThread(PerunSession sess) throws InternalErrorException {
 			// take only reference to perun
 			this.perunBl = (PerunBl) sess.getPerun();
-			this.group = group;
-			try {
-				// create own session
-				this.sess = perunBl.getPerunSession(pp, new PerunClient());
-			} catch (InternalErrorException ex) {
-				log.error("Unable to create internal session for Synchronizer with credentials {} because of exception {}", pp, ex);
-			}
+			this.sess = perunBl.getPerunSession(pp, new PerunClient());
+			//Default settings of not running thread (waiting for another group)
+			this.startTime = 0;
 		}
 
 		public void run() {
-			//text of exception if was thrown, null in exceptionMessage means "no exception, it's ok"
-			String exceptionMessage = null;
-			//text with all skipped members and reasons of this skipping
-			String skippedMembersMessage = null;
-			//if exception which produce fail of whole synchronization was thrown
-			boolean failedDueToException = false;
+			while (true) {
+				//Set thread to default state (waiting for another group to synchronize)
+				this.setThreadToDefaultState();
 
-			try {
-				log.debug("Synchronization thread for group {} has started.", group);
-				// Set the start time, so we can check the timeout of the thread
-				startTime = System.currentTimeMillis();
+				//If this thread was interrupted, end it's running
+				if(this.isInterrupted()) return;
 
-				//synchronize Group and get information about skipped Members
-				List<String> skippedMembers = perunBl.getGroupsManagerBl().synchronizeGroup(sess, group);
+				//text of exception if was thrown, null in exceptionMessage means "no exception, it's ok"
+				String exceptionMessage = null;
+				//text with all skipped members and reasons of this skipping
+				String skippedMembersMessage = null;
+				//if exception which produce fail of whole synchronization was thrown
+				boolean failedDueToException = false;
 
-				if(!skippedMembers.isEmpty()) {
-					skippedMembersMessage = "These members from extSource were skipped: { ";
-
-					for(String skippedMember: skippedMembers) {
-						if(skippedMember == null) continue;
-
-						skippedMembersMessage+= skippedMember + ", ";
-					}
-					skippedMembersMessage+= " }";
-					exceptionMessage = skippedMembersMessage;
-				}
-
-				log.debug("Synchronization thread for group {} has finished in {} ms.", group, System.currentTimeMillis()-startTime);
-			} catch (WrongAttributeValueException | WrongReferenceAttributeValueException | InternalErrorException |
-					WrongAttributeAssignmentException  | GroupNotExistsException |
-					AttributeNotExistsException  | ExtSourceNotExistsException e) {
-				failedDueToException = true;
-				exceptionMessage = "Cannot synchronize group ";
-				log.error(exceptionMessage + group, e);
-				exceptionMessage+= "due to exception: " + e.getName() + " => " + e.getMessage();
-			} catch (Exception e) {
-				//If some other exception has been thrown, log it and throw again
-				failedDueToException = true;
-				exceptionMessage = "Cannot synchronize group ";
-				log.error(exceptionMessage + group, e);
-				exceptionMessage+= "due to unexpected exception: " + e.getClass().getName() + " => " + e.getMessage();
-				throw e;
-			} finally {
-				//Save information about group synchronization, this method run in new transaction
+				//Take another group from the pool to synchronize it
+				Group group = null;
 				try {
-					perunBl.getGroupsManagerBl().saveInformationAboutGroupSynchronization(sess, group, failedDueToException, exceptionMessage);
-				} catch (Exception ex) {
-					log.error("When synchronization group " + group + ", exception was thrown.", ex);
-					log.info("Info about exception from synchronization: " + skippedMembersMessage);
+					group = poolOfGroupsToBeSynchronized.takeJob();
+				} catch (InterruptedException ex) {
+					log.error("Thread was interrupted when trying to take another group to synchronize from pool", ex);
+					//Interrupt this thread
+					this.interrupt();
+					return;
 				}
-				log.debug("GroupSynchronizerThread finished for group: {}", group);
+
+				try {
+					// Set the start time, so we can check the timeout of the thread
+					startTime = System.currentTimeMillis();
+
+					log.debug("Synchronization thread started synchronization for group {}.", group);
+
+					//synchronize Group and get information about skipped Members
+					List<String> skippedMembers = perunBl.getGroupsManagerBl().synchronizeGroup(sess, group);
+
+					if (!skippedMembers.isEmpty()) {
+						skippedMembersMessage = "These members from extSource were skipped: { ";
+
+						for (String skippedMember : skippedMembers) {
+							if (skippedMember == null) continue;
+
+							skippedMembersMessage += skippedMember + ", ";
+						}
+						skippedMembersMessage += " }";
+						exceptionMessage = skippedMembersMessage;
+					}
+					log.debug("Synchronization thread for group {} has finished in {} ms.", group, System.currentTimeMillis() - startTime);
+				} catch (WrongAttributeValueException | WrongReferenceAttributeValueException | InternalErrorException |
+						WrongAttributeAssignmentException  | GroupNotExistsException |
+						AttributeNotExistsException  | ExtSourceNotExistsException e) {
+					failedDueToException = true;
+					exceptionMessage = "Cannot synchronize group ";
+					log.error(exceptionMessage + group, e);
+					exceptionMessage += "due to exception: " + e.getName() + " => " + e.getMessage();
+				} catch (Exception e) {
+					failedDueToException = true;
+					exceptionMessage = "Cannot synchronize group ";
+					log.error(exceptionMessage + group, e);
+					exceptionMessage += "due to unexpected exception: " + e.getClass().getName() + " => " + e.getMessage();
+				} finally {
+					//Save information about group synchronization, this method run in new transaction
+					try {
+						perunBl.getGroupsManagerBl().saveInformationAboutGroupSynchronization(sess, group, failedDueToException, exceptionMessage);
+					} catch (Exception ex) {
+						log.error("When synchronization group " + group + ", exception was thrown.", ex);
+						log.info("Info about exception from synchronization: " + skippedMembersMessage);
+					}
+					//Remove job from running jobs
+					if(!poolOfGroupsToBeSynchronized.removeJob(group)) {
+						log.error("Can't remove running job for object " + group + " from pool of running jobs because it is not containing it.");
+					}
+
+					log.debug("GroupSynchronizerThread finished for group: {}", group);
+				}
 			}
 		}
 
 		public long getStartTime() {
 			return startTime;
+		}
+
+		private void setThreadToDefaultState() {
+			this.startTime = 0;
 		}
 	}
 
@@ -2801,7 +2815,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		return false;
 	}
-
+	
 	/**
 	 * Method sets subGroups names by their parent group
 	 * Private method for moving groups


### PR DESCRIPTION
 - new concurent double ended queue for purpose of preparing groups in
   order to be synchronized
 - add some methods to work with this dequeue (putting and removing
   groups) with checking of possible duplicity
 - change definition of thread pool, now keys are threads itself, values
   are actually processing groups (null if thread is waiting for another
   group)
 - now thread is still running except interupting or timeouting, from
   start it always set everything to default and take another group (or
   wait if no such is waiting) from head of the queue with waiting
   groups
 - number of active concurent threads is limited by new property
   perun.group.maxConcurentGroupsToSynchronize with default value=10,
   this property can be override in perun.properties file for every
   instance separate
 - force propagation now does not start new synchronization, instead it
   add forced group at the head of the queue so it will be processed as
   soon as possible and skip other groups in the queue (it also means
   that can be outrun by another forcing different group)
 - there is still process synchronizeGroups running by cron tool every 5
   minutes but behavior of this process is now little different. It
   remove all interrupted or timeouted threads from threadpool and then
   it creates a new threads and starts them (maximum defined by property
   menationed above). After restarting threads it also add new groups to
   the queue (groups where is already time to run defined by interval)