### PR TITLE
Fix behavior of equals method on objects Member and RichMember

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Member.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Member.java
@@ -131,7 +131,7 @@ public class Member extends Auditable {
 		if (obj == null) {
 			return false;
 		}
-		if (!getClass().equals(obj.getClass())) {
+		if (!(obj instanceof Member)) {
 			return false;
 		}
 		Member other = (Member) obj;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichMember.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichMember.java
@@ -90,8 +90,8 @@ public class RichMember extends Member implements Comparable<PerunBean> {
 		if (obj == null) {
 			return false;
 		}
-		if (getClass() != obj.getClass()) {
-			return false;
+		if (!(obj instanceof RichMember)) {
+			return super.equals(obj);
 		}
 		RichMember other = (RichMember) obj;
 		if (memberAttributes == null) {


### PR DESCRIPTION
 - we should be able to compare objects Member and RichMember if they
   are equal, before this change they were always compared as not equal