### PR TITLE
Fixed deleting group when the group was admin of some entity

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -380,6 +380,52 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			}
 		}
 
+		// remove admin roles of group
+		List<Facility> facilitiesWhereGroupIsAdmin = getGroupsManagerImpl().getFacilitiesWhereGroupIsAdmin(sess, group);
+		for (Facility facility : facilitiesWhereGroupIsAdmin) {
+			try {
+				perunBl.getFacilitiesManagerBl().removeAdmin(sess, facility, group);
+			} catch (GroupNotAdminException e) {
+				log.warn("Can't unset group {} as admin of facility {} due to group not admin exception {}.", group, facility, e);
+			}
+		}
+
+		List<Group> groupsWhereGroupIsAdmin = getGroupsManagerImpl().getGroupsWhereGroupIsAdmin(sess, group);
+		for (Group group1 : groupsWhereGroupIsAdmin) {
+			try {
+				removeAdmin(sess, group1, group);
+			} catch (GroupNotAdminException e) {
+				log.warn("Can't unset group {} as admin of group {} due to group not admin exception {}.", group, group1, e);
+			}
+		}
+
+		List<Resource> resourcesWhereGroupIsAdmin = getGroupsManagerImpl().getResourcesWhereGroupIsAdmin(sess, group);
+		for (Resource resource : resourcesWhereGroupIsAdmin) {
+			try {
+				perunBl.getResourcesManagerBl().removeAdmin(sess, resource, group);
+			} catch (GroupNotAdminException e) {
+				log.warn("Can't unset group {} as admin of resource {} due to group not admin exception {}.", group, resource, e);
+			}
+		}
+
+		List<SecurityTeam> securityTeamsWhereGroupIsAdmin = getGroupsManagerImpl().getSecurityTeamsWhereGroupIsAdmin(sess, group);
+		for (SecurityTeam securityTeam : securityTeamsWhereGroupIsAdmin) {
+			try {
+				perunBl.getSecurityTeamsManagerBl().removeAdmin(sess, securityTeam, group);
+			} catch (GroupNotAdminException e) {
+				log.warn("Can't unset group {} as admin of security team {} due to group not admin exception {}.", group, securityTeam, e);
+			}
+		}
+
+		List<Vo> vosWhereGroupIsAdmin = getGroupsManagerImpl().getVosWhereGroupIsAdmin(sess, group);
+		for (Vo vo1 : vosWhereGroupIsAdmin) {
+			try {
+				perunBl.getVosManagerBl().removeAdmin(sess, vo1, group);
+			} catch (GroupNotAdminException e) {
+				log.warn("Can't unset group {} as admin of facility {} due to group not admin exception {}.", group, vo1, e);
+			}
+		}
+
 		// Deletes also all direct and indirect members of the group
 		getGroupsManagerImpl().deleteGroup(sess, vo, group);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.exceptions.GroupRelationDoesNotExist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -937,6 +938,58 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 			return null;
 		}
 		catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Facility> getFacilitiesWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + FacilitiesManagerImpl.facilityMappingSelectQuery + " from authz join facilities on authz.facility_id=facilities.id " +
+					"where authorized_group_id=? and authz.role_id=(select id from roles where name='facilityadmin')", FacilitiesManagerImpl.FACILITY_MAPPER, group.getId());
+		}  catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Group> getGroupsWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + GroupsManagerImpl.groupMappingSelectQuery + " from authz join groups on authz.group_id=groups.id " +
+					"where authorized_group_id=? and authz.role_id=(select id from roles where name='groupadmin')", GroupsManagerImpl.GROUP_MAPPER, group.getId());
+		}  catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Resource> getResourcesWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + ResourcesManagerImpl.resourceMappingSelectQuery + " from authz join resources " +
+					"on authz.resource_id=resources.id where authorized_group_id=? and authz.role_id=(select id from roles where name='resourceadmin')",
+					ResourcesManagerImpl.RESOURCE_MAPPER, group.getId());
+		}  catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<SecurityTeam> getSecurityTeamsWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + SecurityTeamsManagerImpl.securityTeamMappingSelectQuery + " from authz join security_teams " +
+					"on authz.security_team_id=security_teams.id where authorized_group_id=? and authz.role_id=(select id from roles where name='securityadmin')",
+					SecurityTeamsManagerImpl.SECURITY_TEAM_MAPPER, group.getId());
+		}  catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Vo> getVosWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + VosManagerImpl.voMappingSelectQuery + " from authz join vos on authz.vo_id=vos.id " +
+					"where authorized_group_id=? and authz.role_id=(select id from roles where name='voadmin')", VosManagerImpl.VO_MAPPER, group.getId());
+		}  catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -704,4 +705,54 @@ public interface GroupsManagerImplApi {
 	 * @throws InternalErrorException internal error
 	 */
 	MemberGroupStatus getTotalMemberGroupStatus(PerunSession session, Member member, Group group) throws InternalErrorException;
+
+	/**
+	 * Returns all facilities where given group si FACILITYADMIN.
+	 *
+	 * @param session session
+	 * @param group group
+	 * @return list of all facilities where given group si FACILITYADMIN
+	 * @throws InternalErrorException
+	 */
+	List<Facility> getFacilitiesWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException;
+
+	/**
+	 * Returns all groups where given group si GROUPADMIN.
+	 *
+	 * @param session session
+	 * @param group group
+	 * @return list of all groups where given group is GROUPADMIN
+	 * @throws InternalErrorException
+	 */
+	List<Group> getGroupsWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException;
+
+	/**
+	 * Returns all resources where given group si RESOURCEADMIN.
+	 *
+	 * @param session session
+	 * @param group group
+	 * @return list of all resources where given group is RESOURCEADMIN
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getResourcesWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException;
+
+	/**
+	 * Returns all security teams where given group si SECURITYADMIN.
+	 *
+	 * @param session session
+	 * @param group group
+	 * @return list of all security teams where given group is SECURITYADMIN
+	 * @throws InternalErrorException
+	 */
+	List<SecurityTeam> getSecurityTeamsWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException;
+
+	/**
+	 * Returns all vos where given group si VOADMIN.
+	 *
+	 * @param session session
+	 * @param group group
+	 * @return list of all vos where given group is VOADMIN
+	 * @throws InternalErrorException
+	 */
+	List<Vo> getVosWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException;
 }


### PR DESCRIPTION
Added new methods to find all facilities/groups/resources/security teams/vos where group is admin.
deleteAnyGroup method now unsets admin roles of group before deleting it.