### PR TITLE
Fix usage of <strong> font in GUI footer

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/UiElements.java
@@ -971,7 +971,7 @@ public class UiElements {
 		Anchor a2 = new Anchor("BSD 2", "https://github.com/CESNET/perun/blob/master/LICENSE");
 		a2.setTarget("_blank");
 
-		HTML foot = new HTML("<strong>About: </strong>" + a + "<strong>&nbsp;|&nbsp;License: </strong>"+a2+"&nbsp;|&nbsp;Support: </strong>" + mail+", "+lnk);
+		HTML foot = new HTML("<strong>About: </strong>" + a + "&nbsp;|&nbsp;<strong>License: </strong>"+a2+"&nbsp;|&nbsp;<strong>Support: </strong>" + mail+", "+lnk);
 		ft.setWidget(0, 0, foot);
 
 		ft.setWidget(0, 1, new HTML(PerunWebConstants.INSTANCE.footerPerunCopyright() + " " + JsonUtils.getCurrentYear() + ", version: " + PerunWebConstants.INSTANCE.guiVersion()));


### PR DESCRIPTION
<strong> tag was used to cover also separator between fields, which was
not intensional. Also it was missing for "Support" filed (there was only
enclosing tag).