### PR TITLE
Change of return values of Attribute Cache

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -624,6 +624,38 @@ public class BeansUtils {
 	}
 
 	/**
+	 * Get list of AttributeDefinitions from list of AttributeHolders
+	 * Used in CacheManager to transform result of query (list of AttributeHolders) to list of AttributeDefinitions.
+	 *
+	 * @param attrHolders list of AttributeHolders
+	 * @return list of AttributeDefinitions
+	 */
+	public static List<AttributeDefinition> getAttributeDefinitionsFromAttributeHolders(List<AttributeHolders> attrHolders) {
+		List<AttributeDefinition> attrDefs = new ArrayList<>();
+		for (AttributeHolders attrHolder: attrHolders) {
+			attrDefs.add(new AttributeDefinition(attrHolder));
+		}
+
+		return attrDefs;
+	}
+
+	/**
+	 * Get list of Attributes from list of AttributeHolders
+	 * Used in CacheManager to transform result of query (list of AttributeHolders) to list of Attributes.
+	 *
+	 * @param attrHolders list of AttributeHolders
+	 * @return list of Attributes
+	 */
+	public static List<Attribute> getAttributesFromAttributeHolders(List<AttributeHolders> attrHolders) {
+		List<Attribute> attrs = new ArrayList<>();
+		for (AttributeHolders attrHolder: attrHolders) {
+			attrs.add(new Attribute(attrHolder, true));
+		}
+
+		return attrs;
+	}
+
+	/**
 	 * True if this instance of perun is read only.
 	 * False if not.
 	 *

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/CacheManagerTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/CacheManagerTest.java
@@ -516,7 +516,8 @@ public class CacheManagerTest extends AbstractPerunIntegrationTest {
 
 		List<AttributeDefinition> attributeDefinitions = setUpAttributesDefinitions();
 		List<AttributeDefinition> returnedAttrDefinitions = cacheManager.getAttributesDefinitions();
-		assertEquals("returned attributes are not same as stored", attributeDefinitions, returnedAttrDefinitions);
+		assertTrue("Returned attribute definitions don't contain all set attribute definitions.", returnedAttrDefinitions.containsAll(attributeDefinitions));
+		assertEquals("Returned list doesn't have same size as expected.", attributeDefinitions.size(), returnedAttrDefinitions.size());
 	}
 
 	@Test
@@ -1343,7 +1344,7 @@ public class CacheManagerTest extends AbstractPerunIntegrationTest {
 
 	private AttributeDefinition setUpAttributeDefinition(String namespace, String friendlyName) throws InternalErrorException {
 
-		AttributeDefinition attr = new Attribute();
+		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(namespace);
 		attr.setFriendlyName(friendlyName);
 		attr.setType(String.class.getName());


### PR DESCRIPTION
Attribute cache returned in almost every method AttributeHolders object instead of AttributeDefinition/Attribute object.
Its changed, so get methods now return same type of object as it is written in the return clause.

Methods for transformation of the list of AttributeHolders to the list of AttributeDefinitions/Attributes were added to BeansUtils.

One test in CacheManagerTest.java was changed because it was dependent on the order in the list and it shouldn't.