### PR TITLE
Add missing funcionality to Perun CLI

### DIFF
--- a/perun-cli/Perun/ResourcesAgent.pm
+++ b/perun-cli/Perun/ResourcesAgent.pm
@@ -58,6 +58,11 @@ sub getAllowedMembers
 	return Perun::Common::callManagerMethod('getAllowedMembers', '[]Member', @_);
 }
 
+sub getAssignedMembers
+{
+	return Perun::Common::callManagerMethod('getAssignedMembers', '[]Member', @_);
+}
+
 sub getAllowedUsers
 {
 	return Perun::Common::callManagerMethod('getAllowedUsers', '[]User', @_);


### PR DESCRIPTION
 - missing method getAssignedMembers for Resorce (only allowed members
   are already in CLI)