### PR TITLE
REGISTRAR: Prevent multiple application submission

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/AlreadyProcessingException.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/exceptions/AlreadyProcessingException.java
@@ -1,0 +1,26 @@
+package cz.metacentrum.perun.registrar.exceptions;
+
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+
+/**
+ * Custom exception thrown by Registrar when user submits same application, which is already
+ * processed by another thread. Prevents multiple application creation when code doesn't see
+ * uncommitted data in DB and passes inner tests.
+ *
+ * This exception is silently skipped in GUI
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class AlreadyProcessingException extends PerunException {
+
+	private static final long serialVersionUID = 1L;
+
+	public AlreadyProcessingException(String message) {
+		super(message);
+	}
+
+	public AlreadyProcessingException(String message, Throwable ex) {
+		super(message, ex);
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -147,6 +147,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	private String shibLastNameVar = "sn";
 	private String shibLoAVar = "loa";
 
+	private final Set<String> runningCreateApplication = new HashSet<>();
+
 	public void setDataSource(DataSource dataSource) {
 		this.jdbc = new JdbcPerunTemplate(dataSource);
 	}
@@ -881,11 +883,33 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			application.setUser(session.getPerunPrincipal().getUser());
 		}
 
-		// FIXME - create lock on "application type" and "user identity" to prevent multiple submission bug
+		// lock to prevent multiple submission of same application on server side
 
-		// using this to init inner transaction
-		// all minor exceptions inside are catched, if not, it's ok to throw them
-		Application app = this.registrarManager.createApplicationInternal(session, application, data);
+		String key = application.getType().toString() +
+				application.getVo().getShortName() +
+				((application.getGroup() != null) ? application.getGroup().getName() : "nogroup") +
+				application.getCreatedBy()+application.getExtSourceName()+application.getExtSourceType();
+
+		synchronized(runningCreateApplication) {
+			if (runningCreateApplication.contains(key)) {
+				throw new AlreadyProcessingException("You application submission is being processed already.");
+			} else {
+				runningCreateApplication.add(key);
+			}
+		}
+
+		Application app = null;
+		try {
+			// using this to init inner transaction
+			// all minor exceptions inside are catched, if not, it's ok to throw them out
+			app = this.registrarManager.createApplicationInternal(session, application, data);
+		} catch (Exception ex) {
+			// clear flag and re-throw exception, since application was processed with exception
+			synchronized (runningCreateApplication) {
+				runningCreateApplication.remove(key);
+			}
+			throw ex;
+		}
 
 		// try to verify (or even auto-approve) application
 		try {
@@ -895,7 +919,16 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			AuthzResolverBlImpl.refreshSession(session);
 		} catch (Exception ex) {
 			log.error("[REGISTRAR] Unable to verify or auto-approve application {}, because of exception {}", app, ex);
+			// clear flag and re-throw exception, since application was processed with exception
+			synchronized (runningCreateApplication) {
+				runningCreateApplication.remove(key);
+			}
 			throw ex;
+		}
+
+		// clear flag, since application was processed
+		synchronized (runningCreateApplication) {
+			runningCreateApplication.remove(key);
 		}
 
 		return data;


### PR DESCRIPTION
- When browser lags, it might allow users to send same application
  multiple times. Check on existing application inside might fail,
  since previous attempt is not processed yet (committed in DB).
  So we will use Set with synchronized access and each application
  is stored on processing start and removed on error or finish.
  In case of concurrency, AlreadyProcessingException is thrown
  and will be silently ignored in GUI.