### PR TITLE
CORE: Fixed ClassDefNotFound in tests of attribute modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
 						<argLine>-Dlog4j.configuration=</argLine>
 						<testFailureIgnore>false</testFailureIgnore>
 						<skip>false</skip>
+						<runOrder>alphabetical</runOrder>
 					</configuration>
 				</plugin>
 
@@ -196,7 +197,7 @@
 				<plugin>
 					<groupId>eu.somatik.serviceloader-maven-plugin</groupId>
 					<artifactId>serviceloader-maven-plugin</artifactId>
-					<version>1.0.7</version>
+					<version>1.1.0</version>
 				</plugin>
 
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->


### PR DESCRIPTION
- Problem is, that we initialize static CoreConfig after Perun bean is
  instantiated, but tests of attribute modules doesn't require
  Perun bean. Hence if we call new on login_namespace module class,
  it fails to initialize static variable and then can't instantiate
  module class instance.
- Problem is caused by undefined order of the tests, so we temporary
  fix it by ordering tests alphabetically (authz resolver manager tests
  with perun bean are first).
- Updated ServiceLoader plugin.
- We should think about fixing attribute module tests or find better way
  to initialize perun config.