### PR TITLE
CORE: Added attribute modules for AUP processing with proxy IdP

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_orgAups.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_orgAups.java
@@ -1,0 +1,74 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleImplApi;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This attribute holds all AUPs for each organization/infrastructure managed by Perun and accessed by its ProxyIdP.
+ *
+ * Keys in a map are infrastructure identifiers
+ * Value is JSON array representation of all AUPs
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class urn_perun_entityless_attribute_def_def_orgAups extends EntitylessAttributesModuleAbstract implements EntitylessAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+
+		if(attribute.getValue() == null) return;
+
+		Map<String, String> map = (Map<String, String>) attribute.getValue();
+
+		if(map.isEmpty()) return;
+
+		Set<String> mapKeys = map.keySet();
+		for(String mapKey: mapKeys) {
+
+			String value = map.get(mapKey);
+			if (value == null || value.isEmpty()) throw new WrongAttributeValueException(attribute, "AUPs for key: '"+mapKey+"' can't be empty.");
+
+			// we expect array or AUPs
+			try {
+				JSONArray array = new JSONArray(value);
+				for (int i = 0; i < array.length(); i++) {
+					JSONObject object = array.getJSONObject(i);
+					if (!object.has("version")) throw new WrongAttributeValueException(attribute, "AUP for key: '"+mapKey+"' is missing key version in JSON.");
+					if (!object.has("date")) throw new WrongAttributeValueException(attribute, "AUP for key: '"+mapKey+"' is missing key date in JSON.");
+					if (!object.has("link")) throw new WrongAttributeValueException(attribute, "AUP for key: '"+mapKey+"' is missing key link in JSON.");
+					if (!object.has("text")) throw new WrongAttributeValueException(attribute, "AUP for key: '"+mapKey+"' is missing key text in JSON.");
+				}
+			} catch (JSONException ex) {
+				throw new WrongAttributeValueException(attribute, "AUP for key: '"+mapKey+"' is not valid JSON.", ex);
+			}
+
+		}
+
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+		attr.setFriendlyName("orgAups");
+		attr.setDisplayName("Organisation AUPs");
+		attr.setType(LinkedHashMap.class.getName());
+		attr.setDescription("Contains all AUPs used at organization/infrastructure level.");
+		return attr;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_reqAups.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_reqAups.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Checks if all required AUP for facility are correct (available as keys in urn_perun_entityless_attribute_def_def_orgAups)
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class urn_perun_facility_attribute_def_def_reqAups extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi  {
+
+	private final static String availableAups = AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":orgAups";
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+
+		List<String> aups = (List<String>) attribute.getValue();
+
+		if (aups == null || aups.isEmpty()) return;
+
+		List<Attribute> allAUPS = perunSession.getPerunBl().getAttributesManagerBl().getEntitylessAttributes(perunSession, availableAups);
+		if (allAUPS.isEmpty()) return;
+
+		Set<String> keys = new HashSet<>();
+
+		// fill available keys
+		for (Attribute a : allAUPS) {
+			if (a != null && a.getValue() != null && a.getValue() instanceof LinkedHashMap) {
+				LinkedHashMap<String,String> map = (LinkedHashMap<String,String>)a.getValue();
+				keys.addAll(map.keySet());
+			}
+		}
+
+		for (String aup : aups) {
+			if (!keys.contains(aup)) throw new WrongAttributeValueException(attribute, aup+" AUP doesn't exist in available organization AUPs.");
+		}
+
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
+		attr.setFriendlyName("reqAups");
+		attr.setDisplayName("Required AUP");
+		attr.setType(ArrayList.class.getName());
+		attr.setDescription("List of required AUP names. Users must agree with all recent AUPs before accessing the service represented by this facility.");
+		return attr;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_voShortNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_voShortNames.java
@@ -1,0 +1,53 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.RichResource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityVirtualAttributesModuleImplApi;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * List of VO short names, which have resources on this facility.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class urn_perun_facility_attribute_def_virt_voShortNames extends FacilityVirtualAttributesModuleAbstract implements FacilityVirtualAttributesModuleImplApi {
+
+	@Override
+	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
+
+		Attribute attribute = new Attribute(attributeDefinition);
+
+		Set<String> result = new HashSet<>();
+		List<RichResource> resources = sess.getPerunBl().getFacilitiesManagerBl().getAssignedRichResources(sess, facility);
+		for (RichResource resource : resources) {
+			result.add(resource.getVo().getShortName());
+		}
+
+		if (result.isEmpty()) return attribute; // no resource = no vo short names
+
+		attribute.setValue(new ArrayList<>(result)); // found resource = vo short names
+		return attribute;
+
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_FACILITY_ATTR_VIRT);
+		attr.setFriendlyName("voShortNames");
+		attr.setDisplayName("VO shortNames");
+		attr.setType(ArrayList.class.getName());
+		attr.setDescription("List of VOs short names, which have resources on this facility.");
+		return attr;
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_aup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_aup.java
@@ -1,0 +1,61 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * This attribute holds all AUPs specific for each VO managed by Perun and its services accessed by ProxyIdP.
+ *
+ * Value is JSON array representation of all custom AUPs
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class urn_perun_vo_attribute_def_def_aup extends VoAttributesModuleAbstract implements VoAttributesModuleImplApi {
+
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+
+		String value = (String)attribute.getValue();
+
+		if (value == null || value.isEmpty()) return;
+
+		// we expect array or AUPs
+		try {
+			JSONArray array = new JSONArray(value);
+			for (int i = 0; i < array.length(); i++) {
+				JSONObject object = array.getJSONObject(i);
+				if (!object.has("version")) throw new WrongAttributeValueException(attribute, "AUP is missing key version in JSON.");
+				if (!object.has("date")) throw new WrongAttributeValueException(attribute, "AUP is missing key date in JSON.");
+				if (!object.has("link")) throw new WrongAttributeValueException(attribute, "AUP is missing key link in JSON.");
+				if (!object.has("text")) throw new WrongAttributeValueException(attribute, "AUP is missing key text in JSON.");
+			}
+		} catch (JSONException ex) {
+			throw new WrongAttributeValueException(attribute, "AUP is not valid JSON.", ex);
+		}
+
+	}
+
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_VO_ATTR_DEF);
+		attr.setFriendlyName("aup");
+		attr.setDisplayName("AUP");
+		attr.setType(BeansUtils.largeStringClassName);
+		attr.setDescription("Contains all custom AUPs used at VO level.");
+		return attr;
+	}
+
+}


### PR DESCRIPTION
- Store all infrastructure AUPs in entityless attribute.
- Allow requiring valid AUPs on Facility.
- Allow requiring valid AUPs on VO.
- Provide list of VOs short names on facility as virtual attribute
  so proxy can check VO AUPs too.