### PR TITLE
GUI: Hide create VO button on VO selection tab

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/resources/Utils.java
@@ -547,6 +547,23 @@ public class Utils {
 	}
 
 	/**
+	 * Return TRUE if VO managers should have VO creation disabled in administrative GUI.
+	 *
+	 * @return TRUE if VO creation should be disabled
+	 */
+	public static boolean disableCreateVo() {
+
+		if (PerunWebSession.getInstance().getConfiguration() != null) {
+			String value = PerunWebSession.getInstance().getConfiguration().getCustomProperty("disableCreateVo");
+			if (Objects.equals(value, "true")) {
+				return true;
+			}
+		}
+		return false;
+
+	}
+
+	/**
 	 * Clear all cookies provided by federation IDP in user's browser.
 	 */
 	public static void clearFederationCookies() {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VosSelectTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VosSelectTabItem.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.webgui.client.mainmenu.MainMenu;
 import cz.metacentrum.perun.webgui.client.resources.ButtonType;
 import cz.metacentrum.perun.webgui.client.resources.PerunSearchEvent;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
+import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.vosManager.GetVos;
 import cz.metacentrum.perun.webgui.model.VirtualOrganization;
 import cz.metacentrum.perun.webgui.tabs.TabItem;
@@ -73,7 +74,7 @@ public class VosSelectTabItem implements TabItem, TabItemWithUrl {
 		firstTabPanel.add(tabMenu);
 		firstTabPanel.setCellHeight(tabMenu, "30px");
 
-		if (session.isVoAdmin()) {
+		if (session.isVoAdmin() && !Utils.disableCreateVo()) {
 			// do not display to VO observer
 			tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CREATE, true, ButtonTranslation.INSTANCE.createVo(), new ClickHandler() {
 				@Override


### PR DESCRIPTION
- Added instance wide config option to perun-web-gui.properties
  to hide create VO button on VO selection tab.
  Its disableCreateVo=true if you wish to hide the button.