### PR TITLE
NotGroupMemberException extension

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/NotGroupMemberException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/NotGroupMemberException.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.api.exceptions;
 
+import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.exceptions.rt.NotGroupMemberRuntimeException;
 
@@ -13,6 +14,8 @@ public class NotGroupMemberException extends PerunException {
 	static final long serialVersionUID = 0;
 
 	private Member member;
+
+	private Group group;
 
 	public NotGroupMemberException(NotGroupMemberRuntimeException rt) {
 		super(rt.getMessage(),rt);
@@ -30,12 +33,18 @@ public class NotGroupMemberException extends PerunException {
 		super(cause);
 	}
 
-	public NotGroupMemberException(Member member) {
-		super(member.toString());
+	public NotGroupMemberException(Group group, Member member) {
+		super((group == null ? "null" : group) +
+				", " + (member == null ? "null" : member));
 		this.member = member;
+		this.group = group;
 	}
 
 	public Member getMember() {
 		return member;
+	}
+
+	public Group getGroup() {
+		return group;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -615,7 +615,7 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 			throw new InternalErrorException(ex);
 		}
 		if(ret == 0) {
-			throw new NotGroupMemberException(member);
+			throw new NotGroupMemberException(group, member);
 		} else if(ret >= 1) {
 			return;
 		} else {


### PR DESCRIPTION
- Problem: NotGroupMemberException had just information about member. There was missing information about group.
- Change:  NotGroupMemberException extended, so it's containign both group and member object.
- Result:  When NotGroupMemberException is raised, user will know who is not member of which group.