### PR TITLE
CORE: Initialize AttributesManagerBl after AuthzResolverImpl

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -27,7 +27,6 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	//http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/jdbc.html
 	private static JdbcPerunTemplate jdbc;
 
-	private Perun perun;
 	private final static Pattern patternForExtractingPerunBean = Pattern.compile("^pb_([a-z_]+)_id$");
 
 	private final static String authzRoleMappingSelectQuery = " authz.user_id as authz_user_id, authz.role_id as authz_role_id," +
@@ -131,15 +130,15 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 
 	public void initialize() throws InternalErrorException {
 
-		if(perun.isPerunReadOnly()) log.debug("Loading authzresolver manager init in readOnly version.");
+		if(BeansUtils.isPerunReadOnly()) log.debug("Loading authzresolver manager init in readOnly version.");
 
 		// Check if all roles defined in class Role exists in the DB
 		for (Role role: Role.values()) {
 			try {
 				if (0 == jdbc.queryForInt("select count(*) from roles where name=?", role.getRoleName())) {
 					//Skip creating not existing roles for read only Perun
-					if(perun.isPerunReadOnly()) {
-						throw new InternalErrorException("One of deafult roles not exists in DB - " + role);
+					if(BeansUtils.isPerunReadOnly()) {
+						throw new InternalErrorException("One of default roles not exists in DB - " + role);
 					} else {
 						int newId = Utils.getNewId(jdbc, "roles_id_seq");
 						jdbc.update("insert into roles (id, name) values (?,?)", newId, role.getRoleName());
@@ -547,7 +546,4 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		}
 	}
 
-	public void setPerun(Perun perun) {
-		this.perun = perun;
-	}
 }

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -279,7 +279,8 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<property name="perunBl" ref="perun"/>
 		<constructor-arg ref="extSourcesManagerImpl" />
 	</bean>
-	<bean id="attributesManagerBl" class="cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
+	<bean id="attributesManagerBl" class="cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl" scope="singleton" init-method="initialize" depends-on="authzResolverImpl">
+		<!-- depend on authz resolver impl to make sure roles are inserted in DB before attribute authz is set -->
 		<property name="perunBl" ref="perun"/>
 		<constructor-arg ref="attributesManagerImpl" />
 	</bean>
@@ -353,7 +354,6 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<constructor-arg ref="dataSource" />
 	</bean>
 	<bean id="authzResolverImpl" class="cz.metacentrum.perun.core.impl.AuthzResolverImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
-		<property name="perun" ref="perun"/>
 		<constructor-arg ref="dataSource" />
 	</bean>
 	<bean id="searcherImpl" class="cz.metacentrum.perun.core.impl.SearcherImpl" scope="singleton" depends-on="databaseManagerBl">


### PR DESCRIPTION
- When DB is empty, there are no roles stored in DB and then
  we can't insert attribute authz with null role.
- To make it work we must break spring dependency cycle between
  perun and authzResolverImpl.
  Since perun bean was used in init method of authzResolverImpl only
  to determine "read_only" status, we removed it from it and now it
  calls directly BeansUtils.isPerunReadOnly().