### PR TITLE
Tool for listing of Group roles

### DIFF
--- a/perun-cli/Perun/AuthzResolverAgent.pm
+++ b/perun-cli/Perun/AuthzResolverAgent.pm
@@ -58,4 +58,9 @@ sub getUserRoleNames
 	return Perun::Common::callManagerMethod('getUserRoleNames', '', @_);
 }
 
+sub getGroupRoleNames
+{
+	return Perun::Common::callManagerMethod('getGroupRoleNames', '', @_);
+}
+
 1;

--- a/perun-cli/listOfGroupRoles
+++ b/perun-cli/listOfGroupRoles
@@ -1,0 +1,67 @@
+#!/usr/bin/perl
+
+use strict;
+use Getopt::Long qw(:config no_ignore_case);
+use Text::ASCIITable;
+use Perun::Agent;
+use Perun::Common qw(printMessage tableToPrint getSortingFunction);
+
+sub help {
+	return qq{
+	Prints list of Group Roles
+	---------------------------------
+	Available options:
+	--groupId     | -g  Group identifier
+	--groupName   | -G  Group name
+	--voId        | -v  VO idetifier
+	--voShortName | -V  VO short name
+	--batch       | -b batch
+	--help        | -h prints this help
+	};
+}
+
+our $batch;
+my ($groupId, $groupName, $voId, $voShortName);
+GetOptions("help|h" => sub {
+		print help;
+		exit 0;
+	},
+	"groupId|g=i"     => \$groupId,
+	"groupName|G=s"   => \$groupName,
+	"voId|v=i"        => \$voId,
+	"voShortName|V=s" => \$voShortName,
+	"batch|b"       => \$batch) || die help;
+
+my $agent = Perun::Agent->new();
+my $authzResolverAgent = $agent->getAuthzResolverAgent;
+my $groupsAgent = $agent->getGroupsAgent;
+
+#options check
+unless (defined $groupId) {
+	unless (defined $groupName) { die "ERROR: Group specification required.\n"; }
+	unless (defined $voId) {
+		unless (defined $voShortName) { die "ERROR: VO specification required.\n"; }
+		my $vo = $agent->getVosAgent->getVoByShortName( shortName => $voShortName );
+		$voId = $vo->getId;
+	}
+	my $group = $groupsAgent->getGroupByName( vo => $voId, name => $groupName );
+	$groupId = $group->getId;
+}
+
+
+my $role = $authzResolverAgent->getGroupRoleNames(group => $groupId);
+unless ($role) {
+	printMessage "No Role found", $batch;
+	exit 0;
+}
+
+#output
+my $table = Text::ASCIITable->new({ reportErrors => 0, utf8 => 0 });
+$table->setCols('Role Name');
+
+my @roles = @$role;
+foreach my $rol (@roles) {
+	$table->addRow($rol);
+}
+
+print tableToPrint($table, $batch);

--- a/perun-cli/listOfUserRoles
+++ b/perun-cli/listOfUserRoles
@@ -29,7 +29,7 @@ GetOptions("help|h" => sub {
 my $agent = Perun::Agent->new();
 my $authzResolverAgent = $agent->getAuthzResolverAgent;
 
-my $role = $authzResolverAgent->getUserRoleNames;
+my $role = $authzResolverAgent->getUserRoleNames(user => $userId);
 unless ($role) {
 	printMessage "No Role found", $batch;
 	exit 0;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -171,6 +171,21 @@ public class AuthzResolver {
 	}
 
 	/**
+	 * Get all group role names. Role is defined as a name, translation table is in Role class.
+	 *
+	 * @param sess perun session
+	 * @param group Group
+	 * @throws InternalErrorException
+	 * @throws GroupNotExistsException
+	 * @return list of integers, which represents role from enum Role.
+	 */
+	public static List<String> getGroupRoleNames(PerunSession sess, Group group) throws InternalErrorException, GroupNotExistsException {
+		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, group);
+
+		return cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.getGroupRoleNames(sess, group);
+	}
+
+	/**
 	 * Returns user which is associated with credentials used to log-in to Perun.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1016,6 +1016,18 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	}
 
 	/**
+	 * Get all Group's roles. Role is defined as a name, translation table is in Role class.
+	 *
+	 * @param sess perun session
+	 * @param group Group
+	 * @return list of integers, which represents role from enum Role.
+	 */
+	public static List<String> getGroupRoleNames(PerunSession sess,Group group) throws InternalErrorException {
+
+		return authzResolverImpl.getRoles(group).getRolesNames();
+	}
+
+	/**
 	 * Returns user which is associated with credentials used to log-in to Perun.
 	 *
 	 * @param sess perun session

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -128,6 +128,28 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		return authzRoles;
 	}
 
+	public AuthzRoles getRoles(Group group) throws InternalErrorException {
+		AuthzRoles authzRoles = new AuthzRoles();
+
+		if (group != null) {
+			try {
+				// Get roles from Authz table
+				List<Pair<Role, Map<String, Set<Integer>>>> authzRolesPairs = jdbc.query("select " + authzRoleMappingSelectQuery
+				+ ", roles.name as role_name from authz left join roles on authz.role_id=roles.id where authz.authorized_group_id=?",
+				AUTHZROLE_MAPPER, group.getId());
+
+				for (Pair<Role, Map<String, Set<Integer>>> pair : authzRolesPairs) {
+					authzRoles.putAuthzRoles(pair.getLeft(), pair.getRight());
+				}
+
+			} catch (RuntimeException e) {
+				throw new InternalErrorException(e);
+			}
+		}
+
+		return authzRoles;
+	}
+
 	public void initialize() throws InternalErrorException {
 
 		if(BeansUtils.isPerunReadOnly()) log.debug("Loading authzresolver manager init in readOnly version.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -26,6 +26,14 @@ public interface AuthzResolverImplApi {
 	AuthzRoles getRoles(User user) throws InternalErrorException;
 
 	/**
+	 * Returns all group's roles.
+	 *
+	 * @param group
+	 * @return AuthzRoles object which contains all roles with perunbeans
+	 */
+	AuthzRoles getRoles(Group group) throws InternalErrorException;
+
+	/**
 	 * Removes all authz entries for the sponsoredUser.
 	 *
 	 * @param sess

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -36,7 +36,20 @@ public enum AuthzResolverMethod implements ManagerMethod {
 	getUserRoleNames {
 		@Override
 		public List<String> call(ApiCaller ac, Deserializer parms ) throws PerunException {
-			return cz.metacentrum.perun.core.api.AuthzResolver.getUserRoleNames(ac.getSession(), ac.getUserById(parms.readInt("user"))); } 
+			return cz.metacentrum.perun.core.api.AuthzResolver.getUserRoleNames(ac.getSession(), ac.getUserById(parms.readInt("user"))); 
+		} 
+	},
+	/*#
+	 * Returns list of group's role names.
+	 * 
+	 * @exampleResponse [ "groupadmin" , "self" , "voadmin" ]
+	 * @return List<String> List of roles
+	 */
+	getGroupRoleNames {
+		@Override
+		public List<String> call(ApiCaller ac, Deserializer parms ) throws PerunException {
+			return cz.metacentrum.perun.core.api.AuthzResolver.getGroupRoleNames(ac.getSession(), ac.getGroupById(parms.readInt("group"))); 
+		} 
 	},
 	/*#
 	 * Get all managers for complementaryObject and role with specified attributes.


### PR DESCRIPTION
New tool listOfGroupRoles displays list of all authorized group roles.
Group Id or groupName and VO identifier are required.
Name of called method is corrected.
Calling of api getGroupRoleNames method corrected
Method getGroupRoleNames added to AuthzResolverAgent.pm