### PR TITLE
RPC,CORE: Added getAllowedRichGroupsWithAttributes() to API

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -159,6 +159,23 @@ public interface FacilitiesManager {
 	List<Group> getAllowedGroups(PerunSession perunSession, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, ServiceNotExistsException, VoNotExistsException;
 
 	/**
+	 * Get all RichGroups which can use this facility (Groups must be assigned to Resource which belongs to this facility)
+	 * specificVo and specificService can choose concrete groups
+	 * if specificVo, specificService or both are null, they do not specific (all possible results are returned)
+	 * We also retrieve attributes specified by attrNames for each returned RichGroup.
+	 *
+	 * @param facility        searching for this facility
+	 * @param specificVo      specific only those results which are in specific VO (with null, all results)
+	 * @param specificService specific only those results, which have resource with assigned specific service (if null, all results)
+	 * @param attrNames       with each returned RichGroup we get also attributes specified by this list
+	 * @return list of allowed groups
+	 * @throws FacilityNotExistsException if facility not exist, return this exception
+	 * @throws ServiceNotExistsException  if service is not null and not exist
+	 * @throws VoNotExistsException       if vo is not null and not exist
+	 */
+	List<RichGroup> getAllowedRichGroupsWithAttributes(PerunSession perunSession, Facility facility, Vo specificVo, Service specificService, List<String> attrNames) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, ServiceNotExistsException, VoNotExistsException;
+
+	/**
 	 * Return all users who can use this facility
 	 *
 	 * @return list of users

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -2,7 +2,6 @@ package cz.metacentrum.perun.core.bl;
 
 import java.util.List;
 
-import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.ContactGroup;
 import cz.metacentrum.perun.core.api.Facility;
@@ -14,6 +13,7 @@ import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichFacility;
+import cz.metacentrum.perun.core.api.RichGroup;
 import cz.metacentrum.perun.core.api.RichResource;
 import cz.metacentrum.perun.core.api.RichUser;
 import cz.metacentrum.perun.core.api.SecurityTeam;
@@ -223,6 +223,21 @@ public interface FacilitiesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getAllowedGroups(PerunSession perunSession, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
+
+	/**
+	 * Get all RichGroups which can use this facility (Groups must be assigned to Resource which belongs to this facility)
+	 * specificVo and specificService can choose concrete groups
+	 * if specificVo, specificService or both are null, they do not specific (all possible results are returned)
+	 * We also retrieve attributes specified by attrNames for each returned RichGroup.
+	 *
+	 * @param facility        searching for this facility
+	 * @param specificVo      specific only those results which are in specific VO (with null, all results)
+	 * @param specificService specific only those results, which have resource with assigned specific service (if null, all results)
+	 * @param attrNames       with each returned RichGroup we get also attributes specified by this list
+	 * @return list of allowed groups
+	 * @throws InternalErrorException when implementation fails
+	 */
+	List<RichGroup> getAllowedRichGroupsWithAttributes(PerunSession perunSession, Facility facility, Vo specificVo, Service specificService, List<String> attrNames) throws InternalErrorException;
 
 	/**
 	 * Return all users who can use this facility

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.RichGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +18,6 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.BanOnFacility;
 import cz.metacentrum.perun.core.api.ContactGroup;
-import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Host;
@@ -183,6 +183,13 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 			allowedGroups.addAll(getPerunBl().getResourcesManagerBl().getAssignedGroups(perunSession, r));
 		}
 		return new ArrayList<Group>(allowedGroups);
+	}
+
+	public List<RichGroup> getAllowedRichGroupsWithAttributes(PerunSession perunSession, Facility facility, Vo specificVo, Service specificService, List<String> attrNames) throws InternalErrorException {
+
+		List<Group> allowedGroups = getAllowedGroups(perunSession, facility, specificVo, specificService);
+		return perunBl.getGroupsManagerBl().convertGroupsToRichGroupsWithAttributes(perunSession, allowedGroups, attrNames);
+
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -4,10 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.ActionType;
-import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.RichGroup;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.DestinationNotExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +66,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
 import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
 import cz.metacentrum.perun.core.bl.FacilitiesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.core.impl.AuthzRoles;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.FacilitiesManagerImplApi;
 import java.util.Iterator;
@@ -311,7 +309,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 
 		//Authrorization
 		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility)) {
-			throw new PrivilegeException(perunSession, "getAlloewdGroups");
+			throw new PrivilegeException(perunSession, "getAllowedGroups");
 		}
 
 		getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);
@@ -319,6 +317,25 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		if(specificService != null) getPerunBl().getServicesManagerBl().checkServiceExists(perunSession, specificService);
 
 		return getFacilitiesManagerBl().getAllowedGroups(perunSession, facility, specificVo, specificService);
+	}
+
+	@Override
+	public List<RichGroup> getAllowedRichGroupsWithAttributes(PerunSession perunSession, Facility facility, Vo specificVo, Service specificService, List<String> attrNames) throws InternalErrorException, PrivilegeException, FacilityNotExistsException, ServiceNotExistsException, VoNotExistsException {
+
+		Utils.checkPerunSession(perunSession);
+
+		//Authrorization
+		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(perunSession, "getAllowedRichGroupsWithAttributes");
+		}
+
+		getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);
+		if(specificVo != null) getPerunBl().getVosManagerBl().checkVoExists(perunSession, specificVo);
+		if(specificService != null) getPerunBl().getServicesManagerBl().checkServiceExists(perunSession, specificService);
+
+		List<RichGroup> richGroups = getFacilitiesManagerBl().getAllowedRichGroupsWithAttributes(perunSession, facility, specificVo, specificService, attrNames);
+		return getPerunBl().getGroupsManagerBl().filterOnlyAllowedAttributes(perunSession, richGroups, true);
+
 	}
 
 	public List<User> getAllowedUsers(PerunSession sess, Facility facility) throws InternalErrorException, PrivilegeException, FacilityNotExistsException{

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/FacilitiesManagerMethod.java
@@ -244,6 +244,59 @@ public enum FacilitiesManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Get all assigned RichGroups on Facility with specified set of attributes.
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param attrNames List<String> Attribute names
+	 * @return List<RichGroup> assigned groups
+	 * @exampleParam attrNames [ "urn:perun:group:attribute-def:core:name" , "urn:perun:group:attribute-def:def:synchronizationEnabled" ]
+	 */
+	/*#
+	 * Get all assigned RichGroups on Facility filtered by VO with specified set of attributes.
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param vo int Vo <code>id</code> to filter groups by
+	 * @param attrNames List<String> Attribute names
+	 * @return List<RichGroup> assigned groups
+	 * @exampleParam attrNames [ "urn:perun:group:attribute-def:core:name" , "urn:perun:group:attribute-def:def:synchronizationEnabled" ]
+	 */
+	/*#
+	 * Get all assigned RichGroups on Facility filtered by Service with specified set of attributes.
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param service int Service <code>id</code> to filter groups by
+	 * @param attrNames List<String> Attribute names
+	 * @return List<RichGroup> assigned groups
+	 * @exampleParam attrNames [ "urn:perun:group:attribute-def:core:name" , "urn:perun:group:attribute-def:def:synchronizationEnabled" ]
+	 */
+	/*#
+	 * Get all assigned RichGroups on Facility filtered by VO and Service with specified set of attributes.
+	 *
+	 * @param facility int Facility <code>id</code>
+	 * @param vo int Vo <code>id</code> to filter groups by
+	 * @param service int Service <code>id</code> to filter groups by
+	 * @param attrNames List<String> Attribute names
+	 * @return List<RichGroup> assigned groups
+	 * @exampleParam attrNames [ "urn:perun:group:attribute-def:core:name" , "urn:perun:group:attribute-def:def:synchronizationEnabled" ]
+	 */
+	getAllowedRichGroupsWithAttributes {
+
+		@Override
+		public List<RichGroup> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			Facility facility = ac.getFacilityById(parms.readInt("facility"));
+			Service service = null;
+			Vo vo = null;
+			if (parms.contains("vo")) {
+				vo = ac.getVoById(parms.readInt("vo"));
+			}
+			if (parms.contains("service")) {
+				service = ac.getServiceById(parms.readInt("service"));
+			}
+			return ac.getFacilitiesManager().getAllowedRichGroupsWithAttributes(ac.getSession(), facility, vo, service, parms.readList("attrNames", String.class));
+		}
+	},
+
+	/*#
 	 * Returns all resources assigned to a facility.
 	 *
 	 * @param facility int Facility <code>id</code>


### PR DESCRIPTION
- We can now retrieve all groups allowed on facility (assigned
  to any resource of facility) as RichGroups with specified set of
  group attributes.
- It will be used by proxy IdP to lower number of necessary callbacks
  to RPC API.
- Added to CORE + RPC including javadoc.