### PR TITLE
CORE: Do not validate disabled members when membershipExpiration is set

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_membershipExpiration.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_membershipExpiration.java
@@ -78,7 +78,7 @@ public class urn_perun_member_attribute_def_def_membershipExpiration extends Mem
 		String value = null;
 		if(attribute.getValue() != null) value = (String) attribute.getValue();
 		//If there is some value and member is in status expired or disabled
-		if(value != null && (member.getStatus().equals(Status.EXPIRED) || member.getStatus().equals(Status.DISABLED))) {
+		if(value != null && (member.getStatus().equals(Status.EXPIRED))) {
 			Date expirationDate = null;
 			try {
 				expirationDate = BeansUtils.getDateFormatterWithoutTime().parse(value);


### PR DESCRIPTION
- When member:def:membershipExpiration is set, it checks the value
  and if is in future and member is expired/disabled it validates him.
  We probably don't want this for DISABLED members, since they are
  disabled manually or by synchronization and this shouldn't validate
  them.