### PR TITLE
ENGINE: Added javadoc to classes in scheduling package

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingBoundedMap.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingBoundedMap.java
@@ -14,6 +14,7 @@ public interface BlockingBoundedMap<K, V> {
 
 	/**
 	 * Puts the value into the Map, possibly blocking until there is open space.
+	 *
 	 * @param value Value to be inserted into the map.
 	 * @param key Key under which will be the value inserted
 	 * @return Return value previously associated with the key, null if there was none.
@@ -21,7 +22,19 @@ public interface BlockingBoundedMap<K, V> {
 	 */
 	V blockingPut(K key, V value) throws InterruptedException;
 
+	/**
+	 * Removes key=value from the Map, releasing its space for another blockingPut()
+	 *
+	 * @param key Key to be removed
+	 * @return Removed value
+	 */
 	V remove(K key);
 
+	/**
+	 * Get all values currently held by this blocking map
+	 *
+	 * @return All values
+	 */
 	Collection<V> values();
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingCompletionService.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingCompletionService.java
@@ -5,18 +5,39 @@ import cz.metacentrum.perun.engine.exceptions.TaskExecutionException;
 import java.util.concurrent.Future;
 
 /**
- * This class wraps classic CompletionService, providing extra methods with blocking behaviour.
+ * This class wraps classic CompletionService, providing extra methods with blocking behaviour for Engine purpose
+ *
  * @see java.util.concurrent.CompletionService
+ *
+ * @see cz.metacentrum.perun.engine.scheduling.impl.BlockingGenExecutorCompletionService
+ * @see cz.metacentrum.perun.engine.scheduling.impl.BlockingSendExecutorCompletionService
+ *
+ * Makes any thread wait until there is space for starting new worker and wait to get completed/error worker.
+ *
+ * @author David Šarman
  */
 public interface BlockingCompletionService<V>{
 
 	/**
-	 * Tries to submit the given worker for execution, blocking if the CompletionServices ThreadPool is full.
+	 * Tries to submit the given worker for execution, blocking if the CompletionServices ThreadPool is full
+	 * (backed by BlockingBoundedMap of currently executing tasks)
+	 *
+	 * @see BlockingBoundedMap
+	 *
 	 * @param taskWorker The EngineWorker instance which will be executed
 	 * @return Returns Future holding the executing Task.
 	 * @throws InterruptedException Thrown if the Thread was interrupted while waiting for a place in ThreadPool.
 	 */
 	Future<V> blockingSubmit(EngineWorker<V> taskWorker) throws InterruptedException;
 
+	/**
+	 * Tries to get any completed worker, blocking if non worker is done/or error.
+	 * (backed by BlockingBoundedMap of currently executing tasks)
+	 *
+	 * @return Gen or Send worker (EngineWorker)
+	 * @throws InterruptedException if canceled
+	 * @throws TaskExecutionException when worker failed
+	 */
 	V blockingTake() throws InterruptedException, TaskExecutionException;
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/EngineWorker.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/EngineWorker.java
@@ -25,7 +25,7 @@ public interface EngineWorker<V> extends Callable<V> {
 	/**
 	 * Set Directory to look for scripts
 	 *
-	 * @param directory
+	 * @param directory Directory to look for scripts
 	 */
 	void setDirectory(File directory);
 

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/AbstractWorker.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/AbstractWorker.java
@@ -9,8 +9,14 @@ import java.io.File;
 import java.io.IOException;
 
 /**
+ * Common implementation of EngineWorker interface. Represents Thread, which is started by BlockingCompletionService.
+ * Own worker is created for each GEN/SEND part of processing the Task.
  *
+ * @see cz.metacentrum.perun.engine.scheduling.BlockingCompletionService
+ * @see GenWorkerImpl
+ * @see SendWorkerImpl
  *
+ * @author David Šarman
  */
 public abstract class AbstractWorker<V> implements EngineWorker<V> {
 
@@ -33,14 +39,29 @@ public abstract class AbstractWorker<V> implements EngineWorker<V> {
 		this.directory = directory;
 	}
 
+	/**
+	 * Get return code of the script represented by this worker.
+	 *
+	 * @return return code of the script
+	 */
 	public Integer getReturnCode() {
 		return returnCode;
 	}
 
+	/**
+	 * Get STDOUT of the script represented by this worker.
+	 *
+	 * @return STDOUT of the script
+	 */
 	public String getStdout() {
 		return (stdout == null) ? "" : stdout;
 	}
 
+	/**
+	 * Get STDERR of the script represented by this worker.
+	 *
+	 * @return STDERR of the script
+	 */
 	public String getStderr() {
 		return (stderr == null) ? "" : stderr;
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingBoundedHashMap.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingBoundedHashMap.java
@@ -8,11 +8,28 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 
+/**
+ * Implementation of BlockingBoundedMap<K,V> using ConcurrentHashMap and Semaphore.
+ * Allow holding only specified number of keys. Any thread waits on blockingPut() call if full.
+ *
+ * Used to hold currently executing tasks in Engine.
+ *
+ * @see BlockingBoundedMap
+ * @see Semaphore
+ *
+ * @param <K> key class
+ * @param <V> value class
+ */
 public class BlockingBoundedHashMap<K, V> implements BlockingBoundedMap<K, V> {
 
 	private ConcurrentMap<K, V> map = new ConcurrentHashMap<>();
 	private Semaphore semaphore;
 
+	/**
+	 * Create new BlockingBoundedHashMap with specified size limit.
+	 *
+	 * @param limit Number of allowed keys
+	 */
 	public BlockingBoundedHashMap(int limit) {
 		semaphore = new Semaphore(limit);
 	}
@@ -38,4 +55,5 @@ public class BlockingBoundedHashMap<K, V> implements BlockingBoundedMap<K, V> {
 	public Collection<V> values() {
 		return map.values();
 	}
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -2,11 +2,9 @@ package cz.metacentrum.perun.engine.scheduling.impl;
 
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.engine.jms.JMSQueueManager;
 import cz.metacentrum.perun.taskslib.exceptions.TaskStoreException;
-import cz.metacentrum.perun.engine.scheduling.BlockingBoundedMap;
 import cz.metacentrum.perun.engine.scheduling.SchedulingPool;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
 import cz.metacentrum.perun.taskslib.service.TaskStore;

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/StreamGobbler.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/StreamGobbler.java
@@ -7,6 +7,11 @@ import java.io.InputStreamReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Represents Thread, which waits for script STDOUT and STDERR for both GenWorker and SendWorker.
+ *
+ * @author Michal Voců
+ */
 class StreamGobbler extends Thread {
 
 	private InputStream is;
@@ -24,6 +29,7 @@ class StreamGobbler extends Thread {
 		return sb.toString();
 	}
 
+	@Override
 	public void run() {
 		BufferedReader br = null;
 		try {
@@ -46,4 +52,5 @@ class StreamGobbler extends Thread {
 			}
 		}
 	}
+
 }


### PR DESCRIPTION
- Added better javadoc explaining purpose and @see cross-references
  so anybody should now understand, how engine plans and starts
  GEN/SEND tasks.