### PR TITLE
RPC: Use Cargo plugin for local run instead of Tomcat7

### DIFF
--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -18,7 +18,6 @@
 
 	<properties>
 		<skipTests>true</skipTests>
-		<tomcat7.plugin.tomcat.version>7.0.85</tomcat7.plugin.tomcat.version>
 	</properties>
 
 	<!-- common module build settings used by all profiles -->
@@ -63,129 +62,51 @@
 				</configuration>
 			</plugin>
 
-			<!-- Allow to run Perun locally in Tomcat7 container by command "mvn tomcat7:run-war"
-				 Server is started at ajp://localhost:8009/perun-rpc/
-				 You need to setup Apache web server to provide (or fake) authentication in AJP headers
-				 and to provide http->ajp rewrite so that calls from GUI (browser) are passed to Perun app. -->
+			<!-- Allow to run Perun locally in Tomcat container by command "mvn cargo:run"
+				Server is started at ajp://localhost:8009/perun-rpc/
+				You need to setup Apache web server to provide (or fake) authentication in AJP headers
+				and to provide http->ajp rewrite so that calls from GUI (browser) are passed to Perun app. -->
 			<plugin>
-				<groupId>org.apache.tomcat.maven</groupId>
-				<artifactId>tomcat7-maven-plugin</artifactId>
-				<version>2.2</version>
+				<groupId>org.codehaus.cargo</groupId>
+				<artifactId>cargo-maven2-plugin</artifactId>
+				<version>1.6.8</version>
 				<configuration>
-					<serverXml>tomcat.xml</serverXml>
+					<container>
+						<containerId>tomcat8x</containerId>
+						<artifactInstaller>
+							<groupId>org.apache.tomcat</groupId>
+							<artifactId>tomcat</artifactId>
+							<version>${tomcat.version}</version>
+						</artifactInstaller>
+						<systemProperties>
+							<!-- Force running against real DB -->
+							<spring.profiles.active>production</spring.profiles.active>
+						</systemProperties>
+					</container>
+					<configuration>
+						<home>${basedir}/target/cargo/tomcat8x</home>
+						<files>
+							<copy>
+								<file>${basedir}/tomcat.xml</file>
+								<tofile>conf/server.xml</tofile>
+								<configfile>true</configfile>
+								<overwrite>true</overwrite>
+							</copy>
+						</files>
+					</configuration>
+					<deployables>
+						<deployable>
+							<groupId>cz.metacentrum.perun</groupId>
+							<artifactId>perun-rpc</artifactId>
+							<type>war</type>
+							<!-- force using renamed war -->
+							<location>target/perun-rpc.war</location>
+							<properties>
+								<context>/perun-rpc</context>
+							</properties>
+						</deployable>
+					</deployables>
 				</configuration>
-				<dependencies>
-
-					<!-- Match Tomcat7 version with our Tomcat libraries version -->
-
-					<dependency>
-						<groupId>org.apache.tomcat.embed</groupId>
-						<artifactId>tomcat-embed-core</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-util</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-coyote</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-api</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-jdbc</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-dbcp</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-servlet-api</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-jsp-api</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-jasper</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-jasper-el</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-el-api</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-catalina</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-tribes</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-catalina-ha</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-annotations-api</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<!-- tomcat i18n too ?? -->
-
-					<!-- not sure we need that -->
-					<dependency>
-						<groupId>org.apache.tomcat</groupId>
-						<artifactId>tomcat-juli</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
-						<groupId>org.apache.tomcat.embed</groupId>
-						<artifactId>tomcat-embed-logging-juli</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.tomcat.embed</groupId>
-						<artifactId>tomcat-embed-logging-log4j</artifactId>
-						<version>${tomcat7.plugin.tomcat.version}</version>
-					</dependency>
-
-				</dependencies>
 			</plugin>
 
 		</plugins>

--- a/perun-rpc/tomcat.xml
+++ b/perun-rpc/tomcat.xml
@@ -1,32 +1,46 @@
 <?xml version='1.0' encoding='utf-8'?>
+<Server port="8005" shutdown="SHUTDOWN" debug="FINE">
 
-<!-- This is a simple config for running Perun in embedded Tomcat of Maven Tomcat7 plugin
-     It has no affect on production use (when war is deployed to own Tomcat -->
+<Service name="Catalina" debug="FINE">
 
-<Server port="8005" shutdown="SHUTDOWN">
+	<!-- must be kept, since Cargo plugin check "cargocpc" app on 8080 port -->
+	<Connector port="8080"
+	           maxThreads="150"
+	           minSpareThreads="25"
+	           enableLookups="false"
+	           connectionTimeout="20000"
+	           disableUploadTimeout="true"
+	           scheme="http"
+	           secure="false"
+	           debug="FINE"
+	           URIEncoding="UTF-8" />
 
-	<Listener className="org.apache.catalina.core.JasperListener" />
-	<Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
-	<Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
-	<Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+	<!-- Define an AJP 1.3 Connector on port 8009 for PERUN -->
+	<Connector port="8009"
+	           protocol="AJP/1.3"
+	           address="127.0.0.1"
+	           tomcatAuthentication="false"
+	           URIEncoding="UTF-8"
+	           packetSize="36000"
+	           redirectPort="8080"/>
 
-	<GlobalNamingResources>
-		<Resource name="UserDatabase" auth="Container"
-		          type="org.apache.catalina.UserDatabase"
-		          description="User database that can be updated and saved"
-		          factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
-		          pathname="conf/tomcat-users.xml" />
-	</GlobalNamingResources>
+	<Engine name="Catalina" defaultHost="localhost" debug="FINE">
 
-	<Service name="Catalina">
+		<Realm className="org.apache.catalina.realm.MemoryRealm" />
 
-		<Connector port="8009" protocol="AJP/1.3" address="127.0.0.1" tomcatAuthentication="false" URIEncoding="UTF-8" packetSize="36000" />
+		<!-- deploy cargo apps from "webapps" folder -->
+		<Host name="localhost" appBase="webapps" deployOnStartup="true" autoDeploy="true" unpackWARs="true">
 
-		<Engine name="Catalina" defaultHost="localhost">
-			<Host name="localhost" appBase="" deployOnStartup="false" autoDeploy="false">
-				<Context path="/perun-rpc" docBase="../perun-rpc.war" sessionCookieName="PERUNSESSION" sessionCookiePath="/" />
-			</Host>
-		</Engine>
+			<!-- cargo replaces -->
+			@tomcat.webapps@
 
-	</Service>
+			<!-- Logging -->
+			<Valve className="org.apache.catalina.valves.AccessLogValve"
+			       directory="logs" prefix="localhost_access_log." suffix=".txt"
+			       pattern="common" />
+
+		</Host>
+	</Engine>
+
+</Service>
 </Server>


### PR DESCRIPTION
- tomcat7 maven plugin is not developed anymore and compatibility
  with Tomcat 8+ is missing.
- We can use Cargo plugin in order to run Perun locally in Tomcat 8+.

  Plugin creates tomcat installation in target/ folder, runs it
  and deploys perun-rpc.war

  You first need to build RPC using "mvn clean install", then you can
  run Perun in tomcat using "mvn cargo:run".

- Tomcat version is determined by spring platform dependency.

- Since Cargo plugin deploys also tomcat-manager webapp and own
  cargocpc web app, we must start tomcat also with port 8080,
  otherwise plugin kills tomcat after 200s.

Reminder:
- Also since recent changes in maven profiles and dependencies we
  can no longer run perun locally with in memory-db, since sql
  files are only present in a test phase and not packaged with
  resulting war. Hence we force Cargo to run Perun with sping
  profile "production" requiring real DB to connect and
  expectiong perun configuration in /etc/perun.