### PR TITLE
LDAPc: Allow starting ldapc as service from specified message id

### DIFF
--- a/perun-utils/init.d-scripts/perun-ldapc.debian
+++ b/perun-utils/init.d-scripts/perun-ldapc.debian
@@ -13,6 +13,8 @@
 # Modified by Pavel Zlamal <zlamal@cesnet.cz>
 #
 # 23.03.2018 Reworked perun-engine init.d script for LDAPc
+# 17.04.2018 Respect $LAST_PROCESSED_ID is set in /etc/perun/perun-ldapc
+#            (specify where ldapc should start reading auditer log)
 #
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Perun LDAPc"
@@ -40,7 +42,12 @@ export KRB5CCNAME
 # Read configuration if it is present.
 [ -r /etc/perun/$NAME ] && . /etc/perun/$NAME
 
-DAEMON_OPTS="-Dlogback.configurationFile=$LOG_CONF -Dperun.conf.custom=$PERUN_LDAPC_CONF_DIR $JAVA_OPTS -Dspring.profiles.default=production -jar $JAR"
+# Last processed ID can be set in /etc/perun/perun-ldapc (line above)
+if [ $LAST_PROCESSED_ID ]; then
+  DAEMON_OPTS="-Dlogback.configurationFile=$LOG_CONF -Dperun.conf.custom=$PERUN_LDAPC_CONF_DIR $JAVA_OPTS -Dspring.profiles.default=production -jar $JAR $LAST_PROCESSED_ID"
+else
+  DAEMON_OPTS="-Dlogback.configurationFile=$LOG_CONF -Dperun.conf.custom=$PERUN_LDAPC_CONF_DIR $JAVA_OPTS -Dspring.profiles.default=production -jar $JAR"
+fi
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh


### PR DESCRIPTION
 - We can now set $LAST_PROCESSED_ID in /etc/perun/perun-ldapc
   forcing LDAPc to start processing auditer log from specified
   message ID.
 - If not set we start normally form last message id in auditer
   consumer.