### PR TITLE
Allow facility admin to read group attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -459,7 +459,16 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				if (isAuthorized(sess, Role.VOOBSERVER, group)) return true;
 			}
 			if (roles.containsKey(Role.GROUPADMIN)) if (isAuthorized(sess, Role.GROUPADMIN, group)) return true;
-//			if (roles.containsKey(Role.FACILITYADMIN)) ; //Not allowed
+			if (roles.containsKey(Role.FACILITYADMIN)) {
+				if (roles.get(Role.FACILITYADMIN).contains(actionType)) {
+					List<Resource> resources = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
+					for (Resource groupResource : resources) {
+						if (isAuthorized(sess, Role.FACILITYADMIN, groupResource)) {
+							return true;
+						}
+					}
+				}
+			}
 			if (roles.containsKey(Role.SELF)) {
 				if (roles.get(Role.SELF).contains(ActionType.READ_PUBLIC) || roles.get(Role.SELF).contains(ActionType.WRITE_PUBLIC)) return true;
 				if (roles.get(Role.SELF).contains(ActionType.READ_VO) || roles.get(Role.SELF).contains(ActionType.WRITE_VO)) {


### PR DESCRIPTION
* Problem: if facility admin was allowed to access group attribute, it
had no effect.

* Solution: now, if the facility admin is allowed to access the
attribute and current principal has role facility admin, the
AuthzResolverBlImpl now verifies that he/she has relationship with
group of requested attribute.

Signed-off-by: Vojtěch Sassmann <vojtech.sassmann@gmail.com>