### PR TITLE
DISPATCHER: log reason, why we couldn add task to the pool

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/EventProcessor.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/EventProcessor.java
@@ -180,7 +180,7 @@ public class EventProcessor extends AbstractRunner {
 						schedulingPool.addToPool(task, null);
 						log.debug("[{}] New Task added to pool. {}.", task.getId(), task);
 					} catch (TaskStoreException e) {
-						log.error("[{}] Could not add Task to pool. Task will be lost: {}.", task.getId(), task);
+						log.error("[{}] Could not add Task to pool. Task {} will be lost: {}", task.getId(), task, e);
 					}
 					schedulingPool.scheduleTask(task, -1);
 				}


### PR DESCRIPTION
- Seems like storing Task with ID=0 is a problem and such ID is
  also propagated to the engine.