### PR TITLE
CORE: Extend AttributeDefinition equals() and hashCode()

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Attribute.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Attribute.java
@@ -133,6 +133,7 @@ public class Attribute extends AttributeDefinition {
 		int hash = 7;
 		hash = 53 * hash + getId();
 		hash = 53 * hash + (getFriendlyName() == null ? 0 : getFriendlyName().hashCode());
+		hash = 53 * hash + (getNamespace() == null ? 0 : getNamespace().hashCode());
 		hash = 53 * hash + (value == null ? 0 : value.hashCode());
 		return hash;
 	}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributeDefinition.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/AttributeDefinition.java
@@ -184,6 +184,7 @@ public class AttributeDefinition extends Auditable implements Comparable<PerunBe
 		int hash = 7;
 		hash = 53 * hash + getId();
 		hash = 53 * hash + (friendlyName == null ? 0 : friendlyName.hashCode());
+		hash = 53 * hash + (namespace == null ? 0 : namespace.hashCode());
 		return hash;
 	}
 
@@ -195,7 +196,8 @@ public class AttributeDefinition extends Auditable implements Comparable<PerunBe
 
 		final AttributeDefinition other = (AttributeDefinition) obj;
 
-		return this.getId() == other.getId() && (this.friendlyName == null ? other.friendlyName == null : this.friendlyName.equals(other.friendlyName));
+		return this.getId() == other.getId() && (this.friendlyName == null ? other.friendlyName == null : this.friendlyName.equals(other.friendlyName))
+				&& (this.namespace == null ? other.namespace == null : this.namespace.equals(other.namespace));
 	}
 
 	/**


### PR DESCRIPTION
- We checked only friendlyName of AttributeDefinition in equals()
  and hashCode() implementation, which caused problems when we stored
  attributes from different namespaces and with same friendlyName
  like unixGroupName in a map as keys.