### PR TITLE
GUI: Fixed condition when opening related groups

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupRelationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupRelationsTabItem.java
@@ -219,7 +219,7 @@ public class GroupRelationsTabItem implements TabItem, TabItemWithUrl {
 		CellTable<Group> table = unions.getTable(new FieldUpdater<Group, String>() {
 			@Override
 			public void update(int arg0, Group group, String arg2) {
-				if (session.isGroupAdmin(group.getId()) || session.isVoAdmin(group.getId())) {
+				if (session.isGroupAdmin(group.getId()) || session.isVoAdmin(group.getVoId())) {
 					session.getTabManager().addTab(new GroupDetailTabItem(group.getId()));
 				} else {
 					UiElements.generateInfo("Not privileged", "You are not manager of selected group or its VO.");


### PR DESCRIPTION
 - On Group detail page, tab Relation, there is a check, if user
   is authorized to open related Group detail. There was groupId
   wrongly passed to check of VOADMIN role. Now we correctly pass
   vo_id param.