### PR TITLE
Need to call initialization in Serializable isolation lvl of transaction

### DIFF
--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/api/UtilsApi.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/api/UtilsApi.java
@@ -1,0 +1,91 @@
+package cz.metacentrum.perun.ldapc.initializer.api;
+
+
+import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.ldapc.initializer.beans.PerunInitializer;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Interface for Utils methods
+ *
+ * @author Michal Stava <stavamichal@gmail.com>
+ */
+public interface UtilsApi {
+
+	/**
+	 * This method will generate all data from Perun in the form of LDIF and then will insert them into the LDAP.
+	 * It also can change the last processed ID for LDAPc Consumer.
+	 *
+	 * It is running in special
+	 *
+	 * @param perunInitializer need to be loaded to get all needed dependencies
+	 * @param updateLastProcessedId if processed ID should be updated or not
+	 * @throws InternalErrorException
+	 */
+	void initializeLDAPFromPerun(PerunInitializer perunInitializer, Boolean updateLastProcessedId) throws InternalErrorException;
+
+	/**
+	 * Method to set last processed id for concrete consumer
+	 *
+	 * @param consumerName name of consumer to set
+	 * @param lastProcessedId id to set
+	 * @param perunPrincipal perunPrincipal for initializing RpcCaller
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	void setLastProcessedId(PerunPrincipal perunPrincipal, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Method generate all Vos to the text for using in LDIF.
+	 * Write all these information to writer in perunInitializer object.
+	 *
+	 * @param perunInitializer need to be loaded to get all needed dependencies
+	 *
+	 * @throws InternalErrorException if some problem with initializer or objects in perun-core
+	 * @throws IOException if some problem with writer
+	 */
+	void generateAllVosToWriter(PerunInitializer perunInitializer) throws InternalErrorException, IOException;
+
+
+	/**
+	 * Method generate all Resources to the text for using in LDIF.
+	 * Write all these information to writer in perunInitializer object.
+	 *
+	 * @param perunInitializer need to be loaded to get all needed dependencies
+	 *
+	 * @throws InternalErrorException if some problem with initializer or objects in perun-core
+	 * @throws IOException if some problem with writer
+	 */
+	void generateAllResourcesToWriter(PerunInitializer perunInitializer) throws InternalErrorException, IOException;
+
+	/**
+	 * Method generate all Groups to the text for using in LDIF.
+	 * Write all these information to writer in perunInitializer object.
+	 *
+	 * @param perunInitializer need to be loaded to get all needed dependencies
+	 *
+	 * @throws InternalErrorException if some problem with initializer or objects in perun-core
+	 * @throws IOException if some problem with writer
+	 */
+	void generateAllGroupsToWriter(PerunInitializer perunInitializer) throws InternalErrorException, IOException;
+
+	/**
+	 * Method generate all Users to the text for using in LDIF.
+	 * Write all these information to writer in perunInitializer object.
+	 *
+	 * @param perunInitializer need to be loaded to get all needed dependencies
+	 *
+	 * @throws InternalErrorException if some problem with initializer or objects in perun-core
+	 * @throws IOException if some problem with writer
+	 * @throws AttributeNotExistsException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	void generateAllUsersToWriter(PerunInitializer perunInitializer) throws IOException, InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
+}

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/beans/PerunInitializer.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/beans/PerunInitializer.java
@@ -2,7 +2,8 @@ package cz.metacentrum.perun.ldapc.initializer.beans;
 
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunClient;
-import cz.metacentrum.perun.ldapc.initializer.utils.Utils;
+import cz.metacentrum.perun.ldapc.initializer.api.UtilsApi;
+import cz.metacentrum.perun.ldapc.initializer.impl.Utils;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -11,6 +12,11 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -32,10 +38,10 @@ public class PerunInitializer {
 
 	public PerunInitializer(String outputFileName) throws InternalErrorException, FileNotFoundException {
 		this.perunPrincipal = new PerunPrincipal("perunLdapInitializer", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
-		this.springCtx = new ClassPathXmlApplicationContext("perun-core.xml");
+		this.springCtx = new ClassPathXmlApplicationContext("perun-ldapc-initializer.xml");
 		this.perunBl = springCtx.getBean("perun", PerunBl.class);
 		this.perunSession = perunBl.getPerunSession(perunPrincipal, new PerunClient());
-		this.outputWriter = new BufferedWriter(Utils.getWriterForOutput(outputFileName));
+		this.outputWriter = new BufferedWriter(this.getWriterForOutput(outputFileName));
 	}
 
 	public PerunBl getPerunBl() {
@@ -72,6 +78,11 @@ public class PerunInitializer {
 
 	public void closeWriter() throws IOException {
 		this.outputWriter.close();
+	}
+
+	private Writer getWriterForOutput(String fileName) throws FileNotFoundException {
+		if (fileName != null) return new PrintWriter(fileName);
+		else return new OutputStreamWriter(System.out);
 	}
 }
 

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/main/Main.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/main/Main.java
@@ -1,13 +1,9 @@
 package cz.metacentrum.perun.ldapc.initializer.main;
 
-import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.ldapc.initializer.api.UtilsApi;
 import cz.metacentrum.perun.ldapc.initializer.beans.PerunInitializer;
-import cz.metacentrum.perun.ldapc.initializer.utils.Utils;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -30,7 +26,6 @@ public class Main {
 	public static void main(String[] args) throws Exception {
 		//no options means - output to stdout and without changing processed id
 		String outputFile = null;
-		Boolean changeProcessedId = false;
 
 		//prepare optional command line options for ldapc initializer
 		Options options = new Options();
@@ -60,82 +55,18 @@ public class Main {
 			outputFile = commandLine.getOptionValue("f");
 		}
 
-		//set changing processed id to true if option "c" is set
-		if(commandLine.hasOption("c")) {
-			changeProcessedId = true;
-		}
-
-		//call main with parsed options or with default settings
-		new Main(outputFile, changeProcessedId);
-	}
-
-
-	/**
-	 * Main class for purpose of generating LDIF
-	 *
-	 * GroupOfUniqueNames object class is not supported in new instances of perun LDAP
-	 *
-	 * @param fileName if not null, use file for generating. if null use stdout
-	 * @param changeProcessedId if true, then change processed id for ldapc on the end of initialization, if false don't change it
-	 *
-	 * @throws InternalErrorException
-	 */
-	public Main(String fileName, Boolean changeProcessedId) throws InternalErrorException {
-		PerunInitializer perunInitializer = null;
+		final PerunInitializer perunInitializer;
 		try {
-			try {
-				perunInitializer = new PerunInitializer(fileName);
-			} catch (InternalErrorException ex) {
-				System.err.println("There is problem with Initializing of PerunInitializer. More info can be found in " + fileName);
-				throw ex;
-			} catch (FileNotFoundException ex) {
-				System.err.println("There is problem with preparing writer to file " + fileName);
-				throw new InternalErrorException(ex);
-			}
-
-			//get last message id before start of initializing
-			int lastMessageBeforeInitializingData = perunInitializer.getPerunBl().getAuditer().getLastMessageId();
-			System.err.println("Last message id before starting initializing: " + lastMessageBeforeInitializingData + '\n');
-
-			try {
-				Utils.generateAllVosToWriter(perunInitializer);
-				Utils.generateAllGroupsToWriter(perunInitializer);
-				Utils.generateAllResourcesToWriter(perunInitializer);
-				Utils.generateAllUsersToWriter(perunInitializer);
-			} catch (IOException ex) {
-				System.err.println("Last message id before starting initializing: " + lastMessageBeforeInitializingData + '\n');
-				throw new InternalErrorException(ex);
-			} catch (AttributeNotExistsException | WrongAttributeAssignmentException ex) {
-				System.err.println("Problem with initializing users, there is an attribute which probably not exists.");
-				throw new InternalErrorException(ex);
-			}
-
-			//get last message id after initializing
-			int lastMessageAfterInitializingData = perunInitializer.getPerunBl().getAuditer().getLastMessageId();
-			System.err.println("Last message id after initializing: " + lastMessageAfterInitializingData + '\n');
-
-			//This is the only operation of WRITING to the DB
-			//Call RPC-LIB for this purpose
-			if(changeProcessedId) {
-				try {
-					Utils.setLastProcessedId(perunInitializer.getPerunPrincipal(), perunInitializer.getConsumerName(), lastMessageAfterInitializingData);
-				} catch (InternalErrorException | PrivilegeException ex) {
-					System.err.println("Can't set last processed ID because of lack of privileges or some Internal error.");
-					throw new InternalErrorException(ex);
-				}
-			}
-		} finally {
-			//Close writer if already opened
-			if(perunInitializer != null) {
-				try {
-					perunInitializer.closeWriter();
-				} catch(IOException ex) {
-					System.err.println("Can't close writer by normal way.");
-					throw new InternalErrorException(ex);
-				}
-			}
+			perunInitializer = new PerunInitializer(outputFile);
+		} catch (InternalErrorException ex) {
+			System.err.println("There is problem with Initializing of PerunInitializer. More info can be found in " + outputFile);
+			throw ex;
+		} catch (FileNotFoundException ex) {
+			System.err.println("There is problem with preparing writer to file " + outputFile);
+			throw new InternalErrorException(ex);
 		}
 
-		System.err.println("Generating of initializing LDIF done without error!");
+		UtilsApi utils = perunInitializer.getSpringCtx().getBean(UtilsApi.class);
+		utils.initializeLDAPFromPerun(perunInitializer, commandLine.hasOption("c"));
 	}
 }

--- a/perun-ldapc-initializer/src/main/resources/perun-ldapc-initializer.xml
+++ b/perun-ldapc-initializer/src/main/resources/perun-ldapc-initializer.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:tx="http://www.springframework.org/schema/tx"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
+
+	<import resource="classpath:perun-core.xml"/>
+
+	<aop:config>
+		<aop:advisor advice-ref="txCommonSerialized" pointcut="execution(* cz.metacentrum.perun.ldapc.initializer.api.UtilsApi.initializeLDAPFromPerun(..))"/>
+	</aop:config>
+
+	<tx:advice id="txCommonSerialized" transaction-manager="perunTransactionManager">
+		<tx:attributes>
+			<tx:method name="*" rollback-for="Exception" isolation="SERIALIZABLE"/>
+		</tx:attributes>
+	</tx:advice>
+
+	<bean id="utils" class="cz.metacentrum.perun.ldapc.initializer.impl.Utils"/>
+</beans>


### PR DESCRIPTION
 - redesign Utils class to use interface in API and implementation in
   IMPL package
 - add new method for initialization of LDAP by data from Perun to
   Utils, call this method in SERIALIZABLE isolation level of
   transaction directly from the Main class
 - remove constructor of Main class (it is not needed anymore)
 - add Utils to the perunInitializer class to prevent using "static" in
   the prototype of the methods in Utils