### PR TITLE
REGISTRAR: Extended content length of form items

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,6 +1,6 @@
 set database sql syntax PGS true;
 
--- database version 3.1.47 (don't forget to update insert statement at the end of file)
+-- database version 3.1.48 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -607,8 +607,8 @@ create table application_form_item_apptypes (
 create table application_form_item_texts (
 	item_id integer not null,     --identifier of form item (application_form_items.id)
 	locale varchar(128) not null, --language for application
-	label varchar(4000),          --label of item on app. form
-	options varchar(4000),        --options for items with menu
+	label text,          --label of item on app. form
+	options text,        --options for items with menu
 	help varchar(4000),           --text of help
 	error_message varchar(4000),  --text of error message
 	created_by_uid integer,
@@ -1768,7 +1768,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.47');
+insert into configurations values ('DATABASE VERSION','3.1.48');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -6,6 +6,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.48
+ALTER TABLE application_form_item_texts ALTER COLUMN label TYPE text;
+ALTER TABLE application_form_item_texts ALTER COLUMN options TYPE text;
+update configurations set value='3.1.48' where property='DATABASE VERSION';
+
 -- this update is not supported on hsql since its used only as in-memory db
 3.1.47
 delete from service_dependencies where dependency_id in (select id from exec_services where exec_services.type='GENERATE');

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -6,6 +6,17 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.48
+ALTER TABLE application_form_item_texts ADD (long_label clob);
+ALTER TABLE application_form_item_texts ADD (long_options clob);
+UPDATE application_form_item_texts SET long_label = label;
+UPDATE application_form_item_texts SET long_options = options;
+ALTER TABLE application_form_item_texts DROP COLUMN label;
+ALTER TABLE application_form_item_texts DROP COLUMN options;
+ALTER TABLE application_form_item_texts RENAME COLUMN long_label TO label;
+ALTER TABLE application_form_item_texts RENAME COLUMN long_options TO options;
+update configurations set value='3.1.48' where property='DATABASE VERSION';
+
 3.1.47
 delete from service_dependencies where dependency_id in (select id from exec_services where exec_services.type='GENERATE');
 delete from service_denials where exec_service_id in (select id from exec_services where exec_services.type='GENERATE');

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.48
+ALTER TABLE application_form_item_texts ALTER COLUMN label TYPE text;
+ALTER TABLE application_form_item_texts ALTER COLUMN options TYPE text;
+update configurations set value='3.1.48' where property='DATABASE VERSION';
+
 3.1.47
 delete from service_dependencies where dependency_id in (select id from exec_services where exec_services.type='GENERATE');
 delete from service_denials where exec_service_id in (select id from exec_services where exec_services.type='GENERATE');

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.47 (don't forget to update insert statement at the end of file)
+-- database version 3.1.48 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -615,8 +615,8 @@ create table application_form_item_apptypes (
 create table application_form_item_texts (
 	item_id integer not null,     --identifier of form item (application_form_items.id)
 	locale nvarchar2(128) not null, --language for application
-	label nvarchar2(4000),          --label of item on app. form
-	options nvarchar2(4000),        --options for items with menu
+	label clob,          --label of item on app. form
+	options clob,        --options for items with menu
 	help nvarchar2(4000),           --text of help
 	error_message nvarchar2(4000),  --text of error message
 	created_by_uid integer,
@@ -1771,7 +1771,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.47');
+insert into configurations values ('DATABASE VERSION','3.1.48');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.47 (don't forget to update insert statement at the end of file)
+-- database version 3.1.48 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -606,8 +606,8 @@ create table application_form_item_apptypes (
 create table application_form_item_texts (
 	item_id integer not null,     --identifier of form item (application_form_items.id)
 	locale varchar(128) not null, --language for application
-	label varchar(4000),          --label of item on app. form
-	options varchar(4000),        --options for items with menu
+	label text,    			      --label of item on app. form
+	options text,      			  --options for items with menu
 	help varchar(4000),           --text of help
 	error_message varchar(4000),  --text of error message
 	created_by_uid integer,
@@ -1871,7 +1871,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.47');
+insert into configurations values ('DATABASE VERSION','3.1.48');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
- Extended length to unlimited for content of HTML, Radiobutton,
  Checkbox, Selectionbox, Combobox items. For the HTML is all content,
  for the rest it expand count of possible options.
- There is no change in a code, only DB change is necessary.