### PR TITLE
Replace special characters in NRPE commands by empty string

### DIFF
--- a/perun-utils/listOfNRPECommands
+++ b/perun-utils/listOfNRPECommands
@@ -49,7 +49,9 @@ for my $facility (@facilities) {
 		my @destinations = $servicesAgent->getDestinations( facility => $facilityId, service => $serviceId );
 		for my $destination (@destinations) {
 			my $destinationName = $destination->getDestination;
-			print "command[$serviceName+$destinationName]=$CHECK_COMMAND -S \"$serviceName\" -D \"$destinationName\"\n";
+			my $destinationNameWithoutSpecialCharacters = $destinationName;
+			$destinationNameWithoutSpecialCharacters =~ s/[^a-zA-Z0-9._-]//g;
+			print "command[$serviceName+$destinationNameWithoutSpecialCharacters]=$CHECK_COMMAND -S \"$serviceName\" -D \"$destinationName\"\n";
 		}
 	}
 }


### PR DESCRIPTION
 - replace all non-alphabet, non-numeric characters except '.', '-' and
   '_' by empty string in destination name used in NRPE command
 - the reason is problem with solving such characters on the side of
   NRPE server