### PR TITLE
NOTIF: Do not use changing SQL command in init, when in readOnly mode

### DIFF
--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManagerImpl.java
@@ -50,8 +50,9 @@ public class PerunNotifPoolMessageManagerImpl implements PerunNotifPoolMessageMa
 	@SuppressWarnings("unused")
 	@PostConstruct
 	private void init() throws Exception {
-
-		perunNotifPoolMessageDao.setAllCreatedToNow();
+		if (!perun.isPerunReadOnly()) {
+			perunNotifPoolMessageDao.setAllCreatedToNow();
+		}
 		session = NotifUtils.getPerunSession(perun);
 	}
 


### PR DESCRIPTION
- If perun is set to readOnly mode, do not try to run data modifying
  SQL command on beans initialization.