### PR TITLE
Reinitialize session when user is not recognized

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -540,6 +540,10 @@ public class Api extends HttpServlet {
 				// prevent cookie stealing (if remote user changed, rebuild session)
 				caller = new ApiCaller(getServletContext(), setupPerunPrincipal(req, des), setupPerunClient(req));
 				req.getSession(true).setAttribute(APICALLER, caller);
+			} else if (caller.getSession().getPerunPrincipal().getUser() == null) {
+				// we have authenticated user who doesn't have object User in his session -> try to find it by reinitializing the session
+				// this might happed when new user register himself (registrar creates new session without user object) and after approving of the application the user uses the same session to continue work with Perun  (e.g. open GUI or identity consolidator)
+				caller = new ApiCaller(getServletContext(), setupPerunPrincipal(req, des), setupPerunClient(req));
 			}
 
 			// Does user want to logout from perun?


### PR DESCRIPTION
When user register himself to Perun for the firs time (i.e. new User
object is created), he have the session without User object inside,
because there were no User during the registration time. After
registration is approved and user object created, the user can still
have the original session without the User object inside.

With this patch, new session is created each time when there is no User
object in session which fixes described problem.