### PR TITLE
CORE: Perun complains about unixGroupName-namespace attribute in init

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
@@ -137,7 +137,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends R
 	@Override
 	public List<String> getDependencies() {
 		List<String> dependencies = new ArrayList<>();
-		dependencies.add(AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:");
+		dependencies.add(AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:*");
 		dependencies.add(AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGroupName-namespace");
 		return dependencies;
 	}
@@ -145,7 +145,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends R
 	@Override
 	public List<String> getStrongDependencies() {
 		List<String> dependecies = new ArrayList<String>();
-		dependecies.add(AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace" + ":*");
+		dependecies.add(AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:*");
 		dependecies.add(AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGroupName-namespace");
 		return dependecies;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace.java
@@ -33,14 +33,16 @@ public class urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace e
 		}
 	}
 
+	/*
 	@Override
 	public AttributeDefinition getAttributeDefinition() {
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
-		attr.setFriendlyName("preferredUnixGroupName-namespace:*");
+		attr.setFriendlyName("preferredUnixGroupName-namespace");
 		attr.setType(List.class.getName());
 		attr.setDescription("User preferred unix group name, ordered by user's personal preferrences.");
 		return attr;
 	}
+	*/
 }
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName.java
@@ -124,7 +124,7 @@ public class urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName e
 		attr.setFriendlyName("preferredUnixGroupName");
 		attr.setDisplayName("Preferred Unix GroupName");
 		attr.setType(List.class.getName());
-		attr.setDescription("Choosed users preferred unix groupNames for specific facility namespace.");
+		attr.setDescription("Chosen users preferred unix groupNames for specific facility namespace.");
 		return attr;
 	}
 }


### PR DESCRIPTION
- When attribute dependencies are initialized, Perun complains, that
  group:def:"unixGroupName-namespace:" attribute not exists.
  There was missing * to identify all namespace values instead of
  one specific attribute (with empty namespace).
- Generic modules for namespaced attributes can't have
  getAttributeDefinition() implemented, since there is no logic to
  iterate over existing namespaces (perun doesn't know which namespaces
  exists).