### PR TITLE
NOTIF: Fixed setting From to MimeMessages

### DIFF
--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/mail/MessagePreparator.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/mail/MessagePreparator.java
@@ -101,7 +101,7 @@ public class MessagePreparator implements MimeMessagePreparator {
 		}
 
 		// adding from and subject
-		mimeMessage.setFrom(new InternetAddress(getFrom(), getFromText()));
+		mimeMessage.setFrom(new InternetAddress(getFrom()));
 		mimeMessage.setSubject(getSubject());
 
 		if (getEmailType().equals(EmailType.HTML)) {

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailUserSender.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/senders/PerunNotifEmailUserSender.java
@@ -69,7 +69,7 @@ public class PerunNotifEmailUserSender implements PerunNotifSender {
 
 			String sender = messageDto.getSender();
 			emailDto.setSender(sender);
-			logger.debug("Calculated sender for receiver: {}, sender: {}", Arrays.asList(receiver.getId(), sender));
+			logger.debug("Calculated sender for receiver: {}, sender: {}", receiver.getId(), sender);
 
 			String myReceiverId = dto.getKeyAttributes().get(receiver.getTarget());
 			if (myReceiverId == null || myReceiverId.isEmpty()) {
@@ -81,7 +81,7 @@ public class PerunNotifEmailUserSender implements PerunNotifSender {
 				try {
 					id = Integer.valueOf(myReceiverId);
 				} catch (NumberFormatException ex) {
-					logger.error("Cannot resolve id: {}, error: {}", Arrays.asList(id, ex.getMessage()));
+					logger.error("Cannot resolve id: {}, error: {}", id, ex.getMessage());
 					logger.debug("ST:", ex);
 				}
 				if (id != null) {
@@ -92,10 +92,10 @@ public class PerunNotifEmailUserSender implements PerunNotifSender {
 							emailDto.setReceiver((String) emailAttribute.getValue());
 						}
 					} catch (UserNotExistsException ex) {
-						logger.error("Cannot found user with id: {}, ex: {}", Arrays.asList(id, ex.getMessage()));
+						logger.error("Cannot found user with id: {}, ex: {}", id, ex.getMessage());
 						logger.debug("ST:", ex);
 					} catch (AttributeNotExistsException ex) {
-						logger.warn("Cannot found email for user with id: {}, ex: {}", Arrays.asList(id, ex.getMessage()));
+						logger.warn("Cannot found email for user with id: {}, ex: {}", id, ex.getMessage());
 						logger.debug("ST:", ex);
 					} catch (Exception ex) {
 						logger.error("Error during user email recognition, ex: {}", ex.getMessage());


### PR DESCRIPTION
- Removed passing getFromText() to new InternetAddress(),
  since whole logic expect, that display name of from address
  and actual address are already splitted. But Perun might provide
  either mail address itself or /"displayName" <address>/ format.
- We never used (set) fromText in MessagePreparator, hence it can
  be removed safely. InternetAddress own parser can then correctly
  parse all formats.
- Fixed logging when sending messages (everything was passed to
  the first placeholder only).