### PR TITLE
Prevent cross-site scripting when displaying input from users

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/ApplicationFormGui.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/ApplicationFormGui.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.*;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.Location;
@@ -661,7 +662,7 @@ public class ApplicationFormGui implements EntryPoint {
 			panel.clear();
 			FlexTable ft = new FlexTable();
 			ft.setSize("100%", "300px");
-			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+"<h2>Error: "+ApplicationMessages.INSTANCE.groupMembershipCantBeExtended(group.getName())+"</h2>");
+			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.errorIcon())+"<h2>Error: "+ApplicationMessages.INSTANCE.groupMembershipCantBeExtended(SafeHtmlUtils.fromString(group.getName()).asString())+"</h2>");
 			ft.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_CENTER);
 			ft.getFlexCellFormatter().setVerticalAlignment(0, 0, HasVerticalAlignment.ALIGN_MIDDLE);
 			panel.add(ft);
@@ -738,7 +739,7 @@ public class ApplicationFormGui implements EntryPoint {
 		ft.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_CENTER);
 		ft.getFlexCellFormatter().setVerticalAlignment(0, 0, HasVerticalAlignment.ALIGN_BOTTOM);
 
-		ft.setHTML(1, 0, "<p>"+errorInfo);
+		ft.setHTML(1, 0, "<p>"+ SafeHtmlUtils.fromString(errorInfo).asString());
 		ft.getFlexCellFormatter().setHorizontalAlignment(1, 0, HasHorizontalAlignment.ALIGN_CENTER);
 		ft.getFlexCellFormatter().setVerticalAlignment(1, 0, HasVerticalAlignment.ALIGN_TOP);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
@@ -12,6 +12,7 @@ import com.google.gwt.http.client.UrlBuilder;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.storage.client.Storage;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
@@ -496,46 +497,46 @@ public class UiElements {
 				GeneralObject go = object.cast();
 				if (go.getObjectType().equalsIgnoreCase("RichMember")) {
 					RichMember rm = go.cast();
-					items = items.concat("<li>" + rm.getUser().getFullName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((rm.getUser().getFullName() != null) ? rm.getUser().getFullName() : "").asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("User") || go.getObjectType().equalsIgnoreCase("RichUser")) {
 					User u = go.cast();
-					items = items.concat("<li>" + u.getFullName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString(( u.getFullName() != null) ? u.getFullName() : "").asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("RichDestination")) {
 					Destination d = go.cast();
-					items = items.concat("<li>" + d.getDestination() + " / " + d.getType() + " / " + d.getService().getName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString(d.getDestination() + " / " + d.getType() + " / " + d.getService().getName()).asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("Host")) {
 					Host h = go.cast();
-					items = items.concat("<li>" + h.getName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((h.getName() != null) ? h.getName() : "").asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("Facility") || go.getObjectType().equalsIgnoreCase("RichFacility")) {
 					Facility f = go.cast();
-					items = items.concat("<li>" + f.getName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((f.getName()!=null) ? f.getName() : "").asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("Attribute") || go.getObjectType().equalsIgnoreCase("AttributeDefinition")) {
 					Attribute a = go.cast();
-					items = items.concat("<li>" + a.getDisplayName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((a.getDisplayName()!=null) ? a.getDisplayName() : "").asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("ExecService")) {
 					ExecService e = go.cast();
-					items = items.concat("<li>" + e.getService().getName() + " (" + e.getType() + ")</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString(e.getService().getName() + " (" + e.getType()).asString() + ")</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("UserExtSource")) {
 					UserExtSource ues = go.cast();
-					items = items.concat("<li>" + ues.getLogin() + " / " + ues.getExtSource().getName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString(ues.getLogin() + " / " + ues.getExtSource().getName()).asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("ApplicationMail")) {
 					//items = items.concat("<li>"+go.getName()+"</li>");
 					ApplicationMail mail = go.cast();
-					items = items.concat("<li>" + ApplicationMail.getTranslatedMailType(mail.getMailType()) + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString(ApplicationMail.getTranslatedMailType(mail.getMailType())).asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("PublicationForGUI") || go.getObjectType().equalsIgnoreCase("Publication")) {
 					Publication pub = go.cast();
-					items = items.concat("<li>" + pub.getTitle() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((pub.getTitle()!=null) ? pub.getTitle() : "").asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("ThanksForGUI")) {
 					Thanks th = go.cast();
-					items = items.concat("<li>" + th.getOwnerName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((th.getOwnerName()!= null) ? th.getOwnerName() : "").asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("Author")) {
 					Author aut = go.cast();
-					items = items.concat("<li>" + aut.getDisplayName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((aut.getDisplayName()!=null) ? aut.getDisplayName() : "").asString() + "</li>");
 				} else if (go.getObjectType().equalsIgnoreCase("ResourceTag")) {
 					ResourceTag tag = go.cast();
-					items = items.concat("<li>" + tag.getName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((tag.getName()!=null) ? tag.getName() : "").asString() + "</li>");
 				} else {
-					items = items.concat("<li>" + go.getName() + "</li>");
+					items = items.concat("<li>" + SafeHtmlUtils.fromString((go.getName()!=null) ? go.getName() : "").asString() + "</li>");
 				}
 
 			}
@@ -789,6 +790,8 @@ public class UiElements {
 	 */
 	public void setLogSuccessText(String text) {
 
+		text = SafeHtmlUtils.fromString(text).asString();
+
 		// Add the text to status
 		setStatus(text);
 
@@ -810,6 +813,8 @@ public class UiElements {
 	 * @param text text to be inserted in gui's devel log
 	 */
 	public void setLogErrorText(String text) {
+
+		text = SafeHtmlUtils.fromString(text).asString();
 
 		// sets the log button icon
 		this.prepareToggleLogButton(SmallIcons.INSTANCE.exclamationIcon(), SmallIcons.INSTANCE.exclamationIcon());
@@ -1497,7 +1502,7 @@ public class UiElements {
 
 		if (pp.getUser() != null) {
 			// name
-			nameHyperlink = new Anchor(pp.getUser().getFullNameWithTitles());
+			nameHyperlink = new Anchor(SafeHtmlUtils.fromString(pp.getUser().getFullNameWithTitles()).asString());
 			nameHyperlink.setHTML("<strong>" + nameHyperlink.getHTML() + "</strong>");
 			nameHyperlink.addClickHandler(new ClickHandler() {
 				public void onClick(ClickEvent arg0) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
@@ -9,6 +9,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.storage.client.Storage;
 import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.Window;
@@ -527,7 +528,7 @@ public class WebGui implements EntryPoint, ValueChangeHandler<String> {
 						body.clear();
 						FlexTable ft = new FlexTable();
 						ft.setSize("100%", "300px");
-						ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.acceptIcon())+"<h2>"+ "The email address: <i>"+over.getString()+"</i></h2><h2>was verified and set as your preferred email.</h2>");
+						ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.acceptIcon())+"<h2>"+ "The email address: <i>"+ SafeHtmlUtils.fromString(over.getString())+"</i></h2><h2>was verified and set as your preferred email.</h2>");
 						ft.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_CENTER);
 						ft.getFlexCellFormatter().setVerticalAlignment(0, 0, HasVerticalAlignment.ALIGN_MIDDLE);
 						body.add(ft);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/pages/ApplicationFormPage.java
@@ -9,6 +9,7 @@ import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.Location;
@@ -392,6 +393,7 @@ public class ApplicationFormPage extends ApplicationPage {
 			if (group != null) {
 				succSendText = ApplicationMessages.INSTANCE.applicationSuccessfullySent(group.getName());
 			}
+			succSendText = SafeHtmlUtils.fromString(succSendText).asString();
 
 			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.acceptIcon())+"<h2>"+ succSendText +"</h2>" + validationText + approveText);
 			ft.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_CENTER);
@@ -406,7 +408,7 @@ public class ApplicationFormPage extends ApplicationPage {
 
 			FlexTable ft = new FlexTable();
 			ft.setSize("100%", "300px");
-			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.acceptIcon())+"<h2>" + ApplicationMessages.INSTANCE.membershipExtensionSuccessfullySent(vo.getName()) + "</h2>" +
+			ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.acceptIcon())+"<h2>" + ApplicationMessages.INSTANCE.membershipExtensionSuccessfullySent(SafeHtmlUtils.fromString(vo.getName()).asString()) + "</h2>" +
 					approveText);
 			ft.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_CENTER);
 			ft.getFlexCellFormatter().setVerticalAlignment(0, 0, HasVerticalAlignment.ALIGN_MIDDLE);
@@ -577,9 +579,9 @@ public class ApplicationFormPage extends ApplicationPage {
 
 		for (Identity user : users) {
 
-			ft.setHTML(i, 0, user.getName());
-			ft.setHTML(i, 1, (user.getEmail() != null && !user.getEmail().isEmpty()) ? user.getEmail() : "N/A");
-			ft.setHTML(i, 2, (user.getOrganization() != null && !user.getOrganization().isEmpty()) ? user.getOrganization() : "N/A");
+			ft.setHTML(i, 0, SafeHtmlUtils.fromString(user.getName()).asString());
+			ft.setHTML(i, 1, (user.getEmail() != null && !user.getEmail().isEmpty()) ? SafeHtmlUtils.fromString(user.getEmail()).asString() : "N/A");
+			ft.setHTML(i, 2, (user.getOrganization() != null && !user.getOrganization().isEmpty()) ? SafeHtmlUtils.fromString(user.getOrganization()).asString() : "N/A");
 
 			/*
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebConstants;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -38,7 +39,7 @@ public class JsonErrorHandler {
 
 		if (PerunWebSession.getInstance().isPerunAdmin()) {
 			// PERUN ADMIN SEE RAW ERROR MESSAGE
-			UiElements.generateError(error, getCaption(error), "<span style=\"color:red\">" + error.getName() + "</span><p>" + error.getErrorInfo());
+			UiElements.generateError(error, getCaption(error), "<span style=\"color:red\">" + SafeHtmlUtils.fromString(error.getName()).asString() + "</span><p>" + SafeHtmlUtils.fromString(error.getErrorInfo()).asString());
 		} else {
 			// OTHERS SEE TRANSLATED TEXT
 			UiElements.generateError(error, getCaption(error), getText(error.getName(), error));
@@ -289,17 +290,17 @@ public class JsonErrorHandler {
 
 			if (holder != null) {
 				if (!holder.getName().equalsIgnoreCase("undefined")) {
-					text += "<strong>" + holder.getObjectType() + ":</strong>&nbsp;" + holder.getName() + "<br />";
+					text += "<strong>" + SafeHtmlUtils.fromString(holder.getObjectType()).asString() + ":</strong>&nbsp;" + SafeHtmlUtils.fromString(holder.getName()).asString() + "<br />";
 				}
 			}
 			if (secondHolder != null) {
 				if (!secondHolder.getName().equalsIgnoreCase("undefined")) {
-					text += "<strong>" + secondHolder.getObjectType() + ":</strong>&nbsp;" + secondHolder.getName() + "<br />";
+					text += "<strong>" + SafeHtmlUtils.fromString(secondHolder.getObjectType()).asString() + ":</strong>&nbsp;" + SafeHtmlUtils.fromString(secondHolder.getName()).asString() + "<br />";
 				}
 			}
 			if (a != null) {
-				String attrName = a.getDisplayName();
-				String attrValue = a.getValue();
+				String attrName = SafeHtmlUtils.fromString(a.getDisplayName()).asString();
+				String attrValue = SafeHtmlUtils.fromString(a.getValue()).asString();
 				text += "<strong>Attribute:&nbsp;</strong>" + attrName + "<br /><strong>Value:&nbsp;</strong>" + attrValue;
 			} else {
 				text += "<i>Attribute is null</i>";
@@ -315,9 +316,9 @@ public class JsonErrorHandler {
 			Attribute a2 = error.getReferenceAttribute();
 
 			if (a != null) {
-				String attrName = a.getDisplayName();
-				String attrValue = a.getValue();
-				String entity = a.getEntity();
+				String attrName = SafeHtmlUtils.fromString(a.getDisplayName()).asString();
+				String attrValue = SafeHtmlUtils.fromString(a.getValue()).asString();
+				String entity = SafeHtmlUtils.fromString(a.getEntity()).asString();
 				text += "<p><strong>Attribute&nbsp;1:</strong>&nbsp;" + attrName + " (" + entity + ")";
 				text += "<br/><strong>Value&nbsp;1:</strong>&nbsp;" + attrValue;
 			} else {
@@ -325,9 +326,9 @@ public class JsonErrorHandler {
 			}
 
 			if (a2 != null) {
-				String attrName = a2.getDisplayName();
-				String attrValue = a2.getValue();
-				String entity = a2.getEntity();
+				String attrName = SafeHtmlUtils.fromString(a2.getDisplayName()).asString();
+				String attrValue = SafeHtmlUtils.fromString(a2.getValue()).asString();
+				String entity = SafeHtmlUtils.fromString(a2.getEntity()).asString();
 				text += "<p><strong>Attribute&nbsp;2:</strong>&nbsp;" + attrName + " (" + entity + ")";
 				text += "<br/><strong>Value&nbsp;2:</strong>&nbsp;" + attrValue;
 			} else {
@@ -340,7 +341,7 @@ public class JsonErrorHandler {
 
 			Attribute a = error.getAttribute();
 			if (a != null) {
-				return "Attribute definition for attribute <i>" + a.getName() + "</i> doesn't exist.";
+				return "Attribute definition for attribute <i>" + SafeHtmlUtils.fromString(a.getName()).asString() + "</i> doesn't exist.";
 			} else {
 				return "Attribute definition for attribute <i>null</i> doesn't exist.";
 			}
@@ -360,18 +361,18 @@ public class JsonErrorHandler {
 
 			String text = "";
 			if (error.getUser() != null) {
-				text = error.getUser().getFullName();
+				text = SafeHtmlUtils.fromString(error.getUser().getFullName()).asString();
 			} else {
 				text = "User";
 			}
 			if (error.getVo() != null) {
-				text += " is already manager of VO: " + error.getVo().getName();
+				text += " is already manager of VO: " + SafeHtmlUtils.fromString(error.getVo().getName()).asString();
 			} else if (error.getFacility() != null) {
-				text += " is already manager of Facility: " + error.getFacility().getName();
+				text += " is already manager of Facility: " + SafeHtmlUtils.fromString(error.getFacility().getName()).asString();
 			} else if (error.getGroup() != null) {
-				text += " is already manager of Group: " + error.getGroup().getName();
+				text += " is already manager of Group: " + SafeHtmlUtils.fromString(error.getGroup().getName()).asString();
 			} else if (error.getSecurityTeam() != null) {
-				text += " is already manager of SecurityTeam: " + error.getSecurityTeam().getName();
+				text += " is already manager of SecurityTeam: " + SafeHtmlUtils.fromString(error.getSecurityTeam().getName()).asString();
 			}
 			return text;
 
@@ -384,16 +385,16 @@ public class JsonErrorHandler {
 
 			String text = "";
 			if (error.getLogin() != null) {
-				text += "Login: " + error.getLogin();
+				text += "Login: " + SafeHtmlUtils.fromString(error.getLogin()).asString();
 				if (error.getNamespace() != null) {
-					text += " in namespace: " + error.getNamespace() + " is already reserved.";
+					text += " in namespace: " + SafeHtmlUtils.fromString(error.getNamespace()).asString() + " is already reserved.";
 				} else {
 					text += " is already reserved.";
 				}
 			} else {
 				text += "Login";
 				if (error.getNamespace() != null) {
-					text += " in namespace: " + error.getNamespace() + " is already reserved.";
+					text += " in namespace: " + SafeHtmlUtils.fromString(error.getNamespace()).asString() + " is already reserved.";
 				} else {
 					text += " is already reserved in selected namespace.";
 				}
@@ -403,7 +404,7 @@ public class JsonErrorHandler {
 		} else if ("AttributeAlreadyAssignedException".equalsIgnoreCase(errorName)) {
 
 			if (error.getAttribute() != null) {
-				return "Attribute <i>" + error.getAttribute().getDisplayName() + "</i> is already set as required by service.";
+				return "Attribute <i>" + SafeHtmlUtils.fromString(error.getAttribute().getDisplayName()).asString() + "</i> is already set as required by service.";
 			} else {
 				return "Attribute is already set as required by service.";
 			}
@@ -415,7 +416,7 @@ public class JsonErrorHandler {
 		} else if ("AttributeNotAssignedException".equalsIgnoreCase(errorName)) {
 
 			if (error.getAttribute() != null) {
-				return "Attribute <i>" + error.getAttribute().getDisplayName() + "</i> is already NOT required by service.";
+				return "Attribute <i>" + SafeHtmlUtils.fromString(error.getAttribute().getDisplayName()).asString() + "</i> is already NOT required by service.";
 			} else {
 				return "Attribute is already NOT required by service.";
 			}
@@ -423,12 +424,12 @@ public class JsonErrorHandler {
 		} else if ("AttributeNotExistsException".equalsIgnoreCase(errorName)) {
 
 			// FIXME - attribute object inside is never used, but has good description
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("AttributeValueException".equalsIgnoreCase(errorName)) {
 
 			// FIXME - core always uses extensions of this exception
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("ApplicationNotCreatedException".equalsIgnoreCase(errorName)) {
 
@@ -449,7 +450,7 @@ public class JsonErrorHandler {
 		} else if ("DestinationAlreadyAssignedException".equalsIgnoreCase(errorName)) {
 
 			if (error.getDestination() != null) {
-				return "Destination <i>" + error.getDestination().getDestination() + "</i> already exists for facility/service.";
+				return "Destination <i>" + SafeHtmlUtils.fromString(error.getDestination().getDestination()).asString() + "</i> already exists for facility/service.";
 			} else {
 				return "Same destination already exists for facility/service combination.";
 			}
@@ -457,7 +458,7 @@ public class JsonErrorHandler {
 		} else if ("DestinationAlreadyRemovedException".equalsIgnoreCase(errorName)) {
 
 			if (error.getDestination() != null) {
-				return "Destination <i>" + error.getDestination().getDestination() + "</i> already removed for facility/service.";
+				return "Destination <i>" + SafeHtmlUtils.fromString(error.getDestination().getDestination()).asString() + "</i> already removed for facility/service.";
 			} else {
 				return "Destination is already removed from facility/service combination.";
 			}
@@ -473,7 +474,7 @@ public class JsonErrorHandler {
 		} else if ("DiacriticNotAllowedException".equalsIgnoreCase(errorName)) {
 
 			// has meaningful info
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 			// FIXME - ENTITY exceptions are always extended - we will use specific types
 
@@ -495,8 +496,8 @@ public class JsonErrorHandler {
 
 			if (error.getExtSource() != null) {
 				return "Same external source is already assigned to your VO." +
-						"<p><strong>Name:</strong> " + error.getExtSource().getName() + "</br>" +
-						"<strong>Type:</strong> " + error.getExtSource().getType();
+						"<p><strong>Name:</strong> " + SafeHtmlUtils.fromString(error.getExtSource().getName()).asString() + "</br>" +
+						"<strong>Type:</strong> " + SafeHtmlUtils.fromString(error.getExtSource().getType()).asString();
 			} else {
 				return "Same external source is already assigned to your VO.";
 			}
@@ -505,8 +506,8 @@ public class JsonErrorHandler {
 
 			if (error.getExtSource() != null) {
 				return "Same external source was already removed from your VO." +
-						"<p><strong>Name:</strong> " + error.getExtSource().getName() + "</br>" +
-						"<strong>Type:</strong> " + error.getExtSource().getType();
+						"<p><strong>Name:</strong> " + SafeHtmlUtils.fromString(error.getExtSource().getName()).asString() + "</br>" +
+						"<strong>Type:</strong> " + SafeHtmlUtils.fromString(error.getExtSource().getType()).asString();
 			} else {
 				return "Same external source was already removed from your VO.";
 			}
@@ -515,8 +516,8 @@ public class JsonErrorHandler {
 
 			if (error.getExtSource() != null) {
 				return "Same external source already exists." +
-						"<p><strong>Name:</strong> " + error.getExtSource().getName() + "</br>" +
-						"<strong>Type:</strong> " + error.getExtSource().getType();
+						"<p><strong>Name:</strong> " + SafeHtmlUtils.fromString(error.getExtSource().getName()).asString() + "</br>" +
+						"<strong>Type:</strong> " + SafeHtmlUtils.fromString(error.getExtSource().getType()).asString();
 			} else {
 				return "Same external source already exists.";
 			}
@@ -539,7 +540,7 @@ public class JsonErrorHandler {
 		} else if ("ExtSourceUnsupportedOperationException".equalsIgnoreCase(errorName)) {
 
 			// TODO - probably is never thrown to GUI ??
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("FacilityAlreadyRemovedException".equalsIgnoreCase(errorName)) {
 
@@ -561,7 +562,7 @@ public class JsonErrorHandler {
 
 			Group g = error.getGroup();
 			if (g != null) {
-				return "Group: " + g.getName() + " is already assigned to Resource.";
+				return "Group: " + SafeHtmlUtils.fromString(g.getName()).asString() + " is already assigned to Resource.";
 			} else {
 				return "Group is already assigned to Resource.";
 			}
@@ -599,10 +600,10 @@ public class JsonErrorHandler {
 			Group movingGroup = error.getMovingGroup();
 			Group destinationGroup = error.getDestinationGroup();
 
-			String movingGroupName = (movingGroup != null) ? ("<b>" + movingGroup.getName() + "</b>") : "Group";
-			String destinationGroupName = (destinationGroup != null) ?("under <b>" + destinationGroup.getName() + "</b>") : " to top-level";
+			String movingGroupName = (movingGroup != null) ? ("<b>" + SafeHtmlUtils.fromString(movingGroup.getName()).asString() + "</b>") : "Group";
+			String destinationGroupName = (destinationGroup != null) ?("under <b>" + SafeHtmlUtils.fromString(destinationGroup.getName()).asString() + "</b>") : " to top-level";
 
-			return movingGroupName + " can't be moved " + destinationGroupName + ".<p>Reason: "+error.getErrorInfo();
+			return movingGroupName + " can't be moved " + destinationGroupName + ".<p>Reason: "+SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("GroupRelationAlreadyExists".equalsIgnoreCase(errorName)) {
 
@@ -656,7 +657,7 @@ public class JsonErrorHandler {
 		} else if ("MaxSizeExceededException".equalsIgnoreCase(errorName)) {
 
 			// has meaningfull message
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("MemberAlreadyRemovedException".equalsIgnoreCase(errorName)) {
 
@@ -681,7 +682,7 @@ public class JsonErrorHandler {
 
 		} else if ("MessageParsingFailException".equalsIgnoreCase(errorName)) {
 
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("ModuleNotExistsException".equalsIgnoreCase(errorName)) {
 
@@ -697,11 +698,11 @@ public class JsonErrorHandler {
 
 		} else if ("NumberNotInRangeException".equalsIgnoreCase(errorName)) {
 
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("NumbersNotAllowedException".equalsIgnoreCase(errorName)) {
 
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("OwnerAlreadyAssignedException".equalsIgnoreCase(errorName)) {
 
@@ -746,12 +747,12 @@ public class JsonErrorHandler {
 		} else if ("RelationExistsException".equalsIgnoreCase(errorName)) {
 
 			// FIXME - better text on core side
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("RelationNotExistsException".equalsIgnoreCase(errorName)) {
 
 			// FIXME - better text on core side
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("ResourceAlreadyRemovedException".equalsIgnoreCase(errorName)) {
 
@@ -759,7 +760,7 @@ public class JsonErrorHandler {
 
 		} else if ("ResourceExistsException".equalsIgnoreCase(errorName)) {
 
-			return "Resource with same name \"" + error.getResource().getName() + "\" already exists with id="+error.getResource().getId()+".";
+			return "Resource with same name \"" + SafeHtmlUtils.fromString(error.getResource().getName()).asString() + "\" already exists with id="+SafeHtmlUtils.fromString(error.getResource().getId()+"").asString()+".";
 
 		} else if ("ResourceNotExistsException".equalsIgnoreCase(errorName)) {
 
@@ -778,12 +779,12 @@ public class JsonErrorHandler {
 		} else if ("ResourceTagNotExistsException".equalsIgnoreCase(errorName)) {
 
 			// FIXME - must contain also resource
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("SecurityTeamAlreadyAssignedException".equalsIgnoreCase(errorName)) {
 
 			if (error.getSecurityTeam() != null) {
-				return "SecurityTeam <i>" + error.getSecurityTeam().getName() + "</i> is already assigned to facility.";
+				return "SecurityTeam <i>" + SafeHtmlUtils.fromString(error.getSecurityTeam().getName()).asString() + "</i> is already assigned to facility.";
 			} else {
 				return "Same SecurityTeam is already assigned to facility.";
 			}
@@ -792,7 +793,7 @@ public class JsonErrorHandler {
 
 			// FIXME - must contain also resource
 			if (error.getService() != null) {
-				return "Service " + error.getService().getName() + " is already assigned to resource.";
+				return "Service " + SafeHtmlUtils.fromString(error.getService().getName()).asString() + " is already assigned to resource.";
 			} else {
 				return "Same service is already assigned to resource.";
 			}
@@ -800,7 +801,7 @@ public class JsonErrorHandler {
 		} else if ("ServiceAlreadyBannedException".equalsIgnoreCase(errorName)) {
 
 			if (error.getService() != null && error.getFacility() != null) {
-				return "Service " + error.getService().getName() + " is already banned on facility "+error.getFacility().getName()+".";
+				return "Service " + SafeHtmlUtils.fromString(error.getService().getName()).asString() + " is already banned on facility "+SafeHtmlUtils.fromString(error.getFacility().getName()).asString()+".";
 			} else {
 				return "Same service is already banned on facility.";
 			}
@@ -808,7 +809,7 @@ public class JsonErrorHandler {
 		} else if ("ServiceExistsException".equalsIgnoreCase(errorName)) {
 
 			if (error.getService() != null) {
-				return "Service " + error.getService().getName() + " already exists in Perun. Choose different name.";
+				return "Service " + SafeHtmlUtils.fromString(error.getService().getName()).asString() + " already exists in Perun. Choose different name.";
 			} else {
 				return "Service with same name already exists in Perun.";
 			}
@@ -817,7 +818,7 @@ public class JsonErrorHandler {
 
 			// FIXME - must contain also resource
 			if (error.getService() != null) {
-				return "Service " + error.getService().getName() + " is not assigned to resource.";
+				return "Service " + SafeHtmlUtils.fromString(error.getService().getName()).asString() + " is not assigned to resource.";
 			} else {
 				return "Service is not assigned to resource.";
 			}
@@ -833,7 +834,7 @@ public class JsonErrorHandler {
 		} else if ("ServicesPackageExistsException".equalsIgnoreCase(errorName)) {
 
 			// TODO - we don't support service packages yet
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("ServiceAlreadyRemovedFromServicePackageException".equalsIgnoreCase(errorName)) {
 
@@ -861,15 +862,15 @@ public class JsonErrorHandler {
 
 		} else if ("SpaceNotAllowedException".equalsIgnoreCase(errorName)) {
 
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("SpecialCharsNotAllowedException".equalsIgnoreCase(errorName)) {
 
-			return error.getErrorInfo() + " You can use only letters, numbers and spaces.";
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString() + " You can use only letters, numbers and spaces.";
 
 		} else if ("SpecialCharsNotAllowedException".equalsIgnoreCase(errorName)) {
 
-			return error.getErrorInfo() + " You can use only letters, numbers and spaces.";
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString() + " You can use only letters, numbers and spaces.";
 
 		} else if ("SubGroupCannotBeRemovedException".equalsIgnoreCase(errorName)) {
 
@@ -919,16 +920,16 @@ public class JsonErrorHandler {
 
 		} else if ("WrongModuleTypeException".equalsIgnoreCase(errorName)) {
 
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("WrongRangeOfCountException".equalsIgnoreCase(errorName)) {
 
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("WrongPatternException".equalsIgnoreCase(errorName)) {
 
 			// meaningful message
-			return error.getErrorInfo();
+			return SafeHtmlUtils.fromString(error.getErrorInfo()).asString();
 
 		} else if ("MissingRequiredDataException".equalsIgnoreCase(errorName)) {
 
@@ -938,7 +939,7 @@ public class JsonErrorHandler {
 			if (error.getFormItems() != null) {
 				for (int i = 0; i < error.getFormItems().length(); i++) {
 					missingItems += "<strong>Missing attribute: </strong>";
-					missingItems += error.getFormItems().get(i).getFormItem().getFederationAttribute();
+					missingItems += SafeHtmlUtils.fromString(error.getFormItems().get(i).getFormItem().getFederationAttribute()).asString();
 					missingItems += "<br />";
 				}
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonUtils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonUtils.java
@@ -13,6 +13,7 @@ import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.regexp.shared.SplitResult;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.SimplePager;
@@ -519,9 +520,9 @@ public class JsonUtils {
 	static final public void cantParseIntConfirm(String origin, String value) {
 
 		FlexTable ft = new FlexTable();
-		ft.setHTML(0, 0, "Value \""+value+"\" can't be parsed as number." );
+		ft.setHTML(0, 0, "Value \""+ SafeHtmlUtils.fromString(value).asString()+"\" can't be parsed as number." );
 		if (origin.length() > 0) {
-			ft.setHTML(1, 0, "Input name: "+origin);
+			ft.setHTML(1, 0, "Input name: "+SafeHtmlUtils.fromString(origin).asString());
 		}
 
 		Confirm conf = new Confirm("Can't parse value", ft, true);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichGroups.java
@@ -8,6 +8,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent.ListHandler;
@@ -272,15 +273,15 @@ public class GetAllRichGroups implements JsonCallback, JsonCallbackTable<RichGro
 							authGroup = "No";
 						}
 
-						String html = "Group name: <b>"+name+"</b><br>";
-						html += "Synchronization: <b>"+syncEnabled+"</b><br>";
+						String html = "Group name: <b>"+ SafeHtmlUtils.fromString(name).asString()+"</b><br>";
+						html += "Synchronization: <b>"+SafeHtmlUtils.fromString(syncEnabled).asString()+"</b><br>";
 
 						if (object.isSyncEnabled()) {
-							html += "Last sync. state: <b>"+syncState+"</b><br>";
-							html += "Last sync. timestamp: <b>"+syncTimestamp+"</b><br>";
-							html += "Last successful sync. timestamp: <b>"+syncSuccessTimestamp+"</b><br>";
-							html += "Sync. Interval: <b>"+syncInterval+"</b><br>";
-							html += "Authoritative group: <b>"+authGroup+"</b><br>";
+							html += "Last sync. state: <b>"+SafeHtmlUtils.fromString(syncState).asString()+"</b><br>";
+							html += "Last sync. timestamp: <b>"+SafeHtmlUtils.fromString(syncTimestamp).asString()+"</b><br>";
+							html += "Last successful sync. timestamp: <b>"+SafeHtmlUtils.fromString(syncSuccessTimestamp).asString()+"</b><br>";
+							html += "Sync. Interval: <b>"+SafeHtmlUtils.fromString(syncInterval).asString()+"</b><br>";
+							html += "Authoritative group: <b>"+SafeHtmlUtils.fromString(authGroup).asString()+"</b><br>";
 						}
 
 						FlexTable layout = new FlexTable();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichSubGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetAllRichSubGroups.java
@@ -5,6 +5,7 @@ import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent.ListHandler;
@@ -235,15 +236,15 @@ public class GetAllRichSubGroups implements JsonCallback, JsonCallbackTable<Rich
 							authGroup = "No";
 						}
 
-						String html = "Group name: <b>"+name+"</b><br>";
-						html += "Synchronization: <b>"+syncEnabled+"</b><br>";
+						String html = "Group name: <b>"+ SafeHtmlUtils.fromString(name).asString()+"</b><br>";
+						html += "Synchronization: <b>"+SafeHtmlUtils.fromString(syncEnabled).asString()+"</b><br>";
 
 						if (object.isSyncEnabled()) {
-							html += "Last sync. state: <b>"+syncState+"</b><br>";
-							html += "Last sync. timestamp: <b>"+syncTimestamp+"</b><br>";
-							html += "Last successful sync. timestamp: <b>"+syncSuccessTimestamp+"</b><br>";
-							html += "Sync. Interval: <b>"+syncInterval+"</b><br>";
-							html += "Authoritative group: <b>"+authGroup+"</b><br>";
+							html += "Last sync. state: <b>"+SafeHtmlUtils.fromString(syncState).asString()+"</b><br>";
+							html += "Last sync. timestamp: <b>"+SafeHtmlUtils.fromString(syncTimestamp).asString()+"</b><br>";
+							html += "Last successful sync. timestamp: <b>"+SafeHtmlUtils.fromString(syncSuccessTimestamp).asString()+"</b><br>";
+							html += "Sync. Interval: <b>"+SafeHtmlUtils.fromString(syncInterval).asString()+"</b><br>";
+							html += "Authoritative group: <b>"+SafeHtmlUtils.fromString(authGroup).asString()+"</b><br>";
 						}
 
 						FlexTable layout = new FlexTable();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetRichSubGroups.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/groupsManager/GetRichSubGroups.java
@@ -5,6 +5,7 @@ import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent.ListHandler;
@@ -222,15 +223,15 @@ public class GetRichSubGroups implements JsonCallback, JsonCallbackTable<RichGro
 							authGroup = "No";
 						}
 
-						String html = "Group name: <b>"+name+"</b><br>";
-						html += "Synchronization: <b>"+syncEnabled+"</b><br>";
+						String html = "Group name: <b>"+ SafeHtmlUtils.fromString(name).asString()+"</b><br>";
+						html += "Synchronization: <b>"+SafeHtmlUtils.fromString(syncEnabled).asString()+"</b><br>";
 
 						if (object.isSyncEnabled()) {
-							html += "Last sync. state: <b>"+syncState+"</b><br>";
-							html += "Last sync. timestamp: <b>"+syncTimestamp+"</b><br>";
-							html += "Last successful sync. timestamp: <b>"+syncSuccessTimestamp+"</b><br>";
-							html += "Sync. Interval: <b>"+syncInterval+"</b><br>";
-							html += "Authoritative group: <b>"+authGroup+"</b><br>";
+							html += "Last sync. state: <b>"+SafeHtmlUtils.fromString(syncState).asString()+"</b><br>";
+							html += "Last sync. timestamp: <b>"+SafeHtmlUtils.fromString(syncTimestamp).asString()+"</b><br>";
+							html += "Last successful sync. timestamp: <b>"+SafeHtmlUtils.fromString(syncSuccessTimestamp).asString()+"</b><br>";
+							html += "Sync. Interval: <b>"+SafeHtmlUtils.fromString(syncInterval).asString()+"</b><br>";
+							html += "Authoritative group: <b>"+SafeHtmlUtils.fromString(authGroup).asString()+"</b><br>";
 						}
 
 						FlexTable layout = new FlexTable();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.webgui.json.registrarManager;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.i18n.client.LocaleInfo;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -159,7 +160,8 @@ public class GetApplicationDataById implements JsonCallback{
 		int i = 0;
 		for(final ApplicationFormItemData item : applFormItems){
 
-			RegistrarFormItemGenerator gen = new RegistrarFormItemGenerator(item.getFormItem(), item.getValue(), locale);
+			RegistrarFormItemGenerator gen = new RegistrarFormItemGenerator(item.getFormItem(),
+					(item.getValue() != null) ? SafeHtmlUtils.fromString(item.getValue()).asString() : null, locale);
 			this.applFormGenerators.add(gen);
 
 			// show only visible items - show also hidden to perun admin and vo/group admin
@@ -184,16 +186,16 @@ public class GetApplicationDataById implements JsonCallback{
 					// 0 = label or shortname
 					if (item.getFormItem().getType().startsWith("FROM_FEDERATION_HIDDEN")) {
 						// hidden
-						ft.setHTML(i, 0, "<strong>" + gen.getLabelOrShortname() + "</strong><br /><i>(value provided by external source)</i>");
+						ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong><br /><i>(value provided by external source)</i>");
 					} else if (item.getFormItem().getType().startsWith("FROM_FEDERATION_SHOW")) {
 						// show
-						ft.setHTML(i, 0, "<strong>" + gen.getLabelOrShortname() + "</strong><br /><i>(value provided by external source)</i>");
+						ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong><br /><i>(value provided by external source)</i>");
 					} else {
-						ft.setHTML(i, 0, "<strong>" + gen.getLabelOrShortname() + "</strong>");
+						ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong>");
 					}
 
 					// 1 = value
-					ft.setWidget(i, 1, new HTML(item.getValue()));
+					ft.setWidget(i, 1, new HTML((item.getValue() != null) ? (SafeHtmlUtils.fromString(item.getValue()).asString()) : null));
 
 					// format
 					fcf.setVerticalAlignment(i, 0, HasVerticalAlignment.ALIGN_TOP);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationForm.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationForm.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.webgui.json.registrarManager;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
@@ -178,7 +179,7 @@ public class GetApplicationForm implements JsonCallback {
 			button.addClickHandler(ch);
 
 			String appStyle = "<strong>Approval style: </strong>";
-			String module = "</br><strong>Module name: </strong>" + form.getModuleClassName();
+			String module = "</br><strong>Module name: </strong>" + SafeHtmlUtils.fromString(form.getModuleClassName()).asString();
 
 			if (form.getAutomaticApproval()==true) {
 				appStyle = appStyle + "<span style=\"color:red;\">Automatic</span> (INITIAL)";

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItems.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -256,7 +257,7 @@ public class GetFormItems implements JsonCallback {
 			if (item.isRequired() == true) {
 				label += "*";
 			}
-			ft.setHTML(i, 0, label);
+			ft.setHTML(i, 0, SafeHtmlUtils.fromString(label).asString());
 
 			// 1 = type
 			Label type_label = new Label(CreateFormItemTabItem.inputTypes.get(item.getType()));
@@ -587,7 +588,7 @@ public class GetFormItems implements JsonCallback {
 			if(gen.isLabelShown()){
 
 				// 0 = label
-				ft.setHTML(i, 0, "<strong>" + gen.getLabelOrShortname() + "</strong>");
+				ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong>");
 
 				// 1 = widget
 				Widget w = gen.getWidget();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetFormItemsWithPrefilledValues.java
@@ -5,6 +5,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Window;
@@ -185,7 +186,7 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 						missingItems += ApplicationMessages.INSTANCE.cantResolveIDPNameAttribute(fedAttrName);
 					} else {
 						missingItems += ApplicationMessages.INSTANCE.missingIDPAttribute();
-						missingItems += error.getFormItems().get(i).getFormItem().getFederationAttribute();
+						missingItems += SafeHtmlUtils.fromString(error.getFormItems().get(i).getFormItem().getFederationAttribute()).asString();
 					}
 					missingItems += "<br />";
 				}
@@ -349,10 +350,10 @@ public class GetFormItemsWithPrefilledValues implements JsonCallback {
 				// 0 = label
 				if (item.getFormItem().isRequired() == true) {
 					// required
-					ft.setHTML(i, 0, "<strong>" + gen.getLabelOrShortname() + "*</strong>");
+					ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "*</strong>");
 				} else {
 					// optional
-					ft.setHTML(i, 0, "<strong>" + gen.getLabelOrShortname() + "</strong>");
+					ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong>");
 				}
 
 				// 1 = widget

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/HandleApplication.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/HandleApplication.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
@@ -203,12 +204,12 @@ public class HandleApplication {
 					layout.setWidget(0, 0, new HTML("<p>" + new Image(LargeIcons.INSTANCE.errorIcon())));
 
 					if ("NOT_ACADEMIC".equals(error.getReason())) {
-						layout.setHTML(0, 1, "<p>User is not active academia member and application shouldn't be approved.<p><b>LoA:</b> " + app.getExtSourceLoa() +
-								"</br><b>IdP category:</b> " + (!(error.getCategory().equals("")) ? error.getCategory() : "N/A") +
-								"</br><b>Affiliation:</b> " + (!(error.getAffiliation().equals("")) ? error.getAffiliation().replace(";", ", ") : "N/A") +
+						layout.setHTML(0, 1, "<p>User is not active academia member and application shouldn't be approved.<p><b>LoA:</b> " + SafeHtmlUtils.fromString(app.getExtSourceLoa()+"").asString() +
+								"</br><b>IdP category:</b> " + (!(error.getCategory().equals("")) ? SafeHtmlUtils.fromString(error.getCategory()).asString() : "N/A") +
+								"</br><b>Affiliation:</b> " + (!(error.getAffiliation().equals("")) ? SafeHtmlUtils.fromString(error.getAffiliation().replace(";", ", ")).asString() : "N/A") +
 								((error.isSoft()) ? "<p>You can try to override above restriction by clicking 'Approve anyway' button." : ""));
 					} else {
-						layout.setHTML(0, 1, "<p>" + error.getErrorInfo() + ((error.isSoft()) ? "<p>You can try to override above restriction by clicking 'Approve anyway' button." : ""));
+						layout.setHTML(0, 1, "<p>" + SafeHtmlUtils.fromString(error.getErrorInfo()).asString() + ((error.isSoft()) ? "<p>You can try to override above restriction by clicking 'Approve anyway' button." : ""));
 					}
 
 					layout.getFlexCellFormatter().setAlignment(0, 0, HasHorizontalAlignment.ALIGN_LEFT, HasVerticalAlignment.ALIGN_TOP);
@@ -283,16 +284,16 @@ public class HandleApplication {
 
 								for (Identity user : users) {
 
-									ft.setHTML(i, 0, user.getName());
+									ft.setHTML(i, 0, SafeHtmlUtils.fromString(user.getName()).asString());
 
 									if (user.getEmail() != null && !user.getEmail().isEmpty()) {
-										ft.setHTML(i, 1, user.getEmail());
+										ft.setHTML(i, 1, SafeHtmlUtils.fromString(user.getEmail()).asString());
 									} else {
 										ft.setHTML(i, 1, "N/A");
 									}
 
 									if (user.getOrganization() != null && !user.getOrganization().isEmpty()) {
-										ft.setHTML(i, 2, user.getOrganization());
+										ft.setHTML(i, 2, SafeHtmlUtils.fromString(user.getOrganization()).asString());
 									} else {
 										ft.setHTML(i, 2, "N/A");
 									}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/SetNewAttributeTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/SetNewAttributeTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.HasKeyboardSelectionPolicy.KeyboardSelectionPolicy;
 import com.google.gwt.user.client.ui.*;
@@ -113,7 +114,7 @@ public class SetNewAttributeTabItem implements TabItem {
 			entityIds = entityIds.concat(" "+item.getKey() + ": "+item.getValue());
 		}
 		HTML helper = new HTML();
-		String helperInside = "<p>Enter new values and press Enter key. Save changes by clicking on \"Save changes\" button. Values will be set for<strong>"+entityIds+".</strong></p>";
+		String helperInside = "<p>Enter new values and press Enter key. Save changes by clicking on \"Save changes\" button. Values will be set for<strong>"+ SafeHtmlUtils.fromString(entityIds).asString()+".</strong></p>";
 		helper.setHTML(helperInside);
 
 		// callback

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AddAuthorTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AddAuthorTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -229,7 +230,7 @@ public class AddAuthorTabItem implements TabItem, TabItemWithUrl {
 			text += ", ";
 		}
 
-		text += newlyAdded;
+		text += SafeHtmlUtils.fromString(newlyAdded).asString();
 		alreadyAddedAuthors.setHTML(text);
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/CreateThanksTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/CreateThanksTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -191,7 +192,7 @@ public class CreateThanksTabItem implements TabItem, TabItemWithUrl{
 			text += ", ";
 		}
 
-		text += newlyAdded;
+		text += SafeHtmlUtils.fromString(newlyAdded).asString();
 		alreadyAddedOwners.setHTML(text);
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/PublicationDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/PublicationDetailTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -180,7 +181,7 @@ public class PublicationDetailTabItem implements TabItem, TabItemWithUrl {
 			// set max length
 			main.getElement().setAttribute("maxlength", "4000");
 
-			ft.setHTML(1, 1, publication.getId()+" / <Strong>Ext. Id: </strong>"+publication.getExternalId()+" <Strong>System: </strong>"+publication.getPublicationSystemName());
+			ft.setHTML(1, 1, publication.getId()+" / <Strong>Ext. Id: </strong>"+publication.getExternalId()+" <Strong>System: </strong>"+ SafeHtmlUtils.fromString(publication.getPublicationSystemName()).asString());
 			ft.setWidget(2, 1, title);
 			ft.setWidget(3, 1, year);
 			ft.setWidget(4, 1, listbox);
@@ -188,13 +189,13 @@ public class PublicationDetailTabItem implements TabItem, TabItemWithUrl {
 				// only perunadmin can change rank
 				ft.setWidget(5, 1, rank);
 			} else {
-				ft.setHTML(5, 1, ""+publication.getRank());
+				ft.setHTML(5, 1, SafeHtmlUtils.fromString(String.valueOf(publication.getRank()) +"").asString());
 			}
 			ft.setWidget(6, 1, isbn);
 			ft.setWidget(7, 1, doi);
 			ft.setWidget(8, 1, main);
-			ft.setHTML(9, 1, String.valueOf(publication.getCreatedBy()));
-			ft.setHTML(10, 1, String.valueOf(publication.getCreatedDate()));
+			ft.setHTML(9, 1, SafeHtmlUtils.fromString((publication.getCreatedBy() != null) ? publication.getCreatedBy() : "").asString());
+			ft.setHTML(10, 1, SafeHtmlUtils.fromString((String.valueOf(publication.getCreatedDate()) != null) ? String.valueOf(publication.getCreatedDate()) : "").asString());
 
 			// update button
 
@@ -255,16 +256,16 @@ public class PublicationDetailTabItem implements TabItem, TabItemWithUrl {
 			}
 			ft.getFlexCellFormatter().setWidth(1, 0, "100px");
 
-			ft.setHTML(1, 1, publication.getId()+" / <Strong>Ext. Id: </strong>"+publication.getExternalId()+" <Strong>System: </strong>"+publication.getPublicationSystemName());
-			ft.setHTML(2, 1, publication.getTitle());
-			ft.setHTML(3, 1, String.valueOf(publication.getYear()));
-			ft.setHTML(4, 1, publication.getCategoryName());
-			ft.setHTML(5, 1, String.valueOf(publication.getRank()) + " (default is 0)");
-			ft.setHTML(6, 1, publication.getIsbn());
-			ft.setHTML(7, 1, publication.getDoi());
-			ft.setHTML(8, 1, publication.getMain());
-			ft.setHTML(9, 1, String.valueOf(publication.getCreatedBy()));
-			ft.setHTML(10, 1, String.valueOf(publication.getCreatedDate()));
+			ft.setHTML(1, 1, publication.getId()+" / <Strong>Ext. Id: </strong>"+publication.getExternalId()+" <Strong>System: </strong>"+SafeHtmlUtils.fromString(publication.getPublicationSystemName()).asString());
+			ft.setHTML(2, 1, SafeHtmlUtils.fromString((publication.getTitle() != null) ? publication.getTitle() : "").asString());
+			ft.setHTML(3, 1, SafeHtmlUtils.fromString((String.valueOf(publication.getYear()) != null) ? String.valueOf(publication.getYear()) : "").asString());
+			ft.setHTML(4, 1, SafeHtmlUtils.fromString((publication.getCategoryName() != null) ? publication.getCategoryName() : "").asString());
+			ft.setHTML(5, 1, SafeHtmlUtils.fromString(String.valueOf(publication.getRank()) + " (default is 0)").asString());
+			ft.setHTML(6, 1, SafeHtmlUtils.fromString((publication.getIsbn() != null) ? publication.getIsbn() : "").asString());
+			ft.setHTML(7, 1, SafeHtmlUtils.fromString((publication.getDoi() != null) ? publication.getDoi() : "").asString());
+			ft.setHTML(8, 1, SafeHtmlUtils.fromString((publication.getMain() != null) ? publication.getMain() : "").asString());
+			ft.setHTML(9, 1, SafeHtmlUtils.fromString((publication.getCreatedBy() != null) ? publication.getCreatedBy() : "").asString());
+			ft.setHTML(10, 1, SafeHtmlUtils.fromString((String.valueOf(publication.getCreatedDate()) != null) ? String.valueOf(publication.getCreatedDate()) : "").asString());
 
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/UsersPublicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/UsersPublicationsTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -155,7 +156,7 @@ public class UsersPublicationsTabItem implements TabItem, TabItemWithUrl{
 						for (int i=0; i<list.size(); i++) {
 							if (list.get(i).getLocked() && !session.isPerunAdmin()) {
 								// skip locked pubs
-								UiElements.generateAlert("Publication locked", "Publication <strong>" + list.get(i).getTitle() + "</strong> is locked by " +
+								UiElements.generateAlert("Publication locked", "Publication <strong>" + SafeHtmlUtils.fromString(list.get(i).getTitle()).asString() + "</strong> is locked by " +
 									"administrator and can't be deleted. Please notify administrator about your request.");
 								continue;
 							} else {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -242,7 +243,7 @@ public class AddFacilityManagerTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getFullName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getFullName()).asString());
 		}
 
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitiesPropagationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitiesPropagationsTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
@@ -167,7 +168,7 @@ public class FacilitiesPropagationsTabItem implements TabItem, TabItemWithUrl {
 
 					for (final FacilityState state : clusters) {
 
-						content.setHTML(mainrow, 0, "<strong>" + state.getFacility().getName() + "</strong>");
+						content.setHTML(mainrow, 0, "<strong>" + SafeHtmlUtils.fromString(state.getFacility().getName()).asString() + "</strong>");
 
 						final FlowPanel inner = new FlowPanel();
 						content.setWidget(mainrow+1, 0, inner);
@@ -189,7 +190,7 @@ public class FacilitiesPropagationsTabItem implements TabItem, TabItemWithUrl {
 
 							String show = dest.substring(0, dest.indexOf("."));
 							Anchor hyp = new Anchor();
-							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+show+"</span>");
+							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+SafeHtmlUtils.fromString((show != null) ? show : "").asString()+"</span>");
 							hyp.addClickHandler(new ClickHandler() {
 								public void onClick(ClickEvent clickEvent) {
 									session.getTabManager().addTab(new DestinationResultsTabItem(state.getFacility(), null, dest, false));
@@ -247,7 +248,7 @@ public class FacilitiesPropagationsTabItem implements TabItem, TabItemWithUrl {
 						for (final String dest : destList) {
 
 							Anchor hyp = new Anchor();
-							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+dest+"</span>");
+							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+SafeHtmlUtils.fromString((dest != null) ? dest : "").asString()+"</span>");
 							inner.add(hyp);
 							hyp.addClickHandler(new ClickHandler() {
 								public void onClick(ClickEvent clickEvent) {
@@ -270,7 +271,7 @@ public class FacilitiesPropagationsTabItem implements TabItem, TabItemWithUrl {
 
 						if (destList.isEmpty()) {
 							Anchor hyp = new Anchor();
-							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+state.getFacility().getName()+"</span>");
+							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+SafeHtmlUtils.fromString((state.getFacility().getName() != null) ? state.getFacility().getName() : "").asString()+"</span>");
 							inner.add(hyp);
 							hyp.addStyleName("notdetermined");
 							notDeterminedCounter++;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityAllowedGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityAllowedGroupsTabItem.java
@@ -6,6 +6,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -234,7 +235,7 @@ public class FacilityAllowedGroupsTabItem implements TabItem, TabItemWithUrl {
 					session.getTabManager().addTab(new GroupDetailTabItem(group));
 				} else {
 					// show alert
-					UiElements.generateInfo("You are not VO / Group manager of this group", "You MUST be VO manager or Group manager of group: <strong>"+group.getName()+"</strong> to view it's details.");
+					UiElements.generateInfo("You are not VO / Group manager of this group", "You MUST be VO manager or Group manager of group: <strong>"+SafeHtmlUtils.fromString(group.getName()).asString()+"</strong> to view it's details.");
 				}
 			}
 		});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityDetailTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -158,7 +159,7 @@ public class FacilityDetailTabItem implements TabItem, TabItemWithUrl{
 			column++;
 		}
 
-		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+facility.getDescription()+"&nbsp;</span>");
+		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+ SafeHtmlUtils.fromString((facility.getDescription() != null) ? facility.getDescription() : "").asString()+"&nbsp;</span>");
 
 		dp.add(menu);
 		vp.add(dp);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupExtSourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupExtSourceTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JsArray;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -205,7 +206,7 @@ public class AddGroupExtSourceTabItem implements TabItem, TabItemWithUrl{
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getName()).asString());
 		}
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -227,7 +228,7 @@ public class AddGroupManagerTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getFullName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getFullName()).asString());
 		}
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupUnionTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupUnionTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JsArray;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Label;
@@ -184,7 +185,7 @@ public class AddGroupUnionTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i = 0; i < alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML() + ((i != 0) ? ", " : "") + alreadyAddedList.get(i).getName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML() + ((i != 0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getName()).asString());
 		}
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AssignGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AssignGroupTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -179,7 +180,7 @@ public class AssignGroupTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already assigned to resources: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getName()).asString());
 		}
 
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupDetailTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -162,7 +163,7 @@ public class GroupDetailTabItem implements TabItem, TabItemWithUrl{
 		column++;
 		*/
 
-		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+group.getDescription()+"&nbsp;</span>");
+		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+ SafeHtmlUtils.fromString((group.getDescription() != null) ? group.getDescription() : "").asString()+"&nbsp;</span>");
 
 		dp.add(menu);
 		vp.add(dp);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToGroupTabItem.java
@@ -14,6 +14,7 @@ import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -550,16 +551,16 @@ public class AddMemberToGroupTabItem implements TabItem, TabItemWithUrl {
 			if (alreadyAddedList.get(i).getObjectType().equals("MemberCandidate")) {
 				MemberCandidate c = alreadyAddedList.get(i).cast();
 				if (c.getCandidate() != null) {
-					alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + c.getCandidate().getFullName());
+					alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(c.getCandidate().getFullName()).asString());
 				} else {
-					alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + c.getRichUser().getFullName());
+					alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(c.getRichUser().getFullName()).asString());
 				}
 			} else if (alreadyAddedList.get(i).getObjectType().equals("User") || alreadyAddedList.get(i).getObjectType().equals("RichUser")) {
 				User u = alreadyAddedList.get(i).cast();
-				alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML() + ((i != 0) ? ", " : "") + u.getFullName());
+				alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML() + ((i != 0) ? ", " : "") + SafeHtmlUtils.fromString(u.getFullName()).asString());
 			} else {
 				RichMember m = alreadyAddedList.get(i).cast();
-				alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML() + ((i != 0) ? ", " : "") + m.getUser().getFullName());
+				alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML() + ((i != 0) ? ", " : "") + SafeHtmlUtils.fromString(m.getUser().getFullName()).asString());
 			}
 		}
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToResourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToResourceTabItem.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -281,7 +282,7 @@ public class AddMemberToResourceTabItem implements TabItem  {
 					ArrayList<Service> servList = JsonUtils.jsoAsList(jso);
 					servList = new TableSorter<Service>().sortByName(servList);
 					for (Service s : servList){
-						services.setHTML(services.getHTML().concat(s.getName() + "</br>"));
+						services.setHTML(services.getHTML().concat(SafeHtmlUtils.fromString(s.getName()).asString() + "</br>"));
 					}
 				}
 				@Override

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToVoTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -291,9 +292,9 @@ public class AddMemberToVoTabItem implements TabItem, TabItemWithUrl {
 		for (int i=0; i<alreadyAddedList.size(); i++) {
 			MemberCandidate c = alreadyAddedList.get(i).cast();
 			if (c.getRichUser() != null) {
-				alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + c.getRichUser().getFullName());
+				alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(c.getRichUser().getFullName()).asString());
 			} else {
-				alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML() + ((i != 0) ? ", " : "") + c.getCandidate().getFullName());
+				alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML() + ((i != 0) ? ", " : "") + SafeHtmlUtils.fromString(c.getCandidate().getFullName()).asString());
 			}
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeStatusTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeStatusTabItem.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
@@ -74,7 +75,7 @@ public class ChangeStatusTabItem implements TabItem {
 
 		layout.setHTML(0, 0, "Current status:");
 		layout.getFlexCellFormatter().setStyleName(0, 0, "itemName");
-		layout.setHTML(0, 1, member.getStatus());
+		layout.setHTML(0, 1, SafeHtmlUtils.fromString(member.getStatus()).asString());
 
 		if (member.getStatus().equalsIgnoreCase("VALID")) {
 			layout.setHTML(1, 0, "Member is properly configured and have access on provided resources.");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberAddToGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberAddToGroupTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -144,7 +145,7 @@ public class MemberAddToGroupTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added to groups: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getName()).asString());
 		}
 
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberOverviewTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberOverviewTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
@@ -217,7 +218,7 @@ public class MemberOverviewTabItem implements TabItem {
 				ArrayList<Attribute> list = JsonUtils.jsoAsList(jso);
 				if (list != null && !list.isEmpty()) {
 					for (Attribute a : list) {
-						String value = a.getValue();
+						String value = SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString();
 						if (a.getName().equalsIgnoreCase("urn:perun:user:attribute-def:def:organization")) {
 							if (!"null".equals(value)) {
 								personalLayout.setHTML(0, 1, value);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MembershipExpirationTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MembershipExpirationTabItem.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.datepicker.client.DatePicker;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -75,12 +76,12 @@ public class MembershipExpirationTabItem implements TabItem {
 		layout.setHTML(0, 0, "Current expiration:");
 		layout.getFlexCellFormatter().setStyleName(0, 0, "itemName");
 
-		layout.setHTML(0, 1, member.getStatus());
+		layout.setHTML(0, 1, SafeHtmlUtils.fromString(member.getStatus()).asString());
 
 		final Attribute expire = member.getAttribute("urn:perun:member:attribute-def:def:membershipExpiration");
 		String expirationValue = null;
 		if (expire != null && !"null".equalsIgnoreCase(expire.getValue())) {
-			layout.setHTML(0, 1, expire.getValue());
+			layout.setHTML(0, 1, SafeHtmlUtils.fromString((expire.getValue() != null) ? expire.getValue() : "").asString());
 			expirationValue = expire.getValue().substring(0, ((expire.getValue().length() > 10) ? 9 : expire.getValue().length()-1));
 		} else {
 			layout.setHTML(0, 1, "<i>never</i>");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/SendPasswordResetRequestTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/SendPasswordResetRequestTabItem.java
@@ -9,6 +9,7 @@ import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.datepicker.client.DatePicker;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -100,7 +101,7 @@ public class SendPasswordResetRequestTabItem implements TabItem {
 					for (Attribute a : logins) {
 						if (Utils.getSupportedPasswordNamespaces().contains(a.getFriendlyNameParameter())) {
 							namespaces.addItem(a.getFriendlyNameParameter().toUpperCase(), a.getValue());
-							layout.setHTML(1, 1, a.getValue());
+							layout.setHTML(1, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString());
 						}
 					}
 				}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/PropagationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/PropagationsTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
@@ -168,7 +169,7 @@ public class PropagationsTabItem implements TabItem, TabItemWithUrl {
 
 					for (final FacilityState state : clusters) {
 
-						content.setHTML(mainrow, 0, "<strong>" + state.getFacility().getName() + "</strong>");
+						content.setHTML(mainrow, 0, "<strong>" + SafeHtmlUtils.fromString((state.getFacility().getName() != null) ? state.getFacility().getName() : "").asString() + "</strong>");
 
 						final FlowPanel inner = new FlowPanel();
 						content.setWidget(mainrow+1, 0, inner);
@@ -188,7 +189,7 @@ public class PropagationsTabItem implements TabItem, TabItemWithUrl {
 
 						for (final String dest : destList) {
 
-							String show = dest.substring(0, dest.indexOf("."));
+							String show = SafeHtmlUtils.fromString(dest.substring(0, dest.indexOf("."))).asString();
 							Anchor hyp = new Anchor();
 							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+show+"</span>");
 							hyp.addClickHandler(new ClickHandler() {
@@ -248,7 +249,7 @@ public class PropagationsTabItem implements TabItem, TabItemWithUrl {
 						for (final String dest : destList) {
 
 							Anchor hyp = new Anchor();
-							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+dest+"</span>");
+							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+SafeHtmlUtils.fromString((dest != null) ? dest : "").asString()+"</span>");
 							inner.add(hyp);
 							hyp.addClickHandler(new ClickHandler() {
 								public void onClick(ClickEvent clickEvent) {
@@ -271,7 +272,7 @@ public class PropagationsTabItem implements TabItem, TabItemWithUrl {
 
 						if (destList.isEmpty()) {
 							Anchor hyp = new Anchor();
-							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+state.getFacility().getName()+"</span>");
+							hyp.setHTML("<span style=\"display: inline-block; width: "+width+"px; text-align: center;\">"+SafeHtmlUtils.fromString((state.getFacility().getName() != null) ? state.getFacility().getName() : "").asString()+"</span>");
 							inner.add(hyp);
 							hyp.addStyleName("notdetermined");
 							notDeterminedCounter++;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/ApplicationDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/ApplicationDetailTabItem.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
@@ -109,11 +110,11 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 
 		String text = "<strong>Submitted by:</strong> ";
 		if (app.getUser() != null) {
-			text += app.getUser().getFullNameWithTitles() + " (" + app.getCreatedBy() + ")";
+			text += SafeHtmlUtils.fromString(app.getUser().getFullNameWithTitles() + " (" + app.getCreatedBy() + ")").asString();
 		} else {
-			text += app.getCreatedBy();
+			text += SafeHtmlUtils.fromString(app.getCreatedBy()).asString();
 		}
-		text += " <strong>from External Source:</strong> " + app.getExtSourceName()+" <strong>with Level of Assurance:</strong> " + app.getExtSourceLoa();
+		text += " <strong>from External Source:</strong> " + SafeHtmlUtils.fromString(app.getExtSourceName()).asString()+" <strong>with Level of Assurance:</strong> " + app.getExtSourceLoa();
 		text += " <strong>on: </strong> " + app.getCreatedAt().split("\\.")[0];
 		ft.setHTML(row, 0, text);
 		ft.setCellSpacing(5);
@@ -121,9 +122,9 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 		row++;
 
 		if (app.getGroup() != null) {
-			ft.setHTML(row, 0, "<strong>Application for group: </strong>"+app.getGroup().getName() + "<strong> in VO: </strong>"+app.getVo().getName());
+			ft.setHTML(row, 0, "<strong>Application for group: </strong>"+ SafeHtmlUtils.fromString((app.getGroup().getName() != null) ? app.getGroup().getName() : "").asString() + "<strong> in VO: </strong>"+SafeHtmlUtils.fromString((app.getVo().getName() != null) ? app.getVo().getName() : "").asString());
 		} else {
-			ft.setHTML(row, 0, "<strong>Application for VO: </strong>"+app.getVo().getName());
+			ft.setHTML(row, 0, "<strong>Application for VO: </strong>"+SafeHtmlUtils.fromString((app.getVo().getName() != null) ? app.getVo().getName() : "").asString());
 		}
 
 		if (app.getState().equalsIgnoreCase("APPROVED")) {
@@ -145,7 +146,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 					if (jso != null) {
 						BasicOverlayType basic = jso.cast();
 						row++;
-						ft.setHTML(row, 0, "<strong>New membership expiration:</strong> "+basic.getString());
+						ft.setHTML(row, 0, "<strong>New membership expiration:</strong> "+SafeHtmlUtils.fromString(basic.getString()).asString());
 					}
 				}
 			});
@@ -164,7 +165,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 					if (jso != null) {
 						BasicOverlayType basic = jso.cast();
 						row++;
-						ft.setHTML(row, 0, "<strong>New membership expiration:</strong> "+basic.getString());
+						ft.setHTML(row, 0, "<strong>New membership expiration:</strong> "+SafeHtmlUtils.fromString(basic.getString()).asString());
 					}
 				}
 			});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/PreviewFormTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/PreviewFormTabItem.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.webgui.tabs.registrartabs;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -191,10 +192,10 @@ public class PreviewFormTabItem implements TabItem, TabItemWithUrl {
 				// 0 = label
 				if (item.isRequired() == true) {
 					// required
-					ft.setHTML(i, 0, "<strong>" + gen.getLabelOrShortname() + "*</strong>");
+					ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "*</strong>");
 				} else {
 					// optional
-					ft.setHTML(i, 0, "<strong>" + gen.getLabelOrShortname() + "</strong>");
+					ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong>");
 				}
 
 				// 1 = widget

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/CreateFacilityResourceManageServicesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/CreateFacilityResourceManageServicesTabItem.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
@@ -261,7 +262,7 @@ public class CreateFacilityResourceManageServicesTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already assigned: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getName()).asString());
 		}
 
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/CreateFacilityResourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/CreateFacilityResourceTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -134,7 +135,7 @@ public class CreateFacilityResourceTabItem implements TabItem {
 
 		// Add some standard form options
 		layout.setHTML(0, 0, "On facility:");
-		layout.setHTML(0, 1, facility.getName());
+		layout.setHTML(0, 1, SafeHtmlUtils.fromString((facility.getName() != null) ? facility.getName() : "").asString());
 		layout.setHTML(1, 0, "For VO:");
 		layout.setWidget(1, 1, vosDropDown);
 		layout.setHTML(2, 0, "Name:");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/EditResourceDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/EditResourceDetailsTabItem.java
@@ -9,7 +9,6 @@ import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.localization.ButtonTranslation;
 import cz.metacentrum.perun.webgui.client.resources.ButtonType;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
-import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
 import cz.metacentrum.perun.webgui.json.resourcesManager.UpdateResource;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceDetailTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -157,14 +158,14 @@ public class ResourceDetailTabItem implements TabItem, TabItemWithUrl {
 
 		if (facilityId > 0) {
 			// facility admin view
-			menu.setHTML(0, column, "<strong>VO:</strong><br/><span class=\"inputFormInlineComment\">"+resource.getVoId()+" / "+resource.getVo().getShortName()+"</span>");
+			menu.setHTML(0, column, "<strong>VO:</strong><br/><span class=\"inputFormInlineComment\">"+resource.getVoId()+" / "+SafeHtmlUtils.fromString(resource.getVo().getShortName()).asString()+"</span>");
 			column++;
 			menu.setHTML(0, column, "&nbsp;");
 			menu.getFlexCellFormatter().setWidth(0, column, "25px");
 			column++;
 		}
 
-		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+resource.getDescription()+"&nbsp;</span>");
+		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+ SafeHtmlUtils.fromString((resource.getDescription() != null) ? resource.getDescription() : "").asString()+"&nbsp;</span>");
 
 		if (session.isFacilityAdmin(resource.getFacilityId())) {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/AddSecurityTeamManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/AddSecurityTeamManagerTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -247,7 +248,7 @@ public class AddSecurityTeamManagerTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getFullName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getFullName()).asString());
 		}
 
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/AddUserToBlacklistTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/AddUserToBlacklistTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -268,7 +269,7 @@ public class AddUserToBlacklistTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getFullName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getFullName()).asString());
 		}
 
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamDetailTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -142,7 +143,7 @@ public class SecurityTeamDetailTabItem implements TabItem, TabItemWithUrl{
 			column++;
 		}
 
-		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+securityTeam.getDescription()+"</span>");
+		menu.setHTML(0, column, "<strong>Description:</strong><br/><span class=\"inputFormInlineComment\">"+ SafeHtmlUtils.fromString((securityTeam.getDescription() != null) ? securityTeam.getDescription() : "").asString()+"</span>");
 
 		dp.add(menu);
 		vp.add(dp);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/AddDependencyTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/AddDependencyTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -144,7 +145,7 @@ public class AddDependencyTabItem implements TabItem {
 		layout.setHTML(0, 0, "ExecService:");
 		layout.setHTML(1, 0, "Depend On:");
 
-		layout.setHTML(0, 1, execService.getService().getName() + " " + execService.getType());
+		layout.setHTML(0, 1, SafeHtmlUtils.fromString(execService.getService().getName() + " " + execService.getType()).asString());
 		layout.setWidget(1, 1, listBox);
 
 		final JsonCallbackEvents closeTabEvents = JsonCallbackEvents.closeTabDisableButtonEvents(addButton, tab);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/AddRequiredAttributesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/AddRequiredAttributesTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -173,7 +174,7 @@ public class AddRequiredAttributesTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getName()).asString());
 		}
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ViewExecServiceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ViewExecServiceTabItem.java
@@ -7,6 +7,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -139,7 +140,7 @@ public class ViewExecServiceTabItem implements TabItem, TabItemWithUrl{
 			column++;
 		}
 
-		menu.setHTML(0, column, "<strong>Type:</strong><br/><span class=\"inputFormInlineComment\">"+execService.getType()+"</span>");
+		menu.setHTML(0, column, "<strong>Type:</strong><br/><span class=\"inputFormInlineComment\">"+ SafeHtmlUtils.fromString(execService.getType()).asString()+"</span>");
 		column++;
 		menu.setHTML(0, column, "&nbsp;");
 		menu.getFlexCellFormatter().setWidth(0, column, "25px");
@@ -151,7 +152,7 @@ public class ViewExecServiceTabItem implements TabItem, TabItemWithUrl{
 		menu.getFlexCellFormatter().setWidth(0, column, "25px");
 		column++;
 
-		menu.setHTML(0, column, "<strong>Script path:</strong><br/><span class=\"inputFormInlineComment\">"+execService.getScriptPath()+"</span>");
+		menu.setHTML(0, column, "<strong>Script path:</strong><br/><span class=\"inputFormInlineComment\">"+SafeHtmlUtils.fromString(execService.getScriptPath()).asString()+"</span>");
 		column++;
 		menu.setHTML(0, column, "&nbsp;");
 		menu.getFlexCellFormatter().setWidth(0, column, "25px");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfAuthenticationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfAuthenticationsTabItem.java
@@ -4,6 +4,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -161,7 +162,7 @@ public class SelfAuthenticationsTabItem implements TabItem, TabItemWithUrl {
 						loginsTable.setHTML(row, 0, "Login in "+a.getFriendlyNameParameter().toUpperCase()+":");
 						loginsTable.getFlexCellFormatter().setWidth(row, 0, "150px");
 						loginsTable.getFlexCellFormatter().addStyleName(row, 0, "itemName");
-						loginsTable.setHTML(row, 1, a.getValue());
+						loginsTable.setHTML(row, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString());
 						loginsTable.getFlexCellFormatter().setWidth(row, 1, "150px");
 						// change password if possible
 						if (Utils.getSupportedPasswordNamespaces().contains(a.getFriendlyNameParameter())) {
@@ -228,8 +229,8 @@ public class SelfAuthenticationsTabItem implements TabItem, TabItemWithUrl {
 					for (final UserExtSource a : list) {
 						if (a.getExtSource().getType().equals("cz.metacentrum.perun.core.impl.ExtSourceX509")) {
 							found = true;
-							tab.setHTML(i++, 0, "<strong>"+a.getLogin()+"</strong>");
-							tab.setHTML(i++, 0, "Issuer: " + a.getExtSource().getName());
+							tab.setHTML(i++, 0, "<strong>"+SafeHtmlUtils.fromString((a.getLogin() != null) ? a.getLogin() : "").asString()+"</strong>");
+							tab.setHTML(i++, 0, "Issuer: " + SafeHtmlUtils.fromString((a.getExtSource().getName() != null) ? a.getExtSource().getName() : "").asString());
 							if (!a.isPersistent()) {
 								CustomButton removeButton = new CustomButton("Remove", SmallIcons.INSTANCE.deleteIcon(), new ClickHandler() {
 									@Override

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPersonalTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPersonalTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -323,7 +324,7 @@ public class SelfPersonalTabItem implements TabItem {
 										}
 										if (resultText.length() >= 2) resultText = resultText.substring(0, resultText.length()-2);
 
-										settingsTable.setHTML(2, 0, "You have pending change request. Please check inbox of: "+resultText+" for validation email.");
+										settingsTable.setHTML(2, 0, "You have pending change request. Please check inbox of: "+ SafeHtmlUtils.fromString(resultText).asString()+" for validation email.");
 										settingsTable.getFlexCellFormatter().setStyleName(2, 0, "inputFormInlineComment serverResponseLabelError");
 									}
 
@@ -346,7 +347,7 @@ public class SelfPersonalTabItem implements TabItem {
 													((!resultText.isEmpty()) ? "<p><span class=\"serverResponseLabelError\">You have pending change request. Please check inbox of: "+resultText+" for validation email.</span>" : ""));
 											settingsTable.getFlexCellFormatter().setStyleName(2, 0, "inputFormInlineComment");
 										} else {
-											settingsTable.setHTML(2, 0, (!resultText.isEmpty()) ? "You have pending change request. Please check inbox of: "+resultText+" for validation email." : "");
+											settingsTable.setHTML(2, 0, (!resultText.isEmpty()) ? "You have pending change request. Please check inbox of: "+SafeHtmlUtils.fromString(resultText).asString()+" for validation email." : "");
 											settingsTable.getFlexCellFormatter().setStyleName(2, 0, "inputFormInlineComment serverResponseLabelError");
 										}
 										preferredEmail.setOk();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfResourcesSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfResourcesSettingsTabItem.java
@@ -8,6 +8,7 @@ import com.google.gwt.event.logical.shared.OpenHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
@@ -268,7 +269,7 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 			// if empty
 			if (resources.isEmpty() || resources == null) {
 				FlexTable ft = new FlexTable();
-				ft.setHTML(0, 0, "<p><strong>VO " + vo.getName() + " doesn't provide any resources to configure.</strong></p>");
+				ft.setHTML(0, 0, "<p><strong>VO " + SafeHtmlUtils.fromString((vo.getName() != null) ? vo.getName() : "").asString() + " doesn't provide any resources to configure.</strong></p>");
 				vp.add(ft);
 				return;
 			}
@@ -388,7 +389,7 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 								});
 								if (!a.getValue().equalsIgnoreCase("null")) {
 									// FIXME - we can't offer what default would be, since virt value is always same as def value
-									layoutx.setHTML(row, 1, a.getValue());
+									layoutx.setHTML(row, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString());
 									row++;
 									layoutx.setHTML(row, 1, "You are using specific shell for this resource overriding your global preferences.<br />To get back to default use change button.");
 									layoutx.getFlexCellFormatter().setStyleName(row, 1, "inputFormInlineComment");
@@ -399,7 +400,7 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 										if (a.getValue().equalsIgnoreCase("null") && ia.getValue().equalsIgnoreCase("null")) {
 											layoutx.setHTML(row, 1, "Using default (default: Not set)");
 										} else if (a.getValue().equalsIgnoreCase("null")) {
-											layoutx.setHTML(row, 1, "Using default (default: "+ia.getValue()+")");
+											layoutx.setHTML(row, 1, "Using default (default: "+SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString()+")");
 											row++;
 											layoutx.setHTML(row, 1, "You are using default shell taken from your global preferences.<br />Use change button to set specific shell for this resource.");
 											layoutx.getFlexCellFormatter().setStyleName(row, 1, "inputFormInlineComment");
@@ -428,7 +429,7 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 										if (a.getValue().equalsIgnoreCase("null")) {
 											layoutx.setHTML(rowDataLimit, 1, "Using default (default: error while loading)");
 										} else {
-											layoutx.setHTML(rowDataLimit, 1, String.valueOf(a.getValue())+" (default: error while loading)");
+											layoutx.setHTML(rowDataLimit, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString()+" (default: error while loading)");
 										}
 										quotaChangeButton.addClickHandler(new ClickHandler() {
 											public void onClick(ClickEvent event) {
@@ -443,10 +444,10 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 											if (resAttr.getFriendlyName().equalsIgnoreCase("defaultDataLimit")) {
 												if (a.getValue().equalsIgnoreCase("null")) {
 													// null private + default
-													layoutx.setHTML(rowDataLimit, 1, "Using default (default: "+resAttr.getValue()+")");
+													layoutx.setHTML(rowDataLimit, 1, "Using default (default: "+SafeHtmlUtils.fromString((resAttr.getValue() != null) ? resAttr.getValue() : "").asString()+")");
 												} else {
 													// private - default
-													layoutx.setHTML(rowDataLimit, 1, String.valueOf(a.getValue())+" (default: "+resAttr.getValue()+")");
+													layoutx.setHTML(rowDataLimit, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString()+" (default: "+SafeHtmlUtils.fromString((resAttr.getValue() != null) ? resAttr.getValue() : "").asString()+")");
 												}
 												empty = false;
 												quotaChangeButton.addClickHandler(new ClickHandler() {
@@ -461,7 +462,7 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 											if (a.getValue().equalsIgnoreCase("null")) {
 												layoutx.setHTML(rowDataLimit, 1, "Using default (default: Not set)");
 											} else {
-												layoutx.setHTML(rowDataLimit, 1, String.valueOf(a.getValue())+" (default: Not set)");
+												layoutx.setHTML(rowDataLimit, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString()+" (default: Not set)");
 											}
 											quotaChangeButton.addClickHandler(new ClickHandler() {
 												public void onClick(ClickEvent event) {
@@ -494,7 +495,7 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 										if (a.getValue().equalsIgnoreCase("null")) {
 											layoutx.setHTML(rowFilesQuota, 1, "Using default (default: error while loading)");
 										} else {
-											layoutx.setHTML(rowFilesQuota, 1, String.valueOf(a.getValue())+" (default: error while loading)");
+											layoutx.setHTML(rowFilesQuota, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString()+" (default: error while loading)");
 										}
 										quotaChangeButton.addClickHandler(new ClickHandler() {
 											public void onClick(ClickEvent event) {
@@ -509,10 +510,10 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 											if (resAttr.getFriendlyName().equalsIgnoreCase("defaultFilesLimit")) {
 												if (a.getValue().equalsIgnoreCase("null")) {
 													// null private + default
-													layoutx.setHTML(rowFilesQuota, 1, "Using default (default: "+resAttr.getValue()+")");
+													layoutx.setHTML(rowFilesQuota, 1, "Using default (default: "+SafeHtmlUtils.fromString((resAttr.getValue() != null) ? resAttr.getValue() : "").asString()+")");
 												} else {
 													// private + default
-													layoutx.setHTML(rowFilesQuota, 1, String.valueOf(a.getValue())+" (default: "+resAttr.getValue()+")");
+													layoutx.setHTML(rowFilesQuota, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString()+" (default: "+SafeHtmlUtils.fromString((resAttr.getValue() != null) ? resAttr.getValue() : "").asString()+")");
 												}
 												empty = false;
 												quotaChangeButton.addClickHandler(new ClickHandler() {
@@ -527,7 +528,7 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 											if (a.getValue().equalsIgnoreCase("null")) {
 												layoutx.setHTML(rowFilesQuota, 1, "Using default (default: Not set)");
 											} else {
-												layoutx.setHTML(rowFilesQuota, 1, String.valueOf(a.getValue())+" (default: Not set)");
+												layoutx.setHTML(rowFilesQuota, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString()+" (default: Not set)");
 											}
 											quotaChangeButton.addClickHandler(new ClickHandler() {
 												public void onClick(ClickEvent event) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfServiceUsersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfServiceUsersTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -195,7 +196,7 @@ public class SelfServiceUsersTabItem implements TabItem, TabItemWithUrl {
 					if (session.isSelf(user.getId())) {
 						session.getTabManager().addTab(new SelfDetailTabItem(user));
 					} else {
-						UiElements.generateAlert("You are not authorized", "You are not authorized to view personal details of user "+user.getFullNameWithTitles()+".");
+						UiElements.generateAlert("You are not authorized", "You are not authorized to view personal details of user "+ SafeHtmlUtils.fromString(user.getFullNameWithTitles()).asString()+".");
 					}
 				}
 			});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfVosTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfVosTabItem.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
@@ -177,7 +178,7 @@ public class SelfVosTabItem implements TabItem, TabItemWithUrl {
 
 		FlexTable voHeader = new FlexTable();
 		voHeader.setWidget(0, 0, new Image(LargeIcons.INSTANCE.buildingIcon()));
-		voHeader.setHTML(0, 1, "<p class=\"subsection-heading\">"+vo.getName()+"</p>");
+		voHeader.setHTML(0, 1, "<p class=\"subsection-heading\">"+ SafeHtmlUtils.fromString((vo.getName() != null) ? vo.getName() : "").asString()+"</p>");
 
 		final FlexTable voOverview = new FlexTable();
 		voOverview.setStyleName("inputFormFlexTableDark");
@@ -193,19 +194,21 @@ public class SelfVosTabItem implements TabItem, TabItemWithUrl {
 				for (Attribute a : attrs) {
 					if (a.getFriendlyName().equalsIgnoreCase("userManualsLink")) {
 						voOverview.setHTML(i, 0, "User's manuals:");
-						Anchor link = new Anchor(a.getValue(), a.getValue());
+						String val = SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString();
+						Anchor link = new Anchor(val, val);
 						link.getElement().setPropertyString("target", "_blank");
 						voOverview.setWidget(i, 1, link);
 						i++;
 					} else if (a.getFriendlyName().equalsIgnoreCase("dashboardLink")) {
 						voOverview.setHTML(i, 0, "Dashboard:");
-						Anchor link = new Anchor(a.getValue(), a.getValue());
+						String val = SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString();
+						Anchor link = new Anchor(val, val);
 						link.getElement().setPropertyString("target", "_blank");
 						voOverview.setWidget(i, 1, link);
 						i++;
 					} else if (a.getFriendlyName().equalsIgnoreCase("contactEmail")) {
 						voOverview.setHTML(i, 0, "VO contact:");
-						voOverview.setHTML(i, 1, a.getValue());
+						voOverview.setHTML(i, 1, SafeHtmlUtils.fromString((a.getValue() != null) ? a.getValue() : "").asString());
 						i++;
 					}
 				}
@@ -417,8 +420,8 @@ public class SelfVosTabItem implements TabItem, TabItemWithUrl {
 					groupsTable.setHTML(0, 0, "<strong>Name</strong>");
 					groupsTable.setHTML(0, 1, "<strong>Description</strong>");
 					for (int i=0; i<list.size(); i++){
-						groupsTable.setHTML(i+1, 0, list.get(i).getName());
-						groupsTable.setHTML(i+1, 1, list.get(i).getDescription());
+						groupsTable.setHTML(i+1, 0, SafeHtmlUtils.fromString(list.get(i).getName()).asString());
+						groupsTable.setHTML(i+1, 1, SafeHtmlUtils.fromString(list.get(i).getDescription()).asString());
 					}
 				}
 				});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserDetailTabItem.java
@@ -271,7 +271,7 @@ public class UserDetailTabItem implements TabItem, TabItemWithUrl {
 		layout.setCellSpacing(6);
 		// Add some standard form options
 		layout.setHTML(0, 0, "<strong>Full&nbsp;name:</strong>");
-		layout.setHTML(0, 1, user.getFullNameWithTitles());
+		layout.setHTML(0, 1, SafeHtmlUtils.fromString((user.getFullNameWithTitles() != null) ? user.getFullNameWithTitles() : "").asString());
 		layout.setWidget(0, 2, change);
 		layout.setHTML(0, 3, "<strong>User&nbsp;ID:</strong>");
 		layout.setHTML(0, 4, String.valueOf(user.getId()));
@@ -570,7 +570,7 @@ public class UserDetailTabItem implements TabItem, TabItemWithUrl {
 				entryPanel.setSize("100%", "100%");
 				subContent.setWidget(entryPanel);
 
-				voLabel.setHTML(SafeHtmlUtils.fromSafeConstant("<h2>" + listbox.getSelectedObject().getName() + "</h2>"));
+				voLabel.setHTML(SafeHtmlUtils.fromSafeConstant("<h2>" + SafeHtmlUtils.fromString((listbox.getSelectedObject().getName() != null) ? listbox.getSelectedObject().getName() : "").asString() + "</h2>"));
 				voLabel.setTargetHistoryToken(session.getTabManager().getLinkForTab(new VoDetailTabItem(listbox.getSelectedObject())));
 
 				// detail header
@@ -880,9 +880,9 @@ public class UserDetailTabItem implements TabItem, TabItemWithUrl {
 					if (a.getBaseFriendlyName().equalsIgnoreCase("login-namespace")) {
 						if (a.getValueAsObject() != null) {
 							// name
-							innerTable.setHTML(rowCount, 0, "<strong>"+a.getDisplayName()+"</strong>");
+							innerTable.setHTML(rowCount, 0, "<strong>"+SafeHtmlUtils.fromString(a.getDisplayName()).asString()+"</strong>");
 							// value
-							innerTable.setHTML(rowCount, 1, a.getValue());
+							innerTable.setHTML(rowCount, 1, SafeHtmlUtils.fromString(a.getValue()).asString());
 							// change password
 							if (Utils.getSupportedPasswordNamespaces().contains(a.getFriendlyNameParameter())) {
 								CustomButton cb = new CustomButton("Change password…", SmallIcons.INSTANCE.keyIcon(), new ClickHandler(){
@@ -993,7 +993,7 @@ public class UserDetailTabItem implements TabItem, TabItemWithUrl {
 		entryPanel.setSize("100%", "100%");
 		subContent.setWidget(entryPanel);
 
-		facilityLabel.setHTML(SafeHtmlUtils.fromSafeConstant("<h2>" + listbox.getSelectedObject().getName() + "</h2>"));
+		facilityLabel.setHTML(SafeHtmlUtils.fromSafeConstant("<h2>" + SafeHtmlUtils.fromString((listbox.getSelectedObject().getName() != null) ? listbox.getSelectedObject().getName() : "").asString() + "</h2>"));
 		facilityLabel.setTargetHistoryToken(session.getTabManager().getLinkForTab(new FacilityDetailTabItem(listbox.getSelectedObject())));
 
 		final GetAttributesV2 attributes = new GetAttributesV2();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserExtSourceDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserExtSourceDetailTabItem.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.webgui.tabs.userstabs;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.AbsolutePanel;
 import com.google.gwt.user.client.ui.FlexTable;
@@ -114,12 +115,12 @@ public class UserExtSourceDetailTabItem implements TabItem, TabItemWithUrl {
 			menu.setHTML(0, column, "&nbsp;");
 			menu.getFlexCellFormatter().setWidth(0, column, "25px");
 			column++;
-			menu.setHTML(0, column, "<strong>ES name:</strong><br/><span class=\"inputFormInlineComment\">"+userExtSource.getExtSource().getName()+"</span>");
+			menu.setHTML(0, column, "<strong>ES name:</strong><br/><span class=\"inputFormInlineComment\">"+ SafeHtmlUtils.fromString((userExtSource.getExtSource().getName() != null) ? userExtSource.getExtSource().getName() : "").asString()+"</span>");
 			column++;
 			menu.setHTML(0, column, "&nbsp;");
 			menu.getFlexCellFormatter().setWidth(0, column, "25px");
 			column++;
-			menu.setHTML(0, column, "<strong>ES type:</strong><br/><span class=\"inputFormInlineComment\">"+userExtSource.getExtSource().getType()+"</span>");
+			menu.setHTML(0, column, "<strong>ES type:</strong><br/><span class=\"inputFormInlineComment\">"+SafeHtmlUtils.fromString((userExtSource.getExtSource().getType() != null) ? userExtSource.getExtSource().getType() : "").asString()+"</span>");
 		}
 
 		dp.add(menu);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoExtSourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoExtSourceTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JsArray;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -206,7 +207,7 @@ public class AddVoExtSourceTabItem implements TabItem, TabItemWithUrl{
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getName()).asString());
 		}
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -244,7 +245,7 @@ public class AddVoManagerTabItem implements TabItem {
 		alreadyAdded.setVisible(!alreadyAddedList.isEmpty());
 		alreadyAdded.setWidget(new HTML("<strong>Already added: </strong>"));
 		for (int i=0; i<alreadyAddedList.size(); i++) {
-			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + alreadyAddedList.get(i).getFullName());
+			alreadyAdded.getWidget().getElement().setInnerHTML(alreadyAdded.getWidget().getElement().getInnerHTML()+ ((i!=0) ? ", " : "") + SafeHtmlUtils.fromString(alreadyAddedList.get(i).getFullName()).asString());
 		}
 
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/EditVoDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/EditVoDetailsTabItem.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.webgui.tabs.vostabs;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -121,7 +122,7 @@ public class EditVoDetailsTabItem implements TabItem {
 
 		// Add some standard form options
 		layout.setHTML(0, 0, "Short name:");
-		layout.setHTML(0, 1, vo.getShortName());
+		layout.setHTML(0, 1, SafeHtmlUtils.fromString((vo.getShortName() != null) ? vo.getShortName() : "").asString());
 		layout.setHTML(1, 0, "Name:");
 		layout.setWidget(1, 1, nameTextBox);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoDetailTabItem.java
@@ -5,6 +5,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -149,7 +150,7 @@ public class VoDetailTabItem implements TabItem, TabItemWithUrl{
 			menu.getFlexCellFormatter().setWidth(0, column, "25px");
 			column++;
 
-			menu.setHTML(0, column, "<strong>Short&nbsp;name:</strong><br/><span class=\"inputFormInlineComment\">"+vo.getShortName()+"</span>");
+			menu.setHTML(0, column, "<strong>Short&nbsp;name:</strong><br/><span class=\"inputFormInlineComment\">"+ SafeHtmlUtils.fromString((vo.getShortName() != null) ? vo.getShortName() : "").asString()+"</span>");
 
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/AddRemoveItemsTable.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/AddRemoveItemsTable.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.webgui.widgets;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
@@ -146,11 +147,11 @@ public class AddRemoveItemsTable<T extends JavaScriptObject> extends Composite {
 			});
 
 			if (vertical) {
-				ft.setHTML(row, 0, name);
+				ft.setHTML(row, 0, SafeHtmlUtils.fromString(name).asString());
 				ft.setWidget(row, 1, rb);
 				row++;
 			} else {
-				ft.setHTML(row, column, name);
+				ft.setHTML(row, column, SafeHtmlUtils.fromString(name).asString());
 				ft.setWidget(row, column+1, rb);
 				column = column + 2;
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/BreadcrumbsWidget.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/BreadcrumbsWidget.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.webgui.widgets;
 
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.mainmenu.MainMenu;
 import cz.metacentrum.perun.webgui.client.resources.LargeIcons;
@@ -33,6 +34,9 @@ public class BreadcrumbsWidget extends Composite {
 	}
 
 	public void setLocation(int menuSectionRole, String main, String mainLink, String sub, String subLink) {
+
+		sub = SafeHtmlUtils.fromString(sub).asString();
+		main = SafeHtmlUtils.fromString(main).asString();
 
 		mainWidget.clear();
 
@@ -92,6 +96,8 @@ public class BreadcrumbsWidget extends Composite {
 
 	public void setLocation(VirtualOrganization vo, String subSection, String subSectionLink) {
 
+		subSection = SafeHtmlUtils.fromString(subSection).asString();
+
 		mainWidget.clear();
 
 		Image image = new Image(LargeIcons.INSTANCE.buildingIcon());
@@ -128,6 +134,8 @@ public class BreadcrumbsWidget extends Composite {
 	}
 
 	public void setLocation(Facility facility, String subSection, String subSectionLink) {
+
+		subSection = SafeHtmlUtils.fromString(subSection).asString();
 
 		mainWidget.clear();
 
@@ -166,6 +174,8 @@ public class BreadcrumbsWidget extends Composite {
 
 	public void setLocation(User user, String subSection, String subSectionLink) {
 
+		subSection = SafeHtmlUtils.fromString(subSection).asString();
+
 		mainWidget.clear();
 
 		Image image = new Image(LargeIcons.INSTANCE.userGrayIcon());
@@ -203,6 +213,8 @@ public class BreadcrumbsWidget extends Composite {
 
 	public void setLocation(Group group, String subSection, String subSectionLink) {
 
+		subSection = SafeHtmlUtils.fromString(subSection).asString();
+
 		mainWidget.clear();
 
 		Image image = new Image(LargeIcons.INSTANCE.groupIcon());
@@ -239,6 +251,8 @@ public class BreadcrumbsWidget extends Composite {
 	}
 
 	public void setLocation(SecurityTeam securityTeam, String subSection, String subSectionLink) {
+
+		subSection = SafeHtmlUtils.fromString(subSection).asString();
 
 		mainWidget.clear();
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/ListBoxWithObjects.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/ListBoxWithObjects.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.webgui.widgets;
 
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.ListBox;
 import cz.metacentrum.perun.webgui.client.localization.WidgetTranslation;
 
@@ -145,7 +146,8 @@ public class ListBoxWithObjects<T> extends ListBox {
 	 */
 	public void addItem(T value){
 		this.objects.add(value);
-		this.addItem(this.getValueName(value));
+		String val = this.getValueName(value);
+		this.addItem(SafeHtmlUtils.fromString((val != null) ? val : "").asString());
 	}
 
 	/**
@@ -156,7 +158,7 @@ public class ListBoxWithObjects<T> extends ListBox {
 	 */
 	public void addItem(T value, String label){
 		this.objects.add(value);
-		this.addItem(label);
+		this.addItem(SafeHtmlUtils.fromString((label != null) ? label : "").asString());
 	}
 
 	/**
@@ -187,7 +189,8 @@ public class ListBoxWithObjects<T> extends ListBox {
 	 */
 	public void insertItem(T value, int index)
 	{
-		super.insertItem(this.getValueName(value), index);
+		String val = this.getValueName(value);
+		super.insertItem(SafeHtmlUtils.fromString((val != null) ? val : "").asString(), index);
 		this.objects.add(index, value);
 	}
 
@@ -210,7 +213,8 @@ public class ListBoxWithObjects<T> extends ListBox {
 	 */
 	public void setValue(int index, T value)
 	{
-		super.setValue(index,this.getValueName(value));
+		String val = this.getValueName(value);
+		super.setValue(index,SafeHtmlUtils.fromString((val != null) ? val : "").asString());
 		this.objects.set(index, value);
 
 	}


### PR DESCRIPTION
- Sanitize HTML output when displaying data entered by users,
  like object names and descriptions.
- Whenever input is not ID or enum, use SafeHtmlUtils.