### PR TITLE
def version of elixirBonaFideStatus attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirBonaFideStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirBonaFideStatus.java
@@ -1,0 +1,117 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * This module determines if user is a researcher. If so,
+ * it provides URL: 'http://www.ga4gh.org/beacon/bonafide/ver1.0'.
+ *
+ * The decision depends on attributes 'elixirBonaFideStatusREMS', 'eduPersonScopedAffiliations'
+ * and 'user:def:publications'.
+ * If 'elixirBonaFideStatusREMS' is not empty, user is a researcher.
+ * If 'eduPersonScopedAffiliations' contains affiliation that starts with 'faculty@', user is a researcher.
+ * If 'user:def:publications' contains key 'ELIXIR' and associated value is > 0, user is a researcher
+ * Otherwise, null value is set.
+ *
+ * @author Vojtech Sassmann &lt;vojtech.sassmann@gmail.com&gt;
+ * @author Dominik Frantisek Bucik <bucik@ics.muni.cz>
+ */
+public class urn_perun_user_attribute_def_def_elixirBonaFideStatus extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
+
+	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_elixirBonaFideStatus.class);
+
+	private static final String FRIENDLY_NAME = "elixirBonaFideStatus";
+	private static final String URL = "http://www.ga4gh.org/beacon/bonafide/ver1.0";
+
+	private static final String USER_BONA_FIDE_STATUS_REMS_ATTR_NAME = "elixirBonaFideStatusREMS";
+	private static final String USER_AFFILIATIONS_ATTR_NAME = "eduPersonScopedAffiliations";
+	private static final String USER_PUBLICATIONS_ATTR_NAME = "publications";
+
+	private static final String A_U_D_userBonaFideStatusRems = AttributesManager.NS_USER_ATTR_DEF + ":" + USER_BONA_FIDE_STATUS_REMS_ATTR_NAME;
+	private static final String A_U_D_userPublications = AttributesManager.NS_USER_ATTR_VIRT + ":" + USER_PUBLICATIONS_ATTR_NAME;
+	private static final String A_U_V_userAffiliations = AttributesManager.NS_USER_ATTR_VIRT + ":" + USER_AFFILIATIONS_ATTR_NAME;
+
+	private static final String ELIXIR_KEY = "ELIXIR";
+
+
+	@Override
+	public Attribute fillAttribute(PerunSessionImpl sess, User user, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+		Attribute attribute = new Attribute(attributeDefinition);
+
+		//try to get value from 'elixirBonaFideStatusREMS': if not empty, we have bona_fide
+		try {
+			Attribute statusAttr = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_U_D_userBonaFideStatusRems);
+			if (statusAttr != null && statusAttr.getValue() != null) {
+				attribute.setValue(URL);
+				return attribute;
+			}
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			log.error("Cannot read {} from user {}", USER_BONA_FIDE_STATUS_REMS_ATTR_NAME, user, e);
+		}
+
+		//try to get value from 'eduPersonScopedAffiliations': if has faculty@..., we have bona_fide
+		try {
+			Attribute affiliationsAttr = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_U_V_userAffiliations);
+			if (affiliationsAttr != null && affiliationsAttr.getValue() != null) {
+				ArrayList<String> affiliationsValue = affiliationsAttr.valueAsList();
+				for (String val : affiliationsValue) {
+					if (val.startsWith("faculty@")) {
+						attribute.setValue(URL);
+						return attribute;
+					}
+				}
+			}
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			log.error("Cannot read {} from user {}", USER_AFFILIATIONS_ATTR_NAME, user, e);
+		}
+
+		//try to get value from publications: if has thanks to ELIXIR, we have bona_fide
+		try {
+			Attribute publicationsAttr = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_U_D_userPublications);
+			if (publicationsAttr != null && publicationsAttr.getValue() != null) {
+				Map<String, String> publications = publicationsAttr.valueAsMap();
+				if (publications.containsKey(ELIXIR_KEY)) {
+					String value = publications.get(ELIXIR_KEY);
+					try {
+						int count = Integer.parseInt(value);
+						if (count > 0) {
+							attribute.setValue(URL);
+							return attribute;
+						}
+					} catch (NumberFormatException ex) {
+						log.error("Attribute " + A_U_D_userPublications +" has wrong value for key " + ELIXIR_KEY, ex);
+					}
+				}
+			}
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			log.error("Cannot read {} from user {}", USER_PUBLICATIONS_ATTR_NAME, user, e);
+		}
+
+		return attribute;
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+		attr.setFriendlyName(FRIENDLY_NAME);
+		attr.setDisplayName("Bona fide researcher status");
+		attr.setType(String.class.getName());
+		attr.setDescription("Flag if user is qualified researcher. URI ‘http://www.ga4gh.org/beacon/bonafide/ver1.0’ value is provided if person is bona fide researcher. Empty value otherwise.");
+		return attr;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_elixirBonaFideStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_elixirBonaFideStatus.java
@@ -21,6 +21,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
+ * THIS ATTRIBUTE IS REPLACED BY urn:perun:user:attribute:def:def:elixirBonaFideStatus.
+ * THIS ATTRIBUTE MODULE AND ATTRIBUTE WILL BE DELETED IN FUTURE.
+ *
  * This module determines if user is a researcher. If so,
  * it provides URL: 'http://www.ga4gh.org/beacon/bonafide/ver1.0'.
  *
@@ -34,6 +37,7 @@ import java.util.regex.Pattern;
  *
  * @author Vojtech Sassmann &lt;vojtech.sassmann@gmail.com&gt;
  */
+@Deprecated
 public class urn_perun_user_attribute_def_virt_elixirBonaFideStatus extends UserVirtualAttributesModuleAbstract implements UserVirtualAttributesModuleImplApi {
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_virt_elixirBonaFideStatus.class);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirBonaFideStatusTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirBonaFideStatusTest.java
@@ -1,0 +1,210 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test methods for urn_perun_user_attribute_def_def_elixirBonaFideStatus
+ *
+ * @author Dominik Frantisek Bucik <bucik@ics.muni.cz>
+ */
+public class urn_perun_user_attribute_def_def_elixirBonaFideStatusTest {
+
+	private static final String VALUE = "http://www.ga4gh.org/beacon/bonafide/ver1.0";
+
+	private static final String USER_BONA_FIDE_STATUS_REMS_ATTR_NAME = "elixirBonaFideStatusREMS";
+	private static final String USER_AFFILIATIONS_ATTR_NAME = "eduPersonScopedAffiliations";
+	private static final String USER_PUBLICATIONS_ATTR_NAME = "publications";
+
+	private static final String A_U_D_userBonaFideStatusRems = AttributesManager.NS_USER_ATTR_DEF + ":" + USER_BONA_FIDE_STATUS_REMS_ATTR_NAME;
+	private static final String A_U_D_userPublications = AttributesManager.NS_USER_ATTR_VIRT + ":" + USER_PUBLICATIONS_ATTR_NAME;
+	private static final String A_U_V_userAffiliations = AttributesManager.NS_USER_ATTR_VIRT + ":" + USER_AFFILIATIONS_ATTR_NAME;
+
+	private urn_perun_user_attribute_def_def_elixirBonaFideStatus classInstance;
+
+	private PerunSessionImpl session;
+	private User user;
+	private Attribute eduPersonScopedAffiliations;
+	private Attribute publicationAttribute;
+	private Attribute elixirBonaFideStatusREMS;
+
+	private String ELIXIR_KEY = "ELIXIR";
+
+	@Before
+	public void setUp() {
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+
+		user = new User();
+		user.setId(1);
+
+		List<String> EPSA_VAL = new ArrayList<>();
+		EPSA_VAL.add("faculty@somewhere.edu");
+		EPSA_VAL.add("member@somewhere.edu");
+		eduPersonScopedAffiliations = new Attribute();
+		eduPersonScopedAffiliations.setValue(EPSA_VAL);
+
+		LinkedHashMap<String, String> PUBLICATIONS_VAL = new LinkedHashMap<>();
+		PUBLICATIONS_VAL.put(ELIXIR_KEY, "3");
+		PUBLICATIONS_VAL.put("KEY", "9");
+		publicationAttribute = new Attribute();
+		publicationAttribute.setValue(PUBLICATIONS_VAL);
+
+		elixirBonaFideStatusREMS = new Attribute();
+		elixirBonaFideStatusREMS.setValue("IS_RESEARCHER");
+	}
+
+	@Test
+	public void fillAttributeWithNoDependenciesFilled() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_elixirBonaFideStatus();
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userBonaFideStatusRems)).thenReturn(
+				null
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_V_userAffiliations)).thenReturn(
+				null
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userPublications)).thenReturn(
+				null
+		);
+
+		Attribute receivedAttr = classInstance.fillAttribute(session, user, classInstance.getAttributeDefinition());
+		assertNull("returned value is incorrect", receivedAttr.getValue());
+	}
+
+	@Test
+	public void fillAttributeWithDependenciesHavingUnsatisfyingValues() throws Exception {
+		List<String> EPSA_FAILING_VAL = new ArrayList<>();
+		EPSA_FAILING_VAL.add("member@here.edu");
+		Attribute eduPersonScopedAffiliationsNotSatisfying = new Attribute();
+		eduPersonScopedAffiliations.setValue(EPSA_FAILING_VAL);
+
+		LinkedHashMap<String, String> PUBLICATIONS_FAILING_VAL = new LinkedHashMap<>();
+		PUBLICATIONS_FAILING_VAL.put(ELIXIR_KEY, "0");
+		PUBLICATIONS_FAILING_VAL.put("KEY", "5");
+		Attribute publicationAttributeNotSatisfying = new Attribute();
+		publicationAttributeNotSatisfying.setValue(PUBLICATIONS_FAILING_VAL);
+
+		Attribute elixirBonaFideStatusREMSEmpty = new Attribute();
+		elixirBonaFideStatusREMSEmpty.setValue(null);
+
+		classInstance = new urn_perun_user_attribute_def_def_elixirBonaFideStatus();
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userBonaFideStatusRems)).thenReturn(
+				elixirBonaFideStatusREMSEmpty
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_V_userAffiliations)).thenReturn(
+				eduPersonScopedAffiliationsNotSatisfying
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userPublications)).thenReturn(
+				publicationAttributeNotSatisfying
+		);
+
+		Attribute receivedAttr = classInstance.fillAttribute(session, user, classInstance.getAttributeDefinition());
+		assertNull("returned value is incorrect", receivedAttr.getValue());
+	}
+
+	@Test
+	public void fillAttributeWithOnlyREMSFilled() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_elixirBonaFideStatus();
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userBonaFideStatusRems)).thenReturn(
+				elixirBonaFideStatusREMS
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_V_userAffiliations)).thenReturn(
+				null
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userPublications)).thenReturn(
+				null
+		);
+
+		Attribute receivedAttr = classInstance.fillAttribute(session, user, classInstance.getAttributeDefinition());
+		assertEquals("returned value is incorrect", receivedAttr.getValue(), VALUE);
+	}
+
+	@Test
+	public void fillAttributeWithOnlyEPSAFilled() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_elixirBonaFideStatus();
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userBonaFideStatusRems)).thenReturn(
+				null
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_V_userAffiliations)).thenReturn(
+				eduPersonScopedAffiliations
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userPublications)).thenReturn(
+				null
+		);
+
+		Attribute receivedAttr = classInstance.fillAttribute(session, user, classInstance.getAttributeDefinition());
+		assertEquals("returned value is incorrect", receivedAttr.getValue(), VALUE);
+	}
+
+	@Test
+	public void fillAttributeWithOnlyPublicationsFilled() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_elixirBonaFideStatus();
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userBonaFideStatusRems)).thenReturn(
+				null
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_V_userAffiliations)).thenReturn(
+				null
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userPublications)).thenReturn(
+				publicationAttribute
+		);
+
+		Attribute receivedAttr = classInstance.fillAttribute(session, user, classInstance.getAttributeDefinition());
+		assertEquals("returned value is incorrect", receivedAttr.getValue(), VALUE);
+
+	}
+
+	@Test
+	public void fillAttributeWithAllDependencyAttrsFiled() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_elixirBonaFideStatus();
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userBonaFideStatusRems)).thenReturn(
+				elixirBonaFideStatusREMS
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_V_userAffiliations)).thenReturn(
+				eduPersonScopedAffiliations
+		);
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, A_U_D_userPublications)).thenReturn(
+				publicationAttribute
+		);
+
+		Attribute receivedAttr = classInstance.fillAttribute(session, user, classInstance.getAttributeDefinition());
+		assertEquals("returned value is incorrect", receivedAttr.getValue(), VALUE);
+	}
+
+}


### PR DESCRIPTION
Attribute module for urn:perun:user:attribute:def:def:elixirBonaFideStatus attribute. This attribute replaces the VIRT version with the same name.
Tests for new attribute module
Marked module for VIRT version of attribute as deprecated (will be deleted in future)