### PR TITLE
Fix wrong behavior of processes in o365EmailAddress_mu module

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_o365EmailAddresses_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_o365EmailAddresses_mu.java
@@ -83,9 +83,12 @@ public class urn_perun_member_attribute_def_def_o365EmailAddresses_mu extends Me
 		}
 
 		//check for presence of uco@muni.cz
-		String UCO = getUserUco(sess, member);
+		Attribute attrUCO = getUserUco(sess, member);
+		String UCO = attrUCO.valueAsString();
 		//Throw an exception if UCO is null (we need to have this value not-null to correctly check value of this attribute)
-		if(UCO == null) throw new WrongReferenceAttributeValueException(UCO_ATTRIBUTE + " has null value!");
+		if(UCO == null) {
+			throw new WrongReferenceAttributeValueException(attribute, attrUCO, member, null, UCO_ATTRIBUTE + " has null value!");
+		}
 		String ucoEmail = UCO + "@muni.cz";
 		if (!emails.contains(ucoEmail)) {
 			throw new WrongAttributeValueException(attribute, member, "does not contain " + ucoEmail);
@@ -124,26 +127,26 @@ public class urn_perun_member_attribute_def_def_o365EmailAddresses_mu extends Me
 	}
 
 	/**
-	 * Gets user uco from attribute urn:perun:user:attribute-def:def:login-namespace:mu.
+	 * Gets user uco attribute urn:perun:user:attribute-def:def:login-namespace:mu.
 	 *
-	 * @return UCO if exists, null if not
+	 * @return Attribute with STRING UCO value if exists, with null value if not exists
 	 */
-	private String getUserUco(PerunSessionImpl sess, Member member) throws InternalErrorException, WrongAttributeAssignmentException {
+	private Attribute getUserUco(PerunSessionImpl sess, Member member) throws InternalErrorException, WrongAttributeAssignmentException {
 		try {
 			User user = sess.getPerunBl().getUsersManagerBl().getUserById(sess, member.getUserId());
-			String uco = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, UCO_ATTRIBUTE).valueAsString();
-			return uco;
+			return sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, UCO_ATTRIBUTE);
 		} catch (UserNotExistsException | AttributeNotExistsException e) {
 			throw new InternalErrorException(e.getMessage(), e);
 		}
 	}
 
 	/**
-	 * Returns uco@mail.muni.cz and uco@muni.cz
+	 * @returns uco@muni.cz in list if UCO exists, null if not exists
 	 */
 	private ArrayList<String> getUserUcoEmails(PerunSessionImpl sess, Member member) throws InternalErrorException, WrongAttributeAssignmentException {
-		String uco = getUserUco(sess, member);
-		if(uco == null) return new ArrayList<>();
+		Attribute attributeUCO = getUserUco(sess, member);
+		String uco = attributeUCO.valueAsString();
+		if(uco == null) return null;
 		else return Lists.newArrayList(uco + "@muni.cz");
 	}
 


### PR DESCRIPTION
 - method fill should return not-empty list of emails or null (not empty
   list of emails), this behavior was fixed
 - private method getUserUco now returns whole Attribute instead of just
   it's value, because we need this attribute for information puprose to
   the exception
 - WrongReferrenceAttributeValueException should return also information
   about both attributes and some holders, this was also fixed