### PR TITLE
CABINET: Allow listing of authors to publication creators

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/CabinetManager.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/CabinetManager.java
@@ -341,7 +341,7 @@ public interface CabinetManager {
 	 * @return List of Authors of Publication specified its ID. Empty list of none found.
 	 * @throws InternalErrorException When implementation fails
 	 */
-	List<Author> getAuthorsByPublicationId(PerunSession session, int id) throws InternalErrorException, PrivilegeException;
+	List<Author> getAuthorsByPublicationId(PerunSession session, int id) throws InternalErrorException, PrivilegeException, CabinetException;
 
 	/**
 	 * Return all Authors of Publication specified by Authorships ID. Empty list of none found.


### PR DESCRIPTION
- When user creates new publication, he might not be between authors,
  but GUI loads current (empty) authors, so we must allow reading
  current set of authors to publication creators.