### PR TITLE
Fix typo in the name of attribute in getAttributeDefinition

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_mails_namespace_google.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_mails_namespace_google.java
@@ -64,7 +64,7 @@ public class urn_perun_user_attribute_def_virt_mails_namespace_google extends Us
 	public AttributeDefinition getAttributeDefinition() {
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_USER_FACILITY_ATTR_VIRT);
-		attr.setFriendlyName("emails-namespace:google");
+		attr.setFriendlyName("mails-namespace:google");
 		attr.setDisplayName("Emails in namespace:google");
 		attr.setType(ArrayList.class.getName());
 		attr.setDescription("Emails in google namespace");


### PR DESCRIPTION
 - friendly name of attribute mails-namespace:google should be same in
   method getAttributeDefinition as in the name of module itself