### PR TITLE
New concept of quotas in Perun

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/QuotaNotInAllowedLimitException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/QuotaNotInAllowedLimitException.java
@@ -1,0 +1,44 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+
+import cz.metacentrum.perun.core.api.Pair;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+/**
+ * Raised when transferred quotas attribute value is not in defined limit.
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
+public class QuotaNotInAllowedLimitException extends InternalErrorException {
+	static final long serialVersionUID = 0;
+
+	private Map<String, Pair<BigDecimal, BigDecimal>> quotaToCheck;
+	private Map<String, Pair<BigDecimal, BigDecimal>> limitQuota;
+
+	public QuotaNotInAllowedLimitException(String message) {
+		super(message);
+	}
+
+	public QuotaNotInAllowedLimitException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public QuotaNotInAllowedLimitException(Throwable cause) {
+		super(cause);
+	}
+
+	public QuotaNotInAllowedLimitException(Map<String, Pair<BigDecimal, BigDecimal>> quotaToCheck, Map<String, Pair<BigDecimal, BigDecimal>> limitQuota, String message) {
+		super(message);
+		this.quotaToCheck = quotaToCheck;
+		this.limitQuota = limitQuota;
+	}
+
+	public QuotaNotInAllowedLimitException(Map<String, Pair<BigDecimal, BigDecimal>> quotaToCheck,
+										   Map<String, Pair<BigDecimal, BigDecimal>> limitQuota, String message, Throwable cause) {
+		super(message, cause);
+		this.quotaToCheck = quotaToCheck;
+		this.limitQuota = limitQuota;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -384,7 +384,7 @@ public interface ModulesUtilsBl {
 	 *
 	 * @return map with path in key and pair with <softQuota, hardQuota> in big decimal
 	 *
-	 * @throws InternalErrorException if attribute or his value is null
+	 * @throws InternalErrorException if first mandatory placeholder is null
 	 * @throws WrongAttributeValueException if something is wrong in format of attribute
 	 */
 	Map<String, Pair<BigDecimal, BigDecimal>> checkAndTransferQuotas(Attribute quotasAttribute, PerunBean firstPlaceholder, PerunBean secondPlaceholder, boolean withMetrics) throws InternalErrorException, WrongAttributeValueException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
@@ -337,6 +338,34 @@ public interface ModulesUtilsBl {
 	void checkAttributeRegex(Attribute attribute, String defaultRegex) throws InternalErrorException, WrongAttributeValueException;
 
 	/**
+	 * Check if quotaToCheck is in limit of limitQuota.
+	 * That means that every key of quotaToCheck map must exist in limitQuota and if such key exists, softQuota (left value)
+	 * of quotaToCheck map need to be lower or same as softQuota in limitQuota of the same key and the same must be in effect
+	 * for hardQuota (right value) of both maps.
+	 *
+	 * It uses transferred quotas so it can be used for files and data same way. 0 means unlimited. If no quota is allowed,
+	 * the value for volume shouldn't be in limit quota at all.
+	 *
+	 * Example of possible limitations:
+	 * quotaToCheck -> ( '/var/log/something' => '10000:50000', '/sys/something' => '0:0', '/tmp/something' => '0:0' )
+	 * quotaToLimit -> ( '/var/log/something' => '10000:50000', '/sys/something' => '50:0', '/cache/something' => '0:0' )
+	 * ---------------
+	 * '/var/log/something' => '10000:50000' -- this value is correct, exists in limit quota and both quotas are in limit
+	 * '/sys/something' => '0:0' -- this is not correct, 0 means unlimited quota and we have limit 50 for softQuota (not in limit)
+	 * '/tmp/something' => '0:0' -- this value is not correct, because this path is not set in limit quota at all
+	 * '/cache/something' => '0:0' -- there is no problem, that limit quota has some limited values which are not in quotasToCheck
+	 *
+	 * @param quotaToCheck map of volumes (as keys) and pairs of soft quota (left value) and hard quota (right value) for this volume
+	 *                     we want to check this map against the limit one
+	 * @param limitQuota map of volumes (as keys) and pairs of soft quota (left value) and hard quota (right value) for this volume
+	 *                   we want to use this map as limit one
+	 *
+	 * @throws QuotaNotInAllowedLimitException throw this exception, if check quota is not in limit of limit quota
+	 * @throws InternalErrorException if any of inputs is in unexpected format
+	 */
+	void checkIfQuotasIsInLimit(Map<String, Pair<BigDecimal, BigDecimal>> quotaToCheck, Map<String, Pair<BigDecimal, BigDecimal>> limitQuota) throws QuotaNotInAllowedLimitException, InternalErrorException;
+
+	/**
 	 * Check if value in quotas attribute are in the right format.
 	 * Also transfer and return data in suitable container.
 	 *
@@ -376,16 +405,21 @@ public interface ModulesUtilsBl {
 	Map<String, String> transferQuotasBackToAttributeValue(Map<String, Pair<BigDecimal, BigDecimal>> transferedQuotasMap, boolean withMetrics) throws InternalErrorException;
 
 	/**
-	 * Merge two transfered Quotas together.
+	 * Merge resource default quotas and member-resource specific quotas together. Use override if exists instead.
 	 * Paths are always unique, quotas are merged. (soft together and hard together)
-	 * Together means = bigger is better, 0 means unlimited so it is always bigger
 	 *
-	 * @param firstQuotas  first transfered map with quotas
-	 * @param secondQuotas second transfered map with quotas
+	 * Together means by priority:
+	 * - override has the highest priority but is it used only if path exists in resource or resource-member quotas
+	 * - member-resource quotas has the second highest priority if override not exists
+	 * - resource quotas are used only if contain unique path (path not exists as member-resource or as override)
 	 *
-	 * @return merged quotas transfered map
+	 * @param resourceQuotas transferred map with default resource quotas
+	 * @param memberResourceQuotas transferred map with member-resource specific quotas
+	 * @param quotasOverride transfered map with all manual overrides of quotas
+	 *
+	 * @return merged quotas transferred map
 	 */
-	Map<String,Pair<BigDecimal, BigDecimal>> mergeMemberAndResourceTransferedQuotas(Map<String, Pair<BigDecimal, BigDecimal>> firstQuotas, Map<String, Pair<BigDecimal, BigDecimal>> secondQuotas);
+	Map<String,Pair<BigDecimal, BigDecimal>> mergeMemberAndResourceTransferredQuotas(Map<String, Pair<BigDecimal, BigDecimal>> resourceQuotas, Map<String, Pair<BigDecimal, BigDecimal>> memberResourceQuotas, Map<String, Pair<BigDecimal, BigDecimal>> quotasOverride);
 
 	/**
 	 * Count all quotas for user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -687,8 +687,8 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	public Map<String, Pair<BigDecimal, BigDecimal>> checkAndTransferQuotas(Attribute quotasAttribute, PerunBean firstPlaceholder, PerunBean secondPlaceholder, boolean withMetrics) throws InternalErrorException, WrongAttributeValueException {
 		//firstPlaceholder can't be null
 		if(firstPlaceholder == null) throw new InternalErrorException("Missing first mandatory placeHolder (PerunBean).");
-		//Quotas attribute must exists with not null value
-		if(quotasAttribute == null || quotasAttribute.getValue() == null) throw new InternalErrorException("Attribute quotas for checking and transfering can't be null.");
+		//If quotas attribute is null or it's value is empty, return empty hash map
+		if(quotasAttribute == null || quotasAttribute.getValue() == null) return new HashMap<>();
 
 		//Prepare result container and value of attribute
 		Map<String, Pair<BigDecimal, BigDecimal>> transferedQuotas = new HashMap<>();
@@ -876,8 +876,8 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 			//override has the highest priority
 			if (quotasOverride.containsKey(path)) {
 				mergedTransferedQuotas.put(path, quotasOverride.get(path));
-			//if override not exists, take the original value
 			} else {
+				//if override not exists, take the original value
 				mergedTransferedQuotas.put(path, memberResourceQuotas.get(path));
 			}
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
@@ -59,7 +59,7 @@ public class urn_perun_member_resource_attribute_def_def_dataQuotas extends Reso
 		Map<String, Pair<BigDecimal, BigDecimal>> maxUserDataQuotasForResource;
 		try {
 			maxUserDataQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(maxUserDataQuotasAttribute, resource, null, true);
-		} catch (WrongAttributeValueException | InternalErrorException ex) {
+		} catch (WrongAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, maxUserDataQuotasAttribute, resource, member, resource, null,
 					"Can't set dataQuotas for member on resource, because maxUserQuota is not in correct format. Please fix it first!", ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
@@ -4,16 +4,24 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -22,6 +30,8 @@ import java.util.Map;
  * @author Michal Stava stavamichal@gmail.com
  */
 public class urn_perun_member_resource_attribute_def_def_dataQuotas extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+
+	public static final String A_R_maxUserDataQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserDataQuotas";
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -32,7 +42,41 @@ public class urn_perun_member_resource_attribute_def_def_dataQuotas extends Reso
 
 		//Check if every part of this map has the right pattern
 		//And also check if every quota part has right settings (softQuota<=hardQuota)
-		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, member, resource, true);
+		Map<String, Pair<BigDecimal, BigDecimal>> dataQuotasForMemberOnResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, member, true);
+
+		//If there are no values after converting quota, we can skip testing against maxUserDataQuota attribute, because there is nothing to check
+		if (dataQuotasForMemberOnResource == null || dataQuotasForMemberOnResource.isEmpty()) return;
+
+		//Get maxUserDataQuotas value on this resource
+		Attribute maxUserDataQuotasAttribute;
+		try {
+			maxUserDataQuotasAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, A_R_maxUserDataQuotas);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		//Check and transfer maxUserDataQuotasForResource
+		Map<String, Pair<BigDecimal, BigDecimal>> maxUserDataQuotasForResource;
+		try {
+			maxUserDataQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(maxUserDataQuotasAttribute, resource, null, true);
+		} catch (WrongAttributeValueException | InternalErrorException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, maxUserDataQuotasAttribute, resource, member, resource, null,
+					"Can't set dataQuotas for member on resource, because maxUserQuota is not in correct format. Please fix it first!", ex);
+		}
+
+		try {
+			perunSession.getPerunBl().getModulesUtilsBl().checkIfQuotasIsInLimit(dataQuotasForMemberOnResource, maxUserDataQuotasForResource);
+		} catch (QuotaNotInAllowedLimitException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, maxUserDataQuotasAttribute, member, resource, resource, null,
+					"DataQuotas for member on resource is not in limit of maxUserQuota!", ex);
+		}
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<String>();
+		dependencies.add(A_R_maxUserDataQuotas);
+		return dependencies;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotasOverride.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotasOverride.java
@@ -1,0 +1,58 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Attribute for setting override of the member's quota on the resource.
+ * This override is always used instead of defaultDataQuota on resource or specific member-resource DataQuota
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class urn_perun_member_resource_attribute_def_def_dataQuotasOverride extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		//attribute can be null, it means there are no default settings on resource
+		if(attribute.getValue() == null) {
+			return;
+		}
+
+		//Check if every part of this map has the right pattern
+		//And also check if every quota part has right settings (softQuota<=hardQuota)
+		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, member, true);
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("dataQuotasOverride");
+		attr.setDisplayName("Override of data quotas for member on resource");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription("Override has the highest priority for setting data quotas of member on resource. " +
+				"Every record is the path (to volume) and the quota in format 'SoftQuota:HardQuota'. Example: '1000:2000'.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotas.java
@@ -4,16 +4,24 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -22,6 +30,8 @@ import java.util.Map;
  * @author Michal Stava stavamichal@gmail.com
  */
 public class urn_perun_member_resource_attribute_def_def_fileQuotas extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+
+	public static final String A_R_maxUserFileQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserFileQuotas";
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -32,7 +42,41 @@ public class urn_perun_member_resource_attribute_def_def_fileQuotas extends Reso
 
 		//Check if every part of this map has the right pattern
 		//And also check if every quota part has right settings (softQuota<=hardQuota)
-		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, member, resource, false);
+		Map<String, Pair<BigDecimal, BigDecimal>> fileQuotasForMemberOnResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, member, false);
+
+		//If there are no values after converting quota, we can skip testing against maxUserFileQuota attribute, because there is nothing to check
+		if (fileQuotasForMemberOnResource == null || fileQuotasForMemberOnResource.isEmpty()) return;
+
+		//Get maxUserFileQuotas value on this resource
+		Attribute maxUserFileQuotasAttribute;
+		try {
+			maxUserFileQuotasAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, A_R_maxUserFileQuotas);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		//Check and transfer maxUserFileQuotasForResource
+		Map<String, Pair<BigDecimal, BigDecimal>> maxUserFileQuotasForResource;
+		try {
+			maxUserFileQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(maxUserFileQuotasAttribute, resource, null, false);
+		} catch (WrongAttributeValueException | InternalErrorException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, maxUserFileQuotasAttribute, resource, member, resource, null,
+					"Can't set fileQuotas for member on resource, because maxUserQuota is not in correct format. Please fix it first!", ex);
+		}
+
+		try {
+			perunSession.getPerunBl().getModulesUtilsBl().checkIfQuotasIsInLimit(fileQuotasForMemberOnResource, maxUserFileQuotasForResource);
+		} catch (QuotaNotInAllowedLimitException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, maxUserFileQuotasAttribute, member, resource, resource, null,
+					"FileQuotas for member on resource is not in limit of maxUserQuota!", ex);
+		}
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<String>();
+		dependencies.add(A_R_maxUserFileQuotas);
+		return dependencies;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotas.java
@@ -59,7 +59,7 @@ public class urn_perun_member_resource_attribute_def_def_fileQuotas extends Reso
 		Map<String, Pair<BigDecimal, BigDecimal>> maxUserFileQuotasForResource;
 		try {
 			maxUserFileQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(maxUserFileQuotasAttribute, resource, null, false);
-		} catch (WrongAttributeValueException | InternalErrorException ex) {
+		} catch (WrongAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, maxUserFileQuotasAttribute, resource, member, resource, null,
 					"Can't set fileQuotas for member on resource, because maxUserQuota is not in correct format. Please fix it first!", ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotasOverride.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotasOverride.java
@@ -1,0 +1,58 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Attribute for setting override of the member's quota on the resource.
+ * This override is always used instead of defaultFileQuota on resource or specific member-resource FileQuota
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class urn_perun_member_resource_attribute_def_def_fileQuotasOverride extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		//attribute can be null, it means there are no default settings on resource
+		if(attribute.getValue() == null) {
+			return;
+		}
+
+		//Check if every part of this map has the right pattern
+		//And also check if every quota part has right settings (softQuota<=hardQuota)
+		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, member, false);
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("fileQuotasOverride");
+		attr.setDisplayName("Override of file quotas for member on resource");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription("Override has the highest priority for setting file quotas of member on resource. " +
+				"Every record is the path (to volume) and the quota in format 'SoftQuota:HardQuota'. Example: '1000:2000'.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuotas.java
@@ -58,7 +58,7 @@ public class urn_perun_resource_attribute_def_def_defaultDataQuotas extends Reso
 		Map<String, Pair<BigDecimal, BigDecimal>> maxUserDataQuotasForResource;
 		try {
 			maxUserDataQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(maxUserDataQuotasAttribute, resource, null, true);
-		} catch (WrongAttributeValueException | InternalErrorException ex) {
+		} catch (WrongAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, maxUserDataQuotasAttribute, resource, null, resource, null,
 					"Can't set defaultDataQuotas for resource, because maxUserQuota is not in correct format. Please fix it first!", ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuotas.java
@@ -3,16 +3,24 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -22,16 +30,52 @@ import java.util.Map;
  */
 public class urn_perun_resource_attribute_def_def_defaultDataQuotas extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
+	public static final String A_R_maxUserDataQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserDataQuotas";
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//attribute can be null, it means there are no default settings on resource
-		if(attribute.getValue() == null) {
+		if (attribute.getValue() == null) {
 			return;
 		}
 
 		//Check if every part of this map has the right pattern
 		//And also check if every quota part has right settings (softQuota<=hardQuota)
-		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, true);
+		Map<String, Pair<BigDecimal, BigDecimal>> defaultDataQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, true);
+
+		//If there are no values after converting quota, we can skip testing against maxUserDataQuota attribute, because there is nothing to check
+		if (defaultDataQuotasForResource == null || defaultDataQuotasForResource.isEmpty()) return;
+
+		//Get maxUserDataQuotas value on this resource
+		Attribute maxUserDataQuotasAttribute;
+		try {
+			maxUserDataQuotasAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, A_R_maxUserDataQuotas);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		//Check and transfer maxUserDataQuotasForResource
+		Map<String, Pair<BigDecimal, BigDecimal>> maxUserDataQuotasForResource;
+		try {
+			maxUserDataQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(maxUserDataQuotasAttribute, resource, null, true);
+		} catch (WrongAttributeValueException | InternalErrorException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, maxUserDataQuotasAttribute, resource, null, resource, null,
+					"Can't set defaultDataQuotas for resource, because maxUserQuota is not in correct format. Please fix it first!", ex);
+		}
+
+		try {
+			perunSession.getPerunBl().getModulesUtilsBl().checkIfQuotasIsInLimit(defaultDataQuotasForResource, maxUserDataQuotasForResource);
+		} catch (QuotaNotInAllowedLimitException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, maxUserDataQuotasAttribute, resource, null, resource, null,
+					"DefaultDataQuotas for resource is not in limit of maxUserQuota!", ex);
+		}
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<String>();
+		dependencies.add(A_R_maxUserDataQuotas);
+		return dependencies;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFileQuotas.java
@@ -58,7 +58,7 @@ public class urn_perun_resource_attribute_def_def_defaultFileQuotas extends Reso
 		Map<String, Pair<BigDecimal, BigDecimal>> maxUserFileQuotasForResource;
 		try {
 			maxUserFileQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(maxUserFileQuotasAttribute, resource, null, false);
-		} catch (WrongAttributeValueException | InternalErrorException ex) {
+		} catch (WrongAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, maxUserFileQuotasAttribute, resource, null, resource, null,
 					"Can't set defaultFileQuotas for resource, because maxUserQuota is not in correct format. Please fix it first!", ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFileQuotas.java
@@ -3,16 +3,24 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -21,6 +29,8 @@ import java.util.Map;
  * @author Michal Stava stavamichal@gmail.com
  */
 public class urn_perun_resource_attribute_def_def_defaultFileQuotas extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	public static final String A_R_maxUserFileQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserFileQuotas";
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -31,7 +41,41 @@ public class urn_perun_resource_attribute_def_def_defaultFileQuotas extends Reso
 
 		//Check if every part of this map has the right pattern
 		//And also check if every quota part has right settings (softQuota<=hardQuota)
-		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, false);
+		Map<String, Pair<BigDecimal, BigDecimal>> defaultFileQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, false);
+
+		//If there are no values after converting quota, we can skip testing against maxUserFileQuota attribute, because there is nothing to check
+		if (defaultFileQuotasForResource == null || defaultFileQuotasForResource.isEmpty()) return;
+
+		//Get maxUserFileQuotas value on this resource
+		Attribute maxUserFileQuotasAttribute;
+		try {
+			maxUserFileQuotasAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, A_R_maxUserFileQuotas);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		//Check and transfer maxUserFileQuotasForResource
+		Map<String, Pair<BigDecimal, BigDecimal>> maxUserFileQuotasForResource;
+		try {
+			maxUserFileQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(maxUserFileQuotasAttribute, resource, null, false);
+		} catch (WrongAttributeValueException | InternalErrorException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, maxUserFileQuotasAttribute, resource, null, resource, null,
+					"Can't set defaultFileQuotas for resource, because maxUserQuota is not in correct format. Please fix it first!", ex);
+		}
+
+		try {
+			perunSession.getPerunBl().getModulesUtilsBl().checkIfQuotasIsInLimit(defaultFileQuotasForResource, maxUserFileQuotasForResource);
+		} catch (QuotaNotInAllowedLimitException ex) {
+			throw new WrongReferenceAttributeValueException(attribute, maxUserFileQuotasAttribute, resource, null, resource, null,
+					"DefaultFileQuotas for resource is not in limit of maxUserQuota!", ex);
+		}
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<String>();
+		dependencies.add(A_R_maxUserFileQuotas);
+		return dependencies;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserDataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserDataQuotas.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Attribute for setting maximum of data quotas for any volume on defined resource.
+ * By this attribute, facility manager is able to set maximum for defined resource
+ * which must be adhere by Vo Manager of assigned Vo.
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class urn_perun_resource_attribute_def_def_maxUserDataQuotas extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		//attribute can be null, it means there are no max user settings on resource
+		if(attribute.getValue() == null) {
+			return;
+		}
+
+		//Check if every part of this map has the right pattern
+		//And also check if every quota part has right settings (softQuota<=hardQuota)
+		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, true);
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("maxUserDataQuotas");
+		attr.setDisplayName("Maximum of data quotas of User on any volumes.");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription("This is Facility manager maximum set for Resource on defined volumes. " +
+				"Every record is the path (to volume) and the quota in format 'SoftQuota:HardQuota' in (M, G, T, ...), G is default. Example: '10G:20T'.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserDataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserDataQuotas.java
@@ -41,9 +41,9 @@ public class urn_perun_resource_attribute_def_def_maxUserDataQuotas extends Reso
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
 		attr.setFriendlyName("maxUserDataQuotas");
-		attr.setDisplayName("Maximum of data quotas of User on any volumes.");
+		attr.setDisplayName("Maximum of data quotas of user on any volumes.");
 		attr.setType(LinkedHashMap.class.getName());
-		attr.setDescription("This is Facility manager maximum set for Resource on defined volumes. " +
+		attr.setDescription("Maximum data quota for each user on this resource. " +
 				"Every record is the path (to volume) and the quota in format 'SoftQuota:HardQuota' in (M, G, T, ...), G is default. Example: '10G:20T'.");
 		return attr;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserFileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserFileQuotas.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Attribute for setting maximum of file quotas for any volume on defined resource.
+ * By this attribute, facility manager is able to set maximum for defined resource
+ * which must be adhere by Vo Manager of assigned Vo.
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class urn_perun_resource_attribute_def_def_maxUserFileQuotas extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		//attribute can be null, it means there are no max user settings on resource
+		if(attribute.getValue() == null) {
+			return;
+		}
+
+		//Check if every part of this map has the right pattern
+		//And also check if every quota part has right settings (softQuota<=hardQuota)
+		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, false);
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setFriendlyName("maxUserFileQuotas");
+		attr.setDisplayName("Maximum of file quotas of User on any volumes.");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription("This is Facility manager maximum set for Resource on defined volumes. " +
+				"Every record is the path (to volume) and the quota in format 'SoftQuota:HardQuota'. Example: '1000:2000'.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserFileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserFileQuotas.java
@@ -41,9 +41,9 @@ public class urn_perun_resource_attribute_def_def_maxUserFileQuotas extends Reso
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
 		attr.setFriendlyName("maxUserFileQuotas");
-		attr.setDisplayName("Maximum of file quotas of User on any volumes.");
+		attr.setDisplayName("Maximum of file quotas of user on any volumes.");
 		attr.setType(LinkedHashMap.class.getName());
-		attr.setDescription("This is Facility manager maximum set for Resource on defined volumes. " +
+		attr.setDescription("Maximum file quota for each user on this resource. " +
 				"Every record is the path (to volume) and the quota in format 'SoftQuota:HardQuota'. Example: '1000:2000'.");
 		return attr;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_dataQuotas.java
@@ -30,7 +30,8 @@ import java.util.Map;
 public class urn_perun_user_facility_attribute_def_virt_dataQuotas extends FacilityUserVirtualAttributesModuleAbstract {
 	public static final String A_R_defaultDataQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuotas";
 	public static final String A_MR_dataQuotas = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuotas";
-	
+	public static final String A_MR_dataQuotasOverride = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuotasOverride";
+
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
@@ -54,7 +55,7 @@ public class urn_perun_user_facility_attribute_def_virt_dataQuotas extends Facil
 			} catch (MemberNotExistsException ex) {
 				throw new ConsistencyErrorException("User should have member in this VO, because he was listed in allowed assigned resources " + user + ", " + membersVo + " , " + resource);
 			}
-			
+
 			//get resource quotas
 			Map<String, Pair<BigDecimal, BigDecimal>> resourceTransferedQuotas;
 			Attribute resourceQuotas;
@@ -95,8 +96,29 @@ public class urn_perun_user_facility_attribute_def_virt_dataQuotas extends Facil
 				}
 			}
 
+			//get members quotas override
+			Map<String, Pair<BigDecimal, BigDecimal>> memberTransferedQuotasOverride;
+			Attribute memberQuotasOverride;
+			try {
+				memberQuotasOverride = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, memberOnResource, A_MR_dataQuotasOverride);
+			} catch (AttributeNotExistsException ex) {
+				throw new ConsistencyErrorException(ex);
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
+			} catch (MemberResourceMismatchException ex) {
+				throw new InternalErrorException(ex);
+			}
+			if(memberQuotasOverride == null || memberQuotasOverride.getValue() == null) memberTransferedQuotasOverride = new HashMap<>();
+			else {
+				try {
+					memberTransferedQuotasOverride = sess.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(memberQuotasOverride, resource, memberOnResource, true);
+				} catch (WrongAttributeValueException ex) {
+					throw new ConsistencyErrorException("Override quotas on resource " + resource + " for member " + memberOnResource + " are in bad format.", ex);
+				}
+			}
+
 			//merge quotas and add them to the big map by resources
-			mergedMemberResourceQuotas.add(sess.getPerunBl().getModulesUtilsBl().mergeMemberAndResourceTransferedQuotas(memberTransferedQuotas, resourceTransferedQuotas));
+			mergedMemberResourceQuotas.add(sess.getPerunBl().getModulesUtilsBl().mergeMemberAndResourceTransferredQuotas(resourceTransferedQuotas, memberTransferedQuotas, memberTransferedQuotasOverride));
 		}
 
 		//now we have all resource and member merged quotas, so we need to create 1 transfered map with sum of values


### PR DESCRIPTION
 - adding two new attributes maxUserDataQuotas and maxUserFileQuotas.
   These attributes will add a way how to limit setting of
   defaultData|FileQuotas by attribute with the maximum of available
   values for softQuota and hardQuota for specific volume and specific
   resource by FacilityManagers. Then we can allow setting of
   defaultData|FileQuota attribute by VoManagers, because they will
   be limited by the maximum.
 - adding two new attribute dataQuotaOverride and fileQuotaOverride.
   These attributes will add a way how to set special override values
   for specific member, specific resource and specific volumes. These
   overrides will always replace defaults or member-specific settings.
 - defaultQuotas and member-resource specific quotas now can't exceed
   limits of maxUserQuotas
 - change behavior of counting member-resource quotas. Priority has
   override, if override on volume not exists, use the old way "bigger
   is better" from default and member-specific settings.
 - add tests for all ModuleUtils methods used in this quotas
   functionality