### PR TITLE
GUI: Fix for Chrome+Windows+Kerberos

### DIFF
--- a/perun-web-gui/src/main/webapp/PerunWeb.html
+++ b/perun-web-gui/src/main/webapp/PerunWeb.html
@@ -30,6 +30,13 @@
 	<!--  RPC definition -->
 	<script type="text/javascript" language="javascript" >
 		RPC_SERVER = window.location.pathname.split("/")[1];
+
+		<!-- Fix Windows+Chrome+Kerberos authz - chrome doesn`t trust whole domain, we must call most top-level path -->
+		$.ajax({
+			url: "/" + window.location.pathname.split("/")[1] + "/rpc/",
+			type: "get"
+		});
+
 	</script>
 
 	<!--  Set language -->


### PR DESCRIPTION
- In above specific combination, user is requested to enter username
  and password several times, since chrome trust only most top-level
  path, and not whole domain. Hence we blindly call /[authz]/rpc/
  before GUI loads to limit authentication requests to two.