### PR TITLE
AdminGUI: new task results displaying

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/PropagationStatsReaderMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/PropagationStatsReaderMethod.java
@@ -141,6 +141,30 @@ public enum PropagationStatsReaderMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Return list of only newest TaskResults by a Task for GUI.
+	 *
+	 * @param task int Task
+	 * @return List<TaskResult> Results
+	 */
+	getTaskResultsForGUIByTaskOnlyNewest {
+		public List<TaskResult> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getPropagationStatsReader().getTaskResultsForGUIByTaskOnlyNewest(ac.getSession(), parms.readInt("task"));
+		}
+	},
+
+	/*#
+	 * Return list of TaskResults by a Task and destination for GUI.
+	 *
+	 * @param task int Task
+	 * @return List<TaskResult> Results
+	 */
+	getTaskResultsForGUIByTaskAndDestination {
+		public List<TaskResult> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			return ac.getPropagationStatsReader().getTaskResultsForGUIByTaskAndDestination(ac.getSession(), parms.readInt("task"), parms.readInt("destination"));
+		}
+	},
+
+	/*#
 	 * Return list of TaskResults by a Task for GUI.
 	 *
 	 * @param task int Task

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/controller/service/PropagationStatsReader.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/controller/service/PropagationStatsReader.java
@@ -55,7 +55,11 @@ public interface PropagationStatsReader {
 
 	List<TaskResult> getTaskResultsByTask(int taskId);
 
+	List<TaskResult> getTaskResultsForGUIByTaskOnlyNewest(PerunSession session, int taskId) throws DestinationNotExistsException, PrivilegeException, InternalErrorException;
+
 	List<TaskResult> getTaskResultsForGUIByTask(PerunSession session, int taskId) throws DestinationNotExistsException, PrivilegeException, InternalErrorException;
+
+	List<TaskResult> getTaskResultsForGUIByTaskAndDestination(PerunSession session, int taskId, int destinationId) throws InternalErrorException;
 
 	TaskResult getTaskResultById(int taskResultId);
 

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/controller/service/impl/PropagationStatsReaderImpl.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/controller/service/impl/PropagationStatsReaderImpl.java
@@ -90,6 +90,16 @@ public class PropagationStatsReaderImpl implements PropagationStatsReader {
 	}
 
 	@Override
+	public List<TaskResult> getTaskResultsForGUIByTaskOnlyNewest(PerunSession session, int taskId) throws DestinationNotExistsException, PrivilegeException, InternalErrorException {
+		return taskResultDao.getTaskResultsByTaskOnlyNewest(taskId);
+	}
+
+	@Override
+	public List<TaskResult> getTaskResultsForGUIByTaskAndDestination(PerunSession session, int taskId, int destinationId) throws InternalErrorException {
+		return taskResultDao.getTaskResultsByTaskAndDestination(taskId, destinationId);
+	}
+
+	@Override
 	public List<TaskResult> getTaskResultsForGUIByTask(PerunSession session, int taskId) throws DestinationNotExistsException, PrivilegeException, InternalErrorException {
 		return taskResultDao.getTaskResultsByTask(taskId);
 	}

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/TaskResultDao.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/TaskResultDao.java
@@ -23,12 +23,28 @@ public interface TaskResultDao {
 	List<TaskResult> getTaskResults();
 
 	/**
+	 * List newest TaskResults tied to a certain task
+	 *
+	 * @param taskId
+	 * @return
+	 */
+	List<TaskResult> getTaskResultsByTaskOnlyNewest(int taskId);
+
+	/**
 	 * List TaskResults tied to a certain task
 	 *
 	 * @param taskId
 	 * @return
 	 */
 	List<TaskResult> getTaskResultsByTask(int taskId);
+
+	/**
+	 * List newest TaskResults tied to a certain task and destination
+	 *
+	 * @param taskId
+	 * @return
+	 */
+	List<TaskResult> getTaskResultsByTaskAndDestination(int taskId, int destinationId);
 
 	/**
 	 * Get TaskResult by its ID

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/GetEntityById.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/GetEntityById.java
@@ -50,6 +50,8 @@ public class GetEntityById implements JsonCallback, JsonCallbackWithCache {
 	static private final String URL_SECURITY_TEAM = "securityTeamsManager/getSecurityTeamById";
 	static private final String URL_USER_EXT_SRC = "usersManager/getUserExtSourceById";
 
+	static private final String URL_DESTINATION = "servicesManager/getDestinationById";
+
 	/**
 	 * New callback instance
 	 *
@@ -136,6 +138,8 @@ public class GetEntityById implements JsonCallback, JsonCallbackWithCache {
 		} else if (PerunEntity.USER_EXT_SOURCE.equals(entity)) {
 			param = "userExtSource="+entityId;
 			js.retrieveData(URL_USER_EXT_SRC, param, this);
+		} else if (PerunEntity.DESTINATION.equals(entity)) {
+			js.retrieveData(URL_DESTINATION, param, this);
 		} else {
 			// UNSUPPORTED COMBINATION
 		}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/FacilitiesTabs.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/FacilitiesTabs.java
@@ -85,6 +85,11 @@ public class FacilitiesTabs {
 			return true;
 		}
 
+		if (tab.equals(TaskResultsForDestinationTabItem.URL)) {
+			session.getTabManager().addTab(TaskResultsForDestinationTabItem.load(parameters), open);
+			return true;
+		}
+
 		if (tab.equals(FacilityOwnersTabItem.URL)) {
 			session.getTabManager().addTab(FacilityOwnersTabItem.load(parameters), open);
 			return true;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/UrlMapper.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/UrlMapper.java
@@ -102,6 +102,7 @@ public class UrlMapper {
 			}
 		} catch (RuntimeException e) {
 			UiElements.generateAlert("URL parsing error", "This tab couldn't be opened: " + tabPackage + " / " + tabName + ". ");
+			GWT.log(e.toString());
 		}
 
 		session.getUiElements().setLogText("No entry exists for: " + tabPackage + " | " + tabName);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsForDestinationTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsForDestinationTabItem.java
@@ -1,0 +1,184 @@
+package cz.metacentrum.perun.webgui.tabs.facilitiestabs;
+
+import com.google.gwt.cell.client.FieldUpdater;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.client.UiElements;
+import cz.metacentrum.perun.webgui.client.mainmenu.MainMenu;
+import cz.metacentrum.perun.webgui.client.resources.PerunEntity;
+import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
+import cz.metacentrum.perun.webgui.json.GetEntityById;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.propagationStatsReader.GetRichTaskResultsByTaskAndDestination;
+import cz.metacentrum.perun.webgui.model.Destination;
+import cz.metacentrum.perun.webgui.model.Task;
+import cz.metacentrum.perun.webgui.model.TaskResult;
+import cz.metacentrum.perun.webgui.tabs.FacilitiesTabs;
+import cz.metacentrum.perun.webgui.tabs.TabItem;
+import cz.metacentrum.perun.webgui.tabs.TabItemWithUrl;
+import cz.metacentrum.perun.webgui.tabs.UrlMapper;
+import cz.metacentrum.perun.webgui.widgets.TabMenu;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class TaskResultsForDestinationTabItem implements TabItem, TabItemWithUrl {
+
+	public static final String URL = "taskresultsdetail";
+
+	/**
+	 * Perun web session
+	 */
+	private PerunWebSession session = PerunWebSession.getInstance();
+
+	/**
+	 * Content widget - should be simple panel
+	 */
+	private SimplePanel contentWidget = new SimplePanel();
+
+	/**
+	 * Title widget
+	 */
+	private Label titleWidget = new Label("Loading Task");
+
+	// data
+	private Destination destination;
+	private Task task;
+	private int destinationId;
+	private int taskId;
+
+	public TaskResultsForDestinationTabItem(Task task, Destination destination) {
+		this.destination = destination;
+		this.task = task;
+		this.destinationId = destination.getId();
+		this.taskId = task.getId();
+	}
+
+	public TaskResultsForDestinationTabItem(int taskId, int destinationId) {
+		this.taskId = taskId;
+		this.destinationId = destinationId;
+		new GetEntityById(PerunEntity.DESTINATION, destinationId, new JsonCallbackEvents() {
+			@Override
+			public void onFinished(JavaScriptObject jso) {
+				destination = jso.cast();
+			}
+		}).retrieveData();
+		new GetEntityById(PerunEntity.TASK, taskId, new JsonCallbackEvents() {
+			@Override
+			public void onFinished(JavaScriptObject jso) {
+				task = jso.cast();
+			}
+		}).retrieveData();
+	}
+
+	@Override
+	public String getUrl() {
+		return URL;
+	}
+
+	@Override
+	public String getUrlWithParameters() {
+		return FacilitiesTabs.URL + UrlMapper.TAB_NAME_SEPARATOR + getUrl() + "?id=" + task.getId() + "&destinationId=" + destinationId;
+	}
+
+	@Override
+	public Widget draw() {
+		this.titleWidget.setText(destination.getDestination() + ": " + task.getService().getName());
+
+		VerticalPanel vp = new VerticalPanel();
+		vp.setSize("100%", "100%");
+
+		final GetRichTaskResultsByTaskAndDestination callback =
+				new GetRichTaskResultsByTaskAndDestination(task.getId(), destinationId);
+
+		TabMenu menu = new TabMenu();
+		menu.addWidget(UiElements.getRefreshButton(this));
+
+		CellTable<TaskResult> table = callback.getTable();
+
+		table.addStyleName("perun-table");
+		ScrollPanel sp = new ScrollPanel(table);
+		sp.addStyleName("perun-tableScrollPanel");
+
+		vp.add(menu);
+		vp.setCellHeight(menu, "30px");
+		vp.add(sp);
+
+		session.getUiElements().resizePerunTable(sp, 350, this);
+
+		this.contentWidget.setWidget(vp);
+
+		return getWidget();
+	}
+
+	@Override
+	public Widget getWidget() {
+		return this.contentWidget;
+	}
+
+	@Override
+	public Widget getTitle() {
+		return this.titleWidget;
+	}
+
+	@Override
+	public ImageResource getIcon() {
+		return SmallIcons.INSTANCE.databaseServerIcon();
+	}
+
+	@Override
+	public boolean multipleInstancesEnabled() {
+		return false;
+	}
+
+	@Override
+	public void open() {
+		session.getUiElements().getMenu().openMenu(MainMenu.FACILITY_ADMIN);
+		session.getUiElements().getBreadcrumbs().setLocation(task.getFacility(),
+				"Propagation results detail: " + destination.getDestination() + " - " + task.getService().getName(), getUrlWithParameters());
+	}
+
+	@Override
+	public boolean isAuthorized() {
+		return session.isFacilityAdmin(task.getFacility().getId());
+	}
+
+	@Override
+	public boolean isPrepared() {
+		return task != null && destination != null;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		TaskResultsForDestinationTabItem that = (TaskResultsForDestinationTabItem) o;
+		return taskId == that.taskId &&
+				destinationId == that.destinationId;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(taskId, destinationId);
+	}
+
+	public static TaskResultsForDestinationTabItem load(Task task, Destination destination) {
+		return new TaskResultsForDestinationTabItem(task, destination);
+	}
+
+	public static TaskResultsForDestinationTabItem load(Map<String, String> parameters) {
+		int tid = Integer.parseInt(parameters.get("id"));
+		int did = Integer.parseInt(parameters.get("destinationId"));
+		return new TaskResultsForDestinationTabItem(tid, did);
+	}
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsTabItem.java
@@ -1,8 +1,11 @@
 package cz.metacentrum.perun.webgui.tabs.facilitiestabs;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.cellview.client.CellTable;
+import com.google.gwt.user.cellview.client.ColumnSortEvent;
+import com.google.gwt.user.cellview.client.ColumnSortList;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
@@ -98,7 +101,12 @@ public class TaskResultsTabItem implements TabItem, TabItemWithUrl{
 		}, "Filter results by destination");
 
 
-		CellTable<TaskResult> table = callback.getTable();
+		// on row click
+		CellTable<TaskResult> table = callback.getTable((index, taskResult, value) -> {
+			if (taskResult != null) {
+				session.getTabManager().addTab(new TaskResultsForDestinationTabItem(task.getId(), taskResult.getDestination().getId()));
+			}
+		});
 
 		table.addStyleName("perun-table");
 		ScrollPanel sp = new ScrollPanel(table);
@@ -108,9 +116,17 @@ public class TaskResultsTabItem implements TabItem, TabItemWithUrl{
 		vp.setCellHeight(menu, "30px");
 		vp.add(sp);
 
+		Scheduler.get().scheduleDeferred(() -> {
+			ColumnSortList.ColumnSortInfo csi = new ColumnSortList.ColumnSortInfo(table.getColumn(1), true);
+			table.getColumnSortList().push(csi);
+			ColumnSortEvent.fire(table, table.getColumnSortList());
+		});
+
 		session.getUiElements().resizePerunTable(sp, 350, this);
 
+
 		this.contentWidget.setWidget(vp);
+
 
 		return getWidget();
 


### PR DESCRIPTION
* Problem: current displaying of tasks for a facility is confusing.

* Solution: for each destination there is displayed only the newest task
 result and it is possible to see all task results after clicking the
 newest one.

 Also, the lengths of error messages and standard messages are now on
 the facility tasks results page limited (40 standard/ 150 error) and
 the whole messages can be viewed on the detail page for a destination.