### PR TITLE
GUI: Load group from proper Vo when copying application form items.

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CopyFormTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CopyFormTabItem.java
@@ -102,7 +102,11 @@ public class CopyFormTabItem implements TabItem {
 				vosBox.addAllItems(vos);
 
 				// get them
-				GetAllGroups getGroups = new GetAllGroups(voId, new JsonCallbackEvents(){
+				int backupVoId = voId;
+				if (vos.size() > 0) {
+					backupVoId = vos.get(0).getId();
+				}
+				GetAllGroups getGroups = new GetAllGroups(backupVoId, new JsonCallbackEvents(){
 					@Override
 					public void onFinished(JavaScriptObject jso) {
 						groupsBox.clear();


### PR DESCRIPTION
- When we copy form from another Vo or Group, on first load
  we get groups from the same VO, which was meant as backup solution,
  if user is not VO manager at all. But it might not correspond with
  VO selected in the list. Now its loaded properly.