### PR TITLE
Upgraded to Spring 5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.6.RELEASE</version>
+		<version>2.1.0.RELEASE</version>
 		<relativePath/>
 	</parent>
 
@@ -61,6 +61,7 @@
 
 		<!-- redefine versions of some libraries defined by Spring Boot Starter Parent -->
 		<hsqldb.version>2.3.2</hsqldb.version> <!-- 2.3.3 fails GroupsManagerEntryIntegrationTest.addAdminWhenAlreadyAdmin test -->
+		<tomcat.version>8.5.34</tomcat.version>
 
 		<!-- versions of libraries not defined by the Spring Boot Starter Parent -->
 		<cglib-nodep.version>2.2.2</cglib-nodep.version>


### PR DESCRIPTION
- upgraded Spring Boot Starter Parent to 2.1.0.RELEASE
- which upgrades Spring to 5.1.2
- Spring 5.1 should be compatible with Java 11
- fixed Tomcat version to 8.5 to match the version used on Debian 9 (instead of the Tomcat 9 inherited from SBSP)
