### PR TITLE
CORE: Fixed oracle changelog for 3.1.49

### DIFF
--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -7,7 +7,7 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 3.1.49
-alter table groups_members ADD source_group_status integer not null default 0;
+alter table groups_members ADD source_group_status integer default 0 not null;
 update configurations set value='3.1.49' where property='DATABASE VERSION';
 
 3.1.48


### PR DESCRIPTION
- Order of default and not null constraints matters for Oracle.