### PR TITLE
CORE: Fixed attribute module regexes with DOTALL modifier

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
@@ -38,7 +38,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBanned extends Resou
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_member_resource_attribute_def_virt_isBanned.class);
 
-	private final Pattern banModification = Pattern.compile("Ban ([a-zA-Z]+):\\[(.|\\s)*\\] was (set|removed|updated) for (member|user)Id ([0-9]+) on (resource|facility)Id ([0-9]+)", Pattern.MULTILINE);
+	private final Pattern banModification = Pattern.compile("Ban ([a-zA-Z]+):\\[.*\\] was ([a-z]+) for .*Id ([0-9]+) on .*Id ([0-9]+)", Pattern.DOTALL);
 	private final String OPERATION_SET = "set";
 	private final String OPERATION_REMOVED = "removed";
 	private final String OPERATION_UPDATED = "updated";
@@ -67,7 +67,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBanned extends Resou
 		if(sess.getPerunBl().getResourcesManagerBl().banExists(sess, member.getId(), resource.getId())) attribute.setValue(true);
 		//Ban on facility exists?
         if(sess.getPerunBl().getFacilitiesManagerBl().banExists(sess, user.getId(), facility.getId())) attribute.setValue(true);
-        
+
         return attribute;
 
     }
@@ -76,7 +76,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBanned extends Resou
 	public List<String> resolveVirtualAttributeValueChange(PerunSessionImpl perunSession, String message) throws InternalErrorException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<String> resolvingMessages = new ArrayList<>();
 		if(message == null) return resolvingMessages;
-		
+
 		Matcher banModificationMatcher = banModification.matcher(message);
 		List<Pair<Resource, Member>> listOfAffectedObjects = new ArrayList<>();
 
@@ -85,9 +85,9 @@ public class urn_perun_member_resource_attribute_def_virt_isBanned extends Resou
 		if(banModificationMatcher.find()) {
 			try {
 				String banType = banModificationMatcher.group(1);
-				operationType = banModificationMatcher.group(3);
-				int firstHolderId = Integer.valueOf(banModificationMatcher.group(5));
-				int secondHolderId = Integer.valueOf(banModificationMatcher.group(7));
+				operationType = banModificationMatcher.group(2);
+				int firstHolderId = Integer.valueOf(banModificationMatcher.group(3));
+				int secondHolderId = Integer.valueOf(banModificationMatcher.group(4));
 
 				if(operationType.equals(OPERATION_UPDATED)) {
 					operationType = OPERATION_SET;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
@@ -32,9 +32,9 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations exten
 
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-	private final Pattern userAllAttrsRemovedPattern = Pattern.compile("All attributes removed for User:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern userEPSAMASetPattern = Pattern.compile("Attribute:\\[(.|\\s)*friendlyName=<" + getSecondarySourceAttributeFriendlyName() +">(.|\\s)*] set for User:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern userEPSAMARemovePattern = Pattern.compile("AttributeDefinition:\\[(.|\\s)*friendlyName=<" + getSecondarySourceAttributeFriendlyName() + ">(.|\\s)*] removed for User:\\[(.|\\s)*]", Pattern.MULTILINE);
+	private final Pattern userAllAttrsRemovedPattern = Pattern.compile("All attributes removed for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern userEPSAMASetPattern = Pattern.compile("Attribute:\\[(.*)friendlyName=<" + getSecondarySourceAttributeFriendlyName() +">(.*)] set for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern userEPSAMARemovePattern = Pattern.compile("AttributeDefinition:\\[(.*)friendlyName=<" + getSecondarySourceAttributeFriendlyName() + ">(.*)] removed for User:\\[(.*)]", Pattern.DOTALL);
 
 	@Override
 	public String getSourceAttributeFriendlyName() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_elixirBonaFideStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_elixirBonaFideStatus.java
@@ -42,14 +42,14 @@ public class urn_perun_user_attribute_def_virt_elixirBonaFideStatus extends User
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_virt_elixirBonaFideStatus.class);
 
-	private final Pattern userRemsSetPattern = Pattern.compile("Attribute:\\[(.|\\s)*friendlyName=<elixirBonaFideStatusREMS>(.|\\s)*] set for User:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern userRemsRemovePattern = Pattern.compile("AttributeDefinition:\\[(.|\\s)*friendlyName=<elixirBonaFideStatusREMS>(.|\\s)*] removed for User:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern userPublicationsSetPattern = Pattern.compile("Attribute:\\[(.|\\s)*friendlyName=<publications>(.|\\s)*] set for User:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern userPublicationsRemovePattern = Pattern.compile("AttributeDefinition:\\[(.|\\s)*friendlyName=<publications>(.|\\s)*] removed for User:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern userAllAttrsRemovedPattern = Pattern.compile("All attributes removed for User:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern uesAllAttrsRemovedPattern = Pattern.compile("All attributes removed for UserExtSource:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern uesSetAffiliationAttributePattern = Pattern.compile("Attribute:\\[(.|\\s)*friendlyName=<affiliation>(.|\\s)*] set for UserExtSource:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern uesRemoveAffiliationAttributePattern = Pattern.compile("AttributeDefinition:\\[(.|\\s)*friendlyName=<affiliation>(.|\\s)*] removed for UserExtSource:\\[(.|\\s)*]", Pattern.MULTILINE);
+	private final Pattern userRemsSetPattern = Pattern.compile("Attribute:\\[(.*)friendlyName=<elixirBonaFideStatusREMS>(.*)] set for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern userRemsRemovePattern = Pattern.compile("AttributeDefinition:\\[(.*)friendlyName=<elixirBonaFideStatusREMS>(.*)] removed for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern userPublicationsSetPattern = Pattern.compile("Attribute:\\[(.*)friendlyName=<publications>(.*)] set for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern userPublicationsRemovePattern = Pattern.compile("AttributeDefinition:\\[(.*)friendlyName=<publications>(.*)] removed for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern userAllAttrsRemovedPattern = Pattern.compile("All attributes removed for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern uesAllAttrsRemovedPattern = Pattern.compile("All attributes removed for UserExtSource:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern uesSetAffiliationAttributePattern = Pattern.compile("Attribute:\\[(.*)friendlyName=<affiliation>(.*)] set for UserExtSource:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern uesRemoveAffiliationAttributePattern = Pattern.compile("AttributeDefinition:\\[(.*)friendlyName=<affiliation>(.*)] removed for UserExtSource:\\[(.*)]", Pattern.DOTALL);
 
 	private static final String FRIENDLY_NAME = "elixirBonaFideStatus";
 	private static final String URL = "http://www.ga4gh.org/beacon/bonafide/ver1.0";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_institutionsCountries.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_institutionsCountries.java
@@ -53,8 +53,8 @@ public class urn_perun_user_attribute_def_virt_institutionsCountries extends Use
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_virt_institutionsCountries.class);
 	private final static AttributeDefinition DNS_STATE_MAPPING_ATTR = new urn_perun_entityless_attribute_def_def_dnsStateMapping().getAttributeDefinition();
-	private final static Pattern AUDIT_MESSAGE_SET_DNS_DOMAIN_COUNTRY = Pattern.compile("Attribute:\\[(.|\\s)*" + DNS_STATE_MAPPING_ATTR.getFriendlyName() + "(.|\\s)*] set for ((.|\\s)*)\\.", Pattern.MULTILINE);
-	private final static Pattern AUDIT_MESSAGE_REMOVED_DNS_DOMAIN_COUNTRY = Pattern.compile("AttributeDefinition:\\[(.|\\s)*" + DNS_STATE_MAPPING_ATTR.getFriendlyName() + "(.|\\s)*] removed for ((.|\\s)*)\\.", Pattern.MULTILINE);
+	private final static Pattern AUDIT_MESSAGE_SET_DNS_DOMAIN_COUNTRY = Pattern.compile("Attribute:\\[(.*)" + DNS_STATE_MAPPING_ATTR.getFriendlyName() + "(.*)] set for (.*)\\.", Pattern.DOTALL);
+	private final static Pattern AUDIT_MESSAGE_REMOVED_DNS_DOMAIN_COUNTRY = Pattern.compile("AttributeDefinition:\\[(.*)" + DNS_STATE_MAPPING_ATTR.getFriendlyName() + "(.*)] removed for (.*)\\.", Pattern.DOTALL);
 
 	@Override
 	public String getSourceAttributeFriendlyName() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_kerberosLogins.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_kerberosLogins.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.auditparser.AuditParser;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -22,8 +21,8 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_user_attribute_def_virt_kerberosLogins extends UserVirtualAttributesModuleAbstract implements UserVirtualAttributesModuleImplApi {
 
-	private final Pattern addUserExtSource = Pattern.compile("UserExtSource:\\[(.|\\s)*\\] added to User:\\[(.|\\s)*\\]", Pattern.MULTILINE);
-	private final Pattern removeUserExtSource = Pattern.compile("UserExtSource:\\[(.|\\s)*\\] removed from User:\\[(.|\\s)*\\]", Pattern.MULTILINE);
+	private final Pattern addUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] added to User:\\[(.*)\\]", Pattern.DOTALL);
+	private final Pattern removeUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] removed from User:\\[(.*)\\]", Pattern.DOTALL);
 	private final Pattern extSourceKerberos = Pattern.compile("cz.metacentrum.perun.core.impl.ExtSourceKerberos");
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_userCertDNs.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_userCertDNs.java
@@ -28,8 +28,8 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_user_attribute_def_virt_userCertDNs extends UserVirtualAttributesModuleAbstract implements UserVirtualAttributesModuleImplApi {
 
-	private final Pattern addUserExtSource = Pattern.compile("UserExtSource:\\[(.|\\s)*\\] added to User:\\[(.|\\s)*\\]", Pattern.MULTILINE);
-	private final Pattern removeUserExtSource = Pattern.compile("UserExtSource:\\[(.|\\s)*\\] removed from User:\\[(.|\\s)*\\]", Pattern.MULTILINE);
+	private final Pattern addUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] added to User:\\[(.*)\\]", Pattern.DOTALL);
+	private final Pattern removeUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] removed from User:\\[(.*)\\]", Pattern.DOTALL);
 	private final Pattern extSourceTypeX509 = Pattern.compile("cz.metacentrum.perun.core.impl.ExtSourceX509");
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
@@ -37,9 +37,9 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource<T extends U
 
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-	private final Pattern allAttributesRemovedForUserExtSource = Pattern.compile("All attributes removed for UserExtSource:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern removeUserExtSourceAttribute = Pattern.compile("AttributeDefinition:\\[(.|\\s)*" + getSourceAttributeFriendlyName() + "(.|\\s)*] removed for UserExtSource:\\[(.|\\s)*]", Pattern.MULTILINE);
-	private final Pattern setUserExtSourceAttribute = Pattern.compile("Attribute:\\[(.|\\s)*" + getSourceAttributeFriendlyName() + "(.|\\s)*] set for UserExtSource:\\[(.|\\s)*]", Pattern.MULTILINE);
+	private final Pattern allAttributesRemovedForUserExtSource = Pattern.compile("All attributes removed for UserExtSource:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern removeUserExtSourceAttribute = Pattern.compile("AttributeDefinition:\\[(.*)" + getSourceAttributeFriendlyName() + "(.*)] removed for UserExtSource:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern setUserExtSourceAttribute = Pattern.compile("Attribute:\\[(.*)" + getSourceAttributeFriendlyName() + "(.*)] set for UserExtSource:\\[(.*)]", Pattern.DOTALL);
 	/**
 	 * Specifies friendly (short) name of attribute from namespace urn:perun:ues:attribute-def:def
 	 * whose values are to be collected.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBannedTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBannedTest.java
@@ -55,7 +55,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBannedTest {
 		classInstance = new urn_perun_member_resource_attribute_def_virt_isBanned();
 		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
 		facility = new Facility(1, "testFacility");
-		resource = new Resource(1, "testResource", "desc", 1, 1);
+		resource = new Resource(1, "testResource", "des\nc", 1, 1);
 		vo = new Vo(1, "testVo", "desc");
 		user = new User(1, "name", "surname", "middlename", "title", "title");
 		member = new Member(1, 1, 1, Status.VALID);
@@ -75,7 +75,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBannedTest {
 	@Test
 	public void resolveVirtualAttributeValueChangeTest() throws Exception{
 		System.out.println("urn_perun_user_facility_attribute_def_virt_defaultUnixGID.resolveVirtualAttributeValueChangeTest()");
-				
+
 		List<String> resolvedMessages;
 
 		//for message 1, 2 and 3

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/impl/EventServiceResolverImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/impl/EventServiceResolverImpl.java
@@ -61,8 +61,8 @@ public class EventServiceResolverImpl implements EventServiceResolver {
 	/**
 	 * Expected string format as on: event|x|[timestamp][Event header][Event data]
 	 */
-	private final static String eventParsingPattern = "^\\[([a-zA-Z0-9+: ]+)\\]\\[([^\\]]+)\\]\\[((.|\\s)*)\\]$";
-	private final static Pattern pattern = Pattern.compile(eventParsingPattern, Pattern.MULTILINE);
+	private final static String eventParsingPattern = "^\\[([a-zA-Z0-9+: ]+)\\]\\[([^\\]]+)\\]\\[((.*))\\]$";
+	private final static Pattern pattern = Pattern.compile(eventParsingPattern, Pattern.DOTALL);
 
 	private Properties dispatcherProperties;
 	private Perun perun;


### PR DESCRIPTION
- Reverting changes from commit 249d66b68d where we extended regexes
  with MULTILINE modifier. There was misunderstanding in purpose.
  We should use DOTALL modifier instead, which affects only .*,
  but not ^ and $. With DOTALL they still represents the beginning and
  ending of the whole string. While with MULTILINE they are matched
  to each line of input.
- As result we don't have to include newlines explicitly in regex, since
  DOTALL will also match all kind of newlines and original regex can
  then match PerunBeans with properties containing newlines.