### PR TITLE
Ignore unnecessary properties of Member in JsonDeserializers

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -18,6 +18,7 @@ import org.codehaus.jackson.map.annotate.JsonDeserialize;
 
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import java.io.InputStream;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -69,6 +70,7 @@ public class JsonDeserializer extends Deserializer {
 	private interface UserExtSourceMixIn {}
 
 	@SuppressWarnings("unused")
+	@JsonIgnoreProperties({"groupStatuses", "groupStatus", "beanName"})
 	private interface MemberMixIn {
 		@JsonIgnore
 		void setStatus(String status);
@@ -81,6 +83,16 @@ public class JsonDeserializer extends Deserializer {
 
 		@JsonDeserialize
 		void setMembershipType(MembershipType type);
+
+		@JsonIgnore
+		void setGroupsStatuses(Map<Integer, MemberGroupStatus> groupsStatuses);
+
+		@JsonIgnore
+		void putGroupStatuses(Map<Integer, MemberGroupStatus> groupStatuses);
+
+		@JsonIgnore
+		void putGroupStatus(int groupId, MemberGroupStatus status);
+
 	}
 
 	private static final ObjectMapper mapper = new ObjectMapper();

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import cz.metacentrum.perun.core.api.*;
 import org.codehaus.jackson.JsonNode;
@@ -52,9 +53,19 @@ public class JsonDeserializer extends Deserializer {
 	@JsonIgnoreProperties({"shortName", "beanName"})
 	private interface GroupMixIn {}
 
+	@JsonIgnoreProperties({"groupStatuses", "groupStatus", "beanName"})
 	private interface MemberMixIn {
 		@JsonIgnore
 		void setStatus(String status);
+
+		@JsonIgnore
+		void setGroupsStatuses(Map<Integer, MemberGroupStatus> groupsStatuses);
+
+		@JsonIgnore
+		void putGroupStatuses(Map<Integer, MemberGroupStatus> groupStatuses);
+
+		@JsonIgnore
+		void putGroupStatus(int groupId, MemberGroupStatus status);
 	}
 
 	private static final ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
- Ignore new properties groupStatus and groupStatuses of (Rich)Member
  in JsonDeserializer. They have no corresponding setter right now.
- This fixes synchronization between perun instances.