### PR TITLE
CORE: Check on UES existence must check ID too

### DIFF
--- a/perun-cli/Perun/UsersAgent.pm
+++ b/perun-cli/Perun/UsersAgent.pm
@@ -73,9 +73,19 @@ sub removeUserExtSource
 	return Perun::Common::callManagerMethod('removeUserExtSource', 'null', @_);
 }
 
+sub updateUserExtSource
+{
+	return Perun::Common::callManagerMethod('updateUserExtSource', 'UserExtSource', @_);
+}
+
 sub getUserExtSourceByExtLogin
 {
 	return Perun::Common::callManagerMethod('getUserExtSourceByExtLogin', 'UserExtSource', @_);
+}
+
+sub getUserExtSourceById
+{
+	return Perun::Common::callManagerMethod('getUserExtSourceById', 'UserExtSource', @_);
 }
 
 sub getVosWhereUserIsAdmin

--- a/perun-cli/Perun/beans/UserExtSource.pm
+++ b/perun-cli/Perun/beans/UserExtSource.pm
@@ -40,9 +40,23 @@ sub TO_JSON
 		$loa = 0;
 	}
 
+	my $persistent;
+	if (defined($self->{_persistent})) {
+		$persistent = $self->{_persistent};
+	} else {
+		$persistent = undef;
+	}
+
+	my $userId;
+	if (defined($self->{_userId})) {
+		$userId = $self->{_userId} * 1;
+	} else {
+		$userId = 0;
+	}
+
 	my $extSource = $self->{_extSource};
 
-	return { id => $id, login => $login, loa => $loa, extSource => $extSource };
+	return { id => $id, login => $login, loa => $loa, userId => $userId, persistent => $persistent, extSource => $extSource };
 }
 
 sub getId
@@ -86,6 +100,45 @@ sub setLogin
 {
 	my $self = shift;
 	$self->{_login} = shift;
+
+	return;
+}
+
+sub isPersistent
+{
+	my $self = shift;
+	return ($self->{_persistent}) ? 'true' : 'false';
+}
+
+sub setPersistent
+{
+	my $self = shift;
+	my $value = shift;
+	if (ref $value eq "JSON::XS::Boolean")
+	{
+		$self->{_persistent} = $value;
+	} elsif ($value eq 'true' || $value eq 1)
+	{
+		$self->{_persistent} = JSON::XS::true;
+	} else
+	{
+		$self->{_persistent} = JSON::XS::false;
+	}
+
+	return;
+}
+
+sub getUserId
+{
+	my $self = shift;
+
+	return $self->{_userId};
+}
+
+sub setUserId
+{
+	my $self = shift;
+	$self->{_userId} = shift;
 
 	return;
 }

--- a/perun-cli/removeNotifReceiver
+++ b/perun-cli/removeNotifReceiver
@@ -14,7 +14,7 @@ Available options:
  --NotifReceiverId       | -i id of the NotifReceiver
  --batch                 | -b batch
  --help                  | -h prints this help
- 
+
 };
 }
 

--- a/perun-cli/removeNotifReceiver
+++ b/perun-cli/removeNotifReceiver
@@ -8,12 +8,12 @@ use Perun::Common qw(printMessage);
 
 sub help {
 	return qq{
-Removes NotifReceiver from db by id. Id is required field.
-------------------------------------
-Available options:
- --NotifReceiverId       | -i id of the NotifReceiver
- --batch                 | -b batch
- --help                  | -h prints this help
+	Removes NotifReceiver from db by id. Id is required field.
+	------------------------------------
+	Available options:
+	--NotifReceiverId       | -i id of the NotifReceiver
+	--batch                 | -b batch
+	--help                  | -h prints this help
 
 };
 }

--- a/perun-cli/removeNotifTemplateMessage
+++ b/perun-cli/removeNotifTemplateMessage
@@ -8,12 +8,12 @@ use Perun::Common qw(printMessage);
 
 sub help {
 	return qq{
-Removes NotifTemplateMessage from db by id. Id is required field.
-------------------------------------
-Available options:
- --NotifTemplateMessageId        | -i id of the NotifTemplateMessage
- --batch                         | -b batch
- --help                          | -h prints this help
+	Removes NotifTemplateMessage from db by id. Id is required field.
+	------------------------------------
+	Available options:
+	--NotifTemplateMessageId        | -i id of the NotifTemplateMessage
+	--batch                         | -b batch
+	--help                          | -h prints this help
 
 };
 }

--- a/perun-cli/removeNotifTemplateMessage
+++ b/perun-cli/removeNotifTemplateMessage
@@ -14,7 +14,7 @@ Available options:
  --NotifTemplateMessageId        | -i id of the NotifTemplateMessage
  --batch                         | -b batch
  --help                          | -h prints this help
- 
+
 };
 }
 

--- a/perun-cli/updateGroup
+++ b/perun-cli/updateGroup
@@ -13,7 +13,7 @@ sub help {
 	Available options:
 	--groupId     | -g group id
 	--name        | -n new name for the group
-        --dsc         | -d new description for the group
+	--dsc         | -d new description for the group
 	--batch       | -b batch
 	--help        | -h prints this help
 

--- a/perun-cli/updateNotifReceiver
+++ b/perun-cli/updateNotifReceiver
@@ -11,8 +11,8 @@ sub help {
 Updates NotifReceiver. Id is required field.
 --------------------------------------
 Available options:
- --NotifReceiverId      | -i id of the NotifReceiver 
- --target               | -r target 
+ --NotifReceiverId      | -i id of the NotifReceiver
+ --target               | -r target
  --typeOfReceiver       | -t type of receiver (EMAIL_USER / EMAIL_GROUP / JABBER)
  --templateId           | -p template id (template has to exist)
  --locale 		| -l locale

--- a/perun-cli/updateNotifReceiver
+++ b/perun-cli/updateNotifReceiver
@@ -8,16 +8,16 @@ use Perun::Common qw(printMessage);
 
 sub help {
 	return qq{
-Updates NotifReceiver. Id is required field.
---------------------------------------
-Available options:
- --NotifReceiverId      | -i id of the NotifReceiver
- --target               | -r target
- --typeOfReceiver       | -t type of receiver (EMAIL_USER / EMAIL_GROUP / JABBER)
- --templateId           | -p template id (template has to exist)
- --locale 		| -l locale
- --batch                | -b batch
- --help                 | -h prints this help
+	Updates NotifReceiver. Id is required field.
+	--------------------------------------
+	Available options:
+	--NotifReceiverId      | -i id of the NotifReceiver
+	--target               | -r target
+	--typeOfReceiver       | -t type of receiver (EMAIL_USER / EMAIL_GROUP / JABBER)
+	--templateId           | -p template id (template has to exist)
+	--locale 		       | -l locale
+	--batch                | -b batch
+	--help                 | -h prints this help
 
 };
 }

--- a/perun-cli/updateUserExtSource
+++ b/perun-cli/updateUserExtSource
@@ -1,0 +1,55 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::Agent;
+use Perun::Common qw(printMessage);
+
+sub help {
+	return qq{
+	Updates UserExtSource - change login or LoA or both. UES ID and (login or loa) is required.
+	Only Perun admin is allowed to use this tool.
+	---------------------------------------
+	Available options:
+	--uesId       | -i user ext source ID
+	--login       | -l login to set
+	--loa         | -o level of assurance (0,1,2) to set
+	--batch       | -b batch
+	--help        | -h prints this help
+
+};
+}
+
+my ($uesId, $login, $loa, $batch);
+GetOptions ("help|h"  => sub {
+		print help();
+		exit 0;
+	}, "batch|b"    => \$batch,
+	"uesId|i=i"     => \$uesId,
+	"login|l=s"     => \$login,
+	"loa|o=s"       => \$loa) || die help();
+
+# Check options
+unless (defined($uesId)) { die "ERROR: uesId is required \n";}
+
+unless (defined($login) or defined($loa)) { die "ERROR: login or loa is required \n";}
+
+my $agent = Perun::Agent->new();
+my $usersAgent = $agent->getUsersAgent;
+
+my $ues = $usersAgent->getUserExtSourceById( userExtSource => $uesId );
+
+if (defined($login)) {
+	unless ($login !~ /^\s*$/) { die "ERROR: login cannot be empty string\n";}
+	$ues->setLogin( $login );
+}
+
+if (defined($loa)) {
+	unless ($loa >= 0 and $loa < 3) { die "ERROR: loa can be only 0,1,2\n";}
+	$ues->setLoa( $loa );
+}
+
+$ues = $usersAgent->updateUserExtSource( userExtSource => $ues );
+
+printMessage("User ext source Id:$uesId successfully updated", $batch);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -312,6 +312,7 @@ public interface UsersManager {
 
 	/**
 	 *  Updates user's userExtSource in DB.
+	 *  Login and LoA can be updated this way.
 	 *
 	 * @param perunSession
 	 * @param userExtSource

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -319,9 +319,10 @@ public interface UsersManager {
 	 * @return updated userExtSource
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
-	 * @throws UserExtSourceNotExistsException
+	 * @throws UserExtSourceExistsException When UES with same login/extSource already exists.
+	 * @throws UserExtSourceNotExistsException When UES by its ID doesn't exists
 	 */
-	UserExtSource updateUserExtSource(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException, PrivilegeException;
+	UserExtSource updateUserExtSource(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException, UserExtSourceExistsException, PrivilegeException;
 
 	/**
 	 * Gets list of all user's external sources of the user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -891,7 +891,7 @@ public interface UsersManagerBl {
 
 	void checkUserExtSourceExists(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException;
 
-	boolean checkUserExtSourceExistsById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException;
+	void checkUserExtSourceExistsById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException;
 
 	boolean userExtSourceExists(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -317,8 +317,9 @@ public interface UsersManagerBl {
 	 * @param userExtSource
 	 * @return updated userExtSource
 	 * @throws InternalErrorException
+	 * @throws UserExtSourceExistsException When UES with same login/extSource already exists.
 	 */
-	UserExtSource updateUserExtSource(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException;
+	UserExtSource updateUserExtSource(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceExistsException;
 
 	/**
 	 * Updates user's userExtSource last access time in DB. We can get information which userExtSource has been used as a last one.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -891,6 +891,8 @@ public interface UsersManagerBl {
 
 	void checkUserExtSourceExists(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException;
 
+	boolean checkUserExtSourceExistsById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException;
+
 	boolean userExtSourceExists(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -398,6 +398,8 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 					} catch (UserExtSourceExistsException e1) {
 						throw new ConsistencyErrorException("Adding userExtSource which already exists: " + userExtSource);
 					}
+				} catch (UserExtSourceExistsException e1) {
+					throw new ConsistencyErrorException("Updating login of userExtSource to value which already exists: " + userExtSource);
 				}
 			}
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -29,6 +29,7 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeDefinitionExistsExcepti
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -163,8 +164,8 @@ public class PerunBlImpl implements PerunBl {
 						}
 					}
 				}
-			} catch (ExtSourceNotExistsException | UserExtSourceNotExistsException | UserNotExistsException e) {
-				// OK - We don't know user yet
+			} catch (ExtSourceNotExistsException | UserExtSourceNotExistsException | UserNotExistsException | UserExtSourceExistsException e) {
+				// OK - We don't know user yet or we are modifying more than a LoA and we shouldn't !!
 			}
 		}
 		return perunSession;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -809,8 +809,8 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		getUsersManagerImpl().checkUserExtSourceExists(sess, userExtSource);
 	}
 
-	public boolean checkUserExtSourceExistsById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException {
-		return getUsersManagerImpl().checkUserExtSourceExistsById(sess, id);
+	public void checkUserExtSourceExistsById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException {
+		getUsersManagerImpl().checkUserExtSourceExistsById(sess, id);
 	}
 
 	public boolean userExtSourceExists(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -809,6 +809,10 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		getUsersManagerImpl().checkUserExtSourceExists(sess, userExtSource);
 	}
 
+	public boolean checkUserExtSourceExistsById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException {
+		return getUsersManagerImpl().checkUserExtSourceExistsById(sess, id);
+	}
+
 	public boolean userExtSourceExists(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException {
 		return getUsersManagerImpl().userExtSourceExists(sess, userExtSource);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -460,7 +460,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		return afterUpdatingUser;
 	}
 
-	public UserExtSource updateUserExtSource(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException {
+	public UserExtSource updateUserExtSource(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceExistsException {
 		getPerunBl().getAuditer().log(sess, "{} updated.", userExtSource);
 		return getUsersManagerImpl().updateUserExtSource(sess, userExtSource);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -362,9 +362,12 @@ public class UsersManagerEntry implements UsersManager {
 			throw new PrivilegeException(sess, "updateUserExtSource");
 		}
 
-		getUsersManagerBl().checkUserExtSourceExists(sess, userExtSource);
+		if (getUsersManagerBl().checkUserExtSourceExistsById(sess, userExtSource.getId())) {
+			return getUsersManagerBl().updateUserExtSource(sess, userExtSource);
+		} else {
+			throw new UserExtSourceNotExistsException("UserExtSource: " + userExtSource);
+		}
 
-		return getUsersManagerBl().updateUserExtSource(sess, userExtSource);
 	}
 
 	public List<UserExtSource> getUserExtSources(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -362,11 +362,9 @@ public class UsersManagerEntry implements UsersManager {
 			throw new PrivilegeException(sess, "updateUserExtSource");
 		}
 
-		if (getUsersManagerBl().checkUserExtSourceExistsById(sess, userExtSource.getId())) {
-			return getUsersManagerBl().updateUserExtSource(sess, userExtSource);
-		} else {
-			throw new UserExtSourceNotExistsException("UserExtSource: " + userExtSource);
-		}
+		getUsersManagerBl().checkUserExtSourceExistsById(sess, userExtSource.getId());
+
+		return getUsersManagerBl().updateUserExtSource(sess, userExtSource);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -354,7 +354,7 @@ public class UsersManagerEntry implements UsersManager {
 		return getUsersManagerBl().updateNameTitles(sess, user);
 	}
 
-	public UserExtSource updateUserExtSource(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException, PrivilegeException {
+	public UserExtSource updateUserExtSource(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException, UserExtSourceExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -363,6 +363,12 @@ public class UsersManagerEntry implements UsersManager {
 		}
 
 		getUsersManagerBl().checkUserExtSourceExistsById(sess, userExtSource.getId());
+
+		try {
+			getUsersManagerBl().checkUserExtSourceExists(sess, userExtSource);
+		} catch (UserExtSourceNotExistsException ex) {
+			// silently skip, since it's expected, that new value is not taken already
+		}
 
 		return getUsersManagerBl().updateUserExtSource(sess, userExtSource);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -939,14 +939,26 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		Utils.notNull(userExtSource.getLogin(), "userExtSource.getLogin");
 		Utils.notNull(userExtSource.getExtSource(), "userExtSource.getExtSource");
 
+		boolean exists = false;
 		try {
+
+			// check by ext identity (login/ext source ID)
 			if (userExtSource.getUserId() >= 0) {
-				return 1 == jdbc.queryForInt("select 1 from user_ext_sources where login_ext=? and ext_sources_id=? and user_id=?",
+				exists = 1 == jdbc.queryForInt("select 1 from user_ext_sources where login_ext=? and ext_sources_id=? and user_id=?",
 						userExtSource.getLogin(), userExtSource.getExtSource().getId(), userExtSource.getUserId());
 			} else {
-				return 1 == jdbc.queryForInt("select 1 from user_ext_sources where login_ext=? and ext_sources_id=?",
+				exists = 1 == jdbc.queryForInt("select 1 from user_ext_sources where login_ext=? and ext_sources_id=?",
 						userExtSource.getLogin(), userExtSource.getExtSource().getId());
 			}
+
+			// check by UES ID if present in object
+			if (!exists && userExtSource.getId() > 0) {
+				exists = 1 == jdbc.queryForInt("select 1 from user_ext_sources where id=?",
+						userExtSource.getId());
+			}
+
+			return exists;
+
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -955,7 +967,7 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	public List<User> getUsersByIds(PerunSession sess, List<Integer> usersIds) throws InternalErrorException {
-		// If usersIds is empty, we can immediatelly return empty results
+		// If usersIds is empty, we can immediately return empty results
 		if (usersIds.size() == 0) {
 			return new ArrayList<User>();
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -951,6 +951,13 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 						userExtSource.getLogin(), userExtSource.getExtSource().getId());
 			}
 
+		} catch(EmptyResultDataAccessException ex) {
+			exists = false;
+		} catch(RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+		try {
 			// check by UES ID if present in object
 			if (!exists && userExtSource.getId() > 0) {
 				exists = 1 == jdbc.queryForInt("select 1 from user_ext_sources where id=?",
@@ -958,12 +965,12 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 			}
 
 			return exists;
-
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+
 	}
 
 	public List<User> getUsersByIds(PerunSession sess, List<Integer> usersIds) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -916,10 +916,11 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 		if(!userExtSourceExists(sess, userExtSource)) throw new UserExtSourceNotExistsException("UserExtSource: " + userExtSource);
 	}
 
-	public boolean checkUserExtSourceExistsById(PerunSession sess, int id) throws InternalErrorException {
+	public void checkUserExtSourceExistsById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException {
 
 		try {
-			return 1 == jdbc.queryForInt("select 1 from user_ext_sources where id=?", id);
+			boolean exists = 1 == jdbc.queryForInt("select 1 from user_ext_sources where id=?", id);
+			if (!exists) throw new UserExtSourceNotExistsException("UserExtSource with ID=" + id + " doesn't exists.");
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.api.exceptions.SpecificUserAlreadyRemovedExcept
 import cz.metacentrum.perun.core.api.exceptions.SpecificUserOwnerAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceAlreadyRemovedException;
+import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
@@ -233,8 +234,9 @@ public interface UsersManagerImplApi {
 	 * @param userExtSource
 	 * @return updated user
 	 * @throws InternalErrorException
+	 * @throws UserExtSourceExistsException When UES with same login/extSource already exists.
 	 */
-	UserExtSource updateUserExtSource(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException;
+	UserExtSource updateUserExtSource(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceExistsException;
 
 	/**
 	 *  Updates user's userExtSource last access time in DB.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -403,8 +403,9 @@ public interface UsersManagerImplApi {
 	 * @param perunSession
 	 * @param id
 	 * @throws InternalErrorException
+	 * @throws UserExtSourceNotExistsException
 	 */
-	boolean checkUserExtSourceExistsById(PerunSession perunSession, int id) throws InternalErrorException;
+	void checkUserExtSourceExistsById(PerunSession perunSession, int id) throws InternalErrorException, UserExtSourceNotExistsException;
 
 	/**
 	 * Returns list of VOs, where the user is an Administrator.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -388,7 +388,7 @@ public interface UsersManagerImplApi {
 	boolean userExtSourceExists(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException;
 
 	/**
-	 * Check if userExtSource exists in underlaying data source.
+	 * Check if userExtSource exists in underlaying data source by identity (login/extSource combination)
 	 *
 	 * @param perunSession
 	 * @param userExtSource
@@ -396,6 +396,15 @@ public interface UsersManagerImplApi {
 	 * @throws UserExtSourceNotExistsException
 	 */
 	void checkUserExtSourceExists(PerunSession perunSession, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException;
+
+	/**
+	 * Check if userExtSource exists in underlaying data source by its ID.
+	 *
+	 * @param perunSession
+	 * @param id
+	 * @throws InternalErrorException
+	 */
+	boolean checkUserExtSourceExistsById(PerunSession perunSession, int id) throws InternalErrorException;
 
 	/**
 	 * Returns list of VOs, where the user is an Administrator.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.*;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,6 +23,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * Integration tests of UsersManager.
@@ -405,6 +407,47 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	@Test
+	public void updateUserExtSource() throws Exception {
+		System.out.println(CLASS_NAME + "updateUserExtSource");
+
+		ExtSource ext1 = new ExtSource("test1", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+		ext1 = perun.getExtSourcesManagerBl().createExtSource(sess, ext1, null);
+
+		UserExtSource ues1 = new UserExtSource(ext1, 1, "testExtLogin@test");
+		ues1 = usersManager.addUserExtSource(sess, user, ues1);
+
+		ues1.setLoa(2);
+		usersManager.updateUserExtSource(sess, ues1);
+
+		UserExtSource retrievedUes = usersManager.getUserExtSourceById(sess, ues1.getId());
+		Assert.assertTrue("LoA was not updated", retrievedUes.getLoa() == ues1.getLoa());
+
+		ues1.setLogin("changedTestExtLogin@test");
+		usersManager.updateUserExtSource(sess, ues1);
+
+		retrievedUes = usersManager.getUserExtSourceById(sess, ues1.getId());
+		Assert.assertTrue("Login was not updated", Objects.equals(retrievedUes.getLogin(),ues1.getLogin()));
+
+	}
+
+	@Test (expected = UserExtSourceExistsException.class)
+	public void updateUserExtSourceWhenExists() throws Exception {
+		System.out.println(CLASS_NAME + "updateUserExtSourceWhenExists");
+
+		ExtSource ext1 = new ExtSource("test1", ExtSourcesManagerEntry.EXTSOURCE_IDP);
+		ext1 = perun.getExtSourcesManagerBl().createExtSource(sess, ext1, null);
+
+		UserExtSource ues1 = new UserExtSource(ext1, 1, "testExtLogin@test");
+		ues1 = usersManager.addUserExtSource(sess, user, ues1);
+		UserExtSource ues2 = new UserExtSource(ext1, 1, "testExtLogin2@test");
+		ues2 = usersManager.addUserExtSource(sess, user, ues2);
+
+		ues2.setLogin("testExtLogin@test");
+		usersManager.updateUserExtSource(sess, ues2);
+
+	}
+
+	@Test
 	public void getUserByUserExtSource() throws Exception {
 		System.out.println(CLASS_NAME + "getUserByUserExtSource");
 
@@ -564,7 +607,7 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	@Test
 	public void moveUserExtSource() throws Exception {
 		System.out.println(CLASS_NAME + "removeUserExtSourceWithAttribute");
-		
+
 		//TargetUser
 		User targetUser = setUpEmptyUser();
 


### PR DESCRIPTION
- We initially checked only UES ID, but it caused errors in
  synchronization, so we switched too check on login/extSource.
  But dropping check on ID causes updateUserExtSource to fail,
  since identity might change in posted data but ID prevails.
  So if UES is not found by login/extSource, we try to find it by its
  ID (if not 0) in source object.
- We can now update login and loa form the CLI by updateUserExtSource
  tool.
- Added necessary API call definitions to UsersAgent.pm.
- Correctly align help output in some notif CLI tools.
- Updated UserExtSource definition in CLI (added userId and persistent
  params).