### PR TITLE
CORE, REGISTRAR: Save UES attributes from application

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -187,6 +187,25 @@ public class BeansUtils {
 		return attrNew.toString();
 	}
 
+	/**
+	 * Converts attribute value to string (serialize object to string).
+	 * This is a wrapper for passing value and type only for specific use.
+	 * @see #attributeValueToString(Attribute)
+	 *
+	 * @param attributeValue value of the attribute
+	 * @param type type of resulting attribute
+	 * @return string representation of the value
+	 *
+	 * @throws InternalErrorException
+	 */
+	@SuppressWarnings("unchecked")
+	public static String attributeValueToString(Object attributeValue, String type) throws InternalErrorException {
+		Attribute a = new Attribute();
+		a.setType(type);
+		a.setValue(attributeValue);
+		return attributeValueToString(a);
+	}
+
 
 	/**
 	 * Converts attribute value to string (for storing into DB)


### PR DESCRIPTION
- When we create new user through registration, UES attributes are now
  lost. This change saves UES attributes in application itself.
  On approval, UES attributes are set to newly created UES.
- Added wrapper method attributeValueToString() to BeansUtils.
  It allows us to convert Object (attribute value) to it's expected
  String representation. Current method required whole Attribute object.
- Logic of saving UES attributes from session in PerunBlImpl moved
  to own public method. It's now called by getPerunSession() (during
  session initiation) and by approveApplication() (from registrar).