### PR TITLE
CORE: Login generation must handle empty names on input

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -957,7 +957,9 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		public interface LoginGeneratorFunction {
 
 			/**
-			 * Generate login for user using his name
+			 * Generate login for user using his name.
+			 * Implementation must handle empty/null input on both fields.
+			 *
 			 * @param firstName
 			 * @param lastName
 			 * @return generated login
@@ -988,11 +990,6 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 				List<String> names = Arrays.asList(lastName.split(" "));
 				lastName = names.get(names.size() - 1);
 				lastName = ModulesUtilsBlImpl.normalizeStringForLogin(lastName.split(" ")[0]);
-			}
-
-			// unable to fill login for users without name or with partial name
-			if (firstName == null || firstName.isEmpty() || lastName == null || lastName.isEmpty()) {
-				return null;
 			}
 
 			return function.generateLogin(firstName, lastName);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_ceitec.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_ceitec.java
@@ -86,6 +86,13 @@ public class urn_perun_user_attribute_def_def_login_namespace_ceitec extends urn
 			String login = generator.generateLogin(user, new ModulesUtilsBlImpl.LoginGenerator.LoginGeneratorFunction() {
 				@Override
 				public String generateLogin(String firstName, String lastName) {
+
+					// unable to fill login for users without name or with partial name - use "External.customer1" like logins
+					if (firstName == null || firstName.isEmpty() || lastName == null || lastName.isEmpty()) {
+						firstName = "External";
+						lastName = "customer";
+					}
+
 					String login = firstName+ "." + lastName;
 					if (login.length()>20) {
 						login = login.substring(0, 20);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_vsup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_vsup.java
@@ -90,6 +90,12 @@ public class urn_perun_user_attribute_def_def_login_namespace_vsup extends urn_p
 			String login = generator.generateLogin(user, new ModulesUtilsBlImpl.LoginGenerator.LoginGeneratorFunction() {
 				@Override
 				public String generateLogin(String firstName, String lastName) {
+
+					// unable to fill login for users without name or with partial name
+					if (firstName == null || firstName.isEmpty() || lastName == null || lastName.isEmpty()) {
+						return null;
+					}
+
 					String login = firstName.substring(0, 1)+lastName.substring(0, (6 <= lastName.length()) ? 6 : lastName.length());
 					if (login.length()>20) {
 						login = login.substring(0, 20);


### PR DESCRIPTION
- We previously failed any login generation, if part of name was empty.
  Now each implementor must handle empty input by himself.
  For CEITEC we use "External.customer1" like logins, for VŠUP we
  still fail filling the attribute.