### PR TITLE
GetCompleteCandidates feature

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/MemberCandidate.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/MemberCandidate.java
@@ -1,0 +1,76 @@
+package cz.metacentrum.perun.core.api;
+
+
+/**
+ * Candidate with member and rich user of a Virtual Organization.
+ *
+ * @author Vojtech Sassmann &lt;vojtech.sassmann@gmail.com&gt;
+ */
+public class MemberCandidate {
+
+	private Candidate candidate;
+
+	private Member member;
+
+	private RichUser richUser;
+
+	public Candidate getCandidate() {
+		return candidate;
+	}
+
+	public void setCandidate(Candidate candidate) {
+		this.candidate = candidate;
+	}
+
+	public Member getMember() {
+		return member;
+	}
+
+	public void setMember(Member member) {
+		this.member = member;
+	}
+
+	public RichUser getRichUser() {
+		return richUser;
+	}
+
+	public void setRichUser(RichUser richUser) {
+		this.richUser = richUser;
+	}
+
+	/**
+	 *  Returns bean name like VO, Member, Resource,...
+	 */
+	public String getBeanName() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		MemberCandidate that = (MemberCandidate) o;
+
+		if (candidate != null ? !candidate.equals(that.candidate) : that.candidate != null) return false;
+		if (member != null ? !member.equals(that.member) : that.member != null) return false;
+		return richUser != null ? richUser.equals(that.richUser) : that.richUser == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = candidate != null ? candidate.hashCode() : 0;
+		result = 31 * result + (member != null ? member.hashCode() : 0);
+		result = 31 * result + (richUser != null ? richUser.hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName()+ ":[" +
+				"candidate='" + candidate +
+				"', member='" + member +
+				"', richUser='" + richUser +
+				"']";
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/VosManager.java
@@ -164,6 +164,35 @@ public interface VosManager {
 	List<Candidate> findCandidates(PerunSession sess, Group group, String searchString) throws InternalErrorException, GroupNotExistsException, PrivilegeException;
 
 	/**
+	 * Finds MemberCandidates who can join the Vo.
+	 *
+	 * @param sess session
+	 * @param vo vo to be used
+	 * @param attrNames names of attributes that will be found
+	 * @param searchString depends on the extSource of the Group, could by part of the name, email or something like that.
+	 * @return list of MemberCandidates for given vo.
+	 * @throws InternalErrorException internal error
+	 * @throws VoNotExistsException when vo does not exist
+	 * @throws PrivilegeException privilege exception
+	 */
+	List<MemberCandidate> getCompleteCandidates(PerunSession sess, Vo vo, List<String> attrNames, String searchString) throws InternalErrorException, VoNotExistsException, PrivilegeException;
+
+	/**
+	 * Finds MemberCandidates who can join the Group.
+	 *
+	 * @param sess session
+	 * @param group group to be used
+	 * @param attrNames names of attributes that will be found
+	 * @param searchString depends on the extSource of the Group, could by part of the name, email or something like that.
+	 * @return list of MemberCandidates for given vo.
+	 * @throws InternalErrorException internal error
+	 * @throws GroupNotExistsException when group does not exist
+	 * @throws PrivilegeException privilege exception
+	 */
+	List<MemberCandidate> getCompleteCandidates(PerunSession sess, Group group, List<String> attrNames, String searchString) throws InternalErrorException, GroupNotExistsException, PrivilegeException;
+
+
+	/**
 	 * Add a user administrator to the VO.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -925,6 +925,17 @@ public interface UsersManagerBl {
 	List<RichUser> convertUsersToRichUsersWithAttributesByNames(PerunSession sess, List<User> users, List<String> attrNames) throws InternalErrorException;
 
 	/**
+	 * From User make Rich user (with attributes by names)
+	 *
+	 * @param sess session
+	 * @param user user to be converted
+	 * @param attrNames list of Strings with attribute names
+	 * @return RichUser with attributes
+	 * @throws InternalErrorException internal error
+	 */
+	RichUser convertUserToRichUserWithAttributesByNames(PerunSession sess, User user, List<String> attrNames) throws InternalErrorException;
+
+	/**
 	 * For richUser filter all his user attributes and remove all which principal has no access to.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
@@ -2,8 +2,11 @@ package cz.metacentrum.perun.core.bl;
 
 import java.util.List;
 
+import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Candidate;
+import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.MemberCandidate;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.RichUser;
@@ -133,6 +136,33 @@ public interface VosManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Candidate> findCandidates(PerunSession sess, Group group, String searchString) throws InternalErrorException;
+
+	/**
+	 * Finds MemberCandidates who can join the Vo.
+	 *
+	 * @param sess session
+	 * @param vo vo to be used
+	 * @param attrNames name of attributes to be searched
+	 * @param searchString depends on the extSource of the Vo, could by part of the name, email or something like that.
+	 * @return list of memberCandidates who match the searchString
+	 * @throws InternalErrorException internal error
+	 */
+	List<MemberCandidate> getCompleteCandidates(PerunSession sess, Vo vo, List<String> attrNames, String searchString) throws InternalErrorException;
+
+	/**
+	 * Finds MemberCandidates who can join the Group. If the given vo is not null, it searches only
+	 * users who belong to this Vo.
+	 *
+	 * @param sess session
+	 * @param vo vo if is null, users are searched in whole perun, otherwise only members of this vo are used.
+	 * @param group group to be used
+	 * @param attrNames name of attributes to be searched
+	 * @param searchString depends on the extSource of the Vo, could by part of the name, email or something like that.
+	 * @param extSources extSources used to find candidates
+	 * @return list of memberCandidates who match the searchString
+	 * @throws InternalErrorException internal error
+	 */
+	List<MemberCandidate> getCompleteCandidates(PerunSession sess, Vo vo, Group group, List<String> attrNames, String searchString, List<ExtSource> extSources) throws InternalErrorException;
 
 	/**
 	 * Add a user administrator to the VO.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1796,6 +1796,16 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	}
 
+	@Override
+	public RichUser convertUserToRichUserWithAttributesByNames(PerunSession sess, User user, List<String> attrNames) throws InternalErrorException {
+		AttributesManagerBl attributesManagerBl = this.getPerunBl().getAttributesManagerBl();
+
+		RichUser richUser = new RichUser(user, getUserExtSources(sess, user));
+		richUser.setUserAttributes(attributesManagerBl.getAttributes(sess, user, attrNames));
+
+		return richUser;
+	}
+
 	public List<RichUser> findRichUsersWithAttributes(PerunSession sess, String searchString, List<String> attrsName) throws InternalErrorException, UserNotExistsException {
 
 		if(attrsName == null || attrsName.isEmpty()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * VosManager business logic
@@ -180,97 +181,108 @@ public class VosManagerBlImpl implements VosManagerBl {
 	}
 
 	public List<Candidate> findCandidates(PerunSession sess, Vo vo, String searchString, int maxNumOfResults) throws InternalErrorException {
+		List<ExtSource> extSources = getPerunBl().getExtSourcesManagerBl().getVoExtSources(sess, vo);
+		return this.findCandidates(sess, vo, searchString, maxNumOfResults, extSources, true);
+	}
+
+	public List<Candidate> findCandidates(PerunSession sess, Vo vo, String searchString, int maxNumOfResults, List<ExtSource> extSources, boolean filterExistingMembers) throws InternalErrorException {
 		List<Candidate> candidates = new ArrayList<>();
 		int numOfResults = 0;
 
 		try {
-			// Iterate through all registered extSources
-			for (ExtSource source : getPerunBl().getExtSourcesManagerBl().getVoExtSources(sess, vo)) {
-				// Info if this is only simple ext source, change behavior if not
-				boolean simpleExtSource = true;
-
-				// Get potential subjects from the extSource
-				List<Map<String, String>> subjects;
+			// Iterate through given extSources
+			for (ExtSource source : extSources) {
 				try {
-					if (source instanceof ExtSourceApi) {
-						// find subjects with all their properties
-						subjects = ((ExtSourceApi) source).findSubjects(searchString, maxNumOfResults);
-						simpleExtSource = false;
-					} else {
-						// find subjects only with logins - they then must be retrieved by login
-						subjects = ((ExtSourceSimpleApi) source).findSubjectsLogins(searchString, maxNumOfResults);
-					}
-				} catch (ExtSourceUnsupportedOperationException e1) {
-					log.warn("ExtSource {} doesn't support findSubjects", source.getName());
-					continue;
-				} catch (InternalErrorException e) {
-					log.error("Error occurred on ExtSource {},  Exception {}.", source.getName(), e);
-					continue;
-				} finally {
+					// Info if this is only simple ext source, change behavior if not
+					boolean simpleExtSource = true;
+
+					// Get potential subjects from the extSource
+					List<Map<String, String>> subjects;
 					try {
-						((ExtSourceSimpleApi) source).close();
-					} catch (ExtSourceUnsupportedOperationException e) {
-						// ExtSource doesn't support that functionality, so silently skip it.
-					} catch (InternalErrorException e) {
-						log.error("Can't close extSource connection. Cause: {}", e);
-					}
-				}
-
-				Set<String> uniqueLogins = new HashSet<>();
-				for (Map<String, String> s : subjects) {
-					// Check if the user has unique identifier within extSource
-					if ((s.get("login") == null) || (s.get("login") != null && s.get("login").isEmpty())) {
-						log.error("User '{}' cannot be added, because he/she doesn't have a unique identifier (login)", s);
-						// Skip to another user
-						continue;
-					}
-
-					String extLogin = s.get("login");
-
-					// check uniqueness of every login in extSource
-					if (uniqueLogins.contains(extLogin)) {
-						throw new InternalErrorException("There are more than 1 login '" + extLogin + "' getting from extSource '" + source + "'");
-					} else {
-						uniqueLogins.add(extLogin);
-					}
-
-					// Get Candidate
-					Candidate candidate;
-					try {
-						if (simpleExtSource) {
-							// retrieve data about subjects from ext source based on ext. login
-							candidate = getPerunBl().getExtSourcesManagerBl().getCandidate(sess, source, extLogin);
+						if (source instanceof ExtSourceApi) {
+							// find subjects with all their properties
+							subjects = ((ExtSourceApi) source).findSubjects(searchString, maxNumOfResults);
+							simpleExtSource = false;
 						} else {
-							// retrieve data about subjects from subjects we already have locally
-							candidate = getPerunBl().getExtSourcesManagerBl().getCandidate(sess, s, source, extLogin);
+							// find subjects only with logins - they then must be retrieved by login
+							subjects = ((ExtSourceSimpleApi) source).findSubjectsLogins(searchString, maxNumOfResults);
 						}
-					} catch (ExtSourceNotExistsException e) {
-						throw new ConsistencyErrorException("Getting candidate from non-existing extSource " + source, e);
-					} catch (CandidateNotExistsException e) {
-						throw new ConsistencyErrorException("findSubjects returned that candidate, but getCandidate cannot find him using login " + extLogin, e);
-					} catch (ExtSourceUnsupportedOperationException e) {
-						throw new InternalErrorException("extSource supports findSubjects but not getCandidate???", e);
-					}
-
-					try {
-						getPerunBl().getMembersManagerBl().getMemberByUserExtSources(sess, vo, candidate.getUserExtSources());
-						// Candidate is already a member of the VO, so do not add him to the list of candidates
+					} catch (ExtSourceUnsupportedOperationException e1) {
+						log.warn("ExtSource {} doesn't support findSubjects", source.getName());
 						continue;
-					} catch (MemberNotExistsException e) {
-						// This is OK
+					} catch (InternalErrorException e) {
+						log.error("Error occurred on ExtSource {},  Exception {}.", source.getName(), e);
+						continue;
+					} finally {
+						try {
+							((ExtSourceSimpleApi) source).close();
+						} catch (ExtSourceUnsupportedOperationException e) {
+							// ExtSource doesn't support that functionality, so silently skip it.
+						} catch (InternalErrorException e) {
+							log.error("Can't close extSource connection. Cause: {}", e);
+						}
 					}
 
-					// Add candidate to the list of candidates
-					log.debug("findCandidates: returning candidate: {}", candidate);
-					candidates.add(candidate);
+					Set<String> uniqueLogins = new HashSet<>();
+					for (Map<String, String> s : subjects) {
+						// Check if the user has unique identifier within extSource
+						if ((s.get("login") == null) || (s.get("login") != null && s.get("login").isEmpty())) {
+							log.error("User '{}' cannot be added, because he/she doesn't have a unique identifier (login)", s);
+							// Skip to another user
+							continue;
+						}
 
-					numOfResults++;
-					// Stop getting new members if the number of already retrieved members exceeded the maxNumOfResults
-					if (maxNumOfResults > 0 && numOfResults >= maxNumOfResults) {
-						break;
+						String extLogin = s.get("login");
+
+						// check uniqueness of every login in extSource
+						if (uniqueLogins.contains(extLogin)) {
+							throw new InternalErrorException("There are more than 1 login '" + extLogin + "' getting from extSource '" + source + "'");
+						} else {
+							uniqueLogins.add(extLogin);
+						}
+
+						// Get Candidate
+						Candidate candidate;
+						try {
+							if (simpleExtSource) {
+								// retrieve data about subjects from ext source based on ext. login
+								candidate = getPerunBl().getExtSourcesManagerBl().getCandidate(sess, source, extLogin);
+							} else {
+								// retrieve data about subjects from subjects we already have locally
+								candidate = getPerunBl().getExtSourcesManagerBl().getCandidate(sess, s, source, extLogin);
+							}
+						} catch (ExtSourceNotExistsException e) {
+							throw new ConsistencyErrorException("Getting candidate from non-existing extSource " + source, e);
+						} catch (CandidateNotExistsException e) {
+							throw new ConsistencyErrorException("findSubjects returned that candidate, but getCandidate cannot find him using login " + extLogin, e);
+						} catch (ExtSourceUnsupportedOperationException e) {
+							throw new InternalErrorException("extSource supports findSubjects but not getCandidate???", e);
+						}
+
+						if (filterExistingMembers) {
+							try {
+								getPerunBl().getMembersManagerBl().getMemberByUserExtSources(sess, vo, candidate.getUserExtSources());
+								// Candidate is already a member of the VO, so do not add him to the list of candidates
+								continue;
+							} catch (MemberNotExistsException e) {
+								// This is OK
+							}
+						}
+
+						// Add candidate to the list of candidates
+						log.debug("findCandidates: returning candidate: {}", candidate);
+						candidates.add(candidate);
+
+						numOfResults++;
+						// Stop getting new members if the number of already retrieved members exceeded the maxNumOfResults
+						if (maxNumOfResults > 0 && numOfResults >= maxNumOfResults) {
+							break;
+						}
 					}
+
+				} catch (InternalErrorException e) {
+					log.error("Failed to get candidates from ExtSource: {}", source);
 				}
-
 				// Stop walking through next sources if the number of already retrieved members exceeded the maxNumOfResults
 				if (maxNumOfResults > 0 && numOfResults >= maxNumOfResults) {
 					break;
@@ -289,92 +301,103 @@ public class VosManagerBlImpl implements VosManagerBl {
 	}
 
 	public List<Candidate> findCandidates(PerunSession sess, Group group, String searchString) throws InternalErrorException {
+		List<ExtSource> extSources = getPerunBl().getExtSourcesManagerBl().getGroupExtSources(sess, group);
+		return this.findCandidates(sess, group, searchString, extSources, true);
+	}
+
+	public List<Candidate> findCandidates(PerunSession sess, Group group, String searchString, List<ExtSource> extSources, boolean filterExistingMembers) throws InternalErrorException {
 		List<Candidate> candidates = new ArrayList<>();
 
 		try {
-			// Iterate through all registered extSources in the group
-			for (ExtSource source : getPerunBl().getExtSourcesManagerBl().getGroupExtSources(sess, group)) {
-				// Info if this is only simple ext source, change behavior if not
-				boolean simpleExtSource = true;
-
-				// Get potential subjects from the extSource
-				List<Map<String, String>> subjects;
+			// Iterate through given extSources
+			for (ExtSource source : extSources) {
 				try {
-					if (source instanceof ExtSourceApi) {
-						// find subjects with all their properties
-						subjects = ((ExtSourceApi) source).findSubjects(searchString);
-						simpleExtSource = false;
-					} else {
-						// find subjects only with logins - they then must be retrieved by login
-						subjects = ((ExtSourceSimpleApi) source).findSubjectsLogins(searchString);
-					}
-				} catch (ExtSourceUnsupportedOperationException e1) {
-					log.warn("ExtSource {} doesn't support findSubjects", source.getName());
-					continue;
-				} catch (InternalErrorException e) {
-					log.error("Error occurred on ExtSource {},  Exception {}.", source.getName(), e);
-					continue;
-				} finally {
+					// Info if this is only simple ext source, change behavior if not
+					boolean simpleExtSource = true;
+
+					// Get potential subjects from the extSource
+					List<Map<String, String>> subjects;
 					try {
-						((ExtSourceSimpleApi) source).close();
-					} catch (ExtSourceUnsupportedOperationException e) {
-						// ExtSource doesn't support that functionality, so silently skip it.
-					} catch (InternalErrorException e) {
-						log.error("Can't close extSource connection. Cause: {}", e);
-					}
-				}
-
-				Set<String> uniqueLogins = new HashSet<>();
-				for (Map<String, String> s : subjects) {
-					// Check if the user has unique identifier within extSource
-					if ((s.get("login") == null) || (s.get("login") != null && s.get("login").isEmpty())) {
-						log.error("User '{}' cannot be added, because he/she doesn't have a unique identifier (login)", s);
-						// Skip to another user
-						continue;
-					}
-
-					String extLogin = s.get("login");
-
-					// check uniqueness of every login in extSource
-					if (uniqueLogins.contains(extLogin)) {
-						throw new InternalErrorException("There are more than 1 login '" + extLogin + "' getting from extSource '" + source + "'");
-					} else {
-						uniqueLogins.add(extLogin);
-					}
-
-					// Get Candidate
-					Candidate candidate;
-					try {
-						if (simpleExtSource) {
-							// retrieve data about subjects from ext source based on ext. login
-							candidate = getPerunBl().getExtSourcesManagerBl().getCandidate(sess, source, extLogin);
+						if (source instanceof ExtSourceApi) {
+							// find subjects with all their properties
+							subjects = ((ExtSourceApi) source).findSubjects(searchString);
+							simpleExtSource = false;
 						} else {
-							// retrieve data about subjects from subjects we already have locally
-							candidate = getPerunBl().getExtSourcesManagerBl().getCandidate(sess, s, source, extLogin);
+							// find subjects only with logins - they then must be retrieved by login
+							subjects = ((ExtSourceSimpleApi) source).findSubjectsLogins(searchString);
 						}
-					} catch (ExtSourceNotExistsException e) {
-						throw new ConsistencyErrorException("Getting candidate from non-existing extSource " + source, e);
-					} catch (CandidateNotExistsException e) {
-						throw new ConsistencyErrorException("findSubjects returned that candidate, but getCandidate cannot find him using login " + extLogin, e);
-					} catch (ExtSourceUnsupportedOperationException e) {
-						throw new InternalErrorException("extSource supports findSubjects but not getCandidate???", e);
-					}
-
-					try {
-						Vo vo = getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId());
-						getPerunBl().getMembersManagerBl().getMemberByUserExtSources(sess, vo, candidate.getUserExtSources());
-						// Candidate is already a member of the VO, so do not add him to the list of candidates
+					} catch (ExtSourceUnsupportedOperationException e1) {
+						log.warn("ExtSource {} doesn't support findSubjects", source.getName());
 						continue;
-					} catch (VoNotExistsException e) {
-						throw new InternalErrorException(e);
-					} catch (MemberNotExistsException e) {
-						// This is OK
+					} catch (InternalErrorException e) {
+						log.error("Error occurred on ExtSource {},  Exception {}.", source.getName(), e);
+						continue;
+					} finally {
+						try {
+							((ExtSourceSimpleApi) source).close();
+						} catch (ExtSourceUnsupportedOperationException e) {
+							// ExtSource doesn't support that functionality, so silently skip it.
+						} catch (InternalErrorException e) {
+							log.error("Can't close extSource connection. Cause: {}", e);
+						}
 					}
 
-					// Add candidate to the list of candidates
-					log.debug("findCandidates: returning candidate: {}", candidate);
-					candidates.add(candidate);
+					Set<String> uniqueLogins = new HashSet<>();
+					for (Map<String, String> s : subjects) {
+						// Check if the user has unique identifier within extSource
+						if ((s.get("login") == null) || (s.get("login") != null && s.get("login").isEmpty())) {
+							log.error("User '{}' cannot be added, because he/she doesn't have a unique identifier (login)", s);
+							// Skip to another user
+							continue;
+						}
 
+						String extLogin = s.get("login");
+
+						// check uniqueness of every login in extSource
+						if (uniqueLogins.contains(extLogin)) {
+							throw new InternalErrorException("There are more than 1 login '" + extLogin + "' getting from extSource '" + source + "'");
+						} else {
+							uniqueLogins.add(extLogin);
+						}
+
+						// Get Candidate
+						Candidate candidate;
+						try {
+							if (simpleExtSource) {
+								// retrieve data about subjects from ext source based on ext. login
+								candidate = getPerunBl().getExtSourcesManagerBl().getCandidate(sess, source, extLogin);
+							} else {
+								// retrieve data about subjects from subjects we already have locally
+								candidate = getPerunBl().getExtSourcesManagerBl().getCandidate(sess, s, source, extLogin);
+							}
+						} catch (ExtSourceNotExistsException e) {
+							throw new ConsistencyErrorException("Getting candidate from non-existing extSource " + source, e);
+						} catch (CandidateNotExistsException e) {
+							throw new ConsistencyErrorException("findSubjects returned that candidate, but getCandidate cannot find him using login " + extLogin, e);
+						} catch (ExtSourceUnsupportedOperationException e) {
+							throw new InternalErrorException("extSource supports findSubjects but not getCandidate???", e);
+						}
+
+						if (filterExistingMembers) {
+							try {
+								Vo vo = getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId());
+								getPerunBl().getMembersManagerBl().getMemberByUserExtSources(sess, vo, candidate.getUserExtSources());
+								// Candidate is already a member of the VO, so do not add him to the list of candidates
+								continue;
+							} catch (VoNotExistsException e) {
+								throw new InternalErrorException(e);
+							} catch (MemberNotExistsException e) {
+								// This is OK
+							}
+						}
+
+						// Add candidate to the list of candidates
+						log.debug("findCandidates: returning candidate: {}", candidate);
+						candidates.add(candidate);
+
+					}
+				} catch (InternalErrorException e) {
+					log.error("Failed to get candidates from ExtSource: {}", source);
 				}
 			}
 
@@ -383,6 +406,77 @@ public class VosManagerBlImpl implements VosManagerBl {
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
+	}
+
+	@Override
+	public List<MemberCandidate> getCompleteCandidates(PerunSession sess, Vo vo, List<String> attrNames, String searchString) throws InternalErrorException {
+		List<ExtSource> extSources = getPerunBl().getExtSourcesManagerBl().getVoExtSources(sess, vo);
+		List<RichUser> richUsers = getRichUsersForMemberCandidates(sess, attrNames, searchString);
+		List<Candidate> candidates = findCandidates(sess, vo, searchString, 0, extSources, false);
+
+		return createMemberCandidates(sess, richUsers, vo, candidates, attrNames);
+	}
+
+	@Override
+	public List<MemberCandidate> getCompleteCandidates(PerunSession sess, Vo vo, Group group, List<String> attrNames, String searchString, List<ExtSource> extSources) throws InternalErrorException {
+		List<RichUser> richUsers = getRichUsersForMemberCandidates(sess, vo, attrNames, searchString);
+		List<Candidate> candidates = findCandidates(sess, group, searchString, extSources, false);
+
+		if (vo == null) {
+			vo = getPerunBl().getGroupsManagerBl().getVo(sess, group);
+		}
+
+		return createMemberCandidates(sess, richUsers, vo, group, candidates, attrNames);
+	}
+
+	/**
+	 * <p>Finds RichUsers who matches the given search string. Users are searched in the whole Perun.</p>
+	 * <p>The RichUsers are returned with attributes of given names.</p>
+	 *
+	 * @param sess session
+	 * @param attrNames names of attributes that will be returned
+	 * @param searchString string used to find users
+	 * @return List of RichUsers from whole Perun, who matches the given String
+	 * @throws InternalErrorException internal error
+	 */
+	private List<RichUser> getRichUsersForMemberCandidates(PerunSession sess, List<String> attrNames, String searchString) throws InternalErrorException {
+		return getRichUsersForMemberCandidates(sess, null, attrNames, searchString);
+	}
+
+	/**
+	 * <p>Finds RichUsers who matches the given search string. If the given Vo is null,
+	 * they are searched in the whole Perun. If th Vo is not null, then are returned
+	 * only RichUsers who has a member inside this Vo.</p>
+	 * <p>The RichUsers are returned with attributes of given names.</p>
+	 *
+	 *
+	 * @param sess session
+	 * @param vo virtual organization, users are searched only inside this vo; if is null, then in the whole Perun
+	 * @param attrNames names of attributes that will be returned
+	 * @param searchString string used to find users
+	 * @return List of RichUsers inside given Vo, or in whole perun, who matches the given String
+	 * @throws InternalErrorException internal error
+	 */
+	private List<RichUser> getRichUsersForMemberCandidates(PerunSession sess, Vo vo, List<String> attrNames, String searchString) throws InternalErrorException {
+		List<RichUser> richUsers;
+
+		if (vo != null) {
+			List<Member> voMembers = getPerunBl().getMembersManagerBl().findMembersInVo(sess, vo, searchString);
+			List<User> voUsers = new ArrayList<>();
+			for (Member member : voMembers) {
+				voUsers.add(getPerunBl().getUsersManagerBl().getUserByMember(sess, member));
+			}
+
+			richUsers = getPerunBl().getUsersManagerBl().convertUsersToRichUsersWithAttributesByNames(sess, voUsers, attrNames);
+		} else {
+			try {
+				richUsers = getPerunBl().getUsersManagerBl().findRichUsersWithAttributes(sess, searchString, attrNames);
+			} catch (UserNotExistsException e) {
+				richUsers = new ArrayList<>();
+			}
+
+		}
+		return richUsers;
 	}
 
 	public void addAdmin(PerunSession sess, Vo vo, User user) throws InternalErrorException, AlreadyAdminException {
@@ -604,7 +698,90 @@ public class VosManagerBlImpl implements VosManagerBl {
 			membersManagerBl.removeSponsor(sess, sponsoredMember, user);
 		}
 	}
-	
+
+	/**
+	 * Creates MemberCandidates for given RichUsers, group and candidates. If the given group is not null
+	 * then to all members who are in this group is assigned the sourceGroupId of the given group.
+	 * The given group can be null.
+	 *
+	 * @param sess session
+	 * @param users users
+	 * @param candidates candidates
+	 * @return list of MemberCandidates for given RichUsers, group and candidates
+	 * @throws InternalErrorException internal error
+	 */
+	private List<MemberCandidate> createMemberCandidates(PerunSession sess, List<RichUser> users, Vo vo, List<Candidate> candidates, List<String> attrNames) throws InternalErrorException {
+		return createMemberCandidates(sess, users, vo, null, candidates, attrNames);
+	}
+
+	/**
+	 * Creates MemberCandidates for given RichUsers, vo, group and candidates. If the given group is not null
+	 * then to all members who are in this group is assigned the sourceGroupId of the given group.
+	 * The given group can be null.
+	 *
+	 * @param sess session
+	 * @param users users
+	 * @param group group
+	 * @param candidates candidates
+	 * @return list of MemberCandidates for given RichUsers, group and candidates
+	 * @throws InternalErrorException internal error
+	 */
+	private List<MemberCandidate> createMemberCandidates(PerunSession sess, List<RichUser> users, Vo vo, Group group, List<Candidate> candidates, List<String> attrNames) throws InternalErrorException {
+		List<MemberCandidate> memberCandidates = new ArrayList<>();
+
+		// try to find matching RichUser for candidates
+		for (Candidate candidate : candidates) {
+			MemberCandidate mc = new MemberCandidate();
+			mc.setCandidate(candidate);
+
+			try {
+				User user = getPerunBl().getUsersManagerBl().getUserByUserExtSources(sess, candidate.getUserExtSources());
+				RichUser richUser = getPerunBl().getUsersManagerBl().convertUserToRichUserWithAttributesByNames(sess, user, attrNames);
+
+				mc.setRichUser(richUser);
+			} catch (UserNotExistsException ignored) {
+				// no matching user was found
+			}
+
+			memberCandidates.add(mc);
+		}
+
+		List<RichUser> foundRichUsers = memberCandidates.stream()
+				.map(MemberCandidate::getRichUser)
+				.collect(Collectors.toList());
+
+		// create MemberCandidates for RichUsers without candidate
+		for (RichUser richUser : users) {
+			if (!foundRichUsers.contains(richUser)) {
+				MemberCandidate mc = new MemberCandidate();
+				mc.setRichUser(richUser);
+				memberCandidates.add(mc);
+			}
+		}
+
+		// try to find member for MemberCandidates with not null RichUser
+		for (MemberCandidate memberCandidate : memberCandidates) {
+			if (memberCandidate.getRichUser() != null) {
+				try {
+					Member member = getPerunBl().getMembersManagerBl().getMemberByUser(sess, vo, memberCandidate.getRichUser());
+
+					if (group != null) {
+						// check if member is in group
+						if (getPerunBl().getGroupsManagerBl().isGroupMember(sess, group, member)) {
+							member.setSourceGroupId(group.getId());
+						}
+					}
+					memberCandidate.setMember(member);
+				} catch (MemberNotExistsException ignored) {
+					// no matching member was found
+				}
+			}
+		}
+
+		return memberCandidates;
+	}
+
+
 	/**
 	 * Gets the vosManagerImpl.
 	 *

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/VosManagerMethod.java
@@ -180,6 +180,47 @@ public enum VosManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Find MemberCandidates for VO. MemberCandidates can be used to create new members. They are made of Candidate,
+	 * RichUser and Member objects. Candidates are searched in VO's external sources (if available). RichUsers are
+	 * searched in given VO and are associated with appropriate candidate and member. RichUsers for MemberCandidates
+	 * may also be searched in the whole Perun.
+	 *
+	 * @param vo int VO <code>id</code>
+	 * @param attrNames List<String> list with names of attributes that should be find.
+	 * @param searchString String Text to search by
+	 * @throw VoNotExistsException When <code>id</code> of VO doesn't match any existing VO.
+	 * @return List<MemberCandidate> List of MemberCandidates
+	 */
+	/*#
+	 * Find MemberCandidates for GROUP. MemberCandidates can be used to create new members. They are made of Candidate,
+	 * RichUser and Member objects. Candidates are searched in VO's or GROUP's (depends on privileges) external sources
+	 * (if available). RichUsers are searched in given VO and are associated with appropriate candidate and member.
+	 * RichUsers for appropriate Candidate are also searched in the whole Perun.
+	 *
+	 * @param group int GROUP <code>id</code>
+	 * @param attrNames List<String> list with names of attributes that should be find.
+	 * @param searchString String Text to search by
+	 * @throw GroupNotExistsException When <code>id</code> of GROUP doesn't match any existing GROUP.
+	 * @return List<MemberCandidate> List of MemberCandidates
+	 */
+	getCompleteCandidates {
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if (parms.contains("vo")) {
+				return ac.getVosManager().getCompleteCandidates(ac.getSession(),
+						ac.getVoById(parms.readInt("vo")),
+						parms.readList("attrNames", String.class),
+						parms.readString("searchString"));
+			} else {
+				return ac.getVosManager().getCompleteCandidates(ac.getSession(),
+						ac.getGroupById(parms.readInt("group")),
+						parms.readList("attrNames", String.class),
+						parms.readString("searchString"));
+			}
+		}
+	},
+
+	/*#
 	 * Gets count of all vos.
 
 	 * @return int vos count

--- a/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
+++ b/perun-utils/rpc-methods-javadoc-generator/parseRpcMethods.pl
@@ -135,6 +135,10 @@ $objectExamples{"Candidate"} = "{ \"id\" : 0 , \"serviceUser\" : false , \"first
 $objectExamples{"List&lt;Candidate&gt;"} = $listPrepend . $objectExamples{"Candidate"} . $listAppend;
 $objectExamples{"List<Candidate>"} = $objectExamples{"List&lt;Candidate&gt;"};
 
+$objectExamples("MemberCandidate") = "{ \"candidate\" : " . objectExamples("Candidate") . " , \"member\" : " . objectExamples("Member") . " , \"richUser\" : " . objectExamples("RichUser") . " }";
+$objectExamples("List&lt;MemberCandidate&gt;") = $listPrepend . $objectExamples("MemberCandidate") . $listAppend;
+$objectExamples("List<MemberCandidate>") = $objectExamples("List&lt;MemberCandidate&gt;");
+
 $objectExamples{"SecurityTeam"} = "{ \"id\" : 924 , \"name\" : \"CSIRT\" , \"description\" : \"My CSIRT\" }";
 $objectExamples{"List&lt;SecurityTeam&gt;"} = $listPrepend . $objectExamples{"SecurityTeam"} . $listAppend;
 $objectExamples{"List<SecurityTeam>"} = $objectExamples{"List&lt;SecurityTeam&gt;"};


### PR DESCRIPTION
* Created two new methods in Entry:
  * vosManager.getCompleteCandidates(vo, attrNames, searchString)
  * vosManager.getCompleteCandidates(vo, group, attrNames, searchString)
* Those methods are used to find MemberCandidate entities that consists
of Candidate, RichUser and Member entities.
* Those entities are used to decide if some candidate has appropriate
user in perun, member in a Vo or member in a group.
* The first method can be called only by VO_ADMIN and it searches for
candidates in all VO's ExtSources.
* The second method can be called by VO_ADMIN or GROUP_ADMIN. When it is
called by GROUP_ADMIN, it searches for candidates only in ExtSources
assigned to given group. Otherwise, it searches in all VO's ExtSources.

* Also were created appropriate methods in BL layer and method for
searching candidates - "getCandidates()" - was made more general. Now it
searches for candidates in given List of ExtSources and it can be
decided if it should return candidates for those users, who are already
in given VO.