### PR TITLE
REGISTRAR: Allow empty logins from registration forms

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1140,6 +1140,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 				Type itemType = itemData.getFormItem().getType();
 				if (itemType == USERNAME || itemType == PASSWORD) {
+					// skip logins with empty/null value
+					if (itemData.getValue() == null || itemData.getValue().isEmpty() || itemData.getValue().equals("null")) continue;
 					// skip unchanged pre-filled logins, since they must have been handled last time
 					if (itemData.getValue().equals(itemData.getPrefilledValue()) && itemType != PASSWORD) continue;
 					logins.add(itemData);


### PR DESCRIPTION
- We now allow logins to be optional, hence allow null/empty input.
  But we must skip such form items from processing as logins,
  since it would fail.