### PR TITLE
Exception parameter fix in getResourceById

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -172,7 +172,7 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 		try {
 			return jdbc.queryForObject("select " + resourceMappingSelectQuery + " from resources where resources.id=?", RESOURCE_MAPPER, id);
 		} catch (EmptyResultDataAccessException e) {
-			throw new ResourceNotExistsException(e);
+			throw new ResourceNotExistsException("Resource with ID="+id+" not exists");
 		} catch(RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}


### PR DESCRIPTION
- Problem: When resource for given id didn't exists, ResourceNotExistsException was raised
           with original SQL message: "Incorrect result size: expected 1, actual 0",
           which didn't explain what happened.
- Change:  Exception parameter changed to message: "Resource with ID="+id+" not exists".
- Result:  When getResourceById is called for not existing resource, user will know what actually happened.