### PR TITLE
CORE: We don't want to allow dots in attribute friendlyName

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -105,7 +105,7 @@ public interface AttributesManager {
 
 	String LOGIN_NAMESPACE = "login-namespace";
 
-	String ATTRIBUTES_REGEXP = "^[-a-zA-Z0-9.]+([:][-a-zA-Z0-9.]+)?$";
+	String ATTRIBUTES_REGEXP = "^[-a-zA-Z0-9]+([:][-a-zA-Z0-9]+)?$";
 
 	String[] ENTITY_TYPES = {"facility", "resource", "member_resource", "member_group",
 			"member", "user_facility", "user", "vo", "group", "host", "group_resource", "entityless", "ues"};

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -36,7 +36,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	public static final String A_R_unixGroupName_namespace = AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace";
 	public static final String A_F_unixGID_namespace = AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGID-namespace";
 	public static final String A_F_unixGroupName_namespace = AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGroupName-namespace";
-	public static final String A_F_googleGroupName_namespace = AttributesManager.NS_FACILITY_ATTR_DEF + ":googleGroupNameNamespace";
+	public static final String A_F_googleGroupsDomain = AttributesManager.NS_FACILITY_ATTR_DEF + ":googleGroupsDomain";
 	private static final String A_E_usedGids = AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":usedGids";
 
 	//Often used patterns
@@ -522,7 +522,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	public Attribute getGoogleGroupNameNamespaceAttributeWithNotNullValue(PerunSessionImpl sess, Resource resource) throws InternalErrorException, WrongReferenceAttributeValueException {
 		Facility facility = sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 		try {
-			Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, A_F_googleGroupName_namespace);
+			Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, A_F_googleGroupsDomain);
 			if(googleGroupNameNamespaceAttribute.getValue() == null) throw new WrongReferenceAttributeValueException(googleGroupNameNamespaceAttribute);
 			return googleGroupNameNamespaceAttribute;
 		} catch(AttributeNotExistsException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -1199,7 +1199,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 					getPerunBl().getAttributesManagerBl().setAttribute(sess, user, kerberosLoginsAttr);
 				}
 
-			} else if (loginNamespace.equals("ics.muni.cz")) {
+			} else if (loginNamespace.equals("ics-muni-cz")) {
 
 				List<String> kerberosLogins = new ArrayList<String>();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_googleGroupsDomain.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_googleGroupsDomain.java
@@ -14,18 +14,22 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
 
 /**
- * Module of googleGroupNameNamespace attribute
+ * Module of googleGroupsDomain attribute
  *
  * @author Michal Holič  holic.michal@gmail.com
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class urn_perun_facility_attribute_def_def_googleGroupNameNamespace extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
+public class urn_perun_facility_attribute_def_def_googleGroupsDomain extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Attribute value can't be null");
 
+		// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
+		String namespace = ((String) attribute.getValue()).replaceAll("\\.", "-");
+
 		try {
-			sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + (String) attribute.getValue());
+			sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
 		} catch (AttributeNotExistsException e) {
 			throw new WrongAttributeValueException(attribute, e);
 		}
@@ -34,10 +38,10 @@ public class urn_perun_facility_attribute_def_def_googleGroupNameNamespace exten
 	public AttributeDefinition getAttributeDefinition() {
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
-		attr.setFriendlyName("googleGroupNameNamespace");
-		attr.setDisplayName("Google group name namespace");
+		attr.setFriendlyName("googleGroupsDomain");
+		attr.setDisplayName("Google groups domain");
 		attr.setType(String.class.getName());
-		attr.setDescription("Allowed google group name namespace on facility.");
+		attr.setDescription("Google groups domain on facility. Namespace attribute for group names is derived from the domain value by replacing all dots by dashes.");
 		return attr;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_googleGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_googleGroupName_namespace.java
@@ -31,7 +31,7 @@ public class urn_perun_group_attribute_def_def_googleGroupName_namespace extends
 			// if this is group attribute, its ok
 			return;
 		}else if(!groupName.matches("^[-_a-zA-Z0-9']+$")){
-			throw new WrongAttributeValueException(attribute, group, "GroupName attributte content invalid characters. Allowed are only letters, numbers and characters _ and -.");
+			throw new WrongAttributeValueException(attribute, group, "GroupName attribute content invalid characters. Allowed are only letters, numbers and characters _ and -.");
 		}
 
 		//TODO Check reserved google group names

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
@@ -28,9 +28,8 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getGoogleGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
-		String namespace = (String) googleGroupNameNamespaceAttribute.getValue();
 		// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
-		namespace = namespace.replaceAll("\\.", "-");
+		String namespace = ((String) googleGroupNameNamespaceAttribute.getValue()).replaceAll("\\.", "-");
 		Attribute groupNameAttribute;
 		try {
 			groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
@@ -60,9 +59,8 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 		}
 		Attribute groupNameAttribute;
 		try {
-			String namespace = (String) googleGroupNameNamespaceAttribute.getValue();
 			// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
-			namespace = namespace.replaceAll("\\.", "-");
+			String namespace = ((String) googleGroupNameNamespaceAttribute.getValue()).replaceAll("\\.", "-");
 			groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
 		} catch(AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(ex);
@@ -96,9 +94,8 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 		}
 
 		try {
-			String namespace = (String) googleGroupNameNamespaceAttribute.getValue();
 			// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
-			namespace = namespace.replaceAll("\\.", "-");
+			String namespace = ((String) googleGroupNameNamespaceAttribute.getValue()).replaceAll("\\.", "-");
 			Attribute groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
 			attribute = Utils.copyAttributeToVirtualAttributeWithValue(groupNameAttribute, attribute);
 			return attribute;
@@ -114,9 +111,8 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 		Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getGoogleGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 
 		try {
-			String namespace = (String) googleGroupNameNamespaceAttribute.getValue();
 			// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
-			namespace = namespace.replaceAll("\\.", "-");
+			String namespace = ((String) googleGroupNameNamespaceAttribute.getValue()).replaceAll("\\.", "-");
 			Attribute groupNameAttribute = new Attribute(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace));
 			groupNameAttribute.setValue(attribute.getValue());
 			return sess.getPerunBl().getAttributesManagerBl().setAttributeWithoutCheck(sess, group, groupNameAttribute);
@@ -138,7 +134,7 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 	public List<String> getStrongDependencies() {
 		List<String> dependencies = new ArrayList<String>();
 		dependencies.add(AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace" + ":*");
-		dependencies.add(AttributesManager.NS_FACILITY_ATTR_DEF + ":googleGroupNameNamespace");
+		dependencies.add(AttributesManager.NS_FACILITY_ATTR_DEF + ":googleGroupsDomain");
 		return dependencies;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
@@ -28,9 +28,12 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getGoogleGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
+		String namespace = (String) googleGroupNameNamespaceAttribute.getValue();
+		// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
+		namespace = namespace.replaceAll("\\.", "-");
 		Attribute groupNameAttribute;
 		try {
-			groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + googleGroupNameNamespaceAttribute.getValue());
+			groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
 		} catch(AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(ex);
 		}
@@ -57,7 +60,10 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 		}
 		Attribute groupNameAttribute;
 		try {
-			groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + googleGroupNameNamespaceAttribute.getValue());
+			String namespace = (String) googleGroupNameNamespaceAttribute.getValue();
+			// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
+			namespace = namespace.replaceAll("\\.", "-");
+			groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
 		} catch(AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(ex);
 		}
@@ -90,7 +96,10 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 		}
 
 		try {
-			Attribute groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + googleGroupNameNamespaceAttribute.getValue());
+			String namespace = (String) googleGroupNameNamespaceAttribute.getValue();
+			// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
+			namespace = namespace.replaceAll("\\.", "-");
+			Attribute groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
 			attribute = Utils.copyAttributeToVirtualAttributeWithValue(groupNameAttribute, attribute);
 			return attribute;
 		} catch(WrongAttributeAssignmentException ex) {
@@ -105,7 +114,10 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 		Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getGoogleGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 
 		try {
-			Attribute groupNameAttribute = new Attribute(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + googleGroupNameNamespaceAttribute.getValue()));
+			String namespace = (String) googleGroupNameNamespaceAttribute.getValue();
+			// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
+			namespace = namespace.replaceAll("\\.", "-");
+			Attribute groupNameAttribute = new Attribute(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace));
 			groupNameAttribute.setValue(attribute.getValue());
 			return sess.getPerunBl().getAttributesManagerBl().setAttributeWithoutCheck(sess, group, groupNameAttribute);
 		} catch(AttributeNotExistsException ex) {
@@ -124,10 +136,10 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 
 	@Override
 	public List<String> getStrongDependencies() {
-		List<String> dependecies = new ArrayList<String>();
-		dependecies.add(AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace" + ":*");
-		dependecies.add(AttributesManager.NS_FACILITY_ATTR_DEF + ":googleGroupNameNamespace");
-		return dependecies;
+		List<String> dependencies = new ArrayList<String>();
+		dependencies.add(AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace" + ":*");
+		dependencies.add(AttributesManager.NS_FACILITY_ATTR_DEF + ":googleGroupNameNamespace");
+		return dependencies;
 	}
 
 	@Override

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -21,7 +21,7 @@ public class Utils {
 	public static final String GROUP_NAME_MATCHER = "^[- a-zA-Z.0-9_:]+$";
 	public static final String GROUP_SHORT_NAME_MATCHER = "^[- a-zA-Z.0-9_]+$";
 	public static final String VO_SHORT_NAME_MATCHER = "^[-a-zA-Z0-9_.]+$";
-	public static final String ATTRIBUTE_FRIENDLY_NAME_MATCHER = "^[-a-zA-Z0-9.]+([:][-a-zA-Z0-9.]+)?$";
+	public static final String ATTRIBUTE_FRIENDLY_NAME_MATCHER = "^[-a-zA-Z0-9]+([:][-a-zA-Z0-9]+)?$";
 	public static final String LOGIN_VALUE_MATCHER = "^[a-zA-Z0-9_][-A-z0-9_.@/]*$";
 	public static final String FACILITY_NAME_MATCHER = "^[ a-zA-Z.0-9_-]+$";
 	public static final String SERVICE_NAME_MATCHER = "^[a-zA-Z0-9_]+$";


### PR DESCRIPTION
- Fixed attribute friendly name regex in GUI and CORE (remove dot).
- Fixed reference to login-namespace:ics.muni.cz in password validation
  method, use value with dashes (ics-muni-cz).
- Fixed resolving of GoogleGroup groups names, since GG domain can
  contain dots, but we don't allow them in referenced attribute
  name -> we convert them to dashes.

- On deployment, all related attributes names must be updated in DB.
- All references in external password scripts must be updated
  for login-namespace.