### PR TITLE
New methods getResourcesWhereUser|GroupIsAdmin

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -794,6 +794,40 @@ public interface ResourcesManager {
 	List<Resource> getResourcesWhereUserIsAdmin(PerunSession sess, User user) throws InternalErrorException, UserNotExistsException, PrivilegeException;
 
 	/**
+	 * Return all resources for the facility and the vo where user is authorized as resource manager.
+	 *
+	 * @param sess
+	 * @param facility the facility to which resources should be assigned to
+	 * @param vo the vo to which resources should be assigned to
+	 * @param authorizedUser user with resource manager role for all those resources
+	 * @return list of defined resources where user has role resource manager
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws UserNotExistsException
+	 * @throws FacilityNotExistsException
+	 * @throws VoNotExistsException
+	 */
+	List<Resource> getResourcesWhereUserIsAdmin(PerunSession sess, Facility facility, Vo vo, User authorizedUser) throws InternalErrorException, PrivilegeException, UserNotExistsException, FacilityNotExistsException, VoNotExistsException;
+
+	/**
+	 * Return all resources for the facility and the vo where the group is authorized as resource manager.
+	 *
+	 * @param sess
+	 * @param facility the facility to which resources should be assigned to
+	 * @param vo the vo to which resources should be assigned to
+	 * @param authorizedGroup group with resource manager role for all those resources
+	 * @return list of defined resources where groups has role resource manager
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws GroupNotExistsException
+	 * @throws FacilityNotExistsException
+	 * @throws VoNotExistsException
+	 */
+	List<Resource> getResourcesWhereGroupIsAdmin(PerunSession sess, Facility facility, Vo vo, Group authorizedGroup) throws InternalErrorException, PrivilegeException, GroupNotExistsException, FacilityNotExistsException, VoNotExistsException;
+
+	/**
 	 * Gets list of all group administrators of the Resource.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -756,6 +756,32 @@ public interface ResourcesManagerBl {
 	List<Resource> getResourcesWhereUserIsAdmin(PerunSession sess, User user) throws InternalErrorException;
 
 	/**
+	 * Return all resources for the facility and the vo where user is authorized as resource manager.
+	 *
+	 * @param sess
+	 * @param facility the facility to which resources should be assigned to
+	 * @param vo the vo to which resources should be assigned to
+	 * @param authorizedUser user with resource manager role for all those resources
+	 * @return list of defined resources where user has role resource manager
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getResourcesWhereUserIsAdmin(PerunSession sess, Facility facility, Vo vo, User authorizedUser) throws InternalErrorException;
+
+	/**
+	 * Return all resources for the facility and the vo where the group is authorized as resource manager.
+	 *
+	 * @param sess
+	 * @param facility the facility to which resources should be assigned to
+	 * @param vo the vo to which resources should be assigned to
+	 * @param authorizedGroup group with resource manager role for all those resources
+	 * @return list of defined resources where groups has role resource manager
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getResourcesWhereGroupIsAdmin(PerunSession sess, Facility facility, Vo vo, Group authorizedGroup) throws InternalErrorException;
+
+	/**
 	 * Gets list of all group administrators of the Resource.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -747,6 +747,16 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		return resourcesManagerImpl.getResourcesWhereUserIsAdmin(sess, user);
 	}
 
+	@Override
+	public List<Resource> getResourcesWhereUserIsAdmin(PerunSession sess, Facility facility, Vo vo, User authorizedUser) throws InternalErrorException {
+		return getResourcesManagerImpl().getResourcesWhereUserIsAdmin(sess, facility, vo, authorizedUser);
+	}
+
+	@Override
+	public List<Resource> getResourcesWhereGroupIsAdmin(PerunSession sess, Facility facility, Vo vo, Group authorizedGroup) throws InternalErrorException {
+		return getResourcesManagerImpl().getResourcesWhereGroupIsAdmin(sess, facility, vo, authorizedGroup);
+	}
+
     public List<Group> getAdminGroups(PerunSession sess, Resource resource) throws InternalErrorException {
         return resourcesManagerImpl.getAdminGroups(sess, resource);
     }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -789,6 +789,34 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 		}
 	}
 
+	@Override
+	public List<Resource> getResourcesWhereUserIsAdmin(PerunSession sess, Facility facility, Vo vo, User authorizedUser) throws InternalErrorException {
+		try {
+			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources " +
+							" left outer join authz on authz.resource_id=resources.id " +
+							" where resources.facility_id=? and resources.vo_id=? and authz.user_id=? and authz.role_id=(select id from roles where name=?)"
+					,RESOURCE_MAPPER, facility.getId(), vo.getId(), authorizedUser.getId(), Role.RESOURCEADMIN.getRoleName());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Resource> getResourcesWhereGroupIsAdmin(PerunSession sess, Facility facility, Vo vo, Group authorizedGroup) throws InternalErrorException {
+		try {
+			return jdbc.query("select distinct " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources " +
+							" left outer join authz on authz.resource_id=resources.id " +
+							" where resources.facility_id=? and resources.vo_id=? and authz.authorized_group_id=? and authz.role_id=(select id from roles where name=?)"
+					,RESOURCE_MAPPER, facility.getId(), vo.getId(), authorizedGroup.getId(), Role.RESOURCEADMIN.getRoleName());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
 	public boolean banExists(PerunSession sess, int memberId, int resourceId) throws InternalErrorException {
 		try {
 			return 1 == jdbc.queryForInt("select 1 from resources_bans where member_id=? and resource_id=?", memberId, resourceId);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -586,6 +586,32 @@ public interface ResourcesManagerImplApi {
 	List<Resource> getResourcesWhereUserIsAdmin(PerunSession sess, User user) throws InternalErrorException;
 
 	/**
+	 * Return all resources for the facility and the vo where user is authorized as resource manager.
+	 *
+	 * @param sess
+	 * @param facility the facility to which resources should be assigned to
+	 * @param vo the vo to which resources should be assigned to
+	 * @param authorizedUser user with resource manager role for all those resources
+	 * @return list of defined resources where user has role resource manager
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getResourcesWhereUserIsAdmin(PerunSession sess, Facility facility, Vo vo, User authorizedUser) throws InternalErrorException;
+
+	/**
+	 * Return all resources for the facility and the vo where the group is authorized as resource manager.
+	 *
+	 * @param sess
+	 * @param facility the facility to which resources should be assigned to
+	 * @param vo the vo to which resources should be assigned to
+	 * @param authorizedGroup group with resource manager role for all those resources
+	 * @return list of defined resources where groups has role resource manager
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getResourcesWhereGroupIsAdmin(PerunSession sess, Facility facility, Vo vo, Group authorizedGroup) throws InternalErrorException;
+
+	/**
 	 * Gets list of all group administrators of the Resource.
 	 *
 	 * @param sess

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -98,7 +98,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		Resource resource2 = new Resource();
 		resource2.setName("ResourcesManagerTestResource");
 		resource2.setDescription("Test Resource two");
-		
+
 		resourcesManager.createResource(sess, resource1, vo, facility);
 		resourcesManager.createResource(sess, resource2, vo, facility);
 	}
@@ -1027,16 +1027,16 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource.setName("UpdatedName1");
 		final Resource updatedResource1 = resourcesManager.updateResource(sess, resource);
 		assertEquals(updatedResource1, resourcesManager.getResourceById(sess, resource.getId()));
-		
+
 		resource.setDescription("ChangedDescription");
 		final Resource updatedResource2 = resourcesManager.updateResource(sess, resource);
 		assertEquals(updatedResource2, resourcesManager.getResourceById(sess, resource.getId()));
 	}
-	
+
 	@Test(expected = ResourceExistsException.class)
 	public void updateResourceWithExistingName() throws Exception {
 		System.out.println(CLASS_NAME + "updateResourceWithExistingName");
-		
+
 		vo = setUpVo();
 		facility = setUpFacility();
 		Resource resource1 = setUpResource();
@@ -1055,7 +1055,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		Facility facility2 = new Facility();
 		facility2.setName("DifferentFacility");
 		facility2 = perun.getFacilitiesManagerBl().createFacility(sess, facility2);
-		
+
 		Resource resource1 = setUpResource();
 		Resource resource2 = new Resource();
 		resource2.setName("DifferentResource");
@@ -1065,11 +1065,11 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resource2.setName(resource1.getName());
 		resource2.setDescription(resource1.getDescription());
 		resourcesManager.updateResource(sess, resource2);
-		
+
 		assertEquals(resource1.getName(), resource2.getName());
 		assertNotEquals(resource1.getId(), resource2.getId());
 		assertNotEquals(resource1, resource2);
-	}	
+	}
 
 	@Test
 	public void getAllResourcesTagsForResource() throws Exception {
@@ -1603,6 +1603,38 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 		resourcesManager.addAdmin(sess, resource, u);
 		List<Resource> resources = resourcesManager.getResourcesWhereUserIsAdmin(sess, u);
+
+		assertNotNull(resources);
+		assertTrue(resources.contains(resource));
+	}
+
+	@Test
+	public void getResourcesSpecifiedByVoAndFacilityWhereUserIsAdmin() throws Exception {
+		System.out.println(CLASS_NAME + "getResourcesSpecifiedByVoAndFacilityWhereUserIsAdmin");
+		vo = setUpVo();
+		member = setUpMember(vo);
+		facility = setUpFacility();
+		resource = setUpResource();
+		User u = perun.getUsersManagerBl().getUserByMember(sess, member);
+
+		resourcesManager.addAdmin(sess, resource, u);
+		List<Resource> resources = resourcesManager.getResourcesWhereUserIsAdmin(sess, facility, vo, u);
+
+		assertNotNull(resources);
+		assertTrue(resources.contains(resource));
+	}
+
+	@Test
+	public void getResourcesWhereGroupIsAdmin() throws Exception {
+		System.out.println(CLASS_NAME + "getResourcesWhereGroupIsAdmin");
+		vo = setUpVo();
+		member = setUpMember(vo);
+		facility = setUpFacility();
+		resource = setUpResource();
+		group = setUpGroup(vo, member);
+
+		resourcesManager.addAdmin(sess, resource, group);
+		List<Resource> resources = resourcesManager.getResourcesWhereGroupIsAdmin(sess, facility, vo, group);
 
 		assertNotNull(resources);
 		assertTrue(resources.contains(resource));

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
@@ -599,7 +600,23 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns list of Resources, where the user is an Administrator.
+	 * Returns list of Resources for specified VO and Facility, where the user is an Administrator
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param vo int Vo <code>id</code>
+	 * @param user int User <code>id</code>
+	 * @return List<Resource> Found Resources
+	 */
+	/*#
+	 * Returns list of Resources for specified VO and Facility, where the group is an Administrator.
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param vo int Vo <code>id</code>
+	 * @param group int Group <code>id</code>
+	 * @return List<Resource> Found Resources
+	 */
+	/*#
+	 * Returns list of all Resources, where the user is an Administrator.
 	 *
 	 * @param user int User <code>id</code>
 	 * @return List<Resource> Found Resources
@@ -607,8 +624,26 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 	getResourcesWhereUserIsAdmin {
 		@Override
 		public List<Resource> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getResourcesManager().getResourcesWhereUserIsAdmin(ac.getSession(),
-					ac.getUserById(parms.readInt("user")));
+			if (parms.contains("facility") && parms.contains("vo")) {
+				if (parms.contains("user")) {
+					return ac.getResourcesManager().getResourcesWhereUserIsAdmin(ac.getSession(),
+							ac.getFacilityById(parms.readInt("facility")),
+							ac.getVoById(parms.readInt("vo")),
+							ac.getUserById(parms.readInt("user")));
+				} else if (parms.contains("group")) {
+					return ac.getResourcesManager().getResourcesWhereGroupIsAdmin(ac.getSession(),
+							ac.getFacilityById(parms.readInt("facility")),
+							ac.getVoById(parms.readInt("vo")),
+							ac.getGroupById(parms.readInt("group")));
+				} else {
+					throw new RpcException(RpcException.Type.MISSING_VALUE, "group or user");
+				}
+			} else if (parms.contains("user")) {
+				return ac.getResourcesManager().getResourcesWhereUserIsAdmin(ac.getSession(),
+						ac.getUserById(parms.readInt("user")));
+			} else {
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "facility, vo or user");
+			}
 		}
 	},
 


### PR DESCRIPTION
 - to existing getResourcesWhereUserIsAdmin method, which returns all
   resources for the specific administrator add two new variants with
   specific VO and Facility in parameters (one for user, one for
   authorized group)
 - add these method to all layers and also to RPC
 - add simple tests for these two new methods