### PR TITLE
Attribute modules dependencies graphs

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -122,6 +122,11 @@
 			<version>${tomcat.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>guru.nidi</groupId>
+			<artifactId>graphviz-java</artifactId>
+			<version>${graphviz.version}</version>
+		</dependency>
 
 	</dependencies>
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -704,4 +704,55 @@ public class BeansUtils {
 		}
 		return null;
 	}
+
+
+	/**
+	 * Returns abbreviation in format [Entity]:[V/D/C]:[friendlyName]
+	 * [Entity] is something like 'U' for user, 'G-R' for group-resource etc.
+	 *
+	 * @param ad attribute definition
+	 * @return abbreviation in format [Entity]:[V/D/C]:[friendlyName]
+	 */
+	public static String getAttributeDefinitionAbbreviation(AttributeDefinition ad) {
+		String entity = parseEntityAbbreviation(ad);
+		String type;
+		if (ad.getNamespace().endsWith("virt")) {
+			type = "V";
+		} else if (ad.getNamespace().endsWith("def")) {
+			type = "D";
+		} else {
+			type = "C";
+		}
+
+		String formattedFriendlyName;
+
+		String[] splitFriendlyName = ad.getFriendlyName().split(":");
+		formattedFriendlyName = splitFriendlyName[0];
+		if (splitFriendlyName.length > 1) {
+			formattedFriendlyName += ":*";
+		}
+
+		return entity + ":" + type + ":" + formattedFriendlyName;
+	}
+
+	public static String parseEntityAbbreviation(AttributeDefinition ad) {
+		String entity = "";
+		String[] split = ad.getEntity().split("_");
+
+		if (split.length == 1) {
+			entity = firstLetterCap(split[0]);
+		} else if (split.length == 2) {
+			entity = firstLetterCap(split[0]) + "-" + firstLetterCap(split[1]);
+		}
+
+		return entity;
+	}
+
+	private static String firstLetterCap(String s) {
+		if (!s.isEmpty()) {
+			s = s.substring(0, 1).toUpperCase();
+		}
+
+		return s;
+	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/SvgGraphvizSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/SvgGraphvizSerializer.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.rpc.serializer;
+
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.RpcException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
+import guru.nidi.graphviz.engine.Format;
+import guru.nidi.graphviz.engine.Graphviz;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class SvgGraphvizSerializer implements Serializer {
+
+	private PrintStream outputStream;
+
+	public SvgGraphvizSerializer(OutputStream outputStream) {
+		this.outputStream = new PrintStream(outputStream);
+	}
+
+	@Override
+	public void write(Object object) throws IllegalArgumentException, IOException, RpcException {
+		if (object instanceof Graphviz) {
+			((Graphviz) object).render(Format.SVG).toOutputStream(outputStream);
+		} else {
+			writePerunException(new InternalErrorException("Received object was not Graphviz object."));
+		}
+	}
+
+	@Override
+	public void writePerunException(PerunException pex) throws IOException {
+		outputStream.print(pex);
+	}
+
+	@Override
+	public void writePerunRuntimeException(PerunRuntimeException prex) throws IOException {
+		outputStream.print(prex);
+	}
+
+	@Override
+	public String getContentType() {
+		return "image/svg+xml";
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/TextFileSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/TextFileSerializer.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.rpc.serializer;
+
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.RpcException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class TextFileSerializer implements Serializer {
+	private PrintStream outputStream;
+
+	public TextFileSerializer(OutputStream outputStream) {
+		this.outputStream = new PrintStream(outputStream);
+	}
+
+	@Override
+	public String getContentType() {
+		return "text/plain";
+	}
+
+	@Override
+	public void write(Object object) throws IllegalArgumentException, IOException, RpcException {
+		outputStream.print(object);
+	}
+
+	@Override
+	public void writePerunException(PerunException pex) throws IOException {
+		outputStream.print(pex);
+	}
+
+	@Override
+	public void writePerunRuntimeException(PerunRuntimeException prex) throws IOException {
+		outputStream.print(prex);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/Graph.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/Graph.java
@@ -1,0 +1,151 @@
+package cz.metacentrum.perun.utils.graphs;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class Graph {
+	private final Map<Node, Node> nodes = new HashMap<>();
+	private final Map<Node, Set<GraphEdge>> edges = new HashMap<>();
+
+	/**
+	 * Find nodes that belong to component for given node.
+	 *
+	 * @param node node
+	 * @return Set of nodes that belong to the same component as given Node.
+	 */
+	public Set<Node> getComponentNodes(Node node) {
+		Node graphDefinitionNode = nodes.get(node);
+
+		if (graphDefinitionNode == null) {
+			return Collections.singleton(node);
+		}
+
+		return findComponentNodes(graphDefinitionNode);
+	}
+
+	/**
+	 * Finds nodes that belong to the same graph component as given node.
+	 *
+	 * @param node node
+	 * @return Nodes that belong to the same graph component as given node.
+	 */
+	private static Set<Node> findComponentNodes(Node node) {
+		Set<Node> componentNodes = new HashSet<>();
+		Set<Node> newlyDiscoveredNodes = new HashSet<>();
+
+		newlyDiscoveredNodes.add(node);
+		componentNodes.add(node);
+
+		do {
+			newlyDiscoveredNodes = findOutgoingAndIncomingNodes(newlyDiscoveredNodes);
+		} while (componentNodes.addAll(newlyDiscoveredNodes));
+
+		return componentNodes;
+	}
+
+	/**
+	 * For given nodes finds all of theirs incoming and outgoing nodes.
+	 *
+	 * @param nodesToBeSearched nodes that will be searched.
+	 * @return discovered nodes
+	 */
+	private static Set<Node> findOutgoingAndIncomingNodes(Set<Node> nodesToBeSearched) {
+		Set<Node> newNodesToSearch = new HashSet<>();
+
+		for (Node node : nodesToBeSearched) {
+			for (GraphEdge edge : node.getOutComingEdges()) {
+				newNodesToSearch.add(edge.getTargetNode());
+			}
+			for (GraphEdge edge : node.getInComingEdges()) {
+				newNodesToSearch.add(edge.getSourceNode());
+			}
+		}
+
+		return newNodesToSearch;
+	}
+
+	public void addNodes(Set<Node> nodes) {
+		nodes.forEach(this::addNode);
+	}
+
+	public void addNode(Node node) {
+		if (nodes.keySet().contains(node)) {
+			return;
+		}
+		nodes.put(node, node);
+		edges.put(node, new HashSet<>());
+	}
+
+	public void removeNodes(Set<Node> nodes) {
+		nodes.forEach(this::removeNode);
+	}
+
+	public void removeNode(Node node) {
+		node.getAllEdges().forEach(this::removeEdge);
+
+		nodes.remove(node);
+		edges.remove(node);
+
+		for (GraphEdge edge : node.getInComingEdges()) {
+			edge.getSourceNode().removeOutComingEdge(edge);
+		}
+		for (GraphEdge edge : node.getOutComingEdges()) {
+			edge.getSourceNode().removeInComingEdge(edge);
+		}
+	}
+
+	public void removeEdge(GraphEdge edge) {
+		edges.get(edge.getSourceNode()).remove(edge);
+		edge.getSourceNode().removeOutComingEdge(edge);
+		edge.getTargetNode().removeInComingEdge(edge);
+	}
+
+	public void createEdge(Node source, Node target, GraphEdge.Type type) {
+		source = nodes.get(source);
+		target = nodes.get(target);
+
+		if (source == null) {
+			throw new IllegalArgumentException("Graph does not contain given source node.");
+		}
+		if (target == null) {
+			throw new IllegalArgumentException("Graph does not contain given target node.");
+		}
+
+		GraphEdge edge = new GraphEdge(source, target, type);
+
+		source.addOutComingEdge(edge);
+		target.addInComingEdge(edge);
+
+		edges.get(source).add(edge);
+	}
+
+	public Map<Node, Node> getNodes() {
+		return Collections.unmodifiableMap(nodes);
+	}
+
+	public Map<Node, Set<GraphEdge>> getEdges() {
+		return Collections.unmodifiableMap(edges);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Graph graph = (Graph) o;
+		return Objects.equals(nodes, graph.nodes) &&
+				Objects.equals(edges, graph.edges);
+	}
+
+	@Override
+	public int hashCode() {
+
+		return Objects.hash(nodes, edges);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/GraphEdge.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/GraphEdge.java
@@ -1,0 +1,73 @@
+package cz.metacentrum.perun.utils.graphs;
+
+import java.util.Objects;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class GraphEdge {
+	private Node sourceNode;
+	private Node targetNode;
+	private Type type;
+
+	public GraphEdge(Node sourceNode, Node targetNode, Type type) {
+		this.sourceNode = sourceNode;
+		this.targetNode = targetNode;
+		this.type = type;
+	}
+
+	public Node getSourceNode() {
+		return sourceNode;
+	}
+
+	public void setSourceNode(Node sourceNode) {
+		this.sourceNode = sourceNode;
+	}
+
+	public Node getTargetNode() {
+		return targetNode;
+	}
+
+	public void setTargetNode(Node targetNode) {
+		this.targetNode = targetNode;
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public enum Type {
+		DASHED("dashed"),
+		BOLD("bold");
+
+		private String style;
+
+		public String getStyle() {
+			return style;
+		}
+
+		Type(String style) {
+			this.style = style;
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		GraphEdge edge = (GraphEdge) o;
+		return Objects.equals(sourceNode, edge.sourceNode) &&
+				Objects.equals(targetNode, edge.targetNode) &&
+				type == edge.type;
+	}
+
+	@Override
+	public int hashCode() {
+
+		return Objects.hash(sourceNode, targetNode, type);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/GraphTextFormat.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/GraphTextFormat.java
@@ -1,0 +1,28 @@
+package cz.metacentrum.perun.utils.graphs;
+
+import cz.metacentrum.perun.utils.graphs.serializers.DotGraphSerializer;
+import cz.metacentrum.perun.utils.graphs.serializers.GraphSerializer;
+import cz.metacentrum.perun.utils.graphs.serializers.TGFGraphSerializer;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public enum GraphTextFormat {
+	DOT(DotGraphSerializer::new),
+	TGF(TGFGraphSerializer::new);
+
+	private GetSerializerAction getSerializerAction;
+
+	GraphTextFormat(GetSerializerAction getSerializerAction) {
+		this.getSerializerAction = getSerializerAction;
+	}
+
+	public GraphSerializer getSerializer() {
+		return getSerializerAction.get();
+	}
+
+	@FunctionalInterface
+	private interface GetSerializerAction {
+		GraphSerializer get();
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/Node.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/Node.java
@@ -1,0 +1,102 @@
+package cz.metacentrum.perun.utils.graphs;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Class representing node in {@link Graph}.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class Node {
+	private long id;
+	private String label;
+	private String fillColor;
+	private String style;
+	private Set<GraphEdge> outComingEdges = new HashSet<>();
+	private Set<GraphEdge> inComingEdges = new HashSet<>();
+
+	public long getId() {
+		return id;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public String getFillColor() {
+		return fillColor;
+	}
+
+	public String getStyle() {
+		return style;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	public void setFillColor(String fillColor) {
+		this.fillColor = fillColor;
+	}
+
+	public void setStyle(String style) {
+		this.style = style;
+	}
+
+	public void addOutComingEdge(GraphEdge edge) {
+		if (edge.getSourceNode() != this) {
+			throw new IllegalArgumentException("Invalid edge given. Source node is not equal to this node.");
+		}
+		outComingEdges.add(edge);
+	}
+
+	public void removeOutComingEdge(GraphEdge edge) {
+		outComingEdges.remove(edge);
+	}
+
+	public Set<GraphEdge> getOutComingEdges() {
+		return Collections.unmodifiableSet(outComingEdges);
+	}
+
+	public void addInComingEdge(GraphEdge edge) {
+		if (edge.getTargetNode() != this) {
+			throw new IllegalArgumentException("Invalid edge given. Target node is not equal to this node.");
+		}
+		inComingEdges.add(edge);
+	}
+
+	public void removeInComingEdge(GraphEdge edge) {
+		inComingEdges.remove(edge);
+	}
+
+	public Set<GraphEdge> getInComingEdges() {
+		return Collections.unmodifiableSet(inComingEdges);
+	}
+
+	public Set<GraphEdge> getAllEdges() {
+		Set<GraphEdge> allEdges = new HashSet<>(outComingEdges);
+		allEdges.addAll(inComingEdges);
+		return allEdges;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Node node = (Node) o;
+		return Objects.equals(label, node.label);
+	}
+
+	@Override
+	public int hashCode() {
+
+		return Objects.hash(label);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/GraphDefinition.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/GraphDefinition.java
@@ -1,0 +1,158 @@
+package cz.metacentrum.perun.utils.graphs.generators;
+
+import cz.metacentrum.perun.utils.graphs.GraphEdge;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * <b>Class that defines relations in graph.</b>
+ *
+ * <p>
+ * New relations can be added with method 'addEntitiesData' where the expected format
+ * is a {@link Map} of {@link T} entities where every entity has a {@link Set} of target entities.
+ * In other words, there is an oriented Edge between enetity and its target entities.
+ * After specifying entities data, you have to set edge type with method 'withEdgeType'.
+ *
+ * Example: graphDefinition.addEntitiesData(data).withEdgeType(GraphEdge.Type.BOLD);
+ * </p>
+ *
+ * <p>
+ * New relations can also be added with method 'addEntity'. After specifying the entity,
+ * you have to set target entities with method 'withTargetEntities'. After that you must set
+ * the graph edge type.
+ *
+ * Example: graphDefinition.addEntity(entity).withTargetEntities(targetEntities).withEdgeType(GraphEdge.Type.BOLD);
+ * </p>
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class GraphDefinition<T> {
+
+	private Map<GraphEdge.Type, Map<T, Set<T>>> data = new HashMap<>();
+
+	Set<GraphEdge.Type> getEdgeTypes() {
+		return Collections.unmodifiableSet(data.keySet());
+	}
+
+	Map<T, Set<T>> getEdgeData(GraphEdge.Type edgeType) {
+		return Collections.unmodifiableMap(data.get(edgeType));
+	}
+
+	/**
+	 * Method used to add entities data to definition. After calling this method
+	 * you have to set the Graph edge type.
+	 *
+	 * @param entityWithTargetEntities entities data
+	 * @return object defining that entities data has been set
+	 */
+	public AddEntitiesData addEntitiesData(Map<T, Set<T>> entityWithTargetEntities) {
+		return new AddEntitiesData(entityWithTargetEntities, this);
+	}
+
+	/**
+	 * Method used to add entity to definition. After calling this method
+	 * you have to set the target entities.
+	 *
+	 * @param entity entity
+	 * @return object defining that entity data has been set
+	 */
+	public AddEntity addEntity(T entity) {
+		return new AddEntity(entity, this);
+	}
+
+	/**
+	 * Class representing the state of adding new data to the {@link GraphDefinition}.
+	 * This state represents that entities data has been set and the graph edge type needs to be set.
+	 */
+	public class AddEntitiesData {
+		private Map<T, Set<T>> entityWithTargetEntities;
+		private GraphDefinition<T> graphDefinition;
+
+		public AddEntitiesData(Map<T, Set<T>> entityWithTargetEntities, GraphDefinition<T> graphDefinition) {
+			this.entityWithTargetEntities = entityWithTargetEntities;
+			this.graphDefinition = graphDefinition;
+		}
+
+		/**
+		 * Method used to set the edge type for data that has been passed before.
+		 *
+		 * @param edgeType edge type
+		 * @return graph definition
+		 */
+		public GraphDefinition<T> withEdgeType(GraphEdge.Type edgeType) {
+			if (!data.containsKey(edgeType)) {
+				data.put(edgeType, new HashMap<>());
+			}
+
+			for (T node : entityWithTargetEntities.keySet()) {
+
+				HashSet<T> targetNodes = new HashSet<>(entityWithTargetEntities.get(node));
+
+				data.get(edgeType).put(node, targetNodes);
+			}
+
+			return graphDefinition;
+		}
+	}
+
+	/**
+	 * Class representing the state of adding new entity to the {@link GraphDefinition}.
+	 * This state represents that entity has been set and target entities need to be set.
+	 */
+	public class AddEntity {
+		private T entity;
+		private GraphDefinition<T> graphDefinition;
+
+		public AddEntity(T entity, GraphDefinition<T> graphDefinition) {
+			this.entity = entity;
+			this.graphDefinition = graphDefinition;
+		}
+
+		/**
+		 * Method used to set the target entities to entity that has been set before.
+		 *
+		 * @param targetEntities target entitites
+		 * @return object defining that target nodes has been set
+		 */
+		public WithTargetEntities withTargetEntities(Set<T> targetEntities) {
+			return new WithTargetEntities(graphDefinition, entity, targetEntities);
+		}
+	}
+
+	/**
+	 * Class representing the state of adding target entities.
+	 * This state represents that target entities has been set for entity specified before
+	 * and the graph edge type needs to be set.
+	 */
+	public class WithTargetEntities {
+		private GraphDefinition<T> graphDefinition;
+		private T entity;
+		private Set<T> targetEntities;
+
+		public WithTargetEntities(GraphDefinition<T> graphDefinition, T entity, Set<T> targetEntities) {
+			this.graphDefinition = graphDefinition;
+			this.entity = entity;
+			this.targetEntities = targetEntities;
+		}
+
+		/**
+		 * Method used to set the edge type for data that has been passed before.
+		 *
+		 * @param edgeType edge type
+		 * @return graph definition
+		 */
+		public GraphDefinition<T> withEdgeType(GraphEdge.Type edgeType) {
+			if (!data.containsKey(edgeType)) {
+				data.put(edgeType, new HashMap<>());
+			}
+
+			data.get(edgeType).put(entity, targetEntities);
+
+			return graphDefinition;
+		}
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/GraphGenerator.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/GraphGenerator.java
@@ -1,0 +1,16 @@
+package cz.metacentrum.perun.utils.graphs.generators;
+
+import cz.metacentrum.perun.utils.graphs.Graph;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public interface GraphGenerator<T> {
+
+	/**
+	 * Generates graph from given graph definition and with given node generator.
+	 *
+	 * @return generated graph
+	 */
+	Graph generate(NodeGenerator<T> nodeGenerator, GraphDefinition<T> graphDefinition);
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/ModuleDependencyNodeGenerator.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/ModuleDependencyNodeGenerator.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.utils.graphs.generators;
+
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.utils.graphs.Node;
+
+/**
+ * Implementation of {@link NodeGenerator} for nodes representing attribute moduels.
+ * Label contains abbreviation for given attributeDefinition.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ModuleDependencyNodeGenerator implements NodeGenerator<AttributeDefinition> {
+
+	@Override
+	public Node generate(AttributeDefinition entity, Long id) {
+		Node n = new Node();
+
+		n.setId(id);
+		n.setLabel(BeansUtils.getAttributeDefinitionAbbreviation(entity));
+		n.setFillColor(getNodeColorFromAttributeDefinition(entity));
+		n.setStyle(getNodeStyleFromAttributeDefinition(entity));
+
+		return n;
+	}
+
+	private static String getNodeStyleFromAttributeDefinition(AttributeDefinition ad) {
+		if (ad.getNamespace().endsWith("virt")) {
+			return "filled,dashed";
+		} else if (ad.getNamespace().endsWith("def")) {
+			return "filled";
+		} else {
+			return "filled";
+		}
+	}
+
+	private static String getNodeColorFromAttributeDefinition(AttributeDefinition attributeDefinition) {
+		switch (attributeDefinition.getEntity()) {
+			case "user":
+				return "gray";
+			case "group":
+				return "green";
+			case "resource":
+				return "cyan";
+			case "facility":
+				return "firebrick1";
+			case "vo":
+				return "pink";
+			case "member":
+				return "yellow";
+			case "entityless":
+				return "orange";
+			case "group_resource":
+				return "green:cyan";
+			case "member_group":
+				return "yellow:green";
+			case "member_resource":
+				return "yellow:cyan";
+			case "user_facility":
+				return "gray:firebrick1";
+			default:
+				return "white";
+		}
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/NoDuplicatedEdgesGraphGenerator.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/NoDuplicatedEdgesGraphGenerator.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.utils.graphs.generators;
+
+import cz.metacentrum.perun.utils.graphs.Graph;
+import cz.metacentrum.perun.utils.graphs.GraphEdge;
+import cz.metacentrum.perun.utils.graphs.Node;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of {@link GraphGenerator }. Creates graph from given definition
+ * without duplicated edges and without nodes that has no edges.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class NoDuplicatedEdgesGraphGenerator<T> implements GraphGenerator<T> {
+
+	@Override
+	public Graph generate(NodeGenerator<T> nodeGenerator, GraphDefinition<T> graphDefinition) {
+		Graph graph = new Graph();
+		Long identifier = 0L;
+
+		for (GraphEdge.Type edgeType : graphDefinition.getEdgeTypes()) {
+			addDataFromDependencies(graphDefinition.getEdgeData(edgeType), graph, edgeType, identifier, nodeGenerator);
+		}
+
+		return graph;
+	}
+
+	/**
+	 * Adds data to given graph with specified edge type.
+	 *
+	 * @param data data that are transformed to nodes
+	 * @param graph graph where new data is added
+	 * @param edgeType used edge type
+	 * @param identifier identifier used to generate ids for nodes
+	 */
+	private void addDataFromDependencies(Map<T, Set<T>> data, Graph graph, GraphEdge.Type edgeType, Long identifier,
+										 NodeGenerator<T> nodeGenerator) {
+		for (T source : data.keySet()) {
+			Node sourceNode = nodeGenerator.generate(source, identifier);
+
+			if (data.get(source).isEmpty()) {
+				continue;
+			}
+
+			identifier++;
+
+			if (!graph.getNodes().containsKey(sourceNode)) {
+				graph.addNode(sourceNode);
+			}
+
+			for(T destination : data.get(source)) {
+				Node destinationNode = nodeGenerator.generate(destination, identifier);
+
+				if (!graph.getNodes().containsKey(destinationNode)) {
+					graph.addNode(destinationNode);
+					identifier++;
+				}
+
+				graph.createEdge(sourceNode, destinationNode, edgeType);
+			}
+		}
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/NodeGenerator.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/generators/NodeGenerator.java
@@ -1,0 +1,16 @@
+package cz.metacentrum.perun.utils.graphs.generators;
+
+import cz.metacentrum.perun.utils.graphs.Node;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public interface NodeGenerator<T> {
+
+	/**
+	 * Generates node with given id.
+	 *
+	 * @return generated node
+	 */
+	Node generate(T entity, Long id);
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/serializers/DotGraphSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/serializers/DotGraphSerializer.java
@@ -1,0 +1,71 @@
+package cz.metacentrum.perun.utils.graphs.serializers;
+
+import cz.metacentrum.perun.utils.graphs.Graph;
+import cz.metacentrum.perun.utils.graphs.GraphEdge;
+import cz.metacentrum.perun.utils.graphs.Node;
+
+import java.util.Set;
+
+/**
+ * Graph serializer for DOT format (*.gv)
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class DotGraphSerializer implements GraphSerializer {
+
+	@Override
+	public String generateTextFileContent(Graph graph) {
+		StringBuilder edgesStringBuilder = new StringBuilder();
+
+		generateHeader(edgesStringBuilder);
+		generateBody(edgesStringBuilder, graph);
+		generateFooter(edgesStringBuilder);
+
+		return edgesStringBuilder.toString();
+	}
+
+	private void generateHeader(StringBuilder builder) {
+		builder.append(
+				"digraph strongDependencies {\n" +
+				"\tgraph [nodesep=0.5, ranksep=0.5];\n" +
+				"\trankdir=LR;\n" +
+				"\tnode [shape=box]\n"
+		);
+	}
+
+	private void generateBody(StringBuilder builder, Graph graph) {
+		generateNodesData(builder, graph.getNodes().keySet());
+		generateEdgesData(builder, graph);
+	}
+
+	private void generateEdgesData(StringBuilder builder, Graph graph) {
+		for (Node sourceNode : graph.getNodes().keySet()) {
+			for (GraphEdge edge : graph.getEdges().get(sourceNode)) {
+				generateEdgeData(builder, edge);
+			}
+		}
+	}
+
+	private void generateNodesData(StringBuilder builder, Set<Node> nodes) {
+		for (Node node : nodes) {
+			builder.append("\t\"").append(node.getLabel()).append("\" [\n")
+					.append("\t\tfillcolor=\"").append(node.getFillColor()).append("\"\n")
+					.append("\t\tstyle=\"").append(node.getStyle()).append("\"\n")
+					.append("\t]\n");
+		}
+	}
+
+	private void generateEdgeData(StringBuilder builder, GraphEdge edge) {
+		builder.append("\t\"")
+				.append(edge.getSourceNode().getLabel())
+				.append("\" -> \"")
+				.append(edge.getTargetNode().getLabel())
+				.append("\" [")
+				.append("style=").append(edge.getType().getStyle())
+				.append("];\n");
+	}
+
+	private void generateFooter(StringBuilder builder) {
+		builder.append("}\n");
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/serializers/GraphSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/serializers/GraphSerializer.java
@@ -1,0 +1,16 @@
+package cz.metacentrum.perun.utils.graphs.serializers;
+
+import cz.metacentrum.perun.utils.graphs.Graph;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public interface GraphSerializer {
+
+	/**
+	 * Generates content of a text file describing graph.
+	 *
+	 * @return content of a text file describing relations of given attributes.
+	 */
+	String generateTextFileContent(Graph graph);
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/serializers/TGFGraphSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/utils/graphs/serializers/TGFGraphSerializer.java
@@ -1,0 +1,58 @@
+package cz.metacentrum.perun.utils.graphs.serializers;
+
+import cz.metacentrum.perun.utils.graphs.Graph;
+import cz.metacentrum.perun.utils.graphs.GraphEdge;
+import cz.metacentrum.perun.utils.graphs.Node;
+
+import java.util.Set;
+
+/**
+ * Graph serializer for TGF format (*.tgf)
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class TGFGraphSerializer implements GraphSerializer {
+
+	@Override
+	public String generateTextFileContent(Graph graph) {
+		StringBuilder builder = new StringBuilder();
+
+		generateNodesData(builder, graph.getNodes().keySet());
+		generateDivider(builder);
+		generateEdgesData(builder, graph);
+
+		return builder.toString();
+	}
+
+	private void generateEdgesData(StringBuilder builder, Graph graph) {
+		for (Node sourceNode : graph.getNodes().keySet()) {
+			for (GraphEdge edge : graph.getEdges().get(sourceNode)) {
+				generateEdgeData(builder, edge);
+			}
+		}
+	}
+
+	private void generateNodesData(StringBuilder builder, Set<Node> nodes) {
+		for (Node node : nodes) {
+			generateNodeData(builder, node);
+		}
+	}
+
+	private void generateDivider(StringBuilder builder) {
+		builder.append("#\n");
+	}
+
+	private void generateEdgeData(StringBuilder builder, GraphEdge edge) {
+		builder.append(edge.getSourceNode().getId())
+				.append(" ")
+				.append(edge.getTargetNode().getId())
+				.append("\n");
+	}
+
+	private void generateNodeData(StringBuilder builder, Node node) {
+		builder.append(node.getId())
+				.append(" ")
+				.append(node.getLabel())
+				.append("\n");
+	}
+}

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -234,6 +234,11 @@
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>guru.nidi</groupId>
+			<artifactId>graphviz-java</artifactId>
+			<version>${graphviz.version}</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -21,6 +21,8 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.utils.graphs.GraphTextFormat;
+import guru.nidi.graphviz.engine.Graphviz;
 
 import java.util.HashMap;
 import java.util.List;
@@ -3655,4 +3657,51 @@ public interface AttributesManager {
 	 */
 	void convertAttributeToUnique(PerunSession session, int attrId) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, AttributeAlreadyMarkedUniqueException;
 
+	/**
+	 * Generates graph describing attribute modules dependencies.
+	 * Text output format can be specified by {@link GraphTextFormat} format.
+	 *
+	 * @param session session
+	 * @param format text output format
+	 * @return body of text file containing description of modules dependencies.
+	 * @throws InternalErrorException internal error
+	 * @throws PrivilegeException insufficient permissions
+	 */
+	String getModulesDependenciesGraphText(PerunSession session, GraphTextFormat format) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Generates graph describing dependencies for given AttributeDefinition.
+	 * Text output format can be specified by {@link GraphTextFormat} format.
+	 *
+	 * @param session session
+	 * @param format text output format
+	 * @param attributeName attribute definition which dependencies will be used
+	 * @return body of text file containing description of modules dependencies.
+	 * @throws InternalErrorException internal error
+	 * @throws PrivilegeException insufficient permissions
+	 */
+	String getModulesDependenciesGraphText(PerunSession session, GraphTextFormat format, String attributeName) throws InternalErrorException, PrivilegeException, AttributeNotExistsException;
+
+	/**
+	 * Generates Graphviz representation of a graph describing dependencies
+	 * of attribute modules.
+	 *
+	 * @param session session
+	 * @return {@link Graphviz} representation of modules dependencies.
+	 * @throws InternalErrorException internal error
+	 * @throws PrivilegeException insufficient permissions
+	 */
+	Graphviz getModulesDependenciesGraphImage(PerunSession session) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Generates Graphviz represenRtation of a graph describing dependencies
+	 * for given AttributeDefinition of attribute modules.
+	 *
+	 * @param session session
+	 * @param attributeName attribute definition which dependencies will be used
+	 * @return {@link Graphviz} representation of modules dependencies.
+	 * @throws InternalErrorException internal error
+	 * @throws PrivilegeException insufficient permissions
+	 */
+	Graphviz getModulesDependenciesGraphImage(PerunSession session, String attributeName) throws InternalErrorException, PrivilegeException, AttributeNotExistsException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -37,6 +37,10 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongModuleTypeException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.utils.graphs.Graph;
+import cz.metacentrum.perun.utils.graphs.GraphTextFormat;
+import guru.nidi.graphviz.engine.Graphviz;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -4038,5 +4042,57 @@ public interface AttributesManagerBl {
 	 */
 	void convertAttributeToUnique(PerunSession session, int attrId) throws InternalErrorException, AttributeNotExistsException, AttributeAlreadyMarkedUniqueException;
 
+	/**
+	 * Generates graph describing attribute modules dependencies.
+	 * Text output format can be specified by {@link GraphTextFormat} format.
+	 *
+	 * @param session session
+	 * @param format text output format
+	 * @return body of text file containing description of modules dependencies.
+	 * @throws InternalErrorException internal error
+	 */
+	String getAttributeModulesDependenciesGraphAsString(PerunSession session, GraphTextFormat format) throws InternalErrorException;
+
+	/**
+	 * Generates graph describing dependencies for given AttributeDefinition.
+	 * Text output format can be specified by {@link GraphTextFormat} format.
+	 *
+	 * @param session session
+	 * @param format text output format
+	 * @param attributeDefinition attribute definition which dependencies will be used
+	 * @return body of text file containing description of modules dependencies.
+	 * @throws InternalErrorException internal error
+	 */
+	String getAttributeModulesDependenciesGraphAsString(PerunSession session, GraphTextFormat format, AttributeDefinition attributeDefinition) throws InternalErrorException;
+
+	/**
+	 * Generates Graphviz representation of a graph describing dependencies
+	 * of attribute modules.
+	 *
+	 * @param session session
+	 * @return Graphviz representation of modules dependencies.
+	 * @throws InternalErrorException internal error
+	 */
+	Graphviz getAttributeModulesDependenciesGraphAsImage(PerunSession session) throws InternalErrorException;
+
+	/**
+	 * Generates Graphviz representation of a graph describing dependencies
+	 * for given AttributeDefinition of attribute modules.
+	 *
+	 * @param session session
+	 * @param attributeDefinition attribute definition which dependencies will be used
+	 * @return Graphviz representation of modules dependencies.
+	 * @throws InternalErrorException internal error
+	 */
+	Graphviz getAttributeModulesDependenciesGraphAsImage(PerunSession session, AttributeDefinition attributeDefinition) throws InternalErrorException;
+
+	/**
+	 * Generates graph describing dependencies of attribute modules.
+	 *
+	 * @param session session
+	 * @return graph of dependencies
+	 * @throws InternalErrorException internal error
+	 */
+	Graph getAttributeModulesDependenciesGraph(PerunSession session) throws InternalErrorException;
 }
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -26,6 +26,8 @@ import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.bl.AttributesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.utils.graphs.GraphTextFormat;
+import guru.nidi.graphviz.engine.Graphviz;
 
 /**
  * AttributesManager entry logic.
@@ -3691,6 +3693,46 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.checkPerunSession(session);
 		if(!AuthzResolver.isAuthorized(session, Role.PERUNADMIN)) throw new PrivilegeException("This operation can do only PerunAdmin.");
 		getAttributesManagerBl().convertAttributeToUnique(session, attrId);
+	}
+
+	@Override
+	public String getModulesDependenciesGraphText(PerunSession session, GraphTextFormat format) throws InternalErrorException, PrivilegeException {
+		if (!AuthzResolver.isAuthorized(session, Role.PERUNADMIN)) {
+			throw new PrivilegeException("This operation can be done only by PerunAdmin.");
+		}
+
+		return attributesManagerBl.getAttributeModulesDependenciesGraphAsString(session, format);
+	}
+
+	@Override
+	public String getModulesDependenciesGraphText(PerunSession session, GraphTextFormat format, String attributeName) throws InternalErrorException, PrivilegeException, AttributeNotExistsException {
+		if (!AuthzResolver.isAuthorized(session, Role.PERUNADMIN)) {
+			throw new PrivilegeException("This operation can be done only by PerunAdmin.");
+		}
+
+		AttributeDefinition definition = attributesManagerBl.getAttributeDefinition(session, attributeName);
+
+		return attributesManagerBl.getAttributeModulesDependenciesGraphAsString(session, format, definition);
+	}
+
+	@Override
+	public Graphviz getModulesDependenciesGraphImage(PerunSession session) throws InternalErrorException, PrivilegeException {
+		if (!AuthzResolver.isAuthorized(session, Role.PERUNADMIN)) {
+			throw new PrivilegeException("This operation can be done only by PerunAdmin.");
+		}
+
+		return attributesManagerBl.getAttributeModulesDependenciesGraphAsImage(session);
+	}
+
+	@Override
+	public Graphviz getModulesDependenciesGraphImage(PerunSession session, String attributeName) throws InternalErrorException, PrivilegeException, AttributeNotExistsException {
+		if (!AuthzResolver.isAuthorized(session, Role.PERUNADMIN)) {
+			throw new PrivilegeException("This operation can be done only by PerunAdmin.");
+		}
+
+		AttributeDefinition definition = attributesManagerBl.getAttributeDefinition(session, attributeName);
+
+		return attributesManagerBl.getAttributeModulesDependenciesGraphAsImage(session, definition);
 	}
 
 	public PerunBl getPerunBl() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
 import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
+import cz.metacentrum.perun.utils.graphs.Graph;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.slf4j.Logger;

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -9,10 +9,12 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.utils.graphs.GraphTextFormat;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
+import guru.nidi.graphviz.engine.Graphviz;
 
 public enum AttributesManagerMethod implements ManagerMethod {
 
@@ -3273,6 +3275,90 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			ac.getAttributesManager().convertAttributeToUnique(ac.getSession(), parms.readInt("attrDefId"));
 			return null;
 		}
-	};
+	},
 
+	/*#
+	 * Generates text file describing dependencies between attribute modules.
+	 * The format of text file can be specified by parameter.
+	 * Modules that has no dependency relations are omitted.
+	 *
+	 * Warning: No matter which serializer you specify, this method always
+	 * returns .txt file as an attachment.
+	 *
+	 * @param format String Currently supported formats are DOT and TGF.
+	 * @throw InternalErrorException when some internal error happens.
+	 * @exampleParam format [ "DOT" ]
+	 */
+	/*#
+	 * Generates image file describing dependencies of given attribute.
+	 * The format of text file can be specified by parameter.
+	 * Modules that has no dependency relations are omitted.
+	 *
+	 * Warning: No matter which serializer you specify, this method always
+	 * returns .txt file as an attachment.
+	 *
+	 * @param attrName attribute name which dependencies will be found.
+	 * @param format String Currently supported formats are DOT and TGF.
+	 * @throw InternalErrorException when some internal error happens.
+	 * @throw AttributeNotExistsException when specified attribute doesn't exist.
+	 * @exampleParam format [ "DOT" ]
+	 * @exampleParam attrName [ "urn:perun:resource:attribute-def:virt:unixGID" ]
+	 */
+	getAttributeModulesDependenciesGraphText {
+		@Override
+		public String call(ApiCaller ac, Deserializer parms) throws InternalErrorException, PrivilegeException, AttributeNotExistsException {
+			String formatString = parms.readString("format").toUpperCase();
+
+			GraphTextFormat format;
+
+			try {
+				format = GraphTextFormat.valueOf(formatString);
+			} catch (IllegalArgumentException e) {
+				throw new RpcException(RpcException.Type.WRONG_PARAMETER, "Wrong parameter in format, not supported graph format: " + formatString);
+			}
+
+			if (parms.contains("attrName")) {
+				return ac.getAttributesManager().getModulesDependenciesGraphText(ac.getSession(), format, parms.readString("attrName"));
+			}
+
+			return ac.getAttributesManager().getModulesDependenciesGraphText(ac.getSession(), format);
+		}
+	},
+
+	/*#
+	 * Generates image file describing dependencies between attribute modules.
+	 * Modules that has no dependency relations are omitted.
+	 *
+	 * Warning: No matter which serializer you specify, this method always
+	 * returns .svg file as an attachment.
+	 *
+	 * @throw InternalErrorException when some internal error happens.
+	 */
+	/*#
+	 * Generates image file describing dependencies of given attribute.
+	 * Modules that has no dependency relations are omitted.
+	 *
+	 * Warning: No matter which serializer you specify, this method always
+	 * returns .svg file as an attachment.
+	 *
+	 * @param attrName attribute name which dependencies will be found.
+	 * @throw InternalErrorException when some internal error happens.
+	 * @throw AttributeNotExistsException when specified attribute doesn't exist.
+	 * @exampleParam attrName [ "urn:perun:resource:attribute-def:virt:unixGID" ]
+	 */
+	getAttributeModulesDependenciesGraphImage {
+		@Override
+		public Graphviz call(ApiCaller ac, Deserializer parms) throws InternalErrorException, PrivilegeException, AttributeNotExistsException {
+			if (parms.contains("attrName")) {
+				try {
+					return ac.getAttributesManager().getModulesDependenciesGraphImage(ac.getSession(), parms.readString("attrName"));
+				} catch (AttributeNotExistsException e) {
+					throw new RpcException(RpcException.Type.WRONG_PARAMETER,
+							"Attribute definition not found. If you are trying to find namespace attribute, " +
+										"you have to specify the whole urn. Example: \"urn:perun:group:attribute-def:def:googleGroupName-namespace:einfra-cesnet-cz\"");
+				}
+			}
+			return ac.getAttributesManager().getModulesDependenciesGraphImage(ac.getSession());
+		}
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 		<dumbster.version>1.6</dumbster.version>
 		<expiringmap.version>0.4.3</expiringmap.version>
 		<google-api-services-admin-directory.version>directory_v1-rev78-1.22.0</google-api-services-admin-directory.version>
+		<graphviz.version>0.2.3</graphviz.version>
 		<hornetq.version>2.2.21.Final</hornetq.version>
 		<jackson1.version>1.9.13</jackson1.version>
 		<javax-activation.version>1.1.1</javax-activation.version>


### PR DESCRIPTION
* Created method to access text file containing graph
describing the relations between attribute modules.
Currently there are two supported formats, DOT and TGF.
Example usage:
`http://localhost/krb/rpc/json/attributesManager/getAttributeModulesDependenciesGraphText?format=DOT`

* Created method to generate svg image file containing
graph with attribute modules relations.
Example usage:
`http://localhost/krb/rpc/json/attributesManager/getAttributeModulesDependenciesGraphImage`

* You can specify attrName to get only graph component
containing the specified attribute.

* Implemented classes that works with graphs and create
them from AttributeDefinition dependencies.

* Implemented new serializers that works with txt and svg
files.