### PR TITLE
GUI: Fixed null pointer when updating AttributeDefinition

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionDetailTabItem.java
@@ -33,6 +33,7 @@ import cz.metacentrum.perun.webgui.widgets.TabMenu;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Detail of Attribute definition
@@ -203,7 +204,7 @@ public class AttributeDefinitionDetailTabItem implements TabItem {
 					}
 				}
 
-				if ((!def.getDescription().equals(description.getTextBox().getText().trim()) || !def.getDisplayName().equals(displayName.getTextBox().getText().trim()))) {
+				if ((!Objects.equals(def.getDescription(), description.getTextBox().getText().trim()) || !Objects.equals(def.getDisplayName(), displayName.getTextBox().getText().trim()))) {
 
 					if (!validator.validateTextBox() || !validatorName.validateTextBox()) return;
 


### PR DESCRIPTION
- Comparison with previous AttributeDef value could cause
  null pointer exception. Use Objects.equals() instead.