### PR TITLE
Change parametrization for executing ldapc-initializer from command line

### DIFF
--- a/perun-ldapc-initializer/pom.xml
+++ b/perun-ldapc-initializer/pom.xml
@@ -97,6 +97,11 @@
 			<artifactId>perun-rpc-lib</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/main/Main.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/main/Main.java
@@ -8,6 +8,12 @@ import cz.metacentrum.perun.ldapc.initializer.beans.PerunInitializer;
 import cz.metacentrum.perun.ldapc.initializer.utils.Utils;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,19 +28,47 @@ public class Main {
 	private final static Logger log = LoggerFactory.getLogger(Main.class);
 
 	public static void main(String[] args) throws Exception {
-		//Default is old version and stdout (null file)
-		String fileName = null;
+		//no options means - output to stdout and without changing processed id
+		String outputFile = null;
+		Boolean changeProcessedId = false;
 
-		if(args.length > 1 || args.length == 0) {
-			System.out.println(help());
-		} else if(args[0].equals("-h") || args[0].equals("--help")) {
-			System.out.println(help());
-		} else {
-			fileName = args[0];
-			Main main;
-			main = new Main(fileName);
+		//prepare optional command line options for ldapc initializer
+		Options options = new Options();
+		options.addOption(Option.builder("f").required(false).hasArg().longOpt("outputFile").desc("If set, then define output file to which will be perun ldif content file generated.").build());
+		options.addOption(Option.builder("c").required(false).longOpt("changeProcessedId").desc("If set, then change processed id after finishing of content file generation.").build());
+		options.addOption(Option.builder("h").required(false).longOpt("help").desc("If set, return help (always).").build());
+
+		//parse options
+		CommandLine commandLine;
+		try {
+			commandLine = new DefaultParser().parse(options, args);
+		} catch (MissingOptionException ex) {
+			System.out.println(ex.getMessage());
+			System.exit(1);
+			return;
 		}
+
+		//return help always if option "h" or "help" is set
+		if (commandLine.hasOption("h")) {
+			new HelpFormatter().printHelp("Perun ldapc-initializer:", options);
+			System.exit(0);
+			return;
+		}
+
+		//set path to file if option "f" is set
+		if(commandLine.hasOption("f")) {
+			outputFile = commandLine.getOptionValue("f");
+		}
+
+		//set changing processed id to true if option "c" is set
+		if(commandLine.hasOption("c")) {
+			changeProcessedId = true;
+		}
+
+		//call main with parsed options or with default settings
+		new Main(outputFile, changeProcessedId);
 	}
+
 
 	/**
 	 * Main class for purpose of generating LDIF
@@ -42,10 +76,11 @@ public class Main {
 	 * GroupOfUniqueNames object class is not supported in new instances of perun LDAP
 	 *
 	 * @param fileName if not null, use file for generating. if null use stdout
+	 * @param changeProcessedId if true, then change processed id for ldapc on the end of initialization, if false don't change it
 	 *
 	 * @throws InternalErrorException
 	 */
-	public Main(String fileName) throws InternalErrorException {
+	public Main(String fileName, Boolean changeProcessedId) throws InternalErrorException {
 		PerunInitializer perunInitializer = null;
 		try {
 			try {
@@ -59,8 +94,8 @@ public class Main {
 			}
 
 			//get last message id before start of initializing
-			int LastMessageBeforeInitializingData = perunInitializer.getPerunBl().getAuditer().getLastMessageId();
-			System.err.println("Last message id before starting initializing: " + LastMessageBeforeInitializingData + '\n');
+			int lastMessageBeforeInitializingData = perunInitializer.getPerunBl().getAuditer().getLastMessageId();
+			System.err.println("Last message id before starting initializing: " + lastMessageBeforeInitializingData + '\n');
 
 			try {
 				Utils.generateAllVosToWriter(perunInitializer);
@@ -68,7 +103,7 @@ public class Main {
 				Utils.generateAllResourcesToWriter(perunInitializer);
 				Utils.generateAllUsersToWriter(perunInitializer);
 			} catch (IOException ex) {
-				System.err.println("Last message id before starting initializing: " + LastMessageBeforeInitializingData + '\n');
+				System.err.println("Last message id before starting initializing: " + lastMessageBeforeInitializingData + '\n');
 				throw new InternalErrorException(ex);
 			} catch (AttributeNotExistsException | WrongAttributeAssignmentException ex) {
 				System.err.println("Problem with initializing users, there is an attribute which probably not exists.");
@@ -76,16 +111,18 @@ public class Main {
 			}
 
 			//get last message id after initializing
-			int LastMessageAfterInitializingData = perunInitializer.getPerunBl().getAuditer().getLastMessageId();
-			System.err.println("Last message id after initializing: " + LastMessageAfterInitializingData + '\n');
+			int lastMessageAfterInitializingData = perunInitializer.getPerunBl().getAuditer().getLastMessageId();
+			System.err.println("Last message id after initializing: " + lastMessageAfterInitializingData + '\n');
 
 			//This is the only operation of WRITING to the DB
 			//Call RPC-LIB for this purpose
-			try {
-				Utils.setLastProcessedId(perunInitializer.getPerunPrincipal(), perunInitializer.getConsumerName(), LastMessageAfterInitializingData);
-			} catch (InternalErrorException | PrivilegeException ex) {
-				System.err.println("Can't set last processed ID because of lack of privileges or some Internal error.");
-				throw new InternalErrorException(ex);
+			if(changeProcessedId) {
+				try {
+					Utils.setLastProcessedId(perunInitializer.getPerunPrincipal(), perunInitializer.getConsumerName(), lastMessageAfterInitializingData);
+				} catch (InternalErrorException | PrivilegeException ex) {
+					System.err.println("Can't set last processed ID because of lack of privileges or some Internal error.");
+					throw new InternalErrorException(ex);
+				}
 			}
 		} finally {
 			//Close writer if already opened
@@ -100,25 +137,5 @@ public class Main {
 		}
 
 		System.err.println("Generating of initializing LDIF done without error!");
-	}
-
-	/**
-	 * Message with help about usage.
-	 *
-	 * @return message with help
-	 */
-	private static String help() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("--------------HELP-------------");
-		sb.append('\n');
-		sb.append("-g           =>  generate ldif to stdout");
-		sb.append('\n');
-		sb.append("-gnew        =>  generate ldif without objectClass groupOfUniqueNames to stdout");
-		sb.append('\n');
-		sb.append("-g [file]    =>  generate ldif to file");
-		sb.append('\n');
-		sb.append("-gnew [file] =>  generate ldif without objectClass groupOfUniqueNames to file");
-		sb.append('\n');
-		return sb.toString();
 	}
 }


### PR DESCRIPTION
 - use apache.commons libraries to parse options from main class
   arguments (from command line)
 - add new option for setting if lastProcessedId for ldapcConsumer
   should be changed or not (default is not)