### PR TITLE
Add more debuggin for method resolveVirtualAttributeValueChange

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
@@ -163,6 +163,7 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource<T extends U
 		if (allAttributesRemovedForUserExtSource.matcher(message).find() ||
 				removeUserExtSourceAttribute.matcher(message).find() ||
 				setUserExtSourceAttribute.matcher(message).find()) {
+			log.debug("Resolving virtual attribute value change for attribute " + this.getSourceAttributeFriendlyName() + " and message: " + message);
 			User user = perunSession.getPerunBl().getModulesUtilsBl().getUserFromMessage(perunSession, message);
 			if (user != null) {
 				Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, user, getDestinationAttributeName());
@@ -176,6 +177,7 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource<T extends U
 				}
 				resolvingMessages.add(messageAttributeSet);
 			}
+			if(!resolvingMessages.isEmpty()) log.debug("These new messages will be generated: " + resolvingMessages);
 		}
 
 		return resolvingMessages;


### PR DESCRIPTION
 - result of manual testing of funcionality around method
   resolveVirtualAttributeValueChange in class
   UserVirtualAttributeCollectedFromUserExtSource showed that sometimes
   message about changing value of virtual attribute hasn't been
   generated. So we need more debug information to understand if problem
   is in the method itself or in the functionality around it (Auditer).