### PR TITLE
replaced hardcoded perun version with version read from pom.xml

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/PerunBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/PerunBl.java
@@ -28,7 +28,6 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
  */
 public interface PerunBl extends Perun {
 
-	String PERUNVERSION = "3.0.0";
 	String INTERNALPRINCIPAL = "INTERNAL";
 
 	/**

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -13,7 +13,6 @@ import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
-import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
 import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
@@ -49,6 +48,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -393,7 +393,7 @@ public class Api extends HttpServlet {
 			PerunPrincipal perunPrincipal;
 			try {
 				perunPrincipal = setupPerunPrincipal(req,null);
-				wrt.write("OK! Version: " + PerunBl.PERUNVERSION + ", User: " + perunPrincipal.getActor() + ", extSource: " + perunPrincipal.getExtSourceName());
+				wrt.write("OK! Version: " + getPerunRpcVersion() + ", User: " + perunPrincipal.getActor() + ", extSource: " + perunPrincipal.getExtSourceName());
 			} catch (InternalErrorException | UserNotExistsException e) {
 				wrt.write("ERROR! Exception " + e.getMessage());
 			}
@@ -404,6 +404,23 @@ public class Api extends HttpServlet {
 		} else {
 			serve(req, resp, true, false);
 		}
+	}
+
+	private static final String PERUN_RPC_POM_FILE = "/META-INF/maven/cz.metacentrum.perun/perun-rpc/pom.properties";
+	private String version = null;
+
+	private synchronized String getPerunRpcVersion() {
+		if (version == null) {
+			try {
+				Properties p = new Properties();
+				p.load(getServletContext().getResourceAsStream(PERUN_RPC_POM_FILE));
+				version = p.getProperty("version");
+			} catch (IOException e) {
+				log.error("cannot read file " + PERUN_RPC_POM_FILE, e);
+				version = "UNKNOWN";
+			}
+		}
+		return version;
 	}
 
 	@Override


### PR DESCRIPTION
The version of Perun reported by RPC Api servlet was hardcoded as "3.0.0". Now it is read dynamically from pom.xml which is automatically packaged by Maven.