### PR TITLE
CORE: Respect propagationType for adding existing Destinations

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -464,7 +464,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		if(!getServicesManagerImpl().destinationExists(sess, destination)) {
 			try {
 				//Try to get the destination without id
-				destination = getServicesManagerImpl().getDestination(sess, destination.getDestination(), destination.getType());
+				Destination existingDestination = getServicesManagerImpl().getDestination(sess, destination.getDestination(), destination.getType());
+				// pass new propagation type from API to object retrieved from DB,
+				// since it always contains PARALLEL type
+				existingDestination.setPropagationType(destination.getPropagationType());
+				destination = existingDestination;
 			} catch(DestinationNotExistsException ex) {
 				try {
 					destination = createDestination(sess, destination);
@@ -484,7 +488,11 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		if(!getServicesManagerImpl().destinationExists(perunSession, destination)) {
 			try {
 				//Try to get the destination without id
-				destination = getServicesManagerImpl().getDestination(perunSession, destination.getDestination(), destination.getType());
+				Destination existingDestination = getServicesManagerImpl().getDestination(perunSession, destination.getDestination(), destination.getType());
+				// pass new propagation type from API to object retrieved from DB,
+				// since it always contains PARALLEL type
+				existingDestination.setPropagationType(destination.getPropagationType());
+				destination = existingDestination;
 			} catch(DestinationNotExistsException ex) {
 				try {
 					destination = createDestination(perunSession, destination);


### PR DESCRIPTION
- When adding new destination for facility/service we look, if
  Destinations itself exists. If not, we correctly create a new one.
  If it exist, we use existing Destination, but it is with PARALLEL
  propagationType by default and user requested type is not respected
  (passed to existing destination object).
  This commit fixes the issue, so we can create PARALLEL and/or DUMMY
  destinations for existing destinations too.