### PR TITLE
Allow blocking of all services on facility and destination

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ServiceAlreadyBannedException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ServiceAlreadyBannedException.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.api.exceptions;
 
+import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Service;
 
@@ -14,6 +15,7 @@ public class ServiceAlreadyBannedException extends PerunException {
 
 	private Service service;
 	private Facility facility;
+	private Destination destination;
 
 	public ServiceAlreadyBannedException(String message) {
 		super(message);
@@ -33,12 +35,22 @@ public class ServiceAlreadyBannedException extends PerunException {
 		this.facility = facility;
 	}
 
+	public ServiceAlreadyBannedException(Service service, Destination destination) {
+		this(service.toString() + " is already banned on " + destination.toString());
+		this.service = service;
+		this.destination = destination;
+	}
+
 	public Service getService() {
 		return service;
 	}
 
 	public Facility getFacility() {
 		return facility;
+	}
+
+	public Destination getDestination() {
+		return destination;
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -172,7 +172,7 @@ public interface ServicesManager {
 	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
-	 * Generates the list of attributes per each user and per each resource. Resources are filtered by service. 
+	 * Generates the list of attributes per each user and per each resource. Resources are filtered by service.
 	 * Never return member or member-resource attribute.
 	 *
 	 * @param perunSession
@@ -292,11 +292,11 @@ public interface ServicesManager {
 
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups in vos.
-	 * 
+	 *
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
-	 * @return attributes in special structure. 
+	 * @return attributes in special structure.
 	 *        Facility is in the root, facility children are vos.
 	 *        Vo first child is abstract structure which children are resources.
 	 *        Resource first child is abstract structure which children are groups.
@@ -305,8 +305,8 @@ public interface ServicesManager {
 	 *        Group second chi is abstract structure which children are members.
 	 <pre>
 	 Facility
-	 +---Attrs                              
-	 +---ChildNodes               
+	 +---Attrs
+	 +---ChildNodes
 	        +-----Vo
 	        |      +---Attrs
 	        |      +---ChildNodes
@@ -370,7 +370,7 @@ public interface ServicesManager {
 	 * @throws InternalErrorException
 	 * @throws FacilityNotExistsException
 	 * @throws ServiceNotExistsException
-	 * @throws PrivilegeException 
+	 * @throws PrivilegeException
 	 * @throws VoNotExistsException
 	 */
 	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException, VoNotExistsException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
@@ -756,8 +756,17 @@ public interface ServicesManager {
 	 */
 	void removeAllDestinations(PerunSession perunSession, Service service, Facility facility) throws PrivilegeException, InternalErrorException, ServiceNotExistsException, FacilityNotExistsException;
 
-	@Deprecated
-	int getDestinationIdByName(PerunSession sess, String name) throws InternalErrorException, DestinationNotExistsException;
+	/**
+	 * Return ID of Destination by its value (name) and type.
+	 *
+	 * @param sess
+	 * @param name Name (value) of Destination
+	 * @param type Type of destination
+	 * @return ID of Destination
+	 * @throws InternalErrorException
+	 * @throws DestinationNotExistsException
+	 */
+	int getDestinationIdByName(PerunSession sess, String name, String type) throws InternalErrorException, DestinationNotExistsException;
 
 	/**
 	 * List all services associated with the facility (via resource).

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -139,7 +139,7 @@ public interface ServicesManagerBl {
 	 * @param perunSession
 	 * @param service you will get attributes required by this service
 	 * @param facility you will get attributes for this facility, resources associated with it and users assigned to the resources
-	 * @return attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources. 
+	 * @return attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources.
 	 * 				Facility second child is abstract node with no attribute and it's children are all users.
 	 *
 	 * @throws InternalErrorException
@@ -537,7 +537,17 @@ public interface ServicesManagerBl {
 	 */
 	void checkServicesPackageExists(PerunSession sess, ServicesPackage servicesPackage) throws InternalErrorException, ServicesPackageNotExistsException;
 
-	int getDestinationIdByName(PerunSession sess, String name) throws InternalErrorException, DestinationNotExistsException;
+	/**
+	 * Returns Destinations ID based on destination name and type.
+	 *
+	 * @param sess
+	 * @param name Name (value) of destination
+	 * @param type type of destination
+	 * @return
+	 * @throws InternalErrorException
+	 * @throws DestinationNotExistsException
+	 */
+	int getDestinationIdByName(PerunSession sess, String name, String type) throws InternalErrorException, DestinationNotExistsException;
 
 	/**
 	 * List all services associated with the facility (via resource).

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -660,8 +660,8 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	@Override
-	public int getDestinationIdByName(PerunSession sess, String name) throws InternalErrorException, DestinationNotExistsException {
-		return servicesManagerImpl.getDestinationIdByName(sess, name);
+	public int getDestinationIdByName(PerunSession sess, String name, String type) throws InternalErrorException, DestinationNotExistsException {
+		return servicesManagerImpl.getDestination(sess, name, type).getId();
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -676,8 +676,8 @@ public class ServicesManagerEntry implements ServicesManager {
 	}
 
 	@Override
-	public int getDestinationIdByName(PerunSession sess, String name) throws InternalErrorException, DestinationNotExistsException {
-		return servicesManagerBl.getDestinationIdByName(sess, name);
+	public int getDestinationIdByName(PerunSession sess, String name, String type) throws InternalErrorException, DestinationNotExistsException {
+		return servicesManagerBl.getDestinationIdByName(sess, name, type);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -529,18 +529,6 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 	}
 
 	@Override
-	@Deprecated
-	public int getDestinationIdByName(PerunSession sess, String name) throws InternalErrorException, DestinationNotExistsException {
-		try {
-			return jdbc.queryForInt("select id from destinations where destination=?", name);
-		} catch (EmptyResultDataAccessException e) {
-			throw new DestinationNotExistsException(e);
-		} catch (RuntimeException e) {
-			throw new InternalErrorException(e);
-		}
-	}
-
-	@Override
 	public void addDestination(PerunSession sess, Service service, Facility facility, Destination destination) throws InternalErrorException {
 		try {
 			jdbc.update("insert into facility_service_destinations (service_id, facility_id, destination_id, propagation_type, created_by,created_at,modified_by,modified_at,created_by_uid, modified_by_uid) " +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
@@ -434,9 +434,6 @@ public interface ServicesManagerImplApi {
 	 */
 	void removeAllDestinations(PerunSession perunSession, Facility facility) throws InternalErrorException;
 
-	@Deprecated
-	int getDestinationIdByName(PerunSession sess, String name) throws InternalErrorException, DestinationNotExistsException;
-
 	/**
 	 * Get destination by String destination and type
 	 *

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GeneralServiceManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GeneralServiceManagerMethod.java
@@ -32,9 +32,58 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 	 * @param service int Service <code>id</code>
 	 * @param destination int Destination <code>id</code>
 	 */
+	/*#
+	 * Bans Service on a destination.
+	 *
+	 * @param service int Service <code>id</code>
+	 * @param destinationName String Destination name (like hostnames)
+	 * @param destinationType String Destination type (like host, user@host, user@host:port, email, service-specific, ...)
+	 */
 	blockServiceOnDestination {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.getGeneralServiceManager().blockServiceOnDestination(ac.getSession(), ac.getServiceById(parms.readInt("service")),parms.readInt("destination"));
+
+			if (parms.contains("destination")) {
+				ac.getGeneralServiceManager().blockServiceOnDestination(ac.getSession(), ac.getServiceById(parms.readInt("service")),parms.readInt("destination"));
+			} else {
+				ac.getGeneralServiceManager().blockServiceOnDestination(ac.getSession(), ac.getServiceById(parms.readInt("service")), ac.getServicesManager().getDestinationIdByName(ac.getSession(), parms.readString("destinationName"), parms.readString("destinationType")));
+			}
+			return null;
+		}
+	},
+
+	/*#
+	 * Block all services currently assigned on this facility.
+	 * Newly assigned services are still allowed for propagation.
+	 *
+	 * @param facility int Facility <code>id</code>
+	 */
+	blockAllServicesOnFacility {
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.getGeneralServiceManager().blockAllServicesOnFacility(ac.getSession(), ac.getFacilityById(parms.readInt("facility")));
+			return null;
+		}
+	},
+
+	/*#
+	 * Block all services currently assigned on this destination.
+	 * Newly assigned services are still allowed for propagation.
+	 *
+	 * @param destination int Destination <code>id</code>
+	 */
+	/*#
+	 * Block all services currently assigned on this destination.
+	 * Newly assigned services are still allowed for propagation.
+	 *
+	 * @param destinationName String Destination name (like hostnames)
+	 * @param destinationType String Destination type (like host, user@host, user@host:port, email, service-specific, ...)
+	 */
+	blockAllServicesOnDestination {
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			if (parms.contains("destination")) {
+				ac.getGeneralServiceManager().blockAllServicesOnDestination(ac.getSession(), parms.readInt("destination"));
+			} else {
+				ac.getGeneralServiceManager().blockAllServicesOnDestination(ac.getSession(), ac.getServicesManager().getDestinationIdByName(ac.getSession(), parms.readString("destinationName"), parms.readString("destinationType")));
+			}
 			return null;
 		}
 	},
@@ -114,9 +163,19 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 	 *
 	 * @param destination int Destination <code>id</code>
 	 */
+	/*#
+	 * Erase all the possible denials on this destination.
+	 *
+	 * @param destinationName String Destination name (like hostnames)
+	 * @param destinationType String Destination type (like host, user@host, user@host:port, email, service-specific, ...)
+	 */
 	unblockAllServicesOnDestination {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.getGeneralServiceManager().unblockAllServicesOnDestination(ac.getSession(), parms.readInt("destination"));
+			if (parms.contains("destination")) {
+				ac.getGeneralServiceManager().unblockAllServicesOnDestination(ac.getSession(), parms.readInt("destination"));
+			} else {
+				ac.getGeneralServiceManager().unblockAllServicesOnDestination(ac.getSession(), ac.getServicesManager().getDestinationIdByName(ac.getSession(), parms.readString("destinationName"), parms.readString("destinationType")));
+			}
 			return null;
 		}
 	},
@@ -145,9 +204,22 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 	 * @param service int Service <code>id</code>
 	 * @param destination int Destination <code>id</code>
 	 */
+	/*#
+	 * Free the denial of the Service on this destination. If the Service was banned on
+	 * this destination, it will be freed. In case the Service was not banned on this
+	 * destination, nothing will happen.
+	 *
+	 * @param service int Service <code>id</code>
+	 * @param destinationName String Destination name (like hostnames)
+	 * @param destinationType String Destination type (like host, user@host, user@host:port, email, service-specific, ...)
+	 */
 	unblockServiceOnDestination {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.getGeneralServiceManager().unblockServiceOnDestination(ac.getSession(), ac.getServiceById(parms.readInt("service")),parms.readInt("destination"));
+			if (parms.contains("destination")) {
+				ac.getGeneralServiceManager().unblockServiceOnDestination(ac.getSession(), ac.getServiceById(parms.readInt("service")), parms.readInt("destination"));
+			} else {
+				ac.getGeneralServiceManager().unblockServiceOnDestination(ac.getSession(), ac.getServiceById(parms.readInt("service")), ac.getServicesManager().getDestinationIdByName(ac.getSession(), parms.readString("destinationName"), parms.readString("destinationType")));
+			}
 			return null;
 		}
 	},

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/controller/service/GeneralServiceManager.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/controller/service/GeneralServiceManager.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.controller.model.ServiceForGUI;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Service;
+import cz.metacentrum.perun.core.api.exceptions.DestinationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
@@ -42,7 +43,31 @@ public interface GeneralServiceManager {
 	 * @param destinationId The destination on which we want to ban the Service
 	 * @throws InternalErrorException
 	 */
-	public void blockServiceOnDestination(PerunSession perunSession, Service service, int destinationId) throws InternalErrorException;
+	public void blockServiceOnDestination(PerunSession perunSession, Service service, int destinationId) throws InternalErrorException, PrivilegeException, DestinationNotExistsException, ServiceAlreadyBannedException;
+
+	/**
+	 * Block all services currently assigned on this facility.
+	 * From this moment on, there are no Services being allowed on this facility.
+	 * If you assign a new service to the facility, it will be allowed!
+	 *
+	 * @param perunSession
+	 * @param facility Facility we want to block all services on.
+	 *
+	 * @throws InternalErrorException
+	 */
+	public void blockAllServicesOnFacility(PerunSession perunSession, Facility facility) throws InternalErrorException, FacilityNotExistsException, PrivilegeException;
+
+	/**
+	 * Block all services currently assigned on this destination.
+	 * From this moment on, there are no Services being allowed on this destination.
+	 * If you assign a new service to the destination, it will be allowed!
+	 *
+	 * @param perunSession
+	 * @param destinationId The id of a destination we want to block all services on.
+	 *
+	 * @throws InternalErrorException
+	 */
+	public void blockAllServicesOnDestination(PerunSession perunSession, int destinationId) throws InternalErrorException, PrivilegeException, DestinationNotExistsException;
 
 	/**
 	 * List all the Services that are banned on this facility.

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/ServiceDenialDao.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/ServiceDenialDao.java
@@ -96,4 +96,12 @@ public interface ServiceDenialDao {
 	 */
 	boolean isServiceBlockedOnDestination(int serviceId, int destinationId);
 
+	/**
+	 * Return list of services this destination points to.
+	 *
+	 * @param destinationId ID of destination
+	 * @return Services associated with this destination.
+	 */
+	List<Service> getServicesFromDestination(int destinationId);
+
 }

--- a/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/ServiceDenialDaoJdbc.java
+++ b/perun-tasks-lib/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/ServiceDenialDaoJdbc.java
@@ -62,6 +62,15 @@ public class ServiceDenialDaoJdbc extends JdbcDaoSupport implements ServiceDenia
 	}
 
 	@Override
+	public List<Service> getServicesFromDestination(int destinationId) {
+		List<Service> servicesFromDestination = getJdbcTemplate().query("select distinct " + ServicesManagerImpl.serviceMappingSelectQuery +
+								" from services join facility_service_destinations on facility_service_destinations.service_id = services.id" +
+								" where facility_service_destinations.destination_id = ?",
+						ServicesManagerImpl.SERVICE_MAPPER, destinationId);
+		return servicesFromDestination;
+	}
+
+	@Override
 	public boolean isServiceBlockedOnFacility(int serviceId, int facilityId) {
 		int denials = 0;
 		denials = this.queryForInt("select count(*) from service_denials where service_id = ? and facility_id = ?", serviceId, facilityId);


### PR DESCRIPTION
- We had methods to unblock all blocked services on facility and
  destination, but were missing equal methods to block all services.
- Now we can block all currently assigned services on facility (all
  destination facilities).