### PR TITLE
ENGINE: Reimplemented Task processing

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.util.Date;
 import java.util.Properties;
 import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.Future;
 
 import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.GENERATING;
 
@@ -68,10 +67,7 @@ public class GenPlanner extends AbstractRunner {
 				*/
 				task.setStatus(GENERATING);
 				GenWorker worker = new GenWorkerImpl(task, directory);
-				Future<Task> taskFuture = genCompletionService.blockingSubmit(worker);
-				schedulingPool.addGenTaskFutureToPool(task.getId(), taskFuture);
-				// We actually started, set Time and notify Dispatcher
-				task.setGenStartTime(new Date(System.currentTimeMillis()));
+				genCompletionService.blockingSubmit(worker);
 				try {
 					jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), task.getGenStartTime().getTime());
 				} catch (JMSException e) {

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingBoundedMap.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingBoundedMap.java
@@ -10,6 +10,7 @@ import java.util.Collection;
  *
  * @author David Šarman
  */
+@Deprecated
 public interface BlockingBoundedMap<K, V> {
 
 	/**

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingCompletionService.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/BlockingCompletionService.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.engine.scheduling;
 
 import cz.metacentrum.perun.engine.exceptions.TaskExecutionException;
 
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 
 /**
@@ -39,5 +40,23 @@ public interface BlockingCompletionService<V>{
 	 * @throws TaskExecutionException when worker failed
 	 */
 	V blockingTake() throws InterruptedException, TaskExecutionException;
+
+	/**
+	 * Return map of currently running Tasks. This map must NEVER be modified outside BlockingCompletionService !!
+	 * Its only for inspection reasons !!
+	 *
+	 * @return map of running Futures and Tasks
+	 */
+	ConcurrentMap<Future<V>, V> getRunningTasks();
+
+	/**
+	 * Remove Future from running tasks in completion service and release blocking semaphore.
+	 * This should be called only if we are sure, that Future is either stuck (running for more than
+	 * rescheduleTime) or GenCollector / SendCollector is not running and finished and failed Tasks are kept
+	 * in completion service.
+	 *
+	 * @param future to be removed
+	 */
+	void removeStuckTask(Future<V> future);
 
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/SchedulingPool.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/SchedulingPool.java
@@ -1,57 +1,49 @@
 package cz.metacentrum.perun.engine.scheduling;
 
-import cz.metacentrum.perun.core.api.Destination;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.taskslib.exceptions.TaskStoreException;
-import cz.metacentrum.perun.taskslib.model.SendTask;
 import cz.metacentrum.perun.taskslib.model.Task;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
 import cz.metacentrum.perun.taskslib.service.TaskStore;
 
 import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Future;
 
 /**
  * This class groups all Task queues from Engine, providing means to add new Tasks, cancel/remove present ones, etc.
  */
 public interface SchedulingPool extends TaskStore {
 
-	Future<Task> addGenTaskFutureToPool(Integer id, Future<Task> taskFuture);
-
-	Future<SendTask> addSendTaskFuture(SendTask sendTask, Future<SendTask> sendFuture);
-	
 	String getReport();
 
 	/**
 	 * Method used when SendTasks are being created from parent Task.
-	 * It puts number of SendTasks still running under the Tasks id.
-	 * @param taskId Id of the Task which count we add.
-	 * @param count Number of running sendTasks for a given Task.
-	 * @return Value previously associated with given Task's ID, null if there was none.
+	 * It puts number of Task Destinations - created SendTasks, so Engine can
+	 * count down when whole Task is completed.
+	 *
+	 * @param task Parent Task
+	 * @param count Number of running SendTasks for a given Task.
+	 * @return Value previously associated with given Task, null if there was none.
 	 */
-	Integer addSendTaskCount(int taskId, int count);
+	Integer addSendTaskCount(Task task, int count);
 
 	/**
 	 * Decreases the count of SendTask running for given Task.
-	 * Used when SendTasks finishes executing.
-	 * @param taskId Id of the Task whose SendTask/s finished.
-	 * @param decrease Number by which we reduce the count.
+	 * Used when SendTasks finishes executing, so Engine can
+	 * count down when whole Task is completed.
+	 *
+	 * Once count <=1 Task is removed from scheduling pool
+	 * and status is reported to Dispatcher.
+	 *
+	 * @param task Parent Task
+	 * @param decrease Number by which we reduce the count (usually one)
 	 * @return Return value previously associated with given Task ID.
 	 * @throws TaskStoreException Thrown if inconsistency occurred while saving the Task.
 	 */
-	Integer decreaseSendTaskCount(int taskId, int decrease) throws TaskStoreException;
+	Integer decreaseSendTaskCount(Task task, int decrease) throws TaskStoreException;
 
 	BlockingDeque<Task> getNewTasksQueue();
 
 	BlockingDeque<Task> getGeneratedTasksQueue();
-
-	ConcurrentMap<Integer, Future<Task>> getGenTaskFuturesMap();
-
-	Future<Task> getGenTaskFutureById(int id);
-
-	Future<SendTask> removeSendTaskFuture(int taskId, Destination destination) throws TaskStoreException;
 
 	TaskResult createTaskResult (int taskId, int destinationId, String stderr, String stdout, int returnCode,
 	                             Service service);

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingBoundedHashMap.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingBoundedHashMap.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Semaphore;
  * @param <K> key class
  * @param <V> value class
  */
+@Deprecated
 public class BlockingBoundedHashMap<K, V> implements BlockingBoundedMap<K, V> {
 
 	private ConcurrentMap<K, V> map = new ConcurrentHashMap<>();

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingGenExecutorCompletionService.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingGenExecutorCompletionService.java
@@ -1,16 +1,14 @@
 package cz.metacentrum.perun.engine.scheduling.impl;
 
 import cz.metacentrum.perun.engine.exceptions.TaskExecutionException;
-import cz.metacentrum.perun.engine.scheduling.BlockingBoundedMap;
 import cz.metacentrum.perun.engine.scheduling.BlockingCompletionService;
 import cz.metacentrum.perun.engine.scheduling.EngineWorker;
 import cz.metacentrum.perun.engine.scheduling.GenWorker;
 import cz.metacentrum.perun.taskslib.model.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.util.Date;
 import java.util.concurrent.*;
 
 /**
@@ -25,15 +23,14 @@ import java.util.concurrent.*;
  * @see cz.metacentrum.perun.engine.runners.GenCollector
  *
  * @author David Šarman
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class BlockingGenExecutorCompletionService implements BlockingCompletionService<Task> {
 
 	private final static Logger log = LoggerFactory.getLogger(BlockingGenExecutorCompletionService.class);
 	private CompletionService<Task> completionService;
-	@Autowired
-	@Qualifier("generatingTasks")
-	private BlockingBoundedMap<Integer, Task> executingTasks;
-	private int limit;
+	private ConcurrentMap<Future<Task>, Task> executingGenTasks = new ConcurrentHashMap<>();
+	private Semaphore semaphore;
 
 	/**
 	 * Create new blocking CompletionService for GEN Tasks with specified limit
@@ -41,49 +38,92 @@ public class BlockingGenExecutorCompletionService implements BlockingCompletionS
 	 * @param limit Limit for processing GEN Tasks
 	 */
 	public BlockingGenExecutorCompletionService(int limit) {
-		this.limit = limit;
 		completionService = new ExecutorCompletionService<Task>(Executors.newFixedThreadPool(limit), new LinkedBlockingQueue<Future<Task>>());
+		this.semaphore = new Semaphore(limit);
 	}
 
 	@Override
 	public Future<Task> blockingSubmit(EngineWorker<Task> taskWorker) throws InterruptedException {
+		semaphore.acquire();
 		GenWorker genWorker = (GenWorker) taskWorker;
-		// FIXME - actual debug output differs, since object values are serialized later and might be modified by another thread
-		log.debug("Executing GEN tasks before submit: {}/{}", executingTasks.keySet().size(), limit);
-		executingTasks.blockingPut(genWorker.getTaskId(), genWorker.getTask());
-		return completionService.submit(genWorker);
+		// We must have start time before adding Task to executingGenTasks
+		genWorker.getTask().setGenStartTime(new Date(System.currentTimeMillis()));
+		Future<Task> future = completionService.submit(genWorker);
+		executingGenTasks.put(future, genWorker.getTask());
+		return future;
 	}
 
 	@Override
 	public Task blockingTake() throws InterruptedException, TaskExecutionException {
-		// FIXME - actual debug output differs, since object values are serialized later and might be modified by another thread
-		log.debug("Executing GEN tasks before take: {}/{}", executingTasks.keySet().size(), limit);
+
 		Future<Task> taskFuture = completionService.take();
+
 		try {
-			Task taskResult = taskFuture.get();
-			Task removed = executingTasks.remove(taskResult.getId());
-			if (removed == null) {
-				String errorStr = "Task " + taskResult + " could not be removed from completion services pool " + completionService;
-				log.error(errorStr);
-				throw new TaskExecutionException(taskResult, errorStr);
-			}
-			return taskResult;
+
+			// .get() throws CancellationException if Task processing was cancelled from outside
+			Task task = taskFuture.get();
+			removeTaskFuture(taskFuture);
+			return task;
+
 		} catch (ExecutionException e) {
+
+			Task task = executingGenTasks.get(taskFuture);
+			removeTaskFuture(taskFuture);
+
 			Throwable cause = e.getCause();
-			if (cause.getClass().equals(TaskExecutionException.class)) {
-				TaskExecutionException castedCause = (TaskExecutionException) cause;
-				executingTasks.remove(castedCause.getTask().getId());
-				throw castedCause;
+			if (cause instanceof TaskExecutionException) {
+				// GEN Task failed and related Task and results are part of this exception
+				throw (TaskExecutionException)cause;
 			} else {
-				String errorMsg = "Unexpected exception occurred during Task execution";
-				log.error(errorMsg, e);
-				throw new RuntimeException(errorMsg, e);
+
+				// Unexpected exception during processing, pass stored Task if possible
+				if (task == null) {
+					log.error("We couldn't get Task for failed Future<Task>: {}", e);
+					throw new RuntimeException("We couldn't get Task for failed Future<Task>", e);
+				}
+
+				throw new TaskExecutionException(task, "Unexpected exception during GEN Task processing.", e);
 			}
+
 		} catch (CancellationException ex) {
-			// anyway this seems to be a problem, since GEN Task will be stuck in executingTasks, probably clean job will remove it
-			String errorMsg = "Task to be taken from BlockingGenExecutorCompletionService was canceled";
-			log.error(errorMsg+": {}", ex);
-			throw new RuntimeException(errorMsg, ex);
+
+			// processing was cancelled
+			Task removedTask = executingGenTasks.get(taskFuture);
+			removeTaskFuture(taskFuture);
+			if (removedTask == null) {
+				log.error("Somebody manually removed Future<Task> from executingGenTasks or Task was null: {}", ex);
+				throw ex; // we can't do anything about it
+			}
+
+			// make sure GenCollector always get related Task
+			throw new TaskExecutionException(removedTask, "Processing of Task was cancelled before completion.");
+
+		}
+
+	}
+
+	@Override
+	public ConcurrentMap<Future<Task>, Task> getRunningTasks() {
+		return executingGenTasks;
+	}
+
+	@Override
+	public void removeStuckTask(Future<Task> future) {
+		removeTaskFuture(future);
+	}
+
+	/**
+	 * Remove Future<Task> from executingGenTasks and release semaphore.
+	 *
+	 * @param future to be removed
+	 */
+	private void removeTaskFuture(Future<Task> future) {
+		Task removedTask = executingGenTasks.remove(future);
+		if (removedTask != null) {
+			// release semaphore only if future was really in a map
+			// because it could change during processing
+			semaphore.release();
 		}
 	}
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingSendExecutorCompletionService.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/BlockingSendExecutorCompletionService.java
@@ -1,19 +1,17 @@
 package cz.metacentrum.perun.engine.scheduling.impl;
 
-import cz.metacentrum.perun.core.api.Destination;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.engine.exceptions.TaskExecutionException;
-import cz.metacentrum.perun.engine.scheduling.BlockingBoundedMap;
 import cz.metacentrum.perun.engine.scheduling.BlockingCompletionService;
 import cz.metacentrum.perun.engine.scheduling.EngineWorker;
 import cz.metacentrum.perun.engine.scheduling.SendWorker;
 import cz.metacentrum.perun.taskslib.model.SendTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.util.Date;
 import java.util.concurrent.*;
+
+import static cz.metacentrum.perun.taskslib.model.SendTask.SendTaskStatus.SENDING;
 
 /**
  * Implementation of BlockingCompletionService<SendTask> for sending Tasks in Engine.
@@ -28,15 +26,14 @@ import java.util.concurrent.*;
  * @see cz.metacentrum.perun.engine.runners.SendCollector
  *
  * @author David Šarman
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class BlockingSendExecutorCompletionService implements BlockingCompletionService<SendTask> {
 
 	private final static Logger log = LoggerFactory.getLogger(BlockingSendExecutorCompletionService.class);
 	private CompletionService<SendTask> completionService;
-	@Autowired
-	@Qualifier("sendingSendTasks")
-	private BlockingBoundedMap<Pair<Integer, Destination>, SendTask> executingTasks;
-	private int limit;
+	private ConcurrentMap<Future<SendTask>, SendTask> executingSendTasks = new ConcurrentHashMap<>();
+	private Semaphore semaphore;
 
 	/**
 	 * Create new blocking CompletionService for SEND Tasks with specified limit
@@ -44,43 +41,91 @@ public class BlockingSendExecutorCompletionService implements BlockingCompletion
 	 * @param limit Limit for processing SEND Tasks
 	 */
 	public BlockingSendExecutorCompletionService(int limit) {
-		this.limit = limit;
-		completionService = new ExecutorCompletionService<SendTask>(Executors.newFixedThreadPool(limit), new LinkedBlockingQueue<Future<SendTask>>());
+		this.completionService = new ExecutorCompletionService<SendTask>(Executors.newFixedThreadPool(limit), new LinkedBlockingQueue<Future<SendTask>>());
+		this.semaphore = new Semaphore(limit);
 	}
 
 	@Override
 	public Future<SendTask> blockingSubmit(EngineWorker<SendTask> taskWorker) throws InterruptedException {
+		semaphore.acquire();
 		SendWorker sendWorker = (SendWorker) taskWorker;
-		// FIXME - actual debug output differs, since object values are serialized later and might be modified by another thread
-		log.debug("Executing SEND tasks before submit: {}/{}", executingTasks.keySet().size(), limit);
-		executingTasks.blockingPut(sendWorker.getSendTask().getId(), sendWorker.getSendTask());
-		return completionService.submit(sendWorker);
+		sendWorker.getSendTask().setStartTime(new Date(System.currentTimeMillis()));
+		sendWorker.getSendTask().setStatus(SENDING);
+		Future<SendTask> future = completionService.submit(sendWorker);
+		executingSendTasks.put(future, sendWorker.getSendTask());
+		return future;
 	}
 
 	@Override
 	public SendTask blockingTake() throws InterruptedException, TaskExecutionException {
-		// FIXME - actual debug output differs, since object values are serialized later and might be modified by another thread
-		log.debug("Executing SEND tasks before take: {}/{}", executingTasks.keySet().size(), limit);
+
 		Future<SendTask> taskFuture = completionService.take();
+
 		try {
-			SendTask taskResult = taskFuture.get();
-			SendTask removed = executingTasks.remove(taskResult.getId());
-			if (removed == null) {
-				log.warn("Finished {} was not present in executingTasks map. Probably cleaned by endStuckTasks().", taskResult);
-			}
-			return taskResult;
+			// .get() throws CancellationException if Task processing was cancelled from outside
+			SendTask sendTask = taskFuture.get();
+			removeTaskFuture(taskFuture);
+			return sendTask;
+
 		} catch (ExecutionException e) {
+
+			SendTask sendTask = executingSendTasks.get(taskFuture);
+			removeTaskFuture(taskFuture);
+
 			Throwable cause = e.getCause();
-			if (cause.getClass().equals(TaskExecutionException.class)) {
-				TaskExecutionException castedCause = (TaskExecutionException) cause;
-				executingTasks.remove(new Pair<>(castedCause.getTask().getId(), castedCause.getDestination()));
-				throw castedCause;
+			if (cause instanceof TaskExecutionException) {
+				// SEND Task failed and related Task and results are part of this exception
+				throw (TaskExecutionException)cause;
 			} else {
-				String errorMsg = "Unexpected exception occurred during SendTask execution";
-				log.error(errorMsg, e);
-				throw new RuntimeException(errorMsg, e);
+
+				// Unexpected exception during processing, pass stored SendTask if possible
+				if (sendTask == null) {
+					log.error("We couldn't get SendTask for failed Future<SendTask>: {}", e);
+					throw new RuntimeException("We couldn't get SendTask for failed Future<Task>", e);
+				}
+
+				throw new TaskExecutionException(sendTask.getTask(), sendTask.getDestination(), "Unexpected exception during SEND Task processing.", e);
 			}
+
+		} catch (CancellationException ex) {
+
+			// processing was cancelled
+			SendTask removedSendTask = executingSendTasks.get(taskFuture);
+			removeTaskFuture(taskFuture);
+			if (removedSendTask == null) {
+				log.error("Somebody manually removed Future<SendTask> from executingSendTasks or SendTask was null: {}", ex);
+				throw ex; // we can't do anything about it
+			}
+
+			// make sure SendCollector always get related Task
+			throw new TaskExecutionException(removedSendTask.getTask(), removedSendTask.getDestination(), "Processing of Task was cancelled before completion.");
+
 		}
-		// TODO - catch cancellation exception ?
+
 	}
+
+	@Override
+	public ConcurrentMap<Future<SendTask>, SendTask> getRunningTasks() {
+		return executingSendTasks;
+	}
+
+	@Override
+	public void removeStuckTask(Future<SendTask> future) {
+		removeTaskFuture(future);
+	}
+
+	/**
+	 * Remove Future<SendTask> from executingSendTasks and release semaphore.
+	 *
+	 * @param future to be removed
+	 */
+	private void removeTaskFuture(Future<SendTask> future) {
+		SendTask removedTask = executingSendTasks.remove(future);
+		if (removedTask != null) {
+			// release semaphore only if future was really in a map
+			// because it could change during processing
+			semaphore.release();
+		}
+	}
+
 }

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/SchedulingPoolImpl.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.engine.scheduling.impl;
 
-import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.engine.jms.JMSQueueManager;
@@ -8,7 +7,6 @@ import cz.metacentrum.perun.taskslib.exceptions.TaskStoreException;
 import cz.metacentrum.perun.engine.scheduling.SchedulingPool;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
 import cz.metacentrum.perun.taskslib.service.TaskStore;
-import cz.metacentrum.perun.taskslib.model.SendTask;
 import cz.metacentrum.perun.taskslib.model.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,18 +22,14 @@ import java.util.StringJoiner;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static cz.metacentrum.perun.taskslib.model.Task.TaskStatus.*;
 
 @org.springframework.stereotype.Service(value = "schedulingPool")
 public class SchedulingPoolImpl implements SchedulingPool {
+
 	private final static Logger log = LoggerFactory.getLogger(SchedulingPoolImpl.class);
-	private final ConcurrentMap<Integer, Future<Task>> genTaskFutures = new ConcurrentHashMap<>();
-	private final ConcurrentMap<Integer, ConcurrentMap<Destination, Future<SendTask>>> sendTasks = new ConcurrentHashMap<>();
 	private final ConcurrentMap<Integer, Integer> sendTaskCount = new ConcurrentHashMap<>();
 	private final BlockingDeque<Task> newTasksQueue = new LinkedBlockingDeque<>();
 	private final BlockingDeque<Task> generatedTasksQueue = new LinkedBlockingDeque<>();
@@ -52,28 +46,12 @@ public class SchedulingPoolImpl implements SchedulingPool {
 		this.jmsQueueManager = jmsQueueManager;
 	}
 
-	public Future<Task> addGenTaskFutureToPool(Integer id, Future<Task> taskFuture) {
-		return genTaskFutures.put(id, taskFuture);
-	}
-
-	@Override
-	public Future<SendTask> addSendTaskFuture(SendTask sendTask, Future<SendTask> sendFuture) {
-		ConcurrentMap<Destination, Future<SendTask>> sendTaskFutures = sendTasks.get(sendTask.getId().getLeft());
-		if(sendTaskFutures == null) {
-			sendTaskFutures = new ConcurrentHashMap<Destination, Future<SendTask>>();
-			sendTasks.put(sendTask.getId().getLeft(), sendTaskFutures);
-		}
-		sendTaskFutures.putIfAbsent(sendTask.getDestination(), sendFuture);
-		return sendFuture;
-	}
-
 	@Override
 	public String getReport() {
 		return "Engine SchedulingPool Task report:\n" +
-				" PLANNED: " + printListWithWhitespace(getTasksWithStatus(WAITING)) +
+				" PLANNED: " + printListWithWhitespace(getTasksWithStatus(PLANNED)) +
 				" GENERATING:" + printListWithWhitespace(getTasksWithStatus(GENERATING)) +
-				" SENDING:" + printListWithWhitespace(Stream.concat(getTasksWithStatus(SENDING).stream(),
-				getTasksWithStatus(SENDERROR).stream()).collect(Collectors.toList())) +
+				" SENDING:" + printListWithWhitespace(getTasksWithStatus(SENDING,SENDERROR)) +
 				" SENDTASKCOUNT map: " + sendTaskCount.toString();
 	}
 
@@ -134,45 +112,38 @@ public class SchedulingPoolImpl implements SchedulingPool {
 	}
 
 	@Override
-	public Integer addSendTaskCount(int taskId, int count) {
-		return sendTaskCount.put(taskId, count);
+	public Integer addSendTaskCount(Task task, int count) {
+		return sendTaskCount.put(task.getId(), count);
 	}
 
 	@Override
-	public Integer decreaseSendTaskCount(int taskId, int decrease) throws TaskStoreException {
-		Integer count = sendTaskCount.get(taskId);
-		log.debug("[{}] Task SendTasks count is {}", taskId, count);
+	public Integer decreaseSendTaskCount(Task task, int decrease) throws TaskStoreException {
+
+		Integer count = sendTaskCount.get(task.getId());
+		log.debug("[{}] Task SendTasks count is {}", task.getId(), count);
+
 		if (count == null) {
 			return null;
+
 		} else if (count <= 1) {
-			Task task = taskStore.getTask(taskId);
-			// its weird, but task don't have to be in a TaskStore when we are resolving removal of SendTask
-			if (task != null) {
-				if (!Objects.equals(task.getStatus(), SENDERROR)) {
-					task.setStatus(DONE);
-				}
-				if(task.getSendEndTime() == null) {
-					task.setSendEndTime(new Date(System.currentTimeMillis()));
-				}
-				try {
-					jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), System.currentTimeMillis());
-				} catch (JMSException e) {
-					log.error("[{}] Error while sending final status update for Task to Dispatcher", taskId);
-				}
-				log.debug("[{}] Trying to remove Task from allTasks since its done", taskId);
-			} else {
-				log.error("[{}] Trying to remove Task from allTasks since its done, but it was not there !!", taskId);
+
+			if (!Objects.equals(task.getStatus(), SENDERROR)) {
+				task.setStatus(DONE);
 			}
-			// FIXME - we should probably removeTask() only if its in taskStore, since it doesn't make sense otherwise
-			// FIXME   otherwise we might cancel correctly running gen when late send is not yet reported ?
-			// FIXME   (would be probably caused by cleaning thread removal just before reporting done/error)
-			// FIXME - ALSO WE ARE NOW ABLE TO PASS WHOLE "TASK" object to these methods, making it safe to blindly
-			// FIXME   remove Task from any corresponding structure
-			removeTask(taskId);
+			if(task.getSendEndTime() == null) {
+				task.setSendEndTime(new Date(System.currentTimeMillis()));
+			}
+			try {
+				jmsQueueManager.reportTaskStatus(task.getId(), task.getStatus(), System.currentTimeMillis());
+			} catch (JMSException e) {
+				log.error("[{}] Error while sending final status update for Task to Dispatcher", task.getId());
+			}
+			log.debug("[{}] Trying to remove Task from allTasks since its done", task.getId());
+			removeTask(task);
 			return 1;
 		} else {
-			log.debug("[{}] Task SendTasks count lowered by {}", taskId, decrease);
-			return sendTaskCount.replace(taskId, count - decrease);
+			log.debug("[{}] Task SendTasks count lowered by {}", task.getId(), decrease);
+			return sendTaskCount.replace(task.getId(), count - decrease);
 		}
 	}
 
@@ -187,16 +158,6 @@ public class SchedulingPoolImpl implements SchedulingPool {
 	}
 
 	@Override
-	public ConcurrentMap<Integer, Future<Task>> getGenTaskFuturesMap() {
-		return genTaskFutures;
-	}
-
-	@Override
-	public Future<Task> getGenTaskFutureById(int id) {
-		return genTaskFutures.get(id);
-	}
-
-	@Override
 	public Task removeTask(Task task) throws TaskStoreException {
 		return removeTask(task.getId());
 	}
@@ -205,14 +166,7 @@ public class SchedulingPoolImpl implements SchedulingPool {
 	public Task removeTask(int id) throws TaskStoreException {
 		log.debug("[{}] Removing Task from scheduling pool.", id);
 		Task removed = taskStore.removeTask(id);
-		Future<Task> taskFuture = genTaskFutures.get(id);
-		if (taskFuture != null) {
-			taskFuture.cancel(true);
-		}
-		// FIXME - I don't like this, we should try to cancel sendTasks even it Task was not in a TaskStore, just like for GEN
 		if (removed != null) {
-			log.debug("[{}] Task was in TaskStore (all tasks), canceling SendTasks.", id);
-			cancelSendTasks(id);
 			sendTaskCount.remove(id);
 		} else {
 			log.debug("[{}] Task was not in TaskStore (all tasks)", id);
@@ -223,47 +177,15 @@ public class SchedulingPoolImpl implements SchedulingPool {
 	@Override
 	public void clear() {
 		taskStore.clear();
-		genTaskFutures.clear();
-		sendTasks.clear();
 		sendTaskCount.clear();
 		newTasksQueue.clear();
 		generatedTasksQueue.clear();
-	}
-
-	public Future<SendTask> removeSendTaskFuture(int taskId, Destination destination) throws TaskStoreException {
-		ConcurrentMap<Destination, Future<SendTask>> destinationSendTasks = sendTasks.get(taskId);
-		if (destinationSendTasks != null) {
-			log.debug("[{}] Removing SendTask futures for destination {}", taskId, destination);
-			Future<SendTask> removed = destinationSendTasks.remove(destination);
-			if (removed != null) {
-				log.debug("[{}] Lowering SendTask future counts for destination {}", taskId, destination);
-				decreaseSendTaskCount(taskId, 1);
-			} else {
-				log.debug("[{}] SendTask future hadn't had future for destination: {}", taskId, destination);
-			}
-			return removed;
-		} else {
-			log.debug("[{}] SendTask future hadn't had any destination for: {}", taskId, taskId);
-			return null;
-		}
 	}
 
 	private void handleInterruptedException(Task task, InterruptedException e) {
 		String errorMessage = "Thread was interrupted while trying to put Task " + task + " into new Tasks queue.";
 		log.error(errorMessage, e);
 		throw new RuntimeException(errorMessage, e);
-	}
-
-	private void cancelSendTasks(int taskId) {
-		//TODO: If SendPlanner is currently planning the Task, we may not cancel all sendTasks
-		ConcurrentMap<Destination, Future<SendTask>> futureSendTasks = sendTasks.get(taskId);
-		if (futureSendTasks == null) {
-			return;
-		}
-		for (Future<SendTask> sendTaskFuture : futureSendTasks.values()) {
-			//TODO: Set the with interrupt parameter to true or not?
-			sendTaskFuture.cancel(true);
-		}
 	}
 
 	// TODO this does not belong here, move it somewhere else

--- a/perun-engine/src/main/resources/perun-engine.xml
+++ b/perun-engine/src/main/resources/perun-engine.xml
@@ -32,14 +32,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		-->
     </bean>
 
-    <bean id="generatingTasks" class="cz.metacentrum.perun.engine.scheduling.impl.BlockingBoundedHashMap">
-        <constructor-arg value="${engine.thread.gentasks.max}"/>
-    </bean>
-
-    <bean id="sendingSendTasks" class="cz.metacentrum.perun.engine.scheduling.impl.BlockingBoundedHashMap">
-        <constructor-arg value="${engine.thread.sendtasks.max}"/>
-    </bean>
-
     <bean id="taskStore" class="cz.metacentrum.perun.taskslib.service.impl.TaskStoreImpl"/>
 
     <bean id="schedulingPool" class="cz.metacentrum.perun.engine.scheduling.impl.SchedulingPoolImpl"/>

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/GenPlannerTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/GenPlannerTest.java
@@ -47,7 +47,6 @@ public class GenPlannerTest extends AbstractEngineTest{
 		spy.run();
 
 		verify(genCompletionServiceMock, times(1)).blockingSubmit(any(GenWorker.class));
-		verify(schedulingPoolMock, times(1)).addGenTaskFutureToPool(task1.getId(), futureMock);
 		verify(jmsQueueManagerMock, times(1)).reportTaskStatus(
 				eq(task1.getId()), eq(task1.getStatus()), eq(task1.getGenStartTime().getTime()));
 

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SchedulingPoolTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SchedulingPoolTest.java
@@ -1,23 +1,17 @@
 package cz.metacentrum.perun.engine.unit;
 
-import cz.metacentrum.perun.core.api.Destination;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.engine.AbstractEngineTest;
 import cz.metacentrum.perun.engine.jms.JMSQueueManager;
-import cz.metacentrum.perun.engine.scheduling.BlockingBoundedMap;
 import cz.metacentrum.perun.engine.scheduling.SchedulingPool;
 import cz.metacentrum.perun.engine.scheduling.impl.SchedulingPoolImpl;
 import cz.metacentrum.perun.taskslib.service.impl.TaskStoreImpl;
-import cz.metacentrum.perun.taskslib.model.SendTask;
 import cz.metacentrum.perun.taskslib.model.Task;
 import cz.metacentrum.perun.taskslib.model.Task.TaskStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collection;
-import java.util.concurrent.Future;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -30,20 +24,14 @@ import static org.mockito.Mockito.mock;
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
 public class SchedulingPoolTest extends AbstractEngineTest {
+
 	private SchedulingPool schedulingPool;
 
-	/*
-	@Autowired
-	private BlockingBoundedMap<Integer, Task> generatingTasks;
-	@Autowired
-	private BlockingBoundedMap<Pair<Integer, Destination>, SendTask> sendingSendTasks;
-	*/
-	
 	@Before
 	public void setup() throws Exception {
 		super.setup();
 		schedulingPool = new SchedulingPoolImpl(
-				new TaskStoreImpl(), 
+				new TaskStoreImpl(),
 				mock(JMSQueueManager.class));
 		schedulingPool.addTask(task1);
 	}
@@ -108,17 +96,6 @@ public class SchedulingPoolTest extends AbstractEngineTest {
 	}
 
 	@Test
-	public void getGenTaskFutureById() {
-		Future<Task> future = schedulingPool.getGenTaskFutureById(task1.getId());
-		assertNull("There should be no Future under this id.", future);
-
-		Future<Task> futureMock = mock(Future.class);
-		schedulingPool.getGenTaskFuturesMap().put(task1.getId(), futureMock);
-		future = schedulingPool.getGenTaskFutureById(task1.getId());
-		assertEquals(futureMock, future);
-	}
-
-	@Test
 	public void getTaskByIdTest() throws Exception {
 		Task task = schedulingPool.getTask(task1.getId());
 		assertEquals(task1, task);
@@ -126,11 +103,11 @@ public class SchedulingPoolTest extends AbstractEngineTest {
 
 	@Test
 	public void removeSentTaskTest() throws Exception {
-		schedulingPool.addSendTaskCount(task1.getId(), 2);
+		schedulingPool.addSendTaskCount(task1, 2);
 		assertEquals(1, schedulingPool.getSize());
 
-		schedulingPool.decreaseSendTaskCount(task1.getId(), 1);
-		schedulingPool.decreaseSendTaskCount(task1.getId(), 1);
+		schedulingPool.decreaseSendTaskCount(task1, 1);
+		schedulingPool.decreaseSendTaskCount(task1, 1);
 
 		assertEquals("Task should be removed from pool when associated sendTask count reaches zero",
 				0, schedulingPool.getSize());

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SendCollectorTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SendCollectorTest.java
@@ -45,10 +45,7 @@ public class SendCollectorTest extends AbstractEngineTest {
 		assertEquals(SENDING, sendTask3.getStatus());
 		assertEquals(SENDING, sendTask4.getStatus());
 
-		verify(schedulingPoolMock, times(1)).removeSendTaskFuture(task1.getId(), sendTask1.getDestination());
-		verify(schedulingPoolMock, times(1)).removeSendTaskFuture(task1.getId(), sendTask2.getDestination());
-		verify(schedulingPoolMock, times(1)).removeSendTaskFuture(task1.getId(), sendTask3.getDestination());
-		verify(schedulingPoolMock, times(1)).removeSendTaskFuture(task1.getId(), sendTask4.getDestination());
+		verify(schedulingPoolMock, times(4)).decreaseSendTaskCount(task1, 1);
 		verify(jmsQueueManagerMock, times(4)).reportTaskResult(null);
 
 		// since scheduling pool is mocked, it doesn't switch status to DONE (or ERROR) anymore
@@ -75,8 +72,7 @@ public class SendCollectorTest extends AbstractEngineTest {
 		// since one of SendTasks failed, Task status is changed to SENDERROR
 		assertEquals(Task.TaskStatus.SENDERROR, task1.getStatus());
 
-		verify(schedulingPoolMock, times(1)).removeSendTaskFuture(task1.getId(), sendTask1.getDestination());
-		verify(schedulingPoolMock, times(1)).removeSendTaskFuture(task1.getId(), sendTask2.getDestination());
+		verify(schedulingPoolMock, times(2)).decreaseSendTaskCount(task1, 1);
 		verify(jmsQueueManagerMock, times(2)).reportTaskResult(null);
 
 	}

--- a/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SendPlannerTest.java
+++ b/perun-engine/src/test/java/cz/metacentrum/perun/engine/unit/SendPlannerTest.java
@@ -39,8 +39,7 @@ public class SendPlannerTest extends AbstractEngineTest {
 
 		spy.run();
 
-		verify(schedulingPoolMock, times(1)).addSendTaskCount(task1.getId(),
-				task1.getDestinations().size());
+		verify(schedulingPoolMock, times(1)).addSendTaskCount(task1, task1.getDestinations().size());
 		verify(sendCompletionServiceMock, times(4)).blockingSubmit(any(SendWorker.class));
 		verify(jmsQueueManagerMock, times(1)).reportTaskStatus(eq(task1.getId()), eq(SENDING),
 				anyLong());


### PR DESCRIPTION
- Do not use BlockingBoundedMap to store running Task Futures.
- Related logic was moved directly to BlockingExecutorCompletionService.
- Removed unnecessary logic from SchedulingPool - we gathered Futures
  and Tasks there. Now we only count running/remaining SendTasks
  and on completion Task is removed from pool.

- BlockingExecutorCompletionService now provides blocking on its
  own using same logic like BlockingBoundedMap (using Semaphore).
  Semaphore is released whenever Task / Future finishes (successfully
  or not).
- We can now handle CancellationException, since we get related Task
  for failed Future from running tasks map inside CompletionService.
- Updated setting Task status and times in Collector threads to be more
  close to blocking methods in CompletionService.

- Updated PropagationMaintainerImpl. If any running task (Future) is
  considered as stuck, we try to cancel it first, then Collector
  thread should take it and remove it from the pool.
  If on next check Future is still present and cancelled, then
  we assume collector thread is not working and we report status
  and remove Task from the pool.