### PR TITLE
Fix wrong processing of rights for setting unixGroupName

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGroupName_namespace.java
@@ -61,6 +61,8 @@ public class urn_perun_group_attribute_def_def_unixGroupName_namespace extends G
 			//Fill lists of groups and resources
 			groupsWithSameGroupNameInTheSameNamespace.addAll(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, groupUnixGroupName));
 			resourcesWithSameGroupNameInTheSameNamespace.addAll(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, resourceUnixGroupName));
+			//Remove self from the list of groups with the same namespace
+			groupsWithSameGroupNameInTheSameNamespace.remove(group);
 
 			//If there is no group or resource with same GroupNameInTheSameNamespace, its ok
 			if(groupsWithSameGroupNameInTheSameNamespace.isEmpty() && resourcesWithSameGroupNameInTheSameNamespace.isEmpty()) return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespace.java
@@ -65,6 +65,8 @@ public class urn_perun_resource_attribute_def_def_unixGroupName_namespace extend
 			//Fill lists of groups and resources
 			groupsWithSameGroupNameInTheSameNamespace.addAll(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, groupUnixGroupName));
 			resourcesWithSameGroupNameInTheSameNamespace.addAll(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, resourceUnixGroupName));
+			//Remove self from the list of resources with the same namespace
+			resourcesWithSameGroupNameInTheSameNamespace.remove(resource);
 
 			//If there is no group or resource with same GroupNameInTheSameNamespace, its ok
 			if(groupsWithSameGroupNameInTheSameNamespace.isEmpty() && resourcesWithSameGroupNameInTheSameNamespace.isEmpty()) return;


### PR DESCRIPTION
 - we need to remove group or resource for which we are trying to
   save new value in unixGroupName attribute from the list of all
   groups or resources with the same groupName (for the same namespace).
   If not, we will always get rights for the new group to set this
   value, even if it is already used somewhere else where we are not
   administrators