### PR TITLE
Move strongDependencies under virtual attribute api

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -3836,11 +3836,27 @@ public interface AttributesManagerBl {
 			WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 
 	/**
-	 * This method checkValue on all possible dependent attributes for richAttr.
-	 * RichAttribute is needed for useful objects which are in holders.
+	 * This method check validity of value on all attributes which depends on the attributes in richAttr object.
+	 *
+	 * There are two types of dependency "normal" and "strong" and every non-virtual attribute can have some "normal"
+	 * dependencies and every virtual attribute can have some "normal" and some "strong" dependencies.
+	 *
+	 * Normal dependency means that if we have attributes A and B and attribute A is dependent on attribute B, then if
+	 * value of attribute B has been changed, we need to check that value of attribute A is still valid.
+	 * In other words: If '->' means depends on, then in case that A -> B, if value of B has been changed, we need to check
+	 * that value of A is still valid.
+	 *
+	 * Strong dependency means that if we have attribute A and B and attribute A is strongly dependent on attribute B,
+	 * then if value of attribute B has been changed, it can affect value of attribute A too therefore we need to check
+	 * value of attribute A and also check all attributes which depend on attribute A.
+	 * In other words: If '=>' means strongly depends on and '->' means depends on, then in case that A => B and C -> A,
+	 * if value of B has been changed, we need to check not only A, but also C, because validity of attribute C could
+	 * been affected but change of attribute A.
+	 *
+	 * RichAttribute is needed because it contains useful objects in holders.
 	 *
 	 * @param sess
-	 * @param richAttr
+	 * @param richAttr RichAttribute with attribute an its' holders
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 * @throws WrongAttributeAssignmentException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -6137,7 +6137,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (AttributeDefinition ad : allAttributesDef) {
 			AttributesModuleImplApi module;
 			List<String> depList;
-			List<String> strongDepList;
+			List<String> strongDepList = new ArrayList<>();
 			Set<AttributeDefinition> depSet = new HashSet<>();
 			Set<AttributeDefinition> strongDepSet = new HashSet<>();
 
@@ -6148,7 +6148,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			if (attributeModule != null) {
 				module = (AttributesModuleImplApi) attributeModule;
 				depList = module.getDependencies();
-				strongDepList = module.getStrongDependencies();
+				if(attributeModule instanceof VirtualAttributesModuleImplApi) {
+					strongDepList = ((VirtualAttributesModuleImplApi) module).getStrongDependencies();
+				}
 				//Fill Set of dependencies
 				for (String s : depList) {
 					if (!s.endsWith("*")) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
@@ -64,7 +64,7 @@ public class urn_perun_group_resource_attribute_def_def_projectOwnerLogin extend
 	}
 
 	@Override
-	public List<String> getStrongDependencies() {
+	public List<String> getDependencies() {
 		List<String> strongDependencies = new ArrayList<String>();
 		strongDependencies.add(AttributesManager.NS_USER_FACILITY_ATTR_VIRT + ":login");
 		return strongDependencies;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AttributesModuleAbstract.java
@@ -17,11 +17,6 @@ public abstract class AttributesModuleAbstract implements AttributesModuleImplAp
 		return dependecies;
 	}
 
-	public List<String> getStrongDependencies() {
-		List<String> dependecies = new ArrayList<String>();
-		return dependecies;
-	}
-
 	public List<Role> getAuthorizedRoles() {
 		List<Role> roles = new ArrayList<Role>();
 		return roles;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AttributesModuleImplApi.java
@@ -1,6 +1,8 @@
 package cz.metacentrum.perun.core.implApi.modules.attributes;
 
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.RichAttribute;
 import cz.metacentrum.perun.core.api.Role;
 import java.util.List;
 
@@ -12,18 +14,16 @@ import java.util.List;
 public interface AttributesModuleImplApi {
 
 	/**
-	 * Return all modules which are needed to correct check.
+	 * Get list of attributes whose value are used in checking of validity of this attribute.
+	 * In other words any change of these attributes' values can cause that value of this attribute is no longer valid.
 	 *
-	 * @return list of modules we need to correct check
+	 * An attribute should depend on all attributes used in method "checkAttributeValue" defined in attribute module.
+	 *
+	 * @see cz.metacentrum.perun.core.bl.AttributesManagerBl#checkAttributeDependencies(PerunSession, RichAttribute)
+	 *
+	 * @return list of attributes this attribute depends on
 	 */
 	List<String> getDependencies();
-
-	/**
-	 * Return all modules which are needed to correct check (for strong dependencies do another step at initializing)
-	 *
-	 * @return list of modules we need to correct check
-	 */
-	List<String> getStrongDependencies();
 
 	/**
 	 *  Return list of roles, which are authorized to work with this module

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/FacilityUserVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/FacilityUserVirtualAttributesModuleAbstract.java
@@ -39,4 +39,10 @@ public abstract class FacilityUserVirtualAttributesModuleAbstract extends Facili
 	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException{
 		return new ArrayList<String>();
 	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/FacilityVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/FacilityVirtualAttributesModuleAbstract.java
@@ -38,4 +38,10 @@ public abstract class FacilityVirtualAttributesModuleAbstract extends FacilityAt
 	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		return new ArrayList<String>();
 	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupVirtualAttributesModuleAbstract.java
@@ -38,4 +38,10 @@ public class GroupVirtualAttributesModuleAbstract extends GroupAttributesModuleA
 	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		return new ArrayList<String>();
 	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupVirtualAttributesModuleAbstract.java
@@ -43,4 +43,10 @@ public abstract class MemberGroupVirtualAttributesModuleAbstract extends MemberG
 	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		return new ArrayList<>();
 	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberVirtualAttributesModuleAbstract.java
@@ -38,4 +38,10 @@ public abstract class MemberVirtualAttributesModuleAbstract extends MemberAttrib
 	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		return new ArrayList<String>();
 	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceGroupVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceGroupVirtualAttributesModuleAbstract.java
@@ -40,4 +40,9 @@ public abstract class ResourceGroupVirtualAttributesModuleAbstract extends Resou
 		return new ArrayList<String>();
 	}
 
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleAbstract.java
@@ -40,4 +40,9 @@ public abstract class ResourceMemberVirtualAttributesModuleAbstract extends Reso
 		return new ArrayList<String>();
 	}
 
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceVirtualAttributesModuleAbstract.java
@@ -39,4 +39,10 @@ public abstract class ResourceVirtualAttributesModuleAbstract extends ResourceAt
 	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		return new ArrayList<String>();
 	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserExtSourceVirtualAttributesModuleAbstract.java
@@ -41,4 +41,10 @@ public abstract class UserExtSourceVirtualAttributesModuleAbstract extends UserE
 	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		return new ArrayList<String>();
 	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributesModuleAbstract.java
@@ -43,4 +43,10 @@ public abstract class UserVirtualAttributesModuleAbstract extends UserAttributes
 	public List<User> searchInAttributesValues(PerunSessionImpl perunSession, String attribute) throws InternalErrorException{
 		return null;
 	}
+
+	@Override
+	public List<String> getStrongDependencies() {
+		List<String> dependecies = new ArrayList<>();
+		return dependecies;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/VirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/VirtualAttributesModuleImplApi.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.core.implApi.modules.attributes;
 
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.RichAttribute;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -26,4 +28,17 @@ public interface VirtualAttributesModuleImplApi extends AttributesModuleImplApi 
 	 * @throws WrongReferenceAttributeValueException
 	 */
 	List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException;
+
+	/**
+	 * Get list of attributes which this attribute value is computed from.
+	 * In other words attributes whose values change can also directly affect value of this attribute.
+	 *
+	 * An attribute should strongly depend on all attributes used in method "getAttributeValue" defined in attribute
+	 * module for virtual attributes.
+	 *
+	 * @see cz.metacentrum.perun.core.bl.AttributesManagerBl#checkAttributeDependencies(PerunSession, RichAttribute)
+	 *
+	 * @return list of attributes this attribute strongly depends on
+	 */
+	List<String> getStrongDependencies();
 }


### PR DESCRIPTION
 - move method getStrongDependencies only under virtual attributes api
   (non-virtual attributes can't have strong dependencies). Fix all
   places where moving this method to the new place will occure any
   error.
 - add better javadoc for method getDependencies, getStrongDependencies
   and checkAttributeDependencies to be more understandable