### PR TITLE
Catch any throwable in Group Synchronization Scheduler

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
@@ -52,7 +52,7 @@ public class Synchronizer {
 					log.error("Synchronizer: group synchronization out of sync, resetting.");
 					synchronizeGroupsRunning.set(false);
 				}
-			} catch (InternalErrorException e) {
+			} catch (Throwable e) {
 				log.error("Cannot synchronize groups:", e);
 				synchronizeGroupsRunning.set(false);
 			}


### PR DESCRIPTION
 - we need to set correct status of group synchronization scheduler if
   some nasty exception has been thrown in it. For this reason we need
   to catch any throwable and change value of synchronizeGroupsRunning
   variable to false, when this happend