### PR TITLE
GUI: Enhance password dialog with warning about accented letters

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionsTabItem.java
@@ -102,7 +102,7 @@ public class AttributeDefinitionsTabItem implements TabItem, TabItemWithUrl{
 		deleteButton.addClickHandler(new ClickHandler() {
 			public void onClick(ClickEvent event) {
 				final ArrayList<AttributeDefinition> attrDefToBeDeleted = attrDef.getTableSelectedList();
-				String text = "Following attribute definitions will be deleted.";
+				String text = "Following attribute definitions will be deleted.</p><p style=\"color: red;\">All stored values of such attributes will be deleted too!";
 				UiElements.showDeleteConfirm(attrDefToBeDeleted, text, new ClickHandler() {
 					@Override
 					public void onClick(ClickEvent clickEvent) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
@@ -547,14 +547,18 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 								ft.setHTML(0, 0, "Password:");
 								ft.setWidget(0, 1, serviceUserPassword);
 								ft.getFlexCellFormatter().setStyleName(0, 0, "itemName");
-								ft.setHTML(1, 0, "Re-type password:");
+								ft.setHTML(1, 0, "Re-type&nbsp;password:");
 								ft.setWidget(1, 1, serviceUserPassword2);
 								ft.getFlexCellFormatter().setStyleName(1, 0, "itemName");
 
-								ft.setWidget(2, 1, skipButton);
-								ft.getFlexCellFormatter().setHorizontalAlignment(2, 1, HasHorizontalAlignment.ALIGN_RIGHT);
-								ft.setWidget(3, 1, button);
-								ft.getFlexCellFormatter().setHorizontalAlignment(3, 1, HasHorizontalAlignment.ALIGN_RIGHT);
+								ft.setHTML(2, 0, "Please <b>avoid using accented characters</b>. It might not be supported by all backend components and services.");
+								ft.getFlexCellFormatter().setColSpan(2, 0, 2);
+								ft.getCellFormatter().setStyleName(2, 0,"inputFormInlineComment");
+
+								ft.setWidget(3, 1, skipButton);
+								ft.getFlexCellFormatter().addStyleName(3, 1, "align-right");
+								ft.setWidget(4, 1, button);
+								ft.getFlexCellFormatter().addStyleName(4, 1, "align-right");
 
 								secondTabPanel.add(ft);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPasswordTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPasswordTabItem.java
@@ -433,6 +433,12 @@ public class SelfPasswordTabItem implements TabItem, TabItemWithUrl{
 			layout.getFlexCellFormatter().setStyleName(i, 0, "itemName");
 		}
 
+		int row = layout.getRowCount();
+		layout.setHTML(row, 0, "Please <b>avoid using accented characters</b>. It might not be supported by all backend components and services.");
+		layout.getFlexCellFormatter().setColSpan(row, 0, 2);
+		layout.getCellFormatter().setStyleName(row, 0,"inputFormInlineComment");
+		layout.setWidth("400px");
+
 		if (!action.equals(Actions.CREATE)) {
 			menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 				@Override

--- a/perun-web-gui/src/main/webapp/PerunWeb.css
+++ b/perun-web-gui/src/main/webapp/PerunWeb.css
@@ -368,6 +368,10 @@ table.inputFormFlexTableDark {
     border-collapse: collapse;
 }
 
+.align-right {
+    text-align: right !important;
+}
+
 /* ======== TAB MENU ========== */
 
 /* Buttons position */


### PR DESCRIPTION
- Let user know, that he should avoid using accented letters
  in passwords. Full UTF-8 might not be supported by all backend
  components and services.
- When we delete attribute definition, all stored values are deleted
  too. Let user (admin) know it before deletion.