### PR TITLE
CORE: Fixed select for allowed users, members, resources

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -312,7 +312,7 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 		try  {
 			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from groups_resources join groups on groups_resources.group_id=groups.id" +
 					" join groups_members on groups.id=groups_members.group_id join members on groups_members.member_id=members.id join users on " +
-					" users.id=members.user_id where groups_resources.resource_id=? and members.status!=? and members.status!=? and groups_members.status=?",
+					" users.id=members.user_id where groups_resources.resource_id=? and members.status!=? and members.status!=? and groups_members.source_group_status=?",
 					UsersManagerImpl.USER_MAPPER, resource.getId(),	String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()),
 					String.valueOf(MemberGroupStatus.VALID.getCode()));
 		} catch (EmptyResultDataAccessException e) {
@@ -329,7 +329,7 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 					" left outer join groups_resources on groups_resources.resource_id=resources.id" +
 					" left outer join groups_members on groups_members.group_id=groups_resources.group_id" +
 					" left outer join members on members.id=groups_members.member_id" +
-					" where facilities.id=? and members.user_id=? and members.status!=? and groups_members.status=?",
+					" where facilities.id=? and members.user_id=? and members.status!=? and groups_members.source_group_status=?",
 					RESOURCE_MAPPER, facility.getId(), user.getId(), String.valueOf(Status.INVALID.getCode()), String.valueOf(MemberGroupStatus.VALID.getCode()));
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<Resource>();
@@ -343,7 +343,7 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 		try  {
 			return jdbc.query("select distinct " + MembersManagerImpl.memberMappingSelectQuery + " from groups_resources join groups on groups_resources.group_id=groups.id" +
 					" join groups_members on groups.id=groups_members.group_id join members on groups_members.member_id=members.id " +
-					" where groups_resources.resource_id=? and members.status!=? and members.status!=? and groups_members.status=?", MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, resource.getId(),
+					" where groups_resources.resource_id=? and members.status!=? and members.status!=? and groups_members.source_group_status=?", MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, resource.getId(),
 					String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()), String.valueOf(MemberGroupStatus.VALID.getCode()));
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<Member>();


### PR DESCRIPTION
- Select didn't respect new group member status, since it
  compared value in groups_members.status column, which is always 0.
  Member expiration in stored in direct/indirect membership relation
  in source_group_status, since for each group its calculated later.
  Now we limit selected members/users or resources (for user/facility)
  with respect to groups status too.
  This means, if user is in single group assigned to resource and is
  expired in such group, it is not considered as allowed anymore.

  WARNING: this have strong implication to many attribute modules,
  which will no longer process "not allowed" members. Like data quotas,
  shell, homeMountPoint, basicDefaultGID etc. Also processes like
  assignGroup will skip such members.