### PR TITLE
Upgraded to Spring Boot Starter Parent 2.0.4

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -122,10 +122,29 @@
 			<version>${tomcat.version}</version>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>guru.nidi</groupId>
 			<artifactId>graphviz-java</artifactId>
 			<version>${graphviz.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.eclipsesource.j2v8</groupId>
+					<artifactId>j2v8_macosx_x86_64</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.eclipsesource.j2v8</groupId>
+					<artifactId>j2v8_win32_x86_64</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.eclipsesource.j2v8</groupId>
+					<artifactId>j2v8_win32_x86</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jcl-over-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 	</dependencies>

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -233,12 +233,6 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>guru.nidi</groupId>
-			<artifactId>graphviz-java</artifactId>
-			<version>${graphviz.version}</version>
-		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -147,7 +147,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.2.24</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -111,13 +111,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>${javax-activation.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -141,12 +141,6 @@
 
 	<dependencies>
 
-		<!-- PERUN -->
-
-		<!-- DB -->
-
-		<!-- SPRING -->
-
 		<!-- TESTS -->
 
 		<dependency>
@@ -154,22 +148,6 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<version>${javax-validation.version}</version>
-			<classifier>sources</classifier>
-			<scope>provided</scope>
-		</dependency>
-
-		<!-- LOGGING -->
 
 		<!-- OTHERS -->
 
@@ -186,15 +164,6 @@
 			<version>${gwtVersion}</version>
 			<scope>provided</scope>
 		</dependency>
-
-		<!-- Drag and Drop library
-		<dependency>
-			<groupId>com.googlecode.gwtquery.bundles</groupId>
-			<artifactId>gquery-dnd-bundle</artifactId>
-			<version>1.0.6</version>
-			<scope>provided</scope>
-		</dependency>
-		-->
 
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.0.4.RELEASE</version>
 		<relativePath/>
 	</parent>
 
@@ -60,10 +60,7 @@
 		<spring.profiles.default>default</spring.profiles.default>
 
 		<!-- redefine versions of some libraries defined by Spring Boot Starter Parent -->
-		<postgresql.version>42.2.2</postgresql.version>
 		<hsqldb.version>2.3.2</hsqldb.version> <!-- 2.3.3 fails GroupsManagerEntryIntegrationTest.addAdminWhenAlreadyAdmin test -->
-		<javax-validation.version>1.0.0.GA</javax-validation.version>
-		<mockito.version>2.17.0</mockito.version>
 
 		<!-- versions of libraries not defined by the Spring Boot Starter Parent -->
 		<cglib-nodep.version>2.2.2</cglib-nodep.version>
@@ -71,11 +68,10 @@
 		<commons-collections.version>3.2.2</commons-collections.version>
 		<dumbster.version>1.6</dumbster.version>
 		<expiringmap.version>0.4.3</expiringmap.version>
-		<google-api-services-admin-directory.version>directory_v1-rev78-1.22.0</google-api-services-admin-directory.version>
-		<graphviz.version>0.2.3</graphviz.version>
+		<google-api-services-admin-directory.version>directory_v1-rev103-1.24.1</google-api-services-admin-directory.version>
+		<graphviz.version>0.5.4</graphviz.version>
 		<hornetq.version>2.2.21.Final</hornetq.version>
 		<jackson1.version>1.9.13</jackson1.version>
-		<javax-activation.version>1.1.1</javax-activation.version>
 		<jboss-jms-api.version>1.1.0.GA</jboss-jms-api.version>
 		<jcip.version>1.0</jcip.version>
 		<jdom.version>1.0</jdom.version>
@@ -84,7 +80,7 @@
 		<opencsv.version>3.3</opencsv.version>
 		<oracle.version>12.2.0.1.0</oracle.version>
 		<recaptcha4j.version>0.0.7</recaptcha4j.version>
-		<smack.version>3.1.0</smack.version>
+		<smackx.version>3.1.0</smackx.version>
 		<taglibs-standard.version>1.2.5</taglibs-standard.version>
 	</properties>
 
@@ -381,14 +377,8 @@
 
 			<dependency>
 				<groupId>jivesoftware</groupId>
-				<artifactId>smack</artifactId>
-				<version>${smack.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>jivesoftware</groupId>
 				<artifactId>smackx</artifactId>
-				<version>${smack.version}</version>
+				<version>${smackx.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
- upgraded Spring Boot Starter Parent to 2.0.4, which updates Spring to 5.0.8
- removed some version definitions that are not needed anymore
- excluded dependencies for graphviz-java that contain native JavaScript engine for non-linux platforms