### PR TITLE
CORE: Added module for user:virt:alternativeLoginNames

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_alternativeLoginNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_alternativeLoginNames.java
@@ -1,0 +1,61 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributeCollectedFromUserExtSource;
+
+/**
+ * All alternative logins of user collected from UserExtSources attributes
+ * as list of schacHomeOrganization:altLogin
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+@SuppressWarnings("unused")
+public class urn_perun_user_attribute_def_virt_alternativeLoginNames extends UserVirtualAttributeCollectedFromUserExtSource {
+
+	@Override
+	public String getSourceAttributeFriendlyName() {
+		return "alternativeLoginName";
+	}
+
+	@Override
+	public String getDestinationAttributeFriendlyName() {
+		return "alternativeLoginNames";
+	}
+
+	@Override
+	public String getDestinationAttributeDisplayName() {
+		return "Alternative login names";
+	}
+
+	@Override
+	public String getDestinationAttributeDescription() {
+		return "List of all alternative logins of user in organizations represented as tuples of entityId:alternativeLogin";
+	}
+
+	@Override
+	public String modifyValue(PerunSession session, ModifyValueContext ctx, UserExtSource ues, String value) {
+
+		if (ues != null && ExtSourcesManager.EXTSOURCE_IDP.equals(ues.getExtSource().getType())) {
+			try {
+				Attribute schacAttribute = ((PerunSessionImpl)session).getPerunBl().getAttributesManagerBl().getAttribute(session, ues, AttributesManager.NS_UES_ATTR_DEF + ":schacHomeOrganization");
+				if (schacAttribute.getValue() != null) {
+					return schacAttribute.getValue() + ":" + value;
+				}
+			} catch (InternalErrorException |WrongAttributeAssignmentException | AttributeNotExistsException e) {
+				return null;
+			}
+		}
+
+		return null;
+
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonORCID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonORCID.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributeCollectedFromUserExtSource;
 import org.apache.commons.lang3.StringUtils;
 
@@ -27,7 +29,7 @@ public class urn_perun_user_attribute_def_virt_eduPersonORCID extends UserVirtua
 	}
 
 	@Override
-	public String modifyValue(ModifyValueContext ctx, String value) {
+	public String modifyValue(PerunSession session, ModifyValueContext ctx, UserExtSource ues, String value) {
 		if(value.endsWith("@orcid")) {
 			return "http://orcid.org/"+StringUtils.substringBefore(value,"@");
 		} else {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_institutionsCountries.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_institutionsCountries.java
@@ -2,7 +2,9 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -87,7 +89,7 @@ public class urn_perun_user_attribute_def_virt_institutionsCountries extends Use
 	 * Replaces DNS domain with country name, or null.
 	 */
 	@Override
-	public String modifyValue(DnsMapCtx ctx, String value) {
+	public String modifyValue(PerunSession session, DnsMapCtx ctx, UserExtSource ues, String value) {
 		Map<String, String> dnsMap = ctx.getDnsMap();
 		//find the longest matching key
 		int matchLength = 0;
@@ -136,8 +138,8 @@ public class urn_perun_user_attribute_def_virt_institutionsCountries extends Use
 			//find users that are affected by the change - have schacHomeOrganization value ending in key, but not ending with longerDomains
 			List<User> affectedUsers = sess.getPerunBl().getUsersManagerBl().findUsersWithExtSourceAttributeValueEnding(sess,getSourceAttributeName(),key,longerDomains);
 			for (User user : affectedUsers) {
-				Attribute thisAtribute = am.getAttribute(sess, user, getDestinationAttributeName());
-				messages.add(thisAtribute.serializeToString() + " set for " + user.serializeToString() + ".");
+				Attribute thisAttribute = am.getAttribute(sess, user, getDestinationAttributeName());
+				messages.add(thisAttribute.serializeToString() + " set for " + user.serializeToString() + ".");
 			}
 		}
 		return messages;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.implApi.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -76,18 +77,20 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource<T extends U
 	}
 
 	public String getDestinationAttributeDescription() {
-		return "Collected values of userExtSource atribute " + getDestinationAttributeFriendlyName();
+		return "Collected values of userExtSource attribute " + getDestinationAttributeFriendlyName();
 	}
 
 	/**
 	 * Override this method if you need to modify the original values. The default implementation makes no modification.
 	 * Return null if the value should be skipped.
 	 *
+	 * @param session PerunSession
 	 * @param ctx context initialized in initModifyValueContext method
+	 * @param ues UserExtSource
 	 * @param value of userExtSource attribute
 	 * @return modified value or null to skip the value
 	 */
-	public String modifyValue(T ctx, String value) {
+	public String modifyValue(PerunSession session, T ctx, UserExtSource ues, String value) {
 		return value;
 	}
 
@@ -141,7 +144,7 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource<T extends U
 					//Apache mod_shib joins multiple values with ';', split them again
 					String[] rawValues = ((String) value).split(";");
 					//add non-null values returned by modifyValue()
-					Arrays.stream(rawValues).map(v -> modifyValue(ctx, v)).filter(Objects::nonNull).forEachOrdered(valuesWithoutDuplicities::add);
+					Arrays.stream(rawValues).map(v -> modifyValue(sess, ctx, userExtSource, v)).filter(Objects::nonNull).forEachOrdered(valuesWithoutDuplicities::add);
 				}
 			} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
 				log.error("cannot read " + sourceAttributeFriendlyName + " from userExtSource " + userExtSource.getId() + " of user " + user.getId(), e);


### PR DESCRIPTION
- New module for user:virt:alternativeLoginNames with list of
  alt logins in form of tuples of "schacHomeOrganization:altLogin".
- Updated shared modifyValue() interface method, since we need to
  pass UserExtSource and PerunSession.
- Fixed some typos.