### PR TITLE
In loadExtSourcesDefinitions removed needless variables definition.

### DIFF
--- a/perun-cli/Perun/UsersAgent.pm
+++ b/perun-cli/Perun/UsersAgent.pm
@@ -153,4 +153,9 @@ sub changePassword
 	return Perun::Common::callManagerMethod('changePassword', 'null', @_);
 }
 
+sub moveUserExtSource
+{
+	return Perun::Common::callManagerMethod('moveUserExtSource', 'null', @_);
+}
+
 1;

--- a/perun-cli/loadExtSourcesDefinitions
+++ b/perun-cli/loadExtSourcesDefinitions
@@ -8,8 +8,9 @@ use Perun::Common qw(printMessage);
 
 sub help {
 	return qq{
-	Loads external source definitions. Tool can be used only by PERUNADMIN.
-        It is target for updating of external sources from perun configuration.
+	Loads external sources definitions from perun's 
+	configuration file and updates entries stored in the DB. 
+	Tool can be used only by PERUNADMIN.
 	------------------------------------
 	Available options:
 	--help        | -h prints this help
@@ -17,7 +18,6 @@ sub help {
 	};
 }
 
-my ($groupId, $groupName, $voId, $voShortName, $batch);
 GetOptions ("help|h" => sub {
 		print help();
 		exit 0;
@@ -28,4 +28,4 @@ my $extSourcesAgent = $agent->getExtSourcesAgent;
 
 $extSourcesAgent->loadExtSourcesDefinitions();
 
-printMessage("External sources definitions have been successfully updated", $batch);
+print "External sources definitions have been successfully loaded\n";

--- a/perun-cli/makeUserPerunAdmin
+++ b/perun-cli/makeUserPerunAdmin
@@ -17,7 +17,7 @@ sub help {
 	};
 }
 
-my ($userId, $extSourceId, $extSourceName, $extSourceLogin, $batch);
+my ($userId, $batch);
 GetOptions ("help|h" => sub {
 		print help();
 		exit 0;

--- a/perun-cli/moveUserExtSource
+++ b/perun-cli/moveUserExtSource
@@ -14,7 +14,7 @@ sub help {
 	Available options:
 	--sourcetUserId   | -s source user id
 	--targetUserId    | -t target user id
-	--userExtSourceId | -e external source id
+	--userExtSourceId | -e user external source id
 	--batch           | -b batch
 	--help            | -h prints this help
 	};
@@ -27,7 +27,7 @@ GetOptions ("help|h"     => sub {
 	},
 	"sourceUserId|s=i"       => \$sourceUserId,
 	"targetUserId|t=i"       => \$targetUserId,
-	"userExtSourceId|e=i"    => \$extSourceId,
+	"userExtSourceId|e=i"    => \$userExtSourceId,
 	"batch|b"                => \$batch) || die help();
 
 # Check options


### PR DESCRIPTION
Description of this tool updated.
In makeUserPerunAdmin removed needless variables definition.
In moveUserExtSource corrected variable name.
In Perun/UsersAgent.pm added method moveUserExtSource.