### PR TITLE
Change equals and hashCode methods on specific rich objects in Perun

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
@@ -92,46 +92,6 @@ public class Candidate extends User {
 	}
 
 	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result
-			+ ((attributes == null) ? 0 : attributes.hashCode());
-		result = prime * result
-			+ ((userExtSource == null) ? 0 : userExtSource.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		Candidate other = (Candidate) obj;
-		if (attributes == null) {
-			if (other.attributes != null) {
-				return false;
-			}
-		} else if (!attributes.equals(other.attributes)) {
-			return false;
-		}
-		if (userExtSource == null) {
-			if (other.userExtSource != null) {
-				return false;
-			}
-		} else if (!userExtSource.equals(other.userExtSource)) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
 	public String serializeToString() {
 		StringBuilder str = new StringBuilder();
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Member.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Member.java
@@ -131,7 +131,7 @@ public class Member extends Auditable {
 		if (obj == null) {
 			return false;
 		}
-		if (!getClass().equals(obj.getClass())) {
+		if (!(obj instanceof Member)) {
 			return false;
 		}
 		Member other = (Member) obj;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichMember.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichMember.java
@@ -69,63 +69,6 @@ public class RichMember extends Member implements Comparable<PerunBean> {
 	}
 
 	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result
-			+ ((memberAttributes == null) ? 0 : memberAttributes.hashCode());
-		result = prime * result + ((user == null) ? 0 : user.hashCode());
-		result = prime * result
-			+ ((userAttributes == null) ? 0 : userAttributes.hashCode());
-		result = prime * result
-			+ ((userExtSources == null) ? 0 : userExtSources.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		RichMember other = (RichMember) obj;
-		if (memberAttributes == null) {
-			if (other.memberAttributes != null) {
-				return false;
-			}
-		} else if (!memberAttributes.equals(other.memberAttributes)) {
-			return false;
-		}
-		if (user == null) {
-			if (other.user != null) {
-				return false;
-			}
-		} else if (!user.equals(other.user)) {
-			return false;
-		}
-		if (userAttributes == null) {
-			if (other.userAttributes != null) {
-				return false;
-			}
-		} else if (!userAttributes.equals(other.userAttributes)) {
-			return false;
-		}
-		if (userExtSources == null) {
-			if (other.userExtSources != null) {
-				return false;
-			}
-		} else if (!userExtSources.equals(other.userExtSources)) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
 	public String serializeToString() {
 		StringBuilder str = new StringBuilder();
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichUser.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RichUser.java
@@ -48,47 +48,6 @@ public class RichUser extends User {
 	}
 
 	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result
-			+ ((userAttributes == null) ? 0 : userAttributes.hashCode());
-		result = prime * result
-			+ ((userExtSources == null) ? 0 : userExtSources.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		RichUser other = (RichUser) obj;
-		if (getId() != other.getId()) return false;
-		if (userAttributes == null) {
-			if (other.userAttributes != null) {
-				return false;
-			}
-		} else if (!userAttributes.equals(other.userAttributes)) {
-			return false;
-		}
-		if (userExtSources == null) {
-			if (other.userExtSources != null) {
-				return false;
-			}
-		} else if (!userExtSources.equals(other.userExtSources)) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
 	public String serializeToString() {
 		StringBuilder str = new StringBuilder();
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/User.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/User.java
@@ -255,7 +255,7 @@ public class User extends Auditable implements Comparable<PerunBean> {
 			return true;
 		if (obj == null)
 			return false;
-		if (getClass() != obj.getClass())
+		if (!(obj instanceof User))
 			return false;
 		User other = (User) obj;
 		if (firstName == null) {


### PR DESCRIPTION
 - RichMember, RichUser and Candidate will use equals and hashCode methods
   from parent class (Member and User) instead of using it's own
 - this change will allow to compare instance of parent class with
   instance of child class for these mentioned classes and also use this
   behavior correctly for all types of Collections