### PR TITLE
AD Name need to be unique for set OU Name

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
@@ -84,4 +85,18 @@ public interface SearcherBl {
 	 */
 	List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date) throws InternalErrorException;
 
+	/**
+	 * Return all groups assigned to any resource with following conditions:
+	 * 1] resource has set "resourceAttribute" attribute with same value
+	 * 2] group and resource has set "groupResourceAttribute" attribute with same value
+	 * Attribute values can't be empty.
+	 * If there is no such group, return empty array.
+	 *
+	 * @param sess
+	 * @param groupResourceAttribute expected attribute set between a group and a resource (group need to be assigned to the resource)
+	 * @param resourceAttribute expected attribute set for assigned resource
+	 * @return list of groups with following conditions
+	 * @throws InternalErrorException if any of attributes is null or has empty value, if any of attributes is not in expected namespace
+	 */
+	List<Group> getGroupsByGroupResourceSetting(PerunSession sess, Attribute groupResourceAttribute, Attribute resourceAttribute) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SearcherBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SearcherBlImpl.java
@@ -2,7 +2,8 @@ package cz.metacentrum.perun.core.blImpl;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
-import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
@@ -89,6 +90,21 @@ public class SearcherBlImpl implements SearcherBl {
 	@Override
 	public List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date) throws InternalErrorException {
 		return getSearcherImpl().getMembersByExpiration(sess, operator, date, 0);
+	}
+
+	@Override
+	public List<Group> getGroupsByGroupResourceSetting(PerunSession sess, Attribute groupResourceAttribute, Attribute resourceAttribute) throws InternalErrorException {
+		if(groupResourceAttribute == null || groupResourceAttribute.getValue() == null || resourceAttribute == null || groupResourceAttribute == null) {
+			throw new InternalErrorException("Can't find groups by attributes with null value.");
+		}
+		if(!groupResourceAttribute.getNamespace().equals(AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF)) {
+			throw new InternalErrorException("Group-resource attribute need to be in group-resource-def namespace! - " + groupResourceAttribute);
+		}
+		if(!resourceAttribute.getNamespace().equals(AttributesManager.NS_RESOURCE_ATTR_DEF)) {
+			throw new InternalErrorException("Resource attribute need to be in resource-def namespace!" + resourceAttribute);
+		}
+
+		return getSearcherImpl().getGroupsByGroupResourceSetting(sess, groupResourceAttribute, resourceAttribute);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
@@ -180,6 +181,23 @@ public class SearcherImpl implements SearcherImplApi {
 			throw new InternalErrorException(e);
 		}
 
+	}
+
+	@Override
+	public List<Group> getGroupsByGroupResourceSetting(PerunSession sess, Attribute groupResourceAttribute, Attribute resourceAttribute) throws InternalErrorException {
+		try {
+			return jdbcTemplate.query("select  " + GroupsManagerImpl.groupMappingSelectQuery + " from groups where groups.id in ( " +
+							"select distinct gr.group_id from groups_resources gr " +
+							"join group_resource_attr_values grav on gr.group_id=grav.group_id and gr.resource_id=grav.resource_id " +
+							"join resource_attr_values rav on gr.resource_id=rav.resource_id " +
+							"where rav.attr_id=? and grav.attr_id=? and rav.attr_value=? and grav.attr_value=?)", GroupsManagerImpl.GROUP_MAPPER,
+					resourceAttribute.getId(), groupResourceAttribute.getId(), resourceAttribute.getValue(), groupResourceAttribute.getValue());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<Group>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+
+		}
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adName.java
@@ -1,0 +1,83 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AD Name module
+ * Name in AD for group and resource need to be unique in between
+ * other AD name where assigned resource has OU Name attribute with same value
+ * For example: If the group1 will be assigned to the resource1 and the group2
+ * will be assigned to the resource2, on both resources will be attribute OU Name
+ * set to value 'SPECIFIC_OU', then value of attribute defined by this module need
+ * to be different (unique) for both groups (can't be same). If OU of one of these
+ * resources will be different, then both groups can't have the same name.
+ *
+ * @author Michal Stava  stavamichal@gmail.com
+ */
+public class urn_perun_group_resource_attribute_def_def_adName extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+
+	private static final String A_R_D_AD_OU_NAME = AttributesManager.NS_RESOURCE_ATTR_DEF + ":adOuName";
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		String attributeValue = null;
+
+		//Attribute can be null
+		if(attribute.getValue() == null) {
+			return;
+		}
+
+		Attribute resourceAdOuName;
+		try {
+			resourceAdOuName = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, A_R_D_AD_OU_NAME);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		//if assigned
+		if(resourceAdOuName.getValue() == null) {
+			return;
+		}
+
+		List<Group> groupsWithSameADNameInSameOu = sess.getPerunBl().getSearcherBl().getGroupsByGroupResourceSetting(sess, attribute, resourceAdOuName);
+		if(!groupsWithSameADNameInSameOu.isEmpty()) {
+			throw new WrongReferenceAttributeValueException(attribute, resourceAdOuName, group, resource, resource, null,
+					"Attribute AD Name can't be set for group and resource in this OU, because this value is already " +
+					"set for different group and resource in the same OU!");
+		}
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<String>();
+		dependencies.add(A_R_D_AD_OU_NAME);
+		return dependencies;
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("adName");
+		attr.setDisplayName("AD Name");
+		attr.setType(String.class.getName());
+		attr.setDescription("Name of AD");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SearcherImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SearcherImplApi.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.implApi;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
@@ -56,5 +57,20 @@ public interface SearcherImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Member> getMembersByExpiration(PerunSession sess, String operator, Calendar date, int days) throws InternalErrorException;
+
+	/**
+	 * Return all groups assigned to any resource with following conditions:
+	 * 1] resource has set "resourceAttribute" attribute with same value
+	 * 2] group and resource has set "groupResourceAttribute" attribute with same value
+	 * Attribute values can't be empty.
+	 * If there is no such group, return empty array.
+	 *
+	 * @param sess
+	 * @param groupResourceAttribute expected attribute set between a group and a resource (group need to be assigned to the resource)
+	 * @param resourceAttribute expected attribute set for assigned resource
+	 * @return list of groups with following conditions
+	 * @throws InternalErrorException if any of attributes is null or has empty value, if any of attributes is not in expected namespace
+	 */
+	List<Group> getGroupsByGroupResourceSetting(PerunSession sess, Attribute groupResourceAttribute, Attribute resourceAttribute) throws InternalErrorException;
 
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
@@ -241,6 +241,72 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	}
 
+	@Test
+	public void getGroupsByGroupResourceSetting() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsByGroupResourceSetting");
+
+		Facility facility = new Facility(0, "testName01", "testName01");
+		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
+
+		Group group1 = new Group("testName01", "testName01");
+		group1 = perun.getGroupsManagerBl().createGroup(sess, vo, group1);
+		Group group2 = new Group("testName02", "testName02");
+		group2 = perun.getGroupsManagerBl().createGroup(sess, vo, group2);
+		Group group3 = new Group("testName03", "testName03");
+		group3 = perun.getGroupsManagerBl().createGroup(sess, vo, group3);
+
+		Resource resource1 = new Resource(0, "testName01", "testName01", facility.getId(), vo.getId());
+		resource1 = perun.getResourcesManagerBl().createResource(sess,resource1, vo, facility);
+		Resource resource2 = new Resource(0, "testName02", "testName02", facility.getId(), vo.getId());
+		resource2 = perun.getResourcesManagerBl().createResource(sess,resource2, vo, facility);
+		Resource resource3 = new Resource(0, "testName03", "testName03", facility.getId(), vo.getId());
+		resource3 = perun.getResourcesManagerBl().createResource(sess,resource3, vo, facility);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource1);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group1, resource2);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource1);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource2);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group2, resource3);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group3, resource2);
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group3, resource3);
+
+		Attribute groupResourceAttr01 = new Attribute(setUpGroupResourceAttribute());
+		groupResourceAttr01.setValue("VALUE01");
+		Attribute groupResourceAttr02 = new Attribute(groupResourceAttr01);
+		groupResourceAttr02.setValue("VALUE02");
+		Attribute resourceAttr01 = new Attribute(setUpResourceAttribute());
+		resourceAttr01.setValue("VALUE01");
+		Attribute resourceAttr02 = new Attribute(resourceAttr01);
+		resourceAttr02.setValue("VALUE02");
+
+		perun.getAttributesManagerBl().setAttribute(sess, resource1, resourceAttr01);
+		perun.getAttributesManagerBl().setAttribute(sess, resource2, resourceAttr02);
+		perun.getAttributesManagerBl().setAttribute(sess, resource3, resourceAttr01);
+
+		perun.getAttributesManagerBl().setAttribute(sess, resource1, group1, groupResourceAttr01);
+		perun.getAttributesManagerBl().setAttribute(sess, resource1, group2, groupResourceAttr02);
+		perun.getAttributesManagerBl().setAttribute(sess, resource2, group1, groupResourceAttr02);
+		perun.getAttributesManagerBl().setAttribute(sess, resource2, group2, groupResourceAttr01);
+		perun.getAttributesManagerBl().setAttribute(sess, resource2, group3, groupResourceAttr01);
+		perun.getAttributesManagerBl().setAttribute(sess, resource3, group2, groupResourceAttr02);
+		perun.getAttributesManagerBl().setAttribute(sess, resource3, group3, groupResourceAttr02);
+
+		List<Group> returnedGroups = perun.getSearcherBl().getGroupsByGroupResourceSetting(sess, groupResourceAttr01, resourceAttr01);
+		assertEquals(1, returnedGroups.size());
+		assertTrue(returnedGroups.contains(group1));
+		returnedGroups = perun.getSearcherBl().getGroupsByGroupResourceSetting(sess, groupResourceAttr01, resourceAttr02);
+		assertEquals(2, returnedGroups.size());
+		assertTrue(returnedGroups.contains(group2));
+		assertTrue(returnedGroups.contains(group3));
+		returnedGroups = perun.getSearcherBl().getGroupsByGroupResourceSetting(sess, groupResourceAttr02, resourceAttr01);
+		assertEquals(2, returnedGroups.size());
+		assertTrue(returnedGroups.contains(group2));
+		assertTrue(returnedGroups.contains(group3));
+		returnedGroups = perun.getSearcherBl().getGroupsByGroupResourceSetting(sess, groupResourceAttr02, resourceAttr02);
+		assertEquals(1, returnedGroups.size());
+		assertTrue(returnedGroups.contains(group1));
+	}
+
 	// PRIVATE METHODS -----------------------------------------------------------
 
 	private void setUpUser1() throws Exception {
@@ -368,4 +434,25 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 	}
 
+	private AttributeDefinition setUpResourceAttribute() throws Exception {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace("urn:perun:resource:attribute-def:def");
+		attr.setFriendlyName("testingAttribute01");
+		attr.setType(String.class.getName());
+		attr.setDisplayName("Testing attribute1");
+		attr.setDescription("Testing attribute1");
+
+		return perun.getAttributesManager().createAttribute(sess, attr);
+	}
+
+	private AttributeDefinition setUpGroupResourceAttribute() throws Exception {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace("urn:perun:group_resource:attribute-def:def");
+		attr.setFriendlyName("testingAttribute02");
+		attr.setType(String.class.getName());
+		attr.setDisplayName("Testing attribute2");
+		attr.setDescription("Testing attribute2");
+
+		return perun.getAttributesManager().createAttribute(sess, attr);
+	}
 }


### PR DESCRIPTION
 - AD Name is group-resource attribute which specify name of group in
   AD, OU Name is resource attribute and specify under which OU tree
   will be records saved. For this reason AD Name need to be unique for
   specific OU in all Perun.
 - add new method to Attributes searcher to get all groups with same
   name in the same ou and also add test for this method
 - create a new module for attribute AD Name which will take care about
   checking this uniqueness and add there dependency for OU name
   attribute