### PR TITLE
ENGINE: Log all exceptions thrown in Collector/Planner threads

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenCollector.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenCollector.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.jms.JMSException;
-import java.util.Date;
 import java.util.concurrent.BlockingDeque;
 
 import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.GENERROR;
@@ -73,6 +72,10 @@ public class GenCollector extends AbstractRunner {
 				} catch (TaskStoreException e1) {
 					log.error("Could not remove Task with id {} from SchedulingPool", id, e1);
 				}
+			} catch (Throwable ex) {
+				// FIXME - we should probably remove tasks, but which ones ?
+				// FIXME - if genCompletionService is not emptied, limit is reached and no new service propagation is started !!
+				log.error("Unexpected exception in GenCollector thread: {}.", ex);
 			}
 		}
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
@@ -64,6 +64,9 @@ public class GenPlanner extends AbstractRunner {
 				String errorStr = "Thread executing GEN tasks was interrupted.";
 				log.error(errorStr, e);
 				throw new RuntimeException(errorStr, e);
+			} catch (Throwable ex) {
+				// FIXME - what to do ?
+				log.error("Unexpected exception in GenPlanner thread: {}.", ex);
 			}
 		}
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendCollector.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendCollector.java
@@ -83,6 +83,10 @@ public class SendCollector extends AbstractRunner {
 				stdout = e.getStdout();
 				returnCode = e.getReturnCode();
 				service = task.getService();
+			} catch (Exception ex) {
+				log.error("Unexpected exception in SendCollector thread: {}.", ex);
+				// TODO - determine, what should be done since we might not get TaskID here
+				throw ex;
 			}
 			Task task = schedulingPool.getTask(taskId);
 

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendPlanner.java
@@ -93,6 +93,8 @@ public class SendPlanner extends AbstractRunner {
 				String errorStr = "Thread planning SendTasks was interrupted.";
 				log.error(errorStr);
 				throw new RuntimeException(errorStr, e);
+			} catch (Throwable ex) {
+				log.error("Unexpected exception in SendPlanner thread: {}.", ex);
 			}
 		}
 	}


### PR DESCRIPTION
- Some exception probably stopped this threads so we can't
  get generated tasks from engine back to dispatcher and they are
  internally set to GENERROR. They are re-planned by dispatcher
  and re-sent to engine, but it doesn't start them at all.
- Non-standard exceptions were not logged and we only could see
  in output, that GenCollector throw an exception.
  We will log all non-standard exceptions now and in SendCollector
  we re-throw them, since we can't be sure in which part it failed
  and if we have Task ID so it can be removed/re-planned.