### PR TITLE
Revert of removing empty line after every object in LDAPc-initializer

### DIFF
--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
@@ -274,6 +274,7 @@ public class Utils {
 					writer.write("assignedToResourceId: " + r.getId());
 					writer.write('\n');
 				}
+				writer.write('\n');
 			}
 		}
 	}


### PR DESCRIPTION
 - there was removed empty space after object Group generated by
   LDAPc-initializer in commit d2b2adaf704335fbfe0b33bc356c20ff289d4cda
   but we need it there, so revert this removing