### PR TITLE
Fix wrong reading of jobs in synchronizer

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunBeanProcessingPool.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunBeanProcessingPool.java
@@ -165,7 +165,7 @@ public class PerunBeanProcessingPool<T extends PerunBean> {
 			//get lock for any operation with structures of jobs
 			jobsAccessLock.lock();
 
-			runningJobs = Collections.unmodifiableSet(this.runningJobs);
+			runningJobs = new HashSet<>(this.runningJobs);
 
 		} finally {
 			//in any case unlock access lock
@@ -186,7 +186,7 @@ public class PerunBeanProcessingPool<T extends PerunBean> {
 			//get lock for any operation with structures of jobs
 			jobsAccessLock.lock();
 
-			waitingJobs = Collections.unmodifiableList(this.waitingJobs);
+			waitingJobs = new ArrayList<>(this.waitingJobs);
 		} finally {
 			//in any case unlock access lock
 			jobsAccessLock.unlock();


### PR DESCRIPTION
 - methods "Collections.unmodifiableList|unmodifiableSet" do not create
   a new container, they are just views and they still working with
   these concurent containers so runtime exception can be thrown this
   way
 - for both calls we will create a new set and new array to prevent this
   behavior