### PR TITLE
Fixed problem with boolean column in Oracle

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Compatibility.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Compatibility.java
@@ -24,6 +24,19 @@ public class Compatibility {
 		return "hsqldb".equals(getDbType());
 	}
 
+	public static String getTrue() throws InternalErrorException {
+		switch (getDbType()) {
+			case "oracle":
+				return "'1'";
+			case "postgresql":
+				return "TRUE";
+			case "hsqldb":
+				return "TRUE";
+			default:
+				throw new InternalErrorException("unknown DB type");
+		}
+	}
+
 	public static String getSysdate() throws InternalErrorException {
 		switch (getDbType()) {
 			case "oracle":

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -252,7 +252,7 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 		Member sponsoredMember = this.createMember(session, vo, sponsored);
 		sponsoredMember.setSponsored(true);
 		try {
-			jdbc.update("UPDATE members SET sponsored=TRUE WHERE id=?", sponsoredMember.getId());
+			jdbc.update("UPDATE members SET sponsored="+Compatibility.getTrue()+" WHERE id=?", sponsoredMember.getId());
 			this.addSponsor(session, sponsoredMember, sponsor);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);


### PR DESCRIPTION
Oracle does not have boolean type, it is simulated by CHAR(1) with values '0' or '1'. This fix adds method Compatibility.getTrue() that returns constant '1' for Oracle and TRUE for other databases, which can be used for writing boolean value.

Reading boolean value is not a problem, because ResultSet.getBoolean() accepts '0' and '1' as false and true (it's specified in its javadoc).