### PR TITLE
REGISTRAR: Change fed_info column type to hold more than 4000 chars

### DIFF
--- a/perun-base/src/test/resources/test-data.sql
+++ b/perun-base/src/test/resources/test-data.sql
@@ -2089,7 +2089,7 @@ insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routin
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,2,timestamp '2011-11-15 14:43:13.3','PERUNV3',timestamp '2011-11-15 14:43:13.3','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6071,timestamp '2015-01-21 13:05:00.4',timestamp '2015-01-16 14:29:29.6','PERUNV3',timestamp '2015-01-16 14:29:29.6','PERUNV3','0');
 insert into dispatcher_settings (created_by_uid,modified_by_uid,ip_address,port,last_check_in,created_at,created_by,modified_at,modified_by,status) values (null,null,'127.0.0.1',6060,timestamp '2015-01-16 14:25:00.6',timestamp '2015-01-16 09:39:07.6','PERUNV3',timestamp '2015-01-16 09:39:07.6','PERUNV3','0');
-insert into configurations (property,value) values ('DATABASE VERSION','3.1.44');
+insert into configurations (property,value) values ('DATABASE VERSION','3.1.45');
 
 drop sequence service_principals_id_seq;
 create sequence service_principals_id_seq start with 1;

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -465,7 +465,7 @@ create table application (
 	apptype varchar(128) not null,
 	extSourceName varchar(4000),
 	extSourceType varchar(4000),
-	fed_info varchar(4000),
+	fed_info text,
 	state varchar(128),
 	extSourceLoa integer,
 	group_id integer,

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -5,6 +5,10 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.45
+ALTER TABLE application ALTER COLUMN fed_info TYPE text;
+update configurations set value='3.1.45' where property='DATABASE VERSION';
+
 3.1.44
 CREATE TABLE members_sponsored (active char(1) default '1' not null, sponsored_id INTEGER NOT NULL, sponsor_id INTEGER NOT NULL,created_at timestamp default now not null, created_by varchar(1300) default user not null,created_by_uid integer,modified_at timestamp default now not null, modified_by varchar(1300) default user not null, modified_by_uid integer);
 create index idx_fk_memspons_mem ON members_sponsored(sponsored_id);

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -3,6 +3,13 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.45
+ALTER TABLE application ADD (ues_attrs clob);
+UPDATE application SET ues_attrs = fed_info;
+ALTER TABLE application DROP COLUMN fed_info;
+ALTER TABLE application RENAME COLUMN ues_attrs TO fed_info;
+update configurations set value='3.1.45' where property='DATABASE VERSION';
+
 3.1.44
 CREATE TABLE members_sponsored (active char(1) default '1' not null,sponsored_id INTEGER NOT NULL,sponsor_id INTEGER NOT NULL,created_at date default sysdate not null,created_by nvarchar2(1300) default user not null,created_by_uid integer,modified_at date default sysdate not null,modified_by nvarchar2(1300) default user not null,modified_by_uid integer);
 alter table members_sponsored add ( constraint MEMSPONS_MEM_FK foreign key (sponsored_id) references members(id), constraint MEMSPONS_USR_FK foreign key (sponsor_id) references users(id));

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -3,6 +3,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.45
+ALTER TABLE application ALTER COLUMN fed_info TYPE text;
+update configurations set value='3.1.45' where property='DATABASE VERSION';
+
 3.1.44
 CREATE TABLE members_sponsored (active char(1) default '1' not null, sponsored_id INTEGER NOT NULL, sponsor_id INTEGER NOT NULL,created_at timestamp default now() not null, created_by varchar(1024) default user not null,created_by_uid integer,modified_at timestamp default now() not null, modified_by varchar(1024) default user not null, modified_by_uid integer);
 alter table members_sponsored add constraint memspons_mem_fk foreign key (sponsored_id) references members(id);

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -474,7 +474,7 @@ create table application (
 	apptype nvarchar2(128) not null,
 	extSourceName nvarchar2(4000),
 	extSourceType nvarchar2(4000),
-	fed_info nvarchar2(4000),
+	fed_info clob,
 	state nvarchar2(128),
 	extSourceLoa integer,
 	group_id integer,

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -505,8 +505,8 @@ create table "application" (
 	apptype varchar(128) not null,  --type of application (initial/extension)
 	extSourceName varchar(4000),  --name of external source of users
 	extSourceType varchar(4000),  --type of external source of users (federation...)
-	fed_info varchar(4000),       --data from federation if any
-	state varchar(128),           --state of application (new/verified/approveed/rejected)
+	fed_info text,               --data from federation or cert
+	state varchar(128),           --state of application (new/verified/approved/rejected)
 	extSourceLoa integer,  --level of assurance of user by external source
 	group_id integer,      --identifier of group (groups.id) if application is for group
 	created_at timestamp default statement_timestamp() not null,

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1014,18 +1014,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		LinkedHashMap<String,String> map = new LinkedHashMap<>();
 		map.putAll(session.getPerunPrincipal().getAdditionalInformations());
 		String additionalAttrs = BeansUtils.attributeValueToString(map, LinkedHashMap.class.getName());
-		int bytesLength = 0;
-		try {
-			bytesLength = additionalAttrs.getBytes("UTF-8").length;
-		} catch (UnsupportedEncodingException e) {
-			log.error("Unable to get UTF-8 bytes from AdditionalInformations.", e);
-		}
-		if (bytesLength < 4000) {
-			// TODO - we should probably convert fedInfoColumn to (n)clob/text
-			application.setFedInfo(additionalAttrs);
-		} else {
-			log.error("Unable to store UserExtSource attributes: {}", map);
-		}
+		application.setFedInfo(additionalAttrs);
 
 		Application app = null;
 		try {


### PR DESCRIPTION
- When storing UES attributes in application, we must allow to store
  values longer than 4000 chars.
- Column fed_info is now converted from nvarchar2(4000) to text/clob.