### PR TITLE
GUI: Drop support for IE8 and 9

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web-dev.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web-dev.gwt.xml
@@ -6,10 +6,10 @@
 
 	<!--  Support only these browsers for devel -->
 	<set-property name="user.agent" value="gecko1_8" />
-    <extend-property name="user.agent" values="safari" />
+	<extend-property name="user.agent" values="safari" />
 
 	<!-- enable source maps -->
-    <set-configuration-property name="devModeRedirectEnabled" value="true"/>
-    <set-property name="compiler.useSourceMaps" value="true" />
+	<set-configuration-property name="devModeRedirectEnabled" value="true"/>
+	<set-property name="compiler.useSourceMaps" value="true" />
 
 </module>

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web-prod.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web-prod.gwt.xml
@@ -8,10 +8,7 @@
 
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
 	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
-	<extend-property name="user.agent" values="ie8" /> <!-- IE 8 -->
-	<extend-property name="user.agent" values="ie9" /> <!-- IE 9 -->
-    <extend-property name="user.agent" values="ie10" /> <!--  IE 10 -->
-	<!-- Other possibilities are 'gecko' - for FF2 -->
+	<extend-property name="user.agent" values="ie10" /> <!--  IE 10+ / Edge -->
 	<!-- Or don't specify values to compile for all browsers -->
 
 </module>

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web.gwt.xml
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/perun-web.gwt.xml
@@ -6,7 +6,7 @@
 
 	<!-- We need the JUnit module in the main module, -->
 	<!-- otherwise eclipse complains (Google plugin bug?) -->
-    <!--<inherits name='com.google.gwt.junit.JUnit' />-->
+	<!--<inherits name='com.google.gwt.junit.JUnit' />-->
 
 	<!-- Inherit the default GWT style sheet. You can change -->
 	<!-- the theme of your GWT application by uncommenting -->
@@ -22,7 +22,7 @@
 	<inherits name="com.google.gwt.resources.Resources" />
 	<inherits name="com.google.gwt.regexp.RegExp" />
 
-    <!--<inherits name="gwtquery.plugins.droppable.Droppable"/>-->
+	<!--<inherits name="gwtquery.plugins.droppable.Droppable"/>-->
 
 	<!-- Allow translations - 'default' = English strings, add 'cs' = Czech strings -->
 	<!-- <extend-property name="locale" values="cs" /> -->
@@ -38,8 +38,8 @@
 	<!--  Support only these browsers for devel -->
 
 	<set-property name="user.agent" value="gecko1_8" />	<!-- FF -->
-    <extend-property name="user.agent" values="safari" /> <!-- CHROME -->
-    <!-- Other possibilities are 'ie8', 'ie9', 'ie10', 'gecko' - for FF2 -->
+	<extend-property name="user.agent" values="safari" /> <!-- CHROME -->
+	<!-- Other possibilities are 'ie8', 'ie9', 'ie10', 'gecko' - for FF2 -->
 	<!-- Or don't specify values to compile for all browsers -->
 
 	<!-- Specify the paths for translatable code -->

--- a/perun-web-gui/src/main/webapp/PerunWeb.html
+++ b/perun-web-gui/src/main/webapp/PerunWeb.html
@@ -6,11 +6,6 @@
 	<!-- Charset -->
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
-	<!-- No cache -->
-	<meta http-equiv="pragma" content="no-cache" />
-	<meta http-equiv="cache-control" content="no-cache" />
-	<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
-
 	<!-- Default GWT locale -->
 	<meta name="gwt:property" content="locale=en">
 
@@ -31,7 +26,7 @@
 	<script type="text/javascript" language="javascript" >
 		RPC_SERVER = window.location.pathname.split("/")[1];
 
-		<!-- Fix Windows+Chrome+Kerberos authz - chrome doesn`t trust whole domain, we must call most top-level path -->
+		<!-- Fix Windows+Chrome+Kerberos authz - chrome doesn't trust whole domain, we must call most top-level path -->
 		$.ajax({
 			url: "/" + window.location.pathname.split("/")[1] + "/rpc/",
 			type: "get"
@@ -49,47 +44,40 @@
 			);
 		}
 
+		// determine version of IE
+		function getIEVersion() {
+			var sAgent = window.navigator.userAgent;
+			var Idx = sAgent.indexOf("MSIE");
+
+			// If IE, return version number.
+			if (Idx > 0)
+				return parseInt(sAgent.substring(Idx+ 5, sAgent.indexOf(".", Idx)));
+
+			// If IE 11 then look for Updated user agent string.
+			else if (!!navigator.userAgent.match(/Trident\/7\./))
+				return 11;
+
+			else
+				return 0; //It is not IE
+		}
+
 		var l_lang;
 		l_lang = getURLParameter('locale');
 
-		/*
-		 // if no locale set in URL
-		 if (l_lang == 'default') {
-
-		 if (typeof(Storage) != "undefined") {
-
-		 l_lang = localStorage.getItem("urn:perun:gui:preferences:language")
-
-		 }
-
-		 // if not set, set from browser settings
-		 if (l_lang == null) {
-
-		 if (navigator.userLanguage) // Explorer
-		 l_lang = navigator.userLanguage;
-		 else if (navigator.language) // FF
-		 l_lang = navigator.language;
-		 else
-		 l_lang = "en";
-
-		 }
-
-		 }
-		 */
-		if (l_lang == 'default') {
+		if (l_lang === 'default') {
 			l_lang = 'en';
 		}
 
 		$("meta[name='gwt:property']").attr('content', 'locale='+l_lang);
 
 		// Skip on Chrome 1+, Firefox 3.5+, IE 8+, Opera 15+, Safari 3.2
-		if (document.all && !document.querySelector) {
-			// Is IE < 8
-			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+		if (getIEVersion() !== 0 && getIEVersion() < 10) {
+			// Is IE < 10
+			alert("Unsupported browser. Please use either: Internet Explorer 10+ or Edge, Firefox, Chrome, Opera 15+ or Safari");
 		}
-		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') == -1);
+		var isOperaBefore15 = (window.opera && navigator.userAgent.indexOf(' OPR/') === -1);
 		if (isOperaBefore15) {
-			alert("Unsupported browser. Please use either: Internet Explorer 8+, Firefox, Chrome, Opera 15+ or Safari");
+			alert("Unsupported browser. Please use either: Internet Explorer 10+ or Edge, Firefox, Chrome, Opera 15+ or Safari");
 		}
 
 	</script>
@@ -103,7 +91,7 @@
 
 <!-- OPTIONAL: include this if you want history support -->
 <iframe src="javascript:''" id="__gwt_historyFrame" tabIndex='-1'
-        style="position: absolute; width: 0; height: 0; border: 0"></iframe>
+		style="position: absolute; width: 0; height: 0; border: 0"></iframe>
 
 <!-- RECOMMENDED if your web app will not function without JavaScript enabled -->
 <noscript>


### PR DESCRIPTION
- Removed ie8 and ie9 from compilation permutations.
- Fixed JS detection of a browser and fixed JS warnings.
- Dropped no-cache meta tags from html page, browsers tend to
  ignore it. Apache web server will return correct no-cache headers
  instead.