### PR TITLE
TasksLib:Bugfix

### DIFF
--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskResultDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskResultDaoJdbc.java
@@ -160,7 +160,7 @@ public class TaskResultDaoJdbc extends JdbcDaoSupport implements TaskResultDao {
 				" from tasks_results left join destinations on tasks_results.destination_id = destinations.id " +
 				" left join tasks on tasks.id = tasks_results.task_id" +
 				" left join services on services.id = tasks.service_id" +
-				"where tasks_results.id = ? and tasks_results.engine_id = ?",
+				" where tasks_results.id = ? and tasks_results.engine_id = ?",
 				TASKRESULT_ROWMAPPER, taskResultId, engineID);
 	}
 


### PR DESCRIPTION
* There is a missing whitespace before 'WHERE' in SQL select in method
getTaskResultById.