### PR TITLE
Fixed checkAttributeValue in entityless usedGids module

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_usedGids.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_usedGids.java
@@ -54,14 +54,17 @@ public class urn_perun_entityless_attribute_def_def_usedGids extends EntitylessA
 			if(!keyMatcher.matches()) throw new WrongAttributeValueException(attribute, key, "Key in usedGids can be only in format 'Rx', 'Gx', 'Dx' where 'x' is positive integer.");
 			
 			//Test value
-			String value = map.get(key);
-			if(value == null) throw new WrongAttributeValueException(attribute, key, "Value is usedGids can't be null.");
+			String value = map.get(mapKey);
+			if(value == null) throw new WrongAttributeValueException(attribute, key, "Value in usedGids can't be null.");
 			Matcher valueMatcher = valuePattern.matcher(value);
 			if(!valueMatcher.matches()) throw new WrongAttributeValueException(attribute, key, "Key in usedGids can be only positive integer.");
 		}
 		
 		//If group or resource has some gid, this gid can't be depleted at the same time!
 		for(String mapKey: mapKeys) {
+			//We have to skip keys in usedGids which start with "D",
+			//usedGids always contains key "D" + value when value has key starting with "D"
+			if(mapKey.startsWith("D")) continue;
 			String value = map.get(mapKey);
 			if(map.containsKey("D" + value)) throw new WrongAttributeValueException(attribute, key, "This gid can't be depleted and used at the same time!");
 		}


### PR DESCRIPTION
-In value check, there was map.get(key) command which was not correct,
 because "key" is parameter for entity not key in usedGids.
 That command always returned null value, which cause an exception.
 I changed that to map.get(mapKey), where "mapKey" is one of the keys in usedGids.
-In check, if there is a gid which is depleted and used at the same time,
 was added if statement to skip usedGids whose key starts with "D".
 If we would check also these keys, it would always throw an exception,
 because usedGids always contains key "D" + value when value has key starting with "D".
 We just want to check keys starting with "R" or "G", if there is same usedGid
 starting with "D", which is not correct,
 because gid cannot be used and depleted at the same time.
-These bugs were not revealed by tests, because method checkAttributeValue
 for this module was not implemented in AttributesManagerImpl.