### PR TITLE
Group structure synchronization

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFailed.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFailed.java
@@ -14,7 +14,7 @@ public class GroupStructureSyncFailed extends AuditEvent {
 
 	public GroupStructureSyncFailed(Group group) {
 		this.group = group;
-		this.message = formatMessage( "%s structure synchronization failed.", group);
+		this.message = formatMessage("%s structure synchronization failed.", group);
 	}
 
 	@Override

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFailed.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFailed.java
@@ -1,0 +1,39 @@
+package cz.metacentrum.perun.audit.events.GroupManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+
+public class GroupStructureSyncFailed extends AuditEvent {
+
+    private Group group;
+    private String originalExceptionMessage;
+    private String message;
+
+    @SuppressWarnings("unused") // used by jackson mapper
+    public GroupStructureSyncFailed() {
+    }
+
+    public GroupStructureSyncFailed(Group group, String originalExceptionMessage) {
+        this.group = group;
+        this.originalExceptionMessage = originalExceptionMessage;
+        this.message = formatMessage( "%s structure synchronization failed because of %s.", group, originalExceptionMessage);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public String getOriginalExceptionMessage() {
+        return originalExceptionMessage;
+    }
+
+    @Override
+    public String toString() {
+        return message;
+    }
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFailed.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFailed.java
@@ -5,35 +5,29 @@ import cz.metacentrum.perun.core.api.Group;
 
 public class GroupStructureSyncFailed extends AuditEvent {
 
-    private Group group;
-    private String originalExceptionMessage;
-    private String message;
+	private Group group;
+	private String message;
 
-    @SuppressWarnings("unused") // used by jackson mapper
-    public GroupStructureSyncFailed() {
-    }
+	@SuppressWarnings("unused") // used by jackson mapper
+	public GroupStructureSyncFailed() {
+	}
 
-    public GroupStructureSyncFailed(Group group, String originalExceptionMessage) {
-        this.group = group;
-        this.originalExceptionMessage = originalExceptionMessage;
-        this.message = formatMessage( "%s structure synchronization failed because of %s.", group, originalExceptionMessage);
-    }
+	public GroupStructureSyncFailed(Group group) {
+		this.group = group;
+		this.message = formatMessage( "%s structure synchronization failed.", group);
+	}
 
-    @Override
-    public String getMessage() {
-        return message;
-    }
+	@Override
+	public String getMessage() {
+		return message;
+	}
 
-    public Group getGroup() {
-        return group;
-    }
+	public Group getGroup() {
+		return group;
+	}
 
-    public String getOriginalExceptionMessage() {
-        return originalExceptionMessage;
-    }
-
-    @Override
-    public String toString() {
-        return message;
-    }
+	@Override
+	public String toString() {
+		return message;
+	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFinishedWithErrors.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFinishedWithErrors.java
@@ -1,0 +1,39 @@
+package cz.metacentrum.perun.audit.events.GroupManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+
+public class GroupStructureSyncFinishedWithErrors extends AuditEvent {
+
+    private Group group;
+    private String originalExceptionMessage;
+    private String message;
+
+    @SuppressWarnings("unused") // used by jackson mapper
+    public GroupStructureSyncFinishedWithErrors() {
+    }
+
+    public GroupStructureSyncFinishedWithErrors(Group group, String originalExceptionMessage) {
+        this.group = group;
+        this.originalExceptionMessage = originalExceptionMessage;
+        this.message = formatMessage("%s structure synchronization finished with errors: %s.", group, originalExceptionMessage);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public String getOriginalExceptionMessage() {
+        return originalExceptionMessage;
+    }
+
+    @Override
+    public String toString() {
+        return message;
+    }
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFinishedWithErrors.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupStructureSyncFinishedWithErrors.java
@@ -5,35 +5,29 @@ import cz.metacentrum.perun.core.api.Group;
 
 public class GroupStructureSyncFinishedWithErrors extends AuditEvent {
 
-    private Group group;
-    private String originalExceptionMessage;
-    private String message;
+	private Group group;
+	private String message;
 
-    @SuppressWarnings("unused") // used by jackson mapper
-    public GroupStructureSyncFinishedWithErrors() {
-    }
+	@SuppressWarnings("unused") // used by jackson mapper
+	public GroupStructureSyncFinishedWithErrors() {
+	}
 
-    public GroupStructureSyncFinishedWithErrors(Group group, String originalExceptionMessage) {
-        this.group = group;
-        this.originalExceptionMessage = originalExceptionMessage;
-        this.message = formatMessage("%s structure synchronization finished with errors: %s.", group, originalExceptionMessage);
-    }
+	public GroupStructureSyncFinishedWithErrors(Group group) {
+		this.group = group;
+		this.message = formatMessage("%s structure synchronization finished with errors.", group);
+	}
 
-    @Override
-    public String getMessage() {
-        return message;
-    }
+	@Override
+	public String getMessage() {
+		return message;
+	}
 
-    public Group getGroup() {
-        return group;
-    }
+	public Group getGroup() {
+		return group;
+	}
 
-    public String getOriginalExceptionMessage() {
-        return originalExceptionMessage;
-    }
-
-    @Override
-    public String toString() {
-        return message;
-    }
+	@Override
+	public String toString() {
+		return message;
+	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateGroup.java
@@ -3,6 +3,8 @@ package cz.metacentrum.perun.core.api;
 import java.util.Objects;
 
 /**
+ * Candidate group of Virtual organization
+ *
  * @date 8/30/17.
  * @author Peter Balcirak peter.balcirak@gmail.com
  */
@@ -65,10 +67,13 @@ public class CandidateGroup extends Auditable {
 	public String serializeToString() {
 		StringBuilder str = new StringBuilder();
 
-		return str.append(this.getClass().getSimpleName()).append(":[" +
-				"extSource=<").append(getExtSource() == null ? "\\0" : getExtSource().serializeToString()).append(">" +
-				", parentGroupName=<").append(getParentGroupName()).append(">" +
-				", group=<").append(asGroup() == null ? "\\0" : asGroup().serializeToString()).append(">" +
-				']').toString();
+		return str.append(this.getClass().getSimpleName()).
+				append(":[extSource=<").
+				append(getExtSource() == null ? "\\0" : getExtSource().serializeToString()).
+				append(">, parentGroupName=<").
+				append(getParentGroupName()).
+				append(">, group=<").
+				append(asGroup() == null ? "\\0" : asGroup().serializeToString()).
+				append(">]").toString();
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateGroup.java
@@ -3,7 +3,8 @@ package cz.metacentrum.perun.core.api;
 import java.util.Objects;
 
 /**
- * Candidate group of Virtual organization
+ * Group obtained from an extSource with the name of its parent in the external source.
+ * It can be then created as a group of a virtual organization in Perun.
  *
  * @date 8/30/17.
  * @author Peter Balcirak peter.balcirak@gmail.com
@@ -67,13 +68,13 @@ public class CandidateGroup extends Auditable {
 	public String serializeToString() {
 		StringBuilder str = new StringBuilder();
 
-		return str.append(this.getClass().getSimpleName()).
-				append(":[extSource=<").
-				append(getExtSource() == null ? "\\0" : getExtSource().serializeToString()).
-				append(">, parentGroupName=<").
-				append(getParentGroupName()).
-				append(">, group=<").
-				append(asGroup() == null ? "\\0" : asGroup().serializeToString()).
-				append(">]").toString();
+		return str.append(this.getClass().getSimpleName())
+				.append(":[extSource=<")
+				.append(getExtSource() == null ? "\\0" : getExtSource().serializeToString())
+				.append(">, parentGroupName=<")
+				.append(getParentGroupName())
+				.append(">, group=<")
+				.append(asGroup() == null ? "\\0" : asGroup().serializeToString())
+				.append(">]").toString();
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CandidateGroup.java
@@ -1,0 +1,74 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.Objects;
+
+/**
+ * @date 8/30/17.
+ * @author Peter Balcirak peter.balcirak@gmail.com
+ */
+public class CandidateGroup extends Auditable {
+
+	private ExtSource extSource;
+	private String parentGroupName;
+	private Group group;
+
+	public CandidateGroup() {
+		this.group = new Group();
+	}
+
+	public ExtSource getExtSource() {
+		return extSource;
+	}
+
+	public void setExtSource(ExtSource extSource) {
+		this.extSource = extSource;
+	}
+
+	public String getParentGroupName() {
+		return parentGroupName;
+	}
+
+	public void setParentGroupName(String parentGroupName) {
+		this.parentGroupName = parentGroupName;
+	}
+
+	public Group asGroup() {
+		return group;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+		CandidateGroup that = (CandidateGroup) o;
+		return Objects.equals(getExtSource(), that.getExtSource()) &&
+				Objects.equals(getParentGroupName(), that.getParentGroupName()) &&
+				Objects.equals(asGroup(), that.asGroup());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), getExtSource(), getParentGroupName(), asGroup());
+	}
+
+	@Override
+	public String toString() {
+		return "CandidateGroup{" +
+				"extSource=" + extSource +
+				", parentGroupName='" + parentGroupName + '\'' +
+				", group=" + group +
+				'}';
+	}
+
+	@Override
+	public String serializeToString() {
+		StringBuilder str = new StringBuilder();
+
+		return str.append(this.getClass().getSimpleName()).append(":[" +
+				"extSource=<").append(getExtSource() == null ? "\\0" : getExtSource().serializeToString()).append(">" +
+				", parentGroupName=<").append(getParentGroupName()).append(">" +
+				", group=<").append(asGroup() == null ? "\\0" : asGroup().serializeToString()).append(">" +
+				']').toString();
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -81,8 +81,8 @@ public class CoreConfig {
 	private Map<String, String> oidcIssuersExtsourceTypes = new HashMap<>();
 
 	public int getGroupMaxConcurrentGroupsStructuresToSynchronize() {
-			return groupMaxConcurrentGroupsStructuresToSynchronize;
-		}
+		return groupMaxConcurrentGroupsStructuresToSynchronize;
+	}
 
 	public void setGroupMaxConcurrentGroupsStructuresToSynchronize(int groupMaxConcurrentGroupsStructuresToSynchronize) {
 		this.groupMaxConcurrentGroupsStructuresToSynchronize = groupMaxConcurrentGroupsStructuresToSynchronize;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -34,6 +34,9 @@ public class CoreConfig {
 	private int groupSynchronizationInterval;
 	private int groupSynchronizationTimeout;
 	private int groupMaxConcurentGroupsToSynchronize;
+	private int groupStructureSynchronizationInterval;
+	private int groupStructureSynchronizationTimeout;
+	private int groupMaxConcurrentGroupsStructuresToSynchronize;
 	private int mailchangeValidationWindow;
 	private int pwdresetValidationWindow;
 	private List<String> admins;
@@ -76,6 +79,30 @@ public class CoreConfig {
 	private Map<String, List<AttributeDefinition>> attributesForUpdate = new HashMap<>();
 	private Map<String, String> oidcIssuersExtsourceNames = new HashMap<>();
 	private Map<String, String> oidcIssuersExtsourceTypes = new HashMap<>();
+
+	public int getGroupMaxConcurrentGroupsStructuresToSynchronize() {
+			return groupMaxConcurrentGroupsStructuresToSynchronize;
+		}
+
+	public void setGroupMaxConcurrentGroupsStructuresToSynchronize(int groupMaxConcurrentGroupsStructuresToSynchronize) {
+		this.groupMaxConcurrentGroupsStructuresToSynchronize = groupMaxConcurrentGroupsStructuresToSynchronize;
+	}
+
+	public int getGroupStructureSynchronizationInterval() {
+		return groupStructureSynchronizationInterval;
+	}
+
+	public void setGroupStructureSynchronizationInterval(int groupSynchronizationInterval) {
+		this.groupStructureSynchronizationInterval = groupSynchronizationInterval;
+	}
+
+	public int getGroupStructureSynchronizationTimeout() {
+		return groupStructureSynchronizationTimeout;
+	}
+
+	public void setGroupStructureSynchronizationTimeout(int groupStructureSynchronizationTimeout) {
+		this.groupStructureSynchronizationTimeout = groupStructureSynchronizationTimeout;
+	}
 
 	boolean isDbInitializatorEnabled() {
 		return dbInitializatorEnabled;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupStructureSynchronizationAlreadyRunningException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupStructureSynchronizationAlreadyRunningException.java
@@ -1,0 +1,36 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Group;
+
+/**
+ * Service not exists in underlaying data source.
+ *
+ * @see cz.metacentrum.perun.core.api.exceptions.rt.GroupStructureSynchronizationAlreadyRunningException
+ * @author Peter Balcirak peter.balcirak@gmail.com
+ */
+public class GroupStructureSynchronizationAlreadyRunningException extends PerunException {
+    static final long serialVersionUID = 0;
+
+    private Group group;
+
+    public GroupStructureSynchronizationAlreadyRunningException(String message) {
+        super(message);
+    }
+
+    public GroupStructureSynchronizationAlreadyRunningException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public GroupStructureSynchronizationAlreadyRunningException(Throwable cause) {
+        super(cause);
+    }
+
+    public GroupStructureSynchronizationAlreadyRunningException(Group group) {
+        super(group.toString());
+        this.group = group;
+    }
+
+    public Group getGroup() {
+        return this.group;
+    }
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupStructureSynchronizationAlreadyRunningException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupStructureSynchronizationAlreadyRunningException.java
@@ -3,9 +3,8 @@ package cz.metacentrum.perun.core.api.exceptions;
 import cz.metacentrum.perun.core.api.Group;
 
 /**
- * Service not exists in underlaying data source.
+ * Group structure synchronization is already running for given group
  *
- * @see cz.metacentrum.perun.core.api.exceptions.rt.GroupStructureSynchronizationAlreadyRunningException
  * @author Peter Balcirak peter.balcirak@gmail.com
  */
 public class GroupStructureSynchronizationAlreadyRunningException extends PerunException {

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupStructureSynchronizationAlreadyRunningException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/GroupStructureSynchronizationAlreadyRunningException.java
@@ -8,28 +8,28 @@ import cz.metacentrum.perun.core.api.Group;
  * @author Peter Balcirak peter.balcirak@gmail.com
  */
 public class GroupStructureSynchronizationAlreadyRunningException extends PerunException {
-    static final long serialVersionUID = 0;
+	static final long serialVersionUID = 0;
 
-    private Group group;
+	private Group group;
 
-    public GroupStructureSynchronizationAlreadyRunningException(String message) {
-        super(message);
-    }
+	public GroupStructureSynchronizationAlreadyRunningException(String message) {
+		super(message);
+	}
 
-    public GroupStructureSynchronizationAlreadyRunningException(String message, Throwable cause) {
-        super(message, cause);
-    }
+	public GroupStructureSynchronizationAlreadyRunningException(String message, Throwable cause) {
+		super(message, cause);
+	}
 
-    public GroupStructureSynchronizationAlreadyRunningException(Throwable cause) {
-        super(cause);
-    }
+	public GroupStructureSynchronizationAlreadyRunningException(Throwable cause) {
+		super(cause);
+	}
 
-    public GroupStructureSynchronizationAlreadyRunningException(Group group) {
-        super(group.toString());
-        this.group = group;
-    }
+	public GroupStructureSynchronizationAlreadyRunningException(Group group) {
+		super("Group structure is already running for the group: " + group.toString());
+		this.group = group;
+	}
 
-    public Group getGroup() {
-        return this.group;
-    }
+	public Group getGroup() {
+		return this.group;
+	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -18,7 +18,10 @@
 		<property name="generatedLoginNamespaces" value="#{'${perun.loginNamespace.generated}'.split('\s*,\s*')}"/>
 		<property name="groupSynchronizationInterval" value="${perun.group.synchronization.interval}"/>
 		<property name="groupSynchronizationTimeout" value="${perun.group.synchronization.timeout}"/>
+		<property name="groupStructureSynchronizationInterval" value="${perun.group.structure.synchronization.interval}"/>
+		<property name="groupStructureSynchronizationTimeout" value="${perun.group.structure.synchronization.timeout}"/>
 		<property name="groupMaxConcurentGroupsToSynchronize" value="${perun.group.maxConcurentGroupsToSynchronize}"/>
+		<property name="groupMaxConcurrentGroupsStructuresToSynchronize" value="${perun.group.structure.maxConcurrentGroupsStructuresToSynchronize}"/>
 		<property name="instanceId" value="${perun.instanceId}"/>
 		<property name="instanceName" value="${perun.instanceName}"/>
 		<property name="mailchangeBackupFrom" value="${perun.mailchange.backupFrom}"/>
@@ -75,7 +78,10 @@
 				<prop key="perun.db.type">hsqldb</prop>
 				<prop key="perun.group.synchronization.interval">1</prop>
 				<prop key="perun.group.synchronization.timeout">10</prop>
+				<prop key="perun.group.structure.synchronization.interval">1</prop>
+				<prop key="perun.group.structure.synchronization.timeout">10</prop>
 				<prop key="perun.group.maxConcurentGroupsToSynchronize">10</prop>
+				<prop key="perun.group.structure.maxConcurrentGroupsStructuresToSynchronize">10</prop>
 				<prop key="perun.rpc.powerusers"/>
 				<prop key="perun.perun.db.name">perun</prop>
 				<prop key="perun.rt.url">https://rt3.cesnet.cz/rt/REST/1.0/ticket/new</prop>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -83,7 +83,7 @@ public interface GroupsManager {
 	 * @throws GroupRelationNotAllowed
 	 * @throws GroupRelationAlreadyExists
 	 */
-	Group createGroup(PerunSession perunSession, Group parentGroup, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException, InternalErrorException, GroupRelationNotAllowed, GroupRelationAlreadyExists;
+	Group createGroup(PerunSession perunSession, Group parentGroup, Group group) throws GroupNotExistsException, GroupExistsException, PrivilegeException, InternalErrorException, GroupRelationNotAllowed, GroupRelationAlreadyExists, ExternallyManagedException;
 
 	/**
 	 * If forceDelete is false, delete only group and if this group has members or subgroups, throw an exception.
@@ -852,7 +852,7 @@ public interface GroupsManager {
 	void synchronizeGroups(PerunSession sess) throws InternalErrorException, PrivilegeException;
 
 	/**
-	 * Synchronize all groups structures with members which have enabled group structure synchronization. This method is run by the scheduler every 5 minutes.
+	 * Synchronize all groups structures (with members) which have enabled group structure synchronization. This method is run by the scheduler every 5 minutes.
 	 *
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -21,6 +21,8 @@ import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException
 public interface GroupsManager {
 
 	// Attributes related to the external groups
+	// Contains query need to get the subject groups
+	public static final String GROUPSQUERY_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupsQuery";
 	// Contains query need to get the group members
 	public static final String GROUPMEMBERSQUERY_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupMembersQuery";
 	// Contains optional filter for members in group
@@ -31,10 +33,16 @@ public interface GroupsManager {
 	public static final String GROUPMEMBERSEXTSOURCE_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupMembersExtSource";
 	// If the synchronization is enabled/disabled, value is true/false
 	public static final String GROUPSYNCHROENABLED_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":synchronizationEnabled";
+	// If the group structure synchronization is enabled/disabled, value is true/false
+	public static final String GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureSynchronizationEnabled";
 	// Defines the interval, when the group has to be synchronized. It is fold of 5 minutes
 	public static final String GROUPSYNCHROINTERVAL_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":synchronizationInterval";
+	// Defines the interval, when the group structure has to be synchronized. It is fold of 5 minutes
+	public static final String GROUPSTRUCTURESYNCHROINTERVAL_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureSynchronizationInterval";
 	// Defines if we want to skip updating already existing members in group from extSource (updating attributes etc.)
 	public static final String GROUPLIGHTWEIGHTSYNCHRONIZATION_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":lightweightSynchronization";
+	// Defines if we want to synchronize group structure without group hierarchy
+	public static final String GROUPFLATSYNCHRONIZATION_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":flatGroupStructureEnabled";
 
 	public static final String GROUP_SHORT_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+$";
 	public static final String GROUP_FULL_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+([:][-a-zA-Z.0-9_ ]+)*";
@@ -94,7 +102,7 @@ public interface GroupsManager {
 	 * @throws GroupRelationDoesNotExist
 	 * @throws GroupRelationCannotBeRemoved
 	 */
-	void deleteGroup(PerunSession perunSession, Group group, boolean forceDelete) throws GroupNotExistsException, InternalErrorException, PrivilegeException, RelationExistsException, GroupAlreadyRemovedException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved;
+	void deleteGroup(PerunSession perunSession, Group group, boolean forceDelete) throws GroupNotExistsException, InternalErrorException, PrivilegeException, RelationExistsException, GroupAlreadyRemovedException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved, ExternallyManagedException;
 
 	/**
 	 * Deletes group only if has no subgroups and no members. Other way throw exception.
@@ -112,7 +120,7 @@ public interface GroupsManager {
 	 * @throws GroupRelationDoesNotExist
 	 * @throws GroupRelationCannotBeRemoved
 	 */
-	void deleteGroup(PerunSession perunSession, Group group) throws GroupNotExistsException, InternalErrorException, PrivilegeException, RelationExistsException, GroupAlreadyRemovedException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved;
+	void deleteGroup(PerunSession perunSession, Group group) throws GroupNotExistsException, InternalErrorException, PrivilegeException, RelationExistsException, GroupAlreadyRemovedException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved, ExternallyManagedException;
 
 	/**
 	 * Delete all groups in list from perun. (Except members group)
@@ -139,7 +147,7 @@ public interface GroupsManager {
 	 * @throws GroupRelationDoesNotExist
 	 * @throws GroupRelationCannotBeRemoved
 	 */
-	void deleteGroups(PerunSession perunSession, List<Group> groups, boolean forceDelete) throws GroupNotExistsException, InternalErrorException, PrivilegeException, GroupAlreadyRemovedException, RelationExistsException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved;
+	void deleteGroups(PerunSession perunSession, List<Group> groups, boolean forceDelete) throws GroupNotExistsException, InternalErrorException, PrivilegeException, GroupAlreadyRemovedException, RelationExistsException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved, ExternallyManagedException;
 
 	/**
 	 * Deletes all groups under the VO except built-in groups (members, admins groups).
@@ -823,6 +831,18 @@ public interface GroupsManager {
 	 */
 	void forceGroupSynchronization(PerunSession sess, Group group) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupSynchronizationAlreadyRunningException;
 
+    /**
+     * Puts the group on the first place to the queue of groups waiting for group structure synchronization.
+     *
+     * @param sess
+     * @param group
+     * @throws InternalErrorException
+     * @throws GroupNotExistsException
+     * @throws PrivilegeException
+     * @throws GroupStructureSynchronizationAlreadyRunningException
+     */
+    void forceGroupStructureSynchronization(PerunSession sess, Group group) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupStructureSynchronizationAlreadyRunningException;
+
 	/**
 	 * Synchronize all groups which have enabled synchronization. This method is run by the scheduler every 5 minutes.
 	 *
@@ -830,6 +850,14 @@ public interface GroupsManager {
 	 * @throws PrivilegeException
 	 */
 	void synchronizeGroups(PerunSession sess) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Synchronize all groups structures with members which have enabled group structure synchronization. This method is run by the scheduler every 5 minutes.
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	void synchronizeGroupsStructures(PerunSession sess) throws InternalErrorException, PrivilegeException;
 
 	/**
 	 * Returns all member's groups. Except members groups.
@@ -991,7 +1019,7 @@ public interface GroupsManager {
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, WrongAttributeValueException, WrongReferenceAttributeValueException, ExternallyManagedException;
 
 	/**
 	 * Removes a union relation between two groups. All indirect members that originate from operand group are removed from result group.
@@ -1006,7 +1034,7 @@ public interface GroupsManager {
 	 * @throws GroupRelationCannotBeRemoved
 	 * @throws PrivilegeException
 	 */
-	void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved;
+	void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved, ExternallyManagedException;
 
 	/**
 	 * Get list of group unions for specified group.
@@ -1035,7 +1063,7 @@ public interface GroupsManager {
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void moveGroup(PerunSession sess, Group destinationGroup, Group movingGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupMoveNotAllowedException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void moveGroup(PerunSession sess, Group destinationGroup, Group movingGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupMoveNotAllowedException, WrongAttributeValueException, WrongReferenceAttributeValueException, ExternallyManagedException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Set Members Group status for specified DIRECT member and group.
@@ -1098,5 +1126,4 @@ public interface GroupsManager {
 	 * @return true if given member can extend membership in given group or throws exception with reason why not
 	 */
 	boolean canExtendMembershipInGroupWithReason(PerunSession sess, Member member, Group group) throws InternalErrorException, MemberNotExistsException, GroupNotExistsException, PrivilegeException, ExtendMembershipException;
-
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -34,15 +34,15 @@ public interface GroupsManager {
 	// If the synchronization is enabled/disabled, value is true/false
 	public static final String GROUPSYNCHROENABLED_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":synchronizationEnabled";
 	// If the group structure synchronization is enabled/disabled, value is true/false
-	public static final String GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureSynchronizationEnabled";
+	public static final String GROUPS_STRUCTURE_SYNCHRO_ENABLED_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureSynchronizationEnabled";
 	// Defines the interval, when the group has to be synchronized. It is fold of 5 minutes
 	public static final String GROUPSYNCHROINTERVAL_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":synchronizationInterval";
 	// Defines the interval, when the group structure has to be synchronized. It is fold of 5 minutes
-	public static final String GROUPSTRUCTURESYNCHROINTERVAL_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureSynchronizationInterval";
+	public static final String GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureSynchronizationInterval";
 	// Defines if we want to skip updating already existing members in group from extSource (updating attributes etc.)
 	public static final String GROUPLIGHTWEIGHTSYNCHRONIZATION_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":lightweightSynchronization";
 	// Defines if we want to synchronize group structure without group hierarchy
-	public static final String GROUPFLATSYNCHRONIZATION_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":flatGroupStructureEnabled";
+	public static final String GROUP_FLAT_SYNCHRONIZATION_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":flatGroupStructureEnabled";
 
 	public static final String GROUP_SHORT_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+$";
 	public static final String GROUP_FULL_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+([:][-a-zA-Z.0-9_ ]+)*";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
@@ -267,8 +267,6 @@ public interface ExtSourcesManagerBl {
 	 *
 	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
 	 *
-	 * 	 * Method used by group structure synchronization
-	 *
 	 * @param perunSession
 	 * @param groupSubjectData
 	 * @param source
@@ -284,8 +282,6 @@ public interface ExtSourcesManagerBl {
 	 * 1. For each groupSubjectsData call method get CandidateGroup and then add result to List
 	 *
 	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
-	 *
-	 * Method used by group structure synchronization
 	 *
 	 * @param perunSession
 	 * @param groupSubjectsData

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
@@ -256,14 +256,7 @@ public interface ExtSourcesManagerBl {
 	Map<String, String> getAttributes(ExtSource extSource) throws InternalErrorException;
 
 	/**
-	 * Get the candidate group from subjectData.
-	 *
-	 * 1. Create new candidate group object
-	 * 2. Set extSource to the candidate group
-	 * 3. Set groupName to the candidate group
-	 * 	  (If first name of candidate is not in correct format of name, set null instead)
-	 * 4. Set parentGroupName to the candidate group
-	 * 5. Set description to the candidate group
+	 * Generate a candidate group from a group subject data.
 	 *
 	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
 	 *
@@ -277,9 +270,7 @@ public interface ExtSourcesManagerBl {
 	CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source) throws InternalErrorException;
 
 	/**
-	 * Get the candidate groups from subjectData.
-	 *
-	 * 1. For each groupSubjectsData call method get CandidateGroup and then add result to List
+	 * Generate candidate groups from a group subject data.
 	 *
 	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
@@ -6,6 +6,7 @@ package cz.metacentrum.perun.core.bl;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Candidate;
+import cz.metacentrum.perun.core.api.CandidateGroup;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -253,4 +254,46 @@ public interface ExtSourcesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	Map<String, String> getAttributes(ExtSource extSource) throws InternalErrorException;
+
+	/**
+	 * Get the candidate group from subjectData.
+	 *
+	 * 1. Create new candidate group object
+	 * 2. Set extSource to the candidate group
+	 * 3. Set groupName to the candidate group
+	 * 	  (If first name of candidate is not in correct format of name, set null instead)
+	 * 4. Set parentGroupName to the candidate group
+	 * 5. Set description to the candidate group
+	 *
+	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
+	 *
+	 * 	 * Method used by group structure synchronization
+	 *
+	 * @param perunSession
+	 * @param groupSubjectData
+	 * @param source
+	 *
+	 * @return Candidate group object
+	 * @throws InternalErrorException
+	 */
+	CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source) throws InternalErrorException;
+
+	/**
+	 * Get the candidate groups from subjectData.
+	 *
+	 * 1. For each groupSubjectsData call method get CandidateGroup and then add result to List
+	 *
+	 * IMPORTANT: expected, that these subjectData was get from the ExtSource before using.
+	 *
+	 * Method used by group structure synchronization
+	 *
+	 * @param perunSession
+	 * @param groupSubjectsData
+	 * @param source
+	 *
+	 * @return Candidate group objects
+	 * @throws InternalErrorException
+	 */
+	List<CandidateGroup> generateCandidateGroups(PerunSession perunSession, List<Map<String,String>> groupSubjectsData, ExtSource source) throws InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -949,7 +949,7 @@ public interface GroupsManagerBl {
 	void forceGroupSynchronization(PerunSession sess, Group group) throws InternalErrorException, GroupSynchronizationAlreadyRunningException;
 
 	/**
-	 * Synchronize the group structure with and external group structure. It checks if the synchronization of the same group is already in progress.
+	 * Synchronize the group structure with an external group structure. It checks if the synchronization of the same group is already in progress.
 	 *
 	 * @param group the group to be forced this way
 	 * @throws InternalErrorException
@@ -1290,7 +1290,7 @@ public interface GroupsManagerBl {
 	 * Also log information about failed synchronization to auditer_log.
 	 *
 	 * IMPORTANT: This method runs in new transaction (because of using in synchronization of groups)
-	 * With a new transaction, rollback on the main method, where this one is used, will not revert saving of this information.
+	 * This method is run in a new transaction to ensure successful saving of given information, in case of a rollback in previous transaction.
 	 * However, this method cannot be used in method running in the nested transaction, where the group was changed in the database.
 	 *
 	 * Set timestamp to attribute "group_def_lastSynchronizationTimestamp"
@@ -1317,7 +1317,7 @@ public interface GroupsManagerBl {
 	 *
 	 * IMPORTANT: This method runs in nested transaction so it can be used in another transaction
 	 * With a nested transaction, this method can be used in method running in the nested transaction, where the group was changed in the database.
-	 * However, rollback on the main method, where this one is used, will revert saving of this information.
+	 * However, rollback on the outer transaction, where this method is used, will revert saving of given information.
 	 *
 	 * Set timestamp to attribute "group_def_lastSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastSynchronizationState"
@@ -1342,8 +1342,8 @@ public interface GroupsManagerBl {
 	 * This method will set timestamp, state and exceptionMessage to group attributes for the group structure.
 	 * Also log information about failed group structure synchronization to auditer_log.
 	 *
-	 * IMPORTANT: This method runs in new transaction (because of using in synchronization of groups structures)
-	 * With a new transaction, rollback on the main method, where this one is used, will not revert saving of this information.
+	 * IMPORTANT: This method runs in new transaction (because of it being used in synchronization of groups structures)
+	 * This method is run in a new transaction to ensure successful saving of given information, in case of a rollback in previous transaction.
 	 * However, this method cannot be used in method running in the nested transaction, where the group was changed in the database.
 	 *
 	 * Set timestamp to attribute "group_def_lastGroupStructureSynchronizationTimestamp"
@@ -1368,9 +1368,9 @@ public interface GroupsManagerBl {
 	 * This method will set timestamp, state and exceptionMessage to group attributes for the group structure.
 	 * Also log information about failed group structure synchronization to auditer_log.
 	 *
-	 * IMPORTANT: This method runs in nested transaction (because of using in synchronization of groups structures)
+	 * IMPORTANT: This method runs in nested transaction.
 	 * With a nested transaction, this method can be used in method running in the nested transaction, where the group was changed in the database.
-	 * However, rollback on the main method, where this one is used, will revert saving of this information.
+	 * However, rollback on the outer transaction, where this method is used, will revert saving of given information.
 	 *
 	 * Set timestamp to attribute "group_def_lastGroupStructureSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastGroupStructureSynchronizationState"

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -1298,11 +1298,13 @@ public interface GroupsManagerBl {
 	 * Also log information about failed synchronization to auditer_log.
 	 *
 	 * IMPORTANT: This method runs in new transaction (because of using in synchronization of groups)
+	 * With a new transaction, rollback on the main method, where this one is used, will not revert saving of this information.
+	 * However, this method cannot be used in method running in the nested transaction, where the group was changed in the database.
 	 *
 	 * Set timestamp to attribute "group_def_lastSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastSynchronizationState"
 	 *
-	 * FailedDueToException is true means group synchronization failed at all.
+	 * FailedDueToException is true means group synchronization failed completely.
 	 * FailedDueToException is false means group synchronization is ok or finished with some errors (some members were not synchronized)
 	 *
 	 * @param sess perun session
@@ -1322,6 +1324,8 @@ public interface GroupsManagerBl {
 	 * Also log information about failed synchronization to auditer_log.
 	 *
 	 * IMPORTANT: This method runs in nested transaction so it can be used in another transaction
+	 * With a nested transaction, this method can be used in method running in the nested transaction, where the group was changed in the database.
+	 * However, rollback on the main method, where this one is used, will revert saving of this information.
 	 *
 	 * Set timestamp to attribute "group_def_lastSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastSynchronizationState"
@@ -1347,6 +1351,8 @@ public interface GroupsManagerBl {
 	 * Also log information about failed group structure synchronization to auditer_log.
 	 *
 	 * IMPORTANT: This method runs in new transaction (because of using in synchronization of groups structures)
+	 * With a new transaction, rollback on the main method, where this one is used, will not revert saving of this information.
+	 * However, this method cannot be used in method running in the nested transaction, where the group was changed in the database.
 	 *
 	 * 1. Get current timestamp
 	 * 2. Check if group or session are null
@@ -1360,7 +1366,7 @@ public interface GroupsManagerBl {
 	 * Set timestamp to attribute "group_def_lastGroupStructureSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastGroupStructureSynchronizationState"
 	 *
-	 * FailedDueToException is true means group structure synchronization failed at all.
+	 * FailedDueToException is true means group structure synchronization failed completely.
 	 * FailedDueToException is false means group structure synchronization is ok or finished with some errors (some groups were not synchronized)
 	 *
 	 * @param sess perun session
@@ -1380,6 +1386,8 @@ public interface GroupsManagerBl {
 	 * Also log information about failed group structure synchronization to auditer_log.
 	 *
 	 * IMPORTANT: This method runs in nested transaction (because of using in synchronization of groups structures)
+	 * With a nested transaction, this method can be used in method running in the nested transaction, where the group was changed in the database.
+	 * However, rollback on the main method, where this one is used, will revert saving of this information.
 	 *
 	 * 1. Get current timestamp
 	 * 2. Check if group or session are null
@@ -1393,7 +1401,7 @@ public interface GroupsManagerBl {
 	 * Set timestamp to attribute "group_def_lastGroupStructureSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastGroupStructureSynchronizationState"
 	 *
-	 * FailedDueToException is true means group structure synchronization failed at all.
+	 * FailedDueToException is true means group structure synchronization failed completely.
 	 * FailedDueToException is false means group structure synchronization is ok or finished with some errors (some groups were not synchronized)
 	 *
 	 * @param sess perun session
@@ -1636,8 +1644,7 @@ public interface GroupsManagerBl {
 	List<String> synchronizeGroupStructure(PerunSession sess, Group group) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, ExtSourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupNotExistsException ;
 
 	/**
-	 * Check if there is group structure synchronization enabled for this group or in its parent path
-	 *
+	 * Check if the group or its subgroups are defined as synchronized from an external source at this moment.
 	 *
 	 * @param session
 	 * @param group
@@ -1647,7 +1654,7 @@ public interface GroupsManagerBl {
 	boolean isGroupInStructureSynchronizationTree(PerunSession session, Group group) throws InternalErrorException;
 
 	/**
-	 * Check if there is group structure synchronization enabled in parent path
+	 * Check if the group is defined as synchronized from an external source at this moment.
 	 *
 	 * 1. If group doesn't have parent return false
 	 * 2. Get groups parent object
@@ -1662,7 +1669,7 @@ public interface GroupsManagerBl {
 	boolean isGroupSynchronizedFromExternallSource(PerunSession session, Group group) throws InternalErrorException;
 
 	/**
-	 * Check if there is synchronized child group
+	 * Check if there is a subgroup of the group, which is defined as synchronized from an external source at this moment.
 	 *
 	 * 1. For each subGroup:
 	 *      1.1 if it has enabled group structure synchronization, return true

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -949,9 +949,7 @@ public interface GroupsManagerBl {
 	void forceGroupSynchronization(PerunSession sess, Group group) throws InternalErrorException, GroupSynchronizationAlreadyRunningException;
 
 	/**
-	 * Force group structure synchronization.
-	 *
-	 * 1. Adds the group on the first place to the queue of groups waiting for group structure synchronization.
+	 * Synchronize the group structure with and external group structure. It checks if the synchronization of the same group is already in progress.
 	 *
 	 * @param group the group to be forced this way
 	 * @throws InternalErrorException
@@ -968,12 +966,6 @@ public interface GroupsManagerBl {
 
 	/**
 	 * Synchronize all groups structures which have enabled group structure synchronization. This method is run by the scheduler every 5 minutes.
-	 *
-	 * 1. Process current threads - Interrupt threads after timeout and remove all interrupted threads
-	 * 2. Create and start new threads
-	 * 3. Add new groups to the group structure synchronization pool ( groups which have enabled group structure synchronization)
-	 * 4. Save state of synchronization to the info log
-	 *
 	 *
 	 * @throws InternalErrorException
 	 */
@@ -1354,15 +1346,6 @@ public interface GroupsManagerBl {
 	 * With a new transaction, rollback on the main method, where this one is used, will not revert saving of this information.
 	 * However, this method cannot be used in method running in the nested transaction, where the group was changed in the database.
 	 *
-	 * 1. Get current timestamp
-	 * 2. Check if group or session are null
-	 * 3. Set correct format of currentTimestamp
-	 * 4. prepare container for attributes which will be set
-	 * 5. process exception message
-	 * 6. prepare timestamp and state attributes
-	 * 7. Set attributes at once
-	 *
-	 *
 	 * Set timestamp to attribute "group_def_lastGroupStructureSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastGroupStructureSynchronizationState"
 	 *
@@ -1388,15 +1371,6 @@ public interface GroupsManagerBl {
 	 * IMPORTANT: This method runs in nested transaction (because of using in synchronization of groups structures)
 	 * With a nested transaction, this method can be used in method running in the nested transaction, where the group was changed in the database.
 	 * However, rollback on the main method, where this one is used, will revert saving of this information.
-	 *
-	 * 1. Get current timestamp
-	 * 2. Check if group or session are null
-	 * 3. Set correct format of currentTimestamp
-	 * 4. prepare container for attributes which will be set
-	 * 5. process exception message
-	 * 6. prepare timestamp and state attributes
-	 * 7. Set attributes at once
-	 *
 	 *
 	 * Set timestamp to attribute "group_def_lastGroupStructureSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastGroupStructureSynchronizationState"
@@ -1616,19 +1590,7 @@ public interface GroupsManagerBl {
 	boolean canExtendMembershipInGroupWithReason(PerunSession sess, Member member, Group group) throws InternalErrorException, ExtendMembershipException;
 
 	/**
-	 * Synchronize groups with the external source groups under base group.
-	 *
-	 * 1. Get base group extSource from which will be groups synchronized
-	 * 2. Prepare containers for work with groups
-	 * 3. Get all actual groups
-	 * 4. Get subjects from extSource
-	 * 5. If this is synchronization with flat structure, every parentGroup set to null
-	 * 6. Convert subjects to candidate groups
-	 * 7. Categorize which groups will be added, updated and removed
-	 * 8. Add not presented candidate groups under base group
-	 * 9. Update groups already presented under base group
-	 * 10. Remove groups from base group who are not presented in extSource anymore
-	 * 11. Synchronize members for each subGroup under base group
+	 * Synchronize a group structure with an external source group structure under the group.
 	 *
 	 * @param sess
 	 * @param group base group under which will be synchronized structure of groups
@@ -1656,11 +1618,6 @@ public interface GroupsManagerBl {
 	/**
 	 * Check if the group is defined as synchronized from an external source at this moment.
 	 *
-	 * 1. If group doesn't have parent return false
-	 * 2. Get groups parent object
-	 * 3. If that object has group structure synchronization enabled, return true
-	 * 4. Recursively call this method on the parent group object
-	 *
 	 * @param session
 	 * @param group
 	 * @return
@@ -1670,10 +1627,6 @@ public interface GroupsManagerBl {
 
 	/**
 	 * Check if there is a subgroup of the group, which is defined as synchronized from an external source at this moment.
-	 *
-	 * 1. For each subGroup:
-	 *      1.1 if it has enabled group structure synchronization, return true
-	 * 2. Return false
 	 *
 	 * @param session
 	 * @param group

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -6731,6 +6731,84 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
 		attributes.put(attr, rights);
 
+		//urn:perun:group:attribute-def:def:groupStructureSynchronizationEnabled
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(Boolean.class.getName());
+		attr.setFriendlyName("groupStructureSynchronizationEnabled");
+		attr.setDisplayName("Group structure synchronization enabled");
+		attr.setDescription("Enables group structure synchronization from external source.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
+		//urn:perun:group:attribute-def:def:groupStructuresynchronizationInterval
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("groupStructureSynchronizationInterval");
+		attr.setDisplayName("Group structure synchronization interval");
+		attr.setDescription("Time between two successful group structure synchronizations.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
+		//urn:perun:group:attribute-def:def:lastGroupStructureSynchronizationState
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("lastGroupStructureSynchronizationState");
+		attr.setDisplayName("Last group structure synchronization state");
+		attr.setDescription("If group structure is synchronized, there will be information about state of last synchronization.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
+		//urn:perun:group:attribute-def:def:lastGroupStructureSynchronizationTimestamp
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("lastGroupStructureSynchronizationTimestamp");
+		attr.setDisplayName("Last group structure Synchronization timestamp");
+		attr.setDescription("If group structure is synchronized, there will be the last timestamp of group synchronization.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
+		//urn:perun:group:attribute-def:def:flatGroupStructureEnabled
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(Boolean.class.getName());
+		attr.setFriendlyName("flatGroupStructureEnabled");
+		attr.setDisplayName("Flat group structure enabled");
+		attr.setDescription("If true, then every synchronized group will be right under base group.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Arrays.asList(ActionType.READ, ActionType.WRITE)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
+		//urn:perun:group:attribute-def:def:lastSuccessGroupStructureSynchronizationTimestamp
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("lastSuccessGroupStructuresSynchronizationTimestamp");
+		attr.setDisplayName("Last successful group structure synchronization timestamp");
+		attr.setDescription("If group structure is synchronized, there will be timestamp of last successful synchronization.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
 		//urn:perun:group:attribute-def:def:authoritativeGroup
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -6809,6 +6809,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
 		attributes.put(attr, rights);
 
+		//urn:perun:group:attribute-def:def:groupsQuery
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("groupsQuery");
+		attr.setDisplayName("Groups query");
+		attr.setDescription("Query (SQL) on external source which retrieves list of it's groups.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
 		//urn:perun:group:attribute-def:def:authoritativeGroup
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -460,8 +460,9 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 
 	@Override
 	public CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source) throws InternalErrorException {
-		if(groupSubjectData == null || groupSubjectData.isEmpty()) throw new InternalErrorException(" Group subject data can't be null or empty, at least group name has to exists.");
-		if(source == null) throw new InternalErrorException(" ExtSource cannot be null while generating CandidateGroup");
+		if(groupSubjectData == null) throw new InternalErrorException("Group subject data cannot be null.");
+		if(groupSubjectData.isEmpty()) throw new InternalErrorException("Group subject data cannot be empty, at least group name has to exists.");
+		if(source == null) throw new InternalErrorException("ExtSource cannot be null while generating CandidateGroup");
 
 		CandidateGroup candidateGroup = new CandidateGroup();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Candidate;
+import cz.metacentrum.perun.core.api.CandidateGroup;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -453,6 +454,39 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 		candidate.setAttributes(attributes);
 
 		return candidate;
+	}
+
+	@Override
+	public CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source) throws InternalErrorException {
+		if(groupSubjectData == null || groupSubjectData.isEmpty()) throw new InternalErrorException(" Group subject data can't be null or empty, at least group name has to exists.");
+
+		CandidateGroup candidateGroup = new CandidateGroup();
+
+		candidateGroup.setExtSource(source);
+
+		candidateGroup.asGroup().setName(groupSubjectData.get("groupName"));
+		if(candidateGroup.asGroup().getName() != null) {
+			Matcher name = namePattern.matcher(candidateGroup.asGroup().getName());
+			if(!name.matches()) throw new InternalErrorException("Group subject data has to contains valid group name!");
+		} else {
+			throw new InternalErrorException("group name cannot be null in Group subject data!");
+		}
+
+		candidateGroup.setParentGroupName(groupSubjectData.get("parentGroupName"));
+		candidateGroup.asGroup().setDescription(groupSubjectData.get("description"));
+
+		return candidateGroup;
+	}
+
+	@Override
+	public List<CandidateGroup> generateCandidateGroups(PerunSession perunSession, List<Map<String,String>> subjectsData, ExtSource source) throws InternalErrorException {
+		List<CandidateGroup> candidateGroups= new ArrayList<>();
+
+		for (Map<String, String> subjectData : subjectsData) {
+			candidateGroups.add(generateCandidateGroup(perunSession, subjectData, source));
+		}
+
+		return candidateGroups;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -466,8 +466,9 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 		CandidateGroup candidateGroup = new CandidateGroup();
 
 		candidateGroup.setExtSource(source);
-
 		candidateGroup.asGroup().setName(groupSubjectData.get(GroupsManagerBlImpl.GROUP_NAME));
+
+		// Check if the group name is not null and if it is in valid format.
 		if(candidateGroup.asGroup().getName() != null) {
 			Matcher name = groupNamePattern.matcher(candidateGroup.asGroup().getName());
 			if(!name.matches()) throw new InternalErrorException("Group subject data has to contains valid group name!");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.audit.events.ExtSourcesManagerEvents.ExtSourceCreate
 import cz.metacentrum.perun.audit.events.ExtSourcesManagerEvents.ExtSourceDeleted;
 import cz.metacentrum.perun.audit.events.ExtSourcesManagerEvents.ExtSourceRemovedFromGroup;
 import cz.metacentrum.perun.audit.events.ExtSourcesManagerEvents.ExtSourceRemovedFromVo;
+import cz.metacentrum.perun.core.api.GroupsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 	final static Logger log = LoggerFactory.getLogger(ExtSourcesManagerBlImpl.class);
 	// \\p{L} means any unicode char
 	private static final Pattern namePattern = Pattern.compile("^[\\p{L} ,.0-9_'-]+$");
+	private static final Pattern groupNamePattern = Pattern.compile(GroupsManager.GROUP_SHORT_NAME_REGEXP);
 
 	private final ExtSourcesManagerImplApi extSourcesManagerImpl;
 	private PerunBl perunBl;
@@ -459,21 +461,22 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 	@Override
 	public CandidateGroup generateCandidateGroup(PerunSession perunSession, Map<String,String> groupSubjectData, ExtSource source) throws InternalErrorException {
 		if(groupSubjectData == null || groupSubjectData.isEmpty()) throw new InternalErrorException(" Group subject data can't be null or empty, at least group name has to exists.");
+		if(source == null) throw new InternalErrorException(" ExtSource cannot be null while generating CandidateGroup");
 
 		CandidateGroup candidateGroup = new CandidateGroup();
 
 		candidateGroup.setExtSource(source);
 
-		candidateGroup.asGroup().setName(groupSubjectData.get("groupName"));
+		candidateGroup.asGroup().setName(groupSubjectData.get(GroupsManagerBlImpl.GROUP_NAME));
 		if(candidateGroup.asGroup().getName() != null) {
-			Matcher name = namePattern.matcher(candidateGroup.asGroup().getName());
+			Matcher name = groupNamePattern.matcher(candidateGroup.asGroup().getName());
 			if(!name.matches()) throw new InternalErrorException("Group subject data has to contains valid group name!");
 		} else {
 			throw new InternalErrorException("group name cannot be null in Group subject data!");
 		}
 
-		candidateGroup.setParentGroupName(groupSubjectData.get("parentGroupName"));
-		candidateGroup.asGroup().setDescription(groupSubjectData.get("description"));
+		candidateGroup.setParentGroupName(groupSubjectData.get(GroupsManagerBlImpl.PARENT_GROUP_NAME));
+		candidateGroup.asGroup().setDescription(groupSubjectData.get(GroupsManagerBlImpl.GROUP_DESCRIPTION));
 
 		return candidateGroup;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -3590,9 +3590,11 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			}
 		} else {
 			if(failedDueToException) {
-				getPerunBl().getAuditer().log(sess, new GroupStructureSyncFailed(group, originalExceptionMessage));
+				getPerunBl().getAuditer().log(sess, new GroupStructureSyncFailed(group));
+				log.debug("{} structure synchronization failed because of {}", group, originalExceptionMessage);
 			} else {
-				getPerunBl().getAuditer().log(sess, new GroupStructureSyncFinishedWithErrors(group, originalExceptionMessage));
+				getPerunBl().getAuditer().log(sess, new GroupStructureSyncFinishedWithErrors(group));
+				log.debug("{} structure synchronization finished with errors: {}", group, originalExceptionMessage);
 			}
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -84,7 +84,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "createGroup - subGroup");
 		}
 
-		if(getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, parentGroup))	{
+		if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, parentGroup)) {
 			throw new ExternallyManagedException("Parent group " + parentGroup + " is externally managed");
 		}
 
@@ -106,7 +106,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "deleteGroup");
 				}
 
-		if(getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group) || getGroupsManagerBl().hasGroupSynchronizedChild(sess, group))	{
+		if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group) || getGroupsManagerBl().hasGroupSynchronizedChild(sess, group)) {
 			throw new ExternallyManagedException("Group " + group + " or some of the subGroups are externally managed");
 		}
 		getGroupsManagerBl().deleteGroup(sess, group, forceDelete);
@@ -140,7 +140,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		for(Group group: groups) {
 			getGroupsManagerBl().checkGroupExists(perunSession, group);
 
-			if(getGroupsManagerBl().isGroupInStructureSynchronizationTree(perunSession, group) || getGroupsManagerBl().hasGroupSynchronizedChild(perunSession, group))	{
+			if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(perunSession, group) || getGroupsManagerBl().hasGroupSynchronizedChild(perunSession, group)) {
 				throw new ExternallyManagedException("Group " + group + " or some of the subGroups are externally managed!");
 			}
 
@@ -264,7 +264,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		// Check if the group is externally synchronized
 		Attribute attrSynchronizeEnabled = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GROUPSYNCHROENABLED_ATTRNAME);
-		if (Objects.equals("true", (String) attrSynchronizeEnabled.getValue()) || getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group)) {
+		if ("true".equals(attrSynchronizeEnabled.getValue()) || getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group)) {
 			throw new ExternallyManagedException("Adding of member is not allowed. Group is externally managed.");
 		}
 
@@ -285,7 +285,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		// Check if the group is externally synchronized
 		Attribute attrSynchronizeEnabled = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GROUPSYNCHROENABLED_ATTRNAME);
-		if (Objects.equals("true", (String) attrSynchronizeEnabled.getValue()) || getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group)) {
+		if ("true".equals(attrSynchronizeEnabled.getValue()) || getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group)) {
 			throw new ExternallyManagedException("Removing of member is not allowed. Group is externally managed.");
 		}
 
@@ -988,7 +988,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
 			&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group))  {
-			throw new PrivilegeException(sess, "synchronizeGroupStructure");
+			throw new PrivilegeException(sess, "forceGroupStructureSynchronization");
 		}
 
 		getGroupsManagerBl().forceGroupStructureSynchronization(sess, group);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -981,18 +981,18 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-    public void forceGroupStructureSynchronization(PerunSession sess, Group group) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupStructureSynchronizationAlreadyRunningException {
-        Utils.checkPerunSession(sess);
-        getGroupsManagerBl().checkGroupExists(sess, group);
+	public void forceGroupStructureSynchronization(PerunSession sess, Group group) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupStructureSynchronizationAlreadyRunningException {
+		Utils.checkPerunSession(sess);
+		getGroupsManagerBl().checkGroupExists(sess, group);
 
-        // Authorization
-        if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
-                && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group))  {
-            throw new PrivilegeException(sess, "synchronizeGroupStructure");
-        }
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
+			&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group))  {
+			throw new PrivilegeException(sess, "synchronizeGroupStructure");
+		}
 
-        getGroupsManagerBl().forceGroupStructureSynchronization(sess, group);
-    }
+		getGroupsManagerBl().forceGroupStructureSynchronization(sess, group);
+	}
 
 	@Override
 	public void synchronizeGroups(PerunSession sess) throws InternalErrorException, PrivilegeException {
@@ -1018,8 +1018,8 @@ public class GroupsManagerEntry implements GroupsManager {
 		getGroupsManagerBl().synchronizeGroupsStructures(sess);
 	}
 
-		@Override
-		public List<Group> getMemberGroups(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException {
+	@Override
+	public List<Group> getMemberGroups(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -92,7 +92,7 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public void deleteGroup(PerunSession sess, Group group, boolean forceDelete) throws GroupNotExistsException, InternalErrorException, PrivilegeException, RelationExistsException, GroupAlreadyRemovedException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved {
+	public void deleteGroup(PerunSession sess, Group group, boolean forceDelete) throws GroupNotExistsException, InternalErrorException, PrivilegeException, RelationExistsException, GroupAlreadyRemovedException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved, ExternallyManagedException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, group);
 
@@ -102,11 +102,14 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "deleteGroup");
 				}
 
+		if(getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group) || getGroupsManagerBl().hasGroupSynchronizedChild(sess, group))	{
+			throw new ExternallyManagedException("Group " + group + "or some of the subGroups are externally managed");
+		}
 		getGroupsManagerBl().deleteGroup(sess, group, forceDelete);
 	}
 
 	@Override
-	public void deleteGroup(PerunSession sess, Group group) throws GroupNotExistsException, InternalErrorException, PrivilegeException, RelationExistsException, GroupAlreadyRemovedException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved {
+	public void deleteGroup(PerunSession sess, Group group) throws GroupNotExistsException, InternalErrorException, PrivilegeException, RelationExistsException, GroupAlreadyRemovedException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved, ExternallyManagedException {
 		this.deleteGroup(sess, group, false);
 	}
 
@@ -125,13 +128,18 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public void deleteGroups(PerunSession perunSession, List<Group> groups, boolean forceDelete) throws GroupNotExistsException, InternalErrorException, PrivilegeException, GroupAlreadyRemovedException, RelationExistsException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved {
+	public void deleteGroups(PerunSession perunSession, List<Group> groups, boolean forceDelete) throws GroupNotExistsException, InternalErrorException, PrivilegeException, GroupAlreadyRemovedException, RelationExistsException, GroupAlreadyRemovedFromResourceException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved, ExternallyManagedException {
 		Utils.checkPerunSession(perunSession);
 		Utils.notNull(groups, "groups");
 
 		//Test if all groups exists and user has right to delete all of them
 		for(Group group: groups) {
 			getGroupsManagerBl().checkGroupExists(perunSession, group);
+
+			if(getGroupsManagerBl().isGroupInStructureSynchronizationTree(perunSession, group) || getGroupsManagerBl().hasGroupSynchronizedChild(perunSession, group))	{
+				throw new ExternallyManagedException("Group " + group + "or som of the subGroups are externally managed!");
+			}
+
 			//test of privileges on group
 			if(!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, group) && !AuthzResolver.isAuthorized(perunSession, Role.GROUPADMIN, group)) {
 				throw new PrivilegeException(perunSession, "deleteGroups");
@@ -162,13 +170,22 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public void moveGroup(PerunSession sess, Group destinationGroup, Group movingGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupMoveNotAllowedException, WrongAttributeValueException, WrongReferenceAttributeValueException{
+	public void moveGroup(PerunSession sess, Group destinationGroup, Group movingGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupMoveNotAllowedException, WrongAttributeValueException, WrongReferenceAttributeValueException, ExternallyManagedException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 
 		getGroupsManagerBl().checkGroupExists(sess, movingGroup);
+
+		if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, movingGroup)) {
+			throw new ExternallyManagedException("Moving group: " + movingGroup + " is externally managed!");
+		}
 		//if destination group is null, moving group will be moved as top level group
 		if(destinationGroup != null){
 			getGroupsManagerBl().checkGroupExists(sess, destinationGroup);
+
+			Attribute attrSynchronizeEnabled = getPerunBl().getAttributesManagerBl().getAttribute(sess, destinationGroup, GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME);
+			if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, destinationGroup) || Objects.equals("true", (String) attrSynchronizeEnabled.getValue())) {
+				throw new ExternallyManagedException("Destination group: " + destinationGroup + " is externally managed!");
+			}
 
 			// Authorization (destination group is not null)
 			if ((!AuthzResolver.isAuthorized(sess, Role.VOADMIN, movingGroup) && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, movingGroup)) ||
@@ -244,7 +261,8 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		// Check if the group is externally synchronized
 		Attribute attrSynchronizeEnabled = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GROUPSYNCHROENABLED_ATTRNAME);
-		if (Objects.equals("true", (String) attrSynchronizeEnabled.getValue())) {
+		Attribute structureSynchronizeEnabled = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME);
+		if (Objects.equals("true", (String) attrSynchronizeEnabled.getValue()) || getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group) || Objects.equals(true, structureSynchronizeEnabled.getValue())) {
 			throw new ExternallyManagedException("Adding of member is not allowed. Group is externally managed.");
 		}
 
@@ -265,7 +283,8 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		// Check if the group is externally synchronized
 		Attribute attrSynchronizeEnabled = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GROUPSYNCHROENABLED_ATTRNAME);
-		if (Objects.equals("true", (String) attrSynchronizeEnabled.getValue())) {
+		Attribute structureSynchronizeEnabled = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME);
+		if (Objects.equals("true", (String) attrSynchronizeEnabled.getValue()) || getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group) || Objects.equals(true, structureSynchronizeEnabled.getValue())) {
 			throw new ExternallyManagedException("Removing of member is not allowed. Group is externally managed.");
 		}
 
@@ -961,6 +980,20 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
+    public void forceGroupStructureSynchronization(PerunSession sess, Group group) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupStructureSynchronizationAlreadyRunningException {
+        Utils.checkPerunSession(sess);
+        getGroupsManagerBl().checkGroupExists(sess, group);
+
+        // Authorization
+        if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
+                && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group))  {
+            throw new PrivilegeException(sess, "synchronizeGroupStructure");
+        }
+
+        getGroupsManagerBl().forceGroupStructureSynchronization(sess, group);
+    }
+
+	@Override
 	public void synchronizeGroups(PerunSession sess) throws InternalErrorException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
@@ -973,7 +1006,19 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public List<Group> getMemberGroups(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException {
+	public void synchronizeGroupsStructures(PerunSession sess) throws InternalErrorException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN))  {
+			throw new PrivilegeException(sess, "synchronizeGroupsStructures");
+		}
+
+		getGroupsManagerBl().synchronizeGroupsStructures(sess);
+	}
+
+		@Override
+		public List<Group> getMemberGroups(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
@@ -1243,10 +1288,16 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public Group createGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupRelationNotAllowed, GroupRelationAlreadyExists, WrongAttributeValueException, WrongReferenceAttributeValueException, ExternallyManagedException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, resultGroup);
 		getGroupsManagerBl().checkGroupExists(sess, operandGroup);
+
+		if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, resultGroup)) {
+			throw new ExternallyManagedException("Result group: " + resultGroup + " is externally managed!");
+		} else if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, operandGroup)) {
+			throw new ExternallyManagedException("Operand group: " + operandGroup + " is externally managed!");
+		}
 
 		// Authorization
 		if ((!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resultGroup) && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, resultGroup)) ||
@@ -1258,10 +1309,16 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved {
+	public void removeGroupUnion(PerunSession sess, Group resultGroup, Group operandGroup) throws InternalErrorException, GroupNotExistsException, PrivilegeException, GroupRelationDoesNotExist, GroupRelationCannotBeRemoved, ExternallyManagedException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, resultGroup);
 		getGroupsManagerBl().checkGroupExists(sess, operandGroup);
+
+		if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, resultGroup)) {
+			throw new ExternallyManagedException("Result group: " + resultGroup + " is externally managed!");
+		} else if (getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, operandGroup)) {
+			throw new ExternallyManagedException("Operand group: " + operandGroup + " is externally managed!");
+		}
 
 		// Authorization
 		if ( (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resultGroup) && !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, resultGroup)) ||

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -24,273 +24,290 @@ import org.slf4j.LoggerFactory;
  */
 public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
 
-    private final static Logger log = LoggerFactory.getLogger(ExtSourceCSV.class);
+	private final static Logger log = LoggerFactory.getLogger(ExtSourceCSV.class);
 
-    private String file = null;
-    private String query = null;
-    private String[] header = null;
+	private String file = null;
+	private String query = null;
+	private String[] header = null;
 
-    private static PerunBlImpl perunBl;
+	private static PerunBlImpl perunBl;
 
-    // filled by spring (perun-core.xml)
-    public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-        perunBl = perun;
-        return perun;
-    }
+	// filled by spring (perun-core.xml)
+	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
+		perunBl = perun;
+		return perun;
+	}
 
-    @Override
-    public List<Map<String, String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-        throw new ExtSourceUnsupportedOperationException("For CSV using this method is not optimized, use findSubjects instead.");
-    }
+	@Override
+	public List<Map<String, String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("For CSV using this method is not optimized, use findSubjects instead.");
+	}
 
-    @Override
-    public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-        throw new ExtSourceUnsupportedOperationException("For CSV using this method is not optimized, use findSubjects instead.");
-    }
+	@Override
+	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("For CSV using this method is not optimized, use findSubjects instead.");
+	}
 
-    @Override
-    public List<Map<String, String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-        return findSubjects(searchString, 0);
-    }
+	@Override
+	public List<Map<String, String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		return findSubjects(searchString, 0);
+	}
 
-    @Override
-    public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-        try {
-            query = getAttributes().get("query");
+	@Override
+	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		try {
+			query = getAttributes().get("query");
 
-            if (query == null || query.isEmpty()) {
-                throw new InternalErrorException("query attribute is required");
-            }
+			if (query == null || query.isEmpty()) {
+				throw new InternalErrorException("query attribute is required");
+			}
 
-            if (searchString == null) {
-                throw new InternalErrorException("search string can't be null");
-            }
+			if (searchString == null) {
+				throw new InternalErrorException("search string can't be null");
+			}
 
-            //Replace '?' by searchString
-            query = query.replaceAll("\\?", searchString);
+			//Replace '?' by searchString
+			query = query.replaceAll("\\?", searchString);
 
-            //Get csv file 
-            prepareEnvironment();
+			//Get csv file
+			prepareEnvironment();
 
-            return csvParsing(query, maxResults);
+			return csvParsing(query, maxResults);
 
-        } catch (IOException ex) {
-            log.error("IOException in findSubjects() method while parsing csv file", ex);
-        }
+		} catch (IOException ex) {
+			log.error("IOException in findSubjects() method while parsing csv file", ex);
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    @Override
-    public Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException, ExtSourceUnsupportedOperationException {
-        try {
-            query = getAttributes().get("loginQuery");
+	@Override
+	public Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException, ExtSourceUnsupportedOperationException {
+		try {
+			query = getAttributes().get("loginQuery");
 
-            if (query == null || query.isEmpty()) {
-                throw new InternalErrorException("loginQuery attribute is required");
-            }
+			if (query == null || query.isEmpty()) {
+				throw new InternalErrorException("loginQuery attribute is required");
+			}
 
-            if (login == null || login.isEmpty()) {
-                throw new InternalErrorException("login string can't be null or empty");
-            }
+			if (login == null || login.isEmpty()) {
+				throw new InternalErrorException("login string can't be null or empty");
+			}
 
-            //Replace '?' by searchString
-            query = query.replaceAll("\\?", login);
+			//Replace '?' by searchString
+			query = query.replaceAll("\\?", login);
 
-            //Get csv file 
-            prepareEnvironment();
+			//Get csv file
+			prepareEnvironment();
 
-            List<Map<String, String>> subjects = this.csvParsing(query, 0);
+			List<Map<String, String>> subjects = this.csvParsing(query, 0);
 
-            if (subjects.isEmpty()) {
-                throw new SubjectNotExistsException("Login: " + login);
-            }
-            if (subjects.size() > 1) {
-                throw new InternalErrorException("External source must return exactly one result, search string: " + login);
-            }
+			if (subjects.isEmpty()) {
+				throw new SubjectNotExistsException("Login: " + login);
+			}
+			if (subjects.size() > 1) {
+				throw new InternalErrorException("External source must return exactly one result, search string: " + login);
+			}
 
-            return subjects.get(0);
+			return subjects.get(0);
 
-        } catch (IOException ex) {
-            log.error("IOException in getSubjectByLogin() method while parsing csv file", ex);
-        }
+		} catch (IOException ex) {
+			log.error("IOException in getSubjectByLogin() method while parsing csv file", ex);
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    @Override
-    public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-        try {
-            // Get the query for the group subjects
-            String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		try {
+			// Get the query for the group subjects
+			String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 
-            //If there is no query for group, throw exception
-            if (queryForGroup == null) {
-                throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " can't be null.");
-            }
+			//If there is no query for group, throw exception
+			if (queryForGroup == null) {
+				throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " can't be null.");
+			}
 
-            //Get csv file
-            prepareEnvironment();
+			//Get csv file
+			prepareEnvironment();
 
-            return csvParsing(queryForGroup, 0);
+			return csvParsing(queryForGroup, 0);
 
-        } catch (IOException ex) {
-            log.error("IOException in getGroupSubjects() method while parsing csv file", ex);
-        }
-        return null;
-    }
+		} catch (IOException ex) {
+			log.error("IOException in getGroupSubjects() method while parsing csv file", ex);
+		}
+		return null;
+	}
 
-    @Override
-    public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
-        throw new ExtSourceUnsupportedOperationException("Using this method is not supported for CSV.");
-    }
+	@Override
+	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException("Using this method is not supported for CSV.");
+	}
 
-    private void prepareEnvironment() throws InternalErrorException {
-        //Get csv files
-        file = (String) getAttributes().get("file");
-        if (file == null || file.isEmpty()) {
-            throw new InternalErrorException("File cannot be empty!");
-        }
-    }
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		try {
+			String queryForGroup = attributes.get(GroupsManager.GROUPSQUERY_ATTRNAME);
 
-    private List<Map<String, String>> csvParsing(String query, int maxResults) throws InternalErrorException, FileNotFoundException, IOException {
-        List<Map<String, String>> subjects = new ArrayList<Map<String, String>>();
+			if (queryForGroup == null) {
+				throw new InternalErrorException("Attribute " + GroupsManager.GROUPSQUERY_ATTRNAME + " can't be null.");
+			}
 
-        FileReader fileReader = new FileReader(file);
-        if (fileReader == null) {
-            throw new FileNotFoundException("File was not found!");
-        }
+			prepareEnvironment();
 
-        CSVReader reader = new CSVReader(fileReader);
+			return csvParsing(queryForGroup, 0);
 
-        header = reader.readNext();
-        if (header == null) {
-            throw new RuntimeException("No header in csv file");
-        }
+		} catch (IOException ex) {
+			log.error("IOException in getSubjectGroups() method while parsing csv file", ex);
+		}
+		return null;
+	}
 
-        String[] row;
+	private void prepareEnvironment() throws InternalErrorException {
+		//Get csv files
+		file = (String) getAttributes().get("file");
+		if (file == null || file.isEmpty()) {
+			throw new InternalErrorException("File cannot be empty!");
+		}
+	}
 
-        while ((row = reader.readNext()) != null) {
+	private List<Map<String, String>> csvParsing(String query, int maxResults) throws InternalErrorException, FileNotFoundException, IOException {
+		List<Map<String, String>> subjects = new ArrayList<Map<String, String>>();
 
-            if (header.length != row.length) {
-                throw new RuntimeException("Csv file is not valid - some rows have different number of columns from the header row.");
-            }
+		FileReader fileReader = new FileReader(file);
+		if (fileReader == null) {
+			throw new FileNotFoundException("File was not found!");
+		}
 
-            if (compareRowToQuery(row, query)) {
+		CSVReader reader = new CSVReader(fileReader);
 
-                Map<String, String> map = convertLineToMap(row);
+		header = reader.readNext();
+		if (header == null) {
+			throw new RuntimeException("No header in csv file");
+		}
+		String[] row;
 
-                if (map != null) {
-                    subjects.add(map);
-                }
+		while ((row = reader.readNext()) != null) {
+			if (header.length != row.length) {
+				throw new RuntimeException("Csv file is not valid - some rows have different number of columns from the header row.");
+			}
 
-                if (maxResults > 0) {
-                    if (subjects.size() >= maxResults) {
-                        break;
-                    }
-                }
-            }
-        }
+			if (compareRowToQuery(row, query)) {
 
-        return subjects;
-    }
+				Map<String, String> map = convertLineToMap(row);
 
-    /**
-     * Comparison of 1 row in csv file with the query.
-     * - if the row would be result of the query, then this method returns true
-     * - if not, then this method returns false
-     *
-     * @param row 1 row from csv file
-     * @param query query we want to 'execute' on the row, e.g. nameOfColumn=valueInRow
-     * @return boolean
-     * @throws InternalErrorException
-     */
-    private boolean compareRowToQuery(String[] row, String query) throws InternalErrorException {
+				if (map != null) {
+					subjects.add(map);
+				}
 
-        // symbol '=' indicates getSubjectByLogin() or getGroupSubjects method
-        int index = query.indexOf("=");
-        // word 'contains' indicates findSubjects() method
-        int indexContains = query.indexOf("contains");
+				if (maxResults > 0) {
+					if (subjects.size() >= maxResults) {
+						break;
+					}
+				}
+			}
+		}
 
-        if (index != -1) {
-            String queryType = query.substring(0, index);
-            String value = query.substring(index + 1);
+		return subjects;
+	}
 
-            for (int i = 0; i < row.length; i++) {
-                if ((header[i].compareTo(queryType) == 0 && row[i].compareTo(value) == 0)) {
-                    return true;
-                }
-            }
-        } else {
-            if (indexContains != -1) {
-                String queryType = query.substring(0, indexContains);
-                String value = query.substring(indexContains + "contains".trim().length());
+	/**
+	 * Comparison of 1 row in csv file with the query.
+	 * - if the row would be result of the query, then this method returns true
+	 * - if not, then this method returns false
+	 *
+	 * @param row 1 row from csv file
+	 * @param query query we want to 'execute' on the row, e.g. nameOfColumn=valueInRow
+	 * @return boolean
+	 * @throws InternalErrorException
+	 */
+	private boolean compareRowToQuery(String[] row, String query) throws InternalErrorException {
 
-                for (int i = 0; i < row.length; i++) {
-                    value = value.trim();
-                    queryType = queryType.trim();
+		// symbol '=' indicates getSubjectByLogin() or getGroupSubjects method
+		int index = query.indexOf("=");
+		// word 'contains' indicates findSubjects() method
+		int indexContains = query.indexOf("contains");
 
-                    if (header[i].compareTo(queryType) == 0 && row[i].contains(value)) {
-                        return true;
-                    }
-                }
-            } else {
-                // if there's no symbol '=' or word 'contains' in the query
-                throw new InternalErrorException("Wrong query!");
-            }
-        }
+		if (index != -1) {
+			String queryType = query.substring(0, index);
+			String value = query.substring(index + 1);
 
-        return false;
-    }
+			for (int i = 0; i < row.length; i++) {
+				if ((header[i].compareTo(queryType) == 0 && row[i].compareTo(value) == 0)) {
+					return true;
+				}
+			}
+		} else {
+			if (indexContains != -1) {
+				String queryType = query.substring(0, indexContains);
+				String value = query.substring(indexContains + "contains".trim().length());
 
-    /**
-     * Creates Map<String,String> from 1 row in csv file
-     * 
-     * @param line 1 row from csv file
-     * @return Map<String, String>, like <name,value>
-     * @throws InternalErrorException
-     */
-    private Map<String, String> convertLineToMap(String[] line) throws InternalErrorException {
+				for (int i = 0; i < row.length; i++) {
+					value = value.trim();
+					queryType = queryType.trim();
 
-        Map<String, String> lineAsMap = new HashMap<String, String>();
+					if (header[i].compareTo(queryType) == 0 && row[i].contains(value)) {
+						return true;
+					}
+				}
+			} else {
+				// if there's no symbol '=' or word 'contains' in the query
+				throw new InternalErrorException("Wrong query!");
+			}
+		}
 
-        String mapping = getAttributes().get("csvMapping");
+		return false;
+	}
 
-        String[] mappingArray = mapping.split(",\n");
+	/**
+	 * Creates Map<String,String> from 1 row in csv file
+	 *
+	 * @param line 1 row from csv file
+	 * @return Map<String, String>, like <name,value>
+	 * @throws InternalErrorException
+	 */
+	private Map<String, String> convertLineToMap(String[] line) throws InternalErrorException {
 
-        for (int i = 0; i < mappingArray.length; i++) {
+		Map<String, String> lineAsMap = new HashMap<String, String>();
 
-            for (int j = 0; j < line.length; j++) {
+		String mapping = getAttributes().get("csvMapping");
 
-                String attr = mappingArray[i].trim();
+		String[] mappingArray = mapping.split(",\n");
 
-                int index = attr.indexOf("=");
+		for (int i = 0; i < mappingArray.length; i++) {
 
-                if (index <= 0) {
-                    throw new InternalErrorException("There is no text in csvMapping attribute or there is no '=' character.");
-                }
+			for (int j = 0; j < line.length; j++) {
 
-                String name = attr.substring(0, index);
-                String value = attr.substring(index + 1);
+				String attr = mappingArray[i].trim();
 
-                if (value.startsWith("{")) {
-                    
-                    // exclude curly brackets from value
-                    value = value.substring(1, value.length() - 1);
+				int index = attr.indexOf("=");
 
-                    if (value.compareTo(header[j]) == 0) {
-                        value = line[j];
-                        lineAsMap.put(name.trim(), value.trim());
-                        break;
-                    }
-                } else {
-                    lineAsMap.put(name.trim(), value.trim());
-                    break;
-                }
-            }
-        }
-        return lineAsMap;
-    }
+				if (index <= 0) {
+					throw new InternalErrorException("There is no text in csvMapping attribute or there is no '=' character.");
+				}
+
+				String name = attr.substring(0, index);
+				String value = attr.substring(index + 1);
+
+				if (value.startsWith("{")) {
+
+					// exclude curly brackets from value
+					value = value.substring(1, value.length() - 1);
+
+					if (value.compareTo(header[j]) == 0) {
+						value = line[j];
+						lineAsMap.put(name.trim(), value.trim());
+						break;
+					}
+				} else {
+					lineAsMap.put(name.trim(), value.trim());
+					break;
+				}
+			}
+		}
+		return lineAsMap;
+	}
 
 	protected Map<String,String> getAttributes() throws InternalErrorException {
 		return perunBl.getExtSourcesManagerBl().getAttributes(this);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -24,126 +24,126 @@ import org.slf4j.LoggerFactory;
  */
 public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
 
-	private final static Logger log = LoggerFactory.getLogger(ExtSourceCSV.class);
+    private final static Logger log = LoggerFactory.getLogger(ExtSourceCSV.class);
 
-	private String file = null;
-	private String query = null;
-	private String[] header = null;
+    private String file = null;
+    private String query = null;
+    private String[] header = null;
 
-	private static PerunBlImpl perunBl;
+    private static PerunBlImpl perunBl;
 
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
-	}
+    // filled by spring (perun-core.xml)
+    public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
+        perunBl = perun;
+        return perun;
+    }
 
-	@Override
-	public List<Map<String, String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException("For CSV using this method is not optimized, use findSubjects instead.");
-	}
+    @Override
+    public List<Map<String, String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        throw new ExtSourceUnsupportedOperationException("For CSV using this method is not optimized, use findSubjects instead.");
+    }
 
-	@Override
-	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException("For CSV using this method is not optimized, use findSubjects instead.");
-	}
+    @Override
+    public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        throw new ExtSourceUnsupportedOperationException("For CSV using this method is not optimized, use findSubjects instead.");
+    }
 
-	@Override
-	public List<Map<String, String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		return findSubjects(searchString, 0);
-	}
+    @Override
+    public List<Map<String, String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        return findSubjects(searchString, 0);
+    }
 
-	@Override
-	public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		try {
-			query = getAttributes().get("query");
+    @Override
+    public List<Map<String, String>> findSubjects(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        try {
+            query = getAttributes().get("query");
 
-			if (query == null || query.isEmpty()) {
-				throw new InternalErrorException("query attribute is required");
-			}
+            if (query == null || query.isEmpty()) {
+                throw new InternalErrorException("query attribute is required");
+            }
 
-			if (searchString == null) {
-				throw new InternalErrorException("search string can't be null");
-			}
+            if (searchString == null) {
+                throw new InternalErrorException("search string can't be null");
+            }
 
-			//Replace '?' by searchString
-			query = query.replaceAll("\\?", searchString);
+            //Replace '?' by searchString
+            query = query.replaceAll("\\?", searchString);
 
-			//Get csv file
-			prepareEnvironment();
+            //Get csv file
+            prepareEnvironment();
 
-			return csvParsing(query, maxResults);
+            return csvParsing(query, maxResults);
 
-		} catch (IOException ex) {
-			log.error("IOException in findSubjects() method while parsing csv file", ex);
-		}
+        } catch (IOException ex) {
+            log.error("IOException in findSubjects() method while parsing csv file", ex);
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	@Override
-	public Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException, ExtSourceUnsupportedOperationException {
-		try {
-			query = getAttributes().get("loginQuery");
+    @Override
+    public Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException, ExtSourceUnsupportedOperationException {
+        try {
+            query = getAttributes().get("loginQuery");
 
-			if (query == null || query.isEmpty()) {
-				throw new InternalErrorException("loginQuery attribute is required");
-			}
+            if (query == null || query.isEmpty()) {
+                throw new InternalErrorException("loginQuery attribute is required");
+            }
 
-			if (login == null || login.isEmpty()) {
-				throw new InternalErrorException("login string can't be null or empty");
-			}
+            if (login == null || login.isEmpty()) {
+                throw new InternalErrorException("login string can't be null or empty");
+            }
 
-			//Replace '?' by searchString
-			query = query.replaceAll("\\?", login);
+            //Replace '?' by searchString
+            query = query.replaceAll("\\?", login);
 
-			//Get csv file
-			prepareEnvironment();
+            //Get csv file
+            prepareEnvironment();
 
-			List<Map<String, String>> subjects = this.csvParsing(query, 0);
+            List<Map<String, String>> subjects = this.csvParsing(query, 0);
 
-			if (subjects.isEmpty()) {
-				throw new SubjectNotExistsException("Login: " + login);
-			}
-			if (subjects.size() > 1) {
-				throw new InternalErrorException("External source must return exactly one result, search string: " + login);
-			}
+            if (subjects.isEmpty()) {
+                throw new SubjectNotExistsException("Login: " + login);
+            }
+            if (subjects.size() > 1) {
+                throw new InternalErrorException("External source must return exactly one result, search string: " + login);
+            }
 
-			return subjects.get(0);
+            return subjects.get(0);
 
-		} catch (IOException ex) {
-			log.error("IOException in getSubjectByLogin() method while parsing csv file", ex);
-		}
+        } catch (IOException ex) {
+            log.error("IOException in getSubjectByLogin() method while parsing csv file", ex);
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	@Override
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		try {
-			// Get the query for the group subjects
-			String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+    @Override
+    public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        try {
+            // Get the query for the group subjects
+            String queryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 
-			//If there is no query for group, throw exception
-			if (queryForGroup == null) {
-				throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " can't be null.");
-			}
+            //If there is no query for group, throw exception
+            if (queryForGroup == null) {
+                throw new InternalErrorException("Attribute " + GroupsManager.GROUPMEMBERSQUERY_ATTRNAME + " can't be null.");
+            }
 
-			//Get csv file
-			prepareEnvironment();
+            //Get csv file
+            prepareEnvironment();
 
-			return csvParsing(queryForGroup, 0);
+            return csvParsing(queryForGroup, 0);
 
-		} catch (IOException ex) {
-			log.error("IOException in getGroupSubjects() method while parsing csv file", ex);
-		}
-		return null;
-	}
+        } catch (IOException ex) {
+            log.error("IOException in getGroupSubjects() method while parsing csv file", ex);
+        }
+        return null;
+    }
 
-	@Override
-	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		throw new ExtSourceUnsupportedOperationException("Using this method is not supported for CSV.");
-	}
+    @Override
+    public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        throw new ExtSourceUnsupportedOperationException("Using this method is not supported for CSV.");
+    }
 
 	@Override
 	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
@@ -164,152 +164,152 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
 		return null;
 	}
 
-	private void prepareEnvironment() throws InternalErrorException {
-		//Get csv files
-		file = (String) getAttributes().get("file");
-		if (file == null || file.isEmpty()) {
-			throw new InternalErrorException("File cannot be empty!");
-		}
-	}
+    private void prepareEnvironment() throws InternalErrorException {
+        //Get csv files
+        file = (String) getAttributes().get("file");
+        if (file == null || file.isEmpty()) {
+            throw new InternalErrorException("File cannot be empty!");
+        }
+    }
 
-	private List<Map<String, String>> csvParsing(String query, int maxResults) throws InternalErrorException, FileNotFoundException, IOException {
-		List<Map<String, String>> subjects = new ArrayList<Map<String, String>>();
+    private List<Map<String, String>> csvParsing(String query, int maxResults) throws InternalErrorException, FileNotFoundException, IOException {
+        List<Map<String, String>> subjects = new ArrayList<Map<String, String>>();
 
-		FileReader fileReader = new FileReader(file);
-		if (fileReader == null) {
-			throw new FileNotFoundException("File was not found!");
-		}
+        FileReader fileReader = new FileReader(file);
+        if (fileReader == null) {
+            throw new FileNotFoundException("File was not found!");
+        }
 
-		CSVReader reader = new CSVReader(fileReader);
+        CSVReader reader = new CSVReader(fileReader);
 
-		header = reader.readNext();
-		if (header == null) {
-			throw new RuntimeException("No header in csv file");
-		}
-		String[] row;
+        header = reader.readNext();
+        if (header == null) {
+            throw new RuntimeException("No header in csv file");
+        }
+        String[] row;
 
-		while ((row = reader.readNext()) != null) {
-			if (header.length != row.length) {
-				throw new RuntimeException("Csv file is not valid - some rows have different number of columns from the header row.");
-			}
+        while ((row = reader.readNext()) != null) {
+            if (header.length != row.length) {
+                throw new RuntimeException("Csv file is not valid - some rows have different number of columns from the header row.");
+            }
 
-			if (compareRowToQuery(row, query)) {
+            if (compareRowToQuery(row, query)) {
 
-				Map<String, String> map = convertLineToMap(row);
+                Map<String, String> map = convertLineToMap(row);
 
-				if (map != null) {
-					subjects.add(map);
-				}
+                if (map != null) {
+                    subjects.add(map);
+                }
 
-				if (maxResults > 0) {
-					if (subjects.size() >= maxResults) {
-						break;
-					}
-				}
-			}
-		}
+                if (maxResults > 0) {
+                    if (subjects.size() >= maxResults) {
+                        break;
+                    }
+                }
+            }
+        }
 
-		return subjects;
-	}
+        return subjects;
+    }
 
-	/**
-	 * Comparison of 1 row in csv file with the query.
-	 * - if the row would be result of the query, then this method returns true
-	 * - if not, then this method returns false
-	 *
-	 * @param row 1 row from csv file
-	 * @param query query we want to 'execute' on the row, e.g. nameOfColumn=valueInRow
-	 * @return boolean
-	 * @throws InternalErrorException
-	 */
-	private boolean compareRowToQuery(String[] row, String query) throws InternalErrorException {
+    /**
+     * Comparison of 1 row in csv file with the query.
+     * - if the row would be result of the query, then this method returns true
+     * - if not, then this method returns false
+     *
+     * @param row 1 row from csv file
+     * @param query query we want to 'execute' on the row, e.g. nameOfColumn=valueInRow
+     * @return boolean
+     * @throws InternalErrorException
+     */
+    private boolean compareRowToQuery(String[] row, String query) throws InternalErrorException {
 
-		// symbol '=' indicates getSubjectByLogin() or getGroupSubjects method
-		int index = query.indexOf("=");
-		// word 'contains' indicates findSubjects() method
-		int indexContains = query.indexOf("contains");
+        // symbol '=' indicates getSubjectByLogin() or getGroupSubjects method
+        int index = query.indexOf("=");
+        // word 'contains' indicates findSubjects() method
+        int indexContains = query.indexOf("contains");
 
-		if (index != -1) {
-			String queryType = query.substring(0, index);
-			String value = query.substring(index + 1);
+        if (index != -1) {
+            String queryType = query.substring(0, index);
+            String value = query.substring(index + 1);
 
-			for (int i = 0; i < row.length; i++) {
-				if ((header[i].compareTo(queryType) == 0 && row[i].compareTo(value) == 0)) {
-					return true;
-				}
-			}
-		} else {
-			if (indexContains != -1) {
-				String queryType = query.substring(0, indexContains);
-				String value = query.substring(indexContains + "contains".trim().length());
+            for (int i = 0; i < row.length; i++) {
+                if ((header[i].compareTo(queryType) == 0 && row[i].compareTo(value) == 0)) {
+                    return true;
+                }
+            }
+        } else {
+            if (indexContains != -1) {
+                String queryType = query.substring(0, indexContains);
+                String value = query.substring(indexContains + "contains".trim().length());
 
-				for (int i = 0; i < row.length; i++) {
-					value = value.trim();
-					queryType = queryType.trim();
+                for (int i = 0; i < row.length; i++) {
+                    value = value.trim();
+                    queryType = queryType.trim();
 
-					if (header[i].compareTo(queryType) == 0 && row[i].contains(value)) {
-						return true;
-					}
-				}
-			} else {
-				// if there's no symbol '=' or word 'contains' in the query
-				throw new InternalErrorException("Wrong query!");
-			}
-		}
+                    if (header[i].compareTo(queryType) == 0 && row[i].contains(value)) {
+                        return true;
+                    }
+                }
+            } else {
+                // if there's no symbol '=' or word 'contains' in the query
+                throw new InternalErrorException("Wrong query!");
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * Creates Map<String,String> from 1 row in csv file
-	 *
-	 * @param line 1 row from csv file
-	 * @return Map<String, String>, like <name,value>
-	 * @throws InternalErrorException
-	 */
-	private Map<String, String> convertLineToMap(String[] line) throws InternalErrorException {
+    /**
+     * Creates Map<String,String> from 1 row in csv file
+     *
+     * @param line 1 row from csv file
+     * @return Map<String, String>, like <name,value>
+     * @throws InternalErrorException
+     */
+    private Map<String, String> convertLineToMap(String[] line) throws InternalErrorException {
 
-		Map<String, String> lineAsMap = new HashMap<String, String>();
+        Map<String, String> lineAsMap = new HashMap<String, String>();
 
-		String mapping = getAttributes().get("csvMapping");
+        String mapping = getAttributes().get("csvMapping");
 
-		String[] mappingArray = mapping.split(",\n");
+        String[] mappingArray = mapping.split(",\n");
 
-		for (int i = 0; i < mappingArray.length; i++) {
+        for (int i = 0; i < mappingArray.length; i++) {
 
-			for (int j = 0; j < line.length; j++) {
+            for (int j = 0; j < line.length; j++) {
 
-				String attr = mappingArray[i].trim();
+                String attr = mappingArray[i].trim();
 
-				int index = attr.indexOf("=");
+                int index = attr.indexOf("=");
 
-				if (index <= 0) {
-					throw new InternalErrorException("There is no text in csvMapping attribute or there is no '=' character.");
-				}
+                if (index <= 0) {
+                    throw new InternalErrorException("There is no text in csvMapping attribute or there is no '=' character.");
+                }
 
-				String name = attr.substring(0, index);
-				String value = attr.substring(index + 1);
+                String name = attr.substring(0, index);
+                String value = attr.substring(index + 1);
 
-				if (value.startsWith("{")) {
+                if (value.startsWith("{")) {
 
-					// exclude curly brackets from value
-					value = value.substring(1, value.length() - 1);
+                    // exclude curly brackets from value
+                    value = value.substring(1, value.length() - 1);
 
-					if (value.compareTo(header[j]) == 0) {
-						value = line[j];
-						lineAsMap.put(name.trim(), value.trim());
-						break;
-					}
-				} else {
-					lineAsMap.put(name.trim(), value.trim());
-					break;
-				}
-			}
-		}
-		return lineAsMap;
-	}
+                    if (value.compareTo(header[j]) == 0) {
+                        value = line[j];
+                        lineAsMap.put(name.trim(), value.trim());
+                        break;
+                    }
+                } else {
+                    lineAsMap.put(name.trim(), value.trim());
+                    break;
+                }
+            }
+        }
+        return lineAsMap;
+    }
 
-	protected Map<String,String> getAttributes() throws InternalErrorException {
-		return perunBl.getExtSourcesManagerBl().getAttributes(this);
-	}
+    protected Map<String,String> getAttributes() throws InternalErrorException {
+        return perunBl.getExtSourcesManagerBl().getAttributes(this);
+    }
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import static cz.metacentrum.perun.core.impl.ExtSourceLdap.log;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
@@ -60,6 +61,11 @@ public class ExtSourceEGISSO extends ExtSourceLdap implements ExtSourceApi {
 		}
 
 		return subjects;
+	}
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
@@ -8,6 +8,8 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.admin.directory.Directory;
 import com.google.api.services.admin.directory.DirectoryScopes;
+import com.google.api.services.admin.directory.model.Group;
+import com.google.api.services.admin.directory.model.Groups;
 import com.google.api.services.admin.directory.model.Member;
 import com.google.api.services.admin.directory.model.Members;
 import cz.metacentrum.perun.core.api.ExtSource;
@@ -221,6 +223,11 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 	@Override
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException("Using this method is not supported for Google Groups.");
+	}
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -168,6 +168,11 @@ public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 		throw new ExtSourceUnsupportedOperationException("Using this method is not supported for ISMU");
 	}
 
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        throw new ExtSourceUnsupportedOperationException();
+	}
+
 	protected Map<String,String> getAttributes() throws InternalErrorException {
 		return perunBl.getExtSourcesManagerBl().getAttributes(this);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -170,7 +170,7 @@ public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 
 	@Override
 	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-        throw new ExtSourceUnsupportedOperationException();
+		throw new ExtSourceUnsupportedOperationException();
 	}
 
 	protected Map<String,String> getAttributes() throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISXML.java
@@ -63,6 +63,11 @@ public class ExtSourceISXML extends ExtSourceXML {
 	}
 
 	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
 	protected InputStream createTwoWaySSLConnection(String uri) throws IOException, InternalErrorException {
 		//prepare sslFactory
 		SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
@@ -48,4 +48,9 @@ public class ExtSourceIdp extends ExtSource implements ExtSourceSimpleApi {
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
@@ -48,4 +48,9 @@ public class ExtSourceInternal extends ExtSource implements ExtSourceSimpleApi {
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
@@ -48,4 +48,9 @@ public class ExtSourceKerberos extends ExtSource implements ExtSourceSimpleApi {
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -414,6 +414,11 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 	}
 
 	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
 	public List<Map<String, String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		return findSubjects(searchString, 0);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -8,6 +8,7 @@ import java.net.URLEncoder;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -361,6 +362,11 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 	@Override
 	public void close() throws InternalErrorException {
 		//not needed there
+	}
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
 	}
 
 	protected Map<String,String> getAttributes() throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
@@ -78,6 +78,11 @@ public class ExtSourceREMS extends ExtSourceSqlComplex implements ExtSourceApi {
 		return filterNonExistingUsers(subjects);
 	}
 
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
 	/**
 	 * Filters subjects that does not have a corresponding user in Perun by ues REMS
 	 * or by additionalueses in format: {extSourceName}|{extSourceClass}|{eppn}|0.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Properties;
 
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
+import cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
@@ -352,22 +353,22 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 				Map<String, String> map = new HashMap<String, String>();
 
 				try {
-					map.put("groupName", rs.getString("groupName"));
+					map.put(GroupsManagerBlImpl.GROUP_NAME, rs.getString(GroupsManagerBlImpl.GROUP_NAME));
 				} catch (SQLException e) {
 					// If the column doesn't exists, ignore it
-					map.put("groupName", null);
+					map.put(GroupsManagerBlImpl.GROUP_NAME, null);
 				}
 				try {
-					map.put("parentGroupName", rs.getString("parentGroupName"));
+					map.put(GroupsManagerBlImpl.PARENT_GROUP_NAME, rs.getString(GroupsManagerBlImpl.PARENT_GROUP_NAME));
 				} catch (SQLException e) {
 					// If the column doesn't exists, ignore it
-					map.put("parentGroupName", null);
+					map.put(GroupsManagerBlImpl.PARENT_GROUP_NAME, null);
 				}
 				try {
-					map.put("description", rs.getString("description"));
+					map.put(GroupsManagerBlImpl.GROUP_DESCRIPTION, rs.getString(GroupsManagerBlImpl.GROUP_DESCRIPTION));
 				} catch (SQLException e) {
 					// If the column doesn't exists, ignore it
-					map.put("groupDescription", null);
+					map.put(GroupsManagerBlImpl.GROUP_DESCRIPTION, null);
 				}
 
 				subjects.add(map);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -290,17 +290,7 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 	}
 
 	/**
-	 * Get subject groups from external source
-	 *
-	 * 1. Check extSource attributes (url and driver)
-	 * 2. Register driver
-	 * 3. Check if there is an existing connection. In case of Oracle also checks the connection validity
-	 * 4. Prepare query statement
-	 * 5. Substitute the ? in the query by the searchString
-	 * 6. Limit results by maxResults
-	 * 7. Execute query and for each result process subject and put its attributes into map
-	 * 8. Return subjects
-	 * 9. Close connections
+	 * Get subject groups from an external source
 	 *
 	 * @param query to select subject groups
 	 * @param searchString by which will be ? in query replaced

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
@@ -133,6 +133,11 @@ public class ExtSourceUnity extends ExtSource implements ExtSourceApi {
         throw new UnsupportedOperationException("Using this method is not supported for Unity");
     }
 
+    @Override
+    public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+        throw new ExtSourceUnsupportedOperationException();
+    }
+
     protected Map<String, String> getAttributes() throws InternalErrorException {
         return perunBl.getExtSourcesManagerBl().getAttributes(this);
     }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
@@ -363,4 +363,9 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
     protected Map<String, String> getAttributes() throws InternalErrorException {
         return perunBl.getExtSourcesManagerBl().getAttributes(this);
     }
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
@@ -48,4 +48,9 @@ public class ExtSourceX509 extends ExtSource implements ExtSourceSimpleApi {
 	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -491,6 +491,11 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 		if(con != null) con.disconnect();
 	}
 
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
 	@JsonIgnore
 	public HttpURLConnection getCon() {
 		return con;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -732,6 +732,20 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
+	public List<Group> getGroupsStructuresToSynchronize(PerunSession sess) throws InternalErrorException {
+		try {
+			// Get all groups which have defined
+			return jdbc.query("select " + groupMappingSelectQuery + " from groups, attr_names, group_attr_values " +
+					"where attr_names.attr_name=? and attr_names.id=group_attr_values.attr_id and group_attr_values.attr_value='true' and " +
+					"group_attr_values.group_id=groups.id", GROUP_MAPPER, GroupsManager.GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME);
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<Group>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
 	public List<Integer> getGroupApplicationIds(PerunSession sess, Group group) throws InternalErrorException {
 		// get app ids for all applications
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -734,10 +734,10 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	@Override
 	public List<Group> getGroupsStructuresToSynchronize(PerunSession sess) throws InternalErrorException {
 		try {
-			// Get all groups which have defined
+			// Get all groups which have defined synchronization
 			return jdbc.query("select " + groupMappingSelectQuery + " from groups, attr_names, group_attr_values " +
 					"where attr_names.attr_name=? and attr_names.id=group_attr_values.attr_id and group_attr_values.attr_value='true' and " +
-					"group_attr_values.group_id=groups.id", GROUP_MAPPER, GroupsManager.GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME);
+					"group_attr_values.group_id=groups.id", GROUP_MAPPER, GroupsManager.GROUPS_STRUCTURE_SYNCHRO_ENABLED_ATTRNAME);
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<Group>();
 		} catch (RuntimeException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
@@ -24,6 +24,7 @@ public class Synchronizer {
 
 	private PerunBl perunBl;
 	private AtomicBoolean synchronizeGroupsRunning = new AtomicBoolean(false);
+	private AtomicBoolean synchronizeGroupsStructuresRunning = new AtomicBoolean(false);
 
 	public Synchronizer() {
 	}
@@ -58,6 +59,31 @@ public class Synchronizer {
 			}
 		} else {
 			log.debug("Synchronizer: group synchronization currently running.");
+		}
+	}
+
+	/**
+	 * Start synchronization of groups if not running.
+	 *
+	 * Method is triggered by Spring scheduler (every 5 minutes).
+	 */
+	public void synchronizeGroupsStructures() {
+		if(perunBl.isPerunReadOnly()) {
+			log.debug("This instance is just read only so skip synchronization of groups structures.");
+			return;
+		}
+
+		if (synchronizeGroupsStructuresRunning.compareAndSet(false, true)) {
+			try {
+				log.debug("Synchronizer starting synchronizing the groups structures");
+				this.perunBl.getGroupsManagerBl().synchronizeGroupsStructures(this.sess);
+				synchronizeGroupsStructuresRunning.set(false);
+			} catch (InternalErrorException e) {
+				log.error("Cannot synchronize groups structures:", e);
+				synchronizeGroupsStructuresRunning.set(false);
+			}
+		} else {
+			log.debug("Synchronizer: group structure synchronization currently running.");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Synchronizer.java
@@ -69,7 +69,7 @@ public class Synchronizer {
 	 */
 	public void synchronizeGroupsStructures() {
 		if(perunBl.isPerunReadOnly()) {
-			log.debug("This instance is just read only so skip synchronization of groups structures.");
+			log.warn("This instance is just read only so skip synchronization of groups structures.");
 			return;
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabled.java
@@ -1,0 +1,56 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+
+/**
+ * Flat group structure synchronization
+ *
+ * true if flat structure synchronization is enabled
+ * false if not
+ * empty if there is no setting
+ *
+ * @author Erik Horváth <horvatherik3@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_flatGroupStructureEnabled extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+    private static final String MANDATORY_ATTRIBUTE_NAME = new urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled().getAttributeDefinition().getName();
+
+    @Override
+    public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+        //Null value is ok, means no settings for group
+        if(attribute.getValue() == null) return;
+
+        AttributesManagerBl attributeManager = perunSession.getPerunBl().getAttributesManagerBl();
+        try {
+            Attribute foundAttribute = attributeManager.getAttribute(perunSession, group, MANDATORY_ATTRIBUTE_NAME);
+            if(foundAttribute == null || foundAttribute.getValue() == null) {
+                throw new WrongAttributeAssignmentException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " must be defined first.");
+            }
+        } catch (AttributeNotExistsException exc) {
+            throw new ConsistencyErrorException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " is supposed to exist", exc);
+        }
+    }
+
+    @Override
+    public AttributeDefinition getAttributeDefinition() {
+        AttributeDefinition attr = new AttributeDefinition();
+        attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+        attr.setFriendlyName("flatGroupStructureEnabled");
+        attr.setDisplayName("Flat Group Structure Synchronization Enabled");
+        attr.setType(Boolean.class.getName());
+        attr.setDescription("Enables flat group structure synchronization from external source.");
+        return attr;
+    }
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabled.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -15,6 +16,9 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Flat group structure synchronization
  *
@@ -25,7 +29,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModul
  * @author Erik Horváth <horvatherik3@gmail.com>
  */
 public class urn_perun_group_attribute_def_def_flatGroupStructureEnabled extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
-	private static final String MANDATORY_ATTRIBUTE_NAME = new urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled().getAttributeDefinition().getName();
+	private static final String MANDATORY_ATTRIBUTE_NAME = GroupsManager.GROUPS_STRUCTURE_SYNCHRO_ENABLED_ATTRNAME;
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -41,6 +45,13 @@ public class urn_perun_group_attribute_def_def_flatGroupStructureEnabled extends
 		} catch (AttributeNotExistsException exc) {
 			throw new ConsistencyErrorException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " is supposed to exist", exc);
 		}
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<String>();
+		dependencies.add(MANDATORY_ATTRIBUTE_NAME);
+		return dependencies;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabled.java
@@ -25,32 +25,32 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModul
  * @author Erik Horváth <horvatherik3@gmail.com>
  */
 public class urn_perun_group_attribute_def_def_flatGroupStructureEnabled extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
-    private static final String MANDATORY_ATTRIBUTE_NAME = new urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled().getAttributeDefinition().getName();
+	private static final String MANDATORY_ATTRIBUTE_NAME = new urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled().getAttributeDefinition().getName();
 
-    @Override
-    public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-        //Null value is ok, means no settings for group
-        if(attribute.getValue() == null) return;
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		//Null value is ok, means no settings for group
+		if(attribute.getValue() == null) return;
 
-        AttributesManagerBl attributeManager = perunSession.getPerunBl().getAttributesManagerBl();
-        try {
-            Attribute foundAttribute = attributeManager.getAttribute(perunSession, group, MANDATORY_ATTRIBUTE_NAME);
-            if(foundAttribute == null || foundAttribute.getValue() == null) {
-                throw new WrongAttributeAssignmentException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " must be defined first.");
-            }
-        } catch (AttributeNotExistsException exc) {
-            throw new ConsistencyErrorException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " is supposed to exist", exc);
-        }
-    }
+		AttributesManagerBl attributeManager = perunSession.getPerunBl().getAttributesManagerBl();
+		try {
+			Attribute foundAttribute = attributeManager.getAttribute(perunSession, group, MANDATORY_ATTRIBUTE_NAME);
+			if(foundAttribute == null || foundAttribute.getValue() == null) {
+				throw new WrongAttributeAssignmentException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " must be defined first.");
+			}
+		} catch (AttributeNotExistsException exc) {
+			throw new ConsistencyErrorException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " is supposed to exist", exc);
+		}
+	}
 
-    @Override
-    public AttributeDefinition getAttributeDefinition() {
-        AttributeDefinition attr = new AttributeDefinition();
-        attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
-        attr.setFriendlyName("flatGroupStructureEnabled");
-        attr.setDisplayName("Flat Group Structure Synchronization Enabled");
-        attr.setType(Boolean.class.getName());
-        attr.setDescription("Enables flat group structure synchronization from external source.");
-        return attr;
-    }
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("flatGroupStructureEnabled");
+		attr.setDisplayName("Flat Group Structure Synchronization Enabled");
+		attr.setType(Boolean.class.getName());
+		attr.setDescription("Enables flat group structure synchronization from external source.");
+		return attr;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -50,7 +50,7 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 					throw new WrongReferenceAttributeValueException(attribute, attrSynchronizeEnabled);
 				}
 
-				Attribute requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSTRUCTURESYNCHROINTERVAL_ATTRNAME);
+				Attribute requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME);
 				if (requiredAttribute.getValue() == null) {
 					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -44,11 +44,6 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 				throw new InternalErrorException("Synchronization is already enabled for one of the parent groups.");
 			}
 
-			List<Group> unionGroups = perunSession.getPerunBl().getGroupsManagerBl().getGroupUnions(perunSession, group, false);
-			if (!unionGroups.isEmpty()) {
-				throw new InternalErrorException("There is one or more group unions created for this group.");
-			}
-
 			try {
 				Attribute attrSynchronizeEnabled = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSYNCHROENABLED_ATTRNAME);
 				if (Objects.equals("true", attrSynchronizeEnabled.getValue())) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModul
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -30,55 +31,86 @@ import java.util.Objects;
  * @author Erik Horváth <horvatherik3@gmail.com>
  */
 public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
-    private static final Logger log = LoggerFactory.getLogger(urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.class);
+	private static final Logger log = LoggerFactory.getLogger(urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.class);
 
-    @Override
-    public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-        //Null value is ok, means no settings for group
-        if(attribute.getValue() == null) return;
+	@Override
+	public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		//Null value is ok, means no settings for group
+		if(attribute.getValue() == null) return;
 
-        Attribute attrSynchronizeEnabled = null;
-        try {
-            attrSynchronizeEnabled = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSYNCHROENABLED_ATTRNAME);
-        } catch (AttributeNotExistsException e) {
-            throw new ConsistencyErrorException(e);
-        }
-        if (Objects.equals("true", attrSynchronizeEnabled.getValue())) {
-            throw new WrongReferenceAttributeValueException(attribute, attrSynchronizeEnabled);
-        }
+		if ((boolean) attribute.getValue()) {
 
-        if (!perunSession.getPerunBl().getGroupsManagerBl().getSubGroups(perunSession, group).isEmpty() && (boolean) attribute.getValue()) {
-            throw new InternalErrorException("Group " + group + " has one or more subGroups, so it is not possible to enable group structure synchronization.");
-        }
+			if (!perunSession.getPerunBl().getGroupsManagerBl().getSubGroups(perunSession, group).isEmpty()) {
+				throw new InternalErrorException("Group " + group + " has one or more subGroups, so it is not possible to enable group structure synchronization.");
+			}
 
-        if(perunSession.getPerunBl().getGroupsManagerBl().isGroupInStructureSynchronizationTree(perunSession, group)) {
-            throw new InternalErrorException("Synchronization is already enabled for one of the parent groups.");
-        }
-    }
+			if (!perunSession.getPerunBl().getGroupsManagerBl().getGroupMembers(perunSession, group).isEmpty()) {
+				throw new InternalErrorException("Group " + group + " has one or more members, so it is not possible to enable group structure synchronization.");
+			}
 
-    @Override
-    public void changedAttributeHook(PerunSessionImpl session, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
-        if (attribute.getValue() == null) {
-            try {
-                AttributesManagerBl attributesManager = session.getPerunBl().getAttributesManagerBl();
-                AttributeDefinition removeAttrDef = attributesManager.getAttributeDefinition(session, new urn_perun_group_attribute_def_def_flatGroupStructureEnabled().getAttributeDefinition().getName());
-                attributesManager.removeAttributeWithoutCheck(session, group, removeAttrDef);
-            } catch (WrongAttributeAssignmentException ex) {
-                throw new InternalErrorException(ex);
-            } catch (AttributeNotExistsException ex) {
-                log.debug("Attribute for flat group structure synchronization does not exist", ex);
-            }
-        }
-    }
+			if (perunSession.getPerunBl().getGroupsManagerBl().isGroupSynchronizedFromExternallSource(perunSession, group)) {
+				throw new InternalErrorException("Synchronization is already enabled for one of the parent groups.");
+			}
 
-    @Override
-    public AttributeDefinition getAttributeDefinition() {
-        AttributeDefinition attr = new AttributeDefinition();
-        attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
-        attr.setFriendlyName("groupStructureSynchronizationEnabled");
-        attr.setDisplayName("Group Structure Synchronization Enabled");
-        attr.setType(Boolean.class.getName());
-        attr.setDescription("Enables group structure synchronization from external source.");
-        return attr;
-    }
+			List<Group> unionGroups = perunSession.getPerunBl().getGroupsManagerBl().getGroupUnions(perunSession, group, false);
+			if (!unionGroups.isEmpty()) {
+				throw new InternalErrorException("There is one or more group unions created for this group.");
+			}
+
+			try {
+				Attribute attrSynchronizeEnabled = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSYNCHROENABLED_ATTRNAME);
+				if (Objects.equals("true", attrSynchronizeEnabled.getValue())) {
+					throw new WrongReferenceAttributeValueException(attribute, attrSynchronizeEnabled);
+				}
+
+				Attribute requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSTRUCTURESYNCHROINTERVAL_ATTRNAME);
+				if (requiredAttribute.getValue() == null) {
+					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
+				}
+
+				requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSQUERY_ATTRNAME);
+				if (requiredAttribute.getValue() == null) {
+					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
+				}
+
+				requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+				if (requiredAttribute.getValue() == null) {
+					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
+				}
+
+				requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPEXTSOURCE_ATTRNAME);
+				if (requiredAttribute.getValue() == null) {
+					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
+				}
+			} catch (AttributeNotExistsException e) {
+				throw new ConsistencyErrorException(e);
+			}
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			try {
+				AttributesManagerBl attributesManager = session.getPerunBl().getAttributesManagerBl();
+				AttributeDefinition removeAttrDef = attributesManager.getAttributeDefinition(session, new urn_perun_group_attribute_def_def_flatGroupStructureEnabled().getAttributeDefinition().getName());
+				attributesManager.removeAttributeWithoutCheck(session, group, removeAttrDef);
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
+			} catch (AttributeNotExistsException ex) {
+				log.debug("Attribute for flat group structure synchronization does not exist", ex);
+			}
+		}
+	}
+
+	@Override
+	public AttributeDefinition getAttributeDefinition() {
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setFriendlyName("groupStructureSynchronizationEnabled");
+		attr.setDisplayName("Group Structure Synchronization Enabled");
+		attr.setType(Boolean.class.getName());
+		attr.setDescription("Enables group structure synchronization from external source.");
+		return attr;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -1,0 +1,84 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * Group structure synchronization
+ *
+ * true if structure synchronization is enabled
+ * false if not
+ * empty if there is no setting
+ *
+ * @author Erik Horváth <horvatherik3@gmail.com>
+ */
+public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+    private static final Logger log = LoggerFactory.getLogger(urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.class);
+
+    @Override
+    public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+        //Null value is ok, means no settings for group
+        if(attribute.getValue() == null) return;
+
+        Attribute attrSynchronizeEnabled = null;
+        try {
+            attrSynchronizeEnabled = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSYNCHROENABLED_ATTRNAME);
+        } catch (AttributeNotExistsException e) {
+            throw new ConsistencyErrorException(e);
+        }
+        if (Objects.equals("true", attrSynchronizeEnabled.getValue())) {
+            throw new WrongReferenceAttributeValueException(attribute, attrSynchronizeEnabled);
+        }
+
+        if (!perunSession.getPerunBl().getGroupsManagerBl().getSubGroups(perunSession, group).isEmpty() && (boolean) attribute.getValue()) {
+            throw new InternalErrorException("Group " + group + " has one or more subGroups, so it is not possible to enable group structure synchronization.");
+        }
+
+        if(perunSession.getPerunBl().getGroupsManagerBl().isGroupInStructureSynchronizationTree(perunSession, group)) {
+            throw new InternalErrorException("Synchronization is already enabled for one of the parent groups.");
+        }
+    }
+
+    @Override
+    public void changedAttributeHook(PerunSessionImpl session, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+        if (attribute.getValue() == null) {
+            try {
+                AttributesManagerBl attributesManager = session.getPerunBl().getAttributesManagerBl();
+                AttributeDefinition removeAttrDef = attributesManager.getAttributeDefinition(session, new urn_perun_group_attribute_def_def_flatGroupStructureEnabled().getAttributeDefinition().getName());
+                attributesManager.removeAttributeWithoutCheck(session, group, removeAttrDef);
+            } catch (WrongAttributeAssignmentException ex) {
+                throw new InternalErrorException(ex);
+            } catch (AttributeNotExistsException ex) {
+                log.debug("Attribute for flat group structure synchronization does not exist", ex);
+            }
+        }
+    }
+
+    @Override
+    public AttributeDefinition getAttributeDefinition() {
+        AttributeDefinition attr = new AttributeDefinition();
+        attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+        attr.setFriendlyName("groupStructureSynchronizationEnabled");
+        attr.setDisplayName("Group Structure Synchronization Enabled");
+        attr.setType(Boolean.class.getName());
+        attr.setDescription("Enables group structure synchronization from external source.");
+        return attr;
+    }
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModul
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -73,6 +74,16 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 				throw new ConsistencyErrorException(e);
 			}
 		}
+	}
+
+	@Override
+	public List<String> getDependencies() {
+		List<String> dependencies = new ArrayList<String>();
+		dependencies.add(GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME);
+		dependencies.add(GroupsManager.GROUPSQUERY_ATTRNAME);
+		dependencies.add(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+		dependencies.add(GroupsManager.GROUPEXTSOURCE_ATTRNAME);
+		return dependencies;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -38,15 +38,7 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
 
-		if ((boolean) attribute.getValue()) {
-
-			if (!perunSession.getPerunBl().getGroupsManagerBl().getSubGroups(perunSession, group).isEmpty()) {
-				throw new InternalErrorException("Group " + group + " has one or more subGroups, so it is not possible to enable group structure synchronization.");
-			}
-
-			if (!perunSession.getPerunBl().getGroupsManagerBl().getGroupMembers(perunSession, group).isEmpty()) {
-				throw new InternalErrorException("Group " + group + " has one or more members, so it is not possible to enable group structure synchronization.");
-			}
+		if (attribute.valueAsBoolean()) {
 
 			if (perunSession.getPerunBl().getGroupsManagerBl().isGroupSynchronizedFromExternallSource(perunSession, group)) {
 				throw new InternalErrorException("Synchronization is already enabled for one of the parent groups.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
@@ -40,6 +40,11 @@ public class urn_perun_group_attribute_def_def_synchronizationEnabled extends Gr
 		}
 			try {
 				if (attrValue.equals("true")) {
+
+					if(sess.getPerunBl().getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group)) {
+						throw new InternalErrorException("There is already enabled group structure synchronization for this group or one of the parent groups.");
+					}
+
 					Attribute requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
 					if (requiredAttribute.getValue() == null) {
 						throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
@@ -58,19 +63,6 @@ public class urn_perun_group_attribute_def_def_synchronizationEnabled extends Gr
 			} catch (AttributeNotExistsException e) {
 				throw new ConsistencyErrorException(e);
 			}
-
-		Attribute structureSynchronizeEnabled = null;
-		try {
-			structureSynchronizeEnabled = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME);
-		} catch (AttributeNotExistsException e) {
-			throw new ConsistencyErrorException(e);
-		}
-		if (Objects.equals(true, structureSynchronizeEnabled.getValue())) {
-			throw new WrongReferenceAttributeValueException("There is already enabled group structure synchronization for this group.");
-		}
-		if(sess.getPerunBl().getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group)) {
-			throw new InternalErrorException("There is already enabled group structure synchronization for one of the parent groups.");
-		}
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
@@ -15,6 +15,8 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
 
+import java.util.Objects;
+
 /**
  * Synchronization enabled
  *
@@ -27,7 +29,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModul
 public class urn_perun_group_attribute_def_def_synchronizationEnabled extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
 
@@ -56,6 +58,19 @@ public class urn_perun_group_attribute_def_def_synchronizationEnabled extends Gr
 			} catch (AttributeNotExistsException e) {
 				throw new ConsistencyErrorException(e);
 			}
+
+		Attribute structureSynchronizeEnabled = null;
+		try {
+			structureSynchronizeEnabled = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSSTRUCTURESYNCHROENABLED_ATTRNAME);
+		} catch (AttributeNotExistsException e) {
+			throw new ConsistencyErrorException(e);
+		}
+		if (Objects.equals(true, structureSynchronizeEnabled.getValue())) {
+			throw new WrongReferenceAttributeValueException("There is already enabled group structure synchronization for this group.");
+		}
+		if(sess.getPerunBl().getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group)) {
+			throw new InternalErrorException("There is already enabled group structure synchronization for one of the parent groups.");
+		}
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
@@ -73,4 +73,18 @@ public interface ExtSourceSimpleApi {
 	 * @throws ExtSourceUnsupportedOperationException
 	 */
 	void close() throws InternalErrorException, ExtSourceUnsupportedOperationException;
+
+	/**
+	 * Get the list of the subject groups in the external source.
+	 *
+	 * 	 * 1. Get the query by which will be subject groups selected
+	 * 	 * 2. Get the list of subjects
+	 *
+	 * @param attributes map of attributes used for quering the external source
+	 * @return list of maps, which contains attr name and attr value
+	 * @throws InternalErrorException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
@@ -77,9 +77,6 @@ public interface ExtSourceSimpleApi {
 	/**
 	 * Get the list of the subject groups in the external source.
 	 *
-	 * 	 * 1. Get the query by which will be subject groups selected
-	 * 	 * 2. Get the list of subjects
-	 *
 	 * @param attributes map of attributes used for quering the external source
 	 * @return list of maps, which contains attr name and attr value
 	 * @throws InternalErrorException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -474,6 +474,15 @@ public interface GroupsManagerImplApi {
 	List<Group> getGroupsToSynchronize(PerunSession sess) throws InternalErrorException;
 
 	/**
+	 * Gets all groups which have enabled group structure synchronization.
+	 *
+	 * @param sess
+	 * @return list of groups structures to synchronize
+	 * @throws InternalErrorException
+	 */
+	List<Group> getGroupsStructuresToSynchronize(PerunSession sess) throws InternalErrorException;
+
+	/**
 	 * Returns all groups which have set the attribute with the value. Searching only def and opt attributes.
 	 *
 	 * @param sess

--- a/perun-core/src/main/resources/perun-core-synchronizers.xml
+++ b/perun-core/src/main/resources/perun-core-synchronizers.xml
@@ -12,6 +12,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 	<beans profile="production">
 		<task:scheduled-tasks scheduler="scheduler">
 			<task:scheduled ref="synchronizer" method="synchronizeGroups" cron="0 0/5 * * * ?"/> <!-- every 5 minutes -->
+			<task:scheduled ref="synchronizer" method="synchronizeGroupsStructures" cron="0 0/5 * * * ?"/> <!-- every 5 minutes -->
 			<task:scheduled ref="synchronizer" method="removeAllExpiredBans" cron="0 5 0 * * ?"/> <!-- every day at 00:05 -->
 			<!-- moved to ExpirationNotifScheduler in perun-registrar-lib project -->
 			<!--<task:scheduled ref="synchronizer" method="checkMembersState" cron="0 5 0 * * ?"/> --> <!-- every day at 00:05 -->

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -29,13 +29,16 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.validateMember(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.createMemberSync(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.synchronizeGroup(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.synchronizeGroupStructure(..))"/>
 		<!--<aop:advisor advice-ref="txAdviceAuditerTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.Auditer.*.*(..))"/>-->
 		<aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ExtSourceSql.*(..))"/>
 		<aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ExtSourceSqlComplex.*(..))"/>
 		<aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.Auditer.flush(..))"/>
 		<aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.Auditer.storeMessageToDb(..))"/>
 		<aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.Auditer.storeMessagesToDb(..))"/>
-		<aop:advisor advice-ref="txAdviceRequiresNewTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupSynchronization(..))"/>
+		<aop:advisor advice-ref="txAdviceRequiresNewTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupSynchronizationInNewTransaction(..))"/>
+		<aop:advisor advice-ref="txAdviceRequiresNewTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupStructureSynchronization(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupSynchronizationInNestedTransaction(..))"/>
 		<!-- START OF NESTED TRANSACTIONS FOR COMPATIBILITY WITH POSTGRESQL -->
 		<!-- AttributesManagerImpl -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.setAttributeWithNullValue(..))"/>

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -37,8 +37,9 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.Auditer.storeMessageToDb(..))"/>
 		<aop:advisor advice-ref="txAdviceNoneTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.Auditer.storeMessagesToDb(..))"/>
 		<aop:advisor advice-ref="txAdviceRequiresNewTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupSynchronizationInNewTransaction(..))"/>
-		<aop:advisor advice-ref="txAdviceRequiresNewTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupStructureSynchronization(..))"/>
+		<aop:advisor advice-ref="txAdviceRequiresNewTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupStructureSynchronizationInNewTransaction(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupSynchronizationInNestedTransaction(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.saveInformationAboutGroupStructureSynchronizationInNestedTransaction(..))"/>
 		<!-- START OF NESTED TRANSACTIONS FOR COMPATIBILITY WITH POSTGRESQL -->
 		<!-- AttributesManagerImpl -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.setAttributeWithNullValue(..))"/>

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
@@ -14,6 +14,7 @@ import cz.metacentrum.perun.core.bl.GroupsManagerBl;
 import cz.metacentrum.perun.core.bl.ExtSourcesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
+import cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl;
 import cz.metacentrum.perun.core.impl.ExtSourceLdap;
 import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.junit.After;
@@ -596,11 +597,11 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 
 		public Map<String, String> toMap() {
 			Map<String, String> subject = new HashMap<>();
-			subject.put("groupName", groupName);
+			subject.put(GroupsManagerBlImpl.GROUP_NAME, groupName);
 			if (parentGroupName != null) {
-				subject.put("parentGroupName", parentGroupName);
+				subject.put(GroupsManagerBlImpl.PARENT_GROUP_NAME, parentGroupName);
 			}
-			subject.put("description", description);
+			subject.put(GroupsManagerBlImpl.GROUP_DESCRIPTION, description);
 			return subject;
 		}
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
@@ -94,7 +94,7 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 
 	@Test
 	public void addGroupUnderBaseGroupTest() throws Exception {
-		System.out.println(CLASS_NAME + "addGroupToEmptyStructureTest");
+		System.out.println(CLASS_NAME + "addGroupUnderBaseGroupTest");
 
 		// setup
 		final TestGroup testGroup = new TestGroup("createdGroup", baseGroup.getShortName(), "group is child of base group");
@@ -179,7 +179,7 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 
 	@Test
 	public void addGroupsToBaseGroupInDifferentOrder() throws Exception {
-		System.out.println(CLASS_NAME + "addMultipleGroupsToBaseGroup");
+		System.out.println(CLASS_NAME + "addGroupsToBaseGroupInDifferentOrder");
 
 		final TestGroup testGroupA = new TestGroup("groupA", null, "description of group A");
 		final TestGroup testGroupB = new TestGroup("groupB", "groupA", "description of group B");
@@ -201,7 +201,7 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 
 	@Test
 	public void addGroupAsSubGroupTest() throws Exception {
-		System.out.println(CLASS_NAME + "addGroupParentDoesNotExist");
+		System.out.println(CLASS_NAME + "addGroupAsSubGroupTest");
 
 		// setup
 		final Group subGroup = new Group("baseSubGroup", "child of base group");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
@@ -1,0 +1,607 @@
+package cz.metacentrum.perun.core.entry;
+
+import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.ExtSourcesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
+import cz.metacentrum.perun.core.impl.ExtSourceLdap;
+import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration tests of group structure synchronization.
+ *
+ * @author Peter Balčirák
+ * @author Erik Horváth
+ */
+public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunIntegrationTest{
+	private final static String CLASS_NAME = "GroupsManager.";
+	private static final String EXT_SOURCE_NAME = "GroupSyncExtSource";
+
+	private Group baseGroup = new Group("baseGroup", "I am base group");
+
+	private ExtSource extSource = new ExtSource(0, EXT_SOURCE_NAME, ExtSourcesManager.EXTSOURCE_LDAP);
+
+	private Vo vo;
+
+	// exists before every method
+	@InjectMocks
+	private PerunBl perun;
+	private GroupsManagerBl groupsManagerBl;
+	@Spy
+	private ExtSourcesManagerBl extSourceManagerBl;
+	private AttributesManagerBl attributesManagerBl;
+	private GroupsManager groupsManager;
+	private ExtSourceSimpleApi essa = mock(ExtSourceLdap.class);
+
+	@Before
+	public void setUpBeforeEveryMethod() throws Exception {
+		perun = super.perun;
+		groupsManagerBl = perun.getGroupsManagerBl();
+		attributesManagerBl = perun.getAttributesManagerBl();
+		extSourceManagerBl = perun.getExtSourcesManagerBl();
+		groupsManager = perun.getGroupsManager();
+		vo = setUpVo();
+		setUpBaseGroup(vo);
+
+		MockitoAnnotations.initMocks(this);
+
+		doReturn(essa).when(extSourceManagerBl).getExtSourceByName(any(PerunSession.class), any(String.class));
+		doNothing().when(extSourceManagerBl).addExtSource(any(PerunSession.class), any(Group.class), any(ExtSource.class));
+	}
+
+	@After
+	public void cleanUp() {
+		Mockito.reset(extSourceManagerBl);
+	}
+
+	@Test
+	public void addGroupUnderBaseGroupTest() throws Exception {
+		System.out.println(CLASS_NAME + "addGroupToEmptyStructureTest");
+
+		// setup
+		final TestGroup testGroup = new TestGroup("createdGroup", baseGroup.getShortName(), "group is child of base group");
+		List<Map<String, String>> subjects = Arrays.asList(testGroup.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		// tested method
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		// asserts
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("New sub group should be created under base group!", 1 == subGroups.size());
+
+		Group createdGroup = subGroups.get(0);
+		assertGroup(testGroup.getGroupName(), baseGroup.getId(), testGroup.getDescription(), createdGroup);
+	}
+
+	@Test
+	public void addGroupNoParentGroupTest() throws Exception {
+		System.out.println(CLASS_NAME + "addGroupNoParentGroupTest");
+
+		final TestGroup testGroup = new TestGroup("createdGroup", null, "group without parent");
+		List<Map<String, String>> subjects = Arrays.asList(testGroup.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("New sub group under base group should be created!", 1 == subGroups.size());
+
+		Group createdGroup = subGroups.get(0);
+		assertGroup(testGroup.getGroupName(), baseGroup.getId(), testGroup.getDescription(), createdGroup);
+	}
+
+	@Test
+	public void addGroupParentDoesNotExist() throws Exception {
+		System.out.println(CLASS_NAME + "addGroupParentDoesNotExist");
+
+		final TestGroup testGroup = new TestGroup("createdGroup", "nonExistingParent", "group's parent does not exist");
+		List<Map<String, String>> subjects = Arrays.asList(testGroup.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("New sub group under base group should be created!", 1 == subGroups.size());
+
+		Group createdGroup = subGroups.get(0);
+		assertGroup(testGroup.getGroupName(), baseGroup.getId(), testGroup.getDescription(), createdGroup);
+	}
+
+	@Test
+	public void addMultipleGroupsToBaseGroup() throws Exception {
+		System.out.println(CLASS_NAME + "addMultipleGroupsToBaseGroup");
+
+		final TestGroup testGroupA = new TestGroup("groupA", baseGroup.getShortName(), "description of group A");
+		final TestGroup testGroupB = new TestGroup("groupB", baseGroup.getShortName(), "description of group B");
+		List<Map<String, String>> subjects = Arrays.asList(testGroupA.toMap(), testGroupB.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("2 new sub groups under base group should be created!", 2 == subGroups.size());
+	}
+
+	@Test
+	public void addGroupsToBaseGroupInDifferentOrder() throws Exception {
+		System.out.println(CLASS_NAME + "addMultipleGroupsToBaseGroup");
+
+		final TestGroup testGroupA = new TestGroup("groupA", null, "description of group A");
+		final TestGroup testGroupB = new TestGroup("groupB", "groupA", "description of group B");
+		List<Map<String, String>> subjects = Arrays.asList(testGroupB.toMap(), testGroupA.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		Group groupA = groupsManagerBl.getGroupByName(sess, vo, "baseGroup:groupA");
+		Group groupB = groupsManagerBl.getGroupByName(sess, vo, "baseGroup:groupA:groupB");
+
+		assertTrue("1 new sub group under base group should be created!", 1 == subGroups.size());
+		assertTrue("groupA should be created under base group!", subGroups.contains(groupA));
+		assertTrue("groupB should be created under groupA!", groupsManagerBl.getSubGroups(sess, groupA).contains(groupB));
+	}
+
+	@Test
+	public void addGroupAsSubGroupTest() throws Exception {
+		System.out.println(CLASS_NAME + "addGroupParentDoesNotExist");
+
+		// setup
+		final Group subGroup = new Group("baseSubGroup", "child of base group");
+		groupsManagerBl.createGroup(sess, baseGroup, subGroup);
+		final TestGroup subTestGroup = new TestGroup(subGroup.getShortName(), baseGroup.getShortName(), subGroup.getDescription());
+		List<Map<String, String>> subjects = new ArrayList<>();
+		subjects.add(subTestGroup.toMap());
+
+		final TestGroup testGroup = new TestGroup("createdGroup", subGroup.getShortName(), "child of subgroup (baseGroup -> subGroup -> [this group])");
+		subjects.add(testGroup.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		// tested method
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		// assertions
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, subGroup);
+
+		assertTrue("New sub group under base group should be created!", 1 == subGroups.size());
+
+		Group createdGroup = subGroups.get(0);
+		assertGroup(testGroup.getGroupName(), subGroup.getId(), testGroup.getDescription(), createdGroup);
+	}
+
+	@Test
+	public void addComplexSubTreeTest() throws Exception {
+		System.out.println(CLASS_NAME + "addComplexSubTreeTest");
+
+		List<Map<String, String>> subjects = new ArrayList<>();
+
+		final Group childOfBaseGroup = new Group("childOfBaseGroup", "child of base group");
+		groupsManagerBl.createGroup(sess, baseGroup, childOfBaseGroup);
+		final TestGroup subTestGroup = new TestGroup(childOfBaseGroup.getShortName(), baseGroup.getShortName(), childOfBaseGroup.getDescription());
+		subjects.add(subTestGroup.toMap());
+
+		List<Map<String, String>> complexGroupTree = makeComplexGroupTreeSample(childOfBaseGroup.getShortName());
+		subjects.addAll(complexGroupTree);
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		// assert structure
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("No direct children should be added or removed from base group!", 1 == subGroups.size());
+		Group checkedGroup = subGroups.get(0);
+		assertTrue("Short name of existing group should not change!", childOfBaseGroup.getShortName().equals(checkedGroup.getShortName()));
+		assertTrue("Name of existing group should not change!", childOfBaseGroup.getName().equals(checkedGroup.getName()));
+		assertTrue("Description of existing group should no change!", childOfBaseGroup.getDescription().equals(checkedGroup.getDescription()));
+
+		subGroups = groupsManagerBl.getAllSubGroups(sess, childOfBaseGroup);
+		assertComplexGroupTree(childOfBaseGroup, subGroups);
+	}
+
+	@Test
+	public void removeGroupUnderBaseGroupTest() throws Exception {
+		System.out.println(CLASS_NAME + "removeGroupUnderBaseGroupTest");
+
+		final Group subGroup = new Group("baseSubGroup", "child of base group");
+		groupsManagerBl.createGroup(sess, baseGroup, subGroup);
+
+		List<Map<String, String>> subjects = new ArrayList<>();
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("List of sub groups of base group should be empty!", subGroups.isEmpty());
+	}
+
+	@Test
+	public void removeLeafGroupTest() throws Exception {
+		System.out.println(CLASS_NAME + "removeLeafGroupTest");
+
+		// setup
+		final Group subBaseGroup = new Group("baseSubGroup", "child of base group");
+		groupsManagerBl.createGroup(sess, baseGroup, subBaseGroup);
+
+		final Group subGroup = new Group("subGroup", "child of sub base group");
+		groupsManagerBl.createGroup(sess, subBaseGroup, subGroup);
+
+		final TestGroup subBaseTestGroup = new TestGroup("subGroup", baseGroup.getShortName(), "child of base group");
+		List<Map<String, String>> subjects = Arrays.asList(subBaseTestGroup.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		// tested method
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		// asserts
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("Leaf group should be removed!", 1 == subGroups.size());
+
+		Group returnedGroup = subGroups.get(0);
+		assertGroup(subBaseTestGroup.getGroupName(), baseGroup.getId(), subBaseTestGroup.getDescription(), returnedGroup);
+	}
+
+	@Test
+	public void removeIntermediaryGroupTest() throws Exception {
+		System.out.println(CLASS_NAME + "removeIntermediaryGroupTest");
+
+		final Group subBaseGroup = new Group("baseSubGroup", "child of base group");
+		groupsManagerBl.createGroup(sess, baseGroup, subBaseGroup);
+		final Group interGroup = new Group("interGroup", "child of sub base group");
+		groupsManagerBl.createGroup(sess, subBaseGroup, interGroup);
+		final Group leafGroup = new Group("leafGroup", "leaf group");
+		groupsManagerBl.createGroup(sess, interGroup, leafGroup);
+
+		final TestGroup subBaseTestGroup = new TestGroup("baseSubGroup", baseGroup.getShortName(), "child of base group");
+		final TestGroup leafTestGroup = new TestGroup("leafGroup", subBaseGroup.getShortName(), "leaf group");
+		List<Map<String, String>> subjects = Arrays.asList(subBaseTestGroup.toMap(), leafTestGroup.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("Base group should have exactly one child!", 1 == subGroups.size());
+		Group baseGroupChild = subGroups.get(0);
+		assertGroup(subBaseTestGroup.getGroupName(), baseGroup.getId(), subBaseTestGroup.getDescription(), baseGroupChild);
+
+		subGroups = groupsManagerBl.getSubGroups(sess, baseGroupChild);
+
+		assertTrue("Child of base group should have only one child!", 1 == subGroups.size());
+		Group subBaseGroupChild = subGroups.get(0);
+		assertGroup(leafTestGroup.getGroupName(), baseGroupChild.getId(), leafTestGroup.getDescription(), subBaseGroupChild);
+
+		assertTrue("Leaf group should not have any children!", 0 == groupsManagerBl.getSubGroupsCount(sess, subBaseGroupChild));
+	}
+
+	@Test
+	public void modifyGroupNameTest() throws Exception {
+		System.out.println(CLASS_NAME + "modifyGroupNameTest");
+
+		final Group subBaseGroup = new Group("group1", "child of base group");
+		groupsManagerBl.createGroup(sess, baseGroup, subBaseGroup);
+
+		final TestGroup modifiedSubBaseTestGroup = new TestGroup("modified", baseGroup.getShortName(), "child of base group");
+		List<Map<String, String>> subjects = Arrays.asList(modifiedSubBaseTestGroup.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+		assertTrue("Base group should have exactly one child!", 1 == subGroups.size());
+		Group subBaseGroupChild = subGroups.get(0);
+		assertGroup(modifiedSubBaseTestGroup.getGroupName(), baseGroup.getId(), modifiedSubBaseTestGroup.getDescription(), subBaseGroupChild);
+	}
+
+	@Test
+	public void modifyGroupDescriptionTest() throws Exception {
+		System.out.println(CLASS_NAME + "modifyGroupDescriptionTest");
+
+		final Group subBaseGroup = new Group("group1", "child of base group");
+		groupsManagerBl.createGroup(sess, baseGroup, subBaseGroup);
+
+		final TestGroup modifiedSubBaseTestGroup = new TestGroup("group1", baseGroup.getShortName(), "modified");
+		List<Map<String, String>> subjects = Arrays.asList(modifiedSubBaseTestGroup.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+		assertTrue("Base group should have exactly one child!", 1 == subGroups.size());
+		Group subBaseGroupChild = subGroups.get(0);
+		assertGroup(modifiedSubBaseTestGroup.getGroupName(), baseGroup.getId(), modifiedSubBaseTestGroup.getDescription(), subBaseGroupChild);
+	}
+
+	@Test
+	public void modifyParentGroupTest() throws Exception {
+		System.out.println(CLASS_NAME + "modifyParentGroupTest");
+
+		final Group groupA = new Group("groupA", "group A");
+		groupsManagerBl.createGroup(sess, baseGroup, groupA);
+
+		final Group groupB = new Group("groupB", "group B");
+		groupsManagerBl.createGroup(sess, baseGroup, groupB);
+
+		final TestGroup testGroupA = new TestGroup("groupA", baseGroup.getShortName(), "group A");
+		final TestGroup testGroupB = new TestGroup("groupB", groupA.getShortName(), "group B");
+		List<Map<String, String>> subjects = Arrays.asList(testGroupA.toMap(), testGroupB.toMap());
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+		assertTrue("Base group should have exactly one child!",1 == subGroups.size());
+
+		Group subBaseGroup = subGroups.get(0);
+		assertGroup(testGroupA.getGroupName(), baseGroup.getId(), testGroupA.getDescription(), subBaseGroup);
+
+		subGroups = groupsManagerBl.getSubGroups(sess, subBaseGroup);
+		assertTrue("Child of base group should have exactly one child!", 1 == subGroups.size());
+
+		Group childOfBaseGroup = subGroups.get(0);
+		assertGroup(testGroupB.getGroupName(), groupA.getId(), testGroupB.getDescription(), childOfBaseGroup);
+	}
+
+	@Test
+	public void removeAllGroupsTest() throws Exception {
+		System.out.println(CLASS_NAME + "removeAllGroupsTest");
+
+		final Group subGroupA = new Group("baseSubGroupA", "child A of base group");
+		final Group subGroupB = new Group("baseSubGroupB", "child B of base group");
+		final Group subSubGroup1 = new Group("subGroup1", "child 1 of sub group A");
+		groupsManagerBl.createGroup(sess, baseGroup, subGroupA);
+		groupsManagerBl.createGroup(sess, baseGroup, subGroupB);
+		groupsManagerBl.createGroup(sess, subGroupA, subSubGroup1);
+
+		List<Map<String, String>> subjects = new ArrayList<>();
+		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
+		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
+
+		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
+
+		assertTrue("No users should be skipped!", skipped.isEmpty());
+
+		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
+
+		assertTrue("List of sub groups of base group should be empty!", subGroups.isEmpty());
+	}
+
+
+	private Vo setUpVo() throws Exception {
+
+		Vo newVo = new Vo(0, "UserManagerTestVo", "UMTestVo");
+		Vo returnedVo = perun.getVosManagerBl().createVo(sess, newVo);
+		// create test VO in database
+		assertNotNull("unable to create testing Vo",returnedVo);
+
+		return returnedVo;
+
+	}
+
+	public void setUpBaseGroup(Vo vo) throws Exception {
+		extSource = extSourceManagerBl.createExtSource(sess, extSource, null);
+
+		groupsManagerBl.createGroup(sess, vo, baseGroup);
+
+		extSourceManagerBl.addExtSource(sess, vo, extSource);
+		Attribute attr = attributesManagerBl.getAttribute(sess, baseGroup, groupsManager.GROUPEXTSOURCE_ATTRNAME);
+		attr.setValue(extSource.getName());
+		attributesManagerBl.setAttribute(sess, baseGroup, attr);
+		extSourceManagerBl.addExtSource(sess, baseGroup, extSource);
+
+		Attribute membersQuery = new Attribute(((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME));
+		membersQuery.setValue("SELECT * from members where groupName='?';");
+		attributesManagerBl.setAttribute(sess, baseGroup, membersQuery);
+	}
+
+	/**
+	 * Created structure text visualization:
+	 *
+	 *  Layer 0:                       [rootGroup]
+	 *                                 /         \
+	 *  Layer 1:        --------[groupA]     [groupB]
+	 *                 /         /     \          \
+	 *  Layer 2: [group1] [group2]   [group3]   [group4]
+	 *                      |          |
+	 *  Layer 3:          [groupI]   [groupII]
+	 *                      |
+	 *  Layer 4:        [groupRed]
+	 */
+	private List<Map<String, String>> makeComplexGroupTreeSample(String rootGroupName) {
+		// 1st layer
+		TestGroup groupA = new TestGroup("groupA", rootGroupName, "group A is child of root group");
+		TestGroup groupB = new TestGroup("groupB", rootGroupName, "group B is child of root group");
+		// 2nd layer
+		TestGroup group1 = new TestGroup("group1", groupA.getGroupName(), "group 1 is child of group A");
+		TestGroup group2 = new TestGroup("group2", groupA.getGroupName(), "group 2 is child of group A");
+		TestGroup group3 = new TestGroup("group3", groupA.getGroupName(), "group 3 is child of group A");
+		TestGroup group4 = new TestGroup("group4", groupB.getGroupName(), "group 4 is child of group B");
+		// 3rd layer
+		TestGroup groupI = new TestGroup("groupI", group2.getGroupName(), "group I is child of group 2");
+		TestGroup groupII = new TestGroup("groupII", group3.getGroupName(), "group II is child of group 3");
+		// 4th layer
+		TestGroup groupRed = new TestGroup("groupRed", groupI.getGroupName(), "group Red is child of group I");
+
+		return Arrays.asList(groupA.toMap(), groupB.toMap(),
+				group1.toMap(), group2.toMap(), group3.toMap(), group4.toMap(),
+				groupI.toMap(), groupII.toMap(),
+				groupRed.toMap());
+	}
+
+	private void assertComplexGroupTree(Group rootGroup, List<Group> allGroupsInTree) {
+		// 1st layer
+		List<Group> foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("groupA")).collect(Collectors.toList());
+		assertEquals("Only one group with name groupA should be created!", 1, foundGroups.size());
+		Group groupA = foundGroups.get(0);
+		assertGroup("groupA", rootGroup.getId(), "group A is child of root group", groupA);
+
+		foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("groupB")).collect(Collectors.toList());
+		assertEquals("Only one group with name groupB should be created!", 1, foundGroups.size());
+		Group groupB = foundGroups.get(0);
+		assertGroup("groupB", rootGroup.getId(), "group B is child of root group", groupB);
+
+		// 2nd layer
+		foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("group1")).collect(Collectors.toList());
+		assertEquals("Only one group with name group1 should be created!", 1, foundGroups.size());
+		Group group1 = foundGroups.get(0);
+		assertGroup("group1", groupA.getId(), "group 1 is child of group A", group1);
+
+		foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("group2")).collect(Collectors.toList());
+		assertEquals("Only one group with name group2 should be created!", 1, foundGroups.size());
+		Group group2 = foundGroups.get(0);
+		assertGroup("group2", groupA.getId(), "group 2 is child of group A", group2);
+
+		foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("group3")).collect(Collectors.toList());
+		assertEquals("Only one group with name group3 should be created!", 1, foundGroups.size());
+		Group group3 = foundGroups.get(0);
+		assertGroup("group3", groupA.getId(), "group 3 is child of group A", group3);
+
+		foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("group4")).collect(Collectors.toList());
+		assertEquals("Only one group with name group4 should be created!", 1, foundGroups.size());
+		Group group4 = foundGroups.get(0);
+		assertGroup("group4", groupB.getId(), "group 4 is child of group B", group4);
+
+		// 3rd layer
+		foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("groupI")).collect(Collectors.toList());
+		assertEquals("Only one group with name groupI should be created!", 1, foundGroups.size());
+		Group groupI = foundGroups.get(0);
+		assertGroup("groupI", group2.getId(), "group I is child of group 2", groupI);
+
+		foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("groupII")).collect(Collectors.toList());
+		assertEquals("Only one group with name groupII should be created!", 1, foundGroups.size());
+		Group groupII = foundGroups.get(0);
+		assertGroup("groupII", group3.getId(), "group II is child of group 3", groupII);
+
+		// 4th layer
+		foundGroups = allGroupsInTree.stream().filter(g -> g.getShortName().equals("groupRed")).collect(Collectors.toList());
+		assertEquals("Only one group with name groupRed should be created!", 1, foundGroups.size());
+		Group groupRed = foundGroups.get(0);
+		assertGroup("groupRed", groupI.getId(), "group Red is child of group I", groupRed);
+	}
+
+	private void assertGroup(String expectedName, Integer expectedParentId, String expectedDescription, Group group) {
+		assertTrue("Group should not have null name!", group.getShortName() != null);
+		assertEquals("Group should have correct name!", expectedName, group.getShortName());
+		if (expectedParentId == null) {
+			assertTrue("Group A should have null as parent group!", group.getParentGroupId() == null);
+		} else {
+			assertTrue("Group A should not have null parent group!", group.getParentGroupId() != null);
+			assertEquals("Group A should have tree root as parent group!", (int) expectedParentId, (int) group.getParentGroupId());
+		}
+
+		assertTrue("Group A should not have null description!", group.getDescription() != null);
+		assertEquals("Group A should have correct description!", expectedDescription, group.getDescription());
+	}
+
+	private class TestGroup {
+		private final String groupName;
+		private final String parentGroupName;
+		private final String description;
+
+		public TestGroup(String groupName, String parentGroupName, String description) {
+			this.groupName = groupName;
+			this.parentGroupName = parentGroupName;
+			this.description = description;
+		}
+
+		public String getGroupName() {
+			return groupName;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public Map<String, String> toMap() {
+			Map<String, String> subject = new HashMap<>();
+			subject.put("groupName", groupName);
+			if (parentGroupName != null) {
+				subject.put("parentGroupName", parentGroupName);
+			}
+			subject.put("description", description);
+			return subject;
+		}
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -1666,6 +1666,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	@Test
 	public void deletesGroups() throws Exception {
 		System.out.println(CLASS_NAME + "deletesGroups");
+
 		Vo newVo = new Vo(0, "voForDeletingGroups", "voForDeletingGroups");
 		newVo = perun.getVosManagerBl().createVo(sess, newVo);
 		List<Group> groups = setUpGroupsWithSubgroups(newVo);
@@ -1676,6 +1677,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	@Test (expected=RelationExistsException.class)
 	public void deleteGroupsWithSubgroupAndNoForceDelete() throws Exception {
 		System.out.println(CLASS_NAME + "deleteGroupsWithSubgroupAndNoForceDelete");
+
 		Vo newVo = new Vo(0, "voForDeletingGroups", "voForDeletingGroups");
 		newVo = perun.getVosManagerBl().createVo(sess, newVo);
 		List<Group> groups = setUpGroupsWithSubgroups(newVo);
@@ -1691,6 +1693,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	@Test
 	public void deleteGroupsWithSubgroupAndForceDelete() throws Exception {
 		System.out.println(CLASS_NAME + "deleteGroupsWithSubgroupAndForceDelete");
+
 		Vo newVo = new Vo(0, "voForDeletingGroups", "voForDeletingGroups");
 		newVo = perun.getVosManagerBl().createVo(sess, newVo);
 		List<Group> groups = setUpGroupsWithSubgroups(newVo);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -831,6 +831,22 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Forces group structure synchronization.
+	 *
+	 * @param group int Group <code>id</code>
+	 */
+	forceGroupStructureSynchronization {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			ac.getGroupsManager().forceGroupStructureSynchronization(ac.getSession(),
+					ac.getGroupById(parms.readInt("group")));
+			return null;
+		}
+	},
+
+	/*#
 	 * Returns parent VO of a group.
 	 *
 	 * @param group int Group <code>id</code>

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -839,6 +839,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
 
 			ac.getGroupsManager().forceGroupStructureSynchronization(ac.getSession(),
 					ac.getGroupById(parms.readInt("group")));


### PR DESCRIPTION
-Attributes needs to be set:
	groupStructureSynchronizationEnabled
	group extSource
	groups query
	group members query
	there has to be defined extSource in perun-extSources.xml

- Optional attributes:
	flatGroupStructureEnabled
	group members extSource
	group structure synchronization interval
	group structure synchronization timeout
- For this type of synchronization was created object CandidateGroup,
  which extends Group by parentGroupName (String) and extSource (ExtSource).

-Group structure synchronizations is run by scheduler every 5 minutes (by default).
 It works with threads just like member synchronization, but it has its own pool of threads and variables.
 groups are synchronized by groupName. From extSource are taken subjects with groupName, description and parentGroupName.

-Synchronization of group structure gets subject groups from extSource and creates candidatGroups from them.
 Each candidate is categorized to: group candidate to add, group to update and group to remove.

 1. Adding candidateGroups: If there is already their parentGroup (from extSource) in the structure,
	create group under that parent (CandidateGroup has parentGroupName from extSource).
	If there is no such parentGroup, create Group under baseGroup.
 2. Updating Groups: Check if, after creating new groups, there was added parent group (from extSource) of updating group.
	If there is such a group, then move updating group under that group. Then update also group description.
 3. Removing Groups: Move all subGroups under baseGroup and then remove group.

 Get list of all subGroups of basGroup and order them (leaf groups are first).
 for each subGroup in the list set neccessary attributes and run method synchronizeGroup.
 after that save information about member synchronization for that group.
 after all subGroups were proccessed, save information about group structure synchronization.

-There was also implemented forceGroupStructureSynchronization, which puts group to the first place of the pool.

-For test purposes were implemented methods getSubjectGroups() in  ExtSourceCSV, ExtSourceSql and ExtSourceSqlComplex.

-Method saveInformationAboutGroupSynchronization were duplicated. Original solution is run as new transaction,
 which was causing dataAccessException while saving information about member synchronization for each subGroup of baseGroup.
 The duplicity is run as nested transaction which works fine.