### PR TITLE
CORE: Fixed reference to old facility googleGroupNameNamespace attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
@@ -254,7 +254,7 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 	 *
 	 * It's possible to fill these attributes for Google Groups ExtSource: -
 	 * urn:perun:user:attribute-def:virt:logins-namespace:google={userID}, -
-	 * urn:perun:facility:attribute-def:def:googleGroupNameNamespace={domainName},
+	 * urn:perun:facility:attribute-def:def:googleGroupsDomain={domainName},
 	 * -
 	 * urn:perun:group:attribute-def:def:googleGroupName-namespace:einfra.cesnet.cz={groupName}
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
@@ -14,13 +14,13 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
-import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleImplApi;
 
 /**
+ * Module to resolve correct group name in G-suite (google groups) based on its domain.
  *
  * @author Michal Stava &lt;stavamichal@gmail.com&gt;
  */
@@ -134,7 +134,7 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 	@Override
 	public List<String> getDependencies() {
 		List<String> dependencies = new ArrayList<>();
-		dependencies.add(AttributesManager.NS_FACILITY_ATTR_DEF + ":googleGroupNameNamespace");
+		dependencies.add(AttributesManager.NS_FACILITY_ATTR_DEF + ":googleGroupsDomain");
 		//Disallowed because it does not affect value of dependent attribute
 		//dependencies.add(AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:*");
 		return dependencies;


### PR DESCRIPTION
- We now use facility:def:googleGroupName, fixed reference in
  attribute dependencies and comments.