### PR TITLE
CORE: Allow RPC role to read attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -140,6 +140,11 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 			return true;
 		}
 
+		// RPC can read attributes
+		if (sess.getPerunPrincipal().getRoles().hasRole(Role.RPC) && actionType.equals(ActionType.READ)) {
+			return true;
+		}
+
 		//If attrDef is type of entityless, return false (only perunAdmin can read and write to entityless)
 		if (getPerunBl().getAttributesManagerBl().isFromNamespace(sess, attrDef, AttributesManager.NS_ENTITYLESS_ATTR))
 			return false;


### PR DESCRIPTION
 - Currently we can't call fillAttribute() method externally, since
   it will fail on a fact, that RPC role can't get attribute by ID.
   This change fixes this issue by allowing read action on all
   attributes to RPC role.