### PR TITLE
BASE: Fixed compareTo() on TaskSchedule

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/TaskSchedule.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/taskslib/model/TaskSchedule.java
@@ -42,12 +42,12 @@ public class TaskSchedule implements Delayed {
 
 	@Override
 	public long getDelay(TimeUnit unit) {
-		return unit.convert(delay - (System.currentTimeMillis() - base), TimeUnit.MILLISECONDS);
+		return unit.convert(this.delay - (System.currentTimeMillis() - base), TimeUnit.MILLISECONDS);
 	}
 
 	@Override
 	public int compareTo(Delayed delayed) {
-		return Long.valueOf(this.delay).compareTo(delayed.getDelay(TimeUnit.MILLISECONDS));
+		return Long.compare(getDelay(TimeUnit.MILLISECONDS), delayed.getDelay(TimeUnit.MILLISECONDS));
 	}
 
 	@Override


### PR DESCRIPTION
- We previously compared static value 30 000 ms with calculated delay
  of other scheduled TaskSchedules, which favored repeatedly updated
  TaskSchedules in queue instead of most delayed.
- We now compare calculated delay for both compared TaskSchedules.