### PR TITLE
CORE,RPC: Added removeAttributes for member,group and user

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -3259,6 +3259,20 @@ public interface AttributesManager {
 	 */
 	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
+
+	/**
+	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
+	 * <p>
+	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
+	 * If workWithUserAttributes is true, unset also user attributes.
+	 *
+	 * @param workWithUserAttributes if true, remove also user attributes, if false, remove only member-group attributes
+	 *
+	 * @throws AttributeNotExistsException if the any of attributes doesn't exists in underlying data source
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, Member, Group, AttributeDefinition)
+	 */
+	void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+
 	/**
 	 * Unset all attributes for the member in the group.
 	 * <p>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -3561,6 +3561,11 @@ public class AttributesManagerEntry implements AttributesManager {
 
 	@Override
 	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		removeAttributes(sess, member, group, attributes, false);
+	}
+
+	@Override
+	public void removeAttributes(PerunSession sess, Member member, Group group, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, GroupNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -3569,7 +3574,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		for(AttributeDefinition attrDef: attributes) {
 			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrDef, member, group)) throw new PrivilegeException("Principal has no access to remove attribute = " + attrDef);
 		}
-		getAttributesManagerBl().removeAttributes(sess, member, group, attributes);
+		getAttributesManagerBl().removeAttributes(sess, member, group, attributes, workWithUserAttributes);
 	}
 
 	@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -2847,7 +2847,13 @@ public enum AttributesManagerMethod implements ManagerMethod {
 							attributes);
 				}
 			} else if (parms.contains("member")) {
-				if (parms.contains("workWithUserAttributes")) {
+				if (parms.contains("workWithUserAttributes") && parms.contains("group")) {
+					ac.getAttributesManager().removeAttributes(ac.getSession(),
+							ac.getMemberById(parms.readInt("member")),
+							ac.getGroupById(parms.readInt("group")),
+							attributes,
+							parms.readBoolean("workWithUserAttributes"));
+				} else if (parms.contains("workWithUserAttributes")) {
 					ac.getAttributesManager().removeAttributes(ac.getSession(),
 							ac.getMemberById(parms.readInt("member")),
 							parms.readBoolean("workWithUserAttributes"), attributes);


### PR DESCRIPTION
- We were missing member,group and workWithUserAttributes in API.
  Since GUI sends same combination of params for setAttributes()
  and removeAttributes(), it failed to resolve proper method
  in RPC API, since this combination was not supported for
  removeAttributes().
- Now we use method with boolean param and use it in entry layer
  for both removeAttributes() methods (like we do for resource-group).