### PR TITLE
added check that Attribute has current AttributeDefinition fields

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributeDefinition.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributeDefinition.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.core.api;
 
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+
 /**
  * This class represents definition of attribute. All attributes comes from some definition.
  * Attribute definition is attribute without connection to some object.
@@ -194,6 +196,20 @@ public class AttributeDefinition extends Auditable implements Comparable<PerunBe
 		final AttributeDefinition other = (AttributeDefinition) obj;
 
 		return this.getId() == other.getId() && (this.friendlyName == null ? other.friendlyName == null : this.friendlyName.equals(other.friendlyName));
+	}
+
+	/**
+	 * Compares this instance to other instance, throws exception if they are different.
+	 * Used to check that Attribute has correct AttributeDefinition fields.
+	 *
+	 * @param a other instance to be checked for equality
+	 * @throws ConsistencyErrorException thrown if any of class attributes differ
+	 */
+	public void checkEquality(AttributeDefinition a) throws ConsistencyErrorException {
+		if (!this.getFriendlyName().equals(a.getFriendlyName())) throw new ConsistencyErrorException("attribute friendlyName is altered");
+		if (!this.getNamespace().equals(a.getNamespace())) throw new ConsistencyErrorException("attribute namespace is altered");
+		if (!this.getType().equals(a.getType())) throw new ConsistencyErrorException("attribute type is altered");
+		if (this.isUnique() != a.isUnique()) throw new ConsistencyErrorException("attribute unique flag is altered");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1778,6 +1778,12 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	private boolean setAttributeInDB(final PerunSession sess, final Attribute attribute, final String tableName, List<String> columnNames, List<Object> columnValues) throws InternalErrorException {
 		try {
+			//check that attribute definition is current, non-altered by upper tiers
+			getAttributeDefinitionById(sess, attribute.getId()).checkEquality(attribute);
+		} catch (AttributeNotExistsException e) {
+			throw new InternalErrorException("cannot verify attribute definition",e);
+		}
+		try {
 			// deleting the attibute if the given attribute value is null
 			if (attribute.getValue() == null) {
 				int numAffected = jdbc.update("delete from " + tableName + " where " + buildParameters(columnNames, "=?", " and "), columnValues.toArray());


### PR DESCRIPTION
GUI may send Attribute with incorrect AttributeDefiniton fields, e.g. unique or type. This adds code that compares the Attribute with a fresh copy of AttributeDefinition obtained from database and throws an exception if any inconsistency is found.