### PR TITLE
CORE: Fix for init of attribute modules map

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -5539,6 +5539,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		//Load all attributes modules
 		ServiceLoader<AttributesModuleImplApi> attributeModulesLoader = ServiceLoader.load(AttributesModuleImplApi.class);
+		getAttributesManagerImpl().initAttributeModules(attributeModulesLoader);
 		for (AttributesModuleImplApi module : attributeModulesLoader) {
 			if (module instanceof VirtualAttributesModuleImplApi) {
 				Auditer.registerAttributeModule((VirtualAttributesModuleImplApi) module);
@@ -5546,7 +5547,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			log.debug("Module " + module.getClass().getSimpleName() + " loaded.");
 		}
 
-		//Check if all core atributes exists, create if doesn't
+		//Check if all core attributes exists, create if doesn't
 		Map<AttributeDefinition, List<AttributeRights>> attributes = new HashMap<>();
 		//Facility.id
 		AttributeDefinition attr = new AttributeDefinition();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -5540,12 +5540,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//Load all attributes modules
 		ServiceLoader<AttributesModuleImplApi> attributeModulesLoader = ServiceLoader.load(AttributesModuleImplApi.class);
 		getAttributesManagerImpl().initAttributeModules(attributeModulesLoader);
-		for (AttributesModuleImplApi module : attributeModulesLoader) {
-			if (module instanceof VirtualAttributesModuleImplApi) {
-				Auditer.registerAttributeModule((VirtualAttributesModuleImplApi) module);
-			}
-			log.debug("Module " + module.getClass().getSimpleName() + " loaded.");
-		}
+		getAttributesManagerImpl().registerVirtAttributeModules(attributeModulesLoader);
 
 		//Check if all core attributes exists, create if doesn't
 		Map<AttributeDefinition, List<AttributeRights>> attributes = new HashMap<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -85,6 +85,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static cz.metacentrum.perun.core.api.AttributesManager.NS_FACILITY_ATTR;
@@ -3982,7 +3983,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	/**
-	 * Get the atributeModule
+	 * Get the attributeModule
 	 *
 	 * @param moduleName name of the module
 	 * @return instance of attribute module
@@ -3999,7 +4000,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			attributesModulesMap.put(moduleName, (AttributesModuleImplApi) module);
 			return module;
 		} catch (ClassNotFoundException ex) {
-			//attrribute module don't exist
+			//attribute module doesn't exist
 			return null;
 		} catch (InstantiationException ex) {
 			throw new InternalErrorException("Attribute module " + moduleName + " cannot be instaciated.", ex);
@@ -4007,6 +4008,12 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 
+	}
+
+	public void initAttributeModules(ServiceLoader<AttributesModuleImplApi> modules) {
+		for (AttributesModuleImplApi module : modules) {
+			attributesModulesMap.put(module.getClass().getName(), module);
+		}
 	}
 
 	public void setSelf(AttributesManagerImplApi self) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -58,6 +58,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserExtSourceAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserExtSourceVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.VirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -4003,7 +4004,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			//attribute module doesn't exist
 			return null;
 		} catch (InstantiationException ex) {
-			throw new InternalErrorException("Attribute module " + moduleName + " cannot be instaciated.", ex);
+			throw new InternalErrorException("Attribute module " + moduleName + " cannot be instantiated.", ex);
 		} catch (IllegalAccessException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -4013,6 +4014,16 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	public void initAttributeModules(ServiceLoader<AttributesModuleImplApi> modules) {
 		for (AttributesModuleImplApi module : modules) {
 			attributesModulesMap.put(module.getClass().getName(), module);
+			log.debug("Module {} loaded.", module.getClass().getSimpleName());
+		}
+	}
+
+	public void registerVirtAttributeModules(ServiceLoader<AttributesModuleImplApi> modules) {
+		for (AttributesModuleImplApi module : modules) {
+			if (module instanceof VirtualAttributesModuleImplApi) {
+				Auditer.registerAttributeModule((VirtualAttributesModuleImplApi) module);
+				log.debug("Module {} was registered for audit message listening.", module.getClass().getName());
+			}
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -78,10 +78,10 @@ public class Auditer {
 	private static Set<VirtualAttributesModuleImplApi> registeredAttributesModules = new HashSet<>();
 
 	public static void registerAttributeModule(VirtualAttributesModuleImplApi virtualAttributesModuleImplApi) {
-		log.trace("Auditer: Try to load module {}", (virtualAttributesModuleImplApi == null) ? null : virtualAttributesModuleImplApi.getClass().getName());
+		log.trace("Auditer: Try to register module {}", (virtualAttributesModuleImplApi == null) ? null : virtualAttributesModuleImplApi.getClass().getName());
 		if(virtualAttributesModuleImplApi != null && !registeredAttributesModules.contains(virtualAttributesModuleImplApi)) {
 			registeredAttributesModules.add(virtualAttributesModuleImplApi);
-			log.debug("Auditer: Module {} was loaded.", virtualAttributesModuleImplApi.getClass().getName());
+			log.debug("Auditer: Module {} was registered for audit message listening.", virtualAttributesModuleImplApi.getClass().getName());
 		}
 
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -2,8 +2,10 @@ package cz.metacentrum.perun.core.impl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.sql.DataSource;
@@ -73,10 +75,10 @@ public class Auditer {
 
 	private static final Object LOCK_DB_TABLE_AUDITER_LOG = new Object();
 
-	private static List<VirtualAttributesModuleImplApi> registeredAttributesModules = new ArrayList<VirtualAttributesModuleImplApi>();
+	private static Set<VirtualAttributesModuleImplApi> registeredAttributesModules = new HashSet<>();
 
 	public static void registerAttributeModule(VirtualAttributesModuleImplApi virtualAttributesModuleImplApi) {
-		log.trace("Auditer: Try to load module {}", virtualAttributesModuleImplApi.getClass().getName());
+		log.trace("Auditer: Try to load module {}", (virtualAttributesModuleImplApi == null) ? null : virtualAttributesModuleImplApi.getClass().getName());
 		if(virtualAttributesModuleImplApi != null && !registeredAttributesModules.contains(virtualAttributesModuleImplApi)) {
 			registeredAttributesModules.add(virtualAttributesModuleImplApi);
 			log.debug("Auditer: Module {} was loaded.", virtualAttributesModuleImplApi.getClass().getName());
@@ -178,7 +180,7 @@ public class Auditer {
 		}
 	}
 
-	
+
 	/**
 	 * Log message.
 	 * Message is stored in actual transaction. If no transaction is active message will be immediatelly flushed out.
@@ -321,7 +323,7 @@ public class Auditer {
 	 */
 	public void newTopLevelTransaction() {
 		List<List<List<AuditerMessage>>> topLevelTransactions = (List<List<List<AuditerMessage>>>) TransactionSynchronizationManager.getResource(this);
-		
+
 		// prepare new messages chain
 		List<List<AuditerMessage>> transactionChain = new ArrayList<>();
 		List<AuditerMessage> messages = new ArrayList<>();
@@ -335,10 +337,10 @@ public class Auditer {
 			topLevelTransactions.add(transactionChain);
 		}
 	}
-		
+
 	/**
 	 * Creates new list for saving auditer messages of a new nested transactions.
-	 * 
+	 *
 	 */
 	public void newNestedTransaction() {
 		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
@@ -346,11 +348,11 @@ public class Auditer {
 		List<AuditerMessage> messages = new ArrayList<>();
 		transactionChain.add(messages);
 	}
-	
+
 	/**
 	 * Flush auditer messages of the last messages to the store of the outer transaction.
 	 * There should be at least one nested transaction.
-	 * 
+	 *
 	 */
 	public void flushNestedTransaction() {
 		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
@@ -360,14 +362,14 @@ public class Auditer {
 			return;
 		}
 		List<AuditerMessage> messagesToFlush = transactionChain.get(transactionChain.size() - 1);
-		
+
 		transactionChain.get(transactionChain.size() - 2).addAll(messagesToFlush);
 		List<AuditerMessage> messages = transactionChain.remove(transactionChain.size() - 1);
 	}
-	
+
 	/**
 	 * Erases the auditer messages for the last transaction.
-	 * 
+	 *
 	 */
 	public void cleanNestedTransation() {
 		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
@@ -378,7 +380,7 @@ public class Auditer {
 		}
 		List<AuditerMessage> messages = transactionChain.remove(transactionChain.size() - 1);
 	}
-	
+
 	/**
 	 * Imidiately flushes stored message for last top-level transaction into the log
 	 *
@@ -395,7 +397,7 @@ public class Auditer {
 			topLevelTransactions.remove(topLevelTransactions.size() - 1);
 			return;
 		}
-		
+
 		if (transactionChain.size() != 1) {
 			log.error("There should be only one list of messages while flushing representing the most outer transaction.");
 		}
@@ -439,7 +441,7 @@ public class Auditer {
 	/**
 	 * All prepared auditer messages in the last top-level transaction are erased without storing into db.
 	 * Mostly wanted while rollbacking.
-	 * 
+	 *
 	 */
 	public void clean() {
 		List<List<List<AuditerMessage>>> topLevelTransactions = getTopLevelTransactions();
@@ -447,18 +449,18 @@ public class Auditer {
 			log.trace("No messages to clean");
 			return;
 		}
-		
+
 		List<List<AuditerMessage>> transactionChain = topLevelTransactions.get(topLevelTransactions.size() - 1);
 		if (transactionChain.isEmpty()) {
 			log.trace("No messages to clean");
 		}
-		
+
 		if (transactionChain.size() != 1) {
 			log.error("There should be only one list of messages while cleaning.");
 		}
 
 		topLevelTransactions.remove(topLevelTransactions.size() - 1);
-		
+
 		if (topLevelTransactions.isEmpty()) {
 			TransactionSynchronizationManager.unbindResourceIfPossible(this);
 		}
@@ -533,7 +535,7 @@ public class Auditer {
 			throw new InternalErrorException(err);
 		}
 	}
-	
+
 	private List<List<List<AuditerMessage>>> getTopLevelTransactions() {
 		List<List<List<AuditerMessage>>> topLevelTransactions = (List<List<List<AuditerMessage>>>) TransactionSynchronizationManager.getResource(this);
 		if (topLevelTransactions == null) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -2344,4 +2344,12 @@ public interface AttributesManagerImplApi {
 	 */
 	public void initAttributeModules(ServiceLoader<AttributesModuleImplApi> modules);
 
+	/**
+	 * Register virtual attribute modules in Auditer for message listening.
+	 *
+	 * @see AttributesManagerBlImpl#initialize()
+	 * @param modules List of attribute module class instances
+	 */
+	public void registerVirtAttributeModules(ServiceLoader<AttributesModuleImplApi> modules);
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.ActionType;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.ServiceLoader;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -32,6 +33,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongModuleTypeException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 
 /**
@@ -2332,4 +2335,13 @@ public interface AttributesManagerImplApi {
 	 * @throws ModuleNotExistsException
 	 */
 	public UserVirtualAttributesModuleImplApi getUserVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws ModuleNotExistsException, WrongModuleTypeException, InternalErrorException;
+
+	/**
+	 * Init attribute modules map in Impl layer.
+	 *
+	 * @see AttributesManagerBlImpl#initialize()
+	 * @param modules List of attribute module class instances
+	 */
+	public void initAttributeModules(ServiceLoader<AttributesModuleImplApi> modules);
+
 }


### PR DESCRIPTION
- Initialization of AttributesManagerBl must fill attribute
  modules map in AttributesManagerImpl.
- Auditer: Changed list of registered virt modules to set.
  Whitespace and typo fixes, prevent null pointer in trace log.