### PR TITLE
CORE: Remove unnecessary audit message when deleting all groups

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -410,7 +410,6 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				throw new ConsistencyErrorException(e);
 			}
 		}
-		getPerunBl().getAuditer().log(sess, "All group in {} deleted.", vo);
 	}
 
 	public Group updateGroup(PerunSession sess, Group group) throws InternalErrorException {
@@ -2815,7 +2814,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		return false;
 	}
-	
+
 	/**
 	 * Method sets subGroups names by their parent group
 	 * Private method for moving groups

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -54,7 +54,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 				} else throw new RelationExistsException("Vo vo=" + vo + " contains members");
 			}
 
-			log.debug("Removing vo {} resources and theirs atributes", vo);
+			log.debug("Removing vo {} resources and theirs attributes", vo);
 			// Delete resources
 			List<Resource> resources = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
 			if ((resources.size() == 0) || forceDelete) {


### PR DESCRIPTION
- Since we explicitly audit, that each group is deleted, we
  don't need to log, that all groups were deleted for VO.
  It caused LDAPc to fail, since message also matched on
  "Vo:[...] deleted." and it tried to delete VO with members group
  still present in the ldap tree.