### PR TITLE
REGISTRAR: Source IdP is stored in originIdentityProvider

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2265,7 +2265,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 		if (!itemsWithMissingData.isEmpty() && extSourceType.equals(ExtSourcesManager.EXTSOURCE_IDP)) {
 			// throw exception only if user is logged-in by Federation IDP
-			String IDP = federValues.get("Shib-Identity-Provider");
+			String IDP = federValues.get("originIdentityProvider");
 			log.error("[REGISTRAR] IDP {} doesn't provide data for following form items: {}", IDP, itemsWithMissingData);
 			throw new MissingRequiredDataException("Your IDP doesn't provide data required by this application form.", itemsWithMissingData);
 		}


### PR DESCRIPTION
- IdP entityId (ext source name) is stored under key
  "originIdentityProvider" in additionalInformation in session,
  instead of original key "Shib-Identity-Provider".