### PR TITLE
introduced versioning, removed profiles

### DIFF
--- a/perun-auditer-exporter/pom.xml
+++ b/perun-auditer-exporter/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-auditer-exporter</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-auditer-exporter</name>

--- a/perun-auditer-exporter/pom.xml
+++ b/perun-auditer-exporter/pom.xml
@@ -108,4 +108,31 @@
 		</dependency>
 
 	</dependencies>
+	
+	<profiles>
+
+		<profile>
+			<!-- adds Oracle JDBC drivers if run with "mvn -Doracle=True" -->
+			<id>oracle</id>
+			<activation>
+				<property>
+					<name>oracle</name>
+					<value>True</value>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- Oracle jdbc driver -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>ojdbc8</artifactId>
+				</dependency>
+				<!-- Oracle internationalization -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>orai18n</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+
+	</profiles>
 </project>

--- a/perun-auditer-exporter/pom.xml
+++ b/perun-auditer-exporter/pom.xml
@@ -22,6 +22,7 @@
 	</properties>
 	<!-- common build settings used by all profiles -->
 	<build>
+        <finalName>${project.name}</finalName>
 		<plugins>
 
 			<plugin>

--- a/perun-auditer-exporter/pom.xml
+++ b/perun-auditer-exporter/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-auditer-exporter</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-auditer-exporter</name>
@@ -107,58 +107,4 @@
 		</dependency>
 
 	</dependencies>
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-		</profile>
-
-	</profiles>
-
 </project>

--- a/perun-auditparser/pom.xml
+++ b/perun-auditparser/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-auditparser</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 
 	<name>perun-auditparser</name>
 	<description>Utility for parsing Perun`s Audit-log</description>
@@ -92,59 +92,4 @@
 		</dependency>
 		
 	</dependencies>
-
-	<!-- PROFILES -->
-
-	<profiles>
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-		</profile>
-
-	</profiles>
-
 </project>

--- a/perun-auditparser/pom.xml
+++ b/perun-auditparser/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-auditparser</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 
 	<name>perun-auditparser</name>
 	<description>Utility for parsing Perun`s Audit-log</description>

--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-base</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-base</name>

--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-base</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-base</name>
@@ -124,61 +124,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-		
-
 	</dependencies>
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests >
-			</properties>
-
-		</profile>
-
-	</profiles>
 
 </project>

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -120,8 +120,8 @@
 		</property>
 	</bean>
 
-	<!-- active in Spring profiles "devel" and "production", packs default properties with properties from files as a bean -->
-	<beans profile="devel,production">
+	<!-- active in Spring profile "production", packs default properties with properties from files as a bean -->
+	<beans profile="production">
 		<bean id="coreProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 			<property name="properties" ref="defaultCoreProperties"/>
 			<property name="locations">

--- a/perun-cabinet/pom.xml
+++ b/perun-cabinet/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-cabinet</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-cabinet</name>
@@ -110,58 +110,4 @@
 		</dependency>
 
 	</dependencies>
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-		</profile>
-
-	</profiles>
-
 </project>

--- a/perun-cabinet/pom.xml
+++ b/perun-cabinet/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-cabinet</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-cabinet</name>

--- a/perun-cabinet/src/main/resources/perun-cabinet.xml
+++ b/perun-cabinet/src/main/resources/perun-cabinet.xml
@@ -89,7 +89,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 		<property name="publicationManagerBl" ref="publicationManagerBl" />
 	</bean>
 
-	<beans profile="devel,production">
+	<beans profile="production">
 		<!-- Properties Bean, so far used in tests -->
 		<bean id="cabinetProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 			<property name="locations">

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-core</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-core</name>
@@ -219,114 +219,22 @@
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
 
+		<!-- PostgreSQL driver -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+		</dependency>
+		<!-- SQL Lite -->
+		<dependency>
+			<groupId>org.xerial</groupId>
+			<artifactId>sqlite-jdbc</artifactId>
+		</dependency>
+		<!-- Mysql -->
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+		</dependency>
+
 	</dependencies>
-
-	<profiles>
-
-		<!-- profile used for testing on perun-dev machine -->
-		<profile>
-			<id>devel</id>
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-			<dependencies>
-				<!-- DBs -->
-
-				<!-- PostgreSQL driver -->
-				<dependency>
-					<groupId>org.postgresql</groupId>
-					<artifactId>postgresql</artifactId>
-				</dependency>
-
-				<!-- Oracle jdbc driver -->
-				<dependency>
-					<groupId>com.oracle</groupId>
-					<artifactId>ojdbc8</artifactId>
-				</dependency>
-				<!-- Oracle internationalization -->
-				<dependency>
-					<groupId>com.oracle</groupId>
-					<artifactId>orai18n</artifactId>
-				</dependency>
-
-				<!-- SQL Lite -->
-				<dependency>
-					<groupId>org.xerial</groupId>
-					<artifactId>sqlite-jdbc</artifactId>
-				</dependency>
-
-				<!-- Mysql -->
-				<dependency>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
-				</dependency>
-			</dependencies>
-		</profile>
-
-		<!-- profile used for production machines -->
-		<profile>
-			<id>production</id>
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-			<dependencies>
-				<!-- DBs -->
-
-				<!-- PostgreSQL driver -->
-				<dependency>
-					<groupId>org.postgresql</groupId>
-					<artifactId>postgresql</artifactId>
-				</dependency>
-
-				<!-- Oracle jdbc driver -->
-				<dependency>
-					<groupId>com.oracle</groupId>
-					<artifactId>ojdbc8</artifactId>
-				</dependency>
-				<!-- Oracle internationalization -->
-				<dependency>
-					<groupId>com.oracle</groupId>
-					<artifactId>orai18n</artifactId>
-				</dependency>
-
-				<!-- SQL Lite -->
-				<dependency>
-					<groupId>org.xerial</groupId>
-					<artifactId>sqlite-jdbc</artifactId>
-				</dependency>
-
-				<!-- Mysql -->
-				<dependency>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
-				</dependency>
-			</dependencies>
-		</profile>
-
-	</profiles>
 
 </project>

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-core</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-core</name>

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -237,4 +237,35 @@
 
 	</dependencies>
 
+	<profiles>
+
+		<profile>
+			<!--
+			Run tests against Oracle DB with the following command:
+			  mvn -Dspring.profiles.active=production -Dperun.conf.custom=$HOME/perun_test -Doracle=True test
+			where $HOME/perun_test/ directory contains files jdbc.properties and perun.properties
+			-->
+			<id>oracle</id>
+			<activation>
+				<property>
+					<name>oracle</name>
+					<value>True</value>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- Oracle jdbc driver -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>ojdbc8</artifactId>
+				</dependency>
+				<!-- Oracle internationalization -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>orai18n</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+
+	</profiles>
+	
 </project>

--- a/perun-core/src/main/resources/perun-core-synchronizers.xml
+++ b/perun-core/src/main/resources/perun-core-synchronizers.xml
@@ -9,7 +9,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 
 	<task:scheduler id="scheduler" pool-size="1"/>
 
-	<beans profile="devel,production">
+	<beans profile="production">
 		<task:scheduled-tasks scheduler="scheduler">
 			<task:scheduled ref="synchronizer" method="synchronizeGroups" cron="0 0/5 * * * ?"/> <!-- every 5 minutes -->
 			<task:scheduled ref="synchronizer" method="removeAllExpiredBans" cron="0 5 0 * * ?"/> <!-- every day at 00:05 -->
@@ -17,13 +17,5 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 			<!--<task:scheduled ref="synchronizer" method="checkMembersState" cron="0 5 0 * * ?"/> --> <!-- every day at 00:05 -->
 		</task:scheduled-tasks>
 	</beans>
-
-	<!-- moved to ExpirationNotifScheduler in perun-registrar-lib project
-		<beans profile="devel">
-			<task:scheduled-tasks scheduler="scheduler">
-				<task:scheduled ref="synchronizer" method="checkMembersState" cron="0 5 0 * * ?"/> every day at 00:05
-		</task:scheduled-tasks>
-	</beans>
-	-->
 
 </beans>

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -426,7 +426,7 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 
 	<!-- merged from perun-core-jdbc.xml -->
 
-	<beans profile="devel,production">
+	<beans profile="production">
 		<context:property-placeholder ignore-resource-not-found="true" ignore-unresolvable="true" location="@perun.jdbc@, file:${perun.conf.custom}/jdbc.properties"/>
 
 		<!-- DataSource implementation -->

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/DatabaseManagerImplIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/DatabaseManagerImplIntegrationTest.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.bl.DatabaseManagerBl;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
@@ -22,6 +23,7 @@ public class DatabaseManagerImplIntegrationTest extends AbstractPerunIntegration
 	@Before
 	public void setUp() throws Exception {
 		dbManager = perun.getDatabaseManagerBl();
+		System.out.println("DB information: "+dbManager.getDatabaseInformation());
 	}
 
 	@Test(expected=InternalErrorException.class)

--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-dispatcher</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-dispatcher</name>

--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-dispatcher</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-dispatcher</name>
@@ -138,58 +138,4 @@
 		</dependency>
 
 	</dependencies>
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-		</profile>
-
-	</profiles>
-
 </project>

--- a/perun-dispatcher/src/main/resources/perun-dispatcher.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher.xml
@@ -84,8 +84,8 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 	<!-- pass properties values to Spring placeholders i.e. ${dispatcher.cron.cleantaskresults} -->
 	<context:property-placeholder properties-ref="dispatcherPropertiesBean"	ignore-unresolvable="true"/>
 
-	<!-- active in Spring profiles "devel" and "production", packs default properties with properties from files as a bean -->
-	<beans profile="devel,production">
+	<!-- active in Spring profile "production", packs default properties with properties from files as a bean -->
+	<beans profile="production">
 		<bean id="dispatcherPropertiesBean" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 			<property name="properties" ref="dispatcherDefaultProperties"/>
 			<property name="locations">

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-engine</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-engine</name>
@@ -183,58 +183,4 @@
 		</dependency>
 
 	</dependencies>
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-		</profile>
-
-	</profiles>
-
 </project>

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -26,7 +26,7 @@
 
 	<!-- COMMON BUILD SETTINGS USED BY ALL PROFILES -->
 	<build>
-
+        <finalName>${project.name}</finalName>
 		<plugins>
 
 			<plugin>

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-engine</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-engine</name>

--- a/perun-engine/src/main/resources/perun-engine.xml
+++ b/perun-engine/src/main/resources/perun-engine.xml
@@ -85,8 +85,8 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	<!-- pass properties values to Spring placeholders i.e. ${engine.port} -->
 	<context:property-placeholder properties-ref="propertiesBean"	ignore-unresolvable="true"/>
 
-	<!-- active in Spring profiles "devel" and "production", packs default properties with properties from files as a bean -->
-	<beans profile="devel,production">
+	<!-- active in Spring profile "production", packs default properties with properties from files as a bean -->
+	<beans profile="production">
 		<bean id="propertiesBean" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 			<property name="properties" ref="defaultProperties"/>
 			<property name="locations">

--- a/perun-ldapc-initializer/pom.xml
+++ b/perun-ldapc-initializer/pom.xml
@@ -109,11 +109,12 @@
 	<profiles>
 
 		<profile>
-			<!-- adds Oracle JDBC drivers -->
+			<!-- adds Oracle JDBC drivers if run with "mvn -Doracle=True"-->
 			<id>oracle</id>
 			<activation>
 				<property>
 					<name>oracle</name>
+					<value>True</value>
 				</property>
 			</activation>
 			<dependencies>

--- a/perun-ldapc-initializer/pom.xml
+++ b/perun-ldapc-initializer/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>cz.metacentrum</groupId>
         <artifactId>perun</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 
     <artifactId>perun-ldapc-initializer</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
 	<name>perun-ldapc-initializer</name>
@@ -108,52 +108,25 @@
 	<profiles>
 
 		<profile>
-
-			<id>devel</id>
-
+			<!-- adds Oracle JDBC drivers -->
+			<id>oracle</id>
 			<activation>
 				<property>
-					<name>devel</name>
+					<name>oracle</name>
 				</property>
 			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
+			<dependencies>
+				<!-- Oracle jdbc driver -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>ojdbc8</artifactId>
+				</dependency>
+				<!-- Oracle internationalization -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>orai18n</artifactId>
+				</dependency>
+			</dependencies>
 		</profile>
 
 	</profiles>

--- a/perun-ldapc-initializer/pom.xml
+++ b/perun-ldapc-initializer/pom.xml
@@ -23,6 +23,7 @@
 
 	<!-- common build settings used by all profiles -->
 	<build>
+        <finalName>${project.name}</finalName>
 		<plugins>
 
 			<plugin>

--- a/perun-ldapc-initializer/pom.xml
+++ b/perun-ldapc-initializer/pom.xml
@@ -9,9 +9,7 @@
     </parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
-
     <artifactId>perun-ldapc-initializer</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
 	<name>perun-ldapc-initializer</name>

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-ldapc</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-ldapc</name>
@@ -143,57 +143,5 @@
 
 	</dependencies>
 
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-		</profile>
-
-	</profiles>
 
 </project>

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -23,6 +23,7 @@
 
 	<!-- common build settings used by all profiles -->
 	<build>
+        <finalName>${project.name}</finalName>
 		<plugins>
 
 			<plugin>

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-ldapc</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-ldapc</name>

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-notification</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-notification</name>

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-notification</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-notification</name>
@@ -166,61 +166,5 @@
 			<artifactId>smackx</artifactId>
 		</dependency>
 		
-		
-
 	</dependencies>
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-		</profile>
-
-	</profiles>
-
 </project>

--- a/perun-notification/src/main/resources/perun-notification.xml
+++ b/perun-notification/src/main/resources/perun-notification.xml
@@ -44,7 +44,7 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 	</bean>
 
 	<!-- Properties Bean -->
-	<beans profile="devel,production">
+	<beans profile="production">
 		<bean id="propertiesBean" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 			<property name="locations">
 				<list>

--- a/perun-registrar-lib/pom.xml
+++ b/perun-registrar-lib/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-registrar-lib</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-registrar-lib</name>

--- a/perun-registrar-lib/pom.xml
+++ b/perun-registrar-lib/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-registrar-lib</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-registrar-lib</name>
@@ -109,58 +109,4 @@
 		</dependency>
 
 	</dependencies>
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-		</profile>
-
-	</profiles>
-
 </project>

--- a/perun-registrar-lib/src/main/resources/perun-registrar-lib-scheduler.xml
+++ b/perun-registrar-lib/src/main/resources/perun-registrar-lib-scheduler.xml
@@ -15,10 +15,4 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 		</task:scheduled-tasks>
 	</beans>
 
-	<beans profile="devel">
-		<task:scheduled-tasks scheduler="registrarScheduler">
-			<task:scheduled ref="expirationNotifScheduler" method="checkMembersState" cron="0 5 0 * * ?"/> <!-- every day at 00:05 -->
-		</task:scheduled-tasks>
-	</beans>
-
 </beans>

--- a/perun-registrar-lib/src/main/resources/perun-registrar-lib.xml
+++ b/perun-registrar-lib/src/main/resources/perun-registrar-lib.xml
@@ -47,7 +47,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 	</bean>
 
 	<!-- Properties Bean -->
-	<beans profile="devel,production">
+	<beans profile="production">
 		<bean id="registrarProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 			<property name="locations">
 				<list>

--- a/perun-rpc-lib/pom.xml
+++ b/perun-rpc-lib/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-rpc-lib</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-rpc-lib</name>

--- a/perun-rpc-lib/pom.xml
+++ b/perun-rpc-lib/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-rpc-lib</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>perun-rpc-lib</name>
@@ -78,70 +78,4 @@
 		</dependency>
 
 	</dependencies>
-
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-
-			<build>
-
-				<resources>
-					<resource>
-						<!-- get common resources -->
-						<directory>src/main/resources</directory>
-					</resource>
-				</resources>
-
-			</build>
-
-		</profile>
-
-	</profiles>
-
 </project>

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-rpc</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>perun-rpc</name>

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -61,14 +61,6 @@
 				<version>${maven-war-plugin.version}</version>
 				<configuration>
 					<warName>perun-rpc</warName>
-					<webResources>
-						<resource>
-							<!-- Enable custom location of log4j.xml per webapp -->
-							<filtering>true</filtering>
-							<directory>src/main/webapp/WEB-INF/</directory>
-							<targetPath>WEB-INF</targetPath> <!-- relative to webapp root -->
-						</resource>
-					</webResources>
 				</configuration>
 			</plugin>
 

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-rpc</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>perun-rpc</name>
@@ -244,59 +244,5 @@
 		</dependency>
 
 	</dependencies>
-
-	<profiles>
-
-		<profile>
-
-			<id>devel</id>
-
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-
-		<profile>
-
-			<id>production</id>
-
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-				<spring.profiles.default>production</spring.profiles.default>
-			</properties>
-
-		</profile>
-
-	</profiles>
 
 </project>

--- a/perun-rpc/src/main/webapp/WEB-INF/web.xml
+++ b/perun-rpc/src/main/webapp/WEB-INF/web.xml
@@ -9,10 +9,6 @@
 	</servlet>
 
 	<context-param>
-		<param-name>spring.profiles.default</param-name>
-		<param-value>@spring.profiles.default@</param-value>
-	</context-param>
-	<context-param>
 		<param-name>contextConfigLocation</param-name>
 		<param-value>classpath:perun-rpc.xml</param-value>
 	</context-param>

--- a/perun-tasks-lib/pom.xml
+++ b/perun-tasks-lib/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-tasks-lib</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 
 	<name>perun-tasks-lib</name>
 	<description>Library for managing propagation tasks in Perun</description>

--- a/perun-tasks-lib/pom.xml
+++ b/perun-tasks-lib/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-tasks-lib</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 
 	<name>perun-tasks-lib</name>
 	<description>Library for managing propagation tasks in Perun</description>
@@ -90,47 +90,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
-	<profiles>
-		<profile>
-			<id>devel</id>
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
-			<id>production</id>
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-		</profile>
-	</profiles>
-
 </project>

--- a/perun-utils/init.d-scripts/perun-dispatcher.debian
+++ b/perun-utils/init.d-scripts/perun-dispatcher.debian
@@ -17,7 +17,7 @@
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Perun Dispatcher"
 DAEMON="/usr/bin/java"
-JAR=/home/perun/perun-dispatcher/perun-dispatcher-3.0.1-SNAPSHOT-production.jar
+JAR=/home/perun/perun-dispatcher/perun-dispatcher.jar
 NAME=perun-dispatcher
 SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid

--- a/perun-utils/init.d-scripts/perun-engine.debian
+++ b/perun-utils/init.d-scripts/perun-engine.debian
@@ -22,7 +22,7 @@
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Perun Engine"
 DAEMON="/usr/bin/java"
-JAR=/home/perun/perun-engine/perun-engine-3.0.1-SNAPSHOT-production.jar
+JAR=/home/perun/perun-engine/perun-engine.jar
 NAME=perun-engine
 SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid

--- a/perun-utils/init.d-scripts/perun-ldapc.debian
+++ b/perun-utils/init.d-scripts/perun-ldapc.debian
@@ -19,7 +19,7 @@
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Perun LDAPc"
 DAEMON="/usr/bin/java"
-JAR=/home/perun/perun-ldapc/perun-ldapc-3.0.1-SNAPSHOT-production.jar
+JAR=/home/perun/perun-ldapc/perun-ldapc.jar
 NAME=perun-ldapc
 SCRIPTNAME=/etc/init.d/$NAME
 PIDFILE=/var/run/perun/$NAME.pid

--- a/perun-utils/ldapc-scripts/initialize-ldap.sh
+++ b/perun-utils/ldapc-scripts/initialize-ldap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PERUN_LDAP_INITIALIZATOR=/home/perun/perun-ldapc/perun-ldapc-initializer-3.0.1-SNAPSHOT-production.jar
+PERUN_LDAP_INITIALIZATOR=/home/perun/perun-ldapc/perun-ldapc-initializer.jar
 LDIF_DIFF_LIBRARY=/home/perun/perun-ldapc/ldifdiff.pl
 LDIF_SORT_LIBRARY=/home/perun/perun-ldapc/ldifsort.pl
 LDIF_DIFF_SORT_LIBRARY=/home/perun/perun-ldapc/ldifdiff-sort.pl

--- a/perun-voot/pom.xml
+++ b/perun-voot/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-voot</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 
 	<name>perun-voot</name>
 	<description>Utility to handle VOOT</description>

--- a/perun-voot/pom.xml
+++ b/perun-voot/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-voot</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 
 	<name>perun-voot</name>
 	<description>Utility to handle VOOT</description>
@@ -99,47 +99,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
-	<!-- PROFILES -->
-
-	<profiles>
-		<profile>
-			<id>devel</id>
-			<activation>
-				<property>
-					<name>devel</name>
-				</property>
-			</activation>
-			<properties>
-				<perun.build.type>devel</perun.build.type>
-				<spring.profiles.default>devel</spring.profiles.default>
-			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Make "devel" tests to run against real DB -->
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<systemPropertyVariables>
-								<spring.profiles.default>devel</spring.profiles.default>
-							</systemPropertyVariables>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
-			<id>production</id>
-			<activation>
-				<property>
-					<name>production</name>
-				</property>
-			</activation>
-			<properties>
-				<perun.build.type>production</perun.build.type>
-				<skipTests>true</skipTests>
-			</properties>
-		</profile>
-	</profiles>
 </project>

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<artifactId>perun</artifactId>
 		<groupId>cz.metacentrum</groupId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-web-gui</artifactId>
-	<version>3.0.1-SNAPSHOT-${perun.build.type}</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>perun-web-gui</name>
@@ -213,7 +213,6 @@
 			</activation>
 
 			<properties>
-				<perun.build.type>production</perun.build.type>
 				<skipTests>true</skipTests>
 			</properties>
 
@@ -265,14 +264,5 @@
 		</profile>
 
 	</profiles>
-
-	<!-- uncomment for drag and drop
-	<repositories>
-		<repository>
-			<id>plugins</id>
-			<url>http://gwtquery-plugins.googlecode.com/svn/mavenrepo</url>
-		</repository>
-	</repositories>
-	-->
 
 </project>

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -26,7 +26,7 @@
 
 	<!-- common build settings used by all profiles -->
 	<build>
-		<finalName>${project.name}-${project.version}</finalName>
+		<finalName>${project.name}</finalName>
 		<plugins>
 
 			<plugin>

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -11,7 +11,6 @@
 
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>perun-web-gui</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>perun-web-gui</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<!-- PERUN -->
 	<groupId>cz.metacentrum</groupId>
 	<artifactId>perun</artifactId>
-	<version>3.0.1-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<!-- Spring Boot Starter Parent as parent project - this project inherits versions of dependencies and plugins -->
@@ -49,10 +49,6 @@
 		<!-- USE UTF-8 in whole project -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-		<!-- by default we build devel version of perun and do tests -->
-		<perun.build.type>default</perun.build.type>
-		<skipTests>false</skipTests>
 
 		<!-- macros @perun.conf@ @perun.jdbc@ etc replaced in all filtered resources in /src/main/resources during maven build-->
 		<perun.conf>/etc/perun/</perun.conf>


### PR DESCRIPTION
Cancels continuous development, introduces versioning.
- removed spring profile "devel", so only "default" and "production" exist, default uses in-memory database for tests and default properties, production reads perun.properties and uses real database
-  removed all existing Maven profiles, introduced profile "oracle" to perun-core, perun-ldap-initializer, and perun-auditer-exporter, which adds Oracle drivers (during tests in perun-code, to executable JARs in the two other cases)
- changed version to 3.1.0-SNAPSHOT in anticipation of release 3.1.0