### PR TITLE
CORE: Fixed Candidate comparison

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
@@ -132,4 +132,44 @@ public class Candidate extends User {
 			+ attrNew).append("', additionalUserExtSources='").append(additionalUserExtSources).append("']").toString();
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result
+				+ ((attributes == null) ? 0 : attributes.hashCode());
+		result = prime * result
+				+ ((userExtSource == null) ? 0 : userExtSource.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		Candidate other = (Candidate) obj;
+		if (attributes == null) {
+			if (other.attributes != null) {
+				return false;
+			}
+		} else if (!attributes.equals(other.attributes)) {
+			return false;
+		}
+		if (userExtSource == null) {
+			if (other.userExtSource != null) {
+				return false;
+			}
+		} else if (!userExtSource.equals(other.userExtSource)) {
+			return false;
+		}
+		return true;
+	}
+
 }


### PR DESCRIPTION
- Since Candidate extends User, we must compare it specifically.
  It always have ID=0 hence Users with same name are wrongly
  equals as candidates.