### PR TITLE
NOTIFICATIONS: Lowered number of waiting threads

### DIFF
--- a/perun-notification/src/main/resources/perun-notification-scheduler.xml
+++ b/perun-notification/src/main/resources/perun-notification-scheduler.xml
@@ -9,6 +9,8 @@
 		<property name="quartzProperties">
 			<props>
 				<prop key="org.quartz.threadPool.threadPriority">1</prop>
+				<!-- Since we start single thread once a day, we can lower default thread pool to 1 -->
+				<prop key="org.quartz.threadPool.threadCount">1</prop>
 			</props>
 		</property>
 		<property name="startupDelay" value="20" />


### PR DESCRIPTION
- We trigger single job once a day, hence we don't need thread
  pool with default 10 threads waiting for the job -> set to 1.