### PR TITLE
BASE: Gather also IdPOrganizationName attribute from IdPs.

### DIFF
--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -96,7 +96,7 @@
 				<prop key="perun.DBInitializatorEnabled">false</prop>
 				<prop key="perun.userExtSources.persistent">PERUN,[\w\d]*</prop>
 				<prop key="perun.proxyIdPs"/>
-				<prop key="perun.attributesForUpdate.idp">mail,cn,sn,givenName,o,ou,eppn,affiliation,displayName,uid,epuid,schacHomeOrganization,forwardedScopedAffiliation,alternativeLoginName,isCesnetEligibleLastSeen,IdPOrganizationName</prop>
+				<prop key="perun.attributesForUpdate.idp">mail,cn,sn,givenName,o,ou,eppn,affiliation,displayName,uid,epuid,schacHomeOrganization,forwardedScopedAffiliation,alternativeLoginName,isCesnetEligibleLastSeen,IdPOrganizationName,sourceIdPName</prop>
 				<prop key="perun.attributesForUpdate.x509">mail,cn,o,dn,cadn,certificate</prop>
 				<prop key="perun.instanceId">AOJ26J3D9DCK3OA7</prop>
 				<prop key="perun.instanceName">LOCAL</prop>

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -96,7 +96,7 @@
 				<prop key="perun.DBInitializatorEnabled">false</prop>
 				<prop key="perun.userExtSources.persistent">PERUN,[\w\d]*</prop>
 				<prop key="perun.proxyIdPs"/>
-				<prop key="perun.attributesForUpdate.idp">mail,cn,sn,givenName,o,ou,eppn,affiliation,displayName,uid,epuid,schacHomeOrganization,forwardedScopedAffiliation,alternativeLoginName,isCesnetEligibleLastSeen</prop>
+				<prop key="perun.attributesForUpdate.idp">mail,cn,sn,givenName,o,ou,eppn,affiliation,displayName,uid,epuid,schacHomeOrganization,forwardedScopedAffiliation,alternativeLoginName,isCesnetEligibleLastSeen,IdPOrganizationName</prop>
 				<prop key="perun.attributesForUpdate.x509">mail,cn,o,dn,cadn,certificate</prop>
 				<prop key="perun.instanceId">AOJ26J3D9DCK3OA7</prop>
 				<prop key="perun.instanceName">LOCAL</prop>


### PR DESCRIPTION
- It will contain organization name of original IdP. Value will
  be used in GUI, so users can recognize own identities by organization
  name rather than entityId of IdP.
- After some time, we can remove static translation from GUI and use
  it instead.