### PR TITLE
GUI: Do not search user by ID when adding manager to vo/group/facility

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerTabItem.java
@@ -210,26 +210,6 @@ public class AddFacilityManagerTabItem implements TabItem {
 	protected void startSearching(String text){
 
 		users.clearTable();
-
-		// IS searched string IDs?
-		if (JsonUtils.isStringWithIds(text)) {
-
-			FindUsersByIdsNotInRpc req = new FindUsersByIdsNotInRpc(new JsonCallbackEvents(){
-				@Override
-				public void onFinished(JavaScriptObject jso){
-					ArrayList<User> usersList = JsonUtils.jsoAsList(jso);
-					for(User u : usersList) {
-						users.addToTable(u);
-					}
-				}
-
-			}, text);
-
-			req.retrieveData();
-			return;
-
-		}
-
 		users.searchFor(text);
 
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerTabItem.java
@@ -238,26 +238,6 @@ public class AddGroupManagerTabItem implements TabItem {
 	protected void startSearching(String text){
 
 		users.clearTable();
-
-		// IS searched string IDs?
-		if (JsonUtils.isStringWithIds(text)) {
-
-			FindUsersByIdsNotInRpc req = new FindUsersByIdsNotInRpc(new JsonCallbackEvents(){
-				@Override
-				public void onFinished(JavaScriptObject jso){
-					ArrayList<User> usersList = JsonUtils.jsoAsList(jso);
-					for(User u : usersList) {
-						users.addToTable(u);
-					}
-				}
-
-			}, text);
-
-			req.retrieveData();
-			return;
-
-		}
-
 		users.searchFor(text);
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerTabItem.java
@@ -213,25 +213,6 @@ public class AddVoManagerTabItem implements TabItem {
 	protected void startSearching(String text){
 
 		users.clearTable();
-
-		// IS searched string IDs?
-		if (JsonUtils.isStringWithIds(text)) {
-
-			FindUsersByIdsNotInRpc req = new FindUsersByIdsNotInRpc(new JsonCallbackEvents(){
-				@Override
-				public void onFinished(JavaScriptObject jso){
-					ArrayList<User> usersList = JsonUtils.jsoAsList(jso);
-					for (User u : usersList) {
-						users.addToTable(u);
-					}
-				}
-			}, text);
-
-			req.retrieveData();
-			return;
-
-		}
-
 		users.searchFor(text);
 
 	}


### PR DESCRIPTION
- Old logic retrieved user to be manager by its ID, if numeric search
  string was provided. This collide with numeric logins on MU instance.
  It's much better to use core search logic, since value is checked
  for numeric there too and by IDs users are retrieved.