### PR TITLE
CABINET, GUI: Improved work with publication systems on import

### DIFF
--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/CabinetManager.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/CabinetManager.java
@@ -93,10 +93,12 @@ public interface CabinetManager {
 	/**
 	 * Get all PublicationSystems in Perun. If none, return empty list.
 	 *
+	 *
+	 * @param session PerunSession with authorization
 	 * @return List of all PublicationSystems or empty list.
 	 * @throws InternalErrorException When implementation fails
 	 */
-	List<PublicationSystem> getPublicationSystems() throws InternalErrorException;
+	List<PublicationSystem> getPublicationSystems(PerunSession session) throws InternalErrorException;
 
 
 	// category -------------------------------------

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/api/impl/CabinetManagerImpl.java
@@ -140,8 +140,19 @@ public class CabinetManagerImpl implements CabinetManager {
 	}
 
 	@Override
-	public List<PublicationSystem> getPublicationSystems() throws InternalErrorException {
-		return getPublicationSystemManagerBl().getPublicationSystems();
+	public List<PublicationSystem> getPublicationSystems(PerunSession session) throws InternalErrorException {
+
+		List<PublicationSystem> systems = getPublicationSystemManagerBl().getPublicationSystems();
+		if (AuthzResolverBlImpl.isAuthorized(session, Role.PERUNADMIN)) {
+			return systems;
+		}
+		// clear authz for non-perun admins
+		for (PublicationSystem system : systems) {
+			system.setUsername(null);
+			system.setPassword(null);
+		}
+		return systems;
+
 	}
 
 

--- a/perun-cabinet/src/test/java/cz/metacentrum/perun/cabinet/PublicationSystemManagerIntegrationTest.java
+++ b/perun-cabinet/src/test/java/cz/metacentrum/perun/cabinet/PublicationSystemManagerIntegrationTest.java
@@ -66,7 +66,7 @@ public class PublicationSystemManagerIntegrationTest extends CabinetBaseIntegrat
 	public void deletePublicationSystem() throws Exception {
 		System.out.println("PublicationSystemManagerIntegrationTest.deletePublicationSystem");
 
-		List<PublicationSystem> systems = getCabinetManager().getPublicationSystems();
+		List<PublicationSystem> systems = getCabinetManager().getPublicationSystems(sess);
 
 		assertNotNull(systems);
 		assertTrue(!systems.isEmpty());
@@ -75,7 +75,7 @@ public class PublicationSystemManagerIntegrationTest extends CabinetBaseIntegrat
 
 		getCabinetManager().deletePublicationSystem(sess, ps);
 
-		List<PublicationSystem> systems2 = getCabinetManager().getPublicationSystems();
+		List<PublicationSystem> systems2 = getCabinetManager().getPublicationSystems(sess);
 		assertNotNull(systems2);
 		assertTrue(!systems2.isEmpty());
 		assertTrue(!systems2.contains(ps));
@@ -85,7 +85,7 @@ public class PublicationSystemManagerIntegrationTest extends CabinetBaseIntegrat
 	@Test
 	public void getPublicationSystems() throws Exception {
 		System.out.println("PublicationSystemManagerIntegrationTest.getPublicationSystems");
-		List<PublicationSystem> systems = getCabinetManager().getPublicationSystems();
+		List<PublicationSystem> systems = getCabinetManager().getPublicationSystems(sess);
 
 		assertNotNull(systems);
 		assertTrue(!systems.isEmpty());

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/CabinetManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/CabinetManagerMethod.java
@@ -28,7 +28,7 @@ public enum CabinetManagerMethod implements ManagerMethod {
 	 */
 	getPublicationSystems {
 		public 	List<PublicationSystem> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getCabinetManager().getPublicationSystems();
+			return ac.getCabinetManager().getPublicationSystems(ac.getSession());
 		}
 	},
 


### PR DESCRIPTION
- Retrieve list of available PublicationSystems from Perun,
  restrict username/password to perun admins only.
- Fixed assuming default category, if any exists, pick it.