### PR TITLE
Possibility to remove UserExternalSource in case of persistence is set.

### DIFF
--- a/perun-cli/removeUserExtSource
+++ b/perun-cli/removeUserExtSource
@@ -11,44 +11,59 @@ sub help {
 	Removes an external source from the user. User id and external login and external source id or name are required fields
 	------------------------------------
 	Available options:
-	--userId         | -u user id
-	--extSourceId    | -e external source id
-	--extSourceName  | -E external source name
-	--extSourceLogin | -l external login
-	--batch          | -b batch
-	--help           | -h prints this help
+	--userId          | -u user id
+	--extSourceId     | -e external source id
+	--extSourceName   | -E external source name
+	--extSourceLogin  | -l external login
+	--userExtSourceId | -x user external source id
+	--forceRemove     | -f remove persistent external source too
+	--batch           | -b batch
+	--help            | -h prints this help
 
 	};
 }
 
-my ($userId, $extSourceId, $extSourceName, $extSourceLogin, $batch);
+my ($userId, $extSourceId, $extSourceName, $extSourceLogin, $batch, $force,$userExtSourceId);
 GetOptions ("help|h"     => sub {
 		print help();
 		exit 0;
 	}, "userId|u=i"      => \$userId,
-	"extSourceId|e=i"    => \$extSourceId, "extSourceName|E=s" => \$extSourceName,
-	"extSourceLogin|l=s" => \$extSourceLogin, "batch|b" => \$batch) || die help();
+	"extSourceId|e=i"    => \$extSourceId, 
+	"extSourceName|E=s" => \$extSourceName,
+	"extSourceLogin|l=s" => \$extSourceLogin, 
+	"userExtSourceId|x=i" => \$userExtSourceId,
+	"forceRemove|f" => \$force,
+	"batch|b" => \$batch) || die help();
 
 # Check options
 unless (defined($userId)) { die "ERROR: userId is required \n";}
-unless (defined($extSourceId) or defined($extSourceName)) { die "ERROR: extSourceId or extSourceName is required \n";}
+unless (defined $userExtSourceId) {
+	if ((!defined($extSourceId) and !defined($extSourceName)) or !defined($extSourceLogin)) { die "ERROR: extSourceId or extSourceName and extSourceLogin is required \n";}
+}
 
 my $agent = Perun::Agent->new();
 my $usersAgent = $agent->getUsersAgent;
 my $extSourcesAgent = $agent->getExtSourcesAgent;
 
 my $extSource;
-if ($extSourceId) {
-	$extSource = $extSourcesAgent->getExtSourceById( id => $extSourceId );
+unless (defined $userExtSourceId) {
+	if ($extSourceId) {
+		$extSource = $extSourcesAgent->getExtSourceById( id => $extSourceId );
+	}
+	elsif ($extSourceName) {
+		$extSource = $extSourcesAgent->getExtSourceByName( name => $extSourceName );
+		$extSourceId = $extSource->getId;
+	}
+
+	my $userExtSource = $usersAgent->getUserExtSourceByExtLogin( "extSource" => $extSource, "extSourceLogin" => $extSourceLogin );
+	$userExtSourceId=$userExtSource->getId;
 }
-if ($extSourceName) {
-	$extSource = $extSourcesAgent->getExtSourceByName( name => $extSourceName );
-	$extSourceId = $extSource->getId;
+
+if (defined $force) {
+	$usersAgent->removeUserExtSource( user => $userId, userExtSource => $userExtSourceId, force => 1 );
+} else {
+	$usersAgent->removeUserExtSource( user => $userId, userExtSource => $userExtSourceId );
 }
 
-my $userExtSource = $usersAgent->getUserExtSourceByExtLogin( "extSource" => $extSource, "extSourceLogin" =>
-	$extSourceLogin );
-
-$usersAgent->removeUserExtSource( user => $userId, userExtSource => $userExtSource->getId );
-
-printMessage("External Source: $extSourceId with login: $extSourceLogin removed from user Id: $userId", $batch);
+printMessage("External Source: $extSourceId with login: $extSourceLogin removed from user Id: $userId", $batch) if defined $extSourceLogin;
+printMessage("User external Source: $userExtSourceId removed from user Id: $userId", $batch) if defined $userExtSourceId;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -361,7 +361,7 @@ public interface UsersManager {
 	UserExtSource addUserExtSource(PerunSession perunSession, User user, UserExtSource userExtSource) throws InternalErrorException, UserNotExistsException, PrivilegeException, UserExtSourceExistsException;
 
 	/**
-	 * Removes user's external sources.
+	 * Removes user's external source.
 	 *
 	 * @param perunSession
 	 * @param user
@@ -373,6 +373,21 @@ public interface UsersManager {
 	 * @throws UserExtSourceAlreadyRemovedException if there are 0 rows affected by deleting from DB
 	 */
 	void removeUserExtSource(PerunSession perunSession, User user, UserExtSource userExtSource) throws InternalErrorException, UserNotExistsException, UserExtSourceNotExistsException, PrivilegeException, UserExtSourceAlreadyRemovedException;
+
+	/**
+	 * Removes user's external source.
+	 *
+	 * @param perunSession
+	 * @param user
+	 * @param userExtSource
+	 * @param forceDelete if true, persistent ExtSource is deleted too
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserExtSourceNotExistsException
+	 * @throws UserNotExistsException
+	 * @throws UserExtSourceAlreadyRemovedException if there are 0 rows affected by deleting from DB
+	 */
+	void removeUserExtSource(PerunSession perunSession, User user, UserExtSource userExtSource, boolean forceDelete) throws InternalErrorException, UserNotExistsException, UserExtSourceNotExistsException, PrivilegeException, UserExtSourceAlreadyRemovedException;
 
 	/**
 	 * Take UserExtSource from sourceUser and move it to the targetUser.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -454,6 +454,27 @@ public class UsersManagerEntry implements UsersManager {
 		getUsersManagerBl().removeUserExtSource(sess, user, userExtSource);
 	}
 
+	public void removeUserExtSource(PerunSession sess, User user, UserExtSource userExtSource, boolean forceDelete) throws InternalErrorException, UserNotExistsException, UserExtSourceNotExistsException, PrivilegeException, UserExtSourceAlreadyRemovedException {
+		Utils.checkPerunSession(sess);
+
+		if (forceDelete) {
+
+			// Authorization
+			if(!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN, user)) {
+				throw new PrivilegeException(sess, "removeUserExtSource");
+			}
+
+			getUsersManagerBl().checkUserExists(sess, user);
+			// set userId, so checkUserExtSourceExists can check the userExtSource for the particular user
+			userExtSource.setUserId(user.getId());
+			getUsersManagerBl().checkUserExtSourceExists(sess, userExtSource);
+
+			getUsersManagerBl().removeUserExtSource(sess, user, userExtSource);
+		} else {
+			removeUserExtSource(sess, user, userExtSource);
+		}
+	}
+
 	public void moveUserExtSource(PerunSession sess, User sourceUser, User targetUser, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceNotExistsException, UserNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -475,9 +475,11 @@ public enum UsersManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Remove user's external sources.
+	 * Remove user's external source.
+	 * Persistent UserExtSources are not removed unless <code>force</code> param is present and set to <code>true</code>.
 	 * @param user int User <code>id</code>
 	 * @param userExtSource int UserExtSource <code>id</code>
+	 * @param force boolean If true, use force deletion.
 	 */
 	removeUserExtSource {
 
@@ -485,9 +487,16 @@ public enum UsersManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
-			ac.getUsersManager().removeUserExtSource(ac.getSession(),
+			if (parms.contains("force") && parms.readBoolean("force")) {
+				ac.getUsersManager().removeUserExtSource(ac.getSession(),
+					ac.getUserById(parms.readInt("user")),
+					ac.getUserExtSourceById(parms.readInt("userExtSource")), true);
+			} else {
+				ac.getUsersManager().removeUserExtSource(ac.getSession(),
 					ac.getUserById(parms.readInt("user")),
 					ac.getUserExtSourceById(parms.readInt("userExtSource")));
+			}
+				
 			return null;
 		}
 	},


### PR DESCRIPTION
Tool remoceUserExtSource has new parameter -forceRemove for removing
UserExteSources which are defined as persistant.