### PR TITLE
CORE,RPC: Allow to get UES by login and ext source name

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
@@ -98,7 +98,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+		if (!AuthzResolver.isAuthorized(sess, Role.RPC)) {
 			throw new PrivilegeException(sess, "getExtSourceByName");
 		}
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -249,6 +249,10 @@ public class ApiCaller {
 		return getExtSourcesManager().getExtSourceById(rpcSession, id);
 	}
 
+	public ExtSource getExtSourceByName(String extSourceName) throws PerunException {
+		return getExtSourcesManager().getExtSourceByName(rpcSession, extSourceName);
+	}
+
 	public Service getServiceById(int id) throws PerunException {
 		return getServicesManager().getServiceById(rpcSession, id);
 	}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -496,7 +496,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 					ac.getUserById(parms.readInt("user")),
 					ac.getUserExtSourceById(parms.readInt("userExtSource")));
 			}
-				
+
 			return null;
 		}
 	},
@@ -549,6 +549,23 @@ public enum UsersManagerMethod implements ManagerMethod {
 		public UserExtSource call(ApiCaller ac, Deserializer parms) throws PerunException {
 			return ac.getUsersManager().getUserExtSourceByExtLogin(ac.getSession(),
 					parms.read("extSource", ExtSource.class),
+					parms.readString("extSourceLogin"));
+		}
+	},
+
+	/*#
+	 * Gets user's external source by the user's external login and external source name
+	 *
+	 * @param extSourceName String Name of ext source (eg. entityID of IdP)
+	 * @param extSourceLogin String Login
+	 * @return UserExtSource UserExtSource found user's external source
+	 */
+	getUserExtSourceByExtLoginAndExtSourceName {
+
+		@Override
+		public UserExtSource call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getUsersManager().getUserExtSourceByExtLogin(ac.getSession(),
+					ac.getExtSourceByName(parms.readString("extSourceName")),
 					parms.readString("extSourceLogin"));
 		}
 	},


### PR DESCRIPTION
- Added method getUserExtSourceByExtLoginAndExtSourceName().
  Previously we had to retrieve whole ExtSource object and pass
  it back to the API. Now we can send just ext source name directly
  and we will get same UES.