### PR TITLE
DISPATCHER: Prevent null pointer and array index out of band

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -329,7 +329,12 @@ public class SchedulingPoolImpl implements SchedulingPool {
 					for (TaskStatus sts : TaskStatus.class.getEnumConstants()) {
 						List<Task> tasklist = pool.get(sts);
 						if(tasklist != null) {
-							local_task = tasklist.get(task.getId());
+							for (Task tsk : tasklist) {
+								if (tsk.getId() == task.getId()) {
+									local_task = tsk;
+									break;
+								}
+							}
 						}
 						if(local_task != null) {
 							local_status = sts;

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/TaskSchedulerImpl.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.dispatcher.scheduling.impl;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 
 import cz.metacentrum.perun.controller.service.GeneralServiceManager;
@@ -81,7 +82,7 @@ public class TaskSchedulerImpl implements TaskScheduler {
 		Date time = new Date(System.currentTimeMillis());
 		DispatcherQueue dispatcherQueue = null;
 
-		if (task.getStatus().equals(TaskStatus.PROCESSING) && !task.isPropagationForced()) {
+		if (Objects.equals(task.getStatus(), TaskStatus.PROCESSING) && !task.isPropagationForced()) {
 			log.debug("Task {} already processing, will not schedule again.",
 					task.toString());
 			return true;
@@ -621,7 +622,7 @@ public class TaskSchedulerImpl implements TaskScheduler {
 		}
 		log.debug("Fetched destinations: " + ( (destinations == null) ?  "[]" : destinations.toString()));
 		task.setDestinations(destinations);
-		if(task.getExecService().getExecServiceType().equals(ExecServiceType.SEND) && 
+		if(task.getExecService().getExecServiceType().equals(ExecServiceType.SEND) &&
 		   (destinations == null || destinations.isEmpty())) {
 			log.info("Task [] has no destination, setting to error.");
 			task.setEndTime(new Date(System.currentTimeMillis()));


### PR DESCRIPTION
- Added better equals since Task status might be null at the time
  of comparison.
- Fixed checkTasksDB(), where we wrongly get Task from the list
  by it's id, which is not the same as index. Source data structure is
  a list and not map, so now we iterate over list and try to find
  same Task by its id.