### PR TITLE
New attributes with GID ranges for specific namespace

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -427,4 +427,33 @@ public interface ModulesUtilsBl {
 	 */
 	User getUserFromMessage(PerunSessionImpl sess, String message) throws InternalErrorException;
 
+	/**
+	 * Take attribute with gidRanges value (map of strings) and check if all records of this value are valid ranges.
+	 * Valid range is from minimum to maximum where minimum must be less or equal to maximum. If minimum and maximum
+	 * are equal, the interval has exactly one element. If all ranges are valid, it also checks if there is any
+	 * overlap between ranges. If yes, it throws an error.
+	 *
+	 * If every check is ok, it will return map of integer values where records are ranges, in keys are minimums of
+	 * these ranges, in values are maximum of these ranges and there are no overlaps between any two ranges in map.
+	 *
+	 * Attribute in parameter of this method can't be null but can have null value which returns empty map.
+	 *
+	 * If there are empty or null elements (value or key) in map it will throw an exception.
+	 * If any of minimums and maximums is not a number (convertible to Java Integer) it will throw an exception.
+	 * If any of minimums is less than 1 it also throw an exception.
+	 * If one of ranges is not correct range (minimum is not less or equal to maximum) it will throw an exception.
+	 * If there are any overlaps between two or more ranges, it will throw an exception - ex. 100-102 and 101-103.
+	 *
+	 * Example of valid format of range:
+	 * key='100', value='1000' - range from 100 to 1000 included
+	 * key='1', value ='1' - range with exactly one gid with number "1"
+	 *
+	 * @param gidRangesAttribute attribute with gid ranges value (map of ranges as strings)
+	 *
+	 * @return map of valid ranges without overlaps
+	 *
+	 * @throws InternalErrorException if attribute in parameter of method is null
+	 * @throws WrongAttributeValueException if value of attribute in parameter does not contain valid ranges without overlaps
+	 */
+	Map<Integer, Integer> checkAndConvertGIDRanges(Attribute gidRangesAttribute) throws InternalErrorException, WrongAttributeValueException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_GIDRanges.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_GIDRanges.java
@@ -1,0 +1,37 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleAbstract;
+import java.util.LinkedHashMap;
+
+/**
+ * GID Ranges for specific namespace which can be managed by Perun
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
+public class urn_perun_entityless_attribute_def_def_namespace_GIDRanges extends EntitylessAttributesModuleAbstract implements EntitylessAttributesModuleImplApi {
+
+	public void checkAttributeValue(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		//Check if gid ranges are in correct format (we don't need to use the output of the method there, we want to just check it)
+		perunSession.getPerunBl().getModulesUtilsBl().checkAndConvertGIDRanges(attribute);
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+		attr.setFriendlyName("namespace_GIDRanges");
+		attr.setDisplayName("GID ranges in namespace");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription("Manageable GID ranges in a namespace - key of map is minimum and assigned value is maximum of one range, minimum and maximum can be equal");
+		return attr;
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.List;
 
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_namespace_GIDRanges;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -545,7 +547,140 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		modulesUtilsBl.checkFormatOfShell(shell, attr);
 	}
 
+	@Test
+	public void checkAndConvertGIDRangesWhenAllIsOK() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenAllIsOK");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		Map<Integer, Integer> convertedMap = modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+		assertEquals(value.size(), convertedMap.size());
+		for(Integer minimum : convertedMap.keySet()) {
+			assertTrue(value.containsKey(minimum.toString()));
+			assertEquals(value.get(minimum.toString()), convertedMap.get(minimum).toString());
+		}
+	}
+
+	@Test(expected=InternalErrorException.class)
+	public void checkAndConvertGIDRangesWhenNullAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenNullAttribute");
+		modulesUtilsBl.checkAndConvertGIDRanges(null);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenEmptyValue() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenEmptyValue");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("7", "");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenNullValue() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenNullValue");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("7", null);
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenEmptyKey() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenEmptyKey");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("", "7");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenNullKey() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenNullKey");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put(null, "7");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenBadMinimum1() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenBadMinimum1");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("0", "0");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenBadMinimum2() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenBadMinimum2");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("-5", "-1");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenMaximumLessThanMinimum() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenMaximumLessThanMinimum");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("9", "8");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenKeyIsNotNumber() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenKeyIsNotNumber");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("6s", "7");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenValueIsNotNumber() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenValueIsNotNumber");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("6", "s7");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
+	@Test(expected=WrongAttributeValueException.class)
+	public void checkAndConvertGIDRangesWhenOverlapExist() throws Exception {
+		System.out.println(CLASS_NAME + "checkAndConvertGIDRangesWhenValueIsNotNumber");
+		Attribute attribute = getGIDRangesAttributeWithValidValue();
+		Map<String, String> value = (LinkedHashMap) attribute.getValue();
+		value.put("2000", "3000");
+		attribute.setValue(value);
+		modulesUtilsBl.checkAndConvertGIDRanges(attribute);
+	}
+
 	// private methods ------------------------------------------------------------------
+
+	private Attribute getGIDRangesAttributeWithValidValue() {
+
+		Attribute attribute = new Attribute((new urn_perun_entityless_attribute_def_def_namespace_GIDRanges()).getAttributeDefinition());
+
+		Map<String, String> gidRanges = new LinkedHashMap<>();
+		gidRanges.put("1000", "10000");
+		gidRanges.put("10001", "10002");
+		gidRanges.put("5", "5");
+		gidRanges.put("1", "1");
+		attribute.setValue(gidRanges);
+
+		return attribute;
+	}
 
 	private Vo setUpVo() throws Exception {
 


### PR DESCRIPTION
 - new GIDRanges entityless attribute to set ranges of gids managed by
 system Perun and replace logic of min and max gid entityless attributes
- new GIDRanges virtual facility attribute to replace logic of min and
max gid virtual attributes defined for facility
- these attributes will be used in the future instead minGID and maxGID
attributes, because there is only one interval between min and max
gid and we need to choose some specific gids to manage them too
- method to check and transfer data from gid ranges attribute is
located in ModulsUtils, because we will need it for further work in
other funcionality working with GID ranges
- added tests for this method