### PR TITLE
Refactor patterns used in attribute modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_usedGids.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_usedGids.java
@@ -35,8 +35,8 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_entityless_attribute_def_def_usedGids extends EntitylessAttributesModuleAbstract implements EntitylessAttributesModuleImplApi {
 	
-	private static Pattern keyPattern = Pattern.compile("^[RGD][1-9][0-9]*$");
-	private static Pattern valuePattern = Pattern.compile("^[1-9][0-9]*$");
+	private static final Pattern keyPattern = Pattern.compile("^[RGD][1-9][0-9]*$");
+	private static final Pattern valuePattern = Pattern.compile("^[1-9][0-9]*$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeDirUmask.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeDirUmask.java
@@ -12,12 +12,17 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Checks if the value is valid unix permission mask.
  *
  * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
  */
 public class urn_perun_facility_attribute_def_def_homeDirUmask extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
+
+	private static final Pattern pattern = Pattern.compile("[0-7]{3,4}");
 
 	/**
 	 * Method for checking permission mask of home directory.
@@ -28,9 +33,8 @@ public class urn_perun_facility_attribute_def_def_homeDirUmask extends FacilityA
 		String mask = (String) attribute.getValue();
 
 		if (mask != null) {
-			if(!mask.matches("[0-7]{3,4}")) {
-				throw new WrongAttributeValueException(attribute, "Bad unix permission mask in attribute format " + mask);
-			}
+			Matcher matcher = pattern.matcher(mask);
+			if (!matcher.matches()) throw new WrongAttributeValueException(attribute, "Bad unix permission mask in attribute format " + mask);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scp.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -21,12 +23,15 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
  */
 public class urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scp extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^(/[-_.a-zA-Z0-9]+)+$");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		String value = (String) attribute.getValue();
 
 		if(value == null) throw new WrongAttributeValueException(attribute, "Value can't be null");
-		if(!value.matches("^(/[-_.a-zA-Z0-9]+)+$")) throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected.");
+		Matcher matcher = pattern.matcher(value);
+		if (!matcher.matches()) throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoints.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoints.java
@@ -21,6 +21,8 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
  */
 public class urn_perun_facility_attribute_def_def_homeMountPoints extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
+
 	/**
 	 * Checks attribute facility_homeMountPoints, this attribute must not be null and must be valid *nix path
 	 * @param perunSession current session
@@ -36,12 +38,9 @@ public class urn_perun_facility_attribute_def_def_homeMountPoints extends Facili
 		}
 		List<String> homeMountPoints = (List<String>) attribute.getValue();
 		if (!homeMountPoints.isEmpty()) {
-			Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
 			for (String st : homeMountPoints) {
 				Matcher match = pattern.matcher(st);
-				if (!match.matches()) {
-					throw new WrongAttributeValueException(attribute, "Bad homeMountPoints attribute format " + st);
-				}
+				if (!match.matches()) throw new WrongAttributeValueException(attribute, "Bad homeMountPoints attribute format " + st);
 			}
 		} else {
 			throw new WrongAttributeValueException(attribute,"Attribute can't be empty");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_passwdScpDestinationFile.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_passwdScpDestinationFile.java
@@ -25,6 +25,8 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
  */
 public class urn_perun_facility_attribute_def_def_passwdScpDestinationFile extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
+
 	/**
 	 * Method for checking path of the file.
 	 * Try to check if the path is equal to pattern ^(/[-_a-zA-Z0-9]+)+$
@@ -36,9 +38,8 @@ public class urn_perun_facility_attribute_def_def_passwdScpDestinationFile exten
 		if (path == null) {
 			throw new WrongAttributeValueException(attribute, "Attribute was not filled, therefore there is nothing to be checked.");
 		}
-		if (!path.matches("^(/[-_a-zA-Z0-9]+)+$")) {
-			throw new WrongAttributeValueException(attribute, "Bad path to destination of file in attribute format " + path);
-		}
+		Matcher matcher = pattern.matcher(path);
+		if (!matcher.matches()) throw new WrongAttributeValueException(attribute, "Bad path to destination of file in attribute format " + path);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shell_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shell_passwd_scp.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -21,12 +23,15 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
  */
 public class urn_perun_facility_attribute_def_def_shell_passwd_scp extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^(/[-_.a-zA-Z0-9]+)+$");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		String shell = (String) attribute.getValue();
 
 		if(shell == null) throw new WrongAttributeValueException(attribute, "Value can't be null");
-		if(!shell.matches("^(/[-_.a-zA-Z0-9]+)+$")) throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected");
+		Matcher matcher = pattern.matcher(shell);
+		if(!matcher.matches())  throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_googleGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_googleGroupName_namespace.java
@@ -13,6 +13,8 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModul
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Group googleGroup-namespace attribute.
@@ -20,6 +22,8 @@ import java.util.List;
  * @author Michal Holič  holic.michal@gmail.com
  */
 public class urn_perun_group_attribute_def_def_googleGroupName_namespace extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
+
+	private static final Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9']+$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -30,9 +34,9 @@ public class urn_perun_group_attribute_def_def_googleGroupName_namespace extends
 		if(groupName == null) {
 			// if this is group attribute, its ok
 			return;
-		}else if(!groupName.matches("^[-_a-zA-Z0-9']+$")){
-			throw new WrongAttributeValueException(attribute, group, "GroupName attribute content invalid characters. Allowed are only letters, numbers and characters _ and -.");
 		}
+		Matcher matcher = pattern.matcher(groupName);
+		if(!matcher.matches()) throw new WrongAttributeValueException(attribute, group, "GroupName attribute content invalid characters. Allowed are only letters, numbers and characters _ and -.");
 
 		//TODO Check reserved google group names
 		//sess.getPerunBl().getModulesUtilsBl().checkReservedGoogleGroupNames(attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimit.java
@@ -31,9 +31,9 @@ import java.math.BigDecimal;
 public class urn_perun_group_resource_attribute_def_def_projectDataLimit extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
 
 	private static final String A_GR_projectDataQuota = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectDataQuota";
-	Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
-	Pattern letterPattern = Pattern.compile("[A-Z]");
-	Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
+	private static final Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
+	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
+	private static final Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
 
 	//Definition of K = KB, M = MB etc.
 	long K = 1024;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuota.java
@@ -31,9 +31,9 @@ import java.math.BigDecimal;
 public class urn_perun_group_resource_attribute_def_def_projectDataQuota extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
 
 	private static final String A_GR_projectDataLimit = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectDataLimit";
-	Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
-	Pattern letterPattern = Pattern.compile("[A-Z]");
-	Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
+	private static final Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
+	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
+	private static final Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
 
 	//Definition of K = KB, M = MB etc.
 	long K = 1024;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissions.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissions.java
@@ -24,6 +24,8 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_group_resource_attribute_def_def_projectDirPermissions extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^[01234567]{3}$");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Integer permissions = (Integer) attribute.getValue();
@@ -33,7 +35,6 @@ public class urn_perun_group_resource_attribute_def_def_projectDirPermissions ex
 		String perm = permissions.toString();
 
 		//Only 3 consecutive numbers with value >=0 and <=7 are allowed
-		Pattern pattern = Pattern.compile("^[01234567]{3}$");
 		Matcher match = pattern.matcher(perm);
 
 		if (!match.matches()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectName.java
@@ -34,13 +34,13 @@ public class urn_perun_group_resource_attribute_def_def_projectName extends Reso
 
 	private static final String A_R_projectsBasePath = AttributesManager.NS_RESOURCE_ATTR_DEF + ":projectsBasePath";
 	private static final String A_GR_projectName = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectName";
+	private static final Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9]+$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String name = (String) attribute.getValue();
 		if (name == null) return;
 
-		Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9]+$");
 		Matcher match = pattern.matcher(name);
 
 		if (!match.matches()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
@@ -34,13 +34,13 @@ import java.util.regex.Pattern;
 public class urn_perun_group_resource_attribute_def_def_projectOwnerLogin extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
 
 	private static final String A_UF_V_login = AttributesManager.NS_USER_FACILITY_ATTR_VIRT + ":login";
+	private static final Pattern pattern = Pattern.compile("^[a-zA-Z0-9][-A-z0-9_.@/]*$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String ownerLogin = (String) attribute.getValue();
 		if (ownerLogin == null) return;
 
-		Pattern pattern = Pattern.compile("^[a-zA-Z0-9][-A-z0-9_.@/]*$");
 		Matcher match = pattern.matcher(ownerLogin);
 
 		if (!match.matches()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupName.java
@@ -14,6 +14,8 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
 import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -23,6 +25,7 @@ public class urn_perun_group_resource_attribute_def_def_systemUnixGroupName exte
 
 	private static final String A_GR_systemUnixGID = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGID";
 	private static final String A_GR_systemIsUnixGroup = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":isSystemUnixGroup";
+	private static final Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9]*$");
 
 	@Override
 	public Attribute fillAttribute(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
@@ -48,9 +51,10 @@ public class urn_perun_group_resource_attribute_def_def_systemUnixGroupName exte
 			if(isSystemGroup.getValue() != null && (Integer) isSystemGroup.getValue()==1) {
 				throw new WrongReferenceAttributeValueException(attribute, "Attribute cant be null if " + group + " on " + resource + " is system unix group.");
 			}
-		} else if(groupName.matches("^[-_a-zA-Z0-9]*$")!=true) {
-			throw new WrongAttributeValueException(attribute,"String with other chars than numbers, letters or symbols _ and - is not allowed value.");
 		}
+
+		Matcher matcher = pattern.matcher(groupName);
+		if(!matcher.matches()) throw new WrongAttributeValueException(attribute,"String with other chars than numbers, letters or symbols _ and - is not allowed value.");
 
 		//Get facility for the resource
 		Facility facility = sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_o365EmailAddresses_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_o365EmailAddresses_mu.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static cz.metacentrum.perun.core.impl.Utils.emailPattern;
 import static cz.metacentrum.perun.core.impl.Utils.hasDuplicate;
@@ -53,7 +52,6 @@ public class urn_perun_member_attribute_def_def_o365EmailAddresses_mu extends Me
 
 	private static final String NAMESPACE = AttributesManager.NS_MEMBER_ATTR_DEF;
 	static final String UCO_ATTRIBUTE = AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:mu";
-	static final Pattern MU_EMAIL_SYNTAX = Pattern.compile("\\d+@muni.cz");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
@@ -30,8 +30,8 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Resou
 	private static final String A_R_defaultDataLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit";
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";
 	private static final String A_MR_dataQuota = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuota";
-	Pattern numberPattern = Pattern.compile("[0-9]+(\\.|,)?[0-9]*");
-	Pattern letterPattern = Pattern.compile("[A-Z]");
+	private static final Pattern numberPattern = Pattern.compile("[0-9]+(\\.|,)?[0-9]*");
+	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
 	long K = 1024;
 	long M = K * 1024;
 	long G = M * 1024;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuota.java
@@ -30,8 +30,8 @@ public class urn_perun_member_resource_attribute_def_def_dataQuota extends Resou
 	private static final String A_R_defaultDataLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit";
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";
 	private static final String A_MR_dataLimit = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataLimit";
-	Pattern numberPattern = Pattern.compile("[0-9]+(\\.|,)?[0-9]*");
-	Pattern letterPattern = Pattern.compile("[A-Z]");
+	private static final Pattern numberPattern = Pattern.compile("[0-9]+(\\.|,)?[0-9]*");
+	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
 	long K = 1024;
 	long M = K * 1024;
 	long G = M * 1024;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFile.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFile.java
@@ -22,7 +22,8 @@ import java.util.regex.Pattern;
  * @author Vladimir Mecko vladimir.mecko@gmail.com
  */
 public class urn_perun_resource_attribute_def_def_apacheAuthzFile extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
-	private Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9.?*+$%]+)+$");
+
+	private static final Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9.?*+$%]+)+$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataLimit.java
@@ -28,9 +28,9 @@ import java.math.BigDecimal;
 public class urn_perun_resource_attribute_def_def_defaultDataLimit extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";
-	Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
-	Pattern letterPattern = Pattern.compile("[A-Z]");
-	Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
+	private static final Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
+	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
+	private static final Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
 
 	//Definition of K = KB, M = MB etc.
 	long K = 1024;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuota.java
@@ -28,9 +28,9 @@ import java.math.BigDecimal;
 public class urn_perun_resource_attribute_def_def_defaultDataQuota extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultDataLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit";
-	Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
-	Pattern letterPattern = Pattern.compile("[A-Z]");
-	Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
+	private static final Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
+	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
+	private static final Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
 
 	//Definition of K = KB, M = MB etc.
 	long K = 1024;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultHomeMountPoint.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultHomeMountPoint.java
@@ -30,6 +30,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_defaultHomeMountPoint extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private static final String A_R_homeMountPoints = AttributesManager.NS_RESOURCE_ATTR_DEF + ":homeMountPoints";
+	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
 
 	/**
 	 * Checks if the homemountpoint is contained in list of homemountpoint at underlying facility
@@ -62,7 +63,7 @@ public class urn_perun_resource_attribute_def_def_defaultHomeMountPoint extends 
 		if (!homeMntPoints.contains(attribute.getValue())) {
 			throw new WrongAttributeValueException(attribute, "Attribute value ins't defined in underlying resource. Attribute name=" + A_R_homeMountPoints);
 		}
-		Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
+
 		Matcher match = pattern.matcher((String) attribute.getValue());
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, "Wrong def. mount point format");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_homeMountPoints.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_homeMountPoints.java
@@ -27,6 +27,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_homeMountPoints extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private static final String A_F_homeMountPoints = AttributesManager.NS_FACILITY_ATTR_DEF + ":homeMountPoints";
+	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
 
 	/**
 	 * Fill with attribute from underlying facility
@@ -83,7 +84,6 @@ public class urn_perun_resource_attribute_def_def_homeMountPoints extends Resour
 		}
 		List<String> homeMountPoints = (List<String>) attribute.getValue();
 		if (!homeMountPoints.isEmpty()) {
-			Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
 			for (String st : homeMountPoints) {
 				Matcher match = pattern.matcher(st);
 				if (!match.matches()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k5loginTargetUser.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k5loginTargetUser.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_resource_attribute_def_def_k5loginTargetUser extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
-	Pattern userPattern = Pattern.compile("^[-a-zA-Z0-9_]+$");
+	private static final Pattern userPattern = Pattern.compile("^[-a-zA-Z0-9_]+$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailaliasesTargetUser.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailaliasesTargetUser.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_resource_attribute_def_def_mailaliasesTargetUser extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
-	Pattern userPattern = Pattern.compile("^[-a-zA-Z0-9_]+$");
+	private static final Pattern userPattern = Pattern.compile("^[-a-zA-Z0-9_]+$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_projectsBasePath.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_projectsBasePath.java
@@ -22,6 +22,8 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_resource_attribute_def_def_projectsBasePath extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String path = (String) attribute.getValue();
@@ -29,7 +31,6 @@ public class urn_perun_resource_attribute_def_def_projectsBasePath extends Resou
 			throw new WrongAttributeValueException(attribute, resource, "Attribute can't be empty.");
 		}
 
-		Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
 		Matcher match = pattern.matcher(path);
 
 		if (!match.matches()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUser.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUser.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_resource_attribute_def_def_sshkeysTargetUser extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
-	Pattern pattern = Pattern.compile("^(?!-)[-_.a-zA-Z0-9]+$");
+	private static final Pattern pattern = Pattern.compile("^(?!-)[-_.a-zA-Z0-9]+$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_vomsRoles.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_vomsRoles.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_resource_attribute_def_def_vomsRoles extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
-	private final Pattern pattern = Pattern.compile("^[^<>&]*$");
+	private static final Pattern pattern = Pattern.compile("^[^<>&]*$");
 
 	@Override
 	@SuppressWarnings("unchecked")

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_IPAddresses.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_IPAddresses.java
@@ -14,6 +14,8 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Attribute represents IP Addresses in ArrayList.
@@ -24,15 +26,18 @@ import java.util.List;
  */
 public class urn_perun_user_attribute_def_def_IPAddresses extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
-	private static final String IPv4_PATTERN = "^(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}$";
-	private static final String IPv6_PATTERN = "^(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$";
-	private static final String IPv6_PATTERN_SHORT = "^((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)$";
+	private static final Pattern IPv4_PATTERN = Pattern.compile("^(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}$");
+	private static final Pattern IPv6_PATTERN = Pattern.compile("^(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$");
+	private static final Pattern IPv6_PATTERN_SHORT = Pattern.compile("^((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		List<String> value = attribute.valueAsList();
 		for (String address : value) {
-			if (!address.matches(IPv4_PATTERN) && !address.matches(IPv6_PATTERN) && !address.matches(IPv6_PATTERN_SHORT))
+			Matcher matcherIPv4 = IPv4_PATTERN.matcher(address);
+			Matcher matcherIPv6 = IPv6_PATTERN.matcher(address);
+			Matcher matcherIPv6Short = IPv6_PATTERN_SHORT.matcher(address);
+			if (!matcherIPv4.matches() && !matcherIPv6.matches() && !matcherIPv6Short.matches())
 				throw new WrongAttributeValueException(attribute, "IP address is not in the correct format.");
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_eduroamIdentities.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_eduroamIdentities.java
@@ -2,6 +2,8 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -22,12 +24,15 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
  */
 public class urn_perun_user_attribute_def_def_eduroamIdentities extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^[-\\/_.a-zA-Z0-9]+@[-_.A-z0-9]+$");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		if(attribute == null) return; //null is OK
 		List<String> value = (List<String>) attribute.getValue();
 		for(String login : value) {
-			if(!login.matches("^[-\\/_.a-zA-Z0-9]+@[-_.A-z0-9]+$")) throw new WrongAttributeValueException(attribute, "Value is not in correct format. format: login@organization");
+			Matcher matcher = pattern.matcher(login);
+			if(!matcher.matches()) throw new WrongAttributeValueException(attribute, "Value is not in correct format. format: login@organization");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirScopedAffiliation.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirScopedAffiliation.java
@@ -10,6 +10,8 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Attribute represents list of scoped affiliations.
@@ -19,7 +21,7 @@ import java.util.List;
  */
 public class urn_perun_user_attribute_def_def_elixirScopedAffiliation extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
-	private static final String REGEX = "^[member|affiliate|faculty]+@[-A-Za-z0-9]+(\\.[-A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
+	private static final Pattern pattern = Pattern.compile("^[member|affiliate|faculty]+@[-A-Za-z0-9]+(\\.[-A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -28,7 +30,8 @@ public class urn_perun_user_attribute_def_def_elixirScopedAffiliation extends Us
 		if (values != null && !values.isEmpty()) {
 			for (String value : values) {
 				// check each value
-				if(!value.matches(REGEX)) throw new WrongAttributeValueException(attribute, "Wrong format. List of \"[member|affiliate|faculty]@scope\" expected.");
+				Matcher matcher = pattern.matcher(value);
+				if(!matcher.matches()) throw new WrongAttributeValueException(attribute, "Wrong format. List of \"[member|affiliate|faculty]@scope\" expected.");
 			}
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosAdminPrincipal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosAdminPrincipal.java
@@ -14,6 +14,9 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Checks specified kerberos admin principal (check existence of only one kerberos principal)
  *
@@ -21,11 +24,14 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
  */
 public class urn_perun_user_attribute_def_def_kerberosAdminPrincipal extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^[-\\/_.a-zA-Z0-9]+@[-_.A-z0-9]+$");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "Attribute's value can't be null");
 		String value = (String) attribute.getValue();
-		if(!value.matches("^[-\\/_.a-zA-Z0-9]+@[-_.A-z0-9]+$")) throw new WrongAttributeValueException(attribute, user, "Attribute's value is not in correct format. format: login@realm");
+		Matcher matcher = pattern.matcher(value);
+		if(!matcher.matches()) throw new WrongAttributeValueException(attribute, user, "Attribute's value is not in correct format. format: login@realm");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosLogins.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosLogins.java
@@ -14,11 +14,15 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
 import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Slavek Licehammer &lt;glory@ics.muni.cz&gt;
  */
 public class urn_perun_user_attribute_def_def_kerberosLogins extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
+
+	private static final Pattern pattern = Pattern.compile("^[-\\/_.a-zA-Z0-9@]+@[-_.A-z0-9]+$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
@@ -26,7 +30,8 @@ public class urn_perun_user_attribute_def_def_kerberosLogins extends UserAttribu
 		List<String> value = (List<String>) attribute.getValue();
 		if(value.isEmpty()) throw new WrongAttributeValueException(attribute, user, "Attribute's value can't be empty list");
 		for(String login : value) {
-			if(!login.matches("^[-\\/_.a-zA-Z0-9@]+@[-_.A-z0-9]+$")) throw new WrongAttributeValueException(attribute, user, "Attribute's value is not in correct format. format: login@realm");
+			Matcher matcher = pattern.matcher(login);
+			if(!matcher.matches()) throw new WrongAttributeValueException(attribute, user, "Attribute's value is not in correct format. format: login@realm");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace.java
@@ -12,6 +12,8 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -19,13 +21,17 @@ import java.util.List;
  */
 public class urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^[-_.a-zA-Z0-9]+$");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		if(attribute.getValue()!= null) {
-			for(String groupName: (List<String>)attribute.getValue())
-				if(!groupName.matches("^[-_.a-zA-Z0-9]+$")) throw new WrongAttributeValueException(attribute, user,"GroupName: " + groupName + " content invalid characters. Allowed are only letters, numbers and characters _ and - and .");
+			for(String groupName: (List<String>)attribute.getValue()) {
+				Matcher matcher = pattern.matcher(groupName);
+				if (!matcher.matches()) throw new WrongAttributeValueException(attribute, user, "GroupName: " + groupName + " content invalid characters. Allowed are only letters, numbers and characters _ and - and .");
 			}
 		}
+	}
 
 	@Override
 	public AttributeDefinition getAttributeDefinition() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertDNs.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertDNs.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_user_attribute_def_def_userCertDNs extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
-	Pattern certPattern = Pattern.compile("^/");
+	private static final Pattern certPattern = Pattern.compile("^/");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailAlias.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailAlias.java
@@ -44,7 +44,7 @@ import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_user_a
 public class urn_perun_user_attribute_def_def_vsupMailAlias extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	// VŠUP MAIL ALIAS PATTERN !!
-	public static final Pattern emailAliasPattern = Pattern.compile("^[A-Za-z]+\\.[A-Za-z]+([0-9])*@vsup\\.cz$");
+	private static final Pattern emailAliasPattern = Pattern.compile("^[A-Za-z]+\\.[A-Za-z]+([0-9])*@vsup\\.cz$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonPrincipalNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonPrincipalNames.java
@@ -12,6 +12,8 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttribute
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * User edu Person principal Names (eppn)
@@ -19,6 +21,8 @@ import java.util.List;
  * @author Michal Šťava <stavamichal@gmail.com>
  */
 public class urn_perun_user_attribute_def_virt_eduPersonPrincipalNames extends UserVirtualAttributesModuleAbstract implements UserVirtualAttributesModuleImplApi {
+
+	private static final Pattern pattern = Pattern.compile("[^@]+@[^@]+");
 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
@@ -33,7 +37,8 @@ public class urn_perun_user_attribute_def_virt_eduPersonPrincipalNames extends U
 
 				if(type != null && login != null) {
 					// insert only EPPN formatted data
-					if(type.equals(ExtSourcesManager.EXTSOURCE_IDP) && login.matches("[^@]+@[^@]+")) {
+					Matcher matcher = pattern.matcher(login);
+					if(type.equals(ExtSourcesManager.EXTSOURCE_IDP) && matcher.matches()) {
 						idpLogins.add(login);
 					}
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_groupNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_groupNames.java
@@ -33,8 +33,8 @@ public class urn_perun_user_attribute_def_virt_groupNames extends UserVirtualAtt
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_virt_groupNames.class);
 	private static final String FRIENDLY_NAME = "groupNames";
 
-	private Pattern memberAddedToPattern = Pattern.compile("Member:\\[(.*)\\] added to Group:\\[(.*)\\]", Pattern.DOTALL);
-	private Pattern memberTotallyRemovedFromPattern = Pattern.compile("Member:\\[(.*)\\] was removed from Group:\\[(.*)\\] totally", Pattern.DOTALL);
+	private static final Pattern memberAddedToPattern = Pattern.compile("Member:\\[(.*)\\] added to Group:\\[(.*)\\]", Pattern.DOTALL);
+	private static final Pattern memberTotallyRemovedFromPattern = Pattern.compile("Member:\\[(.*)\\] was removed from Group:\\[(.*)\\] totally", Pattern.DOTALL);
 
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_kerberosLogins.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_kerberosLogins.java
@@ -21,9 +21,9 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_user_attribute_def_virt_kerberosLogins extends UserVirtualAttributesModuleAbstract implements UserVirtualAttributesModuleImplApi {
 
-	private final Pattern addUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] added to User:\\[(.*)\\]", Pattern.DOTALL);
-	private final Pattern removeUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] removed from User:\\[(.*)\\]", Pattern.DOTALL);
-	private final Pattern extSourceKerberos = Pattern.compile("cz.metacentrum.perun.core.impl.ExtSourceKerberos");
+	private static final Pattern addUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] added to User:\\[(.*)\\]", Pattern.DOTALL);
+	private static final Pattern removeUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] removed from User:\\[(.*)\\]", Pattern.DOTALL);
+	private static final Pattern extSourceKerberos = Pattern.compile("cz.metacentrum.perun.core.impl.ExtSourceKerberos");
 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_logins_namespace_google.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_logins_namespace_google.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -25,7 +26,7 @@ public class urn_perun_user_attribute_def_virt_logins_namespace_google extends U
 
 	private static final String NAMESPACE = "google";
 	private static final String EXTSOURCE = "https://login.cesnet.cz/google-idp/";
-	private static final String LOGIN_REGEX = "^.+[@]google[.]extidp[.]cesnet[.]cz$";
+	private static final Pattern pattern = Pattern.compile("^.+[@]google[.]extidp[.]cesnet[.]cz$");
 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
@@ -35,8 +36,11 @@ public class urn_perun_user_attribute_def_virt_logins_namespace_google extends U
 		for(UserExtSource uES: userExtSources) {
 			if(uES.getExtSource() != null && EXTSOURCE.equals(uES.getExtSource().getName())) {
 				String login = uES.getLogin();
-				if(login != null && !login.isEmpty() && login.matches(LOGIN_REGEX)) {
-					googleLogins.add(login.replaceAll("[@].*$", ""));
+				if (login != null && !login.isEmpty()) {
+					Matcher matcher = pattern.matcher(login);
+					if (matcher.matches()) {
+						googleLogins.add(login.replaceAll("[@].*$", ""));
+					}
 				}
 			}
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_optionalLogin_namespace_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_optionalLogin_namespace_mu.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 public class urn_perun_user_attribute_def_virt_optionalLogin_namespace_mu extends UserVirtualAttributesModuleAbstract {
 
 	private final String EXTSOURCE_MUNI_IDP2 = "https://idp2.ics.muni.cz/idp/shibboleth";
-	private final Pattern loginMUPattern = Pattern.compile("^([0-9]+)[@]muni[.]cz$");
+	private static final Pattern loginMUPattern = Pattern.compile("^([0-9]+)[@]muni[.]cz$");
 
 	private static final String A_U_D_loginNamespace_mu = AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:mu";
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_userCertDNs.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_userCertDNs.java
@@ -28,9 +28,9 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_user_attribute_def_virt_userCertDNs extends UserVirtualAttributesModuleAbstract implements UserVirtualAttributesModuleImplApi {
 
-	private final Pattern addUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] added to User:\\[(.*)\\]", Pattern.DOTALL);
-	private final Pattern removeUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] removed from User:\\[(.*)\\]", Pattern.DOTALL);
-	private final Pattern extSourceTypeX509 = Pattern.compile("cz.metacentrum.perun.core.impl.ExtSourceX509");
+	private static final Pattern addUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] added to User:\\[(.*)\\]", Pattern.DOTALL);
+	private static final Pattern removeUserExtSource = Pattern.compile("UserExtSource:\\[(.*)\\] removed from User:\\[(.*)\\]", Pattern.DOTALL);
+	private static final Pattern extSourceTypeX509 = Pattern.compile("cz.metacentrum.perun.core.impl.ExtSourceX509");
 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPoint.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPoint.java
@@ -31,6 +31,8 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttribut
  */
 public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$*");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl session, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
@@ -56,7 +58,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends Fa
 		if (!homeMntPointsOnAllResources.contains((String) attribute.getValue())) {
 			throw new WrongAttributeValueException(attribute, user, facility, "User's home mount point is invalid. Valid mount points: " + homeMntPointsOnAllResources);
 		}
-		Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$*");
+
 		Matcher match = pattern.matcher((String) attribute.getValue());
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, "Attribute has wrong format");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
@@ -15,18 +15,24 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  *
  * @author Slavek Licehammer &lt;glory@ics.muni.cz&gt;
  */
 public class urn_perun_user_facility_attribute_def_def_shell_passwd_scp extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
 
+	private static final Pattern pattern = Pattern.compile("^(/[-_.a-zA-Z0-9]+)+$");
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		String shell = (String) attribute.getValue();
 
 		if(shell == null) throw new WrongAttributeValueException(attribute, "Value can't be null");
-		if(!shell.matches("^(/[-_.a-zA-Z0-9]+)+$")) throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected");
+		Matcher matcher = pattern.matcher(shell);
+		if(!matcher.matches()) throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
@@ -37,7 +37,7 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource<T extends U
 
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-	private final Pattern allAttributesRemovedForUserExtSource = Pattern.compile("All attributes removed for UserExtSource:\\[(.*)]", Pattern.DOTALL);
+	private static final Pattern allAttributesRemovedForUserExtSource = Pattern.compile("All attributes removed for UserExtSource:\\[(.*)]", Pattern.DOTALL);
 	private final Pattern removeUserExtSourceAttribute = Pattern.compile("AttributeDefinition:\\[(.*)" + getSourceAttributeFriendlyName() + "(.*)] removed for UserExtSource:\\[(.*)]", Pattern.DOTALL);
 	private final Pattern setUserExtSourceAttribute = Pattern.compile("Attribute:\\[(.*)" + getSourceAttributeFriendlyName() + "(.*)] set for UserExtSource:\\[(.*)]", Pattern.DOTALL);
 	/**


### PR DESCRIPTION
- Problem: Many of the modules were compiling regexes in methods where they wanted to use them.
	   As a result, the compilation of the same regex was often called multiple times unnecessarily.
- Change:  Every regex compilation changed to private static final field (if it was possible).
	   private- some of the patterns could not been changed to private,
		    because they are used in multiple modules.
	   static-  due to precompilation, but some of the patterns could not been changed to static
		    because they are calling some non static methods.
	   final-   we do not want to change the pattern once it is compiled (usualy).
	   These fields are used in methods where some value needs to be checked.
	   Some of the patterns were unused, so they were erased.
- Result:  Logic of the code did not changed.
	   Time should be saved while checking attribute values on regexes.