### PR TITLE
set scope of Oracle dependencies in perun-core to test

### DIFF
--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -256,11 +256,13 @@
 				<dependency>
 					<groupId>com.oracle</groupId>
 					<artifactId>ojdbc8</artifactId>
+					<scope>test</scope>
 				</dependency>
 				<!-- Oracle internationalization -->
 				<dependency>
 					<groupId>com.oracle</groupId>
 					<artifactId>orai18n</artifactId>
+					<scope>test</scope>
 				</dependency>
 			</dependencies>
 		</profile>


### PR DESCRIPTION
Without the scope "test", Oracle JDBC drivers would be included into perun-rpc.war if "mvn install -Doracle=True" is run, because they become runtime dependency of perun-core.jar.
With the scope, they will be used only during tests of perun-core.