### PR TITLE
REGISTRAR: Fill first/lastName from fed values

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2252,6 +2252,11 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				// We do require value from IDP (federation) if attribute is supposed to be pre-filled and item is required and not editable to users
 				if ((itemW.getPrefilledValue() == null || itemW.getPrefilledValue().isEmpty()) && itemW.getFormItem().isRequired() &&
 						(Type.FROM_FEDERATION_HIDDEN.equals(itemW.getFormItem().getType()) || Type.FROM_FEDERATION_SHOW.equals(itemW.getFormItem().getType()))) {
+
+					if (URN_USER_DISPLAY_NAME.equals(item.getPerunDestinationAttribute())) {
+						log.error("Couldn't resolve displayName from: {}, parsedNames were: {}", federValues, parsedName);
+					}
+
 					itemsWithMissingData.add(itemW);
 				}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2720,9 +2720,15 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			parsedName = Utils.parseCommonName(commonName);
 		} else {
 			parsedName = new HashMap<String, String>();
+		}
+		// try to fill if initial parsing failed -> returned null
+		if (parsedName.get("firstName") == null) {
 			parsedName.put("firstName", federValues.get(shibFirstNameVar));
+		}
+		if (parsedName.get("lastName") == null) {
 			parsedName.put("lastName", federValues.get(shibLastNameVar));
 		}
+
 		return parsedName;
 
 	}


### PR DESCRIPTION
- Even if value for displayName or commonName was provided, parsing
  could return null values for first/lastName.
  So now we check, if its keys are null and then we parse them
  from giveName and sn directly.