### PR TITLE
Use loginNamespace from property file without setting to LowerCase

### DIFF
--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/beans/PerunInitializer.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/beans/PerunInitializer.java
@@ -67,7 +67,7 @@ public class PerunInitializer {
 	}
 
 	public String getLoginNamespace() throws InternalErrorException {
-		return BeansUtils.getPropertyFromCustomConfiguration(ldapcPropertyFile, "ldap.loginNamespace").toLowerCase();
+		return BeansUtils.getPropertyFromCustomConfiguration(ldapcPropertyFile, "ldap.loginNamespace");
 	}
 
 	public void closeWriter() throws IOException {

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/utils/Utils.java
@@ -452,7 +452,7 @@ public class Utils {
 					if(loginNamespace != null && loginNamespaceAttribute.getValue() != null) {
 						String loginNamespaceAttributeValue = (String) loginNamespaceAttribute.getValue();
 						writer.write("login;x-ns-" + loginNamespaceAttribute.getFriendlyNameParameter() + ": " + loginNamespaceAttributeValue + '\n');
-						if(loginNamespaceAttribute.getFriendlyNameParameter().equals(loginNamespace)) {
+						if(loginNamespaceAttribute.getFriendlyNameParameter().toLowerCase().equals(loginNamespace.toLowerCase())) {
 							writer.write(userPassword + "{SASL}" + loginNamespaceAttributeValue  + '@' + loginNamespace + '\n');
 						}
 					}


### PR DESCRIPTION
 - we want to use the same value from property file when setting
   namespace for password, so we don't want to use it in lower-case
   format
 - we want to use lower-case format only when trying to equal namespace
   from perun with namespace from property file (ldap)