### PR TITLE
fixed NRPE access to krb ticket and stderr

### DIFF
--- a/perun-utils/checkLastTaskResult.sh
+++ b/perun-utils/checkLastTaskResult.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 source /etc/perun/perun-engine
-/opt/perun-cli/bin/checkLastTaskResult $*
+KRB5CCNAME=/tmp/krb5cc_perun-engine-nagios
+/opt/perun-cli/bin/checkLastTaskResult $* 2>&1 || exit 2


### PR DESCRIPTION
fixed three problems:

- the NRPE server runs under user nagios and it needs access to its own krb ticket
- the NRPE server does not read stderr, only stdout, thus redirection of stderr to stdout was added
- Nagios needs error status 2 to indicate failure, other statuses reports as unknown