### PR TITLE
RPC: fix of facility deletion

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -358,6 +358,9 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 			}
 		}
 
+		//Remove all service denials
+		getFacilitiesManagerImpl().removeAllServiceDenials(facility.getId());
+
 		// delete facility
 		getFacilitiesManagerImpl().deleteFacilityOwners(sess, facility);
 		getFacilitiesManagerImpl().deleteFacility(sess, facility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -9,6 +9,7 @@ import javax.sql.DataSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -1346,5 +1347,14 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 			mergedContactGroups.add(contactGroup);
 		}
 		return mergedContactGroups;
+	}
+
+	@Override
+	public void removeAllServiceDenials(int facilityId) throws InternalErrorException {
+		try {
+			jdbc.update("delete from service_denials where facility_id=?", facilityId);
+		} catch (DataAccessException e) {
+			throw new InternalErrorException(e);
+		}
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -834,4 +834,15 @@ public interface FacilitiesManagerImplApi {
 	 * @throws BanNotExistsException
 	 */
 	void removeBan(PerunSession sess, int userId, int facilityId) throws InternalErrorException, BanNotExistsException;
+
+	/**
+	 * Remove all service denials on given facility.
+	 *
+	 * WARNING: this method should be removed in the future if
+	 * the tasks module is merged into core module.
+	 *
+	 * @param facilityId facility id
+	 * @throws InternalErrorException when db operation fails
+	 */
+	void removeAllServiceDenials(int facilityId) throws InternalErrorException;
 }


### PR DESCRIPTION
* Problem: deletion of facility fails if there is a service denial on it
and if the service has been deleted.

* Solution: added call that before deleting facility removes all of its
serice denials.

* WARNING: method removeAllServiceDenials inside facilities manager
will be probably removed in the future if there will be merge of  core and
tasks-lib modules. This is more of a temporary fix.