### PR TITLE
workaround for broken OpenJDK on Debian/Ubuntu causing tests to fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,8 +172,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration>
-						<!-- disable logging for maven's tests / Test in you IDE will log normally -->
-						<argLine>-Dlog4j.configuration=</argLine>
+						<!-- workaround for broken OpenJDK 8u181-b13-2 on Debian/Ubuntu which causes tests to fail,
+						     see https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
+						<argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
 						<testFailureIgnore>false</testFailureIgnore>
 						<skip>false</skip>
 						<runOrder>alphabetical</runOrder>


### PR DESCRIPTION
- recent security update to OpenJDK 8u181-b13-2 on Debian/Ubuntu broke maven-surefire-plugin which uses absolute URLs in JAR manifest files
- see https://issues.apache.org/jira/browse/SUREFIRE-1588 for details
- workaround is to set -Djdk.net.URLClassPath.disableClassPathURLCheck=true for the maven-surefire-plugin in the main pom.xml