### PR TITLE
RPC: Update tomcat version used in tomcat7 maven plugin

### DIFF
--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -19,7 +19,7 @@
 
 	<properties>
 		<skipTests>true</skipTests>
-		<tomcat7.plugin.tomcat.version>7.0.56</tomcat7.plugin.tomcat.version>
+		<tomcat7.plugin.tomcat.version>7.0.85</tomcat7.plugin.tomcat.version>
 	</properties>
 
 	<!-- common module build settings used by all profiles -->


### PR DESCRIPTION
- Use latest Tomcat version 7.0.85 as included in tomcat7 maven plugin,
  since 7.0.56 does have problems with tomcat8 servlet-api provided
  by new spring platform (compiled on java8).
- This affect only locally running tomcats started by developers
  using command: "mvn tomcat7:run-war".