### PR TITLE
CORE: Fixed getting facility by attribute value

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -412,7 +413,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 				throw new InternalErrorException("Attribute " + attributeName + " is large attribute, which is not supported.");
 			}
 			Attribute attribute = new Attribute(attributeDef);
-			attribute.setValue(attributeValue);
+			attribute.setValue(BeansUtils.stringToAttributeValue(attributeValue, attribute.getType()));
 			getPerunBl().getAttributesManagerBl().checkNamespace(sess, attribute, AttributesManager.NS_FACILITY_ATTR);
 			if (!(getPerunBl().getAttributesManagerBl().isDefAttribute(sess, attribute) || getPerunBl().getAttributesManagerBl().isOptAttribute(sess, attribute)))
 				throw new WrongAttributeAssignmentException("This method can process only def and opt attributes");


### PR DESCRIPTION
- We previously used String raw value directly to search for exact
  matched. This prevented array, boolean or integer like attributes to
  found based on type-value mismatch.
- Now if value is properly escaped on input, its parsed to proper
  data type.
- Based on impl layer implementation we still can't search by large
  or unique attributes (same goes to our searcher).