### PR TITLE
New Role - ResourceSelfService

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceSelfServiceAddedForGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceSelfServiceAddedForGroup.java
@@ -1,0 +1,45 @@
+package cz.metacentrum.perun.audit.events.ResourceManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+
+/**
+ * Event for setting the ResourceSelfService role for group.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ResourceSelfServiceAddedForGroup extends AuditEvent {
+
+	private Group group;
+	private Resource resource;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public ResourceSelfServiceAddedForGroup() {
+	}
+
+	public ResourceSelfServiceAddedForGroup(Resource resource, Group group) {
+		this.group = group;
+		this.resource = resource;
+		this.message = formatMessage("%s was added as ResourceSelfService for %s.", group, resource);
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	public Group getGroup() {
+		return group;
+	}
+
+	public Resource getResource() {
+		return resource;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceSelfServiceAddedForUser.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceSelfServiceAddedForUser.java
@@ -1,0 +1,45 @@
+package cz.metacentrum.perun.audit.events.ResourceManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.User;
+
+/**
+ * Event for setting the ResourceSelfService role for user.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ResourceSelfServiceAddedForUser extends AuditEvent {
+
+	private Resource resource;
+	private User user;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public ResourceSelfServiceAddedForUser() {
+	}
+
+	public ResourceSelfServiceAddedForUser(Resource resource, User user) {
+		this.resource = resource;
+		this.user = user;
+		this.message = formatMessage("%s was added as ResourceSelfService for %s.", user, resource);
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	public Resource getResource() {
+		return resource;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceSelfServiceRemovedForGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceSelfServiceRemovedForGroup.java
@@ -1,0 +1,45 @@
+package cz.metacentrum.perun.audit.events.ResourceManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+
+/**
+ * Event for removing the ResourceSelfService role for group.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ResourceSelfServiceRemovedForGroup extends AuditEvent {
+
+	private Group group;
+	private Resource resource;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public ResourceSelfServiceRemovedForGroup() {
+	}
+
+	public ResourceSelfServiceRemovedForGroup(Resource resource, Group group) {
+		this.group = group;
+		this.resource = resource;
+		this.message = formatMessage("%s was removed as ResourceSelfService for %s.", group, resource);
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	public Group getGroup() {
+		return group;
+	}
+
+	public Resource getResource() {
+		return resource;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceSelfServiceRemovedForUser.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ResourceManagerEvents/ResourceSelfServiceRemovedForUser.java
@@ -1,0 +1,45 @@
+package cz.metacentrum.perun.audit.events.ResourceManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.User;
+
+/**
+ * Event for removing the ResourceSelfService role for user.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ResourceSelfServiceRemovedForUser extends AuditEvent {
+
+	private Resource resource;
+	private User user;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public ResourceSelfServiceRemovedForUser() {
+	}
+
+	public ResourceSelfServiceRemovedForUser(Resource resource, User user) {
+		this.resource = resource;
+		this.user = user;
+		this.message = formatMessage("%s was removed as ResourceSelfService for %s.", user, resource);
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	public Resource getResource() {
+		return resource;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Role.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Role.java
@@ -8,6 +8,7 @@ public enum Role {
 	SELF ("self"),
 	FACILITYADMIN ("facilityadmin"),
 	RESOURCEADMIN ("resourceadmin"),
+	RESOURCESELFSERVICE("resourceselfservice"),
 	REGISTRAR ("registrar"),
 	ENGINE ("engine"),
 	RPC ("rpc"),

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AlreadyAdminException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AlreadyAdminException.java
@@ -44,6 +44,13 @@ public class AlreadyAdminException extends PerunException {
 		this.role = role;
 	}
 
+	public AlreadyAdminException(String message, Throwable cause, User user, Resource resource, Role role) {
+		super(message, cause);
+		this.user = user;
+		this.resource = resource;
+		this.role = role;
+	}
+
 
 	public AlreadyAdminException(String message, Throwable cause, User user, User sponsoredUser) {
 		super(message, cause);
@@ -83,6 +90,13 @@ public class AlreadyAdminException extends PerunException {
 		super(message, cause);
 		this.authorizedGroup = authorizedGroup;
 		this.vo = vo;
+		this.role = role;
+	}
+
+	public AlreadyAdminException(String message, Throwable cause, Group authorizedGroup, Resource resource, Role role) {
+		super(message, cause);
+		this.authorizedGroup = authorizedGroup;
+		this.resource = resource;
 		this.role = role;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ResourcesManager.java
@@ -984,4 +984,52 @@ public interface ResourcesManager {
 	 * @throws PrivilegeException
 	 */
 	void removeBan(PerunSession sess, int memberId, int resourceId) throws InternalErrorException, BanNotExistsException, PrivilegeException, ResourceNotExistsException;
+
+	/**
+	 * Sets ResourceSelfService role to given user for given resource.
+	 *
+	 * @param sess     session
+	 * @param resource resource
+	 * @param user     user id
+	 * @throws InternalErrorException internal error
+	 * @throws PrivilegeException     insufficient permissions
+	 * @throws AlreadyAdminException  already has the role
+	 */
+	void addResourceSelfServiceUser(PerunSession sess, Resource resource, User user) throws InternalErrorException, PrivilegeException, AlreadyAdminException;
+
+	/**
+	 * Sets ResourceSelfService role to given group for given resource.
+	 *
+	 * @param sess     session
+	 * @param resource resource
+	 * @param group    group
+	 * @throws InternalErrorException internal error
+	 * @throws PrivilegeException     insufficient permissions
+	 * @throws AlreadyAdminException  already has the role
+	 */
+	void addResourceSelfServiceGroup(PerunSession sess, Resource resource, Group group) throws InternalErrorException, PrivilegeException, AlreadyAdminException;
+
+	/**
+	 * Unset ResourceSelfService role to given user for given resource.
+	 *
+	 * @param sess       session
+	 * @param resource resource
+	 * @param user     user
+	 * @throws InternalErrorException     internal error
+	 * @throws PrivilegeException         insufficient permissions
+	 * @throws UserNotAdminException      user did not have the role
+	 */
+	void removeResourceSelfServiceUser(PerunSession sess, Resource resource, User user) throws InternalErrorException, PrivilegeException, UserNotAdminException;
+
+	/**
+	 * Unset ResourceSelfService role to given group for given resource.
+	 *
+	 * @param sess       session
+	 * @param resource resource
+	 * @param group   group
+	 * @throws InternalErrorException     internal error
+	 * @throws PrivilegeException         insufficient permissions
+	 * @throws GroupNotAdminException     group did not have the role
+	 */
+	void removeResourceSelfServiceGroup(PerunSession sess, Resource resource, Group group) throws InternalErrorException, PrivilegeException, GroupNotAdminException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -995,4 +995,48 @@ public interface ResourcesManagerBl {
 	 * @throws InternalErrorException internal error
 	 */
 	List<Resource> getResources(PerunSession sess) throws InternalErrorException;
+
+	/**
+	 * Sets ResourceSelfService role to given user for given resource.
+	 *
+	 * @param sess     session
+	 * @param resource resource
+	 * @param user     user
+	 * @throws AlreadyAdminException  already has role
+	 * @throws InternalErrorException internal error
+	 */
+	void addResourceSelfServiceUser(PerunSession sess, Resource resource, User user) throws AlreadyAdminException, InternalErrorException;
+
+	/**
+	 * Sets ResourceSelfService role to given group for given resource.
+	 *
+	 * @param sess     session
+	 * @param resource resource
+	 * @param group    group
+	 * @throws AlreadyAdminException  already has role
+	 * @throws InternalErrorException internal error
+	 */
+	void addResourceSelfServiceGroup(PerunSession sess, Resource resource, Group group) throws AlreadyAdminException, InternalErrorException;
+
+	/**
+	 * Unset ResourceSelfService role to given user for given resource.
+	 *
+	 * @param sess     session
+	 * @param resource resource
+	 * @param user     user
+	 * @throws UserNotAdminException  user did not have the role
+	 * @throws InternalErrorException internal error
+	 */
+	void removeResourceSelfServiceUser(PerunSession sess, Resource resource, User user) throws UserNotAdminException, InternalErrorException;
+
+	/**
+	 * Unset ResourceSelfService role to given group for given resource.
+	 *
+	 * @param sess     session
+	 * @param resource resource
+	 * @param group    group
+	 * @throws GroupNotAdminException group did not have the role
+	 * @throws InternalErrorException internal error
+	 */
+	void removeResourceSelfServiceGroup(PerunSession sess, Resource resource, Group group) throws GroupNotAdminException, InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1032,7 +1032,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 						if (user != null) authzResolverImpl.removeResourceRole(sess, role, (Resource) complementaryObject, user);
 						else authzResolverImpl.removeResourceRole(sess, role, (Resource) complementaryObject, authorizedGroup);
 					} else {
-						throw new InternalErrorException("Not supported complementary object for VoObserver: " + complementaryObject);
+						throw new InternalErrorException("Not supported complementary object for resourceSelfService: " + complementaryObject);
 					}
 				} else {
 					throw new InternalErrorException("Not supported role: " + role);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -638,7 +638,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                 perun session
 	 * @param user                 the user for setting role
-	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | securityadmin  )
+	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | securityadmin | resourceselfservice | resourceAdmin )
 	 * @param complementaryObjects objects for which role will be set
 	 */
 	public static void setRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, AlreadyAdminException {
@@ -669,7 +669,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                perun session
 	 * @param user                the user for setting role
-	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | securityadmin | resourceselfservice )
+	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | securityadmin | resourceselfservice | resourceAdmin )
 	 * @param complementaryObject object for which role will be set
 	 */
 	public static void setRole(PerunSession sess, User user, PerunBean complementaryObject, Role role) throws InternalErrorException, AlreadyAdminException {
@@ -686,7 +686,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                 perun session
 	 * @param authorizedGroup      the group for setting role
-	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice )
+	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice | resourceAdmin )
 	 * @param complementaryObjects objects for which role will be set
 	 */
 	public static void setRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, AlreadyAdminException {
@@ -717,7 +717,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                perun session
 	 * @param authorizedGroup     the group for setting role
-	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice )
+	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice | resourceAdmin )
 	 * @param complementaryObject object for which role will be set
 	 */
 	public static void setRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, Role role) throws InternalErrorException, AlreadyAdminException {
@@ -734,7 +734,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                 perun session
 	 * @param user                 the user for unsetting role
-	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice )
+	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice | resourceAdmin )
 	 * @param complementaryObjects objects for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, UserNotAdminException {
@@ -765,7 +765,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                perun session
 	 * @param user                the user for unsetting role
-	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator )
+	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice | resourceAdmin )
 	 * @param complementaryObject object for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, User user, PerunBean complementaryObject, Role role) throws InternalErrorException, UserNotAdminException {
@@ -782,7 +782,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                 perun session
 	 * @param authorizedGroup      the group for unsetting role
-	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator )
+	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice | resourceAdmin )
 	 * @param complementaryObjects objects for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, GroupNotAdminException {
@@ -813,7 +813,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                perun session
 	 * @param authorizedGroup     the group for unsetting role
-	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator )
+	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice | resourceAdmin )
 	 * @param complementaryObject object for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, Role role) throws InternalErrorException, GroupNotAdminException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -669,7 +669,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                perun session
 	 * @param user                the user for setting role
-	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | securityadmin )
+	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | securityadmin | resourceselfservice )
 	 * @param complementaryObject object for which role will be set
 	 */
 	public static void setRole(PerunSession sess, User user, PerunBean complementaryObject, Role role) throws InternalErrorException, AlreadyAdminException {
@@ -686,7 +686,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                 perun session
 	 * @param authorizedGroup      the group for setting role
-	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator )
+	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice )
 	 * @param complementaryObjects objects for which role will be set
 	 */
 	public static void setRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, AlreadyAdminException {
@@ -717,7 +717,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                perun session
 	 * @param authorizedGroup     the group for setting role
-	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator )
+	 * @param role                role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice )
 	 * @param complementaryObject object for which role will be set
 	 */
 	public static void setRole(PerunSession sess, Group authorizedGroup, PerunBean complementaryObject, Role role) throws InternalErrorException, AlreadyAdminException {
@@ -734,7 +734,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 *
 	 * @param sess                 perun session
 	 * @param user                 the user for unsetting role
-	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator )
+	 * @param role                 role of user in a session ( perunadmin | voadmin | groupadmin | self | facilityadmin | voobserver | topgroupcreator | resourceselfservice )
 	 * @param complementaryObjects objects for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, UserNotAdminException {
@@ -927,6 +927,14 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 					} else {
 						throw new InternalErrorException("Not supported complementary object for SponsoredUser: " + complementaryObject);
 					}
+				} else if (role.equals(Role.RESOURCESELFSERVICE)) {
+					if (complementaryObject == null) {
+						throw new InternalErrorException("Not supported operation, can't set ResourceSelfService rights without resource.");
+					} else if (complementaryObject instanceof Resource) {
+						if (user != null) authzResolverImpl.addResourceRole(sess, user, role, (Resource) complementaryObject);
+						else authzResolverImpl.addResourceRole(sess, authorizedGroup, role, (Resource) complementaryObject);
+					}
+
 				} else {
 					throw new InternalErrorException("Not supported role: " + role);
 				}
@@ -1016,6 +1024,15 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for Sponsor: " + complementaryObject);
+					}
+				} else if (role.equals(Role.RESOURCESELFSERVICE)) {
+					if (complementaryObject == null) {
+						throw new InternalErrorException("Not supported operation, can't unset ResourceSelfService rights without resource this way.");
+					} else if (complementaryObject instanceof Resource) {
+						if (user != null) authzResolverImpl.removeResourceRole(sess, role, (Resource) complementaryObject, user);
+						else authzResolverImpl.removeResourceRole(sess, role, (Resource) complementaryObject, authorizedGroup);
+					} else {
+						throw new InternalErrorException("Not supported complementary object for VoObserver: " + complementaryObject);
 					}
 				} else {
 					throw new InternalErrorException("Not supported role: " + role);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -14,6 +14,10 @@ import cz.metacentrum.perun.audit.events.ResourceManagerEvents.GroupAssignedToRe
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.GroupRemovedFromResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ResourceCreated;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ResourceDeleted;
+import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ResourceSelfServiceAddedForGroup;
+import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ResourceSelfServiceAddedForUser;
+import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ResourceSelfServiceRemovedForGroup;
+import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ResourceSelfServiceRemovedForUser;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ResourceUpdated;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ServiceAssignedToResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ServiceRemovedFromResource;
@@ -954,6 +958,30 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	@Override
 	public List<Resource> getResources(PerunSession sess) throws InternalErrorException {
 		return getResourcesManagerImpl().getResources(sess);
+	}
+
+	@Override
+	public void addResourceSelfServiceUser(PerunSession sess, Resource resource, User user) throws AlreadyAdminException, InternalErrorException {
+		AuthzResolverBlImpl.setRole(sess, user, resource, Role.RESOURCESELFSERVICE);
+		getPerunBl().getAuditer().log(sess, new ResourceSelfServiceAddedForUser(resource, user));
+	}
+
+	@Override
+	public void addResourceSelfServiceGroup(PerunSession sess, Resource resource, Group group) throws AlreadyAdminException, InternalErrorException {
+		AuthzResolverBlImpl.setRole(sess, group, resource, Role.RESOURCESELFSERVICE);
+		getPerunBl().getAuditer().log(sess, new ResourceSelfServiceAddedForGroup(resource, group));
+	}
+
+	@Override
+	public void removeResourceSelfServiceUser(PerunSession sess, Resource resource, User user) throws UserNotAdminException, InternalErrorException {
+		AuthzResolverBlImpl.unsetRole(sess, user, resource, Role.RESOURCESELFSERVICE);
+		getPerunBl().getAuditer().log(sess, new ResourceSelfServiceRemovedForUser(resource, user));
+	}
+
+	@Override
+	public void removeResourceSelfServiceGroup(PerunSession sess, Resource resource, Group group) throws GroupNotAdminException, InternalErrorException {
+		AuthzResolverBlImpl.unsetRole(sess, group, resource, Role.RESOURCESELFSERVICE);
+		getPerunBl().getAuditer().log(sess, new ResourceSelfServiceRemovedForGroup(resource, group));
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -1144,6 +1144,114 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		getResourcesManagerBl().removeBan(sess, memberId, resourceId);
 	}
 
+	@Override
+	public void addResourceSelfServiceUser(PerunSession sess, Resource resource, User user) throws InternalErrorException, PrivilegeException, AlreadyAdminException {
+		Utils.checkPerunSession(sess);
+
+		Vo vo;
+		Facility facility;
+
+		try {
+			facility = sess.getPerun().getFacilitiesManager().getFacilityById(sess, resource.getFacilityId());
+		} catch (FacilityNotExistsException e) {
+			throw new InternalErrorException("Failed to find facility for given resource.");
+		}
+
+		try {
+			vo = sess.getPerun().getVosManager().getVoById(sess, resource.getVoId());
+		} catch (VoNotExistsException e) {
+			throw new InternalErrorException("Failed to find vo for given resource.");
+		}
+
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
+		    !AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "addResourceSelfServiceUser");
+		}
+
+		getResourcesManagerBl().addResourceSelfServiceUser(sess, resource, user);
+	}
+
+	@Override
+	public void addResourceSelfServiceGroup(PerunSession sess, Resource resource, Group group) throws InternalErrorException, PrivilegeException, AlreadyAdminException {
+		Utils.checkPerunSession(sess);
+
+		Vo vo;
+		Facility facility;
+
+		try {
+			facility = sess.getPerun().getFacilitiesManager().getFacilityById(sess, resource.getFacilityId());
+		} catch (FacilityNotExistsException e) {
+			throw new InternalErrorException("Failed to find facility for given resource.");
+		}
+
+		try {
+			vo = sess.getPerun().getVosManager().getVoById(sess, resource.getVoId());
+		} catch (VoNotExistsException e) {
+			throw new InternalErrorException("Failed to find vo for given resource.");
+		}
+
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
+			!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "addResourceSelfServiceUser");
+		}
+
+		getResourcesManagerBl().addResourceSelfServiceGroup(sess, resource, group);
+	}
+
+	@Override
+	public void removeResourceSelfServiceUser(PerunSession sess, Resource resource, User user) throws InternalErrorException, PrivilegeException, UserNotAdminException {
+		Utils.checkPerunSession(sess);
+
+		Vo vo;
+		Facility facility;
+
+		try {
+			facility = sess.getPerun().getFacilitiesManager().getFacilityById(sess, resource.getFacilityId());
+		} catch (FacilityNotExistsException e) {
+			throw new InternalErrorException("Failed to find facility for given resource.");
+		}
+
+		try {
+			vo = sess.getPerun().getVosManager().getVoById(sess, resource.getVoId());
+		} catch (VoNotExistsException e) {
+			throw new InternalErrorException("Failed to find vo for given resource.");
+		}
+
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
+			!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "addResourceSelfServiceUser");
+		}
+
+		getResourcesManagerBl().removeResourceSelfServiceUser(sess, resource, user);
+	}
+
+	@Override
+	public void removeResourceSelfServiceGroup(PerunSession sess, Resource resource, Group group) throws InternalErrorException, PrivilegeException, GroupNotAdminException {
+		Utils.checkPerunSession(sess);
+
+		Vo vo;
+		Facility facility;
+
+		try {
+			facility = sess.getPerun().getFacilitiesManager().getFacilityById(sess, resource.getFacilityId());
+		} catch (FacilityNotExistsException e) {
+			throw new InternalErrorException("Failed to find facility for given resource.");
+		}
+
+		try {
+			vo = sess.getPerun().getVosManager().getVoById(sess, resource.getVoId());
+		} catch (VoNotExistsException e) {
+			throw new InternalErrorException("Failed to find vo for given resource.");
+		}
+
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
+			!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "addResourceSelfServiceUser");
+		}
+
+		getResourcesManagerBl().removeResourceSelfServiceGroup(sess, resource, group);
+	}
+
 	/**
 	 * Filter out resources where user in session has not role resource admin for them
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -281,7 +281,12 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) &&
 				!AuthzResolver.isAuthorized(sess, Role.RESOURCEADMIN, resource)) {
-			throw new PrivilegeException(sess, "assignGroupToResource");
+
+			if (!AuthzResolver.isAuthorized(sess, Role.RESOURCESELFSERVICE, resource) ||
+				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
+
+				throw new PrivilegeException(sess, "assignGroupToResource");
+			}
 		}
 
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -298,7 +303,16 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, resource) &&
 				!AuthzResolver.isAuthorized(perunSession, Role.RESOURCEADMIN, resource)) {
-			throw new PrivilegeException(perunSession, "assignGroupsToResource");
+
+			if (!AuthzResolver.isAuthorized(perunSession, Role.RESOURCESELFSERVICE, resource)) {
+				throw new PrivilegeException(perunSession, "assignGroupsToResource");
+			}
+
+			for (Group group : groups) {
+				if (!AuthzResolver.isAuthorized(perunSession, Role.GROUPADMIN, group)) {
+					throw new PrivilegeException(perunSession, "assignGroupsToResource");
+				}
+			}
 		}
 
 		for(Group g: groups) {
@@ -333,8 +347,13 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) &&
-				!AuthzResolver.isAuthorized(sess, Role.RESOURCEADMIN, resource)) {
-			throw new PrivilegeException(sess, "removeGroupFromResource");
+			!AuthzResolver.isAuthorized(sess, Role.RESOURCEADMIN, resource)) {
+
+			if (!AuthzResolver.isAuthorized(sess, Role.RESOURCESELFSERVICE, resource) ||
+				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
+
+				throw new PrivilegeException(sess, "removeGroupFromResource");
+			}
 		}
 
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
@@ -351,7 +370,16 @@ public class ResourcesManagerEntry implements ResourcesManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(perunSession, Role.VOADMIN, resource) &&
 				!AuthzResolver.isAuthorized(perunSession, Role.RESOURCEADMIN, resource)) {
-			throw new PrivilegeException(perunSession, "removeGroupsFromResource");
+
+			if (!AuthzResolver.isAuthorized(perunSession, Role.RESOURCESELFSERVICE, resource)) {
+				throw new PrivilegeException(perunSession, "removeGroupsFromResource");
+			}
+
+			for (Group group : groups) {
+				if (!AuthzResolver.isAuthorized(perunSession, Role.GROUPADMIN, group)) {
+					throw new PrivilegeException(perunSession, "removeGroupsFromResource");
+				}
+			}
 		}
 
 		for(Group g: groups) {
@@ -1192,7 +1220,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
 			!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
-			throw new PrivilegeException(sess, "addResourceSelfServiceUser");
+			throw new PrivilegeException(sess, "addResourceSelfServiceGroup");
 		}
 
 		getResourcesManagerBl().addResourceSelfServiceGroup(sess, resource, group);
@@ -1219,7 +1247,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
 			!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
-			throw new PrivilegeException(sess, "addResourceSelfServiceUser");
+			throw new PrivilegeException(sess, "removeResourceSelfServiceUser");
 		}
 
 		getResourcesManagerBl().removeResourceSelfServiceUser(sess, resource, user);
@@ -1246,7 +1274,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
 			!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
-			throw new PrivilegeException(sess, "addResourceSelfServiceUser");
+			throw new PrivilegeException(sess, "removeResourceSelfServiceGroup");
 		}
 
 		getResourcesManagerBl().removeResourceSelfServiceGroup(sess, resource, group);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -610,4 +610,57 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		}
 	}
 
+	@Override
+	public void addResourceRole(PerunSession sess, User user, Role role, Resource resource) throws InternalErrorException, AlreadyAdminException {
+		if (!role.equals(Role.RESOURCESELFSERVICE)) {
+			throw new InternalErrorException("Role '" + role + "' cannot be set on resource.");
+		}
+		try {
+			jdbc.update("insert into authz (user_id, role_id, resource_id) values (?, (select id from roles where name=?), ?)", user.getId(),
+				role.getRoleName(), resource.getId());
+		} catch (DataIntegrityViolationException e) {
+			throw new AlreadyAdminException("User id=" + user.getId() + " is already "+role+" in resource " + resource, e, user, resource, role);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public void addResourceRole(PerunSession sess, Group group, Role role, Resource resource) throws InternalErrorException, AlreadyAdminException {
+		if (!role.equals(Role.RESOURCESELFSERVICE)) {
+			throw new IllegalArgumentException("Role "+role+" cannot be set on VO");
+		}
+		try {
+			jdbc.update("insert into authz (role_id, resource_id, authorized_group_id) values ((select id from roles where name=?), ?, ?)",
+				role.getRoleName(), resource.getId(), group.getId());
+		} catch (DataIntegrityViolationException e) {
+			throw new AlreadyAdminException("Group id=" + group.getId() + " is already "+role+" of resource " + resource, e, group, resource, role);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+
+	@Override
+	public void removeResourceRole(PerunSession sess, Role role, Resource resource, User user) throws InternalErrorException, UserNotAdminException {
+		try {
+			if (0 == jdbc.update("delete from authz where user_id=? and resource_id=? and role_id=(select id from roles where name=?)", user.getId(), resource.getId(), role.getRoleName())) {
+				throw new UserNotAdminException("User id=" + user.getId() + " is not "+role+" in the resource " + resource);
+			}
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public void removeResourceRole(PerunSession sess, Role role, Resource resource, Group group) throws InternalErrorException, GroupNotAdminException {
+		try {
+			if (0 == jdbc.update("delete from authz where authorized_group_id=? and resource_id=? and role_id=(select id from roles where name=?)", group.getId(), resource.getId(), role.getRoleName())) {
+				throw new GroupNotAdminException("Group id=" + group.getId() + " is not "+role+" in the resource " + resource);
+			}
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -613,7 +613,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addResourceRole(PerunSession sess, User user, Role role, Resource resource) throws InternalErrorException, AlreadyAdminException {
 		if (!role.equals(Role.RESOURCESELFSERVICE)) {
-			throw new InternalErrorException("Role '" + role + "' cannot be set on resource.");
+			throw new InternalErrorException("Role " + role + " cannot be set on resource.");
 		}
 		try {
 			jdbc.update("insert into authz (user_id, role_id, resource_id) values (?, (select id from roles where name=?), ?)", user.getId(),
@@ -628,13 +628,13 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	@Override
 	public void addResourceRole(PerunSession sess, Group group, Role role, Resource resource) throws InternalErrorException, AlreadyAdminException {
 		if (!role.equals(Role.RESOURCESELFSERVICE)) {
-			throw new IllegalArgumentException("Role "+role+" cannot be set on VO");
+			throw new IllegalArgumentException("Role "+role+" cannot be set on resource.");
 		}
 		try {
 			jdbc.update("insert into authz (role_id, resource_id, authorized_group_id) values ((select id from roles where name=?), ?, ?)",
 				role.getRoleName(), resource.getId(), group.getId());
 		} catch (DataIntegrityViolationException e) {
-			throw new AlreadyAdminException("Group id=" + group.getId() + " is already "+role+" of resource " + resource, e, group, resource, role);
+			throw new AlreadyAdminException("Group id=" + group.getId() + " is already "+role+" in resource " + resource, e, group, resource, role);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -429,7 +429,7 @@ public interface AuthzResolverImplApi {
 	void removeResourceRole(PerunSession sess, Role role, Resource resource, User user) throws InternalErrorException, UserNotAdminException;
 
 	/**
-	 * Remove role ro group for resource.
+	 * Remove role to group for resource.
 	 *
 	 * @param sess session
 	 * @param role role

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -302,7 +302,7 @@ public interface AuthzResolverImplApi {
 	 * Remove role perunAdmin for user.
 	 *
 	 * @param sess
-	 * @param user 
+	 * @param user
 	 * @throws InternalErrorException
 	 */
 	void removePerunAdmin(PerunSession sess, User user) throws InternalErrorException, UserNotAdminException;
@@ -391,4 +391,52 @@ public interface AuthzResolverImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Integer> getVoIdsForUserInRole(PerunSession sess, User user, Role role) throws InternalErrorException;
+
+	/**
+	 * Sets role to given user for given resource.
+	 *
+	 * @param sess session
+	 * @param user user
+	 * @param role role
+	 * @param resource resource
+	 * @throws InternalErrorException internal error
+	 * @throws AlreadyAdminException when already in role
+	 */
+	void addResourceRole(PerunSession sess, User user, Role role, Resource resource) throws InternalErrorException, AlreadyAdminException;
+
+	/**
+	 * Sets role to given group for given resource.
+	 *
+	 * @param sess session
+	 * @param group group
+	 * @param role role
+	 * @param resource resource
+	 * @throws InternalErrorException internal error
+	 * @throws AlreadyAdminException when already in role
+	 */
+	void addResourceRole(PerunSession sess, Group group, Role role, Resource resource) throws InternalErrorException, AlreadyAdminException;
+
+	/**
+	 * Remove role to user for resource.
+	 *
+	 * @param sess session
+	 * @param role role
+	 * @param resource resource
+	 * @param user user
+	 * @throws InternalErrorException internal error
+	 * @throws UserNotAdminException user was not admin
+	 */
+	void removeResourceRole(PerunSession sess, Role role, Resource resource, User user) throws InternalErrorException, UserNotAdminException;
+
+	/**
+	 * Remove role ro group for resource.
+	 *
+	 * @param sess session
+	 * @param role role
+	 * @param resource resource
+	 * @param group group
+	 * @throws InternalErrorException internal error
+	 * @throws GroupNotAdminException group was not admin
+	 */
+	void removeResourceRole(PerunSession sess, Role role, Resource resource, Group group) throws InternalErrorException, GroupNotAdminException;
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -47,6 +47,76 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 	}
 
 	@Test
+	public void setRoleResourceSelfServiceForUser() throws Exception {
+		System.out.println(CLASS_NAME + "setRoleResourceSelfServiceForUser");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+		final Resource resource = setUpResource(createdVo, setUpFacility());
+
+		AuthzResolver.setRole(sess, createdUser, resource, Role.RESOURCESELFSERVICE);
+
+		PerunSession session = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(session);
+
+		assertTrue(AuthzResolver.isAuthorized(session, Role.RESOURCESELFSERVICE, resource));
+	}
+
+	@Test
+	public void unsetRoleResourceSelfServiceForUser() throws Exception {
+		System.out.println(CLASS_NAME + "unsetRoleResourceSelfServiceForUser");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final User createdUser = perun.getUsersManagerBl().getUserByMember(sess, createdMember);
+		final Resource resource = setUpResource(createdVo, setUpFacility());
+
+		AuthzResolver.setRole(sess, createdUser, resource, Role.RESOURCESELFSERVICE);
+
+		PerunSession userSession = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(userSession);
+
+		AuthzResolver.unsetRole(sess, createdUser, resource, Role.RESOURCESELFSERVICE);
+		AuthzResolver.refreshAuthz(userSession);
+
+		assertFalse(AuthzResolver.isAuthorized(userSession, Role.RESOURCESELFSERVICE, resource));
+	}
+
+	@Test
+	public void setRoleResourceSelfServiceForGroup() throws Exception {
+		System.out.println(CLASS_NAME + "setRoleResourceSelfServiceForUser");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final Resource resource = setUpResource(createdVo, setUpFacility());
+		final Group group = setUpGroup(createdVo, createdMember);
+
+		AuthzResolver.setRole(sess, group, resource, Role.RESOURCESELFSERVICE);
+
+		PerunSession userSession = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(userSession);
+
+		assertTrue(AuthzResolver.isAuthorized(userSession, Role.RESOURCESELFSERVICE, resource));
+	}
+
+	@Test
+	public void unsetRoleResourceSelfServiceForGroup() throws Exception {
+		System.out.println(CLASS_NAME + "unsetRoleResourceSelfServiceForGroup");
+		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
+		final Member createdMember = createSomeMember(createdVo);
+		final Resource resource = setUpResource(createdVo, setUpFacility());
+		final Group group = setUpGroup(createdVo, createdMember);
+
+		AuthzResolver.setRole(sess, group, resource, Role.RESOURCESELFSERVICE);
+
+		PerunSession userSession = getHisSession(createdMember);
+		AuthzResolver.refreshAuthz(userSession);
+
+		AuthzResolver.unsetRole(sess, group, resource, Role.RESOURCESELFSERVICE);
+		AuthzResolver.refreshAuthz(userSession);
+
+		assertFalse(AuthzResolver.isAuthorized(userSession, Role.RESOURCESELFSERVICE, resource));
+	}
+
+	@Test
 	public void setRoleVoAdmin() throws Exception {
 		System.out.println(CLASS_NAME + "setRole");
 		final Vo createdVo = perun.getVosManager().createVo(sess, new Vo(0,"test123test123","test123test123"));
@@ -401,6 +471,42 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 	}
 
 	// private methods ==============================================================
+
+	private Facility setUpFacility() throws Exception {
+
+		Facility facility = new Facility();
+		facility.setName("ResourcesManagerTestFacility");
+		facility = perun.getFacilitiesManager().createFacility(sess, facility);
+		/*
+			 Owner owner = new Owner();
+			 owner.setName("ResourcesManagerTestOwner");
+			 owner.setContact("testingOwner");
+			 perun.getOwnersManager().createOwner(sess, owner);
+			 perun.getFacilitiesManager().addOwner(sess, facility, owner);
+			 */
+		return facility;
+
+	}
+
+	private Resource setUpResource(Vo vo, Facility facility) throws Exception {
+
+		Resource resource = new Resource();
+		resource.setName("ResourcesManagerTestResource");
+		resource.setDescription("Testovaci");
+		resource = perun.getResourcesManagerBl().createResource(sess, resource, vo, facility);
+		return resource;
+
+	}
+
+	private Group setUpGroup(Vo vo, Member member) throws Exception {
+
+		Group group = new Group("Test group", "test group");
+		group = perun.getGroupsManagerBl().createGroup(sess, vo, group);
+
+		perun.getGroupsManagerBl().addMember(sess, group, member);
+
+		return group;
+	}
 
 	private Candidate setUpCandidate(String login) {
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1644,7 +1645,92 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 
 	}
 
+	@Test
+	public void addResourceSelfServiceUser() throws Exception {
+		System.out.println(CLASS_NAME + "addResourceSelfServiceGroup");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		Resource resource = setUpResource();
+		User user = setUpUser("Milos", "Zeman");
+
+		resourcesManager.addResourceSelfServiceUser(sess, resource, user);
+
+		List<String> roles = AuthzResolverBlImpl.getUserRoleNames(sess, user);
+
+		assertTrue(roles.contains("resourceselfservice"));
+	}
+
+	@Test
+	public void removeResourceSelfServiceUser() throws Exception {
+		System.out.println(CLASS_NAME + "removeResourceSelfServiceUser");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		Resource resource = setUpResource();
+		User user = setUpUser("Milos", "Zeman");
+
+		resourcesManager.addResourceSelfServiceUser(sess, resource, user);
+
+		resourcesManager.removeResourceSelfServiceUser(sess, resource, user);
+
+		List<String> roles = AuthzResolverBlImpl.getUserRoleNames(sess, user);
+
+		assertFalse(roles.contains("resourceselfservice"));
+	}
+
+	@Test
+	public void addResourceSelfServiceGroup() throws Exception {
+		System.out.println(CLASS_NAME + "addResourceSelfServiceGroup");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+
+		Resource resource = setUpResource();
+
+		resourcesManager.addResourceSelfServiceGroup(sess, resource, group);
+
+		List<String> roles = AuthzResolverBlImpl.getGroupRoleNames(sess, group);
+
+		assertTrue(roles.contains("resourceselfservice"));
+	}
+
+	@Test
+	public void removeResourceSelfServiceGroup() throws Exception {
+		System.out.println(CLASS_NAME + "removeResourceSelfServiceGroup");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		member = setUpMember(vo);
+		group = setUpGroup(vo, member);
+
+		Resource resource = setUpResource();
+
+		resourcesManager.addResourceSelfServiceGroup(sess, resource, group);
+
+		resourcesManager.removeResourceSelfServiceGroup(sess, resource, group);
+
+		List<String> roles = AuthzResolverBlImpl.getGroupRoleNames(sess, group);
+
+		assertFalse(roles.contains("resourceselfservice"));
+	}
+
 	// PRIVATE METHODS -----------------------------------------------------------
+
+	private User setUpUser(String firstName, String lastName) throws Exception {
+
+		User user = new User();
+		user.setFirstName(firstName);
+		user.setMiddleName("");
+		user.setLastName(lastName);
+		user.setTitleBefore("");
+		user.setTitleAfter("");
+		assertNotNull(perun.getUsersManagerBl().createUser(sess, user));
+
+		return user;
+	}
 
 	private Vo setUpVo() throws Exception {
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ResourcesManagerMethod.java
@@ -1121,5 +1121,77 @@ public enum ResourcesManagerMethod implements ManagerMethod {
 			}
 			return null;
 		}
+	},
+
+	/*#
+	 * Sets ResourceSelfService role to given user for given resource.
+	 *
+	 * @param resourceId int Resource <code>id</code>
+	 * @param userId int User <code>id</code>
+	 */
+	addResourceSelfServiceUser {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			ac.getResourcesManager().addResourceSelfServiceUser(ac.getSession(),
+				ac.getResourceById(parms.readInt("resourceId")), ac.getUserById(parms.readInt("userId")));
+
+			return null;
+		}
+	},
+
+	/*#
+	 * Sets ResourceSelfService role to given group for given resource.
+	 *
+	 * @param resourceId int Resource <code>id</code>
+	 * @param groupId int Group <code>id</code>
+	 */
+	addResourceSelfServiceGroup {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			ac.getResourcesManager().addResourceSelfServiceGroup(ac.getSession(),
+				ac.getResourceById(parms.readInt("resourceId")), ac.getGroupById(parms.readInt("groupId")));
+
+			return null;
+		}
+	},
+
+	/*#
+	 * Unset ResourceSelfService role to given user for given resource.
+	 *
+	 * @param resourceId int Resource <code>id</code>
+	 * @param userId int User <code>id</code>
+	 */
+	removeResourceSelfServiceUser {
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			ac.getResourcesManager().removeResourceSelfServiceUser(ac.getSession(),
+				ac.getResourceById(parms.readInt("resourceId")), ac.getUserById(parms.readInt("userId")));
+
+			return null;
+		}
+	},
+
+	/*#
+	 * Unset ResourceSelfService role to given group for given resource.
+	 *
+	 * @param resourceId int Resource <code>id</code>
+	 * @param groupId int Group <code>id</code>
+	 */
+	removeResourceSelfServiceGroup {
+		@Override
+		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+
+			ac.getResourcesManager().removeResourceSelfServiceGroup(ac.getSession(),
+				ac.getResourceById(parms.readInt("resourceId")), ac.getGroupById(parms.readInt("groupId")));
+
+			return null;
+		}
 	};
 }


### PR DESCRIPTION
* Created methods for setting and unsetting this new role
 to user-resource or group-resource relations.

* Methods: 'assignGroupToResource', 'assignGroupsToResource',
'removeGroupFromResource' and 'removeGroupsFromResource'.

* New behaviour: now, these methods allow to be called by user
with role 'ResourceSelfService' if he has this role set for
given resource and if he is 'GroupAdmin' of given group(s).


