### PR TITLE
Add two user virtual attributes to Perun LDAP

### DIFF
--- a/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
+++ b/perun-auditparser/src/main/java/cz/metacentrum/perun/auditparser/AuditParser.java
@@ -433,6 +433,8 @@ public class AuditParser {
 		userExtSource.setId(Integer.valueOf(beanAttr.get("id")));
 		userExtSource.setLoa(Integer.valueOf(beanAttr.get("loa")));
 		userExtSource.setLogin(BeansUtils.eraseEscaping(beanAttr.get("login")));
+		//Add userId if exists
+		if(beanAttr.get("userId") != null) userExtSource.setUserId(Integer.valueOf(beanAttr.get("userId")));
 		//Parse and get ExtSource
 		ExtSource extSource;
 		if(beanAttr.get("source").equals("\\0")) extSource = null;
@@ -768,5 +770,5 @@ public class AuditParser {
 
 		return richResource;
 	}
-	
+
 }

--- a/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
+++ b/perun-auditparser/src/test/java/cz/metacentrum/perun/auditparser/AuditParserTest.java
@@ -30,7 +30,7 @@ public class AuditParserTest {
 	private final User user = new User(5, textMismatch,textMismatch, textMismatch, textMismatch, textMismatch, false, false);
 	private final ExtSource extSource = new ExtSource(9, textMismatch, textMismatch);
 	private final UserExtSource userExtSource1 = new UserExtSource(12, extSource, textMismatch, user.getId(), 133);
-	private final UserExtSource userExtSource2 = new UserExtSource(15, extSource, textMismatch, user.getId(), 156);
+	private final UserExtSource userExtSource2 = new UserExtSource(15, extSource, textMismatch, -1, 156);
 	private final Vo vo = new Vo(15, textMismatch, textMismatch);
 	private final Facility facility = new Facility(13, textMismatch);
 	private final Resource resource = new Resource(19, textMismatch, textMismatch, facility.getId(), vo.getId());
@@ -147,7 +147,7 @@ public class AuditParserTest {
 
 		String log2 = "RichMember:[id=<12521>, userId=<9181>, voId=<21>, status=<DISABLED>, sourceGroupId=<\\0>, sponsored=<true>, "
 			+ "user=<User:[id=<9181>,titleBefore=<null>,firstName=<Gracian>,lastName=<Tejral>,middleName=<null>,titleAfter=<null>]>, "
-			+ "userExtSources=<[UserExtSource:[id=<13621>, login=<8087>, source=<ExtSource:[id=<2>, name=<PERUNPEOPLE>, type=<cz.metacentrum.perun.core.impl.ExtSourceSql>]>, loa=<0>]]>, "
+			+ "userExtSources=<[UserExtSource:[id=<13621>, login=<8087>, source=<ExtSource:[id=<2>, name=<PERUNPEOPLE>, type=<cz.metacentrum.perun.core.impl.ExtSourceSql>]>, userId=<-1> loa=<0>]]>, "
 			+ "userAttributes=<[Attribute:[id=<800>, friendlyName=<kerberosLogins>, namespace=<urn:perun:user:attribute-def:def>, type=<java.util.ArrayList>, value=<[tejral@META, tejral@EINFRA]>], "
 			+ "Attribute:[id=<49>, friendlyName=<id>, namespace=<urn:perun:user:attribute-def:core>, type=<java.lang.Integer>, value=<9181>], "
 			+ "Attribute:[id=<50>, friendlyName=<firstName>, namespace=<urn:perun:user:attribute-def:core>, type=<java.lang.String>, value=<Gracian>], "

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/UserExtSource.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/UserExtSource.java
@@ -109,6 +109,7 @@ public class UserExtSource extends Auditable implements Comparable<PerunBean> {
 				"id=<").append(getId()).append(">").append(
 				", login=<").append(getLogin() == null ? "\\0" : BeansUtils.createEscaping(getLogin())).append(">").append(
 				", source=<").append(extSource == null ? "\\0" : getExtSource().serializeToString()).append(">").append(
+				", userId=<").append(getUserId()).append(">").append(
 				", loa=<").append(getLoa()).append(">").append(
 				']').toString();
 	}
@@ -118,9 +119,10 @@ public class UserExtSource extends Auditable implements Comparable<PerunBean> {
 		StringBuilder str = new StringBuilder();
 
 		return str.append(getClass().getSimpleName()).append(":[").append(
-				"id='").append(getId()).append(
-				"', login='").append(login).append('\'').append(
+				"id='").append(getId()).append('\'').append(
+				", login='").append(login).append('\'').append(
 				", source='").append(extSource).append('\'').append(
+				", userId='").append(getUserId()).append('\'').append(
 				", loa='").append(loa).append('\'').append(
 				']').toString();
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
@@ -409,5 +410,21 @@ public interface ModulesUtilsBl {
 	 * @return true if the fqdn is valid
 	 */
 	boolean isFQDNValid(PerunSessionImpl sess, String fqdn);
+
+	/**
+	 * Get object User from Perun audit message.
+	 * Try to find it by different objects in this order: User, UserExtSource, Member.
+	 * Always return first occurrence of User using objects above:
+	 * - if user has been found, return it (do not look for another user)
+	 * - if no user has been found, try to find UserExtSource and get user from it
+	 * - if no UserExtSource has been found, try to find Member and get user from it
+	 * - if there is no such object, return null
+	 *
+	 * @param message audit message in machine format (with characters '<' as brackets)
+	 *
+	 * @return user if found or null if not found
+	 * @throws InternalErrorException
+	 */
+	User getUserFromMessage(PerunSessionImpl sess, String message) throws InternalErrorException;
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_kerberosLogins.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_kerberosLogins.java
@@ -78,7 +78,7 @@ public class urn_perun_user_attribute_def_virt_kerberosLogins extends UserVirtua
 
 		if(extSourceKerberosMatcher.find()) {
 			if (addUserExtSourceMatcher.find() || removeUserExtSourceMatcher.find()) {
-				user = getUserFromMessage(message);
+				user = perunSession.getPerunBl().getModulesUtilsBl().getUserFromMessage(perunSession, message);
 				if (user != null) {
 					attrVirtKerberosLogins = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_VIRT + ":kerberosLogins");
 					String messageAttributeSet = attrVirtKerberosLogins.serializeToString() + " set for " + user.serializeToString() + ".";
@@ -104,28 +104,5 @@ public class urn_perun_user_attribute_def_virt_kerberosLogins extends UserVirtua
 		attr.setType(ArrayList.class.getName());
 		attr.setDescription("Logins in kerberos (including realm and kerberos UserExtSources)");
 		return attr;
-	}
-
-	/**
-	 * Get User from message if exists and there is only one. In other case return null instead.
-	 *
-	 * @param message
-	 * @return user or null
-	 * @throws InternalErrorException
-	 */
-	private User getUserFromMessage(String message) throws InternalErrorException {
-		User user = null;
-		List<PerunBean> perunBeans = AuditParser.parseLog(message);
-
-		for(PerunBean pb: perunBeans) {
-			if(pb instanceof User) {
-				if(user != null) {
-					return null;
-				} else {
-					user = (User) pb;
-				}
-			}
-		}
-		return user;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
@@ -1,18 +1,27 @@
 package cz.metacentrum.perun.core.implApi.modules.attributes;
 
+import cz.metacentrum.perun.auditparser.AuditParser;
 import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations;
+import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_user_attribute_def_virt_schacHomeOrganizations;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.AttributesManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Common ancestor class for user virtual attributes that just collect values from userExtSource attributes.
@@ -27,6 +36,8 @@ import java.util.Objects;
 public abstract class UserVirtualAttributeCollectedFromUserExtSource extends UserVirtualAttributesModuleAbstract {
 
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+	private final Pattern allAttributesRemovedForUserExtSource = Pattern.compile("All attributes removed for UserExtSource:\\[(.*)\\]");
 
 	/**
 	 * Specifies friendly (short) name of attribute from namespace urn:perun:ues:attribute-def:def
@@ -67,7 +78,8 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource extends Use
 	public Attribute getAttributeValue(PerunSessionImpl sess, User user, AttributeDefinition destinationAttributeDefinition) throws InternalErrorException {
 
 		Attribute destinationAttribute = new Attribute(destinationAttributeDefinition);
-		List<String> values = new ArrayList<>();
+		//for values use set because of avoiding duplicities
+		Set<String> valuesWithoutDuplicities = new HashSet<>();
 
 		String sourceAttributeFriendlyName = getSourceAttributeFriendlyName();
 		List<UserExtSource> userExtSources = sess.getPerunBl().getUsersManagerBl().getUserExtSources(sess, user);
@@ -75,20 +87,54 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource extends Use
 
 		for (UserExtSource userExtSource : userExtSources) {
 			try {
-				Attribute a = am.getAttribute(sess, userExtSource, "urn:perun:ues:attribute-def:def:" + sourceAttributeFriendlyName);
+				Attribute a = am.getAttribute(sess, userExtSource, AttributesManager.NS_UES_ATTR_DEF + ":" + sourceAttributeFriendlyName);
 				Object value = a.getValue();
 				if (value != null && value instanceof String) {
 					//Apache mod_shib joins multiple values with ';', split them again
 					String[] rawValues = ((String) value).split(";");
 					//add non-null values returned by modifyValue()
-					Arrays.stream(rawValues).map(this::modifyValue).filter(Objects::nonNull).forEachOrdered(values::add);
+					Arrays.stream(rawValues).map(this::modifyValue).filter(Objects::nonNull).forEachOrdered(valuesWithoutDuplicities::add);
 				}
 			} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
 				log.error("cannot read " + sourceAttributeFriendlyName + " from userExtSource " + userExtSource.getId() + " of user " + user.getId(), e);
 			}
 		}
-		destinationAttribute.setValue(values);
+
+		//convert set to list (values in list will be without duplicities)
+		destinationAttribute.setValue(new ArrayList<>(valuesWithoutDuplicities));
 		return destinationAttribute;
+	}
+
+
+	@Override
+	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
+		List<String> resolvingMessages = new ArrayList<String>();
+		if(message == null) return resolvingMessages;
+
+		Matcher allAttributesRemovedMatcher = allAttributesRemovedForUserExtSource.matcher(message);
+		Pattern removeUserExtSourceAttribute = Pattern.compile("AttributeDefinition:\\[(.*)" + getSourceAttributeFriendlyName() + "(.*)\\] removed for UserExtSource:\\[(.*)\\]");
+		Pattern setUserExtSourceAttribute = Pattern.compile("Attribute:\\[(.*)" + getSourceAttributeFriendlyName() + "(.*)\\] set for UserExtSource:\\[(.*)\\]");
+
+		Matcher removeUESAttributeMatcher = removeUserExtSourceAttribute.matcher(message);
+		Matcher setUESAttributeMatcher = setUserExtSourceAttribute.matcher(message);
+
+		if(allAttributesRemovedMatcher.find() || removeUESAttributeMatcher.find() || setUESAttributeMatcher.find()) {
+			User user = perunSession.getPerunBl().getModulesUtilsBl().getUserFromMessage(perunSession, message);
+			if(user != null) {
+				Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_VIRT + ":" + getDestinationAttributeFriendlyName());
+				List<String> attributeValue = (ArrayList<String>) attribute.getValue();
+				String messageAttributeSet;
+				if(attributeValue == null || attributeValue.isEmpty()) {
+					AttributeDefinition attributeDefinition = new AttributeDefinition(attribute);
+					messageAttributeSet = attributeDefinition.serializeToString() + " removed for " + user.serializeToString() + ".";
+				} else {
+					messageAttributeSet = attribute.serializeToString() + " set for " + user.serializeToString() + ".";
+				}
+				resolvingMessages.add(messageAttributeSet);
+			}
+		}
+
+		return resolvingMessages;
 	}
 
 	public AttributeDefinition getAttributeDefinition() {

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
@@ -333,6 +333,8 @@ public class Utils {
 			Attribute attrPreferredMail = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_DEF + ":preferredMail");
 			Attribute attrOrganization = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_DEF + ":organization");
 			Attribute attrVirtCertDNs = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_VIRT + ":userCertDNs");
+			Attribute attrSchacHomeOrganizations = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_VIRT + ":schacHomeOrganizations");
+			Attribute attrEduPersonScopedAffiliations = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_VIRT + ":eduPersonScopedAffiliations");
 			Attribute attrLibraryIDs = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_DEF + ":libraryIDs");
 			Attribute attrPhone = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_DEF + ":phone");
 			perunUserId+= String.valueOf(user.getId());
@@ -389,6 +391,24 @@ public class Utils {
 			if(certSubjectsWithoutPrefix != null && !certSubjectsWithoutPrefix.isEmpty()) {
 				for(String s: certSubjectsWithoutPrefix) {
 					writer.write("userCertificateSubject: " + s + '\n');
+				}
+			}
+			List<String> schacHomeOrganizations = new ArrayList<>();
+			if(attrSchacHomeOrganizations.getValue() != null) {
+				schacHomeOrganizations = (ArrayList) attrSchacHomeOrganizations.getValue();
+			}
+			if(schacHomeOrganizations != null && !schacHomeOrganizations.isEmpty()) {
+				for(String organization : schacHomeOrganizations) {
+					writer.write("schacHomeOrganizations: " + organization + '\n');
+				}
+			}
+			List<String> eduPersonScopedAffiliations = new ArrayList<>();
+			if(attrEduPersonScopedAffiliations.getValue() != null) {
+				eduPersonScopedAffiliations = (ArrayList) attrEduPersonScopedAffiliations.getValue();
+			}
+			if(eduPersonScopedAffiliations != null && !eduPersonScopedAffiliations.isEmpty()) {
+				for(String affiliation : eduPersonScopedAffiliations) {
+					writer.write("eduPersonScopedAffiliations: " + affiliation + '\n');
 				}
 			}
 			List<String> libraryIDs = new ArrayList<>();

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/LdapConnector.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/LdapConnector.java
@@ -218,6 +218,22 @@ public interface LdapConnector {
 	public void updateUsersCertSubjects(String userId, String[] certSubjects);
 
 	/**
+	 * Update all values of user shac home organizations in ldap
+	 *
+	 * @param userId user id
+	 * @param organizations values of organizations
+	 */
+	public void updateUsersShacHomeOrganizations(String userId, String[] organizations);
+
+	/**
+	 * Update all values of user edu person scoped affiliations
+	 *
+	 * @param userId user id
+	 * @param affiliations values of affiliations
+	 */
+	public void updateUsersEduPersonScopedAffiliations(String userId, String[] affiliations);
+
+	/**
 	 * Update all values of user library IDs in ldap.
 	 *
 	 * @param userId user id

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
@@ -480,29 +480,49 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 					}
 					//USER CERT DNS WILL BE SET (special method for updating)
 				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":userCertDNs")) {
-					Map<String, String> certDNsMap = new HashMap<String, String>();
-					if(this.attribute.getValue() != null) certDNsMap = (Map) this.attribute.getValue();
-					else certDNsMap = null;
+					Map<String, String> certDNsMap = (this.attribute.getValue() != null) ? (Map) this.attribute.getValue() : null;
 
-					if(certDNsMap == null || certDNsMap.isEmpty()) {
-						if(ldapConnector.userAttributeExist(this.user, "userCertificateSubject")) {
+					if (certDNsMap == null || certDNsMap.isEmpty()) {
+						if (ldapConnector.userAttributeExist(this.user, "userCertificateSubject")) {
 							updateUserAttribute("userCertificateSubject", null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
 						}
 					} else {
-						Set<String> certSubjectsWithPrefixes =((Map) this.attribute.getValue()).keySet();
+						Set<String> certSubjectsWithPrefixes = ((Map) this.attribute.getValue()).keySet();
 						Set<String> certSubjectsWithoutPrefixes = new HashSet<>();
 						//remove prefixes from certificates
-						for(String key: certSubjectsWithPrefixes) {
+						for (String key : certSubjectsWithPrefixes) {
 							certSubjectsWithoutPrefixes.add(key.replaceFirst("^[0-9]+[:]", ""));
 						}
 						String[] subjectsArray = Arrays.copyOf(certSubjectsWithoutPrefixes.toArray(), certSubjectsWithoutPrefixes.toArray().length, String[].class);
 						ldapConnector.updateUsersCertSubjects(String.valueOf(this.user.getId()), subjectsArray);
 					}
+				//USER SCHAC HOME ORGANIZATIONS WILL BE SET (special method for updating)
+				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":schacHomeOrganizations")) {
+					List<String> shacHomeOrganizationsList = (this.attribute.getValue() != null) ? (ArrayList) this.attribute.getValue() : null;
+
+					if(shacHomeOrganizationsList == null || shacHomeOrganizationsList.isEmpty()) {
+						if(ldapConnector.userAttributeExist(this.user, "shacHomeOrganizations")) {
+							updateUserAttribute("shacHomeOrganizations", null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
+						}
+					} else {
+						String[] subjectsArray = Arrays.copyOf(shacHomeOrganizationsList.toArray(), shacHomeOrganizationsList.toArray().length, String[].class);
+						ldapConnector.updateUsersShacHomeOrganizations(String.valueOf(this.user.getId()), subjectsArray);
+					}
+				//USER EDU PERSON SPCOPED AFFILIATIONS WILL BE SET (special method for updating)
+				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":eduPersonScopedAffiliations")) {
+					List<String> eduPersonScopedAffiliationsList = (this.attribute.getValue() != null) ? (ArrayList) this.attribute.getValue() : null;
+
+					if(eduPersonScopedAffiliationsList == null || eduPersonScopedAffiliationsList.isEmpty()) {
+						if(ldapConnector.userAttributeExist(this.user, "eduPersonScopedAffiliations")) {
+							updateUserAttribute("eduPersonScopedAffiliations", null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
+						}
+					} else {
+						String[] subjectsArray = Arrays.copyOf(eduPersonScopedAffiliationsList.toArray(), eduPersonScopedAffiliationsList.toArray().length, String[].class);
+						ldapConnector.updateUsersEduPersonScopedAffiliations(String.valueOf(this.user.getId()), subjectsArray);
+					}
 				//USER LIBRARY IDs WILL BE SET (special method for updating)
 				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_DEF + ":libraryIDs")) {
-					List<String> libraryIDsList = new ArrayList<>();
-					if(this.attribute.getValue() != null) libraryIDsList = (ArrayList) this.attribute.getValue();
-					else libraryIDsList = null;
+					List<String> libraryIDsList = (this.attribute.getValue() != null) ? (ArrayList) this.attribute.getValue() : null;
 
 					if(libraryIDsList == null || libraryIDsList.isEmpty()) {
 						if(ldapConnector.userAttributeExist(this.user, "libraryIDs")) {
@@ -569,6 +589,14 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 				} else if(this.attributeDef.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":userCertDNs")) {
 					if(ldapConnector.userAttributeExist(this.user, "userCertificateSubject")) {
 						updateUserAttribute("userCertificateSubject", null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
+					}
+				} else if(this.attributeDef.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":eduPersonScopedAffiliations")) {
+					if(ldapConnector.userAttributeExist(this.user, "eduPersonScopedAffiliations")) {
+						updateUserAttribute("eduPersonScopedAffiliations", null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
+					}
+				} else if(this.attributeDef.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":schacHomeOrganizations")) {
+					if(ldapConnector.userAttributeExist(this.user, "schacHomeOrganizations")) {
+						updateUserAttribute("schacHomeOrganizations", null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
 					}
 				} else if(this.attributeDef.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_DEF + ":libraryIDs")) {
 					if(ldapConnector.userAttributeExist(this.user, "libraryIDs")) {
@@ -724,6 +752,8 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 		nonOptionalAttributes.add("preferredMail");
 		nonOptionalAttributes.add("o");
 		nonOptionalAttributes.add("userCertificateSubject");
+		nonOptionalAttributes.add("schacHomeOrganizations");
+		nonOptionalAttributes.add("eduPersonScopedAffiliations");
 		nonOptionalAttributes.add("libraryIDs");
 		if(nonOptionalAttributes.contains(attributeName)) return true;
 

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/LdapConnectorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/LdapConnectorImpl.java
@@ -332,6 +332,20 @@ public class LdapConnectorImpl implements LdapConnector {
 		log.debug("Entry modified in LDAP: UserId {}.", userId);
 	}
 
+	public void updateUsersShacHomeOrganizations(String userId, String[] organizations) {
+		DirContextOperations context = ldapTemplate.lookupContext(getUserDN(userId));
+		context.setAttributeValues("schacHomeOrganizations", organizations);
+		ldapTemplate.modifyAttributes(context);
+		log.debug("Entry modified in LDAP: UserId {}.", userId);
+	}
+
+	public void updateUsersEduPersonScopedAffiliations(String userId, String[] affiliations) {
+		DirContextOperations context = ldapTemplate.lookupContext(getUserDN(userId));
+		context.setAttributeValues("eduPersonScopedAffiliations", affiliations);
+		ldapTemplate.modifyAttributes(context);
+		log.debug("Entry modified in LDAP: UserId {}.", userId);
+	}
+
 	public void updateUsersLibraryIds(String userId, String[] libraryIDs) {
 		DirContextOperations context = ldapTemplate.lookupContext(getUserDN(userId));
 		context.setAttributeValues("libraryIDs", libraryIDs);


### PR DESCRIPTION
 - add attributes schacHomeOrganizations and eduPersonScopedAffiliations
   to the Perun LDAP. Both attributes are calucated from all user's
   extSources and their behavior is affected by removing and adding
   values of specific attributes in user's ext sources.
 - there is method for purpose of finding User in message from auditer, this
   message is used by more than one module so the method was moved to
   modules utils methods
 - remove not used variables in affected modules
 - add user to the log messages with removing attribute or adding
   attribute to the user extSource
 - add support of new attributes to LDAPc
 - add support of new attributes to LDAPc-Initializer
 - remove possible duplicities for values of both virtual attributes mentioned above