### PR TITLE
CABINET: Allow engine role to fetch necessary data

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
@@ -287,7 +287,8 @@ public class CabinetManagerImpl implements CabinetManager {
 	@Override
 	public List<Author> getAllAuthors(PerunSession sess) throws CabinetException, InternalErrorException {
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN) &&
+				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new CabinetException("You are not authorized to list all authors.", NOT_AUTHORIZED);
 		}
 		return getAuthorshipManagerBl().getAllAuthors();


### PR DESCRIPTION
 - Role ENGINE must be able to list all authors.