### PR TITLE
Optimalization of import from external source

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/UserDuplicateException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/UserDuplicateException.java
@@ -1,0 +1,41 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This exception serves for detection, that one person has more User identities in Perun.
+ * This person needs to be merged to one User identity.
+ *
+ * @author  Jan Zverina
+ */
+public class UserDuplicateException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	private List<User> users;
+
+	public UserDuplicateException(String message) {
+		super(message);
+	}
+
+	public UserDuplicateException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public UserDuplicateException(Throwable cause) {
+		super(cause);
+	}
+
+	public UserDuplicateException(User user1, User user2) {
+		super(user1.toString() + " " + user2.toString());
+		users = new ArrayList<>();
+		users.add(user1);
+		users.add(user2);
+	}
+
+	public List<User> getUsers() {
+		return users;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -4,7 +4,33 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
+import cz.metacentrum.perun.core.api.exceptions.AlreadySponsorException;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupOperationsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.MemberAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotSponsoredException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotValidYetException;
+import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordCreationFailedException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordOperationTimeoutException;
+import cz.metacentrum.perun.core.api.exceptions.PasswordStrengthFailedException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotInRoleException;
+import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 
 /**
  * MembersManager can find members.
@@ -21,6 +47,9 @@ public interface MembersManager {
 	static final String membershipDoNotExtendLoaKeyName = "doNotExtendLoa";
 	static final String membershipPeriodLoaKeyName = "periodLoa";
 	static final String membershipDoNotAllowLoaKeyName = "doNotAllowLoa";
+
+	// Defines name of member-group attribute which stores hash code of data gained from external source
+	String MEMBERGROUPHASHCODE_ATTRNAME = AttributesManager.NS_MEMBER_GROUP_ATTR_DEF + ":hashCode";
 
 	/**
 	 * Attribute which contains rules for membership expiration

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1537,6 +1537,39 @@ public interface AttributesManagerBl {
 	 */
 	void setAttributeInNestedTransaction(PerunSession sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
+	/**
+	 * Store the particular attribute associated with the group. Core attributes can't be set this way.
+	 *
+	 * This method creates nested transaction to prevent storing value to DB if it throws any exception.
+	 *
+	 * @param sess perun session
+	 * @param group group to set on
+	 * @param attribute attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is core attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributeInNestedTransaction(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Store the particular attribute associated with the member-group relationship. Core attributes can't be set this way.
+	 *
+	 * This method creates nested transaction to prevent storing value to DB if it throws any exception.
+	 *
+	 * @param sess perun session
+	 * @param member member to set on
+	 * @param group group group where is member
+	 * @param attribute attribute to set
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is illegal
+	 * @throws WrongAttributeAssignmentException if attribute is not member-group attribute or if it is core attribute
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	void setAttributeInNestedTransaction(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException;
+
 
 	/**
 	 * Store the attribute associated with the facility and user combination.  Core attributes can't be set this way.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
@@ -192,11 +192,13 @@ public interface ExtSourcesManagerBl {
 	List<User> getInvalidUsers(PerunSession perunSession, ExtSource source) throws InternalErrorException;
 
 	/**
-	 * Get the candidate from the ExtSource defined by the extsource login.
+	 * Get the candidate from the ExtSource.
+	 * Login of candidate will be used to gain data from ExtSource.
 	 *
-	 * @param perunSession
-	 * @param source
-	 * @param login
+	 * @param perunSession Perun session
+	 * @param source External source which will be used to get data about candidate
+	 * @param login Login of candidate
+	 *
 	 * @return a Candidate object
 	 * @throws InternalErrorException
 	 * @throws ExtSourceNotExistsException
@@ -206,14 +208,14 @@ public interface ExtSourcesManagerBl {
 	Candidate getCandidate(PerunSession perunSession, ExtSource source, String login) throws InternalErrorException, ExtSourceNotExistsException, CandidateNotExistsException, ExtSourceUnsupportedOperationException;
 
 	/**
-	 * Get the candidate from subjectData where at least login must exists.
+	 * Get the candidate from subject where at least login must exists.
 	 *
 	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
 	 *
-	 * @param perunSession
-	 * @param subjectData
-	 * @param source
-	 * @param login
+	 * @param perunSession Perun session
+	 * @param subject Subject with data about candidate
+	 * @param source External source, which was used to gain subject
+	 * @param login Login of candidate
 	 *
 	 * @return a Candidate object
 	 * @throws InternalErrorException
@@ -221,7 +223,7 @@ public interface ExtSourcesManagerBl {
 	 * @throws CandidateNotExistsException
 	 * @throws ExtSourceUnsupportedOperationException
 	 */
-	Candidate getCandidate(PerunSession perunSession, Map<String,String> subjectData ,ExtSource source, String login) throws InternalErrorException, ExtSourceNotExistsException, CandidateNotExistsException, ExtSourceUnsupportedOperationException;
+	Candidate getCandidate(PerunSession perunSession, Map<String,String> subject ,ExtSource source, String login) throws InternalErrorException, ExtSourceNotExistsException, CandidateNotExistsException, ExtSourceUnsupportedOperationException;
 
 	void checkExtSourceExists(PerunSession sess, ExtSource extSource) throws InternalErrorException, ExtSourceNotExistsException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -56,6 +56,7 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
  *
  * @author  Michal Prochazka
  * @author  Slavek Licehammer
+ * @author  Jan Zverina
  * @see Perun
  */
 public interface GroupsManagerBl {
@@ -1135,6 +1136,7 @@ public interface GroupsManagerBl {
 	 * IMPORTANT: This method runs in new transaction (because of using in synchronization of groups)
 	 *
 	 * Set timestamp to attribute "group_def_lastSynchronizationTimestamp"
+	 * Set timestamp to attribute "group_def_startOfLastSuccessSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastSynchronizationState"
 	 *
 	 * FailedDueToException is true means group synchronization failed at all.
@@ -1150,7 +1152,7 @@ public interface GroupsManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws WrongAttributeValueException
 	 */
-	void saveInformationAboutGroupSynchronization(PerunSession sess, Group group, boolean failedDueToException, String exceptionMessage) throws AttributeNotExistsException, InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeValueException;
+	void saveInformationAboutGroupSynchronization(PerunSession sess, Group group, long startTime, boolean failedDueToException, String exceptionMessage) throws AttributeNotExistsException, InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeValueException;
 
 	/**
 	 * Get all groups in specific vo with assigned extSource

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1934,6 +1934,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		setAttribute(sess, user, attribute);
 	}
 
+	public void setAttributeInNestedTransaction(PerunSession sess, Member member, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException {
+		setAttribute(sess, member, group, attribute);
+	}
+
+	public void setAttributeInNestedTransaction(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+		setAttribute(sess, group, attribute);
+	}
+
 	public boolean setAttributeWithoutCheck(PerunSession sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_USER_ATTR);
 		if(getAttributesManagerImpl().isCoreAttribute(sess, attribute)) throw new WrongAttributeAssignmentException(attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1,7 +1,5 @@
 package cz.metacentrum.perun.core.impl;
 
-import java.util.*;
-
 import cz.metacentrum.perun.core.api.ActionType;
 import java.io.IOException;
 
@@ -12,6 +10,14 @@ import java.sql.Clob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
@@ -75,10 +81,8 @@ import cz.metacentrum.perun.core.api.exceptions.ActionTypeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
-import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.ModuleNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -4247,7 +4251,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		attr.setDisplayName("Group members query");
 		attributes.add(attr);
 
-		//urn:perun:group:attribute-def:def:synchronizatinEnabled
+		//urn:perun:group:attribute-def:def:synchronizationEnabled
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
 		attr.setType(String.class.getName());
@@ -4281,6 +4285,24 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		attr.setDescription("If group is synchronized, there will be the last timestamp of group synchronization.");
 		attr.setFriendlyName("lastSynchronizationTimestamp");
 		attr.setDisplayName("Last Synchronization timestamp");
+		attributes.add(attr);
+
+		//urn:perun:group:attribute-def:def:startOfLastSuccessSynchronizationTimestamp
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setDescription("Timestamp of start of last successful synchronization.");
+		attr.setFriendlyName("startOfLastSuccessSynchronizationTimestamp");
+		attr.setDisplayName("Start of last success synchronization");
+		attributes.add(attr);
+
+		//urn:perun:member_group:attribute-def:def:hashCode
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setDescription("Hashcode of attribute map received from external source.");
+		attr.setFriendlyName("hashCode");
+		attr.setDisplayName("Hash Code");
 		attributes.add(attr);
 
 		if(perun.isPerunReadOnly()) log.debug("Loading attributes manager init in readOnly version.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -1,13 +1,22 @@
 package cz.metacentrum.perun.core.impl;
 
 import com.opencsv.CSVReader;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
@@ -15,12 +24,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- *
- * @author Sona Mastrakova
+ * @author Sona Mastrakova, Jan Zverina
  */
 public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
 
@@ -29,10 +35,11 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
     private String file = null;
     private String query = null;
     private String[] header = null;
+    private HashMap<String, String> csvMapping = null;
 
     private static PerunBlImpl perunBl;
 
-    // filled by spring (perun-core.xml)
+    // Filled by Spring (perun-core.xml)
     public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
         perunBl = perun;
         return perun;
@@ -69,16 +76,17 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
             //Replace '?' by searchString
             query = query.replaceAll("\\?", searchString);
 
-            //Get csv file 
-            prepareEnvironment();
+            //Get csv file
+            prepareFile();
 
-            return csvParsing(query, maxResults);
+			List<Map<String, String>> subjects = new ArrayList<>();
+            csvParsing(query, maxResults, subjects);
+            return subjects;
 
         } catch (IOException ex) {
             log.error("IOException in findSubjects() method while parsing csv file", ex);
+            throw new InternalErrorException(ex);
         }
-
-        return null;
     }
 
     @Override
@@ -97,10 +105,11 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
             //Replace '?' by searchString
             query = query.replaceAll("\\?", login);
 
-            //Get csv file 
-            prepareEnvironment();
+            //Get csv file
+            prepareFile();
 
-            List<Map<String, String>> subjects = this.csvParsing(query, 0);
+            List<Map<String, String>> subjects = new ArrayList<>();
+            this.csvParsing(query, 0, subjects);
 
             if (subjects.isEmpty()) {
                 throw new SubjectNotExistsException("Login: " + login);
@@ -113,31 +122,53 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
 
         } catch (IOException ex) {
             log.error("IOException in getSubjectByLogin() method while parsing csv file", ex);
+            throw new InternalErrorException(ex);
         }
-
-        return null;
     }
 
+    /**
+     * Get subjects of group. These subjects will be stored in maps obtained in parameters.
+     *
+     *
+     * @param sess
+     * @param group Map of attributes used for quering the external source
+     * @param status Status about synchronization (lightweight, full). Not used in CSV external source.
+     * @param subjects list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
+     * @return String containing status about data received from external source (e.g. data are sorted,
+     * @throws InternalErrorException
+     * @throws ExtSourceUnsupportedOperationException
+     */
     @Override
-    public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+    public String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException, ExtSourceUnsupportedOperationException {
         try {
-            // Get the query for the group subjects
-            String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
-
-            //If there is no query for group, throw exception
-            if (queryForGroup == null) {
-                throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSEXTSOURCE_ATTRNAME + " can't be null.");
+            Attribute queryForGroupAttribute = null;
+            try {
+                queryForGroupAttribute = perunBl.getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+            } catch (WrongAttributeAssignmentException e) {
+                // Should not happen
+                throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " is not from group namespace.");
+            } catch (AttributeNotExistsException e) {
+                throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " must exists.");
             }
 
-            //Get csv file
-            prepareEnvironment();
+            // Get the query for the group subjects
+            String queryForGroup = BeansUtils.attributeValueToString(queryForGroupAttribute);
 
-            return csvParsing(queryForGroup, 0);
+            // If there is no query for group, throw exception
+            if (queryForGroup == null) {
+                throw new InternalErrorException("Value of " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " can't be null.");
+            }
+
+            // Get CSV file
+            prepareFile();
+
+            csvParsing(queryForGroup, 0, subjects);
+            return GroupsManager.GROUP_SYNC_STATUS_FULL;
 
         } catch (IOException ex) {
             log.error("IOException in getGroupSubjects() method while parsing csv file", ex);
+            throw new InternalErrorException(ex);
         }
-        return null;
     }
 
     @Override
@@ -145,39 +176,57 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
         throw new ExtSourceUnsupportedOperationException("For CSV, using this method is not optimized, use findSubjects instead.");
     }
 
-    private void prepareEnvironment() throws InternalErrorException {
-        //Get csv files
-        file = (String) getAttributes().get("file");
+    private void prepareFile() throws InternalErrorException {
+        //Get csv file
+        file = getAttributes().get("file");
         if (file == null || file.isEmpty()) {
             throw new InternalErrorException("File cannot be empty!");
         }
     }
 
-    private List<Map<String, String>> csvParsing(String query, int maxResults) throws InternalErrorException, FileNotFoundException, IOException {
-        List<Map<String, String>> subjects = new ArrayList<Map<String, String>>();
-
-        FileReader fileReader = new FileReader(file);
-        if (fileReader == null) {
-            throw new FileNotFoundException("File was not found!");
-        }
-
-        CSVReader reader = new CSVReader(fileReader);
-
+    private void csvParsing(String query, int maxResults, List<Map<String,String>> subjects) throws InternalErrorException, IOException {
+        CSVReader reader = initializeCSVReader(file);
         header = reader.readNext();
         if (header == null) {
             throw new RuntimeException("No header in csv file");
         }
+        createSubjectsFromRows(query, reader, maxResults, subjects);
+    }
 
+    /**
+     * Initialize CSVReader object to read CSV file from path defined in parameter.
+     *
+     * @param fileName Path to file
+     * @return CSVReader object
+     * @throws FileNotFoundException
+     */
+    private CSVReader initializeCSVReader(String fileName) throws FileNotFoundException {
+        FileReader fileReader = new FileReader(fileName);
+        if (fileReader == null) {
+            throw new FileNotFoundException("File was not found!");
+        }
+        return new CSVReader(fileReader);
+    }
+
+    /**
+     * Converts reader of rows from file to list of subjects obtained in parameter.
+     * This method CONTROLS maximum of results.
+     *
+     * @param query Query to select correct rows with users from file.
+     * @param reader Reader of file without header
+     * @param maxResults Maximum of results, which will be stored to subjects. If 0, its unlimited.
+     * @param subjects List to store subjects.
+     * @throws InternalErrorException
+     * @throws IOException
+     */
+    private void createSubjectsFromRows(String query, CSVReader reader, int maxResults, List<Map<String,String>> subjects) throws InternalErrorException, IOException {
         String[] row;
-
         while ((row = reader.readNext()) != null) {
-
             if (header.length != row.length) {
                 throw new RuntimeException("Csv file is not valid - some rows have different number of columns from the header row.");
             }
 
             if (compareRowToQuery(row, query)) {
-
                 Map<String, String> map = convertLineToMap(row);
 
                 if (map != null) {
@@ -191,26 +240,21 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
                 }
             }
         }
-
-        return subjects;
     }
 
     /**
-     * Comparison of 1 row in csv file with the query.
-     * - if the row would be result of the query, then this method returns true
-     * - if not, then this method returns false
+     * Comparison of one row in CSV file with the query.
+     * - If the row would be result of the query, then this method returns true
+     * - If not, then this method returns false
      *
-     * @param row 1 row from csv file
+     * @param row one row from CSV file
      * @param query query we want to 'execute' on the row, e.g. nameOfColumn=valueInRow
      * @return boolean
      * @throws InternalErrorException
      */
     private boolean compareRowToQuery(String[] row, String query) throws InternalErrorException {
-
-        // symbol '=' indicates getSubjectByLogin() or getGroupSubjects method
+        // Symbol '=' indicates getSubjectByLogin()
         int index = query.indexOf("=");
-        // word 'contains' indicates findSubjects() method
-        int indexContains = query.indexOf("contains");
 
         if (index != -1) {
             String queryType = query.substring(0, index);
@@ -222,6 +266,9 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
                 }
             }
         } else {
+            // Word 'contains' indicates findSubjects() method or getGroupSubjects() method
+            int indexContains = query.indexOf("contains");
+
             if (indexContains != -1) {
                 String queryType = query.substring(0, indexContains);
                 String value = query.substring(indexContains + "contains".trim().length());
@@ -235,17 +282,16 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
                     }
                 }
             } else {
-                // if there's no symbol '=' or word 'contains' in the query
+                // If there's no symbol '=' or word 'contains' in the query
                 throw new InternalErrorException("Wrong query!");
             }
         }
-
         return false;
     }
 
     /**
      * Creates Map<String,String> from 1 row in csv file
-     * 
+     *
      * @param line 1 row from csv file
      * @return Map<String, String>, like <name,value>
      * @throws InternalErrorException
@@ -274,7 +320,7 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
                 String value = attr.substring(index + 1);
 
                 if (value.startsWith("{")) {
-                    
+
                     // exclude curly brackets from value
                     value = value.substring(1, value.length() - 1);
 
@@ -292,6 +338,12 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
         return lineAsMap;
     }
 
+    /**
+     * Get attributes of external source (defined in perun-extSources.xml).
+     *
+     * @return map with attributes about external source
+     * @throws InternalErrorException
+     */
 	protected Map<String,String> getAttributes() throws InternalErrorException {
 		return perunBl.getExtSourcesManagerBl().getAttributes(this);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
@@ -1,9 +1,13 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import static cz.metacentrum.perun.core.impl.ExtSourceLdap.log;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import java.io.BufferedReader;
 import java.io.File;
@@ -31,35 +35,43 @@ import javax.naming.directory.SearchResult;
 public class ExtSourceEGISSO extends ExtSourceLdap implements ExtSourceApi {
 
 	@Override
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException {
-		List<Map<String, String>> subjects = new ArrayList<>();
+	public String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException {
 		NamingEnumeration<SearchResult> results = null;
 
-		String query = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+		cz.metacentrum.perun.core.api.Attribute queryForGroupAttribute = null;
+		try {
+			queryForGroupAttribute = perunBl.getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+		} catch (WrongAttributeAssignmentException e) {
+			// Should not happen
+			throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " is not from group namespace.");
+		} catch (AttributeNotExistsException e) {
+			throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " must exists.");
+		}
+
+		// Get the query and base for the group subjects
+		String queryForGroup = BeansUtils.attributeValueToString(queryForGroupAttribute);
 		String base = "ou=People,dc=egi,dc=eu";
 
-		List<String> ldapGroupSubjects = new ArrayList<>();
 		try {
 			SearchControls controls = new SearchControls();
 			controls.setTimeLimit(5000);
-			results = getContext().search(base, query, controls);
+			results = getContext().search(base, queryForGroup, controls);
 			while(results.hasMore()) {
 				SearchResult searchResult = results.next();
 				subjects.add(processResultToSubject(searchResult));
 			}
 		} catch (NamingException e) {
-			log.error("LDAP exception during query {}.", query);
-			throw new InternalErrorException("LDAP exception during running query " + query , e);
+			log.error("LDAP exception during query {}.", queryForGroup);
+			throw new InternalErrorException("LDAP exception during running query " + queryForGroup , e);
 		} finally {
 			try {
 				if (results != null) { results.close(); }
 			} catch (Exception e) {
-				log.error("LDAP exception during closing result, while running query '{}'", query);
+				log.error("LDAP exception during closing result, while running query '{}'", queryForGroup);
 				throw new InternalErrorException(e);
 			}
 		}
-
-		return subjects;
+		return GroupsManager.GROUP_SYNC_STATUS_FULL;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
@@ -6,6 +6,8 @@ package cz.metacentrum.perun.core.impl;
 import java.util.List;
 import java.util.Map;
 
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +38,7 @@ public class ExtSourceIdp extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	public String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
@@ -6,6 +6,8 @@ package cz.metacentrum.perun.core.impl;
 import java.util.List;
 import java.util.Map;
 
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +38,7 @@ public class ExtSourceInternal extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	public String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
@@ -6,6 +6,8 @@ package cz.metacentrum.perun.core.impl;
 import java.util.List;
 import java.util.Map;
 
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +38,7 @@ public class ExtSourceKerberos extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	public String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -1,6 +1,9 @@
 package cz.metacentrum.perun.core.impl;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
@@ -18,22 +21,30 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import cz.metacentrum.perun.core.api.ExtSource;
-import cz.metacentrum.perun.core.api.GroupsManager;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 
 /**
  * Ext source implementation for LDAP.
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  * @author Pavel Zlámal <zlamal@cesnet.cz>
+ * @author Jan Zverina <zverina@cesnet.cz>
  */
 public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 
@@ -51,7 +62,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		return dirContext;
 	}
 
-	private static PerunBlImpl perunBl;
+	protected static PerunBlImpl perunBl;
 
 	// filled by spring (perun-core.xml)
 	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
@@ -106,30 +117,140 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		return subjects.get(0);
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException {
-
+	public String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException {
 		NamingEnumeration<SearchResult> results = null;
+		// String for detection, which type of synchronization this will be (full or modified)
+		String typeOfSynchronization = GroupsManager.GROUP_SYNC_STATUS_FULL;
+		// Check if we need to save new value of LDAP modify timestamp of group
+		boolean saveCheck = false;
 
-		List<String> ldapGroupSubjects = new ArrayList<String>();
+		// Get all group attributes and store them to map (info like query, time interval etc.)
+		List<cz.metacentrum.perun.core.api.Attribute> groupAttributes = perunBl.getAttributesManagerBl().getAttributes(sess, group);
+		Map<String, String> groupAttributesMap = new HashMap<>();
+		for (cz.metacentrum.perun.core.api.Attribute attr: groupAttributes) {
+			String value = BeansUtils.attributeValueToString(attr);
+			String name = attr.getName();
+			groupAttributesMap.put(name, value);
+		}
 
 		// Get the LDAP group name
-		String ldapGroupName = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+		String ldapGroupName = groupAttributesMap.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 		// Get optional filter for members filtering
-		String filter = attributes.get(GroupsManager.GROUPMEMBERSFILTER_ATTRNAME);
+		String filter = groupAttributesMap.get(GroupsManager.GROUPMEMBERSFILTER_ATTRNAME);
+		// If attribute filter not exists, use optional default filter from extSource definition
+		if(filter == null) filter = filteredQuery;
+		// Get modifyTimestamp of Group
+		String groupModifyTimestamp = groupAttributesMap.get(GroupsManager.GROUPCHANGEDETECTION_ATTRNAME);
+
+		String newModifyTimestamp = null;
+		try {
+			log.info("LDAP External Source: search for modifyTimestamp of ldap group: [{}]", ldapGroupName);
+
+			// If modifyTimestamp attribute exists, compare it with the one from last synchronization cycle
+			if (getAttributes().containsKey("timestampAttribute")) {
+				// Get name of timestamp attribute
+				String modifyTimestampName = getAttributes().get("timestampAttribute");
+				// Get format of modifyTimestamp from definition of extSource
+				String modifyTimestampFormat = getAttributes().get("timestampFormat");
+				if (modifyTimestampFormat == null) {
+					throw new InternalErrorException("LDAP: Format of modifyTimestamp is not defined. Declare timestampFormat in definition of extSource.");
+				}
+
+				// Get the modify timestamp attribute of group
+				Attributes attrsModifyTimestamp = getContext().getAttributes(ldapGroupName, new String[] {modifyTimestampName});
+				Attribute modifyTimestampAttribute = attrsModifyTimestamp.get(modifyTimestampName);
+
+				// Get string from modify timestamp attribute gained from external source
+				if (modifyTimestampAttribute != null) {
+					newModifyTimestamp = (String) modifyTimestampAttribute.get();
+
+					// If obtained modifyTimestamp is equal to the stored one, get list of modified members from the extSource
+					if (newModifyTimestamp != null && newModifyTimestamp.equals(groupModifyTimestamp)) {
+
+						// If its Lightweight synchronization, we don't need to gain data from extSource in this case
+						if (status.equals(GroupsManager.GROUP_SYNC_STATUS_LIGHTWEIGHT)) {
+							return GroupsManager.GROUP_SYNC_STATUS_MODIFIED;
+						}
+
+						// If start of last successful synchronization is stored in attribute, get modified members from this date
+						String startOfLastSuccessSync = groupAttributesMap.get(GroupsManager.GROUPSTARTOFLASTSUCCESSSYNC_ATTRNAME);
+						if (startOfLastSuccessSync != null) {
+							try {
+								Date startDate = BeansUtils.getDateFormatter().parse(startOfLastSuccessSync);
+								// Create string with filter to detect modified records (e.g. (modifyTimestamp>=20170414220836Z))
+								SimpleDateFormat sdf = new SimpleDateFormat(modifyTimestampFormat);
+								String dateForFilter = sdf.format(startDate);
+								String additionToFilter = "(" + modifyTimestampName + ">=" + dateForFilter + ")";
+								if (filter == null) {
+									filter = additionToFilter;
+								} else {
+									String tmp = "(&" + additionToFilter + filter + ")";
+									filter = tmp;
+								}
+								log.debug("LDAP: Filter is {}", filter);
+
+								typeOfSynchronization = GroupsManager.GROUP_SYNC_STATUS_MODIFIED;
+							} catch (ParseException e) {
+								// Should not happen
+								log.error("LDAP: Attribute " + GroupsManager.GROUPSTARTOFLASTSUCCESSSYNC_ATTRNAME + " has bad format: {}", startOfLastSuccessSync);
+								throw new InternalErrorException("Error in parsing of date with start of last success sync: " + startOfLastSuccessSync, e);
+							}
+						}
+					} else {
+						// Set check of saving new value of modify timestamp to true
+						saveCheck = true;
+					}
+				} else {
+					throw new InternalErrorException("Attribute with timestamp of group was not obtained from external source.");
+				}
+			}
+			// Gain subjects from extSource
+			queryForGroupSubjectsExtSource(ldapGroupName, filter, subjects);
+
+		} catch (NamingException e) {
+			log.error("LDAP exception during modifyTimestamp query '{}'", ldapGroupName);
+			throw new InternalErrorException("Entry '" + ldapGroupName + "' was not found in LDAP.", e);
+		} finally {
+			try {
+				if (results != null) { results.close(); }
+			} catch (Exception e) {
+				log.error("LDAP exception during closing result, while running query for group '{}'", ldapGroupName);
+				throw new InternalErrorException(e);
+			}
+		}
+
+		if (saveCheck) {
+			log.info("Saving new LDAP Group modify timestamp {}", newModifyTimestamp);
+			// Save new LDAP modify timestamp to group
+			try {
+				AttributeDefinition attributeDefinition = perunBl.getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPCHANGEDETECTION_ATTRNAME);
+				cz.metacentrum.perun.core.api.Attribute timestamp = new cz.metacentrum.perun.core.api.Attribute(attributeDefinition);
+				timestamp.setValue(newModifyTimestamp);
+				perunBl.getAttributesManagerBl().setAttributeInNestedTransaction(sess, group, timestamp);
+			} catch (WrongAttributeValueException | WrongAttributeAssignmentException | WrongReferenceAttributeValueException | AttributeNotExistsException e) {
+				throw new InternalErrorException("There is a problem with saving of new modify timestamp of group. New modify timestamp is " + newModifyTimestamp + ".");
+			}
+		}
+
+		return typeOfSynchronization;
+	}
+
+	private void queryForGroupSubjectsExtSource(String ldapGroupName, String filter, List<Map<String, String>> subjects) throws InternalErrorException {
+		List<String> ldapGroupSubjects = new ArrayList<String>();
 
 		try {
 			log.trace("LDAP External Source: searching for group subjects [{}]", ldapGroupName);
 
 			String attrName;
 			if (getAttributes().containsKey("memberAttribute")) {
-				attrName = (String) getAttributes().get("memberAttribute");
+				attrName = getAttributes().get("memberAttribute");
 			} else {
 				// Default value
 				attrName = "uniqueMember";
 			}
+
 			List<String> retAttrs = new ArrayList<String>();
 			retAttrs.add(attrName);
-
 			String[] retAttrsArray = retAttrs.toArray(new String[retAttrs.size()]);
 			Attributes attrs = getContext().getAttributes(ldapGroupName, retAttrsArray);
 
@@ -139,7 +260,6 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 				// Get the attribute which holds group subjects
 				ldapAttribute = attrs.get(attrName);
 			}
-
 			if (ldapAttribute != null) {
 				// Get the DNs of the subjects
 				for (int i=0; i < ldapAttribute.size(); i++) {
@@ -149,28 +269,13 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 				}
 			}
 
-			List<Map<String, String>> subjects = new ArrayList<Map<String, String>>();
-
-			// If attribute filter not exists, use optional default filter from extSource definition
-			if(filter == null) filter = filteredQuery;
-
 			// Now query LDAP again and search for each subject
 			for (String ldapSubjectName : ldapGroupSubjects) {
 				subjects.addAll(this.querySource(filter, ldapSubjectName, 0));
 			}
-
-			return subjects;
-
 		} catch (NamingException e) {
 			log.error("LDAP exception during running query '{}'", ldapGroupName);
 			throw new InternalErrorException("Entry '"+ldapGroupName+"' was not found in LDAP." , e);
-		} finally {
-			try {
-				if (results != null) { results.close(); }
-			} catch (Exception e) {
-				log.error("LDAP exception during closing result, while running query '{}'", ldapGroupName);
-				throw new InternalErrorException(e);
-			}
 		}
 	}
 
@@ -181,22 +286,22 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		env.put(Context.INITIAL_CONTEXT_FACTORY,"com.sun.jndi.ldap.LdapCtxFactory");
 		env.put(Context.SECURITY_AUTHENTICATION, "simple");
 		if (getAttributes().containsKey("referral")) {
-			env.put(Context.REFERRAL, (String) getAttributes().get("referral"));
+			env.put(Context.REFERRAL, getAttributes().get("referral"));
 		}
 		if (getAttributes().containsKey("url")) {
-			env.put(Context.PROVIDER_URL, (String) getAttributes().get("url"));
+			env.put(Context.PROVIDER_URL, getAttributes().get("url"));
 		} else {
 			throw new InternalErrorException("url attributes is required");
 		}
 		if (getAttributes().containsKey("user")) {
-			env.put(Context.SECURITY_PRINCIPAL, (String) getAttributes().get("user"));
+			env.put(Context.SECURITY_PRINCIPAL, getAttributes().get("user"));
 		}
 		if (getAttributes().containsKey("password")) {
-			env.put(Context.SECURITY_CREDENTIALS, (String) getAttributes().get("password"));
+			env.put(Context.SECURITY_CREDENTIALS, getAttributes().get("password"));
 		}
 
 		if (getAttributes().containsKey("filteredQuery")) {
-			filteredQuery = (String) getAttributes().get("filteredQuery");
+			filteredQuery = getAttributes().get("filteredQuery");
 		}
 
 		try {
@@ -204,8 +309,8 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 			if (getAttributes().get("ldapMapping") == null) {
 				throw new InternalErrorException("ldapMapping attributes is required");
 			}
-			String ldapMapping[] = ((String) getAttributes().get("ldapMapping")).trim().split(",\n");
-			mapping = new HashMap<String, String>();
+			String ldapMapping[] = (getAttributes().get("ldapMapping")).trim().split(",\n");
+			mapping = new HashMap<>();
 			for (String entry: ldapMapping) {
 				String values[] = entry.trim().split("=", 2);
 				mapping.put(values[0].trim(), values[1].trim());
@@ -247,7 +352,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		String ldapAttrName;
 		String rule = null;
 		Matcher matcher = null;
-		String attrValue = "";;
+		String attrValue = "";
 
 		// Check if the ldapAttrName contains regex
 		if (ldapAttrNameRaw.contains("|")) {
@@ -347,7 +452,6 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 			// If query is null, then we are finding object by the base
 			if (query == null) {
 				log.trace("search base [{}]", base);
-				// TODO jmena atributu spise prijimiat pres vstupni parametr metody
 				Attributes ldapAttributes = getContext().getAttributes(base);
 				if (ldapAttributes.size() > 0) {
 					Map<String, String> attributes = this.getSubjectAttributes(ldapAttributes);
@@ -369,9 +473,7 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 				if (base == null) base = "";
 
 				results = getContext().search(base, query, controls);
-
 				while (results.hasMore()) {
-
 					SearchResult searchResult = (SearchResult) results.next();
 					Attributes attributes = searchResult.getAttributes();
 					Map<String,String> subjectAttributes = this.getSubjectAttributes(attributes);
@@ -381,7 +483,6 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 				}
 			}
 
-			log.trace("Returning [{}] subjects", subjects.size());
 			return subjects;
 
 		} catch (NamingException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
@@ -7,6 +7,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,22 +16,32 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import cz.metacentrum.perun.core.api.ExtSource;
-import cz.metacentrum.perun.core.api.GroupsManager;
-import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 
 /**
  * @author Michal Prochazka michalp@ics.muni.cz
+ * @author Jan Zverina <zverina@cesnet.cz>
  */
 public class ExtSourceSqlComplex extends ExtSource implements ExtSourceApi {
 
@@ -86,7 +98,9 @@ public class ExtSourceSqlComplex extends ExtSource implements ExtSourceApi {
 			throw new InternalErrorException("query attribute is required");
 		}
 
-		return this.querySource(query, searchString, maxResults);
+		List<Map<String, String>> subjects = new ArrayList<>();
+		this.querySource(query, searchString, maxResults, subjects);
+		return subjects;
 	}
 
 	public Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException {
@@ -95,7 +109,8 @@ public class ExtSourceSqlComplex extends ExtSource implements ExtSourceApi {
 			throw new InternalErrorException("loginQuery attribute is required");
 		}
 
-		List<Map<String, String>> subjects = this.querySource(query, login, 0);
+		List<Map<String, String>> subjects = new ArrayList<>();
+		this.querySource(query, login, 0, subjects);
 
 		if (subjects.size() < 1) {
 			throw new SubjectNotExistsException("Login: " + login);
@@ -107,14 +122,147 @@ public class ExtSourceSqlComplex extends ExtSource implements ExtSourceApi {
 		return subjects.get(0);
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException {
-		// Get the sql query for the group subjects
-		String sqlQueryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+	public String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException {
+		// Get all group attributes and store them to map (info like query, time interval etc.)
+		List<Attribute> groupAttributes = perunBl.getAttributesManagerBl().getAttributes(sess, group);
+		Map<String, String> groupAttributesMap = new HashMap<>();
+		for (Attribute attr: groupAttributes) {
+			String value = BeansUtils.attributeValueToString(attr);
+			String name = attr.getName();
+			groupAttributesMap.put(name, value);
+		}
 
-		return this.querySource(sqlQueryForGroup, null, 0);
+		// Get url of database
+		if (getAttributes().get("url") == null) {
+			throw new InternalErrorException("url attribute is required");
+		}
+
+		// Register driver if the attribute has been defined
+		if (getAttributes().get("driver") != null) {
+			try {
+				Class.forName(getAttributes().get("driver"));
+			} catch (ClassNotFoundException e) {
+				throw new InternalErrorException("Driver " + getAttributes().get("driver") + " cannot be registered", e);
+			}
+		}
+
+		// Query for members (can be changed later, if we can get only modified members)
+		String queryForMembers = groupAttributesMap.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+		if (queryForMembers == null || queryForMembers.isEmpty()) {
+			throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " must be defined for group " + group + ".");
+		}
+
+		// Status of synchronization process (if we get all subjects from extSource or only modified)
+		String extSourceStatus = GroupsManager.GROUP_SYNC_STATUS_FULL;
+		// Check if we need to save new value of CRC to group change detection value
+		boolean saveCheck = false;
+		// Get query for group change detection
+		String queryForChangeDetection = groupAttributesMap.get(GroupsManager.GROUPCHANGEDETECTIONQUERY_ATTRNAME);
+		// String storing new value of CRC
+		String crc = null;
+
+		// Prepare statement and result for queries
+		PreparedStatement st = null;
+		ResultSet rs = null;
+		try {
+			// Check if we have existing connection. In case of Oracle also checks the connection validity
+			if (this.con == null || (this.isOracle && !this.con.isValid(0))) {
+				this.createConnection();
+			}
+
+			// If group has filled group detection query
+			if (queryForChangeDetection != null && !queryForChangeDetection.isEmpty()) {
+				st = this.con.prepareStatement(queryForChangeDetection);
+				rs = st.executeQuery();
+
+				while (rs.next()) {
+					crc = rs.getString("crc");
+					log.info("CRC: {}", crc);
+				}
+
+				// Get format of modifyTimestamp from definition of extSource
+				String dateFormat = getAttributes().get("timestampFormat");
+				if (dateFormat == null || dateFormat.isEmpty()) {
+					throw new InternalErrorException("ExtSourceSQLComplex: Format of timestamp is not defined. Declare timestampFormat attribute in definition of external source: " + this);
+				}
+
+				// Get query to get modified members
+				String modifiedMembersQuery = groupAttributesMap.get(GroupsManager.GROUPMODIFIEDMEMBERSQUERY_ATTRNAME);
+				if (modifiedMembersQuery == null || modifiedMembersQuery.isEmpty()) {
+					throw new InternalErrorException("ExtSourceSQLComplex: Group [" + group + "] has filled query for change detection, but doesn't have defined query for modified members.");
+				}
+
+				// Get group attribute with change detection value
+				String groupChangeDetection = groupAttributesMap.get(GroupsManager.GROUPCHANGEDETECTION_ATTRNAME);
+				if (groupChangeDetection != null && !groupChangeDetection.isEmpty()) {
+					// Compare obtained CRC with the stored one in change detection value
+					if (groupChangeDetection.equals(crc)) {
+						// If its Lightweight synchronization, we don't need to gain data from extSource in this case
+						if (status.equals(GroupsManager.GROUP_SYNC_STATUS_LIGHTWEIGHT)) {
+							return GroupsManager.GROUP_SYNC_STATUS_MODIFIED;
+						}
+
+						String startOfLastSuccessSync = groupAttributesMap.get(GroupsManager.GROUPSTARTOFLASTSUCCESSSYNC_ATTRNAME);
+						try {
+							if (startOfLastSuccessSync != null && !startOfLastSuccessSync.isEmpty()) {
+								java.util.Date startDate = BeansUtils.getDateFormatter().parse(startOfLastSuccessSync);
+								SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+								String date = sdf.format(startDate);
+								String tmp = modifiedMembersQuery.replace("?", date);
+								queryForMembers = tmp;
+								extSourceStatus = GroupsManager.GROUP_SYNC_STATUS_MODIFIED;
+							}
+						} catch (ParseException e) {
+							// Should not happen
+							log.error("ExtSourceSQLComplex: Attribute " + GroupsManager.GROUPSTARTOFLASTSUCCESSSYNC_ATTRNAME + " has bad format: {}", startOfLastSuccessSync);
+							throw new InternalErrorException("Error in parsing of date with start of last success sync: " + startOfLastSuccessSync, e);
+						}
+					} else {
+						// We need to update value of change detection
+						saveCheck = true;
+					}
+				} else {
+					// We don't have stored CRC value in change detection attribute yet, so we need to store it
+					saveCheck = true;
+				}
+			}
+
+		} catch (SQLException e) {
+			log.error("SQL exception during query '{}'", queryForChangeDetection);
+			throw new InternalErrorRuntimeException(e);
+		} finally {
+			try {
+				if (rs != null) rs.close();
+				if (st != null) st.close();
+			} catch (SQLException e) {
+				log.error("SQL exception during closing the resultSet {} or statement {}.", rs, st);
+				throw new InternalErrorRuntimeException(e);
+			}
+		}
+		log.info("STATUS: {}", extSourceStatus);
+		log.info("QUERY: {}", queryForMembers);
+
+		// Query external sources for members
+		this.querySource(queryForMembers, null, 0, subjects);
+
+		// Save new value of change detection if needed
+		if (saveCheck) {
+			log.info("Saving new Group's change detection value {}", crc);
+			// Save new LDAP modify timestamp to group
+			try {
+				AttributeDefinition attributeDefinition = perunBl.getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPCHANGEDETECTION_ATTRNAME);
+				Attribute newChangeDetectionValue = new Attribute(attributeDefinition);
+				newChangeDetectionValue.setValue(crc);
+				perunBl.getAttributesManagerBl().setAttributeInNestedTransaction(sess, group, newChangeDetectionValue);
+			} catch (WrongAttributeValueException | WrongAttributeAssignmentException | WrongReferenceAttributeValueException | AttributeNotExistsException e) {
+				throw new InternalErrorException("There is a problem with saving of change detection value attribute to group "
+						+ group + ". New value is " + crc + ".");
+			}
+		}
+		return extSourceStatus;
 	}
 
-	protected List<Map<String,String>> querySource(String query, String searchString, int maxResults) throws InternalErrorException {
+	protected void querySource(String query, String searchString, int maxResults, List<Map<String, String>> subjects) throws InternalErrorException {
 		PreparedStatement st = null;
 		ResultSet rs = null;
 
@@ -155,9 +303,6 @@ public class ExtSourceSqlComplex extends ExtSource implements ExtSourceApi {
 
 			}
 			rs = st.executeQuery();
-
-			List<Map<String, String>> subjects = new ArrayList<Map<String, String>>();
-
 			log.trace("Query {}", query);
 
 			while (rs.next()) {
@@ -263,7 +408,6 @@ public class ExtSourceSqlComplex extends ExtSource implements ExtSourceApi {
 			}
 
 			log.debug("Returning {} subjects from external source {} for searchString {}", new Object[] {subjects.size(), this, searchString});
-			return subjects;
 
 		} catch (SQLException e) {
 			log.error("SQL exception during searching for subject '{}'", query);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
@@ -6,6 +6,8 @@ package cz.metacentrum.perun.core.impl;
 import java.util.List;
 import java.util.Map;
 
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +38,7 @@ public class ExtSourceX509 extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+	public String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
@@ -3,6 +3,8 @@ package cz.metacentrum.perun.core.implApi;
 import java.util.List;
 import java.util.Map;
 
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -59,12 +61,16 @@ public interface ExtSourceSimpleApi {
 	/**
 	 * Get the list of the subjects in the external group.
 	 *
-	 * @param attributes map of attributes used for quering the external source
-	 * @return list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
+	 *
+	 *
+	 * @param sess
+	 * @param group map of attributes used for quering the external source
+	 * @param status
+	 * @param subjects
 	 * @throws InternalErrorException
 	 * @throws ExtSourceUnsupportedOperationException
 	 */
-	List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException;
+	String getGroupSubjects(PerunSession sess, Group group, String status, List<Map<String, String>> subjects) throws InternalErrorException, ExtSourceUnsupportedOperationException;
 
 	/**
 	 * If extSource needs to be closed, this method must be called.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -1,5 +1,13 @@
 package cz.metacentrum.perun.core.api;
 
+import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
+import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
+import cz.metacentrum.perun.core.api.exceptions.GroupOperationsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.UserDuplicateException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.AuthzRoles;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -9,7 +17,6 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.List;
 
-import cz.metacentrum.perun.core.api.exceptions.*;
 import org.junit.Test;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
@@ -300,7 +307,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 	}
 
-	private Member createSomeMember(final Vo createdVo) throws ExtendMembershipException, AlreadyMemberException, WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, GroupOperationsException {
+	private Member createSomeMember(final Vo createdVo) throws ExtendMembershipException, AlreadyMemberException, WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, GroupOperationsException, UserDuplicateException {
 		final Candidate candidate = setUpCandidate();
 		final Member createdMember = perun.getMembersManagerBl().createMemberSync(sess, createdVo, candidate);
 		return createdMember;


### PR DESCRIPTION
ExtSource*:
 - Methods getGroupSubjects now return string with status. It fills subjects through given parameter now.
 - Private methods changed to support change mentioned above.

---

Methods categorizeMembersForLightweightSynchronization and categorizeMembersForSynchronization were changed.
Now it uses map where key is login from needed external source and value is RichMember attached to this login.
Thanks to this is checking if user is already in group faster.

---

Methods to getCandidate were refactored. Now they count hash code of subject obtained from external source.
Hashcodes of subjects are stored in member-group attribute. If it has same value in the next synchronization cycle,
we don't need to update this member's attributes.

---

Communication with external sources SQL, SQLComplex and LDAP was changed.
Now they can send us only modified members of group, when it is possible.

---

UserDuplicateException was created. It is thrown when candidate,
which should be added to group, represents more than one User.