### PR TITLE
REGISTRAR: Allow to get form item by ID and update its texts

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -97,6 +97,16 @@ public interface RegistrarManager {
 	ApplicationForm getFormById(PerunSession sess, int id) throws PerunException;
 
 	/**
+	 * Gets an application form for a given form item ID.
+	 *
+	 * @param sess PerunSession for authz
+	 * @param id ID of application form item to get form for
+	 * @return registration form
+	 * @throws PerunException
+	 */
+	ApplicationForm getFormByItemId(PerunSession sess, int id) throws PerunException;
+
+	/**
 	 * Adds a new item to a form.
 	 *
 	 * @param user            the user that adds the items
@@ -155,9 +165,17 @@ public interface RegistrarManager {
 	 * Updates internationalized texts for a form item.
 	 * @param user user changing the form item texts
 	 * @param item the form item to be changed
-	 * @param locale the locale for which texts shoudl be changed
+	 * @param locale the locale for which texts should be changed
 	 */
-	void updateFormItemTexts(PerunSession user, ApplicationFormItem item, Locale locale);
+	void updateFormItemTexts(PerunSession user, ApplicationFormItem item, Locale locale) throws PrivilegeException, PerunException;
+
+	/**
+	 * Updates internationalized texts for a form item (all locales are replaced by current value)
+	 *
+	 * @param user user changing the form item texts
+	 * @param item the form item to be changed
+	 */
+	void updateFormItemTexts(PerunSession user, ApplicationFormItem item) throws PrivilegeException, PerunException;
 
 	/**
 	 * Gets all form items.
@@ -357,10 +375,31 @@ public interface RegistrarManager {
 	/**
 	 * Returns full form item including texts and appTypes
 	 *
+	 * @param session PerunSession for authz
+	 * @param id ID of form item to return
+	 * @return form item
+	 * @throws PrivilegeException
+	 */
+	ApplicationFormItem getFormItemById(PerunSession session, int id) throws PrivilegeException;
+
+	/**
+	 * Returns full form item including texts and appTypes
+	 * For Internal use only !!
+	 *
 	 * @param id ID of form item to return
 	 * @return form item
 	 */
 	ApplicationFormItem getFormItemById(int id);
+
+	/**
+	 * Update form item by it's ID.
+	 *
+	 * @param session PerunSession for authz
+	 * @param item Application form item to update
+	 * @throws PrivilegeException
+	 * @throws PerunException
+	 */
+	void updateFormItem(PerunSession session, ApplicationFormItem item) throws PrivilegeException, PerunException;
 
 	/**
 	 * Returns application object by it's ID

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -355,6 +355,47 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Update label, options, help and error message for specified form item and locale.
+	 * FormItem is specified by its ID.
+	 *
+	 * @param formItem ApplicationFormItem Form item to update
+	 * @param locale String Locale specified like: cs, en, ...
+	 */
+	/*#
+	 * Replace label, options, help and error message for specified form item and all locales by current value.
+	 * FormItem is specified by its ID.
+	 *
+	 * @param formItem ApplicationFormItem Form item to update
+	 */
+	updateFormItemTexts {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			ApplicationFormItem item = parms.read("formItem", ApplicationFormItem.class);
+			if (parms.contains("locale")) {
+				ac.getRegistrarManager().updateFormItemTexts(ac.getSession(), item, new Locale(parms.readString("locale")));
+			} else {
+				ac.getRegistrarManager().updateFormItemTexts(ac.getSession(), item);
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Return form item by its ID, you must be authorized to manipulate the form.
+	 *
+	 * @param id int ID of application form item
+	 */
+	getFormItemById {
+		@Override
+		public ApplicationFormItem call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getRegistrarManager().getFormItemById(ac.getSession(), parms.readInt("id"));
+		}
+	},
+
+	/*#
 	 * Gets the content for an application form for a given type of application and user.
 	 * The values are prefilled from database for extension applications, and always from federation values
 	 * taken from the user argument.
@@ -774,7 +815,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	 * @param toVo int Destination VO <code>id</code>
 	 * @return Object Always null
 	 */
-		/*#
+	/*#
 	 * Copy all form items from selected Group into another.
 	 *
 	 * @param fromGroup int Source Group <code>id</code>


### PR DESCRIPTION
- Added methods to registrar manager and RPC API to get form item
  by its ID - caller must be authorized for a form.
- Added methods to update form item texts for specific locale (update)
  or all locales (replace).
- Added method to update single form item by its ID.