### PR TITLE
Fix user common name for LDAP

### DIFF
--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/beans/PerunInitializer.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/beans/PerunInitializer.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.ldapc.initializer.beans;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.ldapc.initializer.utils.Utils;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
@@ -27,6 +28,7 @@ public class PerunInitializer {
 	private final PerunPrincipal perunPrincipal;
 	private final BufferedWriter outputWriter;
 	private final String consumerName = "ldapcConsumer";
+	private final String ldapcPropertyFile = "/etc/perun/perun-ldapc.properties";
 
 	public PerunInitializer(String outputFileName) throws InternalErrorException, FileNotFoundException {
 		this.perunPrincipal = new PerunPrincipal("perunLdapInitializer", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
@@ -58,6 +60,10 @@ public class PerunInitializer {
 
 	public String getConsumerName() {
 		return consumerName;
+	}
+
+	public String getLdapBase() throws InternalErrorException {
+		return BeansUtils.getPropertyFromCustomConfiguration(ldapcPropertyFile, "ldap.base");
 	}
 
 	public void closeWriter() throws IOException {

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/main/Main.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/main/Main.java
@@ -42,8 +42,7 @@ public class Main {
 	 * GroupOfUniqueNames object class is not supported in new instances of perun LDAP
 	 *
 	 * @param fileName if not null, use file for generating. if null use stdout
-	 * @param newLDAPversion if true, then do not use GroupOfUniqueNames object class
-	 * 
+	 *
 	 * @throws InternalErrorException
 	 */
 	public Main(String fileName) throws InternalErrorException {

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
@@ -346,10 +346,11 @@ public class Utils {
 			dn+= "perunUserId=" + user.getId() + ",ou=People,dc=perun,dc=cesnet,dc=cz";
 			String firstName = user.getFirstName();
 			String lastName = user.getLastName();
-			if(firstName == null) firstName = "";
+			if(firstName == null || firstName.isEmpty()) firstName = "";
+			else cn+= firstName + " ";
 			if(lastName == null || lastName.isEmpty()) lastName = "N/A";
 			sn+= lastName;
-			cn+= firstName + " " + lastName;
+			cn+= lastName;
 			if(user.isServiceUser()) isServiceUser+= "1";
 			else isServiceUser+= "0";
 			if(user.isSponsoredUser()) isSponsoredUser+= "1";

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
@@ -84,6 +84,8 @@ public class Utils {
 		if(perunInitializer == null) throw new InternalErrorException("PerunInitializer must be loaded before using in generating methods!");
 		PerunSession perunSession = perunInitializer.getPerunSession();
 		PerunBl perun = perunInitializer.getPerunBl();
+		String ldapBase = perunInitializer.getLdapBase();
+		String branchOuPeople = "ou=People," + ldapBase;
 		BufferedWriter writer = perunInitializer.getOutputWriter();
 
 		//Get list of all vos
@@ -101,7 +103,7 @@ public class Utils {
 			perunVoId+= String.valueOf(vo.getId());
 			o+= vo.getShortName();
 			desc+= vo.getName();
-			dn+= "perunVoId=" + vo.getId() + ",dc=perun,dc=cesnet,dc=cz";
+			dn+= "perunVoId=" + vo.getId() + "," + ldapBase;
 			writer.write(dn + '\n');
 			writer.write(oc1 + '\n');
 			writer.write(oc2 + '\n');
@@ -112,7 +114,7 @@ public class Utils {
 			//Generate all members in member groups of this vo and add them here (only members with status Valid)
 			List<Member> validMembers = perun.getMembersManagerBl().getMembers(perunSession, vo, Status.VALID);
 			for(Member m: validMembers) {
-				writer.write("uniqueMember: perunUserId=" + m.getUserId() + ",ou=People,dc=perun,dc=cesnet,dc=cz" + '\n');
+				writer.write("uniqueMember: perunUserId=" + m.getUserId() + "," + branchOuPeople + '\n');
 			}
 			writer.write('\n');
 		}
@@ -132,6 +134,7 @@ public class Utils {
 		if(perunInitializer == null) throw new InternalErrorException("PerunInitializer must be loaded before using in generating methods!");
 		PerunSession perunSession = perunInitializer.getPerunSession();
 		PerunBl perun = perunInitializer.getPerunBl();
+		String ldapBase = perunInitializer.getLdapBase();
 		BufferedWriter writer = perunInitializer.getOutputWriter();
 
 		//first get all Vos
@@ -169,7 +172,7 @@ public class Utils {
 				perunVoId+= String.valueOf(resource.getVoId());
 				perunFacilityId+= String.valueOf(resource.getFacilityId());
 				perunResourceId+= String.valueOf(resource.getId());
-				dn+= "perunResourceId=" + resource.getId() + ",perunVoId=" + resource.getVoId() + ",dc=perun,dc=cesnet,dc=cz";
+				dn+= "perunResourceId=" + resource.getId() + ",perunVoId=" + resource.getVoId() + "," + ldapBase;
 				cn+= resource.getName();
 				String descriptionValue = resource.getDescription();
 				if(descriptionValue != null) {
@@ -209,6 +212,8 @@ public class Utils {
 		if(perunInitializer == null) throw new InternalErrorException("PerunInitializer must be loaded before using in generating methods!");
 		PerunSession perunSession = perunInitializer.getPerunSession();
 		PerunBl perun = perunInitializer.getPerunBl();
+		String ldapBase = perunInitializer.getLdapBase();
+		String branchOuPeople = "ou=People," + ldapBase;
 		BufferedWriter writer = perunInitializer.getOutputWriter();
 
 		//First get all vos
@@ -234,7 +239,7 @@ public class Utils {
 				members = perun.getGroupsManagerBl().getGroupMembers(perunSession, group, Status.VALID);
 				perunGroupId+= String.valueOf(group.getId());
 				perunVoId+= String.valueOf(group.getVoId());
-				dn+= "perunGroupId=" + group.getId() + ",perunVoId=" + group.getVoId() + ",dc=perun,dc=cesnet,dc=cz";
+				dn+= "perunGroupId=" + group.getId() + ",perunVoId=" + group.getVoId() + "," + ldapBase;
 				cn+= group.getName();
 				perunUniqueGroupName+= vo.getShortName() + ":" + group.getName();
 				String descriptionValue = group.getDescription();
@@ -243,7 +248,7 @@ public class Utils {
 				}
 				if(group.getParentGroupId() != null) {
 					parentGroupId+= group.getParentGroupId();
-					parentGroup+= "perunGroupId=" + group.getParentGroupId()+ ",perunVoId=" + group.getVoId() + ",dc=perun,dc=cesnet,dc=cz";
+					parentGroup+= "perunGroupId=" + group.getParentGroupId()+ ",perunVoId=" + group.getVoId() + "," + ldapBase;
 				}
 				List<Member> admins = new ArrayList<>();
 				writer.write(dn + '\n');
@@ -260,7 +265,7 @@ public class Utils {
 				}
 				//ADD Group Members
 				for(Member m: members) {
-					writer.write("uniqueMember: " + "perunUserId=" + m.getUserId() + ",ou=People,dc=perun,dc=cesnet,dc=cz");
+					writer.write("uniqueMember: " + "perunUserId=" + m.getUserId() + "," + branchOuPeople);
 					writer.write('\n');
 				}
 				//ADD resources which group is assigned to
@@ -293,6 +298,8 @@ public class Utils {
 		if(perunInitializer == null) throw new InternalErrorException("PerunInitializer must be loaded before using in generating methods!");
 		PerunSession perunSession = perunInitializer.getPerunSession();
 		PerunBl perun = perunInitializer.getPerunBl();
+		String ldapBase = perunInitializer.getLdapBase();
+		String branchOuPeople = "ou=People," + ldapBase;
 		BufferedWriter writer = perunInitializer.getOutputWriter();
 
 		List<User> users = perun.getUsersManagerBl().getUsers(perunSession);
@@ -329,7 +336,7 @@ public class Utils {
 					List<Group> groups;
 					groups = perun.getGroupsManagerBl().getAllMemberGroups(perunSession, member);
 					for(Group group: groups) {
-						membersOf.add("memberOf: " + "perunGroupId=" + group.getId() + ",perunVoId=" + group.getVoId() + ",dc=perun,dc=cesnet,dc=cz");
+						membersOf.add("memberOf: " + "perunGroupId=" + group.getId() + ",perunVoId=" + group.getVoId() + "," + ldapBase);
 					}
 				}
 			}
@@ -343,7 +350,7 @@ public class Utils {
 			Attribute attrLibraryIDs = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_DEF + ":libraryIDs");
 			Attribute attrPhone = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_DEF + ":phone");
 			perunUserId+= String.valueOf(user.getId());
-			dn+= "perunUserId=" + user.getId() + ",ou=People,dc=perun,dc=cesnet,dc=cz";
+			dn+= "perunUserId=" + user.getId() + "," + branchOuPeople;
 			String firstName = user.getFirstName();
 			String lastName = user.getLastName();
 			if(firstName == null || firstName.isEmpty()) firstName = "";

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
@@ -712,10 +712,13 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 				List<Pair<String,String>> replaceList = new ArrayList<Pair<String, String>>();
 				String firstName = this.user.getFirstName();
 				String lastName = this.user.getLastName();
-				if(firstName == null) firstName = "";
+				String commonName = "";
+				if(firstName == null || firstName.isEmpty()) firstName = "";
+				else commonName+= firstName + " ";
 				if(lastName == null || lastName.isEmpty()) lastName = "N/A";
+				commonName+=lastName;
 				replaceList.add(new Pair(ldapAttrSurname,lastName));
-				replaceList.add(new Pair(ldapAttrCommonName, firstName + " " + lastName));
+				replaceList.add(new Pair(ldapAttrCommonName, commonName));
 				// IF firstName is empty, maybe need to be removed first
 				if(firstName.isEmpty()) {
 					//if first name exists and new one is empty, then remove it, else do nothing

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/LdapConnectorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/LdapConnectorImpl.java
@@ -288,14 +288,17 @@ public class LdapConnectorImpl implements LdapConnector {
 
 		String firstName = user.getFirstName();
 		String lastName = user.getLastName();
-		if(firstName == null) firstName = "";
+		String commonName = "";
+		if(firstName == null || firstName.isEmpty()) firstName = "";
+		else commonName+= firstName + " ";
 		if(lastName == null || lastName.isEmpty()) lastName = "N/A";
+		commonName+= lastName;
 
 		// Add attributes
 		attributes.put(objClasses);
 		attributes.put(EventProcessorImpl.ldapAttrEntryStatus, "active");
 		attributes.put(EventProcessorImpl.ldapAttrSurname, lastName);
-		attributes.put(EventProcessorImpl.ldapAttrCommonName, firstName + " " + lastName);
+		attributes.put(EventProcessorImpl.ldapAttrCommonName, commonName);
 		if(!firstName.isEmpty()) attributes.put(EventProcessorImpl.ldapAttrGivenName, firstName);
 		attributes.put(EventProcessorImpl.ldapAttrPerunUserId, String.valueOf(user.getId()));
 		if(user.isServiceUser()) attributes.put(EventProcessorImpl.ldapAttrIsServiceUser, "1");


### PR DESCRIPTION
 - common name for user is created from firstName na lastName, but
   firstName can be empty so in such case we need to also skip adding
   an empty space between empty firstName and not empty lastName
 - this problem was fixed in LDAPc-initializer, in LDAPc when creating
   new user and when updating existing user name