### PR TITLE
GUI: Super-dev mode doesn't compile without gwt-dev provided dependency

### DIFF
--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -182,6 +182,13 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.google.gwt</groupId>
+			<artifactId>gwt-dev</artifactId>
+			<version>${gwtVersion}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- Drag and Drop library
 		<dependency>
 			<groupId>com.googlecode.gwtquery.bundles</groupId>


### PR DESCRIPTION
- It worked last week, since it seems to share unit-cache in /tmp
  with other gwt projects. Now dependencies are aligned with WUI apps.