### PR TITLE
Update force option in deleteGroup tool.

### DIFF
--- a/perun-cli/deleteGroup
+++ b/perun-cli/deleteGroup
@@ -51,7 +51,7 @@ if (!defined($groupId)) {
 
 if (defined($force)) {
 	my $forcevalue = 1;
-	$groupsAgent->deleteGroup( group => $groupId, forceDelete => $forcevalue );
+	$groupsAgent->deleteGroup( group => $groupId, force => $forcevalue );
 } else {
 	$groupsAgent->deleteGroup( group => $groupId );
 }


### PR DESCRIPTION
In deleteGroup was used old paremeter forceDelete, instead of correct parameter force in calling of RPC method. Option force was non-functioning. After correcting function of force option is correct.