### PR TITLE
RPC: Disable moveGroup() function in RPC API

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
@@ -187,6 +188,8 @@ public enum GroupsManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
+			throw new InternalErrorException("Moving groups is temporary disabled.");
+			/*
 			if(parms.contains("destinationGroup")) {
 				ac.getGroupsManager().moveGroup(ac.getSession(),
 						ac.getGroupById(parms.readInt("destinationGroup")),
@@ -197,6 +200,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 						ac.getGroupById(parms.readInt("movingGroup")));
 			}
 			return null;
+			*/
 		}
 	},
 


### PR DESCRIPTION
- Moving groups is temporary disabled, since we incorrectly update
  the DB. It's not blocked in core, since we would need to ignore
  multiple tests instead of throwing one exception. Plus nobody yet
  uses this function from a code.
- Change is done, so we can safely deploy all code to production and
  once fixed we will enable this again.
- In GUI, this function is already visible only to perun admins.