### PR TITLE
Synchronize only direct members

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1233,8 +1233,8 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			Map<Candidate, RichMember> membersToUpdate = new HashMap<>();
 			List<RichMember> membersToRemove = new ArrayList<>();
 
-			//get all actual members of group
-			List<RichMember> actualGroupMembers = getPerunBl().getGroupsManagerBl().getGroupRichMembers(sess, group);
+			//get all direct members of synchronized group (only direct, because we want to set direct membership with this group by synchronization)
+			List<RichMember> actualGroupMembers = getPerunBl().getGroupsManagerBl().getGroupDirectRichMembers(sess, group);
 
 			if(lightweightSynchronization) {
 				categorizeMembersForLightweightSynchronization(sess, group, source, membersSource, actualGroupMembers, candidatesToAdd, membersToRemove, skippedMembers);


### PR DESCRIPTION
 - from now synchronization should synchronize members to group always
   as direct members (do not skip them if they are already there as
   indirect members). This should prevent unexepcted state of member
   after his synchronization especialy in group structure
   synchronzation process.