### PR TITLE
Increase tiemout for communication between CLI and Perun RPC

### DIFF
--- a/perun-cli/Perun/Agent.pm
+++ b/perun-cli/Perun/Agent.pm
@@ -73,7 +73,7 @@ sub new {
 		$rpcType = $ENV{PERUN_RPC_TYPE};
 	}
 
-	$self->{_lwpUserAgent} = LWP::UserAgent->new( agent => "Agent.pm/$agentVersion", timeout => 2000 );
+	$self->{_lwpUserAgent} = LWP::UserAgent->new( agent => "Agent.pm/$agentVersion", timeout => 4000 );
 	# Enable cookies if enviromental variable with path exists or home env is available
 	if (defined($ENV{PERUN_COOKIE})) {
 		local $SIG{'__WARN__'} = sub { warn @_ unless $_[0] =~ /does not seem to contain cookies$/; };  #supress one concrete warning message from package HTTP::Cookies


### PR DESCRIPTION
 - default is 2000s =~ 33minutes, some services need more time to obtain
   all data (40minutes+-) so we need to double this value to 4000s