### PR TITLE
Attribute dependency test fix for DB

### DIFF
--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTest.java
@@ -45,6 +45,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
+import org.springframework.test.annotation.IfProfileValue;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -9271,7 +9272,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_all = new ArrayList<>();
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
-		assertEquals("Found invalid number of attributes", 2, attrs_all.size());
+		assertTrue("Found invalid number of attributes", 2 <= attrs_all.size());
 		assertTrue(attrs_all.contains(vo1_toEmail_attribute));
 		assertTrue(attrs_all.contains(vo2_toEmail_attribute));
 	}
@@ -9542,7 +9543,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
 		//actually contains 4 user attributes because of test user John Doe
-		assertEquals("Invalid number of attributes found", 4, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 4 <= attrs_all.size());
 		assertTrue(attrs_all.contains(user1_phone_attribute));
 		assertTrue(attrs_all.contains(user2_phone_attribute));
 		//contains empty user3 attribute
@@ -9847,7 +9848,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_phone_all = new ArrayList<>();
 		ra_phone_all.forEach(ra -> attrs_phone_all.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 4, attrs_phone_all.size());
+		assertTrue("Invalid number of attributes found", 4 <= attrs_phone_all.size());
 		assertTrue(attrs_phone_all.contains(member1OfUser1_phone_attribute));
 		assertTrue(attrs_phone_all.contains(member1OfUser2_phone_attribute));
 		//contains 2 empty attributes from member1OfUser3 and member2OfUser3
@@ -10120,7 +10121,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_all = new ArrayList<>();
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 6 <= attrs_all.size());
 		assertTrue(attrs_all.contains(group1InVo1_email_atr));
 		assertTrue(attrs_all.contains(group2InVo1_email_atr));
 		assertTrue(attrs_all.contains(group1InVo2_email_atr));
@@ -10464,7 +10465,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_all = new ArrayList<>();
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 4, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 4 <= attrs_all.size());
 		assertTrue(attrs_all.contains(resource1InVo1_test_atr));
 		assertTrue(attrs_all.contains(resource2InVo1_test_atr));
 		assertTrue(attrs_all.contains(resource1InVo2_test_atr));
@@ -10833,7 +10834,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_all = new ArrayList<>();
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 3, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 3 <= attrs_all.size());
 		assertTrue(attrs_all.contains(facility1_test_atr));
 		assertTrue(attrs_all.contains(facility2_test_atr));
 		assertTrue(attrs_all.contains(facility3_test_atr));
@@ -11236,7 +11237,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_all = new ArrayList<>();
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 6 <= attrs_all.size());
 		assertTrue(attrs_all.contains(host1F1_test_atr));
 		assertTrue(attrs_all.contains(host2F1_test_atr));
 		assertTrue(attrs_all.contains(host1F2_test_atr));
@@ -11318,6 +11319,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	//----------------------UESs--------------------------//
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByUser() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByUser");
@@ -11349,6 +11351,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByMember() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByMember");
@@ -11378,6 +11381,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByGroup() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByGroup");
@@ -11411,6 +11415,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByResource() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByResource");
@@ -11444,6 +11449,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByVo() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByVo");
@@ -11478,6 +11484,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByFacility() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByFacility");
@@ -11514,6 +11521,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByHost() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByHost");
@@ -11550,6 +11558,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByUserExtSource() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByUserExtSource");
@@ -11570,6 +11579,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByKey() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByKey");
@@ -11594,6 +11604,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	@SuppressWarnings({"unchecked"})
+	@IfProfileValue(name = "default")
 	@Test
 	public void getUserExtSourceAttributesByUserFacility() throws Exception {
 		System.out.println(CLASS_NAME + "getUserExtSourceAttributesByUserFacility");
@@ -12027,7 +12038,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_all = new ArrayList<>();
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 6 <= attrs_all.size());
 		assertTrue(attrs_all.contains(group1VO1Res1VO1_test_attribute));
 		assertTrue(attrs_all.contains(group2VO1Res1VO1_test_attribute));
 		assertTrue(attrs_all.contains(group2VO1Res2VO1_test_attribute));
@@ -12448,7 +12459,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		attrs_all = attrs_all.stream().filter(a -> a.getValue() != null).collect(Collectors.toList());
 
 		System.out.println(attrs_all);
-		assertEquals("Invalid number of attributes found", 6, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 6 <= attrs_all.size());
 		assertTrue(attrs_all.contains(member1U1Group1Vo1_test_attribute));
 		assertTrue(attrs_all.contains(member1U1Group2Vo1_test_attribute));
 		assertTrue(attrs_all.contains(member1U2Group1Vo2_test_attribute));
@@ -12875,7 +12886,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_all = new ArrayList<>();
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 7, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 7 <= attrs_all.size());
 		assertTrue(attrs_all.contains(member1U1Res1Vo1_test_attribute));
 		assertTrue(attrs_all.contains(member1U1Res2Vo1_test_attribute));
 		assertTrue(attrs_all.contains(member1U2Res1Vo2_test_attribute));
@@ -13341,7 +13352,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_all = new ArrayList<>();
 		ra_all.forEach(ra -> attrs_all.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 7, attrs_all.size());
+		assertTrue("Invalid number of attributes found", 7 <= attrs_all.size());
 		assertTrue(attrs_all.contains(user1Facility1_test_attribute));
 		assertTrue(attrs_all.contains(user1Facility2_test_attribute));
 		assertTrue(attrs_all.contains(user2Facility2_test_attribute));
@@ -13385,7 +13396,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_key1 = new ArrayList<>();
 		ra_key1.forEach(ra -> attrs_key1.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 1, attrs_key1.size());
+		assertTrue("Invalid number of attributes found", 1 <= attrs_key1.size());
 		assertTrue(attrs_key1.contains(entityless_test_attribute1));
 
 		List<RichAttribute> ra_key3 = (List<RichAttribute>) testedMethod.invoke(attributesManagerBl,
@@ -13393,7 +13404,7 @@ public class AttributesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 		List<Attribute> attrs_key3 = new ArrayList<>();
 		ra_key3.forEach(ra -> attrs_key3.add(ra.getAttribute()));
 
-		assertEquals("Invalid number of attributes found", 1, attrs_key3.size());
+		assertTrue("Invalid number of attributes found", 1 <= attrs_key3.size());
 		assertTrue(attrs_key3.contains(entityless_test_attribute3));
 	}
 


### PR DESCRIPTION
* Now tests for attribute dependency work well against real DB.
* Some of the test are set to run only against in-memory DB and others
were edited to count with more results.