### PR TITLE
ENGINE: We must remove SendTask future in all cases

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/PropagationMaintainerImpl.java
@@ -37,7 +37,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 	private BlockingBoundedHashMap<Integer, Task> generatingTasks;
 	@Autowired
 	private BlockingBoundedHashMap<Pair<Integer, Destination>, SendTask> sendingSendTasks;
-	
+
 	private SchedulingPool schedulingPool;
 	private JMSQueueManager jmsQueueManager;
 
@@ -69,7 +69,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 		for (Task task : generatingTasks.values()) {
 			Date startTime = task.getGenStartTime();
 			int howManyMinutesAgo = 0;
-			if(startTime != null) { 
+			if(startTime != null) {
 				howManyMinutesAgo = (int) (System.currentTimeMillis() - startTime.getTime()) / 1000 / 60;
 			}
 			// If too much time has passed something is broken
@@ -94,14 +94,14 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 							sendTask.getId().getLeft(), sendTask.getId().getRight());
 				} catch (TaskStoreException e) {
 					log.error("Failed during removal of SendTaskFuture {} from SchedulingPool", sendTaskFuture);
-				}	
+				}
 				if (sendTaskFuture == null) {
 					log.error("Stale SendTask {} was not removed.", sendTask);
 				}
 				TaskResult taskResult = null;
 				try {
 					taskResult = schedulingPool.createTaskResult(sendTask.getId().getLeft(),
-							sendTask.getDestination().getId(), 
+							sendTask.getDestination().getId(),
 							sendTask.getStderr(), sendTask.getStdout(),
 							sendTask.getReturnCode(), sendTask.getTask().getService());
 					jmsQueueManager.reportTaskResult(taskResult);
@@ -111,13 +111,13 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 
 			}
 		}
-		
+
 		// check all known tasks
 		Collection<Task> allTasks = schedulingPool.getAllTasks();
 		if(allTasks == null) {
 			return;
 		}
-		
+
 		for(Task task : allTasks) {
 			switch(task.getStatus()) {
 			case PLANNED:
@@ -133,13 +133,13 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 					}
 				}
 				break;
-			
+
 			case GENERATING:
 				// this is basically the same check as for the generating tasks above,
 				// but now for tasks missing in generatingTasks collection
 				Date startTime = task.getGenStartTime();
 				int howManyMinutesAgo = 0;
-				if(startTime != null) { 
+				if(startTime != null) {
 					howManyMinutesAgo = (int) (System.currentTimeMillis() - startTime.getTime()) / 1000 / 60;
 				}
 				// If too much time has passed something is broken
@@ -148,18 +148,18 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 					abortTask(task, TaskStatus.GENERROR);
 				}
 				break;
-				
+
 			case SENDING:
 				break;
 
 			case SENDERROR:
 				Date endTime = task.getSendEndTime();
 				howManyMinutesAgo = 0;
-				if(endTime != null) { 
+				if(endTime != null) {
 					howManyMinutesAgo = (int) (System.currentTimeMillis() - endTime.getTime()) / 1000 / 60;
 				}
 				// If too much time has passed something is broken
-				if(endTime == null || howManyMinutesAgo >= rescheduleTime) { 
+				if(endTime == null || howManyMinutesAgo >= rescheduleTime) {
 					abortTask(task, TaskStatus.SENDERROR);
 				}
 				break;
@@ -172,11 +172,11 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 				// should be taken by SendPlanner or reported
 				endTime = task.getGenEndTime();
 				howManyMinutesAgo = 0;
-				if(endTime != null) { 
+				if(endTime != null) {
 					howManyMinutesAgo = (int) (System.currentTimeMillis() - endTime.getTime()) / 1000 / 60;
 				}
 				// If too much time has passed something is broken
-				if((endTime == null || howManyMinutesAgo >= rescheduleTime) && 
+				if((endTime == null || howManyMinutesAgo >= rescheduleTime) &&
 						!schedulingPool.getGeneratedTasksQueue().contains(task)) {
 					abortTask(task, TaskStatus.GENERROR);
 				}
@@ -201,7 +201,7 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 				abortTask(task, TaskStatus.ERROR);
 			}
 		}
-	}	
+	}
 
 
 	private void abortTask(Task task, TaskStatus status) {
@@ -223,6 +223,6 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 		} catch (JMSException e) {
 			log.warn("Error trying to send {} to Dispatcher: {}", task, e);
 		}
-		
+
 	}
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -210,12 +210,17 @@ public class SchedulingPoolImpl implements SchedulingPool {
 	public Future<SendTask> removeSendTaskFuture(int taskId, Destination destination) throws TaskStoreException {
 		ConcurrentMap<Destination, Future<SendTask>> destinationSendTasks = sendTasks.get(taskId);
 		if (destinationSendTasks != null) {
+			log.debug("[{}] Removing SendTask futures for destination {}", taskId, destination);
 			Future<SendTask> removed = destinationSendTasks.remove(destination);
 			if (removed != null) {
+				log.debug("[{}] Lowering SendTask future counts for destination {}", taskId, destination);
 				decreaseSendTaskCount(taskId, 1);
+			} else {
+				log.debug("[{}] SendTask future hadn't had future for destination: {}", taskId, destination);
 			}
 			return removed;
 		} else {
+			log.debug("[{}] SendTask future hadn't had any destination for: {}", taskId, taskId);
 			return null;
 		}
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SendWorkerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SendWorkerImpl.java
@@ -56,13 +56,13 @@ public class SendWorkerImpl extends AbstractWorker<SendTask> implements SendWork
 				sendTask.setStderr("");
 				sendTask.setReturnCode(0);
 				sendTask.setEndTime(new Date(System.currentTimeMillis()));
-				
+
 				log.info("[{}] SEND worker skipped for dummy destination for Task.",
 						new Object[]{sendTask.getTask().getId()});
 
 				sendTask.setStatus(SENT);
 				return sendTask;
-			} 
+			}
 
 			// start the script and wait for results
 			super.execute(pb);


### PR DESCRIPTION
- Even if propagation failed with non-zero return code
  (TaskExecutionException), we must call removing SendTask futures.
  Otherwise Task is stuck in Engine and incoming planned Tasks
  are ignored.