### PR TITLE
Fixed wrong usage of 'select 1'

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcesManagerImpl.java
@@ -479,7 +479,13 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	public boolean extSourceExists(PerunSession perunSession, ExtSource extSource) throws InternalErrorException {
 		Utils.notNull(extSource, "extSource");
 		try {
-			return 1 == jdbc.queryForInt("select 1 from ext_sources where id=?", extSource.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from ext_sources where id=?", extSource.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("ExtSource " + extSource + " exists more than once.");
+			}
+			return false;
 		} catch (EmptyResultDataAccessException ex) {
 			return false;
 		} catch (RuntimeException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -412,11 +412,11 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public void addOwner(PerunSession sess, Facility facility, Owner owner) throws InternalErrorException, OwnerAlreadyAssignedException {
 		try {
-			try {
-				// Check if the owner is already assigned
-				jdbc.queryForInt("select 1 from facility_owners where facility_id=? and owner_id=?", facility.getId(), owner.getId());
+			// Check if the owner is already assigned
+			int numberOfExistences = jdbc.queryForInt("select count(1) from facility_owners where facility_id=? and owner_id=?", facility.getId(), owner.getId());
+			if (numberOfExistences >= 1) {
 				throw new OwnerAlreadyAssignedException("Owner: " + owner + " facility: " + facility);
-			} catch (EmptyResultDataAccessException e) {
+			} else {
 				jdbc.update("insert into facility_owners(facility_id, owner_id,created_by,created_at,modified_by,modified_at,created_by_uid, modified_by_uid) " +
 						"values (?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)", facility.getId(), owner.getId(),
 						sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
@@ -546,7 +546,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public boolean facilityExists(PerunSession sess, Facility facility) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from facilities where id=?", facility.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from facilities where id=?", facility.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Facility " + facility + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -727,7 +733,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public boolean hostExists(PerunSession sess, Host host) throws InternalErrorException {
 		try {
-			return 1==jdbc.queryForInt("select 1 from hosts where id=?", host.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from hosts where id=?", host.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Host " + host + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch (RuntimeException e) {
@@ -958,7 +970,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 
 	private boolean facilityContactExists(PerunSession sess, Facility facility, String name, Owner owner) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from facility_contacts where facility_id=? and name=? and owner_id=?", facility.getId(), name, owner.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from facility_contacts where facility_id=? and name=? and owner_id=?", facility.getId(), name, owner.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Facility contact of " + facility + " and " + name + " and " + owner + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -968,7 +986,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 
 	private boolean facilityContactExists(PerunSession sess, Facility facility, String name, User user) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from facility_contacts where facility_id=? and name=? and user_id=?", facility.getId(), name, user.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from facility_contacts where facility_id=? and name=? and user_id=?", facility.getId(), name, user.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Facility contact of " + facility + " and " + name + " and " + user + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -978,7 +1002,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 
 	private boolean facilityContactExists(PerunSession sess, Facility facility, String name, Group group) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from facility_contacts where facility_id=? and name=? and group_id=?", facility.getId(), name, group.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from facility_contacts where facility_id=? and name=? and group_id=?", facility.getId(), name, group.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Facility contact of " + facility + " and " + name + " and " + group + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -1110,7 +1140,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public boolean banExists(PerunSession sess, int userId, int facilityId) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from facilities_bans where user_id=? and facility_id=?", userId, facilityId);
+			int numberOfExistences = jdbc.queryForInt("select count(1) from facilities_bans where user_id=? and facility_id=?", userId, facilityId);
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Ban of user with ID=" + userId + " on facility with ID=" + facilityId + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -1121,7 +1157,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	@Override
 	public boolean banExists(PerunSession sess, int banId) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from facilities_bans where id=?", banId);
+			int numberOfExistences = jdbc.queryForInt("select count(1) from facilities_bans where id=?", banId);
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Ban with ID=" + banId + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -1240,7 +1282,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 
 	private boolean isSecurityTeamAssigned(PerunSession sess, Facility facility, SecurityTeam securityTeam) throws InternalErrorException {
 		try {
-			int number = jdbc.queryForInt("select 1 from security_teams_facilities where security_team_id=? and facility_id=?", securityTeam.getId(), facility.getId());
+			int number = jdbc.queryForInt("select count(1) from security_teams_facilities where security_team_id=? and facility_id=?", securityTeam.getId(), facility.getId());
 			if (number == 1) {
 				return true;
 			} else if (number > 1) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -699,7 +699,13 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	@Override
 	public boolean groupExists(PerunSession sess, Group group) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from groups where id=?", group.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from groups where id=?", group.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Group " + group + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch (RuntimeException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -254,7 +254,13 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	@Override
 	public boolean resourceExists(PerunSession sess, Resource resource) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from resources where id=?", resource.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from resources where id=?", resource.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Resource " + resource + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -269,7 +275,13 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 
 	public boolean resourceTagExists(PerunSession sess, ResourceTag resourceTag) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from res_tags where id=?", resourceTag.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from res_tags where id=?", resourceTag.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Resource tag " + resourceTag + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -874,7 +886,13 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	@Override
 	public boolean banExists(PerunSession sess, int memberId, int resourceId) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from resources_bans where member_id=? and resource_id=?", memberId, resourceId);
+			int numberOfExistences = jdbc.queryForInt("select count(1) from resources_bans where member_id=? and resource_id=?", memberId, resourceId);
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Ban on member with ID=" + memberId + " and resource with ID=" + resourceId + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -885,7 +903,13 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	@Override
 	public boolean banExists(PerunSession sess, int banId) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from resources_bans where id=?", banId);
+			int numberOfExistences = jdbc.queryForInt("select count(1) from resources_bans where id=?", banId);
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Ban with ID=" + banId + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
@@ -312,7 +312,7 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 	@Override
 	public void checkSecurityTeamUniqueName(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException, SecurityTeamExistsException {
 		try {
-			int number = jdbc.queryForInt("select 1 from security_teams where name=?", securityTeam.getName());
+			int number = jdbc.queryForInt("select count(1) from security_teams where name=?", securityTeam.getName());
 			if (number == 1) {
 				throw new SecurityTeamExistsException("Name of security team " +securityTeam+ " is not unique. It already exists.");
 			} else if (number > 1) {
@@ -358,7 +358,7 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 	@Override
 	public boolean isUserBlacklisted(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException {
 		try {
-			int number = jdbc.queryForInt("select 1 from blacklists where security_team_id=? and user_id=?", securityTeam.getId(), user.getId());
+			int number = jdbc.queryForInt("select count(1) from blacklists where security_team_id=? and user_id=?", securityTeam.getId(), user.getId());
 			if (number == 1) {
 				return true;
 			} else if (number > 1) {
@@ -377,7 +377,7 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 	@Override
 	public boolean isUserBlacklisted(PerunSession sess, User user) throws InternalErrorException {
 		try {
-			int number = jdbc.queryForInt("select 1 from blacklists where user_id=?", user.getId());
+			int number = jdbc.queryForInt("select count(1) from blacklists where user_id=?", user.getId());
 			if (number >= 1) return true;
 			return false;
 		} catch(EmptyResultDataAccessException ex) {
@@ -389,7 +389,7 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 
 	private boolean securityTeamExists(SecurityTeam securityTeam) throws InternalErrorException {
 		try {
-			int number = jdbc.queryForInt("select 1 from security_teams where id=?", securityTeam.getId());
+			int number = jdbc.queryForInt("select count(1) from security_teams where id=?", securityTeam.getId());
 			if (number == 1) {
 				return true;
 			} else if (number > 1) {
@@ -424,7 +424,7 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 
 	private boolean isGroupSecurityAdmin(Group group, SecurityTeam securityTeam) throws InternalErrorException {
 		try {
-			int number = jdbc.queryForInt("select 1 from authz where authorized_group_id=? and security_team_id=?", group.getId(), securityTeam.getId());
+			int number = jdbc.queryForInt("select count(1) from authz where authorized_group_id=? and security_team_id=?", group.getId(), securityTeam.getId());
 			if (number == 1) {
 				return true;
 			} else if (number > 1) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -473,7 +474,13 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 	@Override
 	public boolean serviceExists(PerunSession sess, Service service) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from services where id=?", service.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from services where id=?", service.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Service " + service + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -495,7 +502,13 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 	@Override
 	public boolean servicesPackageExists(PerunSession sess, ServicesPackage servicesPackage) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from service_packages where id=?", servicesPackage.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from service_packages where id=?", servicesPackage.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("ServicesPackage " + servicesPackage + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -642,7 +655,13 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 	@Override
 	public boolean destinationExists(PerunSession sess, Service service, Facility facility, Destination destination) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from facility_service_destinations fsd join destinations d on fsd.destination_id = d.id where fsd.service_id=? and fsd.facility_id=? and d.destination=? and d.type=?", service.getId(), facility.getId(), destination.getDestination(), destination.getType());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from facility_service_destinations fsd join destinations d on fsd.destination_id = d.id where fsd.service_id=? and fsd.facility_id=? and d.destination=? and d.type=?", service.getId(), facility.getId(), destination.getDestination(), destination.getType());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Destination " + destination + " of service " + service + " and facility " + facility + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -653,7 +672,13 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 	@Override
 	public boolean destinationExists(PerunSession sess, Destination destination) throws InternalErrorException {
 		try {
-			return 1 == jdbc.queryForInt("select 1 from destinations where id=? and destination=? and type=?", destination.getId(), destination.getDestination(), destination.getType());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from destinations where id=? and destination=? and type=?", destination.getId(), destination.getDestination(), destination.getType());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Destination " + destination + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/VosManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/VosManagerImpl.java
@@ -262,7 +262,13 @@ public class VosManagerImpl implements VosManagerImplApi {
 	public boolean voExists(PerunSession sess, Vo vo) throws InternalErrorException {
 		Utils.notNull(vo, "vo");
 		try {
-			return 1 == jdbc.queryForInt("select 1 from vos where id=?", vo.getId());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from vos where id=?", vo.getId());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Vo " + vo + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {
@@ -273,7 +279,13 @@ public class VosManagerImpl implements VosManagerImplApi {
 	public boolean shortNameForVoExists(PerunSession sess, Vo vo) throws InternalErrorException {
 		Utils.notNull(vo, "vo");
 		try{
-			return 1 == jdbc.queryForInt("select 1 from vos where short_name=?", vo.getShortName());
+			int numberOfExistences = jdbc.queryForInt("select count(1) from vos where short_name=?", vo.getShortName());
+			if (numberOfExistences == 1) {
+				return true;
+			} else if (numberOfExistences > 1) {
+				throw new ConsistencyErrorException("Short name " + vo.getShortName() + " exists more than once.");
+			}
+			return false;
 		} catch(EmptyResultDataAccessException ex) {
 			return false;
 		} catch(RuntimeException ex) {


### PR DESCRIPTION
Fixed all methods that use 'select 1 from * where *' in jdbc.queryForInt(*) which would throw unpleasant exception if more than one row was found.