### PR TITLE
CORE: Allow to set group virt attribute using attr module

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1690,7 +1690,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		boolean changed;
 		if (isVirtAttribute(sess, attribute)) {
-			throw new InternalErrorException("Virtual attribute can't be set this way yet. Please set physical attribute instead.");
+			try {
+				changed = getAttributesManagerImpl().setVirtualAttribute(sess, group, attribute);
+			} catch (WrongReferenceAttributeValueException ex) {
+				throw new InternalErrorException(ex);
+			}
 		} else {
 			changed = getAttributesManagerImpl().setAttribute(sess, group, attribute);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1954,6 +1954,10 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		return getResourceVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, resource, attribute);
 	}
 
+	public boolean setVirtualAttribute(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		return getGroupVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, group, attribute);
+	}
+
 	public boolean setVirtualAttribute(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		return getFacilityUserVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, facility, user, attribute);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -914,6 +914,20 @@ public interface AttributesManagerImplApi {
 	boolean setVirtualAttribute(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongModuleTypeException, ModuleNotExistsException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Store the particular virtual attribute associated with the group.
+	 *
+	 * @param sess perun session
+	 * @param group
+	 * @param attribute attribute to set
+	 * @return true if attribute was really changed
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws ModuleNotExistsException
+	 * @throws WrongModuleTypeException
+	 * @throws WrongReferenceAttributeValueException
+	 */
+	boolean setVirtualAttribute(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongModuleTypeException, ModuleNotExistsException, WrongReferenceAttributeValueException;
+
+	/**
 	 * Store the particular virtual attribute associated with the facility and user combination.
 	 *
 	 * @param sess perun session


### PR DESCRIPTION
- Don't throw exception, when we try to set group:virt attribute,
  call attr module instead. Default module impl returns false and make
  no change to attribute.