### PR TITLE
Consistency for authz for registrar to change pwd

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -745,7 +745,8 @@ public class UsersManagerEntry implements UsersManager {
 		getUsersManagerBl().checkUserExists(sess, user);
 
 		// Authorization
-		if(!AuthzResolver.isAuthorized(sess, Role.SELF, user)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.SELF, user) &&
+				!AuthzResolver.isAuthorized(sess, Role.REGISTRAR)) {
 			throw new PrivilegeException(sess, "changePassword");
 		}
 


### PR DESCRIPTION
Registrar role is authorized to change password for any user in any
namespace. Before this commit it was authorized to change it only using
login of the user as input parameter. Now, it's possible also using User
object as a parameter.

Now, there should be consistent authorization regardless of the method
used to do the same operation.