### PR TITLE
Changed regex pattern for checking unix-like file paths.

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFile.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFile.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
  * @author Vladimir Mecko vladimir.mecko@gmail.com
  */
 public class urn_perun_resource_attribute_def_def_apacheAuthzFile extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
-	private Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
+	private Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9.?*+$%]+)+$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFileTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFileTest.java
@@ -44,4 +44,12 @@ public class urn_perun_resource_attribute_def_def_apacheAuthzFileTest {
 		attr.setValue("pathToFile");
 		authzFileAttr.checkAttributeValue(ps, new Resource(), attr);
 	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void checkAttributeEndingWithSlash() throws Exception {
+		System.out.println("checkAttributeEndingWithSlash()");
+		final Attribute attr = new Attribute();
+		attr.setValue("/ending/with/slash/");
+		authzFileAttr.checkAttributeValue(ps, new Resource(), attr);
+	}
 }


### PR DESCRIPTION
I changed the regex pattern so it now also accept special symbols stated
between these quotation marks ". ? * + $ %". I also added one new test
testing if file doesn't end with slash '/' (because that way if would be
directory and not file path).