### PR TITLE
CORE,GUI,CLI: Use CSRF protection in Perun API

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -62,7 +62,7 @@ public class CoreConfig {
 	private String smsProgram;
 	private String userExtSourcesPersistent;
 	private List<String> allowedCorsDomains;
-	private boolean isCsrfEnabled;
+	private boolean isCsrfProtectionEnabled;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -474,12 +474,12 @@ public class CoreConfig {
 		this.allowedCorsDomains = allowedCorsDomains;
 	}
 
-	public boolean isCsrfEnabled() {
-		return isCsrfEnabled;
+	public boolean isCsrfProtectionEnabled() {
+		return isCsrfProtectionEnabled;
 	}
 
-	public void setCsrfEnabled(boolean csrfEnabled) {
-		isCsrfEnabled = csrfEnabled;
+	public void setCsrfProtectionEnabled(boolean csrfProtectionEnabled) {
+		isCsrfProtectionEnabled = csrfProtectionEnabled;
 	}
 
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -62,6 +62,7 @@ public class CoreConfig {
 	private String smsProgram;
 	private String userExtSourcesPersistent;
 	private List<String> allowedCorsDomains;
+	private boolean isCsrfEnabled;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -472,4 +473,13 @@ public class CoreConfig {
 	public void setAllowedCorsDomains(List<String> allowedCorsDomains) {
 		this.allowedCorsDomains = allowedCorsDomains;
 	}
+
+	public boolean isCsrfEnabled() {
+		return isCsrfEnabled;
+	}
+
+	public void setCsrfEnabled(boolean csrfEnabled) {
+		isCsrfEnabled = csrfEnabled;
+	}
+
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -61,6 +61,7 @@ public class CoreConfig {
 	private String rtUrl;
 	private String smsProgram;
 	private String userExtSourcesPersistent;
+	private List<String> allowedCorsDomains;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -462,5 +463,13 @@ public class CoreConfig {
 
 	public void setProperties(Properties properties) {
 		this.properties = properties;
+	}
+
+	public List<String> getAllowedCorsDomains() {
+		return allowedCorsDomains;
+	}
+
+	public void setAllowedCorsDomains(List<String> allowedCorsDomains) {
+		this.allowedCorsDomains = allowedCorsDomains;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -46,6 +46,7 @@
 		<property name="attributesForUpdateX509" value="#{'${perun.attributesForUpdate.x509}'.split('\s*,\s*')}"/>
 		<property name="oidcIssuers" value="#{'${perun.oidc.issuers}'.split('\s*,\s*')}"/>
 		<property name="allowedCorsDomains" value="#{'${perun.allowedCorsDomains}'.split('\s*,\s*')}" />
+		<property name="csrfEnabled" value="${perun.csrfEnabled}" />
 	</bean>
 
 
@@ -101,6 +102,7 @@
 				<prop key="perun.instanceId">AOJ26J3D9DCK3OA7</prop>
 				<prop key="perun.instanceName">LOCAL</prop>
 				<prop key="perun.allowedCorsDomains"></prop>
+				<prop key="perun.csrfEnabled">false</prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -45,6 +45,7 @@
 		<property name="attributesForUpdateIdP" value="#{'${perun.attributesForUpdate.idp}'.split('\s*,\s*')}"/>
 		<property name="attributesForUpdateX509" value="#{'${perun.attributesForUpdate.x509}'.split('\s*,\s*')}"/>
 		<property name="oidcIssuers" value="#{'${perun.oidc.issuers}'.split('\s*,\s*')}"/>
+		<property name="allowedCorsDomains" value="#{'${perun.allowedCorsDomains}'.split('\s*,\s*')}" />
 	</bean>
 
 
@@ -99,6 +100,7 @@
 				<prop key="perun.attributesForUpdate.x509">mail,cn,o,dn,cadn,certificate</prop>
 				<prop key="perun.instanceId">AOJ26J3D9DCK3OA7</prop>
 				<prop key="perun.instanceName">LOCAL</prop>
+				<prop key="perun.allowedCorsDomains"></prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -46,7 +46,7 @@
 		<property name="attributesForUpdateX509" value="#{'${perun.attributesForUpdate.x509}'.split('\s*,\s*')}"/>
 		<property name="oidcIssuers" value="#{'${perun.oidc.issuers}'.split('\s*,\s*')}"/>
 		<property name="allowedCorsDomains" value="#{'${perun.allowedCorsDomains}'.split('\s*,\s*')}" />
-		<property name="csrfEnabled" value="${perun.csrfEnabled}" />
+		<property name="csrfProtectionEnabled" value="${perun.csrfProtectionEnabled}" />
 	</bean>
 
 
@@ -102,7 +102,7 @@
 				<prop key="perun.instanceId">AOJ26J3D9DCK3OA7</prop>
 				<prop key="perun.instanceName">LOCAL</prop>
 				<prop key="perun.allowedCorsDomains"></prop>
-				<prop key="perun.csrfEnabled">false</prop>
+				<prop key="perun.csrfProtectionEnabled">false</prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
@@ -78,7 +78,6 @@ public class AuditMessagesManagerEntry implements AuditMessagesManager {
 		if (!AuthzResolver.isAuthorized(perunSession, Role.PERUNADMIN)) {
 			throw new PrivilegeException(perunSession, "pollConsumerMessagesForParser");
 		}
-
 		return getAuditMessagesManagerBl().pollConsumerMessagesForParser(consumerName);
 	}
 

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/main/LdapcStarter.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/main/LdapcStarter.java
@@ -2,7 +2,6 @@ package cz.metacentrum.perun.ldapc.main;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
@@ -52,7 +51,8 @@ public class LdapcStarter {
 		PerunPrincipal pp = new PerunPrincipal("perunLdapc", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
 
 		try {
-			RpcCaller rpcCaller = new RpcCallerImpl(pp);
+
+			RpcCaller rpcCaller = new RpcCallerImpl(pp, 300000);
 
 			LdapcStarter ldapcStarter = new LdapcStarter();
 

--- a/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/api/RpcCaller.java
+++ b/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/api/RpcCaller.java
@@ -3,10 +3,34 @@ package cz.metacentrum.perun.rpclib.api;
 import java.util.Map;
 
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.rpclib.api.Deserializer;
 
+/**
+ * Interface for Java RPC Client
+ *
+ * @author Michal Šťava
+ * @author Pavel Zlámal
+ */
 public interface RpcCaller {
+
+	/**
+	 * Call RPC API method without params
+	 *
+	 * @param managerName called manager
+	 * @param methodName called method
+	 * @return JsonDeserializer with response
+	 * @throws PerunException If anything fails
+	 */
 	public Deserializer call(String managerName, String methodName) throws PerunException;
 
+	/**
+	 * Call RPC API method with params
+	 *
+	 * @param managerName called manager
+	 * @param methodName called method
+	 * @param params method params passed with the call
+	 * @return JsonDeserializer with response
+	 * @throws PerunException If anything fails
+	 */
 	public Deserializer call(String managerName, String methodName, Map<String, Object> params) throws PerunException;
+
 }

--- a/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/impl/RpcCallerImpl.java
+++ b/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/impl/RpcCallerImpl.java
@@ -3,17 +3,9 @@ package cz.metacentrum.perun.rpclib.impl;
 import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.net.Authenticator;
-import java.net.CookieHandler;
-import java.net.CookieManager;
-import java.net.HttpCookie;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.PasswordAuthentication;
 import java.net.ProtocolException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +13,17 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthenticationException;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,26 +34,59 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.rpclib.api.Deserializer;
 import cz.metacentrum.perun.rpclib.api.RpcCaller;
 
+/**
+ * Implementation of Java Client calling remote Perun RPC using HTTP POST requests.
+ * Client delegate local credentials.
+ *
+ * @author Michal Šťava
+ * @author Pavel Zlámal
+ */
 public class RpcCallerImpl implements RpcCaller {
+
 	private static String format = "json";
 	private String perunUrl;
 	private PerunPrincipal perunPrincipal;
-	private CookieManager cookieManager;
+	private BasicCookieStore cookieStore = new BasicCookieStore();
+	private String username;
+	private String password;
+	private int timeout = 0;
 
 	private final static Logger log = LoggerFactory.getLogger(RpcCallerImpl.class);
 
+	/**
+	 * Create instance of Java RPC API client
+	 *
+	 * @param perunPrincipal Credential to delegate
+	 * @throws InternalErrorException If initialization fails
+	 */
 	public RpcCallerImpl(PerunPrincipal perunPrincipal) throws InternalErrorException {
-		// Set default Authenticator
-		Authenticator.setDefault(new PerunAuthenticator());
 
 		perunUrl = getPropertyFromConfiguration("perun.rpc.lib.perun.url");
 		log.debug("Loaded Perun URL [{}]", perunUrl);
 
+		try {
+			username = getPropertyFromConfiguration("perun.rpc.lib.username");
+			password = getPropertyFromConfiguration("perun.rpc.lib.password");
+		} catch (InternalErrorException e) {
+			log.error("Cannot load credentials for the RPC from the configuration file");
+		}
+
 		this.perunPrincipal = perunPrincipal;
 
-		// Set system wide cookie manager
-		cookieManager = new CookieManager();
-		CookieHandler.setDefault(cookieManager);
+	}
+
+	/**
+	 * Create instance of Java RPC API client
+	 *
+	 * @param perunPrincipal Credential to delegate
+	 * @param timeout timeout for all callbacks
+	 * @throws InternalErrorException If initialization fails
+	 */
+	public RpcCallerImpl(PerunPrincipal perunPrincipal, int timeout) throws InternalErrorException {
+
+		this(perunPrincipal);
+		this.timeout = timeout;
+
 	}
 
 	public Deserializer call(String managerName, String methodName) throws PerunException {
@@ -59,111 +95,70 @@ public class RpcCallerImpl implements RpcCaller {
 
 	public Deserializer call(String managerName, String methodName, Map<String, Object> params) throws PerunException {
 
-		// Get the connection
-		HttpURLConnection conn = this.getHttpURLConnection(managerName, methodName);
+		// Prepare sending message
+		HttpResponse response;
+		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+		if (this.timeout > 0) {
+			// if timeout specified
+			RequestConfig requestConfig = RequestConfig.custom()
+					.setConnectionRequestTimeout(this.timeout)
+					.setConnectTimeout(this.timeout)
+					.setSocketTimeout(this.timeout)
+					.build();
+			httpClientBuilder.setDefaultRequestConfig(requestConfig);
+		}
+		httpClientBuilder.setDefaultCookieStore(cookieStore);
+		HttpClient httpClient = httpClientBuilder.build();
 
-		log.debug("Calling RPC method {}.{}, using connection {}", new Object[] {managerName, methodName, conn});
+		String commandUrl = perunUrl + format + "/" + managerName + "/" + methodName;
+		log.debug("Calling [{}]", commandUrl);
 
-		if (params == null) {
-			params = new HashMap<String, Object>();
+		HttpPost post = new HttpPost(commandUrl);
+		post.setHeader("Content-Type", "application/json");
+		post.setHeader("charset", "utf-8");
+		post.setHeader("Connection", "Close");
+
+		// XSRF protection
+		URI domainUri = null;
+		try {
+			domainUri = new URI(perunUrl);
+			log.debug("URI: {}", domainUri);
+		} catch (URISyntaxException e) {
+			log.error("Can't parse perunUrl property to URI: {}", perunUrl);
+		}
+		if (domainUri != null) {
+
+			List<Cookie> cookies = cookieStore.getCookies();
+
+			for (Cookie cookie : cookies) {
+				if (Objects.equals(cookie.getDomain(), domainUri.getHost()) &&
+						Objects.equals(cookie.getName(), "XSRF-TOKEN")) {
+					post.setHeader("X-XSRF-TOKEN", cookie.getValue());
+					log.debug("XSFR header set.");
+					break;
+				}
+			}
 		}
 
-		// Setup delegated identity
+		// Authz
+		UsernamePasswordCredentials creds = new UsernamePasswordCredentials(username, password);
+		try {
+			post.addHeader(new BasicScheme().authenticate(creds, post, null));
+		} catch (AuthenticationException e) {
+			log.error("User '{}' can't authenticate to {}", username, perunUrl);
+			return null;
+		}
+
+
+		if (params == null) {
+			params = new HashMap<>();
+		}
+
 		params.put("delegatedLogin", perunPrincipal.getActor());
 		params.put("delegatedExtSourceName", perunPrincipal.getExtSourceName());
 		params.put("delegatedExtSourceType", perunPrincipal.getExtSourceType());
 
-		// Send the parameters to the RPC server
-		try {
-			this.sendParametersToRpcServer(conn.getOutputStream(), params);
-		} catch (IOException e) {
-			this.processIOException(conn, e);
-		}
-
-		// If Perun's RPC is temporarily unavailable, and Apache respond in HTML instead of JSON
-		try {
-			int responseCode = conn.getResponseCode();
-			if (responseCode != HttpURLConnection.HTTP_OK) {
-				throw new RpcException(RpcException.Type.PERUN_RPC_SERVER_ERROR_HTTP_CODE, "Perun server on URL: " + perunUrl + " returned HTTP code: " + responseCode);
-			}
-		} catch (IOException ex) {
-			this.processIOException(conn, ex);
-		}
-
-		// Get the answer from the server
-		InputStream rpcServerAnswer = null;
-		try {
-			rpcServerAnswer = conn.getInputStream();
-		} catch (IOException e) {
-			try {
-				this.processIOException(conn, e);
-			} catch (RpcException e1) {
-				this.processRpcServerException(conn.getErrorStream());
-			}
-		}
-		// Initialize deserializer with the data received from the RPC server
-		JsonDeserializer des = null;
-		try {
-			des = new JsonDeserializer(rpcServerAnswer);
-		} catch (IOException e) {
-			this.processIOException(conn, e);
-		}
-
-		return des;
-	}
-
-	protected void processRpcServerException(InputStream errorStream) throws RpcException, InternalErrorException, PerunException {
-		JsonDeserializer errDes;
-		try {
-			errDes = new JsonDeserializer(errorStream);
-		} catch (IOException e) {
-			this.processIOException(e);
-			return;
-		}
-
-		// Error occured, read the Exception if it is in response
-		String errorId = errDes.readString("errorId");
-		if (errorId != null ) {
-
-			String exceptionName = errDes.readString("name");
-			if (!exceptionName.equals(RpcException.class.getSimpleName())) {
-				String errorClass = errDes.readString("name");
-				String errorInfo = errDes.readString("message");
-				try {
-					Class<?> exceptionClass = Class.forName("cz.metacentrum.perun.core.api.exceptions." + errorClass);
-
-					Class<?> constructorParams[] = new Class[1];
-					constructorParams[0] = String.class;
-					Constructor<?> exceptionConstructor = exceptionClass.getConstructor(constructorParams);
-					Object arglist[] = new Object[1];
-					arglist[0] = errorInfo;
-					PerunException exception = (PerunException) exceptionConstructor.newInstance(arglist);
-					exception.setErrorId(errorId);
-
-					throw exception;
-				} catch (ClassNotFoundException e1) {
-					throw new InternalErrorException(e1);
-				} catch (InstantiationException e1) {
-					throw new InternalErrorException(e1);
-				} catch (IllegalAccessException e1) {
-					throw new InternalErrorException(e1);
-				} catch (IllegalArgumentException e1) {
-					throw new InternalErrorException(e1);
-				} catch (InvocationTargetException e1) {
-					throw new InternalErrorException(e1);
-				} catch (NoSuchMethodException e1) {
-					throw new InternalErrorException(e1);
-				}
-			} else {
-				// RPC Exception
-				String errorClass = errDes.readString("type");
-				String errorInfo = errDes.readString("errorInfo");
-				throw new RpcException(errorClass, errorInfo);
-			}
-		}
-	}
-
-	protected void sendParametersToRpcServer(OutputStream out, Map<String, Object> params) throws RpcException, InternalErrorException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		JsonSerializer ser = null;
 
 		try {
@@ -172,89 +167,94 @@ public class RpcCallerImpl implements RpcCaller {
 			out.flush();
 		} catch (IOException e) {
 			this.processIOException(e);
-			return;
-		}
-	}
-
-	protected HttpURLConnection getHttpURLConnection(String managerName, String methodName) throws InternalErrorException {
-		// Compose an URL
-		String commandUrl = perunUrl + format + "/" + managerName + "/" + methodName;
-		log.debug("Calling [{}]", commandUrl);
-
-		URL url;
-		try {
-			url = new URL(commandUrl);
-		} catch (MalformedURLException e) {
-			throw new InternalErrorException(e);
+			return null;
 		}
 
-		HttpURLConnection conn = null;
+		post.setEntity(new ByteArrayEntity(out.toByteArray()));
+
+		InputStream rpcServerAnswer = null;
+
 		try {
-			conn = (HttpURLConnection) url.openConnection();
+			response = httpClient.execute(post);
 
-			conn.setRequestProperty("content-type", "application/json; charset=utf-8");
-
-			// XSRF protection
-			URI domainUri = null;
-			try {
-				domainUri = new URI(perunUrl);
-			} catch (URISyntaxException e) {
-				log.error("Can't parse perunUrl property to URI: {}", perunUrl);
+			// If Perun's RPC is temporarily unavailable, and Apache respond in HTML instead of JSON
+			int responseCode = response.getStatusLine().getStatusCode();
+			if (responseCode != 200) {
+				throw new RpcException(RpcException.Type.PERUN_RPC_SERVER_ERROR_HTTP_CODE, "Perun server on URL: " + perunUrl + " returned HTTP code: " + responseCode);
 			}
-			if (domainUri != null) {
 
-				List<HttpCookie> cookies = cookieManager.getCookieStore().get(domainUri);
+			rpcServerAnswer = response.getEntity().getContent();
 
-				for (HttpCookie cookie : cookies) {
-					if (Objects.equals(cookie.getDomain(), domainUri.getHost()) &&
-					Objects.equals(cookie.getName(), "XSRF-TOKEN")) {
-						conn.setRequestProperty("X-XSRF-TOKEN", cookie.getValue());
-						break;
+		} catch(IOException ex) {
+			this.processIOException(ex);
+		}
+
+		// Initialize deserializer with the data received from the RPC server
+		JsonDeserializer des = null;
+		try {
+			des = new JsonDeserializer(rpcServerAnswer);
+
+			// Error occur, read the Exception if it is in response
+			if (des.contains("errorId")) {
+
+				String errorId = des.readString("errorId");
+				if (errorId != null ) {
+
+					String exceptionName = des.readString("name");
+					if (!exceptionName.equals(RpcException.class.getSimpleName())) {
+						String errorClass = des.readString("name");
+						String errorInfo = des.readString("message");
+						try {
+							Class<?> exceptionClass = Class.forName("cz.metacentrum.perun.core.api.exceptions." + errorClass);
+
+							Class<?> constructorParams[] = new Class[1];
+							constructorParams[0] = String.class;
+							Constructor<?> exceptionConstructor = exceptionClass.getConstructor(constructorParams);
+							Object arglist[] = new Object[1];
+							arglist[0] = errorInfo;
+							PerunException exception = (PerunException) exceptionConstructor.newInstance(arglist);
+							exception.setErrorId(errorId);
+
+							throw exception;
+						} catch (ClassNotFoundException e1) {
+							throw new InternalErrorException(e1);
+						} catch (InstantiationException e1) {
+							throw new InternalErrorException(e1);
+						} catch (IllegalAccessException e1) {
+							throw new InternalErrorException(e1);
+						} catch (IllegalArgumentException e1) {
+							throw new InternalErrorException(e1);
+						} catch (InvocationTargetException e1) {
+							throw new InternalErrorException(e1);
+						} catch (NoSuchMethodException e1) {
+							throw new InternalErrorException(e1);
+						}
+					} else {
+						// RPC Exception
+						String errorClass = des.readString("type");
+						String errorInfo = des.readString("errorInfo");
+						throw new RpcException(errorClass, errorInfo);
 					}
 				}
+
 			}
 
-			// Try Keep-Alive
-			conn.setRequestProperty("Connection", "Close");
-			// We will send output
-			conn.setDoOutput(true);
-			// Using POST
-			conn.setRequestMethod("POST");
-
-			log.debug("Connection opened");
 		} catch (IOException e) {
-			this.processIOException(conn, e);
+			this.processIOException(e);
 		}
 
-		return conn;
+		return des;
 	}
 
 	protected void processIOException(Throwable e) throws RpcException {
-		this.processIOException(null, e);
-	}
 
-	protected void processIOException(HttpURLConnection conn, Throwable e) throws RpcException {
-		// Process known IOExceptions
 		if (e instanceof ProtocolException) {
 			throw new RpcException(RpcException.Type.COMMUNICATION_ERROR_WITH_PERUN_RPC_SERVER, "Communication problem with Perun server on URL: " + perunUrl, e);
 		} else if (e instanceof UnknownHostException) {
 			throw new RpcException(RpcException.Type.UNKNOWN_PERUN_RPC_SERVER, "Perun server cannot be contacted on URL: " + perunUrl, e);
 		}
+		log.error("IO Exception: {}", e);
 
-		// If the connection has been provided, check the responseCode
-		if (conn != null) {
-			// Check return code
-			int responseCode;
-			try {
-				responseCode = conn.getResponseCode();
-
-				if (responseCode != HttpURLConnection.HTTP_OK) {
-					throw new RpcException(RpcException.Type.PERUN_RPC_SERVER_ERROR_HTTP_CODE, "Perun server on URL: " + perunUrl + " returned HTTP code: " + responseCode, e);
-				}
-			} catch (IOException e1) {
-				throw new RpcException(RpcException.Type.UNKNOWN_EXCEPTION, "Failed to contact Perun server on URL: " + perunUrl, e1);
-			}
-		}
 	}
 
 	protected static String getPropertyFromConfiguration(String propertyName) throws InternalErrorException {
@@ -282,19 +282,4 @@ public class RpcCallerImpl implements RpcCaller {
 		}
 	}
 
-	static class PerunAuthenticator extends Authenticator {
-		public PasswordAuthentication getPasswordAuthentication() {
-			String username = null;
-			String password = null;
-
-			try {
-				username = getPropertyFromConfiguration("perun.rpc.lib.username");
-				password = getPropertyFromConfiguration("perun.rpc.lib.password");
-			} catch (InternalErrorException e) {
-				log.error("Cannot load credentials for the RPC from the configuration file");
-			}
-
-			return new PasswordAuthentication(username, password.toCharArray());
-		}
-	}
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -426,11 +426,13 @@ public class Api extends HttpServlet {
 	 */
 	@Override
 	protected void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-		checkOriginHeader(req,resp);
-		resp.setHeader("Access-Control-Allow-Methods","GET, POST, OPTIONS");
-		resp.setHeader("Access-Control-Allow-Headers","Authorization, Content-Type");
-		resp.setIntHeader("Access-Control-Max-Age",86400);
-		resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
+		if (checkOriginHeader(req,resp)) {
+			resp.setHeader("Access-Control-Allow-Methods","GET, POST, OPTIONS");
+			resp.setHeader("Access-Control-Allow-Headers","Authorization, Content-Type");
+			resp.setHeader("Access-Control-Allow-Credentials", "true");
+			resp.setIntHeader("Access-Control-Max-Age",86400);
+			resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
+		}
 	}
 
 	/**
@@ -439,7 +441,7 @@ public class Api extends HttpServlet {
 	 * @param req HttpServletRequest to check
 	 * @param resp HttpServletResponse to modify
 	 */
-	private void checkOriginHeader(HttpServletRequest req, HttpServletResponse resp) {
+	private boolean checkOriginHeader(HttpServletRequest req, HttpServletResponse resp) {
 		String origin = req.getHeader("Origin");
 		log.debug("Incoming Origin header: {}", origin);
 
@@ -455,12 +457,14 @@ public class Api extends HttpServlet {
 				log.debug("ADDING HEADER Access-Control-Allow-Origin to response: {}", origin);
 				resp.setHeader("Access-Control-Allow-Origin",origin);
 				resp.setHeader("Vary","Origin");
+				return true;
 			}
 		} else {
 			// no origin, don't modify header
 			// origin = "*";
 		}
 
+		return false;
 	}
 
 	@SuppressWarnings("ConstantConditions")

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -441,10 +441,18 @@ public class Api extends HttpServlet {
 	 */
 	private void checkOriginHeader(HttpServletRequest req, HttpServletResponse resp) {
 		String origin = req.getHeader("Origin");
+		log.debug("Incoming Origin header: {}", origin);
+
+		log.debug("Available headers: {}", Collections.list(req.getHeaderNames()));
+		for (String headerName : Collections.list(req.getHeaderNames())) {
+			log.debug("Header: {}={}", headerName, req.getHeader(headerName));
+		}
 
 		if (origin != null) {
 			List<String> allowedDomains = BeansUtils.getCoreConfig().getAllowedCorsDomains();
+			log.debug("Allowed domains: {}", allowedDomains);
 			if (allowedDomains.contains(origin)) {
+				log.debug("ADDING HEADER Access-Control-Allow-Origin to response: {}", origin);
 				resp.setHeader("Access-Control-Allow-Origin",origin);
 				resp.setHeader("Vary","Origin");
 			}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -431,8 +431,8 @@ public class Api extends HttpServlet {
 			resp.setHeader("Access-Control-Allow-Headers","Authorization, Content-Type");
 			resp.setHeader("Access-Control-Allow-Credentials", "true");
 			resp.setIntHeader("Access-Control-Max-Age",86400);
-			resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
 		}
+		resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
 	}
 
 	/**

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -385,7 +385,7 @@ public class Api extends HttpServlet {
 
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-		mirrorOriginHeader(req,resp);
+		checkOriginHeader(req,resp);
 		if (req.getPathInfo() == null || req.getPathInfo().equals("/")) {
 			resp.setContentType("text/plain; charset=utf-8");
 			Writer wrt = resp.getWriter();
@@ -408,13 +408,13 @@ public class Api extends HttpServlet {
 
 	@Override
 	protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-		mirrorOriginHeader(req,resp);
+		checkOriginHeader(req,resp);
 		serve(req, resp, false, true);
 	}
 
 	@Override
 	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-		mirrorOriginHeader(req,resp);
+		checkOriginHeader(req,resp);
 		serve(req, resp, false, false);
 	}
 
@@ -426,14 +426,20 @@ public class Api extends HttpServlet {
 	 */
 	@Override
 	protected void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-		mirrorOriginHeader(req,resp);
+		checkOriginHeader(req,resp);
 		resp.setHeader("Access-Control-Allow-Methods","GET, POST, OPTIONS");
 		resp.setHeader("Access-Control-Allow-Headers","Authorization, Content-Type");
 		resp.setIntHeader("Access-Control-Max-Age",86400);
 		resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
 	}
 
-	private void mirrorOriginHeader(HttpServletRequest req, HttpServletResponse resp) {
+	/**
+	 * Check Origin header, if it's between allowed domains for CORS
+	 *
+	 * @param req HttpServletRequest to check
+	 * @param resp HttpServletResponse to modify
+	 */
+	private void checkOriginHeader(HttpServletRequest req, HttpServletResponse resp) {
 		String origin = req.getHeader("Origin");
 
 		if (origin != null) {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -206,7 +206,7 @@ public class Api extends HttpServlet {
 		String remoteUser = req.getRemoteUser();
 
 		CoreConfig config = BeansUtils.getCoreConfig();
-		
+
 		// If we have header Shib-Identity-Provider, then the user uses identity federation to authenticate
 		if (isNotEmpty(shibIdentityProvider)) {
 			extSourceName = getOriginalIdP(shibIdentityProvider, sourceIdpEntityId);
@@ -435,9 +435,18 @@ public class Api extends HttpServlet {
 
 	private void mirrorOriginHeader(HttpServletRequest req, HttpServletResponse resp) {
 		String origin = req.getHeader("Origin");
-		if(origin==null) origin = "*";
-		resp.setHeader("Access-Control-Allow-Origin",origin);
-		resp.setHeader("Vary","Origin");
+
+		if (origin != null) {
+			List<String> allowedDomains = BeansUtils.getCoreConfig().getAllowedCorsDomains();
+			if (allowedDomains.contains(origin)) {
+				resp.setHeader("Access-Control-Allow-Origin",origin);
+				resp.setHeader("Vary","Origin");
+			}
+		} else {
+			// no origin, don't modify header
+			// origin = "*";
+		}
+
 	}
 
 	@SuppressWarnings("ConstantConditions")

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/csrf/CsrfFilter.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/csrf/CsrfFilter.java
@@ -99,7 +99,7 @@ public final class CsrfFilter implements Filter {
 				return;
 			}
 			// Is CSRF protection enabled ?
-			if (!BeansUtils.getCoreConfig().isCsrfEnabled()) {
+			if (!BeansUtils.getCoreConfig().isCsrfProtectionEnabled()) {
 				filterChain.doFilter(servletRequest, servletResponse);
 				return;
 			}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/csrf/CsrfFilter.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/csrf/CsrfFilter.java
@@ -31,6 +31,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +93,11 @@ public final class CsrfFilter implements Filter {
 			if (this.allowedMethods.contains(request.getMethod())) {
 				log.trace("Skip CSRF check on GET | HEAD | TRACE | OPTIONS method.");
 				filterChain.doFilter(request, response);
+				return;
+			}
+			// Is CSRF protection enabled ?
+			if (!BeansUtils.getCoreConfig().isCsrfEnabled()) {
+				filterChain.doFilter(servletRequest, servletResponse);
 				return;
 			}
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/csrf/CsrfFilter.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/csrf/CsrfFilter.java
@@ -1,0 +1,216 @@
+package cz.metacentrum.perun.rpc.csrf;
+
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.WebUtils;
+
+/**
+ * This is an implementation of CSRF protection based on Spring framework solution.
+ *
+ * We create Cookie with CsrfToken, which is valid during whole HTTP session.
+ * Client JS app or CLI can read the Cookie value and provide it back within HTTP Header.
+ * CsrfToken value is also stored within HTTP session.
+ *
+ * On each request, where Cookie is not present, Token is generated and set to the Session.
+ * On any state changing request, CsrfToken value must match between Cookie, Header and Session.
+ * Check for "GET", "HEAD", "TRACE", "OPTIONS" HTTP methods is disabled.
+ *
+ * @see CsrfToken
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public final class CsrfFilter implements Filter {
+
+	private final Logger log = LoggerFactory.getLogger(CsrfFilter.class);
+	private final HashSet<String> allowedMethods = new HashSet<>(Arrays.asList("GET", "HEAD", "TRACE", "OPTIONS"));
+
+	private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
+	private static final String CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+	private static final String CSRF_REQUEST_ATTR_NAME = CsrfToken.class.getName();
+
+	public CsrfFilter() {
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+
+	}
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+
+		if (servletRequest instanceof HttpServletRequest && servletResponse instanceof HttpServletResponse) {
+
+			log.trace("Processing CSRF filter.");
+
+			HttpServletRequest request = (HttpServletRequest)servletRequest;
+			HttpServletResponse response = (HttpServletResponse)servletResponse;
+
+			// load token from cookie or create cookie
+			CsrfToken cookieCsrfToken = loadToken(request);
+			final boolean missingToken = (cookieCsrfToken == null);
+			if (missingToken) {
+				log.debug("Missing CSRF token - generating new.");
+				cookieCsrfToken = generateToken();
+				saveToken(cookieCsrfToken, request, response);
+			}
+
+			// Skip this filter for unprotected methods GET | HEAD | TRACE | OPTIONS
+			if (this.allowedMethods.contains(request.getMethod())) {
+				log.trace("Skip CSRF check on GET | HEAD | TRACE | OPTIONS method.");
+				filterChain.doFilter(request, response);
+				return;
+			}
+
+			log.trace("Perform CSRF check.");
+
+			CsrfToken httpSessionToken = (CsrfToken)request.getSession(true).getAttribute(CSRF_REQUEST_ATTR_NAME);
+
+			String actualToken = request.getHeader(CSRF_HEADER_NAME);
+
+			// check if sent Cookie and Header are the same
+			if (!Objects.equals(cookieCsrfToken.getValue(), actualToken)) {
+
+				log.trace("Invalid CSRF token found for {} COOKIE: {} | HEADER: {}.", request.getRequestURI(), cookieCsrfToken.getValue(), actualToken);
+
+				if (missingToken) {
+					// missing token
+					response.setStatus(HttpStatus.SC_FORBIDDEN);
+				} else {
+					// invalid token
+					response.setStatus(HttpStatus.SC_FORBIDDEN);
+				}
+				return;
+			}
+
+			// since caller might forge both Cookie and Header
+			// check if sent Header and stored HttpSession token are the same
+			if (!Objects.equals(httpSessionToken.getValue(), actualToken)) {
+
+				log.trace("Invalid CSRF token found for {} SESSION: {} | HEADER: {}.", request.getRequestURI(), httpSessionToken.getValue(), actualToken);
+
+				if (missingToken) {
+					// missing token
+					response.setStatus(HttpStatus.SC_FORBIDDEN);
+				} else {
+					// invalid token
+					response.setStatus(HttpStatus.SC_FORBIDDEN);
+				}
+				return;
+			}
+
+			log.trace("Tokens match SESSION: {} | COOKIE: {} | HEADER: {}.", httpSessionToken.getValue(), cookieCsrfToken.getValue(), actualToken);
+
+			// continue to the next filter
+			filterChain.doFilter(request, response);
+
+		} else {
+
+			log.trace("Processing CSRF filter skipped.");
+
+			// this filter was not applied - continue to the next filter
+			filterChain.doFilter(servletRequest, servletResponse);
+
+		}
+
+	}
+
+	@Override
+	public void destroy() {
+
+	}
+
+	/**
+	 * Load CsrfToken from Cookie associated with HttpServletRequest.
+	 * If cookie is not present or is empty, NULL is returned.
+	 *
+	 * @param request HttpServletRequest to read Cookie from
+	 * @return CsrfToken from Cookie
+	 */
+	private CsrfToken loadToken(HttpServletRequest request) {
+
+		// if cookie was not sent in request
+		Cookie cookie = WebUtils.getCookie(request, CSRF_COOKIE_NAME);
+		if (cookie == null) {
+			return null;
+		}
+
+		// if cookie is empty
+		String tokenValue = cookie.getValue();
+		if (!StringUtils.hasLength(tokenValue)) {
+			return null;
+		}
+
+		// return cookie version of the token
+		return new CsrfToken(tokenValue);
+
+	}
+
+	/**
+	 * Generate new CsrfToken
+	 *
+	 * @return new CsrfToken
+	 */
+	private CsrfToken generateToken() {
+		return new CsrfToken();
+	}
+
+	/**
+	 * Save generated CsrfToken as a Cookie in HttpServletResponse and original object in HttpServletRequest session.
+	 *
+	 * @param token CsrfToken
+	 * @param request Request
+	 * @param response Response
+	 */
+	private void saveToken(CsrfToken token, HttpServletRequest request, HttpServletResponse response) {
+		String tokenValue = token == null ? "" : token.getValue();
+		Cookie cookie = new Cookie(CSRF_COOKIE_NAME, tokenValue);
+		cookie.setSecure(request.isSecure());
+		cookie.setPath("/");
+		if (token == null) {
+			cookie.setMaxAge(0);
+		} else {
+			cookie.setMaxAge(-1);
+		}
+		// allow our GUI (JS apps to read Cookie content)
+		cookie.setHttpOnly(false);
+		// save cookie and token
+		response.addCookie(cookie);
+		request.getSession(true).setAttribute(CSRF_REQUEST_ATTR_NAME, token);
+	}
+
+}
+

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/csrf/CsrfToken.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/csrf/CsrfToken.java
@@ -1,0 +1,49 @@
+package cz.metacentrum.perun.rpc.csrf;
+
+import java.util.UUID;
+
+/**
+ * CsrfToken is used to prevent CSRF attack in web browsers.
+ * This class simply generates token value and holds it within self.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class CsrfToken {
+
+	private String value = null;
+
+	/**
+	 * Create CSRF token with new random value
+	 */
+	public CsrfToken() {
+		this.value = UUID.randomUUID().toString();
+	}
+
+	/**
+	 * Create CSRF token with specified value
+	 *
+	 * @param value Value of the Token
+	 */
+	public CsrfToken(String value) {
+		this.value = value;
+	}
+
+	/**
+	 * Get value of CSRF token.
+	 *
+	 * @return value of CSRF token
+	 */
+	public String getValue() {
+		return value;
+	}
+
+	/**
+	 * Set value of CSRF token
+	 *
+	 * @param value value of CSRF token
+	 */
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+}

--- a/perun-rpc/src/main/webapp/WEB-INF/web.xml
+++ b/perun-rpc/src/main/webapp/WEB-INF/web.xml
@@ -16,7 +16,7 @@
 		<param-name>contextConfigLocation</param-name>
 		<param-value>classpath:perun-rpc.xml</param-value>
 	</context-param>
-	
+
 	<!-- Logback -->
 	<listener>
 		<listener-class>ch.qos.logback.classic.servlet.LogbackServletContextListener</listener-class>
@@ -41,6 +41,14 @@
 	</filter>
 	<filter-mapping>
 		<filter-name>MDCInsertingServletFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+	<filter>
+		<filter-name>csrfFilter</filter-name>
+		<filter-class>cz.metacentrum.perun.rpc.csrf.CsrfFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>csrfFilter</filter-name>
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonClient.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonClient.java
@@ -1,10 +1,12 @@
 package cz.metacentrum.perun.webgui.json;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.http.client.*;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
+import com.google.gwt.user.client.Cookies;
 import com.google.gwt.user.client.Window;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.localization.WidgetTranslation;
@@ -109,6 +111,11 @@ public class JsonClient {
 
 		// request building
 		RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, requestUrl);
+
+		if (Cookies.getCookie("XSRF-TOKEN") != null) {
+			// FIXME - we protect only POST/PUT calls
+			//builder.setHeader("X-XSRF-TOKEN", Cookies.getCookie("XSRF-TOKEN"));
+		}
 		try {
 
 			// sends the request

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonPostClient.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonPostClient.java
@@ -8,6 +8,7 @@ import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
+import com.google.gwt.user.client.Cookies;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebConstants;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
@@ -190,6 +191,10 @@ public class JsonPostClient {
 
 		// request building
 		RequestBuilder builder = new RequestBuilder(RequestBuilder.POST, requestUrl);
+
+		if (Cookies.getCookie("XSRF-TOKEN") != null) {
+			builder.setHeader("X-XSRF-TOKEN", Cookies.getCookie("XSRF-TOKEN"));
+		}
 		try {
 			// sends the request
 			onRequestLoadingStart();


### PR DESCRIPTION
- CSRF protection is implemented using custom filter.
- We use cookie based tokens, since JS client need to access them
  from the browser and also CLI will need to send the cookie value
  in the header.
- Token is valid as long as http session.
- For state changing requests (like POST/PUT) we check, that token
  value is the same for all Cookie, Header and server side Session.

CORE: Read allowed CORS domains from perun config

- Allow CORS only from trusted domains from perun config.

CLI: Support CSRF protection in our API

- Since creation of Agent instance calls API, we will get
  CSRF cookie and we can use it later for all requests made by
  our Agent instance (set as default header).
- For "localhost" we change domain to "localhost.local" since
  its stored like this in a cookie_jar.
- Configuration of cookie file is respected, new cookie is stored
  along side PERUNSESSION cookie.

GUI,RPC-LIB: Support for CSRF (send header if cookie is present).


!! After merge it must be deployed also with update to WUI and any third-party application calling our API !!