### PR TITLE
made Perun compatible with Java 11

### DIFF
--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -136,5 +136,11 @@
 			<artifactId>jboss-jms-api</artifactId>
 		</dependency>
 
+		<!-- @Resource and @PostConstruct for Java 11 -->
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -157,6 +157,11 @@
 			<groupId>jivesoftware</groupId>
 			<artifactId>smackx</artifactId>
 		</dependency>
-		
+
+		<!-- @Resource and @PostConstruct for Java 11 -->
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
- annotations @ PostConstruct and @ Resource are missing in Java 10 and Java 11
- added Maven dependency javax.annotation:javax.annotation-api to perun-dispatcher and perun-notification projects which use these annotations
- tested successfully on Oracle JDK 8, OpenJDK 10 and Oracle JDK 11