### PR TITLE
changed format of LDIF files to be usable by ldapmodify

### DIFF
--- a/perun-utils/ldapc-scripts/schemas/inetUser-schema.ldif
+++ b/perun-utils/ldapc-scripts/schemas/inetUser-schema.ldif
@@ -1,9 +1,11 @@
-version: 1
-dn: cn=inetUser,cn=schema,cn=config
-objectClass: olcSchemaConfig
-cn: inetUser
+dn: cn={5}inetUser,cn=schema,cn=config
+changetype: modify
+replace: olcAttributeTypes
 olcAttributeTypes: {0}( 1.2.840.113556.1.2.102 NAME 'memberOf' DESC 'Group that the entry belongs to' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN 'Netscape Delegated Administrator' )
 olcAttributeTypes: {1}( 2.16.840.1.113730.3.1.692 NAME 'inetUserStatus' DESC '"active", "inactive", or "deleted" status of a user' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'Netscape subscriber interoperability' )
 olcAttributeTypes: {2}( 2.16.840.1.113730.3.1.693 NAME 'inetUserHttpURL' DESC 'A users Web addresses' SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'Netscape subscriber interoperability' )
+-
+replace: olcObjectClasses
 olcObjectClasses: {0}( 2.16.840.1.113730.3.2.130 NAME 'inetUser' DESC 'Auxiliary class which must be present in an entry for delivery of subscriber services' SUP top AUXILIARY MAY ( uid $ inetUserStatus $ inetUserHTTPURL $ userPassword $ memberOf ) X-ORIGIN 'Netscape subscriber interoperability' )
+-
 

--- a/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
+++ b/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
@@ -1,7 +1,6 @@
-version: 1
-dn: cn=perun,cn=schema,cn=config
-objectClass: olcSchemaConfig
-cn: perun
+dn: cn={4}perun,cn=schema,cn=config
+changetype: modify
+replace: olcAttributeTypes
 olcAttributeTypes: {0}( 1.3.6.1.4.1.8057.2.80.1 NAME 'perunUserId' DESC 'Unique user identifier managed by Perun' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: {1}( 1.3.6.1.4.1.8057.2.80.16 NAME 'perunResourceId' DESC 'Unique resource identifier managed by Perun' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: {2}( 1.3.6.1.4.1.8057.2.80.17 NAME 'perunFacilityId' DESC 'Unique facilityId identifier managed by Perun' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
@@ -27,8 +26,11 @@ olcAttributeTypes: {21}( 1.3.6.1.4.1.8057.2.80.25 NAME 'bonaFideStatus' DESC 'bo
 olcAttributeTypes: {22}( 1.3.6.1.4.1.8057.2.80.26 NAME 'groupNames' DESC 'Names of groups where user is member' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcAttributeTypes: {23}( 1.3.6.1.4.1.8057.2.80.27 NAME 'OIDCClientID' DESC 'ClientID for OIDC of Resource on Facility' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)
 olcAttributeTypes: {24}( 1.3.6.1.4.1.8057.2.80.28 NAME 'institutionsCountries' DESC 'Countries of schacOrgs' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+-
+replace: olcObjectClasses
 olcObjectClasses: {0}( 1.3.6.1.4.1.8057.2.80.4 NAME 'perunUser' DESC 'User managed by Perun' SUP inetOrgPerson STRUCTURAL MUST ( perunUserId $ isServiceUser  $ isSponsoredUser ) MAY ( preferredMail $ userCertificateSubject $ uidNumber $ login $ eduPersonPrincipalNames $ userPassword $ memberOfPerunVo $ libraryIDs $ schacHomeOrganizations $ eduPersonScopedAffiliations $ bonaFideStatus $ groupNames $ institutionsCountries ) )
 olcObjectClasses: {1}( 1.3.6.1.4.1.8057.2.80.5 NAME 'perunGroup' DESC 'Group managed by Perun' SUP top  STRUCTURAL MUST ( cn $ perunGroupId $ perunVoId $ perunUniqueGroupName ) MAY ( uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ perunParentGroup $ perunParentGroupId $ assignedToResourceId ) )
 olcObjectClasses: {2}( 1.3.6.1.4.1.8057.2.80.15 NAME 'perunResource' DESC 'Resource managed by Perun' SUP top STRUCTURAL MUST ( cn $  perunResourceId $ perunVoId $ perunFacilityId ) MAY (uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ assignedGroupId  $ entityID $ OIDCClientID))
 olcObjectClasses: {3}( 1.3.6.1.4.1.8057.2.80.6 NAME 'perunVO' DESC 'VO managed by Perun' SUP organization STRUCTURAL MUST perunVoId MAY uniqueMember )
+-
 

--- a/perun-utils/ldapc-scripts/schemas/tenOperEntry-schema.ldif
+++ b/perun-utils/ldapc-scripts/schemas/tenOperEntry-schema.ldif
@@ -1,11 +1,13 @@
-version: 1
-dn: cn=tenOperEntry,cn=schema,cn=config
-objectClass: olcSchemaConfig
-cn: tenOperEntry
+dn: cn={6}tenOperEntry,cn=schema,cn=config
+changetype: modify
+replace: olcAttributeTypes
 olcAttributeTypes: {0}( 1.3.6.1.4.1.8057.2.84.1 NAME 'entryStatus' DESC 'status of the entry' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: {1}( 1.3.6.1.4.1.8057.2.84.2 NAME 'entryStatusTimestamp' DESC 'time of last modification of entryStatus' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: {2}( 1.3.6.1.4.1.8057.2.84.3 NAME 'entryStatusModifier' DESC 'entry that performed tha last modification of entryStatus' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE )
 olcAttributeTypes: {3}( 1.3.6.1.4.1.8057.2.84.4 NAME 'sponsor' DESC 'Sponsor' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 olcAttributeTypes: {4}( 1.3.6.1.4.1.8057.2.84.5 NAME 'sponsorshipApprovedUntil' DESC 'Expiry of sponsorship' SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 SINGLE-VALUE )
+-
+replace: olcObjectClasses
 olcObjectClasses: {0}( 1.3.6.1.4.1.8057.2.84.6 NAME 'tenOperEntry' DESC 'entry operational description' AUXILIARY MUST entryStatus MAY ( entryStatusModifier $ entryStatusTimestamp $ sponsor $ sponsorshipApprovedUntil ) )
+-
 


### PR DESCRIPTION
These files should be used by Ansible to create LDAP schema, in the new format they are directly usable for calling ldapmodify.