### PR TITLE
CORE: Cleanup aop context

### DIFF
--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -74,7 +74,6 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.OwnersManagerImpl.createOwner(..))"/>
 		<!-- ResourcesManagerImpl -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ResourcesManagerImpl.createResource(..))"/>
-		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ResourcesManagerImpl.setFacility(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ResourcesManagerImpl.assignGroupToResource(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ResourcesManagerImpl.assignService(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ResourcesManagerImpl.updateResource(..))"/>


### PR DESCRIPTION
- We already removed ResourcesManagerImpl.setFacility(), but it was
  forgotten in AOP context config. Now its removed too.