### PR TITLE
checkAttributeValue methods for Entityless and Hosts

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -3215,7 +3215,7 @@ public interface AttributesManager {
 	 * @throws AttributeNotExistsException if given attribute doesn't exist
 	 * @throws HostNotExistsException if specified host doesn't exist
 	 */
-	void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws PrivilegeException, InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException,AttributeNotExistsException, HostNotExistsException;
+	void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws PrivilegeException, InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, HostNotExistsException, WrongReferenceAttributeValueException;
 
 	/**
 	 * PRIVILEGE: Check attributes only when principal has access to write on them.
@@ -3223,7 +3223,7 @@ public interface AttributesManager {
 	 * batch version of checkAttributeValue
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession, Host, Attribute)
 	 */
-	void checkAttributesValue(PerunSession sess, Host host, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, HostNotExistsException, WrongAttributeValueException,WrongAttributeAssignmentException;
+	void checkAttributesValue(PerunSession sess, Host host, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, HostNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Checks if value of this group attribute is valid

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2762,13 +2762,13 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongAttributeAssignmentException if the attribute isn't host attribute
 	 */
-	void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws InternalErrorException,WrongAttributeValueException,WrongAttributeAssignmentException;
+	void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Batch version of checkAttributeValue
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession,Host,Attribute)
 	 */
-	void checkAttributesValue(PerunSession sess, Host host, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException,WrongAttributeAssignmentException;
+	void checkAttributesValue(PerunSession sess, Host host, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if the value of this entityless attribute is valid

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1978,8 +1978,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(changed) {
 			getPerunBl().getAuditer().log(sess, "{} set for {}.", attribute, host);
-			//TODO this method not existed yet!
-			//getAttributesManagerImpl().changedAttributeHook(sess, host, attribute);
+			getAttributesManagerImpl().changedAttributeHook(sess, host, attribute);
 		}
 
 		return changed;
@@ -2067,8 +2066,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 		if(changed) {
 			getPerunBl().getAuditer().log(sess, "{} set for {}.", attribute, key);
-			//TODO this method not existed yet
-			//getAttributesManagerImpl().changedAttributeHook(sess, key, attribute);
+			getAttributesManagerImpl().changedAttributeHook(sess, key, attribute);
 		}
 
 		return changed;
@@ -3203,14 +3201,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 	}
 
-	public void checkAttributesValue(PerunSession sess, Host host, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException,WrongAttributeAssignmentException{
+	public void checkAttributesValue(PerunSession sess, Host host, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, AttributesManager.NS_HOST_ATTR);
 
 		for(Attribute attribute : attributes) {
 			getAttributesManagerImpl().checkAttributeValue(sess, host, attribute);
 		}
 	}
-	public void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException,WrongAttributeAssignmentException{
+	public void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_HOST_ATTR);
 
 		getAttributesManagerImpl().checkAttributeValue(sess, host, attribute);
@@ -3471,7 +3469,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 	}
 
-	public void removeAttribute(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException {
+	public void removeAttribute(PerunSession sess, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		if (removeAttributeWithoutCheck(sess, host, attribute)) {
 			checkAttributeValue(sess, host, new Attribute(attribute));
 			try {
@@ -3488,22 +3486,21 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		boolean changed = getAttributesManagerImpl().removeAttribute(sess, host, attribute);
 		if (changed) {
-			//TODO HOOK FOR HOSTS!
-			/*try {
+			try {
 				getAttributesManagerImpl().changedAttributeHook(sess, host, new Attribute(attribute));
-				} catch (WrongAttributeValueException ex) {
+			} catch (WrongAttributeValueException ex) {
 			//TODO better exception here
 			throw new InternalErrorException(ex);
 			} catch (WrongReferenceAttributeValueException ex) {
 			//TODO better exception here
 			throw new InternalErrorException(ex);
-			}*/
+			}
 			getPerunBl().getAuditer().log(sess, "{} removed for {}", attribute, host);
 		}
 		return changed;
 	}
 
-	public void removeAttributes(PerunSession sess, Host host, List<? extends AttributeDefinition> attributesDefinition) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException {
+	public void removeAttributes(PerunSession sess, Host host, List<? extends AttributeDefinition> attributesDefinition) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributesDefinition, AttributesManager.NS_HOST_ATTR);
 		List<AttributeDefinition> attributesToCheck = new ArrayList<AttributeDefinition>();
 		for(AttributeDefinition attribute : attributesDefinition) {
@@ -3535,19 +3532,17 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			throw new WrongAttributeValueException(ex);
 		}
 
-		//TODO HOOK FOR HOSTS
-		/*
-			 for(Attribute attribute: attributes) {
-			 try {
-			 getAttributesManagerImpl().changedAttributeHook(sess, host, new Attribute(attribute));
-			 } catch (WrongAttributeValueException ex) {
-		//TODO better exception here
-		throw new InternalErrorException(ex);
-		} catch (WrongReferenceAttributeValueException ex) {
-		//TODO better exception here
-		throw new InternalErrorException(ex);
+		for(Attribute attribute: attributes) {
+			try {
+			getAttributesManagerImpl().changedAttributeHook(sess, host, new Attribute(attribute));
+			} catch (WrongAttributeValueException ex) {
+			//TODO better exception here
+			throw new InternalErrorException(ex);
+			} catch (WrongReferenceAttributeValueException ex) {
+			//TODO better exception here
+			throw new InternalErrorException(ex);
+			}
 		}
-		}*/
 	}
 
 	public void removeAttribute(PerunSession sess, Vo vo, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -2918,7 +2918,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeValue(sess, user, attribute);
 	}
 
-	public void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws PrivilegeException, InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException,AttributeNotExistsException, HostNotExistsException {
+	public void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws PrivilegeException, InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, HostNotExistsException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getFacilitiesManagerBl().checkHostExists(sess, host);
@@ -2928,7 +2928,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		getAttributesManagerBl().checkAttributeValue(sess, host, attribute);
 	}
 
-	public void checkAttributesValue(PerunSession sess, Host host, List<Attribute> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, HostNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException{
+	public void checkAttributesValue(PerunSession sess, Host host, List<Attribute> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, HostNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		getPerunBl().getFacilitiesManagerBl().checkHostExists(sess, host);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_maxGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_maxGID.java
@@ -25,12 +25,12 @@ public class urn_perun_entityless_attribute_def_def_namespace_maxGID extends Ent
 			if(maxGID<1) throw new WrongAttributeValueException(attribute, "Attribute value must be min 1.");
 			try {
 				Attribute minGIDAttr = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, key, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minGID");
+				Integer minGID = (Integer) minGIDAttr.getValue();
+				if(minGID != null) {
+					if(maxGID < minGID) throw new WrongAttributeValueException(attribute, "Attribute value must be more than minGID. MinGID = " + minGID + ", and maxGID try to set = " + maxGID);
+				}
 			} catch (AttributeNotExistsException ex) {
 				throw new ConsistencyErrorException("Attribute namespace-minGID is supposed to exist.",ex);
-			}
-			Integer minGID = (Integer) attribute.getValue();
-			if(minGID != null) {
-				if(maxGID < minGID) throw new WrongAttributeValueException(attribute, "Attribute value must be more than minGID. MinGID = " + minGID + ", and maxGID try to set = " + maxGID);
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_maxUID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_maxUID.java
@@ -24,13 +24,13 @@ public class urn_perun_entityless_attribute_def_def_namespace_maxUID extends Ent
 		if(maxUID != null) {
 			if(maxUID<1) throw new WrongAttributeValueException(attribute, "Attribute value must be min 1.");
 			try {
-				Attribute minGIDAttr = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, key, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minUID");
+				Attribute minUIDAttr = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, key, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minUID");
+				Integer minUID = (Integer) minUIDAttr.getValue();
+				if(minUID != null) {
+					if(maxUID < minUID) throw new WrongAttributeValueException(attribute, "Attribute value must be more than minUID. MinUID = " + minUID + ", and maxUID try to set = " + maxUID);
+				}
 			} catch (AttributeNotExistsException ex) {
 				throw new ConsistencyErrorException("Attribute namespace-minUID is supposed to exist.",ex);
-			}
-			Integer minUID = (Integer) attribute.getValue();
-			if(minUID != null) {
-				if(maxUID < minUID) throw new WrongAttributeValueException(attribute, "Attribute value must be more than minUID. MinUID = " + minUID + ", and maxUID try to set = " + maxUID);
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_minGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_minGID.java
@@ -25,12 +25,12 @@ public class  urn_perun_entityless_attribute_def_def_namespace_minGID extends En
 			if(minGID<1) throw new WrongAttributeValueException(attribute, "Attribute value must be min 1.");
 			try {
 				Attribute maxGIDAttr = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, key, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-maxGID");
+				Integer maxGID = (Integer) maxGIDAttr.getValue();
+				if(maxGID != null) {
+					if(minGID > maxGID) throw new WrongAttributeValueException(attribute, "Attribute value must be less than maxGID. MaxGID = " + maxGID + ", and minGID try to set = " + minGID);
+				}
 			} catch (AttributeNotExistsException ex) {
 				throw new ConsistencyErrorException("Attribute namespace-maxGID is supposed to exist.",ex);
-			}
-			Integer maxGID = (Integer) attribute.getValue();
-			if(maxGID != null) {
-				if(minGID > maxGID) throw new WrongAttributeValueException(attribute, "Attribute value must be less than maxGID. MaxGID = " + maxGID + ", and minGID try to set = " + minGID);
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_minUID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_minUID.java
@@ -25,12 +25,12 @@ public class  urn_perun_entityless_attribute_def_def_namespace_minUID extends En
 			if(minUID<1) throw new WrongAttributeValueException(attribute, "Attribute value must be min 1.");
 			try {
 				Attribute maxUIDAttr = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, key, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-maxUID");
+				Integer maxUID = (Integer) maxUIDAttr.getValue();
+				if(maxUID != null) {
+					if(minUID > maxUID) throw new WrongAttributeValueException(attribute, "Attribute value must be less than maxUID. MaxUID = " + maxUID + ", and minUID try to set = " + minUID);
+				}
 			} catch (AttributeNotExistsException ex) {
 				throw new ConsistencyErrorException("Attribute namespace-maxUID is supposed to exist.",ex);
-			}
-			Integer maxUID = (Integer) attribute.getValue();
-			if(maxUID != null) {
-				if(minUID > maxUID) throw new WrongAttributeValueException(attribute, "Attribute value must be less than maxUID. MaxUID = " + maxUID + ", and minUID try to set = " + minUID);
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1688,7 +1688,7 @@ public interface AttributesManagerImplApi {
 	 */
 	void checkAttributeValue(PerunSession sess, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException;
 
-	void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributeValue(PerunSession sess, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	void checkAttributeValue(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/HostAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/HostAttributesModuleAbstract.java
@@ -1,0 +1,34 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Host;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * Abstract class for Host Attributes modules.
+ * -----------------------------------------------------------------------------
+ * Implements methods for modules to perform default function.
+ * In the function that the method in the module does nothing, it is not necessary to implement it, simply extend this abstract class.
+ *
+ * @author Peter Balcirak <peter.balcirak@gmail.com>
+ *
+ */
+public abstract class HostAttributesModuleAbstract implements HostAttributesModuleImplApi {
+
+	public void checkAttributeValue(PerunSessionImpl session, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+
+	}
+
+	public Attribute fillAttribute(PerunSessionImpl session, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+		return new Attribute(attribute);
+	}
+
+	public void changedAttributeHook(PerunSessionImpl session, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/HostAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/HostAttributesModuleImplApi.java
@@ -1,0 +1,58 @@
+package cz.metacentrum.perun.core.implApi.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Host;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+
+/**
+ * Interface for checking and filling in host's attributes.
+ *
+ * @author Peter Balcirak <peter.balcirak@gmail.com>
+ */
+public interface HostAttributesModuleImplApi extends AttributesModuleImplApi {
+	/**
+	 * Checks if assigned attribute to the member is valid.
+	 *
+	 * @param session Perun session
+	 * @param host Host
+	 * @param attribute Attribute of the member.
+	 *
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongReferenceAttributeValueException if an referenced attribute against
+	 *         the parameter is to be compared is not available
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	void checkAttributeValue(PerunSessionImpl session, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+
+	/**
+	 * Tries to fill an attribute to the specified host.
+	 *
+	 * @param session Perun Session
+	 * @param host Host
+	 * @param attribute Attribute of the member
+	 * @return Attribute which MAY be filled in
+	 *
+	 * @throws InternalErrorException if an exception is raised in particular
+	 *         implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	Attribute fillAttribute(PerunSessionImpl session, Host host, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+
+	/**
+	 * If you need to do some further work with other modules, this method do that
+	 *
+	 * @param session session
+	 * @param host Host
+	 * @param attribute the attribute
+	 */
+	void changedAttributeHook(PerunSessionImpl session, Host host, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+
+}


### PR DESCRIPTION
- Created classes HostAttributesModuleImplApi and HostAttributesModuleAbstract,
  which are needed for checkAttributeValue method for Hosts.
- Implemented getHostAttributeModule, which is used in method checkAttributeValue for Hosts.
- Implemented checkAttributeValue methods in Impl layer for entityless and hosts,
  because there was no implementation in that layer for these entities and attributeModules
  (specialy for Entityless) didn't check anything.
- Implemented changedAttributeHook for Hosts in Impl layer, which was in TODOs in couple of methods.
  These TODOs were uncommented.
- Implemented fillAttribute for Hosts in Impl layer,
  which was marked as TODO due to missing class HostAttributesModuleAbstract.
- in method setAttributeWithoutCheck for Entityless was TODO comment which was saying,
  that there isn't implemented method changedAttributeHook for Entityless,
  but in fact this method is already implemented, so this TODO was uncommented.