### PR TITLE
BASE,RPC: Allow cors only from specified domains

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -61,6 +61,7 @@ public class CoreConfig {
 	private String rtUrl;
 	private String smsProgram;
 	private String userExtSourcesPersistent;
+	private List<String> allowedCorsDomains;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -463,4 +464,13 @@ public class CoreConfig {
 	public void setProperties(Properties properties) {
 		this.properties = properties;
 	}
+
+	public List<String> getAllowedCorsDomains() {
+		return allowedCorsDomains;
+	}
+
+	public void setAllowedCorsDomains(List<String> allowedCorsDomains) {
+		this.allowedCorsDomains = allowedCorsDomains;
+	}
+
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -45,6 +45,7 @@
 		<property name="attributesForUpdateIdP" value="#{'${perun.attributesForUpdate.idp}'.split('\s*,\s*')}"/>
 		<property name="attributesForUpdateX509" value="#{'${perun.attributesForUpdate.x509}'.split('\s*,\s*')}"/>
 		<property name="oidcIssuers" value="#{'${perun.oidc.issuers}'.split('\s*,\s*')}"/>
+		<property name="allowedCorsDomains" value="#{'${perun.allowedCorsDomains}'.split('\s*,\s*')}" />
 	</bean>
 
 
@@ -99,6 +100,7 @@
 				<prop key="perun.attributesForUpdate.x509">mail,cn,o,dn,cadn,certificate</prop>
 				<prop key="perun.instanceId">AOJ26J3D9DCK3OA7</prop>
 				<prop key="perun.instanceName">LOCAL</prop>
+				<prop key="perun.allowedCorsDomains"></prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -206,7 +206,7 @@ public class Api extends HttpServlet {
 		String remoteUser = req.getRemoteUser();
 
 		CoreConfig config = BeansUtils.getCoreConfig();
-		
+
 		// If we have header Shib-Identity-Provider, then the user uses identity federation to authenticate
 		if (isNotEmpty(shibIdentityProvider)) {
 			extSourceName = getOriginalIdP(shibIdentityProvider, sourceIdpEntityId);
@@ -385,7 +385,7 @@ public class Api extends HttpServlet {
 
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-		mirrorOriginHeader(req,resp);
+		checkOriginHeader(req,resp);
 		if (req.getPathInfo() == null || req.getPathInfo().equals("/")) {
 			resp.setContentType("text/plain; charset=utf-8");
 			Writer wrt = resp.getWriter();
@@ -408,13 +408,13 @@ public class Api extends HttpServlet {
 
 	@Override
 	protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-		mirrorOriginHeader(req,resp);
+		checkOriginHeader(req,resp);
 		serve(req, resp, false, true);
 	}
 
 	@Override
 	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-		mirrorOriginHeader(req,resp);
+		checkOriginHeader(req,resp);
 		serve(req, resp, false, false);
 	}
 
@@ -426,18 +426,38 @@ public class Api extends HttpServlet {
 	 */
 	@Override
 	protected void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-		mirrorOriginHeader(req,resp);
-		resp.setHeader("Access-Control-Allow-Methods","GET, POST, OPTIONS");
-		resp.setHeader("Access-Control-Allow-Headers","Authorization, Content-Type");
-		resp.setIntHeader("Access-Control-Max-Age",86400);
+		if (checkOriginHeader(req,resp)) {
+			resp.setHeader("Access-Control-Allow-Methods","GET, POST, OPTIONS");
+			resp.setHeader("Access-Control-Allow-Headers","Authorization, Content-Type");
+			resp.setIntHeader("Access-Control-Max-Age",86400);
+		}
 		resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
 	}
 
-	private void mirrorOriginHeader(HttpServletRequest req, HttpServletResponse resp) {
+	/**
+	 * Check Origin header, if it's between allowed domains for CORS
+	 *
+	 * @param req HttpServletRequest to check
+	 * @param resp HttpServletResponse to modify
+	 */
+	private boolean checkOriginHeader(HttpServletRequest req, HttpServletResponse resp) {
 		String origin = req.getHeader("Origin");
-		if(origin==null) origin = "*";
-		resp.setHeader("Access-Control-Allow-Origin",origin);
-		resp.setHeader("Vary","Origin");
+		log.trace("Incoming Origin header: {}", origin);
+
+		if (origin != null) {
+			List<String> allowedDomains = BeansUtils.getCoreConfig().getAllowedCorsDomains();
+			if (allowedDomains.contains(origin)) {
+				log.trace("Adding header Access-Control-Allow-Origin to response: {}", origin);
+				resp.setHeader("Access-Control-Allow-Origin",origin);
+				resp.setHeader("Vary","Origin");
+				return true;
+			}
+		} else {
+			// no origin, don't modify header
+			// origin = "*";
+		}
+
+		return false;
 	}
 
 	@SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
- We don't want to mirror any origin header, instead we read list from
  perun.properties config file.
  New property "perun.allowedCorsDomains=" can contain comma separated
  list of allowed origins (protocol://domain:port) (port is optional).
- We still alow CORS only those clients, which use OIDC, since
  standard browser requests need to authenticate in apache
  and request usually fails. Also "withCredentials" on XmlHttpRequest
  is not allowed by our CORS settings.