### PR TITLE
CORE,RPC: Fixed selecting UES attributes by names

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1170,7 +1170,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 		try {
 			return namedParameterJdbcTemplate.query("select " + getAttributeMappingSelectQuery("ues") + " from attr_names " +
-							"left join user_ext_source_attr_values ues on id=ues.attr_id and ues_id=:uesId " +
+							"left join user_ext_source_attr_values ues on id=ues.attr_id and user_ext_source_id=:uesId " +
 							"where namespace in ( :nSC,:nSO,:nSD,:nSV ) and attr_names.attr_name in ( :attrNames )",
 					parameters, new SingleBeanAttributeRowMapper<>(sess, this, ues));
 		} catch (EmptyResultDataAccessException ex) {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -464,7 +464,8 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param vo int VO <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
 	 */
-	/* Sets the attributes.
+	/*#
+	 * Sets the attributes.
 	 *
 	 * @param userExtSource int UserExtSource <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
@@ -539,7 +540,6 @@ public enum AttributesManagerMethod implements ManagerMethod {
 	 * @param user int User <code>id</code>
 	 * @param attributes List<Attribute> List of attributes
 	 */
-
 	/*#
 	 * Sets the attributes.
 	 *


### PR DESCRIPTION
- There was bad column name when selecting UserExtSource attributes
  by their names (URNs).
- Fixed RPC javadoc for getAttributes() for UserExtSource.