### PR TITLE
ENGINE: Modify Task processing to be more thread safe

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/SendTask.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/SendTask.java
@@ -223,8 +223,8 @@ public class SendTask implements Serializable {
 	public String toString() {
 		StringBuilder str = new StringBuilder();
 		str.append(getClass().getSimpleName()).append(":[status='").append(status)
-				.append("', startTime='").append(BeansUtils.getDateFormatter().format(startTime))
-				.append("', endTime='").append(BeansUtils.getDateFormatter().format(endTime))
+				.append("', startTime='").append((startTime!=null) ? BeansUtils.getDateFormatter().format(startTime) : startTime)
+				.append("', endTime='").append((endTime!=null) ? BeansUtils.getDateFormatter().format(endTime) : endTime)
 				.append("', returnCode='").append(returnCode)
 				.append("', task='").append(task)
 				.append("', destination='").append(destination)

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/exceptions/TaskExecutionException.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/exceptions/TaskExecutionException.java
@@ -1,36 +1,76 @@
 package cz.metacentrum.perun.engine.exceptions;
 
+import cz.metacentrum.perun.core.api.Destination;
+import cz.metacentrum.perun.taskslib.model.Task;
 
-public class TaskExecutionException extends EngineException{
+/**
+ * Exception thrown, when execution of GEN or SEND Task fails for any reason.
+ * Contains all relevant data like Task itself, process return code, stdout/err.
+ * For SEND Tasks relevant Destination is also present.
+ *
+ * @author David Šarman
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class TaskExecutionException extends EngineException {
+
+	private Task task;
 	private int returnCode;
 	private String stdout;
 	private String stderr;
-	private Object id;
+	private Destination destination;
 
-	public TaskExecutionException(Object id, String message) {
+	public TaskExecutionException(Task task, String message) {
 		super(message);
-		this.id = id;
+		this.task = task;
 	}
 
-	public TaskExecutionException(Object id, String message, Throwable cause) {
-		super(message, cause);
-		this.id = id;
+	public TaskExecutionException(Task task, Destination destination, String message) {
+		this(task, message);
+		this.destination = destination;
 	}
 
-	public TaskExecutionException(Object id, Throwable cause) {
+	public TaskExecutionException(Task task, Throwable cause) {
 		super(cause);
-		this.id = id;
+		this.task = task;
 	}
 
-	public TaskExecutionException(Object id, int returnCode, String stdout, String stderr) {
+	public TaskExecutionException(Task task, String message, Throwable cause) {
+		super(message, cause);
+		this.task = task;
+	}
+
+	public TaskExecutionException(Task task, Destination destination, String message, Throwable cause) {
+		this(task, message, cause);
+		this.destination = destination;
+	}
+
+	public TaskExecutionException(Task task, int returnCode, String stdout, String stderr) {
+		super();
+		this.task = task;
 		this.returnCode = returnCode;
 		this.stdout = stdout;
 		this.stderr = stderr;
-		this.id = id;
 	}
 
-	public Object getId() {
-		return id;
+	public TaskExecutionException(Task task, Destination destination, int returnCode, String stdout, String stderr) {
+		this(task, returnCode, stdout, stderr);
+		this.destination = destination;
+	}
+
+	public Task getTask() {
+		return task;
+	}
+
+	public void setTask(Task task) {
+		this.task = task;
+	}
+
+	public Destination getDestination() {
+		return destination;
+	}
+
+	public void setDestination(Destination destination) {
+		this.destination = destination;
 	}
 
 	public int getReturnCode() {
@@ -66,4 +106,5 @@ public class TaskExecutionException extends EngineException{
 	public String getErrorId() {
 		return super.getErrorId();
 	}
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/jms/JMSQueueManager.java
@@ -168,7 +168,7 @@ public class JMSQueueManager {
 		synchronized(producer) {
 			producer.send(message, DeliveryMode.PERSISTENT, 2, 0);
 		}
-		log.info("TaskResult for {} reported and destination {} sent to dispatcher.", taskResult.getTaskId(),
+		log.info("[{}] TaskResult for destination {} sent to dispatcher.", taskResult.getTaskId(),
 				taskResult.getDestinationId());
 	}
 
@@ -177,7 +177,7 @@ public class JMSQueueManager {
 				+ propertiesBean.getProperty("engine.unique.id") + ":"
 				+ id + ":" + status + ":" + miliseconds);
 		producer.send(message, DeliveryMode.PERSISTENT, 6, 0);
-		log.info("Task with id {} reported state {} to dispatcher.", id, status);
+		log.info("[{}] Task state {} sent to dispatcher.", id, status);
 	}
 
 	public void sendGoodByeAndClose() {

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventProcessorImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventProcessorImpl.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-
 @org.springframework.stereotype.Service(value = "eventProcessor")
 public class EventProcessorImpl implements EventProcessor {
 
@@ -57,15 +56,13 @@ public class EventProcessorImpl implements EventProcessor {
 				try {
 					schedulingPool.addTask(task);
 				} catch (TaskStoreException e) {
-					log.error("Could not save Task {} into Engine SchedulingPool because of {}, it will be ignored",
-							task, e);
-					// XXX - should probably report ERROR back to dispatcher...
+					log.error("Could not save Task {} into Engine SchedulingPool because of {}, it will be ignored", task, e);
+					// FIXME - should probably report ERROR back to dispatcher...
 				}
 			} else {
-				log.debug("[{}] Task found in SchedulingPool.", task.getId(), currentTask);
-				log.debug("[{}] Resetting current task destination list to {}", task.getId(), task.getDestinations());
-				currentTask.setDestinations(task.getDestinations());
-				currentTask.setPropagationForced(task.isPropagationForced());
+				// since we always remove Task from pool at the end and Dispatcher doesn't send partial Destinations,
+				// we don't need to update existing Task object !! Let engine finish the processing.
+				log.debug("[{}] Task found in SchedulingPool, message skipped.", task.getId(), currentTask);
 			}
 		}
 		log.debug("[{}] POOL SIZE: {}", task.getId(), schedulingPool.getSize());

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventProcessorImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/processing/impl/EventProcessorImpl.java
@@ -28,7 +28,6 @@ public class EventProcessorImpl implements EventProcessor {
 
 	@Override
 	public void receiveEvent(String event) {
-		log.info("Current pool size BEFORE event processing: {}", schedulingPool.getSize());
 		log.debug("Event {} is going to be resolved.", event);
 
 		Task task = null;
@@ -41,17 +40,20 @@ public class EventProcessorImpl implements EventProcessor {
 		}
 
 		if (task == null) {
+			log.debug("Task not found in event {}", event);
 			return;
 		}
 		task.setStatus(Task.TaskStatus.PLANNED);
 
-		log.debug("\t Facility[{}]", task.getFacility());
+		log.info("Current pool size BEFORE event processing: {}", schedulingPool.getSize());
+
+		log.debug("\t Resolved Facility[{}]", task.getFacility());
 		log.debug("\t Resolved Service[{}]", task.getService());
 		if (task.getFacility() != null && task.getService() != null) {
-			log.debug("TESTSTRE -> Gonna check if the task {} exists", task);
+			log.debug("[{}] Check if Task exist in SchedulingPool: {}", task.getId(), task);
 			Task currentTask = schedulingPool.getTask(task.getId());
-			log.debug("TESTSTRE -> Found {}", currentTask);
 			if (currentTask == null) {
+				log.debug("[{}] Task not found in SchedulingPool.", task.getId());
 				try {
 					schedulingPool.addTask(task);
 				} catch (TaskStoreException e) {
@@ -60,13 +62,14 @@ public class EventProcessorImpl implements EventProcessor {
 					// XXX - should probably report ERROR back to dispatcher...
 				}
 			} else {
-				log.debug("Resetting current task destination list to {}", task.getDestinations());
+				log.debug("[{}] Task found in SchedulingPool.", task.getId(), currentTask);
+				log.debug("[{}] Resetting current task destination list to {}", task.getId(), task.getDestinations());
 				currentTask.setDestinations(task.getDestinations());
 				currentTask.setPropagationForced(task.isPropagationForced());
 			}
 		}
-		log.debug("POOL SIZE: {}", schedulingPool.getSize());
-		log.info("Current pool size AFTER event processing: {}", schedulingPool.getSize());
+		log.debug("[{}] POOL SIZE: {}", task.getId(), schedulingPool.getSize());
+		log.info("[{}] Current pool size AFTER event processing: {}", task.getId(), schedulingPool.getSize());
 	}
 
 	public EventParser getEventParser() {

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenCollector.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenCollector.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.engine.runners;
 
-
 import cz.metacentrum.perun.engine.exceptions.TaskExecutionException;
 import cz.metacentrum.perun.taskslib.exceptions.TaskStoreException;
 import cz.metacentrum.perun.engine.jms.JMSQueueManager;
@@ -18,12 +17,26 @@ import java.util.concurrent.BlockingDeque;
 import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.GENERROR;
 
 /**
- * This class takes Task which were generated (both successfully and not), reports their state change to the Dispatcher
- * and puts them in queue of Tasks waiting to be sent to their Destinations.
+ * This class represents permanently running thread, which should run in a single instance.
+ *
+ * It takes all done GEN Tasks (both successfully and not) from BlockingGenExecutorCompletionService
+ * and report their outcome to the Dispatcher. Successful Tasks are put to the generatedTasks blocking deque
+ * for later processing by SendPlanner (waiting to be sent to destinations). Failed Tasks are removed from
+ * SchedulingPool (Engine).
+ *
+ * Expected Task status change is GENERATING -> GENERATED | GENERROR based on GenWorker outcome.
+ *
+ * @see cz.metacentrum.perun.engine.scheduling.impl.GenWorkerImpl
+ * @see BlockingGenExecutorCompletionService
+ * @see SchedulingPool#getGeneratedTasksQueue()
+ *
+ * @author David Šarman
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class GenCollector extends AbstractRunner {
-	private final static Logger log = LoggerFactory
-			.getLogger(GenCollector.class);
+
+	private final static Logger log = LoggerFactory.getLogger(GenCollector.class);
+
 	@Autowired
 	private SchedulingPool schedulingPool;
 	@Autowired
@@ -45,42 +58,62 @@ public class GenCollector extends AbstractRunner {
 		BlockingDeque<Task> generatedTasks = schedulingPool.getGeneratedTasksQueue();
 		while (!shouldStop()) {
 			try {
+
 				Task task = genCompletionService.blockingTake();
+				// set ok status immediately
+				task.setStatus(Task.TaskStatus.GENERATED);
+				// report to Dispatcher
+				try {
+					jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), task.getGenEndTime().getTime());
+				} catch (JMSException e) {
+					jmsErrorLog(task.getId(), task.getStatus());
+				}
+
+				// push Task to generated
 				if (task.isPropagationForced()) {
 					generatedTasks.putFirst(task);
 				} else {
 					generatedTasks.put(task);
 				}
-				try {
-					jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), task.getGenEndTime().getTime());
-				} catch (JMSException e) {
-					jmsErrorLog(task.getId());
-				}
+
 			} catch (InterruptedException e) {
+
 				String errorStr = "Thread collecting generated Tasks was interrupted.";
 				log.error(errorStr);
 				throw new RuntimeException(errorStr, e);
+
 			} catch (TaskExecutionException e) {
-				Integer id = (Integer) e.getId();
-				try {
-					jmsQueueManager.reportTaskStatus(id, GENERROR, System.currentTimeMillis());
-				} catch (JMSException e1) {
-					jmsErrorLog(id);
+
+				// GEN Task failed
+				Task task = e.getTask();
+
+				if (task == null) {
+					log.error("GEN Task failed, but TaskExecutionException doesn't contained Task object! Tasks will be cleaned by PropagationMaintainer#endStuckTasks()");
+				} else {
+
+					task.setStatus(GENERROR);
+
+					try {
+						jmsQueueManager.reportTaskStatus(task.getId(), GENERROR, System.currentTimeMillis());
+					} catch (JMSException e1) {
+						jmsErrorLog(task.getId(), task.getStatus());
+					}
+					try {
+						schedulingPool.removeTask(task.getId());
+					} catch (TaskStoreException e1) {
+						log.error("[{}] Could not remove error GEN Task from SchedulingPool: {}", task.getId(), e1);
+					}
+
 				}
-				try {
-					schedulingPool.removeTask(id);
-				} catch (TaskStoreException e1) {
-					log.error("[{}] Could not remove Task from SchedulingPool: {}", id, e1);
-				}
+
 			} catch (Throwable ex) {
-				// FIXME - we should probably remove tasks, but which ones ?
-				// FIXME - if genCompletionService is not emptied, limit is reached and no new service propagation is started !!
-				log.error("Unexpected exception in GenCollector thread: {}.", ex);
+				log.error("Unexpected exception in GenCollector thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later. {}", ex);
 			}
 		}
 	}
 
-	private void jmsErrorLog(Integer id) {
-		log.warn("Could not send GEN status update to task with id {}.", id);
+	private void jmsErrorLog(Integer id, Task.TaskStatus status) {
+		log.warn("[{}] Could not send GEN status update to {} to Dispatcher.", id, status);
 	}
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenCollector.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenCollector.java
@@ -70,7 +70,7 @@ public class GenCollector extends AbstractRunner {
 				try {
 					schedulingPool.removeTask(id);
 				} catch (TaskStoreException e1) {
-					log.error("Could not remove Task with id {} from SchedulingPool", id, e1);
+					log.error("[{}] Could not remove Task from SchedulingPool: {}", id, e1);
 				}
 			} catch (Throwable ex) {
 				// FIXME - we should probably remove tasks, but which ones ?

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.engine.runners;
 
-
 import cz.metacentrum.perun.engine.jms.JMSQueueManager;
 import cz.metacentrum.perun.engine.scheduling.GenWorker;
 import cz.metacentrum.perun.engine.scheduling.SchedulingPool;
@@ -22,11 +21,24 @@ import java.util.concurrent.Future;
 import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.GENERATING;
 
 /**
- * This class takes all new Tasks received from Dispatcher, and puts in a queue where they wait to be generated.
+ * This class represents permanently running thread, which should run in a single instance.
+ *
+ * It takes all new Tasks received from Dispatcher (from newTasks blocking deque),
+ * and put them to BlockingGenExecutorCompletionService. Processing waits on call of blockingSubmit()
+ *
+ * Expected Task status change PLANNED -> GENERATING is reported to Dispatcher.
+ *
+ * @see SchedulingPool#getNewTasksQueue()
+ * @see BlockingGenExecutorCompletionService
+ * @see GenWorkerImpl
+ *
+ * @author David Šarman
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class GenPlanner extends AbstractRunner {
-	private final static Logger log = LoggerFactory
-			.getLogger(GenPlanner.class);
+
+	private final static Logger log = LoggerFactory.getLogger(GenPlanner.class);
+
 	@Autowired
 	private SchedulingPool schedulingPool;
 	@Autowired
@@ -50,10 +62,15 @@ public class GenPlanner extends AbstractRunner {
 			try {
 				log.debug("Getting new Task in the newTasks BlockingDeque");
 				Task task = newTasks.take();
+				/*
+				!! Change status immediately, so it won't be picked by PropagationMaintainer#endStuckTasks()
+				because we might be waiting on blockingSubmit() here !!
+				*/
+				task.setStatus(GENERATING);
 				GenWorker worker = new GenWorkerImpl(task, directory);
 				Future<Task> taskFuture = genCompletionService.blockingSubmit(worker);
 				schedulingPool.addGenTaskFutureToPool(task.getId(), taskFuture);
-				task.setStatus(GENERATING);
+				// We actually started, set Time and notify Dispatcher
 				task.setGenStartTime(new Date(System.currentTimeMillis()));
 				try {
 					jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), task.getGenStartTime().getTime());
@@ -61,22 +78,22 @@ public class GenPlanner extends AbstractRunner {
 					log.warn("[{}] Could not send Tasks {} GEN status update: {}", task.getId(), task, e);
 				}
 			} catch (InterruptedException e) {
+
 				String errorStr = "Thread executing GEN tasks was interrupted.";
 				log.error(errorStr, e);
 				throw new RuntimeException(errorStr, e);
+
 			} catch (Throwable ex) {
-				// FIXME - what to do ?
-				log.error("Unexpected exception in GenPlanner thread: {}.", ex);
+				log.error("Unexpected exception in GenPlanner thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later {}.", ex);
 			}
 		}
 	}
 
 	@Autowired
 	public void setPropertiesBean(Properties propertiesBean) {
-		//log.debug("TESTSTR --> Gen property bean set");
 		if (propertiesBean != null) {
-			//log.debug("TESTSTR --> Gen script path from properties is {}", propertiesBean.getProperty("engine.genscript.path"));
 			directory = new File(propertiesBean.getProperty("engine.genscript.path"));
 		}
 	}
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
@@ -58,7 +58,7 @@ public class GenPlanner extends AbstractRunner {
 				try {
 					jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), task.getGenStartTime().getTime());
 				} catch (JMSException e) {
-					log.warn("Could not send Tasks [{}] GEN status update.", task);
+					log.warn("[{}] Could not send Tasks {} GEN status update: {}", task.getId(), task, e);
 				}
 			} catch (InterruptedException e) {
 				String errorStr = "Thread executing GEN tasks was interrupted.";
@@ -73,9 +73,9 @@ public class GenPlanner extends AbstractRunner {
 
 	@Autowired
 	public void setPropertiesBean(Properties propertiesBean) {
-		log.debug("TESTSTR --> Gen property bean set");
+		//log.debug("TESTSTR --> Gen property bean set");
 		if (propertiesBean != null) {
-			log.debug("TESTSTR --> Gen script path from properties is {}", propertiesBean.getProperty("engine.genscript.path"));
+			//log.debug("TESTSTR --> Gen script path from properties is {}", propertiesBean.getProperty("engine.genscript.path"));
 			directory = new File(propertiesBean.getProperty("engine.genscript.path"));
 		}
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendCollector.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendCollector.java
@@ -1,8 +1,6 @@
 package cz.metacentrum.perun.engine.runners;
 
-
 import cz.metacentrum.perun.core.api.Destination;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.engine.exceptions.TaskExecutionException;
 import cz.metacentrum.perun.engine.jms.JMSQueueManager;
@@ -18,13 +16,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.jms.JMSException;
 import java.util.Date;
-
-import static cz.metacentrum.perun.taskslib.model.SendTask.SendTaskStatus.SENT;
+import java.util.Objects;
 
 /**
- * This class takes all executed SendTasks (both successfully and not) and reports their state to the Dispatcher.
- * It also watches for the number of SendTasks associated with their parent Task, which will be removed from Engine
- * once all its SendTask are executed.
+ * This class represents permanently running thread, which should run in a single instance.
+ *
+ * It takes all done SEND SendTasks (both successfully and not) from BlockingSendExecutorCompletionService.
+ * For each SendTask its outcome is reported to Dispatcher as a TaskResult.
+ *
+ * If any of SendTasks fails its processing (has ERROR status), whole Task is set to SENDERROR.
+ * Otherwise SENDING or DONE is kept for whole Task.
+ * Once all SendTasks are finished Task status is reported to Dispatcher.
+ *
+ * Expected Task status change is SENDING -> DONE | SENDERROR based on all SendWorkers outcome.
+ *
+ * @see BlockingSendExecutorCompletionService
+ * @see SchedulingPool#createTaskResult(int, int, String, String, int, Service)
+ * @see SchedulingPool#removeSendTaskFuture(int, Destination)
+ *
+ * @author David Šarman
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class SendCollector extends AbstractRunner {
 
@@ -49,86 +60,100 @@ public class SendCollector extends AbstractRunner {
 	@Override
 	public void run() {
 		while (!shouldStop()) {
-			Task.TaskStatus status = Task.TaskStatus.SENDERROR;
-			int taskId;
+
+			SendTask sendTask = null;
+			Task task = null;
+			Service service = null;
+			Destination destination = null;
 			String stderr;
 			String stdout;
 			int returnCode;
-			Service service = null;
+
+			// FIXME - doesn't provide nice output and clog the log
 			log.debug(schedulingPool.getReport());
-			SendTask sendTask = null;
-			Destination destination = null;
+
 			try {
+
 				sendTask = sendCompletionService.blockingTake();
-				status = null;
-				taskId = sendTask.getId().getLeft();
-				sendTask.setStatus(SENT);
-				sendTask.setEndTime(new Date(System.currentTimeMillis()));
+				task = sendTask.getTask();
+				if (!Objects.equals(task.getStatus(), Task.TaskStatus.SENDERROR)) {
+					// keep SENDING status only if if task previously doesn't failed
+					task.setStatus(Task.TaskStatus.SENDING);
+				}
+				/*
+				 Set Task "sendEndTime" immediately for each done SendTask, so it's not considered as stuck
+				 by PropagationMaintainer#endStuckTasks().
+				 Like this we can maximally propagate for "rescheduleTime" for each Destination and not
+				 all Destinations (whole Task). Default rescheduleTime is 3 hours * no.of destinations.
+				 */
+				task.setSendEndTime(new Date(System.currentTimeMillis()));
 				destination = sendTask.getDestination();
 				stderr = sendTask.getStderr();
 				stdout = sendTask.getStdout();
 				returnCode = sendTask.getReturnCode();
 				service = sendTask.getTask().getService();
+
 			} catch (InterruptedException e) {
-				log.error("Thread collecting sent SendTasks was interrupted: {}", e);
-				continue;
+
+				String errorStr = "Thread collecting sent SendTasks was interrupted.";
+				log.error(errorStr + ": {}", e);
+				throw new RuntimeException(errorStr, e);
+
 			} catch (TaskExecutionException e) {
-				//log.error("Execution exception: {}", e); - is already logged as EngineException
-				Pair<Integer, Destination> id = (Pair<Integer, Destination>) e.getId();
-				Task task = schedulingPool.getTask(id.getLeft());
-				if (task != null) {
-					log.warn("[{}] Error occurred while sending {} to destination {}", task.getId(), task, id.getRight());
-					taskId = task.getId();
-					destination = id.getRight();
-					stderr = e.getStderr();
-					stdout = e.getStdout();
-					returnCode = e.getReturnCode();
-					service = task.getService();
-				} else {
-					log.error("[{}] Error occurred while sending {} to destination {}", id.getLeft(), task, id.getRight());
-					log.error("[{}] Task no longer in pool after sending to destination {}", id.getLeft(), id.getRight());
-					// we can't get service from exception on null task, hence we can't report TaskResult
-					taskId = id.getLeft();
-					destination = id.getRight();
-					stderr = e.getStderr();
-					stdout = e.getStdout();
-					returnCode = e.getReturnCode();
-				}
+
+				task = e.getTask();
+				// set SENDERROR status immediately as first SendTask (Destination) fails
+				task.setStatus(Task.TaskStatus.SENDERROR);
+				/*
+				 Set Task "sendEndTime" immediately for each done SendTask, so it's not considered as stuck
+				 by PropagationMaintainer#endStuckTasks().
+				 Like this we can maximally propagate for "rescheduleTime" for each Destination and not
+				 all Destinations (whole Task). Default rescheduleTime is 3 hours * no.of destinations.
+				 */
+				task.setSendEndTime(new Date(System.currentTimeMillis()));
+				destination = e.getDestination();
+				stderr = e.getStderr();
+				stdout = e.getStdout();
+				returnCode = e.getReturnCode();
+				service = task.getService();
+
+				log.error("[{}] Error occurred while sending Task to destination {}", task.getId(), e.getDestination());
+
 			} catch (Throwable ex) {
-				log.error("Unexpected exception in SendCollector thread: {}.", ex);
+				log.error("Unexpected exception in SendCollector thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later. {}", ex);
 				continue;
 			}
 
-			Task task = schedulingPool.getTask(taskId);
+			// this is just interesting cross-check
+			if (schedulingPool.getTask(task.getId()) == null) {
+				log.warn("[{}] Task retrieved from SendTask is no longer in SchedulingPool. Probably cleaning thread removed it before completion. " +
+						"This might create possibility of running GEN and SEND of same Task together!", task.getId());
+			}
 
 			try {
-				//log.debug("TESTSTR --> Sending TaskResult: taskid {}, destionationId {}, stderr {}, stdout {}, " +
-				//		"returnCode {}, service {}", new Object[]{taskId, destination.getId(), stderr, stdout, returnCode, service});
-				if (service != null) {
-					jmsQueueManager.reportTaskResult(schedulingPool.createTaskResult(taskId, destination.getId(), stderr, stdout, returnCode, service));
-				}
+
+				// report TaskResult to Dispatcher for this SendTask (Destination)
+				jmsQueueManager.reportTaskResult(schedulingPool.createTaskResult(task.getId(), destination.getId(), stderr, stdout, returnCode, service));
+
 			} catch (JMSException e1) {
-				if (sendTask != null && sendTask.getId() != null) {
-					log.error("[{}] Error trying to reportTaskResult of {} to Dispatcher: {}", sendTask.getId().getLeft(), sendTask, e1);
-				} else if (sendTask != null && sendTask.getTask() != null) {
-					log.error("[{}] Error trying to reportTaskResult of {} to Dispatcher: {}", sendTask.getTask().getId(), sendTask, e1);
-				} else {
-
-					log.error("[{}] Error trying to reportTaskResult of {} to Dispatcher: {}", (task != null) ? task.getId() : "unknown", sendTask, e1);
-				}
-			}
-
-			if (status != null && task != null) {
-				task.setStatus(status);
-				task.setSendEndTime(new Date(System.currentTimeMillis()));
+				log.error("[{}] Error trying to reportTaskResult for Destination: {} to Dispatcher: {}", task.getId(), destination, e1);
 			}
 
 			try {
-				//schedulingPool.decreaseSendTaskCount(taskId, 1);
-				// always try to remove send task future even on TaskExecutionException.
-				schedulingPool.removeSendTaskFuture(taskId, destination);
+
+				// Decrease SendTask count and remove its Future<SendTask>
+				// Consequently, if count is <=1, Task is reported to Dispatcher
+				// as DONE/SENDERROR and removed from SchedulingPool (Engine).
+				schedulingPool.removeSendTaskFuture(task.getId(), destination);
+				// FIXME - this method call rely on current pool content and consequently calls canceling gen/sendFutures twice,
+				// FIXME - which is bad, since it might interfere with another run of the same Task.
+				// FIXME - we should probably call 3 methods and update them to handle inconsistent state and not to call each other
+				// schedulingPool.removeSendTaskFuture(task.getId(), destination);
+				// schedulingPool.decreaseSendTaskCount(task.getId(),1 );
+				// schedulingPool.removeTask(task);
+
 			} catch (TaskStoreException e) {
-				log.error("[{}] Task {} could not be removed from SchedulingPool: {}", taskId, task, e);
+				log.error("[{}] Task {} could not be removed from SchedulingPool: {}", task.getId(), task, e);
 			}
 		}
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendPlanner.java
@@ -65,7 +65,7 @@ public class SendPlanner extends AbstractRunner {
 					try {
 						schedulingPool.removeTask(task);
 					} catch (TaskStoreException e) {
-						log.error("Task {} could not be removed from SchedulingPool", e);
+						log.error("[{}] Task {} could not be removed from SchedulingPool: {}", task.getId(), task, e);
 					}
 					continue;
 				}
@@ -105,9 +105,9 @@ public class SendPlanner extends AbstractRunner {
 
 	@Autowired
 	public void setPropertiesBean(Properties propertiesBean) {
-		log.debug("TESTSTR --> Send property bean set");
+		//log.debug("TESTSTR --> Send property bean set");
 		if (propertiesBean != null) {
-			log.debug("TESTSTR --> Send script path from properties is {}", propertiesBean.getProperty("engine.sendscript.path"));
+			//log.debug("TESTSTR --> Send script path from properties is {}", propertiesBean.getProperty("engine.sendscript.path"));
 			directory = new File(propertiesBean.getProperty("engine.sendscript.path"));
 		}
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendPlanner.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.engine.runners;
 
-
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.engine.jms.JMSQueueManager;
 import cz.metacentrum.perun.engine.scheduling.SchedulingPool;
@@ -25,12 +24,27 @@ import java.util.concurrent.Future;
 import static cz.metacentrum.perun.taskslib.model.SendTask.SendTaskStatus.SENDING;
 
 /**
- * Takes all Tasks planned for sending, creates a SendTask for every one of their Destinations and puts it into queue,
- * where they wait to be sent.
+ * This class represents permanently running thread, which should run in a single instance.
+ *
+ * It takes all GENERATED Tasks from generatedTasks blocking queue provided by GenCollector
+ * and creates SendTask and SendWorker for each Destination and put them to BlockingSendExecutorCompletionService.
+ * Processing waits on call of blockingSubmit() for each SendWorker.
+ *
+ * Expected Task status change GENERATED -> SENDING is reported to Dispatcher.
+ * For Tasks without any Destination, status changes GENERATED -> ERROR and Task is removed from SchedulingPool (Engine).
+ *
+ * @see SchedulingPool#getGeneratedTasksQueue()
+ * @see SendTask
+ * @see SendWorkerImpl
+ * @see BlockingSendExecutorCompletionService
+ *
+ * @author David Šarman
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class SendPlanner extends AbstractRunner {
-	private final static Logger log = LoggerFactory
-			.getLogger(SendPlanner.class);
+
+	private final static Logger log = LoggerFactory.getLogger(SendPlanner.class);
+
 	@Autowired
 	private BlockingSendExecutorCompletionService sendCompletionService;
 	@Autowired
@@ -55,6 +69,9 @@ public class SendPlanner extends AbstractRunner {
 		while (!shouldStop()) {
 			try {
 				Task task = generatedTasks.take();
+				// set Task status immediately
+				// no destination -> ERROR
+				// has destinations -> SENDING
 				if (task.getDestinations().isEmpty()) {
 					task.setStatus(Task.TaskStatus.ERROR);
 					try {
@@ -65,11 +82,16 @@ public class SendPlanner extends AbstractRunner {
 					try {
 						schedulingPool.removeTask(task);
 					} catch (TaskStoreException e) {
-						log.error("[{}] Task {} could not be removed from SchedulingPool: {}", task.getId(), task, e);
+						log.error("[{}] Generated Task without destinations could not be removed from SchedulingPool: {}", task.getId(), e);
 					}
+					// skip to next generated Task
 					continue;
 				}
+				// Task has destinations
 				task.setStatus(Task.TaskStatus.SENDING);
+
+				// TODO - would be probably better to have this as one time call after first SendWorker is submitted
+				// TODO   but then processing stuck tasks must reflect, that SENDING task might have sendStartTime=NULL
 				task.setSendStartTime(new Date(System.currentTimeMillis()));
 				schedulingPool.addSendTaskCount(task.getId(), task.getDestinations().size());
 				try {
@@ -78,37 +100,40 @@ public class SendPlanner extends AbstractRunner {
 					jmsLogError(task);
 				}
 
-
+				// create SendTask and SendWorker for each Destination
 				for (Destination destination : task.getDestinations()) {
+
 					SendTask sendTask = new SendTask(task, destination);
 					SendWorker worker = new SendWorkerImpl(sendTask, directory);
-
+					// submit for execution
 					Future<SendTask> sendFuture = sendCompletionService.blockingSubmit(worker);
 					schedulingPool.addSendTaskFuture(sendTask, sendFuture);
 					sendTask.setStartTime(new Date(System.currentTimeMillis()));
 					sendTask.setStatus(SENDING);
+
 				}
 
 			} catch (InterruptedException e) {
+
 				String errorStr = "Thread planning SendTasks was interrupted.";
 				log.error(errorStr);
 				throw new RuntimeException(errorStr, e);
+
 			} catch (Throwable ex) {
-				log.error("Unexpected exception in SendPlanner thread: {}.", ex);
+				log.error("Unexpected exception in SendPlanner thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later. {}", ex);
 			}
 		}
 	}
 
 	private void jmsLogError(Task task) {
-		log.warn("Could not send status update to Dispatcher for [{}] .", task);
+		log.warn("[{}] Could not send SEND status update to {} to Dispatcher.", task.getId(), task.getStatus());
 	}
 
 	@Autowired
 	public void setPropertiesBean(Properties propertiesBean) {
-		//log.debug("TESTSTR --> Send property bean set");
 		if (propertiesBean != null) {
-			//log.debug("TESTSTR --> Send script path from properties is {}", propertiesBean.getProperty("engine.sendscript.path"));
 			directory = new File(propertiesBean.getProperty("engine.sendscript.path"));
 		}
 	}
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingBoundedMap.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingBoundedMap.java
@@ -37,4 +37,10 @@ public interface BlockingBoundedMap<K, V> {
 	 */
 	Collection<V> values();
 
+	/**
+	 * Get all keys currently held by this blocking map
+	 * @return
+	 */
+	Collection<K> keySet();
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/SendWorker.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/SendWorker.java
@@ -12,6 +12,11 @@ public interface SendWorker extends EngineWorker<SendTask> {
 	@Override
 	SendTask call() throws Exception;
 
+	/**
+	 * Return SendTask associated with this SendWorker
+	 *
+	 * @return SendTask
+	 */
 	SendTask getSendTask();
 
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/AbstractWorker.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/AbstractWorker.java
@@ -75,7 +75,7 @@ public abstract class AbstractWorker<V> implements EngineWorker<V> {
 	 */
 	protected void execute(ProcessBuilder pb) throws InterruptedException, IOException {
 
-		log.debug("The directory for the worker will be [{}]", getDirectory());
+		log.trace("The directory for the worker will be [{}]", getDirectory());
 		if (getDirectory() != null) {
 			// set path relative to current working dir
 			pb.directory(getDirectory());

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingBoundedHashMap.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingBoundedHashMap.java
@@ -56,4 +56,9 @@ public class BlockingBoundedHashMap<K, V> implements BlockingBoundedMap<K, V> {
 		return map.values();
 	}
 
+	@Override
+	public Collection<K> keySet() {
+		return map.keySet();
+	}
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/GenWorkerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/GenWorkerImpl.java
@@ -13,11 +13,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 
-import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.GENERATED;
-import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.GENERROR;
-
 /**
  * Implementation of GenWorker, which is used for starting GEN scripts.
+ * On completion, genEndTime is set.
+ *
+ * Workers are created by GenPlanner, done/error workers are collected by GenCollector.
+ *
+ * @see cz.metacentrum.perun.engine.runners.GenPlanner
+ * @see cz.metacentrum.perun.engine.runners.GenCollector
  *
  * @author David Šarman
  * @author Pavel Zlámal <zlamal@cesnet.cz>
@@ -42,7 +45,7 @@ public class GenWorkerImpl extends AbstractWorker<Task> implements GenWorker {
 		Service service = getTask().getService();
 
 		log.info("[{}] Executing GEN worker for Task with Service ID: {} and Facility ID: {}.",
-				new Object[]{getTask().getId(), getTask().getServiceId(), getTask().getFacilityId()});
+				getTask().getId(), getTask().getServiceId(), getTask().getFacilityId());
 
 		ProcessBuilder pb = new ProcessBuilder(service.getScript(), "-f", String.valueOf(getTask().getFacilityId()));
 
@@ -57,29 +60,25 @@ public class GenWorkerImpl extends AbstractWorker<Task> implements GenWorker {
 			if (getReturnCode() != 0) {
 
 				log.error("[{}] GEN worker failed for Task. Ret code {}, STDOUT: {}, STDERR: {}",
-						new Object[]{getTask().getId(), getReturnCode(), getStdout(), getStderr()});
+						getTask().getId(), getReturnCode(), getStdout(), getStderr());
 
-				getTask().setStatus(GENERROR);
-				throw new TaskExecutionException(task.getId(), getReturnCode(), getStdout(), getStderr());
+				throw new TaskExecutionException(task, getReturnCode(), getStdout(), getStderr());
 
 			} else {
 
 				log.info("[{}] GEN worker finished for Task. Ret code {}, STDOUT: {}, STDERR: {}",
-						new Object[]{getTask().getId(), getReturnCode(), getStdout(), getStderr()});
+						getTask().getId(), getReturnCode(), getStdout(), getStderr());
 
-				getTask().setStatus(GENERATED);
 				return getTask();
 
 			}
 
 		} catch (IOException e) {
 			log.error("[{}] GEN worker failed for Task. IOException: {}.",  task.getId(), e);
-			getTask().setStatus(GENERROR);
-			throw new TaskExecutionException(task.getId(), e);
+			throw new TaskExecutionException(task, e);
 		} catch (InterruptedException e) {
 			log.warn("[{}] GEN worker failed for Task. Execution was interrupted {}.", task.getId(), e);
-			task.setStatus(GENERROR);
-			throw new TaskExecutionException(task.getId(), e);
+			throw new TaskExecutionException(task, e);
 		}
 
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -19,6 +19,8 @@ import javax.jms.JMSException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -66,9 +68,9 @@ public class SchedulingPoolImpl implements SchedulingPool {
 	@Override
 	public String getReport() {
 		return "Engine SchedulingPool Task report:\n" +
-				" PLANNED: " + getTasksWithStatus(WAITING) +
-				" GENERATING:" + getTasksWithStatus(GENERATING) +
-				" SENDING:" + getTasksWithStatus(SENDING) +
+				" PLANNED: " + printListWithWhitespace(getTasksWithStatus(WAITING)) +
+				" GENERATING:" + printListWithWhitespace(getTasksWithStatus(GENERATING)) +
+				" SENDING:" + printListWithWhitespace(getTasksWithStatus(SENDING)) +
 				" SENDTASKCOUNT map: " + sendTaskCount.toString();
 	}
 
@@ -134,24 +136,32 @@ public class SchedulingPoolImpl implements SchedulingPool {
 	@Override
 	public Integer decreaseSendTaskCount(int taskId, int decrease) throws TaskStoreException {
 		Integer count = sendTaskCount.get(taskId);
+		log.debug("[{}] Task SendTasks count is {}", taskId, count);
 		if (count == null) {
 			return null;
 		} else if (count <= 1) {
 			Task task = taskStore.getTask(taskId);
-			if (task.getStatus() != SENDERROR) {
-				task.setStatus(DONE);
-			}
-			if(task.getSendEndTime() == null) {
-				task.setSendEndTime(new Date(System.currentTimeMillis()));
-			}
-			try {
-				jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), System.currentTimeMillis());
-			} catch (JMSException e) {
-				log.error("Error while sending final status update for Task with ID {} to Dispatcher", taskId);
+			// its weird, but task don't have to be in a TaskStore when we are resolving removal of SendTask
+			if (task != null) {
+				if (!Objects.equals(task.getStatus(), SENDERROR)) {
+					task.setStatus(DONE);
+				}
+				if(task.getSendEndTime() == null) {
+					task.setSendEndTime(new Date(System.currentTimeMillis()));
+				}
+				try {
+					jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), System.currentTimeMillis());
+				} catch (JMSException e) {
+					log.error("[{}] Error while sending final status update for Task to Dispatcher", taskId);
+				}
+				log.debug("[{}] Trying to remove Task from allTasks since its done", taskId);
+			} else {
+				log.error("[{}] Trying to remove Task from allTasks since its done, but it was not there !!", taskId);
 			}
 			removeTask(taskId);
 			return 1;
 		} else {
+			log.debug("[{}] Task SendTasks count lowered by {}", taskId, decrease);
 			return sendTaskCount.replace(taskId, count - decrease);
 		}
 	}
@@ -183,14 +193,19 @@ public class SchedulingPoolImpl implements SchedulingPool {
 
 	@Override
 	public Task removeTask(int id) throws TaskStoreException {
+		log.debug("[{}] Removing Task from scheduling pool.", id);
 		Task removed = taskStore.removeTask(id);
 		Future<Task> taskFuture = genTaskFutures.get(id);
 		if (taskFuture != null) {
 			taskFuture.cancel(true);
 		}
+		// FIXME - I don't like this, we should try to cancel sendTasks even it Task was not in a TaskStore, just like for GEN
 		if (removed != null) {
+			log.debug("[{}] Task was in TaskStore (all tasks), canceling SendTasks.", id);
 			cancelSendTasks(id);
 			sendTaskCount.remove(id);
+		} else {
+			log.debug("[{}] Task was not in TaskStore (all tasks)", id);
 		}
 		return removed;
 	}
@@ -256,4 +271,16 @@ public class SchedulingPoolImpl implements SchedulingPool {
 		taskResult.setService(service);
 		return taskResult;
 	}
+
+	private String printListWithWhitespace(List<Task> list) {
+
+		if (list == null) return "[]";
+		StringJoiner joiner = new StringJoiner(", ");
+		for (Task task : list) {
+			if (task != null) joiner.add(String.valueOf(task.getId()));
+		}
+		return "[" + joiner.toString() + "]";
+
+	}
+
 }

--- a/perun-engine/src/main/resources/perun-engine.xml
+++ b/perun-engine/src/main/resources/perun-engine.xml
@@ -83,7 +83,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<prop key="engine.cron.processpool">0 0/1 * * * ?</prop>
 				<prop key="engine.cron.taskexecutor">0 0/2 * * * ?</prop>
 				<prop key="engine.thread.gentasks.max">15</prop>
-				<prop key="engine.thread.sendtasks.max">1000</prop>
+				<prop key="engine.thread.sendtasks.max">150</prop>
 				<prop key="engine.genscript.path">gen</prop>
 				<prop key="engine.sendscript.path">send</prop>
 			</props>

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/AbstractEngineTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/AbstractEngineTest.java
@@ -149,8 +149,8 @@ public abstract class AbstractEngineTest {
 		sendTask4.setReturnCode(0);
 
 		sendTaskFalse = new SendTask(task2, destination1);
-		sendTask4.setStartTime(new Date(System.currentTimeMillis()));
-		sendTask4.setStatus(SendTask.SendTaskStatus.SENDING);
+		sendTaskFalse.setStartTime(new Date(System.currentTimeMillis()));
+		sendTaskFalse.setStatus(SendTask.SendTaskStatus.SENDING);
 		sendTaskFalse.setReturnCode(1);
 	}
 

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/GenCollectorTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/GenCollectorTest.java
@@ -55,7 +55,7 @@ public class GenCollectorTest extends AbstractEngineTest {
 	public void testGenCollectorTaskException() throws Exception {
 
 		when(schedulingPoolMock.getGeneratedTasksQueue()).thenReturn(generatedTasksQueue);
-		when(genCompletionServiceMock.blockingTake()).thenThrow(new TaskExecutionException(task1.getId(), "Test err"));
+		when(genCompletionServiceMock.blockingTake()).thenThrow(new TaskExecutionException(task1, "Test err"));
 		doReturn(false, true).when(spy).shouldStop();
 
 		spy.run();

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/GenWorkerImplTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/GenWorkerImplTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import java.util.Date;
 
-import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.GENERATED;
+import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.PLANNED;
 import static org.junit.Assert.*;
 
 public class GenWorkerImplTest extends AbstractEngineTest {
@@ -20,7 +20,9 @@ public class GenWorkerImplTest extends AbstractEngineTest {
 		Task resultTask = worker.call();
 		Date now = new Date(System.currentTimeMillis());
 		assertTrue(resultTask.getGenEndTime().before(now) || resultTask.getGenEndTime().equals(now));
-		assertEquals(GENERATED, resultTask.getStatus());
+		// GenWorker itself doesn't change status anymore, since it caused race condition with endStuckTasks() process
+		// Its now responsibility of GenCollector thread to switch status -> only genEndTime is set by worker.
+		assertEquals(PLANNED, resultTask.getStatus());
 	}
 
 	@Test
@@ -30,7 +32,7 @@ public class GenWorkerImplTest extends AbstractEngineTest {
 			worker.call();
 			fail("TaskExecutionException should be thrown.");
 		} catch (TaskExecutionException e) {
-			assertEquals(task2.getId(), e.getId());
+			assertEquals(task2.getId(), e.getTask().getId());
 			assertEquals(1, e.getReturnCode());
 		} catch (Exception e) {
 			fail("Unexpected exception caught " + e);

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SendPlannerTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SendPlannerTest.java
@@ -1,17 +1,13 @@
 package cz.metacentrum.perun.engine.unit;
 
-import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.engine.AbstractEngineTest;
 import cz.metacentrum.perun.engine.runners.SendPlanner;
 import cz.metacentrum.perun.engine.scheduling.SendWorker;
 import cz.metacentrum.perun.engine.scheduling.impl.BlockingSendExecutorCompletionService;
-import cz.metacentrum.perun.taskslib.model.SendTask;
 import cz.metacentrum.perun.taskslib.model.Task;
-import cz.metacentrum.perun.taskslib.model.TaskResult;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Date;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SendWorkerImplTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SendWorkerImplTest.java
@@ -32,7 +32,8 @@ public class SendWorkerImplTest extends AbstractEngineTest {
 			worker.call();
 			fail("TaskExecutionException should be thrown");
 		} catch (TaskExecutionException e) {
-			assertEquals(sendTaskFalse.getId(), e.getId());
+			assertEquals(sendTaskFalse.getTask(), e.getTask());
+			assertEquals(sendTaskFalse.getDestination(), e.getDestination());
 			assertEquals(1, e.getReturnCode());
 		} catch (Exception e) {
 			fail("Unknown exception caught " + e);


### PR DESCRIPTION
- Added javadoc and comments to many places with explanation and
  reasoning for changes or original source.
- Lowered number of concurrently running SendTasks to 150 from 1000.
  Some machines doesn't like so many sleeping/waiting threads.
- Updated tests to match changes listed below.

EventProcessorImpl
- If Task is already in pool, do not modify it. Let engine finish
  the job. Dispatcher doesn't reschedule partial destinations
  or forced flag anyway.

TaskExecutionException
- Modified to contain whole Task and related Destination if any.
- This make sure we can always get related Task if propagation fails.

GenPlanner
- Change Task status immediately after its taken from incoming queue.
- Set startTime after is really submitted for execution.
- This prevents cleaning thread from wrongly killing processing
  Tasks with seemingly inconsistent state.

GenCollector
- Change Task status immediately after its taken from
  genCompletionService.
- Report Task status to Dispatcher before submitting to generatedTasks
  queue since SendPlanner takes it immediately and modify state and
  report different status (SENDING overrun GENERATED).

SendPlanner
- Change Task status immediately after its taken from generatedTasks
  queue and report status to Dispatcher.

SendCollector
- Reimplemented to manage Task status change and endTime. Once
  SendTask is done, its removed from Engine. If there are no more
  SendTasks for Task, Task is also removed.
- We now have Task and Destination always available, since
  implementation of TaskExecutionException changed.

GenWorkerImpl
- No longer modify Task status, since it might collide with cleaning
  tread which might overrun blockingTake from the queue.

SendWorkerImpl
- Properly set SendTask status and end time, since SendCollector
  manages only Task as a whole. Pass related Task in
  TaskExecutionException.

PropagationMaintainer
- Updated implementation of endStuckTasks() to reflect changes in
  workers and planners/collectors.
- Added many explaining comments for implementation reasoning.