### PR TITLE
CORE: Refactored attribute methods to match member-resource namespace

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -185,8 +185,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Get only those attributes the principal has access to.
 	 *
 	 * @param sess     perun session
-	 * @param resource to get the attributes from
 	 * @param member   to get the attributes from
+	 * @param resource to get the attributes from
 	 * @return list of attributes
 	 * @throws InternalErrorException          if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException              if privileges are not given
@@ -194,7 +194,7 @@ public interface AttributesManager {
 	 * @throws MemberNotExistsException        if the member doesn't have access to this resource
 	 * @throws MemberResourceMismatchException if member and resource are not in the same VO
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member) throws PrivilegeException, InternalErrorException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource) throws PrivilegeException, InternalErrorException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * Gets all <b>non-empty</b> attributes associated with the member on the resource and if workWithUserAttributes is
@@ -202,8 +202,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Get only those attributes the principal has access to.
 	 *
 	 * @param sess                   perun session
-	 * @param resource               to get the attributes from
 	 * @param member                 to get the attributes from
+	 * @param resource               to get the attributes from
 	 * @param workWithUserAttributes if true returns also user-facility, user and member attributes (user is automatically get from member and facility is get from resource)
 	 * @return list of attributes
 	 * @throws PrivilegeException              if privileges are not given
@@ -214,7 +214,7 @@ public interface AttributesManager {
 	 *                                         <p>
 	 *                                         !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * Gets selected <b>non-empty</b> attributes associated with the member and the resource.
@@ -223,8 +223,8 @@ public interface AttributesManager {
 	 * Attributes are selected by list of attr_names. Empty list means all attributes.
 	 *
 	 * @param sess                   perun session
-	 * @param resource               to get the attributes from
 	 * @param member                 to get the attributes from
+	 * @param resource               to get the attributes from
 	 * @param attrNames              list of attributes to get
 	 * @param workWithUserAttributes if true returns also user and user-facility attributes (user is automatically get from member a facility is get from resource)
 	 * @return list of selected attributes
@@ -234,7 +234,7 @@ public interface AttributesManager {
 	 * @throws MemberNotExistsException        if the member doesn't have access to this resource
 	 * @throws MemberResourceMismatchException if member and resource are not in the same VO
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the member in the group.
@@ -703,8 +703,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
 	 *
 	 * @param sess       perun session
-	 * @param resource   resource to set on
 	 * @param member     member to set on
+	 * @param resource   resource to set on
 	 * @param attributes attribute to set
 	 * @throws InternalErrorException                if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException                    if privileges are not given
@@ -716,7 +716,7 @@ public interface AttributesManager {
 	 * @throws WrongReferenceAttributeValueException if attribute which is reference for used attribute has illegal value
 	 * @throws MemberResourceMismatchException       if member and resource are not in the same VO
 	 */
-	void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void setAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Store the attributes associated with the resource and member combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -725,8 +725,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
 	 *
 	 * @param sess                   perun session
-	 * @param resource               resource to set on
 	 * @param member                 member to set on
+	 * @param resource               resource to set on
 	 * @param attributes             attribute to set
 	 * @param workWithUserAttributes method can process also user, user-facility and member attributes (user is automatically get from member a facility is get from resource)
 	 * @throws PrivilegeException                    if privileges are not given
@@ -741,7 +741,7 @@ public interface AttributesManager {
 	 *                                               <p>
 	 *                                               !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void setAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Store the attributes associated with the member and group combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -1047,8 +1047,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Principal need to have access to attribute which wants to get.
 	 *
 	 * @param sess          perun session
-	 * @param resource      to get attribute from
 	 * @param member        to get attribute from
+	 * @param resource      to get attribute from
 	 * @param attributeName attribute name defined in the particular manager
 	 * @return attribute
 	 * @throws InternalErrorException            if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
@@ -1059,7 +1059,7 @@ public interface AttributesManager {
 	 * @throws MemberResourceMismatchException   if member and resource are not in the same VO
 	 * @throws WrongAttributeAssignmentException if attribute is not member_resource attribute
 	 */
-	Attribute getAttribute(PerunSession sess, Resource resource, Member member, String attributeName) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, MemberResourceMismatchException, WrongAttributeAssignmentException;
+	Attribute getAttribute(PerunSession sess, Member member, Resource resource, String attributeName) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, MemberResourceMismatchException, WrongAttributeAssignmentException;
 
 	/**
 	 * Get particular attribute for the member in this group.
@@ -1319,8 +1319,8 @@ public interface AttributesManager {
 	 * <p>
 	 * PRIVILEGE: Principal need to have access to attribute which wants to get.
 	 *
-	 * @param resource to get attribute from
 	 * @param member   to get attribute from
+	 * @param resource to get attribute from
 	 * @param id       attribute id
 	 * @return attribute
 	 * @throws InternalErrorException            if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
@@ -1330,7 +1330,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException if attribute isn't resource-member attribute
 	 * @throws AttributeNotExistsException       if the attribute doesn't exists in the underlying data source
 	 */
-	Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	Attribute getAttributeById(PerunSession sess, Member member, Resource resource, int id) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * Get particular attribute for the member in this group.
@@ -1521,8 +1521,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Principal need to have access to all attributes which he wants to set.
 	 *
 	 * @param sess      perun session
-	 * @param resource  resource to set on
 	 * @param member    member to set on
+	 * @param resource  resource to set on
 	 * @param attribute attribute to set
 	 * @throws InternalErrorException            if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException                if privileges are not given
@@ -1532,7 +1532,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeValueException      if the attribute value is illegal
 	 * @throws WrongAttributeAssignmentException if attribute is not member-resource attribute or if it is core attribute
 	 */
-	void setAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void setAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Store the particular attribute associated with the group and member combination. Core attributes can't be set this way.
@@ -1741,15 +1741,15 @@ public interface AttributesManager {
 	 *
 	 * @param sess                      perun session
 	 * @param resourceToGetServicesFrom getRequired attributes from services which are assigned on this resource
-	 * @param resource                  you get attributes for this resource and the member
 	 * @param member                    you get attributes for this member and the resource
+	 * @param resource                  you get attributes for this resource and the member
 	 * @return list of member-resource attributes which are required by services which are assigned to specified resource
 	 * @throws InternalErrorException     if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException         if privileges are not given
 	 * @throws ResourceNotExistsException if the resource doesn't exists in underlying data source
 	 * @throws MemberNotExistsException   if the member doesn't have access to this resource
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * Get member-resource attributes which are required by services and if workWithUserAttributes is true also user, user-facility and member attributes.
@@ -1759,15 +1759,15 @@ public interface AttributesManager {
 	 *
 	 * @param sess                      perun session
 	 * @param resourceToGetServicesFrom getRequired attributes from services which are assigned on this resource
-	 * @param resource                  you get attributes for this resource and the member
 	 * @param member                    you get attributes for this member and the resource
+	 * @param resource                  you get attributes for this resource and the member
 	 * @param workWithUserAttributes    method can process also user, user-facility and member attributes (user is automatically get from member a facility is get from resource)
 	 * @return list of member-resource attributes (if workWithUserAttributes is true also user, user-facility and member attributes) which are required by services which are assigned to another resource.
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 *                                <p>
 	 *                                !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * Get member-group attributes which are required by services defined on specified resource
@@ -1926,15 +1926,15 @@ public interface AttributesManager {
 	 * PRIVILEGE: Get only those required attributes principal has access to.
 	 *
 	 * @param sess     perun session
-	 * @param resource you get attributes for this resource and the member
 	 * @param member   you get attributes for this member and the resource
+	 * @param resource you get attributes for this resource and the member
 	 * @return list of member-resource attributes which are required by services which are assigned to resource.
 	 * @throws InternalErrorException     if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException         if privileges are not given
 	 * @throws ResourceNotExistsException if the resource doesn't exists in underlying data source
 	 * @throws MemberNotExistsException   if the member doesn't have access to this resource
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, Member member) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Resource resource) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * If workWithUserAttribute is false => Get member-resource attributes which are required by services which are relater to this member-resource.
@@ -1943,15 +1943,15 @@ public interface AttributesManager {
 	 * PRIVILEGE: Get only those required attributes principal has access to.
 	 *
 	 * @param sess                   perun session
-	 * @param resource               you get attributes for this resource and the member
 	 * @param member                 you get attributes for this member and the resource
+	 * @param resource               you get attributes for this resource and the member
 	 * @param workWithUserAttributes method can process also user, user-facility and member attributes (user is automatically get from member a facility is get from resource)
 	 * @return list of member-resource attributes or if workWithUserAttributes is true return list of member-resource, user, member and user-facility attributes
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 *                                <p>
 	 *                                !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, MemberResourceMismatchException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Resource resource, boolean workWithUserAttributes) throws PrivilegeException, WrongAttributeAssignmentException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * Get user-facility attributes which are required by services which are related to this user-facility.
@@ -2124,9 +2124,9 @@ public interface AttributesManager {
 	 * PRIVILEGE: Get only those required attributes principal has access to.
 	 *
 	 * @param sess     perun session
-	 * @param resource you get attributes for this resource and the member
-	 * @param member   you get attributes for this member and the resource
 	 * @param service  attributes required by this services you'll get
+	 * @param member   you get attributes for this member and the resource
+	 * @param resource you get attributes for this resource and the member
 	 * @return list of attributes which are required by the service.
 	 * @throws InternalErrorException     if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException         if privileges are not given
@@ -2135,14 +2135,14 @@ public interface AttributesManager {
 	 * @throws ServiceNotExistsException  if the service doesn't exists in underlying data source
 	 * @throws MemberNotExistsException   if the member doesn't have access to this resource
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * PRIVILEGE: Get only those required attributes principal has access to.
 	 * <p>
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * Get member, member-resource and member-group attributes required by the specified service.
@@ -2352,8 +2352,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Fill attribute only when principal has access to write on it.
 	 *
 	 * @param sess      perun session
-	 * @param resource  resource which attribute you want to fill
 	 * @param member    member which attribute you want to fill
+	 * @param resource  resource which attribute you want to fill
 	 * @param attribute attribute to fill. If attribute already have set value, this value won't be overwritten. This means the attribute value must be empty otherwise this method won't fill it.
 	 * @return attribute which MAY have filled value
 	 * @throws InternalErrorException      if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
@@ -2362,16 +2362,16 @@ public interface AttributesManager {
 	 * @throws MemberNotExistsException    if member doesn't exists in underlying data source or he doesn't have access to this resource
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in underlying data source
 	 */
-	Attribute fillAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	Attribute fillAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * PRIVILEGE: Fill attributes only when principal has access to write on them.
 	 * <p>
 	 * Batch version of fillAttribute. This method skips all attributes with not-null value.
 	 *
-	 * @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession, Resource, Member, Attribute)
+	 * @see AttributesManager#fillAttribute(PerunSession, Member, Resource, Attribute)
 	 */
-	List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * PRIVILEGE: Fill attributes only when principal has access to write on them.
@@ -2379,7 +2379,7 @@ public interface AttributesManager {
 	 * @param workWithUserAttributes method can process also user and user-facility attributes (user is automatically get from member a facility is get from resource)
 	 *                               !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * This method tries to fill value of the member-group attribute. This value is automatically generated, but not all attributes can be filled this way.
@@ -2445,7 +2445,7 @@ public interface AttributesManager {
 	 * <p>
 	 * Batch version of fillAttribute. This method skips all attributes with not-null value.
 	 *
-	 * @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession, Resource, Member, Attribute)
+	 * @see AttributesManager#fillAttribute(PerunSession, Member, Resource, Attribute)
 	 */
 	List<Attribute> fillAttributes(PerunSession sess, Member member, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
@@ -2679,8 +2679,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Check attribute only when principal has access to write on it.
 	 *
 	 * @param sess      perun session
-	 * @param resource  resource for which (and for specified member) you want to check validity of attribute
 	 * @param member    member for which (and for specified resource) you want to check validity of attribute
+	 * @param resource  resource for which (and for specified member) you want to check validity of attribute
 	 * @param attribute attribute to check
 	 * @throws InternalErrorException            if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException                if privileges are not given
@@ -2688,16 +2688,16 @@ public interface AttributesManager {
 	 * @throws WrongAttributeValueException      if the attribute value is wrong/illegal
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute
 	 */
-	void checkAttributeValue(PerunSession sess, Resource resource, Member member, Attribute attribute) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException;
+	void checkAttributeValue(PerunSession sess, Member member, Resource resource, Attribute attribute) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * PRIVILEGE: Check attributes only when principal has access to write on them.
 	 * <p>
 	 * Batch version of fillAttribute
 	 *
-	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession, Resource, Member, Attribute)
+	 * @see AttributesManager#checkAttributeValue(PerunSession, Member, Resource, Attribute)
 	 */
-	void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException;
+	void checkAttributesValue(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * PRIVILEGE: Check attributes only when principal has access to write on them.
@@ -2706,9 +2706,9 @@ public interface AttributesManager {
 	 *
 	 * @param workWithUserAttributes method can process also user and user-facility attributes (user is automatically get from member a facility is get from resource)
 	 *                               !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
-	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession, Resource, Member, Attribute)
+	 * @see AttributesManager#checkAttributeValue(PerunSession, Member, Resource, Attribute)
 	 */
-	void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException;
+	void checkAttributesValue(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * Check if value of this member-group attribute is valid.
@@ -2773,7 +2773,7 @@ public interface AttributesManager {
 	 * <p>
 	 * Batch version of fillAttribute
 	 *
-	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession, Resource, Member, Attribute)
+	 * @see AttributesManager#checkAttributeValue(PerunSession, Member, Resource, Attribute)
 	 */
 	void checkAttributesValue(PerunSession sess, Member member, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException;
 
@@ -3195,8 +3195,8 @@ public interface AttributesManager {
 	 * PRIVILEGE: Remove attribute only when principal has access to write on it.
 	 *
 	 * @param sess      perun session
-	 * @param resource  remove attributes for this resource
 	 * @param member    remove attribute from this member
+	 * @param resource  remove attributes for this resource
 	 * @param attribute attribute to remove
 	 * @throws InternalErrorException            if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException                if privileges are not given
@@ -3205,7 +3205,7 @@ public interface AttributesManager {
 	 * @throws ResourceNotExistsException        if the resource doesn't exists in underlying data source
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
 	 */
-	void removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void removeAttribute(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * PRIVILEGE: Remove attributes only when principal has access to write on them.
@@ -3213,9 +3213,9 @@ public interface AttributesManager {
 	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
 	 *
 	 * @throws AttributeNotExistsException if the any of attributes doesn't exists in underlying data source
-	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, Resource, Member, AttributeDefinition)
+	 * @see AttributesManager#removeAttribute(PerunSession, Member, Resource, AttributeDefinition)
 	 */
-	void removeAttributes(PerunSession sess, Resource resource, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void removeAttributes(PerunSession sess, Member member, Resource resource, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Unset all attributes for the member on the resource.
@@ -3224,12 +3224,13 @@ public interface AttributesManager {
 	 *
 	 * @param sess   perun session
 	 * @param member remove attributes from this member
+	 * @param resource remove attributes on this resource
 	 * @throws InternalErrorException     if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws PrivilegeException         if privileges are not given
 	 * @throws MemberNotExistsException   if the member doesn't exists in underlying data source
 	 * @throws ResourceNotExistsException if the resource doesn't exists in underlying data source
 	 */
-	void removeAllAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException, PrivilegeException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Unset particular attribute for the member in the group. Core attributes can't be removed this way.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -136,33 +136,33 @@ public interface AttributesManagerBl {
 	 * Get all virtual attributes associated with the member-resource attributes.
 	 *
 	 * @param sess perun session
-	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
+	 * @param resource to get the attributes from
 	 * @return list of attributes
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getVirtualAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
+	List<Attribute> getVirtualAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the member on the resource.
 	 *
 	 * @param sess perun session
-	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
+	 * @param resource to get the attributes from
 	 * @return list of attributes
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws MemberResourceMismatchException
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException,  MemberResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException,  MemberResourceMismatchException;
 
 	/**
 	 * Gets all <b>non-empty</b> attributes associated with the member on the resource and if workWithUserAttributes is
 	 * true, gets also all <b>non-empty</b> user, user-facility and member attributes.
 	 *
 	 * @param sess perun session
-	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
+	 * @param resource to get the attributes from
 	 * @param workWithUserAttributes if true returns also user-facility, user and member attributes (user is automatically get from member a facility is get from resource)
 	 * @return list of attributes
 	 *
@@ -171,7 +171,7 @@ public interface AttributesManagerBl {
 	 *
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
 
 	/**
 	 * Gets selected <b>non-empty</b> attributes associated with the member and the resource.
@@ -180,8 +180,8 @@ public interface AttributesManagerBl {
 	 * Attributes are selected by list of attr_names. Empty list means all attributes.
 	 *
 	 * @param sess perun session
-	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
+	 * @param resource to get the attributes from
 	 * @param workWithUserAttributes if true returns also user and user-facility attributes (user is automatically get from member and facility is get from resource)
 	 * @return list of selected attributes
 	 *
@@ -190,7 +190,7 @@ public interface AttributesManagerBl {
 	 *
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
 
 	/**
 	 * Gets selected attributes associated with the member, group and the resource.
@@ -200,8 +200,8 @@ public interface AttributesManagerBl {
 	 *
 	 * @param sess perun session
 	 * @param group group to get the attributes from
-	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
+	 * @param resource to get the attributes from
 	 * @param workWithUserAttributes if true returns also user and user-facility attributes (user is automatically get from member and facility is get from resource)
 	 * @return list of selected attributes
 	 *
@@ -211,7 +211,7 @@ public interface AttributesManagerBl {
 	 *
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Group group, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException;
+	List<Attribute> getAttributes(PerunSession sess, Group group, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException;
 
 	/**
 	 * Get all <b>non-empty</b> attributes associated with the member in the group.
@@ -634,8 +634,8 @@ public interface AttributesManagerBl {
 	 * Just store the particular attribute associated with the member-resource, doesn't preform any value check. Core attributes can't be set this way.
 	 *
 	 * @param sess
-	 * @param resource
 	 * @param member
+	 * @param resource
 	 * @param attribute
 	 * @param workWithUserAttributes
 	 * @return
@@ -645,7 +645,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws MemberResourceMismatchException
 	 */
-	boolean setAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	boolean setAttributeWithoutCheck(PerunSession sess, Member member, Resource resource, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Just store the particular attribute associated with the member-group, doesn't preform any value check. Core attributes can't be set this way.
@@ -752,8 +752,8 @@ public interface AttributesManagerBl {
 	 * Store the attributes associated with the resource and member combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
 	 *
 	 * @param sess perun session
-	 * @param resource resource to set on
 	 * @param member member to set on
+	 * @param resource resource to set on
 	 * @param attributes attribute to set
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
@@ -762,15 +762,15 @@ public interface AttributesManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws MemberResourceMismatchException
 	 */
-	void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void setAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Store the attributes associated with the resource and member combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
 	 * If workWithUserAttributes is true, the method stores also the attributes associated with user, user-facility and member.
 	 *
 	 * @param sess perun session
-	 * @param resource resource to set on
 	 * @param member member to set on
+	 * @param resource resource to set on
 	 * @param attributes attribute to set
 	 * @param workWithUserAttributes method can process also user, user-facility and member attributes (user is automatically get from member a facility is get from resource)
 	 *
@@ -782,7 +782,7 @@ public interface AttributesManagerBl {
 	 *
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void setAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Store the attributes associated with the resource and member combination. If an attribute is core attribute then the attribute isn't stored (It's skipped without any notification).
@@ -1002,8 +1002,8 @@ public interface AttributesManagerBl {
 	 * Get particular attribute for the member on this resource.
 	 *
 	 * @param sess
-	 * @param resource to get attribute from
 	 * @param member to get attribute from
+	 * @param resource to get attribute from
 	 * @param attributeName attribute name defined in the particular manager
 	 * @return attribute
 	 *
@@ -1011,7 +1011,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws MemberResourceMismatchException
 	 */
-	Attribute getAttribute(PerunSession sess, Resource resource, Member member, String attributeName) throws InternalErrorException, MemberResourceMismatchException, WrongAttributeAssignmentException, AttributeNotExistsException;
+	Attribute getAttribute(PerunSession sess, Member member, Resource resource, String attributeName) throws InternalErrorException, MemberResourceMismatchException, WrongAttributeAssignmentException, AttributeNotExistsException;
 
 	/**
 	 * Get particular attribute for the member in this group.
@@ -1233,8 +1233,8 @@ public interface AttributesManagerBl {
 	 * Get particular attribute for the member on this resource.
 	 *
 	 * @param sess
-	 * @param resource to get attribute from
 	 * @param member to get attribute from
+	 * @param resource to get attribute from
 	 * @param id attribute id
 	 * @return attribute
 	 *
@@ -1242,7 +1242,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws MemberResourceMismatchException
 	 */
-	Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberResourceMismatchException;
+	Attribute getAttributeById(PerunSession sess, Member member, Resource resource, int id) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberResourceMismatchException;
 
 	/**
 	 * Get particular attribute for the member in this group. Also it can return only member or only user attribute
@@ -1518,8 +1518,8 @@ public interface AttributesManagerBl {
 	 * Store the particular attribute associated with the resource and member combination.  Core attributes can't be set this way.
 	 *
 	 * @param sess perun session
-	 * @param resource resource to set on
 	 * @param member member to set on
+	 * @param resource resource to set on
 	 * @param attribute attribute to set
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
@@ -1528,7 +1528,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws MemberResourceMismatchException
 	 */
-	void setAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void setAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Store the particular attribute associated with the group and member combination. Core attributes can't be set this way.
@@ -1789,14 +1789,14 @@ public interface AttributesManagerBl {
 	 *
 	 * @param sess perun session
 	 * @param resourceToGetServicesFrom resource from which the services are taken
-	 * @param resource you get attributes for this resource and the member
 	 * @param member you get attributes for this member
+	 * @param resource you get attributes for this resource and the member
 	 * @return list of facility attributes which are required by services which are assigned to resource.
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws MemberResourceMismatchException
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member) throws InternalErrorException, MemberResourceMismatchException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource) throws InternalErrorException, MemberResourceMismatchException;
 
 	/**
 	 * Get member-resource attributes which are required by services and if workWithUserAttributes is true also user, user-facility and member attributes.
@@ -1804,8 +1804,8 @@ public interface AttributesManagerBl {
 	 *
 	 * @param sess perun session
 	 * @param resourceToGetServicesFrom getRequired attributes from services which are assigned on this resource
-	 * @param resource you get attributes for this resource and the member
 	 * @param member you get attributes for this member and the resource
+	 * @param resource you get attributes for this resource and the member
 	 * @param workWithUserAttributes method can process also user, user-facility and member attributes (user is automatically get from member a facility is get from resource)
 	 * @return list of member-resource attributes (if workWithUserAttributes is true also user, user-facility and member attributes) which are required by services which are assigned to another resource.
 	 *
@@ -1814,7 +1814,7 @@ public interface AttributesManagerBl {
 	 *
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
+	List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
 
 	/**
 	 * Get member-group attributes which are required by services. Services are known from the resourceToGetServicesFrom.
@@ -1963,22 +1963,22 @@ public interface AttributesManagerBl {
 	 * Get member-resource attributes which are required by services which are relater to this member-resource.
 	 *
 	 * @param sess perun session
-	 * @param resource you get attributes for this resource and the member
 	 * @param member you get attributes for this member and the resource
+	 * @param resource you get attributes for this resource and the member
 	 * @return list of facility attributes which are required by services which are assigned to resource.
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws MemberResourceMismatchException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, MemberResourceMismatchException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException, MemberResourceMismatchException;
 
 	/**
 	 * If workWithUserAttribute is false => Get member-resource attributes which are required by services which are relater to this member-resource.
 	 * If workWithUserAttributes is true => Get member-resource, user-facility, user and member attributes. (user is get from member and facility from resource)
 	 *
 	 * @param sess perun session
-	 * @param resource you get attributes for this resource and the member
 	 * @param member you get attributes for this member and the resource
+	 * @param resource you get attributes for this resource and the member
 	 * @param workWithUserAttributes method can process also user, user-facility and member attributes (user is automatically get from member a facility is get from resource)
 	 * @return list of member-resource attributes or if workWithUserAttributes is true return list of member-resource, user, member and user-facility attributes
 	 *
@@ -1987,7 +1987,7 @@ public interface AttributesManagerBl {
 	 *
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Resource resource, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
 
 
 	/**
@@ -2091,17 +2091,17 @@ public interface AttributesManagerBl {
 	 * Get member-resource attributes which are required by the service.
 	 *
 	 * @param sess perun session
-	 * @param resource you get attributes for this resource and the member
-	 * @param member you get attributes for this member and the resource
 	 * @param service attribute required by this service you'll get
+	 * @param member you get attributes for this member and the resource
+	 * @param resource you get attributes for this resource and the member
 	 * @return list of attributes which are required by the service.
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws MemberResourceMismatchException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws InternalErrorException, MemberResourceMismatchException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource) throws InternalErrorException, MemberResourceMismatchException;
 
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException;
 
 	/**
 	 * Get member, member-resource and member-group attributes which are required by the service.
@@ -2313,8 +2313,8 @@ public interface AttributesManagerBl {
 	 * This method try to fill value of the member-resource attribute. This value is automatically generated, but not all attributes can be filled this way.
 	 *
 	 * @param sess perun session
-	 * @param resource  attribute of this resource (and member) and you want to fill
 	 * @param member attribute of this member (and resource) and you want to fill
+	 * @param resource  attribute of this resource (and member) and you want to fill
 	 * @param attribute attribute to fill. If attributes already have set value, this value won't be overwritten. This means the attribute value must be empty otherwise this method won't fill it.
 	 * @return attribute which MAY have filled value
 	 *
@@ -2322,20 +2322,20 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws MemberResourceMismatchException
 	 */
-	Attribute fillAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	Attribute fillAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 *  Batch version of fillAttribute. This method skips all attributes with not-null value.
 	 *  @throws WrongAttributeValueException if any of attributes values is wrong/illegal
-	 *  @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession,Resource,Member,Attribute)
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession, Member, Resource, Attribute)
 	 */
-	List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * @param workWithUserAttributes method can process also user and user-facility attributes (user is automatically get from member a facility is get from resource)
 	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	List<Attribute> fillAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * This method tries to fill value of the member-group attribute. This value is automatically generated, but not all attributes can be filled this way.
@@ -2421,7 +2421,7 @@ public interface AttributesManagerBl {
 	/**
 	 *  Batch version of fillAttribute. This method skips all attributes with not-null value.
 	 *  @throws WrongAttributeValueException if any of attributes values is wrong/illegal
-	 *  @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession,Resource,Member,Attribute)
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#fillAttribute(PerunSession, Member, Resource, Attribute)
 	 */
 	List<Attribute> fillAttributes(PerunSession sess, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException;
 
@@ -2615,8 +2615,8 @@ public interface AttributesManagerBl {
 	 *
 	 *
 	 * @param sess perun session
-	 * @param resource resource for which (and for specified member) you want to check validity of attribute
 	 * @param member member for which (and for specified resource) you want to check validity of attribute
+	 * @param resource resource for which (and for specified member) you want to check validity of attribute
 	 * @param attribute attribute to check
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
@@ -2625,21 +2625,20 @@ public interface AttributesManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws MemberResourceMismatchException
 	 */
-	void checkAttributeValue(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void checkAttributeValue(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 *  Batch version of fillAttribute
-	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession,Resource,Member,Attribute)
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession, Member, Resource, Attribute)
 	 */
-	void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void checkAttributesValue(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 *  Batch version of fillAttribute
-	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession,Resource,Member,Attribute)
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession, Member, Resource, Attribute)
 	 * @param workWithUserAttributes method can process also user and user-facility attributes (user is automatically get from member a facility is get from resource)
-	 * !!WARNING THIS IS VERY TIME-CONSUMING METHOD. DON'T USE IT IN BATCH!!
 	 */
-	void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void checkAttributesValue(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 
 	/**
@@ -2724,7 +2723,7 @@ public interface AttributesManagerBl {
 
 	/**
 	 *  Batch version of fillAttribute
-	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession,Resource,Member,Attribute)
+	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeValue(PerunSession, Member, Resource, Attribute)
 	 */
 	void checkAttributesValue(PerunSession sess, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
@@ -3128,22 +3127,23 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
 	 * @throws MemberResourceMismatchException
 	 */
-	void removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void removeAttribute(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
 	 */
-	void removeAttributes(PerunSession sess, Resource resource, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void removeAttributes(PerunSession sess, Member member, Resource resource, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Unset all attributes for the member on the resource.
 	 *
 	 * @param sess perun session
 	 * @param member remove attributes from this member
+	 * @param resource remove attributes from this resources
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+	void removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Unset particular attribute for the member in the group. Core attributes can't be removed this way.
@@ -3195,7 +3195,7 @@ public interface AttributesManagerBl {
 
 	/**
 	 * Batch version of removeAttribute. This method automatically skip all core attributes which can't be removed this way.
-	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute)
+	 * @see cz.metacentrum.perun.core.api.AttributesManager#removeAttribute(PerunSession, Member, Resource, AttributeDefinition)
 	 */
 	void removeAttributes(PerunSession sess, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
@@ -3437,15 +3437,15 @@ public interface AttributesManagerBl {
 	 * Unset all attributes for the member-resource without check of value.
 	 *
 	 * @param sess
-	 * @param resource
 	 * @param member
+	 * @param resource
 	 * @param attribute
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws MemberResourceMismatchException
 	 */
-	boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * Unset all attributes for the member-group without check of value.
@@ -3707,8 +3707,8 @@ public interface AttributesManagerBl {
 	 * Check if this the attribute is truly required for the member and the resource right now. Truly means that the nothing (member, resource...) is invalid.
 	 *
 	 * @param sess
-	 * @param resource
 	 * @param member
+	 * @param resource
 	 * @param attributeDefinition
 	 * @return
 	 *
@@ -3716,7 +3716,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws MemberResourceMismatchException
 	 */
-	boolean isTrulyRequiredAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	boolean isTrulyRequiredAttribute(PerunSession sess, Member member, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
 
 	/**
 	 * Check if this the attribute is truly required for the member and the group right now. Truly means that the nothing (member, group...) is invalid.
@@ -4107,7 +4107,7 @@ public interface AttributesManagerBl {
 	 * @throws InternalErrorException internal error
 	 */
 	Graph getAttributeModulesDependenciesGraph(PerunSession session) throws InternalErrorException;
-	 
+
 	/**
 	 * Check if attribute is from the same namespace as it's handler
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -236,13 +236,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getVirtualAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException {
-		return getAttributesManagerImpl().getVirtualAttributes(sess, resource, member);
+	public List<Attribute> getVirtualAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException {
+		return getAttributesManagerImpl().getVirtualAttributes(sess, member, resource);
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, MemberResourceMismatchException {
-		return getAttributes(sess, resource, member, false);
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException, MemberResourceMismatchException {
+		return getAttributes(sess, member, resource, false);
 	}
 
 	@Override
@@ -309,11 +309,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		// get virtual attributes
-		List<Attribute> attributes = getAttributesManagerImpl().getAttributes(sess, resource, member);
-		List<Attribute> virtualAttributes = getVirtualAttributes(sess, resource, member);
+		List<Attribute> attributes = getAttributesManagerImpl().getAttributes(sess, member, resource);
+		List<Attribute> virtualAttributes = getVirtualAttributes(sess, member, resource);
 		//remove virtual attributes with null value
 		Iterator<Attribute> virtualAttributesIterator = virtualAttributes.iterator();
 		while (virtualAttributesIterator.hasNext())
@@ -333,9 +333,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
-		if (attrNames.isEmpty()) return this.getAttributes(sess, resource, member, workWithUserAttributes);
+		if (attrNames.isEmpty()) return this.getAttributes(sess, member, resource, workWithUserAttributes);
 
 		List<String> userAndMemberAttributeNames = new ArrayList<>();
 		List<String> memberResourceAttributeNames = new ArrayList<>();
@@ -368,9 +368,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Group group, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException {
+	public List<Attribute> getAttributes(PerunSession sess, Group group, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException, GroupResourceMismatchException {
 		checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
-		List<Attribute> attributes = getAttributes(sess, resource, member, attrNames, workWithUserAttributes);
+		List<Attribute> attributes = getAttributes(sess, member, resource, attrNames, workWithUserAttributes);
 
 		if (attrNames.isEmpty()) {
 			attributes.addAll(getAttributes(sess, member, group));
@@ -630,7 +630,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public List<Attribute> getAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		List<Attribute> attributes = new ArrayList<>();
-		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, resource, member));
+		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, member, resource));
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, facility, user));
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, user));
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, member));
@@ -764,8 +764,8 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
-		setAttributes(sess, resource, member, attributes, false);
+	public void setAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+		setAttributes(sess, member, resource, attributes, false);
 	}
 
 	@Override
@@ -868,7 +868,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 
 	@Override
-	public void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void setAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		// clasification of attributes to attributes to remove and attributes to set
 		List<Attribute> attributesToRemove = new ArrayList<>();
 		List<Attribute> attributesToSet = new ArrayList<>();
@@ -887,7 +887,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			for (Attribute attribute : attributesToSet) {
 				//skip core attributes
 				if (!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
-					setAttributeWithoutCheck(sess, resource, member, attribute, false);
+					setAttributeWithoutCheck(sess, member, resource, attribute, false);
 				}
 			}
 			log.debug("addMember timer: setAttributes (for(Attribute attribute : attributes)) [{}].", Utils.getRunningTime(timer));
@@ -904,7 +904,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 					if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
 						timer = Utils.startTimer();
-						changed = setAttributeWithoutCheck(sess, resource, member, attribute, false);
+						changed = setAttributeWithoutCheck(sess, member, resource, attribute, false);
 						if (changed) {
 							log.debug("addMember timer: setAttribute rm [{}] [{}].", attribute, Utils.getRunningTime(timer));
 						}
@@ -934,7 +934,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 
 		//if checkAttributesValue fails it causes rollback so no attribute will be stored
-		checkAttributesValue(sess, resource, member, attributesToSet, workWithUserAttributes);
+		checkAttributesValue(sess, member, resource, attributesToSet, workWithUserAttributes);
 		this.checkAttributesDependencies(sess, resource, member, attributesToSet, workWithUserAttributes);
 	}
 
@@ -957,7 +957,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			if (!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
 
 				if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					setAttributeWithoutCheck(sess, resource, member, attribute, false);
+					setAttributeWithoutCheck(sess, member, resource, attribute, false);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					setAttributeWithoutCheck(sess, facility, user, attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
@@ -994,7 +994,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			if (!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
 
 				if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					setAttributeWithoutCheck(sess, resource, member, attribute, false);
+					setAttributeWithoutCheck(sess, member, resource, attribute, false);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					setAttributeWithoutCheck(sess, facility, user, attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
@@ -1305,13 +1305,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public Attribute getAttribute(PerunSession sess, Resource resource, Member member, String attributeName) throws InternalErrorException, MemberResourceMismatchException, WrongAttributeAssignmentException, AttributeNotExistsException {
+	public Attribute getAttribute(PerunSession sess, Member member, Resource resource, String attributeName) throws InternalErrorException, MemberResourceMismatchException, WrongAttributeAssignmentException, AttributeNotExistsException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		//check namespace
 		if (!attributeName.startsWith(AttributesManager.NS_MEMBER_RESOURCE_ATTR))
 			throw new WrongAttributeAssignmentException("Attribute name=" + attributeName);
 
-		return getAttributesManagerImpl().getAttribute(sess, resource, member, attributeName);
+		return getAttributesManagerImpl().getAttribute(sess, member, resource, attributeName);
 	}
 
 	@Override
@@ -1563,12 +1563,12 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberResourceMismatchException {
+	public Attribute getAttributeById(PerunSession sess, Member member, Resource resource, int id) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		AttributeDefinition attributeDefinition = getAttributeDefinitionById(sess, id);
 
 		if (getAttributesManagerImpl().isFromNamespace(attributeDefinition, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-			Attribute attribute = getAttributesManagerImpl().getAttributeById(sess, resource, member, id);
+			Attribute attribute = getAttributesManagerImpl().getAttributeById(sess, member, resource, id);
 			getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_RESOURCE_ATTR);
 			return attribute;
 		} else if (getAttributesManagerImpl().isFromNamespace(attributeDefinition, AttributesManager.NS_USER_FACILITY_ATTR)) {
@@ -1679,7 +1679,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			//skip core attributes
 			if (!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
 				if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					this.setAttributeWithoutCheck(sess, resource, member, attribute, false);
+					this.setAttributeWithoutCheck(sess, member, resource, attribute, false);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					this.setAttributeWithoutCheck(sess, facility, user, attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
@@ -1699,7 +1699,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Attribute attr : attributes) {
 			if (this.isVirtAttribute(sess, attr)) {
 				if (getAttributesManagerImpl().isFromNamespace(attr, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					attr.setValue(this.getAttribute(sess, resource, member, attr.getName()).getValue());
+					attr.setValue(this.getAttribute(sess, member, resource, attr.getName()).getValue());
 				} else if (getAttributesManagerImpl().isFromNamespace(attr, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					attr.setValue(this.getAttribute(sess, facility, user, attr.getName()).getValue());
 				} else if (getAttributesManagerImpl().isFromNamespace(attr, AttributesManager.NS_USER_ATTR)) {
@@ -1875,14 +1875,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void setAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void setAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		convertEmptyAttrValueToNull(attribute);
 		if (attribute.getValue() == null) {
-			removeAttribute(sess, resource, member, attribute);
+			removeAttribute(sess, member, resource, attribute);
 			return;
 		}
-		if (setAttributeWithoutCheck(sess, resource, member, attribute, false)) {
-			checkAttributeValue(sess, resource, member, attribute);
+		if (setAttributeWithoutCheck(sess, member, resource, attribute, false)) {
+			checkAttributeValue(sess, member, resource, attribute);
 			this.checkAttributeDependencies(sess, new RichAttribute<>(resource, member, attribute));
 		}
 	}
@@ -1904,19 +1904,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void setAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		convertEmptyAttrValueToNull(attribute);
 		if (attribute.getValue() == null) {
-			removeAttribute(sess, resource, member, attribute);
+			removeAttribute(sess, member, resource, attribute);
 			return;
 		}
 		if (!workWithUserAttributes) {
-			if (setAttributeWithoutCheck(sess, resource, member, attribute, false)) {
+			if (setAttributeWithoutCheck(sess, member, resource, attribute, false)) {
 				this.checkAttributeDependencies(sess, new RichAttribute<>(resource, member, attribute));
-				checkAttributeValue(sess, resource, member, attribute);
+				checkAttributeValue(sess, member, resource, attribute);
 			}
 		} else {
-			if (setAttributeWithoutCheck(sess, resource, member, attribute, true)) {
+			if (setAttributeWithoutCheck(sess, member, resource, attribute, true)) {
 				List<Attribute> listOfAttributes = new ArrayList<>();
 				listOfAttributes.add(attribute);
-				checkAttributesValue(sess, resource, member, listOfAttributes, true);
+				checkAttributesValue(sess, member, resource, listOfAttributes, true);
 				this.checkAttributesDependencies(sess, resource, member, listOfAttributes, true);
 			}
 		}
@@ -1950,7 +1950,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public boolean setAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public boolean setAttributeWithoutCheck(PerunSession sess, Member member, Resource resource, Attribute attribute, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		if (getAttributesManagerImpl().isCoreAttribute(sess, attribute))
 			throw new WrongAttributeAssignmentException(attribute);
@@ -1964,7 +1964,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				changed = getAttributesManagerImpl().setAttribute(sess, resource, member, attribute);
 				if (changed) {
 					getPerunBl().getAuditer().log(sess, new AttributeSetForResourceAndMember(attribute, resource, member));
-					getAttributesManagerImpl().changedAttributeHook(sess, resource, member, attribute);
+					getAttributesManagerImpl().changedAttributeHook(sess, member, resource, attribute);
 				}
 			}
 		} else if (workWithUserAttributes) {
@@ -2544,16 +2544,16 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member) throws InternalErrorException, MemberResourceMismatchException {
-		return getResourceRequiredAttributes(sess, resourceToGetServicesFrom, resource, member, false);
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource) throws InternalErrorException, MemberResourceMismatchException {
+		return getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, resource, false);
 	}
 
 	@Override
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		List<Attribute> attributes = new ArrayList<>();
 
-		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, resourceToGetServicesFrom, resource, member));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, resourceToGetServicesFrom, member, resource));
 
 		if (workWithUserAttributes) {
 			User user;
@@ -2618,13 +2618,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, MemberResourceMismatchException {
-		return this.getResourceRequiredAttributes(sess, resource, resource, member);
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException, MemberResourceMismatchException {
+		return this.getResourceRequiredAttributes(sess, resource, member, resource);
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
-		return this.getResourceRequiredAttributes(sess, resource, resource, member, workWithUserAttributes);
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Resource resource, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
+		return this.getResourceRequiredAttributes(sess, resource, member, resource, workWithUserAttributes);
 	}
 
 	@Override
@@ -2686,7 +2686,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		List<Attribute> attributes = new ArrayList<>();
-		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, resourceToGetServicesFrom, resource, member));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, resourceToGetServicesFrom, member, resource));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, resourceToGetServicesFrom, facility, user));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, resourceToGetServicesFrom, user));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, resourceToGetServicesFrom, member));
@@ -2757,21 +2757,21 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws InternalErrorException, MemberResourceMismatchException {
-		return getRequiredAttributes(sess, service, resource, member, false);
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource) throws InternalErrorException, MemberResourceMismatchException {
+		return getRequiredAttributes(sess, service, member, resource, false);
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource, boolean workWithUserAttributes) throws InternalErrorException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		if (!workWithUserAttributes)
-			return getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, member);
+			return getAttributesManagerImpl().getRequiredAttributes(sess, service, member, resource);
 
 		User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 
 		List<Attribute> attributes = new ArrayList<>();
-		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, member));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member, resource));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, user));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, user));
@@ -2786,7 +2786,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Attribute> attributes = new ArrayList<>();
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member, group));
-		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, member));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member, resource));
 
 		if (workWithUserAttributes) {
 			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
@@ -2940,7 +2940,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		List<Attribute> attributes = new ArrayList<>();
-		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, resource, member));
+		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member, resource));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, member));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, facility, user));
 		attributes.addAll(getAttributesManagerImpl().getRequiredAttributes(sess, service, user));
@@ -3015,27 +3015,27 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public Attribute fillAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_RESOURCE_ATTR);
 
-		return getAttributesManagerImpl().fillAttribute(sess, resource, member, attribute);
+		return getAttributesManagerImpl().fillAttribute(sess, member, resource, attribute);
 	}
 
 	@Override
-	public List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
-		return fillAttributes(sess, resource, member, attributes, false);
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+		return fillAttributes(sess, member, resource, attributes, false);
 	}
 
 	@Override
-	public List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		if (!workWithUserAttributes) {
 			List<Attribute> filledAttributes = new ArrayList<>();
 			for (Attribute attribute : attributes) {
 				getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_RESOURCE_ATTR);
 				if (attribute.getValue() == null) {
-					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, resource, member, attribute));
+					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, member, resource, attribute));
 				} else {
 					//skip non-empty attribute
 					filledAttributes.add(attribute);
@@ -3051,7 +3051,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Attribute attribute : attributes) {
 			if (attribute.getValue() == null) {
 				if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, resource, member, attribute));
+					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, member, resource, attribute));
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, facility, user, attribute));
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
@@ -3127,7 +3127,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Attribute attribute : attributes) {
 			if (attribute.getValue() == null) {
 				if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, resource, member, attribute));
+					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, member, resource, attribute));
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					filledAttributes.add(getAttributesManagerImpl().fillAttribute(sess, facility, user, attribute));
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
@@ -3157,7 +3157,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				if (attribute.getValue() == null) {
 					Attribute a;
 					if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-						a = getAttributesManagerImpl().fillAttribute(sess, resource, member, attribute);
+						a = getAttributesManagerImpl().fillAttribute(sess, member, resource, attribute);
 					} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 						a = getAttributesManagerImpl().fillAttribute(sess, facility, user, attribute);
 					} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
@@ -3416,17 +3416,17 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributeValue(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void checkAttributeValue(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_RESOURCE_ATTR);
 
-		if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, resource, member, attribute)) return;
-		getAttributesManagerImpl().checkAttributeValue(sess, resource, member, attribute);
+		if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, resource, attribute)) return;
+		getAttributesManagerImpl().checkAttributeValue(sess, member, resource, attribute);
 	}
 
 	@Override
-	public void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
-		checkAttributesValue(sess, resource, member, attributes, false);
+	public void checkAttributesValue(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+		checkAttributesValue(sess, member, resource, attributes, false);
 	}
 
 	@Override
@@ -3491,14 +3491,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void checkAttributesValue(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		if (!workWithUserAttributes) {
 			for (Attribute attribute : attributes) {
 				getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_RESOURCE_ATTR);
-				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, resource, member, attribute))
+				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, resource, attribute))
 					continue;
-				getAttributesManagerImpl().checkAttributeValue(sess, resource, member, attribute);
+				getAttributesManagerImpl().checkAttributeValue(sess, member, resource, attribute);
 			}
 		} else {
 			Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
@@ -3506,9 +3506,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 			for (Attribute attribute : attributes) {
 				if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, resource, member, attribute))
+					if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, resource, attribute))
 						continue;
-					getAttributesManagerImpl().checkAttributeValue(sess, resource, member, attribute);
+					getAttributesManagerImpl().checkAttributeValue(sess, member, resource, attribute);
 
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, facility, user, attribute))
@@ -3536,9 +3536,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		for (Attribute attribute : attributes) {
 			if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, resource, member, attribute))
+				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, resource, attribute))
 					continue;
-				getAttributesManagerImpl().checkAttributeValue(sess, resource, member, attribute);
+				getAttributesManagerImpl().checkAttributeValue(sess, member, resource, attribute);
 			} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, facility, user, attribute))
 					continue;
@@ -3561,9 +3561,9 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
 		for (Attribute attribute : attributes) {
 			if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, resource, member, attribute))
+				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, resource, attribute))
 					continue;
-				getAttributesManagerImpl().checkAttributeValue(sess, resource, member, attribute);
+				getAttributesManagerImpl().checkAttributeValue(sess, member, resource, attribute);
 			} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, facility, user, attribute))
 					continue;
@@ -3853,7 +3853,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
 					if (removeAttributeWithoutCheck(sess, user, attribute)) attributesToCheck.add(attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					if (removeAttributeWithoutCheck(sess, resource, member, attribute))
+					if (removeAttributeWithoutCheck(sess, member, resource, attribute))
 						attributesToCheck.add(attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					if (removeAttributeWithoutCheck(sess, facility, user, attribute)) attributesToCheck.add(attribute);
@@ -3880,7 +3880,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
 					if (removeAttributeWithoutCheck(sess, user, attribute)) attributesToCheck.add(attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-					if (removeAttributeWithoutCheck(sess, resource, member, attribute))
+					if (removeAttributeWithoutCheck(sess, member, resource, attribute))
 						attributesToCheck.add(attribute);
 				} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 					if (removeAttributeWithoutCheck(sess, facility, user, attribute)) attributesToCheck.add(attribute);
@@ -4239,24 +4239,24 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
-		if (removeAttributeWithoutCheck(sess, resource, member, attribute)) {
-			checkAttributeValue(sess, resource, member, new Attribute(attribute));
+	public void removeAttribute(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+		if (removeAttributeWithoutCheck(sess, member, resource, attribute)) {
+			checkAttributeValue(sess, member, resource, new Attribute(attribute));
 			this.checkAttributeDependencies(sess, new RichAttribute<>(resource, member, new Attribute(attribute)));
 		}
 	}
 
 	@Override
-	public boolean removeAttributeWithoutCheck(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_RESOURCE_ATTR);
 		if (getAttributesManagerImpl().isCoreAttribute(sess, attribute))
 			throw new WrongAttributeAssignmentException(attribute);
 
-		boolean changed = getAttributesManagerImpl().removeAttribute(sess, resource, member, attribute);
+		boolean changed = getAttributesManagerImpl().removeAttribute(sess, member, resource, attribute);
 		if (changed) {
 			try {
-				getAttributesManagerImpl().changedAttributeHook(sess, resource, member, new Attribute(attribute));
+				getAttributesManagerImpl().changedAttributeHook(sess, member, resource, new Attribute(attribute));
 			} catch (WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
 				throw new InternalErrorException(ex);
 			}
@@ -4268,21 +4268,21 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void removeAttributes(PerunSession sess, Resource resource, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void removeAttributes(PerunSession sess, Member member, Resource resource, List<? extends AttributeDefinition> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_MEMBER_RESOURCE_ATTR);
 		List<AttributeDefinition> attributesToCheck = new ArrayList<>();
 		for (AttributeDefinition attribute : attributes) {
 			if (!getAttributesManagerImpl().isCoreAttribute(sess, attribute)) {
-				if (removeAttributeWithoutCheck(sess, resource, member, attribute)) attributesToCheck.add(attribute);
+				if (removeAttributeWithoutCheck(sess, member, resource, attribute)) attributesToCheck.add(attribute);
 			}
 		}
-		checkAttributesValue(sess, resource, member, attributesFromDefinitions(attributesToCheck));
+		checkAttributesValue(sess, member, resource, attributesFromDefinitions(attributesToCheck));
 		this.checkAttributesDependencies(sess, resource, member, attributesFromDefinitions(attributesToCheck));
 	}
 
 	private void removeAttributes(PerunSession sess, Resource resource, Member member, List<? extends AttributeDefinition> attributes, boolean workWithUserAttributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		if (!(workWithUserAttributes)) {
-			removeAttributes(sess, resource, member, attributes);
+			removeAttributes(sess, member, resource, attributes);
 		} else {
 			List<AttributeDefinition> attributesToCheck = new ArrayList<>();
 			for (AttributeDefinition attribute : attributes) {
@@ -4290,7 +4290,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 					Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
 					User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 					if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
-						if (removeAttributeWithoutCheck(sess, resource, member, attribute))
+						if (removeAttributeWithoutCheck(sess, member, resource, attribute))
 							attributesToCheck.add(attribute);
 					} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 						if (removeAttributeWithoutCheck(sess, facility, user, attribute))
@@ -4304,30 +4304,30 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 					}
 				}
 			}
-			checkAttributesValue(sess, resource, member, attributesFromDefinitions(attributesToCheck), true);
+			checkAttributesValue(sess, member, resource, attributesFromDefinitions(attributesToCheck), true);
 			this.checkAttributesDependencies(sess, resource, member, attributesFromDefinitions(attributesToCheck), true);
 		}
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
-		List<Attribute> attributes = getAttributes(sess, resource, member);
-		getAttributesManagerImpl().removeAllAttributes(sess, resource, member);
+		List<Attribute> attributes = getAttributes(sess, member, resource);
+		getAttributesManagerImpl().removeAllAttributes(sess, member, resource);
 
 		log.info("{} removed all attributes from member {} on resource {}.",sess.getLogId(), member.getId(), resource.getId());
 		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForResourceAndMember(resource, member));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
-			checkAttributesValue(sess, resource, member, attributes);
+			checkAttributesValue(sess, member, resource, attributes);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new ConsistencyErrorException(ex);
 		}
 
 		for (Attribute attribute : attributes) {
 			try {
-				getAttributesManagerImpl().changedAttributeHook(sess, resource, member, new Attribute(attribute));
+				getAttributesManagerImpl().changedAttributeHook(sess, member, resource, new Attribute(attribute));
 			} catch (WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
 				throw new InternalErrorException(ex);
 			}
@@ -4994,7 +4994,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public boolean isTrulyRequiredAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public boolean isTrulyRequiredAttribute(PerunSession sess, Member member, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		this.checkNamespace(sess, attributeDefinition, NS_MEMBER_RESOURCE_ATTR);
 		List<Member> allowedMembers = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
@@ -5564,7 +5564,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 							if (richAttribute.getPrimaryHolder() != null && richAttribute.getPrimaryHolder() instanceof Resource) {
 								if (richAttribute.getSecondaryHolder() != null && richAttribute.getSecondaryHolder() instanceof Member) {
 									try {
-										this.checkAttributeValue(sess, (Resource) richAttribute.getPrimaryHolder(), (Member) richAttribute.getSecondaryHolder(), richAttribute.getAttribute());
+										this.checkAttributeValue(sess, (Member) richAttribute.getSecondaryHolder(), (Resource) richAttribute.getPrimaryHolder(), richAttribute.getAttribute());
 									} catch (MemberResourceMismatchException ex) {
 										throw new ConsistencyErrorException(ex);
 									}
@@ -5574,7 +5574,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 							} else if (richAttribute.getSecondaryHolder() != null && richAttribute.getSecondaryHolder() instanceof Resource) {
 								if (richAttribute.getPrimaryHolder() != null && richAttribute.getPrimaryHolder() instanceof Member) {
 									try {
-										this.checkAttributeValue(sess, (Resource) richAttribute.getSecondaryHolder(), (Member) richAttribute.getPrimaryHolder(), richAttribute.getAttribute());
+										this.checkAttributeValue(sess, (Member) richAttribute.getPrimaryHolder(), (Resource) richAttribute.getSecondaryHolder(), richAttribute.getAttribute());
 									} catch (MemberResourceMismatchException ex) {
 										throw new ConsistencyErrorException(ex);
 									}
@@ -9979,7 +9979,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			List<Resource> resources = getPerunBl().getResourcesManagerBl().getAllowedResources(sess, member);
 			for (Resource resourceElement : resources) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, member, attrDef.getName());
+				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resourceElement, attrDef.getName());
 				listOfRichAttributes.add(new RichAttribute<>(resourceElement, member, attribute));
 			}
 		}
@@ -10008,7 +10008,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			membersForResourceElement = new ArrayList<>(new HashSet<>(membersForResourceElement));
 			for (Member memberElement : membersForResourceElement) {
 				if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
+					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, resourceElement, attrDef.getName());
 					listOfRichAttributes.add(new RichAttribute<>(resourceElement, memberElement, attribute));
 				}
 			}
@@ -10033,7 +10033,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Member> members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
 		for (Member memberElement : members) {
 			if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, memberElement)) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, memberElement, attrDef.getName());
+				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, resource, attrDef.getName());
 				listOfRichAttributes.add(new RichAttribute<>(resource, memberElement, attribute));
 			}
 		}
@@ -10137,7 +10137,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		membersFromGroup.retainAll(membersFromResource);
 		membersFromGroup = new ArrayList<>(new HashSet<>(membersFromGroup));
 		for (Member memberElement : membersFromGroup) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, memberElement, attrDef.getName());
+			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, resource, attrDef.getName());
 			listOfRichAttributes.add(new RichAttribute<>(resource, memberElement, attribute));
 		}
 		listOfRichAttributes = new ArrayList<>(new HashSet<>(listOfRichAttributes));
@@ -10163,7 +10163,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
 			List<Resource> resourcesFromGroup = getPerunBl().getResourcesManagerBl().getAssignedResources(sess, group);
 			for (Resource resourceElement : resourcesFromGroup) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, member, attrDef.getName());
+				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resourceElement, attrDef.getName());
 				listOfRichAttributes.add(new RichAttribute<>(resourceElement, member, attribute));
 			}
 		}
@@ -10186,7 +10186,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	private List<RichAttribute> getMemberResourceAttributes(PerunSession sess, Member member, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		List<RichAttribute> listOfRichAttributes = new ArrayList<>();
 		if (getPerunBl().getMembersManagerBl().isMemberAllowed(sess, member)) {
-			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, member, attrDef.getName());
+			Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, attrDef.getName());
 			listOfRichAttributes.add(new RichAttribute<>(resource, member, attribute));
 		}
 		listOfRichAttributes = new ArrayList<>(new HashSet<>(listOfRichAttributes));
@@ -10219,7 +10219,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			membersForResourceElement.retainAll(membersFromUser);
 			membersForResourceElement = new ArrayList<>(new HashSet<>(membersForResourceElement));
 			for (Member memberElement : membersForResourceElement) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
+				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, resourceElement, attrDef.getName());
 				listOfRichAttributes.add(new RichAttribute<>(resourceElement, memberElement, attribute));
 			}
 		}
@@ -10248,7 +10248,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Resource resourceElement : resources) {
 			List<Member> membersFromResource = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resourceElement);
 			for (Member memberElement : membersFromResource) {
-				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, resourceElement, memberElement, attrDef.getName());
+				Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, memberElement, resourceElement, attrDef.getName());
 				listOfRichAttributes.add(new RichAttribute<>(resourceElement, memberElement, attribute));
 			}
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -122,7 +122,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			getPerunBl().getAttributesManagerBl().removeAllAttributes(sess, member);
 			List<Resource> resources = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
 			for(Resource resource : resources) {
-				getPerunBl().getAttributesManagerBl().removeAllAttributes(sess, resource, member);
+				getPerunBl().getAttributesManagerBl().removeAllAttributes(sess, member, resource);
 			}
 		} catch(AttributeValueException ex) {
 			throw new ConsistencyErrorException("Member is removed from all groups. There are no required attribute for this member. Member's attributes can be removed without problem.", ex);
@@ -983,7 +983,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			List<Attribute> userAttributes = new ArrayList<Attribute>();
 			List<Attribute> memberAttributes = new ArrayList<Attribute>();
 
-			List<Attribute> attributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, resource, richMember, attrNames, true);
+			List<Attribute> attributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, richMember, resource, attrNames, true);
 
 			for(Attribute attribute: attributes) {
 				if(attribute.getName().startsWith(AttributesManager.NS_USER_ATTR)) userAttributes.add(attribute);
@@ -1028,7 +1028,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			List<Attribute> userAttributes = new ArrayList<>();
 			List<Attribute> memberAttributes = new ArrayList<>();
 
-			List<Attribute> attributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, group, resource, richMember, attrNames, true);
+			List<Attribute> attributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, group, richMember, resource, attrNames, true);
 
 			for(Attribute attribute: attributes) {
 				if(attribute.getName().startsWith(AttributesManager.NS_USER_ATTR)) userAttributes.add(attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -9,7 +9,6 @@ import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminUserRemovedF
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.BanRemovedForResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.BanSetForResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.BanUpdatedForResource;
-import cz.metacentrum.perun.audit.events.ResourceManagerEvents.FacilitySetForResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.GroupAssignedToResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.GroupRemovedFromResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.ResourceCreated;
@@ -117,10 +116,10 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 			List<Member> templateResourceMembers = perunBl.getResourcesManagerBl().getAssignedMembers(sess, templateResource);
 			try {
 				for (Member member : templateResourceMembers) {
-					List<Attribute> memberResourceAttrs = perunBl.getAttributesManagerBl().getAttributes(sess, templateResource, member);
+					List<Attribute> memberResourceAttrs = perunBl.getAttributesManagerBl().getAttributes(sess, member, templateResource);
 					for (Attribute attr : memberResourceAttrs) {
 						if (!attr.getNamespace().startsWith(AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT)) {
-							perunBl.getAttributesManagerBl().setAttribute(sess, newResource, member, attr);
+							perunBl.getAttributesManagerBl().setAttribute(sess, member, newResource, attr);
 						}
 					}
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -285,7 +285,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	private ServiceAttributes getData(PerunSession sess, Service service, Resource resource, Member member) throws InternalErrorException {
 		ServiceAttributes memberServiceAttributes = new ServiceAttributes();
 		try {
-			memberServiceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, resource, member, true));
+			memberServiceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, member, resource, true));
 		} catch(MemberResourceMismatchException ex) {
 			throw new InternalErrorException(ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -131,8 +131,8 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException {
-		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, resource, member);
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException {
+		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, member, resource);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
@@ -145,12 +145,12 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
-		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, resource, member, workWithUserAttributes);
+		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, member, resource, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
@@ -178,12 +178,12 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member, List<String> attrNames, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException {
+	public List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource, List<String> attrNames, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 
-		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, resource, member, attrNames, workWithUserAttributes);
+		List<Attribute> attributes = getAttributesManagerBl().getAttributes(sess, member, resource, attrNames, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
@@ -708,7 +708,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void setAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -717,7 +717,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		for(Attribute attr: attributes) {
 			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), member , resource)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attr));
 		}
-		getAttributesManagerBl().setAttributes(sess, resource, member, attributes);
+		getAttributesManagerBl().setAttributes(sess, member, resource, attributes);
 	}
 
 	@Override
@@ -759,7 +759,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void setAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void setAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -781,7 +781,7 @@ public class AttributesManagerEntry implements AttributesManager {
 				throw new WrongAttributeAssignmentException("One of setting attribute has not correct type : " + new AttributeDefinition(attr));
 			}
 		}
-		getAttributesManagerBl().setAttributes(sess, resource, member, attributes, workWithUserAttributes);
+		getAttributesManagerBl().setAttributes(sess, member, resource, attributes, workWithUserAttributes);
 	}
 
 	@Override
@@ -1007,12 +1007,12 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public Attribute getAttribute(PerunSession sess, Resource resource, Member member, String attributeName) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, MemberResourceMismatchException, WrongAttributeAssignmentException {
+	public Attribute getAttribute(PerunSession sess, Member member, Resource resource, String attributeName) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, MemberResourceMismatchException, WrongAttributeAssignmentException {
 		Utils.checkPerunSession(sess);
 		Utils.notNull(attributeName, "attributeName");
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		Attribute attr = getAttributesManagerBl().getAttribute(sess, resource, member, attributeName);
+		Attribute attr = getAttributesManagerBl().getAttribute(sess, member, resource, attributeName);
 		//Choose to which attributes has the principal access
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attr, member, resource)) throw new PrivilegeException("Principal has no access to get attribute = " + new AttributeDefinition(attr));
 		else attr.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attr, member, resource));
@@ -1200,11 +1200,11 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public Attribute getAttributeById(PerunSession sess, Member member, Resource resource, int id) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, AttributeNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		Attribute attr = getAttributesManagerBl().getAttributeById(sess, resource, member, id);
+		Attribute attr = getAttributesManagerBl().getAttributeById(sess, member, resource, id);
 		//Choose to which attributes has the principal access
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, attr, member, resource)) throw new PrivilegeException("Principal has no access to get attribute = " + new AttributeDefinition(attr));
 		else attr.setWritable(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attr, member, resource));
@@ -1343,13 +1343,13 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void setAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void setAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws PrivilegeException, ResourceNotExistsException, InternalErrorException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, member, resource)) throw new PrivilegeException("Principal has no access to set attribute = " + new AttributeDefinition(attribute));
-		getAttributesManagerBl().setAttribute(sess, resource, member, attribute);
+		getAttributesManagerBl().setAttribute(sess, member, resource, attribute);
 	}
 
 	@Override
@@ -1477,12 +1477,12 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, resource, member);
+		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, resource);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
@@ -1494,12 +1494,12 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public List<Attribute> getResourceRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resourceToGetServicesFrom);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, resource, member, workWithUserAttributes);
+		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, resource, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
@@ -1714,7 +1714,7 @@ public class AttributesManagerEntry implements AttributesManager {
 			throw new MemberGroupMismatchException("Member and Group are not in the same VO.");
 		}
 
-		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, resource, member, workWithUserAttributes);
+		List<Attribute> attributes = getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, resource, workWithUserAttributes);
 		attributes.addAll(getAttributesManagerBl().getResourceRequiredAttributes(sess, resourceToGetServicesFrom, member, group));
 
 		User user = getPerunBl().getUsersManagerBl().getUserById(sess, member.getUserId());
@@ -1781,11 +1781,11 @@ public class AttributesManagerEntry implements AttributesManager {
 
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, Member member) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, MemberResourceMismatchException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Resource resource) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, resource, member);
+		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, member, resource);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
@@ -1797,11 +1797,11 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, MemberResourceMismatchException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Member member, Resource resource, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, resource, member, workWithUserAttributes);
+		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, member, resource, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
@@ -2039,12 +2039,12 @@ public class AttributesManagerEntry implements AttributesManager {
 		return attributes;
 	}
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, resource, member);
+		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, member, resource);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		//Choose to which attributes has the principal access
 		while(attrIter.hasNext()) {
@@ -2056,12 +2056,12 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException {
+	public List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, ServiceNotExistsException, MemberNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
-		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, resource, member, workWithUserAttributes);
+		List<Attribute> attributes = getAttributesManagerBl().getRequiredAttributes(sess, service, member, resource, workWithUserAttributes);
 		Iterator<Attribute> attrIter = attributes.iterator();
 		User user = null;
 		Facility facility = null;
@@ -2438,26 +2438,26 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public Attribute fillAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		//Choose to which attributes has the principal access
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attribute), member , resource)) throw new PrivilegeException("Principal has no access to fill attribute = " + new AttributeDefinition(attribute));
 
-		Attribute attr = getAttributesManagerBl().fillAttribute(sess, resource, member, attribute);
+		Attribute attr = getAttributesManagerBl().fillAttribute(sess, member, resource, attribute);
 		attr.setWritable(true);
 		return attr;
 	}
 
 	@Override
-	public List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
-		List<Attribute> listOfAttributes = getAttributesManagerBl().fillAttributes(sess, resource, member, attributes);
+		List<Attribute> listOfAttributes = getAttributesManagerBl().fillAttributes(sess, member, resource, attributes);
 		Iterator<Attribute> attrIter = listOfAttributes.iterator();
 		while(attrIter.hasNext()) {
 			Attribute attrNext = attrIter.next();
@@ -2469,13 +2469,13 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public List<Attribute> fillAttributes(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public List<Attribute> fillAttributes(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		//Choose to which attributes has the principal access
-		List<Attribute> listOfAttributes = getAttributesManagerBl().fillAttributes(sess, resource, member, attributes, workWithUserAttributes);
+		List<Attribute> listOfAttributes = getAttributesManagerBl().fillAttributes(sess, member, resource, attributes, workWithUserAttributes);
 		Iterator<Attribute> attrIter = listOfAttributes.iterator();
 
 		while(attrIter.hasNext()) {
@@ -2935,7 +2935,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributeValue(PerunSession sess, Resource resource, Member member, Attribute attribute) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
+	public void checkAttributeValue(PerunSession sess, Member member, Resource resource, Attribute attribute) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
@@ -2943,11 +2943,11 @@ public class AttributesManagerEntry implements AttributesManager {
 		//Choose to which attributes has the principal access
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attribute), member , resource)) throw new PrivilegeException("Principal has no access to check attribute = " + new AttributeDefinition(attribute));
 
-		getAttributesManagerBl().checkAttributeValue(sess, resource, member, attribute);
+		getAttributesManagerBl().checkAttributeValue(sess, member, resource, attribute);
 	}
 
 	@Override
-	public void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
+	public void checkAttributesValue(PerunSession sess, Member member, Resource resource, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
@@ -2956,7 +2956,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		for(Attribute attr: attributes) {
 			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, new AttributeDefinition(attr), member , resource)) throw new PrivilegeException("Principal has no access to check attribute = " + new AttributeDefinition(attr));
 		}
-		getAttributesManagerBl().checkAttributesValue(sess, resource, member, attributes);
+		getAttributesManagerBl().checkAttributesValue(sess, member, resource, attributes);
 	}
 
 	@Override
@@ -3007,7 +3007,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributesValue(PerunSession sess, Resource resource, Member member, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
+	public void checkAttributesValue(PerunSession sess, Member member, Resource resource, List<Attribute> attributes, boolean workWithUserAttributes) throws PrivilegeException, InternalErrorException, ResourceNotExistsException, MemberNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
@@ -3029,7 +3029,7 @@ public class AttributesManagerEntry implements AttributesManager {
 				throw new WrongAttributeAssignmentException("There is some attribute which is not type of any possible choice.");
 			}
 		}
-		getAttributesManagerBl().checkAttributesValue(sess, resource, member, attributes, workWithUserAttributes);
+		getAttributesManagerBl().checkAttributesValue(sess, member, resource, attributes, workWithUserAttributes);
 	}
 
 	@Override
@@ -3518,7 +3518,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void removeAttribute(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -3526,11 +3526,11 @@ public class AttributesManagerEntry implements AttributesManager {
 		//Choose to which attributes has the principal access
 		if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attribute, member , resource)) throw new PrivilegeException("Principal has no access to remove attribute = " + new AttributeDefinition(attribute));
 
-		getAttributesManagerBl().removeAttribute(sess, resource, member, attribute);
+		getAttributesManagerBl().removeAttribute(sess, member, resource, attribute);
 	}
 
 	@Override
-	public void removeAttributes(PerunSession sess, Resource resource, Member member, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void removeAttributes(PerunSession sess, Member member, Resource resource, List<? extends AttributeDefinition> attributes) throws InternalErrorException, PrivilegeException, AttributeNotExistsException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
@@ -3539,20 +3539,20 @@ public class AttributesManagerEntry implements AttributesManager {
 		for(AttributeDefinition attrDef: attributes) {
 			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attrDef, member , resource)) throw new PrivilegeException("Principal has no access to remove attribute = " + attrDef);
 		}
-		getAttributesManagerBl().removeAttributes(sess, resource, member, attributes);
+		getAttributesManagerBl().removeAttributes(sess, member, resource, attributes);
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+	public void removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException, PrivilegeException, MemberNotExistsException, ResourceNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
 		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
 		//Choose if principal has access to remove all attributes
-		List<Attribute> allAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, resource, member);
+		List<Attribute> allAttributes = getPerunBl().getAttributesManagerBl().getAttributes(sess, member, resource);
 		for(Attribute attr: allAttributes) {
 			if(!AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, attr, member , resource)) throw new PrivilegeException("Principal has no access to remove attribute = " + new AttributeDefinition(attr));
 		}
-		getAttributesManagerBl().removeAllAttributes(sess, resource, member);
+		getAttributesManagerBl().removeAllAttributes(sess, member, resource);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
@@ -40,7 +40,7 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Resou
 	long E = P * 1024;
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrDataQuota = null;
 		String dataQuota = null;
 		String dataLimit = null;
@@ -52,7 +52,7 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Resou
 
 		//Get attrDataQuota attribute
 		try {
-			attrDataQuota = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, member, A_MR_dataQuota);
+			attrDataQuota = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, member, resource, A_MR_dataQuota);
 		} catch (AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException("Attribute with dataQuota from member " + member.getId() + " and resource " + resource.getId() + " could not obtained.", ex);
 		} catch (MemberResourceMismatchException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuota.java
@@ -40,7 +40,7 @@ public class urn_perun_member_resource_attribute_def_def_dataQuota extends Resou
 	long E = P * 1024;
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrDataLimit = null;
 		String dataQuota = null;
 		String dataLimit = null;
@@ -52,7 +52,7 @@ public class urn_perun_member_resource_attribute_def_def_dataQuota extends Resou
 
 		//Get attrDataLimit attribute
 		try {
-			attrDataLimit = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, member, A_MR_dataLimit);
+			attrDataLimit = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, member, resource, A_MR_dataLimit);
 		} catch (AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException("Attribute with dataLimit from member " + member.getId() + " and resource " + resource.getId() + " could not obtained.", ex);
 		} catch (MemberResourceMismatchException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
@@ -19,7 +19,6 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttrib
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,7 @@ public class urn_perun_member_resource_attribute_def_def_dataQuotas extends Reso
 	public static final String A_R_maxUserDataQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserDataQuotas";
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//attribute can be null, it means there are no default settings on resource
 		if(attribute.getValue() == null) {
 			return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotasOverride.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotasOverride.java
@@ -4,12 +4,8 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
-import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
@@ -17,12 +13,7 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Attribute for setting override of the member's quota on the resource.
@@ -33,7 +24,7 @@ import java.util.Map;
 public class urn_perun_member_resource_attribute_def_def_dataQuotasOverride extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//attribute can be null, it means there are no default settings on resource
 		if(attribute.getValue() == null) {
 			return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotas.java
@@ -19,7 +19,6 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttrib
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,7 @@ public class urn_perun_member_resource_attribute_def_def_fileQuotas extends Reso
 	public static final String A_R_maxUserFileQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserFileQuotas";
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//attribute can be null, it means there are no default settings on resource
 		if(attribute.getValue() == null) {
 			return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotasOverride.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotasOverride.java
@@ -4,12 +4,8 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
-import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
@@ -17,12 +13,7 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Attribute for setting override of the member's quota on the resource.
@@ -33,7 +24,7 @@ import java.util.Map;
 public class urn_perun_member_resource_attribute_def_def_fileQuotasOverride extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//attribute can be null, it means there are no default settings on resource
 		if(attribute.getValue() == null) {
 			return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimit.java
@@ -29,14 +29,14 @@ public class urn_perun_member_resource_attribute_def_def_filesLimit extends Reso
 	private static final String A_MR_filesQuota = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":filesQuota";
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrFilesQuota = null;
 		Integer filesQuota = null;
 		Integer filesLimit = null;
 
 		//Get FilesQuotaAttribute
 		try {
-			attrFilesQuota = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, member, A_MR_filesQuota);
+			attrFilesQuota = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, member, resource, A_MR_filesQuota);
 		} catch (AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException("Attribute with filesQuota from member " + member.getId() + " and resource " + resource.getId() + " could not obtained.", ex);
 		} catch (MemberResourceMismatchException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuota.java
@@ -29,14 +29,14 @@ public class urn_perun_member_resource_attribute_def_def_filesQuota extends Reso
 	private static final String A_MR_filesLimit = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":filesLimit";
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrFilesLimit = null;
 		Integer filesQuota = null;
 		Integer filesLimit = null;
 
 		//Get FilesLimit attribute
 		try {
-			attrFilesLimit = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, member, A_MR_filesLimit);
+			attrFilesLimit = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, member, resource, A_MR_filesLimit);
 		} catch (AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(attribute + " from member " + member.getId() + " and resource " + resource.getId() + " could not obtained.", ex);
 		} catch (MemberResourceMismatchException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_dataQuotas.java
@@ -36,7 +36,7 @@ public class urn_perun_member_resource_attribute_def_virt_dataQuotas extends Res
 	public static final String A_MR_dataQuotasOverride = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuotasOverride";
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Member member, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		//get resource quotas
@@ -63,7 +63,7 @@ public class urn_perun_member_resource_attribute_def_virt_dataQuotas extends Res
 		Map<String, Pair<BigDecimal, BigDecimal>> memberTransferedQuotas;
 		Attribute memberQuotas;
 		try {
-			memberQuotas = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, member, A_MR_dataQuotas);
+			memberQuotas = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, A_MR_dataQuotas);
 		} catch (AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(ex);
 		} catch (WrongAttributeAssignmentException ex) {
@@ -85,7 +85,7 @@ public class urn_perun_member_resource_attribute_def_virt_dataQuotas extends Res
 		Map<String, Pair<BigDecimal, BigDecimal>> memberTransferedQuotasOverride;
 		Attribute memberQuotasOverride;
 		try {
-			memberQuotasOverride = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, member, A_MR_dataQuotasOverride);
+			memberQuotasOverride = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, A_MR_dataQuotasOverride);
 		} catch (AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(ex);
 		} catch (WrongAttributeAssignmentException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_fileQuotas.java
@@ -36,7 +36,7 @@ public class urn_perun_member_resource_attribute_def_virt_fileQuotas extends Res
 	public static final String A_MR_fileQuotasOverride = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":fileQuotasOverride";
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Member member, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		//get resource quotas
@@ -63,7 +63,7 @@ public class urn_perun_member_resource_attribute_def_virt_fileQuotas extends Res
 		Map<String, Pair<BigDecimal, BigDecimal>> memberTransferedQuotas;
 		Attribute memberQuotas;
 		try {
-			memberQuotas = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, member, A_MR_fileQuotas);
+			memberQuotas = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, A_MR_fileQuotas);
 		} catch (AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(ex);
 		} catch (WrongAttributeAssignmentException ex) {
@@ -85,7 +85,7 @@ public class urn_perun_member_resource_attribute_def_virt_fileQuotas extends Res
 		Map<String, Pair<BigDecimal, BigDecimal>> memberTransferedQuotasOverride;
 		Attribute memberQuotasOverride;
 		try {
-			memberQuotasOverride = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, member, A_MR_fileQuotasOverride);
+			memberQuotasOverride = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, A_MR_fileQuotasOverride);
 		} catch (AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(ex);
 		} catch (WrongAttributeAssignmentException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
@@ -44,7 +44,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBanned extends Resou
 	private final String OPERATION_UPDATED = "updated";
 
 	@Override
-    public Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Member member, AttributeDefinition attributeDefinition) throws InternalErrorException {
+    public Attribute getAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException {
         Attribute attribute = new Attribute(attributeDefinition);
 		//Default value is false
 		attribute.setValue(false);
@@ -115,7 +115,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBanned extends Resou
 
 		for(Pair<Resource, Member> affectedObjects : listOfAffectedObjects) {
 			try {
-				Attribute attrVirtMemberResourceIsBanned = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, affectedObjects.getLeft(), affectedObjects.getRight(), AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT + ":isBanned");
+				Attribute attrVirtMemberResourceIsBanned = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, affectedObjects.getRight(), affectedObjects.getLeft(), AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT + ":isBanned");
 
 				resolvingMessages.add(attrVirtMemberResourceIsBanned.serializeToString() + " " + operationType + " for " + affectedObjects.getLeft().serializeToString() + " and " + affectedObjects.getRight().serializeToString());
 			} catch (AttributeNotExistsException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_dataQuotas.java
@@ -65,7 +65,7 @@ public class urn_perun_user_facility_attribute_def_virt_dataQuotas extends Facil
 			Map<String, Pair<BigDecimal, BigDecimal>> memberResourceFinalDataQuotas;
 			Attribute memberResourceFinalDataQuotasAttribute;
 			try {
-				memberResourceFinalDataQuotasAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, memberOnResource, A_MR_V_dataQuotas);
+				memberResourceFinalDataQuotasAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, memberOnResource, resource, A_MR_V_dataQuotas);
 			} catch (MemberResourceMismatchException | WrongAttributeAssignmentException ex) {
 				throw new InternalErrorException(ex);
 			} catch (AttributeNotExistsException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_fileQuotas.java
@@ -65,7 +65,7 @@ public class urn_perun_user_facility_attribute_def_virt_fileQuotas extends Facil
 			Map<String, Pair<BigDecimal, BigDecimal>> memberResourceFinalFileQuotas;
 			Attribute memberResourceFinalFileQuotasAttribute;
 			try {
-				memberResourceFinalFileQuotasAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, memberOnResource, A_MR_V_fileQuotas);
+				memberResourceFinalFileQuotasAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, memberOnResource, resource, A_MR_V_fileQuotas);
 			} catch (MemberResourceMismatchException | WrongAttributeAssignmentException ex) {
 				throw new InternalErrorException(ex);
 			} catch (AttributeNotExistsException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -172,25 +172,25 @@ public interface AttributesManagerImplApi {
 	 * Get all <b>non-empty</b> attributes associated with the member on the resource.
 	 *
 	 * @param sess perun session
-	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
+	 * @param resource to get the attributes from
 	 * @return list of attributes
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
+	List<Attribute> getAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Get all virtual attributes associated with the member on the resource.
 	 *
 	 * @param sess perun session
-	 * @param resource to get the attributes from
 	 * @param member to get the attributes from
+	 * @param resource to get the attributes from
 	 * @return list of attributes
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getVirtualAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
+	List<Attribute> getVirtualAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Get all <b>non-empty, non-virtual</b> attributes associated with the member in the group.
@@ -584,15 +584,15 @@ public interface AttributesManagerImplApi {
 	/**
 	 * Get particular attribute for the member on this resource.
 	 *
-	 * @param attributeName attribute name defined in the particular manager
-	 * @param resource to get attribute from
 	 * @param member to get attribute from
+	 * @param resource to get attribute from
+	 * @param attributeName attribute name defined in the particular manager
 	 * @return attribute
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlaying data source
 	 */
-	Attribute getAttribute(PerunSession sess, Resource resource, Member member, String attributeName) throws InternalErrorException, AttributeNotExistsException;
+	Attribute getAttribute(PerunSession sess, Member member, Resource resource, String attributeName) throws InternalErrorException, AttributeNotExistsException;
 
 	/**
 	 * Get particular attribute for the member in this group.
@@ -763,15 +763,15 @@ public interface AttributesManagerImplApi {
 	/**
 	 * Get particular attribute for the member on this resource.
 	 *
-	 * @param id attribute id
-	 * @param resource to get attribute from
 	 * @param member to get attribute from
+	 * @param resource to get attribute from
+	 * @param id attribute id
 	 * @return attribute
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws AttributeNotExistsException if the attribute doesn't exists in the underlaying data source
 	 */
-	Attribute getAttributeById(PerunSession sess, Resource resource, Member member, int id) throws InternalErrorException, AttributeNotExistsException;
+	Attribute getAttributeById(PerunSession sess, Member member, Resource resource, int id) throws InternalErrorException, AttributeNotExistsException;
 
 	/**
 	 * Get particular attribute for the member in this group.
@@ -1140,13 +1140,13 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param resourceToGetServicesFrom resource from which the services are taken
-	 * @param resource you get attributes for this resource and the member
 	 * @param member you get attributes for this member and the resource
+	 * @param resource you get attributes for this resource and the member
 	 * @return list of member-resource attributes which are required by services which are assigned to another resource.
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Resource resource, Member member) throws InternalErrorException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Resource resourceToGetServicesFrom, Member member, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Get user-facility attributes which are required by services. Services are known from the resource.
@@ -1242,14 +1242,14 @@ public interface AttributesManagerImplApi {
 	 * Get member-resource attributes which are required by the service.
 	 *
 	 * @param sess perun session
-	 * @param resource you get attributes for this resource and the member
-	 * @param member you get attributes for this member and the resource
 	 * @param service attribute required by this service you'll get
+	 * @param member you get attributes for this member and the resource
+	 * @param resource you get attributes for this resource and the member
 	 * @return list of attributes which are required by the service.
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Resource resource, Member member) throws InternalErrorException;
+	List<Attribute> getRequiredAttributes(PerunSession sess, Service service, Member member, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Get member-resource attributes which are required by service for each member in list of members.
@@ -1386,14 +1386,14 @@ public interface AttributesManagerImplApi {
 	 * This method try to fill value of the member-resource attribute. This value is automatically generated, but not all atrributes can be filled this way.
 	 *
 	 * @param sess perun session
-	 * @param resource  attribute of this resource (and member) and you want to fill
 	 * @param member attribute of this member (and resource) and you want to fill
+	 * @param resource  attribute of this resource (and member) and you want to fill
 	 * @param attribute attribute to fill. If attributes already have set value, this value won't be owerwriten. This means the attribute value must be empty otherwise this method won't fill it.
 	 * @return attribute which MAY have filled value
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	Attribute fillAttribute(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException;
+	Attribute fillAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException;
 
 	/**
 	 * This method tries to fill value of the member-group attribute. This value is automatically generated, but not all attributes can be filled this way.
@@ -1576,14 +1576,14 @@ public interface AttributesManagerImplApi {
 	 * If you need to do some further work with other modules, this method do that
 	 *
 	 * @param sess
-	 * @param resource
 	 * @param member
+	 * @param resource
 	 * @param attribute
 	 * @throws InternalErrorException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws WrongAttributeValueException
 	 */
-	void changedAttributeHook(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void changedAttributeHook(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * If you need to do some further work with other modules, this method do that
@@ -1678,15 +1678,15 @@ public interface AttributesManagerImplApi {
 	 *
 	 *
 	 * @param sess perun session
-	 * @param resource resource for which (and for specified member) you want to check validity of attribute
 	 * @param member member for which (and for specified resource) you want to check validity of attribute
+	 * @param resource resource for which (and for specified member) you want to check validity of attribute
 	 * @param attribute attribute to check
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void checkAttributeValue(PerunSession sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void checkAttributeValue(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this member-group attribute is valid.
@@ -1894,23 +1894,24 @@ public interface AttributesManagerImplApi {
 	 * Unset particular member-resorce attribute for the member on the resource.
 	 *
 	 * @param sess perun session
-	 * @param resource remove attributes for this resource
 	 * @param member remove attribute from this member
+	 * @param resource remove attributes for this resource
 	 * @param attribute attribute to remove
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean removeAttribute(PerunSession sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttribute(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Unset all (member-resource) attributes for the member on the resource.
 	 *
 	 * @param sess perun session
 	 * @param member remove attributes from this member
+	 * @param resource remove attributes from this resource
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Resource resource, Member member) throws InternalErrorException;
+	void removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Unset particular attribute for the member in the group. Core attributes can't be removed this way.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberAttributesModuleAbstract.java
@@ -4,14 +4,11 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Abstract class for Resource Member Attributes modules.
@@ -24,15 +21,15 @@ import java.util.List;
  */
 public abstract class ResourceMemberAttributesModuleAbstract extends AttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
 
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 	}
 
-	public Attribute fillAttribute(PerunSessionImpl session, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl session, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		return new Attribute(attribute);
 	}
 
-	public void changedAttributeHook(PerunSessionImpl session, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberAttributesModuleImplApi.java
@@ -24,8 +24,8 @@ public interface ResourceMemberAttributesModuleImplApi extends AttributesModuleI
 	 * This method checks Member's attributes at a specified resource.
 	 *
 	 * @param perunSession Perun session
-	 * @param resource Resource
 	 * @param member Member
+	 * @param resource Resource
 	 * @param attribute Attribute to be checked.
 	 *
 	 * @throws InternalErrorException if an exception is raised in particular
@@ -35,14 +35,14 @@ public interface ResourceMemberAttributesModuleImplApi extends AttributesModuleI
 	 *         the parameter is to be compared is not available
 	 * @throws WrongAttributeAssignmentException
 	 */
-	void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 
 	/**
 	 * This method MAY fill Member's attributes at a specified resource.
 	 *
 	 * @param perunSession Perun session
-	 * @param resource Resource
 	 * @param member Member
+	 * @param resource Resource
 	 * @param attribute Attribute to be filled in
 	 *
 	 * @return Attribute which MAY be filled in.
@@ -51,15 +51,14 @@ public interface ResourceMemberAttributesModuleImplApi extends AttributesModuleI
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeAssignmentException
 	 */
-	Attribute fillAttribute(PerunSessionImpl perunSession, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	Attribute fillAttribute(PerunSessionImpl perunSession, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * If you need to do some further work with other modules, this method do that
-	 *
-	 * @param session session
-	 * @param resource the resource
+	 *  @param session session
 	 * @param member the member
+	 * @param resource the resource
 	 * @param attribute the attribute
 	 */
-	void changedAttributeHook(PerunSessionImpl session, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+	void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleAbstract.java
@@ -23,15 +23,15 @@ import java.util.List;
 public abstract class ResourceMemberVirtualAttributesModuleAbstract extends ResourceMemberAttributesModuleAbstract implements ResourceMemberVirtualAttributesModuleImplApi{
 
 
-	public Attribute getAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException {
 		return new Attribute(attribute);
 	}
 
-	public boolean setAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		return false;
 	}
 
-	public boolean removeAttributeValue(PerunSessionImpl perunSession, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		return false;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceMemberVirtualAttributesModuleImplApi.java
@@ -20,38 +20,38 @@ public interface ResourceMemberVirtualAttributesModuleImplApi extends ResourceMe
 	 * This method will return computed value.
 	 *
 	 * @param sess perun session
-	 * @param resource resource which is needed for computing the value
 	 * @param member member which is needed for computing the value
+	 * @param resource resource which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException;
+	Attribute getAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Method sets attributes' values which are dependent on this virtual attribute.
 	 *
 	 * @param sess
-	 * @param resource resource which is needed for computing the value
 	 * @param member member which is needed for computing the value
+	 * @param resource resource which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return true if attribute was really changed
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean setAttributeValue(PerunSessionImpl sess, Resource resource, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+	boolean setAttributeValue(PerunSessionImpl sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Currently do nothing.
 	 *
 	 * @param sess
-	 * @param resource resource which is needed for computing the value
 	 * @param member member which is needed for computing the value
+	 * @param resource resource which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Member member, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean removeAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
@@ -1044,8 +1044,8 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		perun.getAttributesManagerBl().setAttribute(sess, resource, group, attributes.get(0));
 		assertEquals(attributes.get(0), perun.getAttributesManagerBl().getAttribute(sess, resource, group, attributes.get(0).getName()));
 		attributes = setUpMemberResourceAttribute();
-		perun.getAttributesManagerBl().setAttribute(sess, resource, member, attributes.get(0));
-		assertEquals(attributes.get(0), perun.getAttributesManagerBl().getAttribute(sess, resource, member, attributes.get(0).getName()));
+		perun.getAttributesManagerBl().setAttribute(sess, member, resource, attributes.get(0));
+		assertEquals(attributes.get(0), perun.getAttributesManagerBl().getAttribute(sess, member, resource, attributes.get(0).getName()));
 		attributes = setUpUserLargeAttribute();
 		perun.getAttributesManagerBl().setAttribute(sess, user, attributes.get(0));
 		assertEquals(attributes.get(0), perun.getAttributesManagerBl().getAttribute(sess, user, attributes.get(0).getName()));
@@ -1194,9 +1194,9 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 		attributes = setUpMemberResourceAttribute();
-		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, resource, attributes.get(0));
 
-		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, resource);
 		assertNotNull("unable to get member-resource attributes", retAttr);
 		assertTrue("our attribute was not returned",retAttr.contains(attributes.get(0)));
 
@@ -1219,7 +1219,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributesManager.setAttribute(sess, user, attributes.get(0));
 
 		// return members and users attributes from resources members
-		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member, true);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, resource, true);
 		assertNotNull("unable to get member-resource(work with user) attributes", retAttr);
 		assertTrue("our attribute was not returned", retAttr.contains(attributes.get(0)));
 
@@ -1232,7 +1232,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		vo = setUpVo();
 		member = setUpMember();
 
-		attributesManager.getAttributes(sess, new Resource(), member, true);
+		attributesManager.getAttributes(sess, member, new Resource(), true);
 		// shouldn't find resource
 
 	}
@@ -1245,7 +1245,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getAttributes(sess, resource, new Member(), true);
+		attributesManager.getAttributes(sess, new Member(), resource, true);
 		// shouldn't find member
 
 	}
@@ -1927,9 +1927,9 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, member, resource, attributes);
 
-		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, resource);
 		assertNotNull("unable to get member-resource attributes", retAttr);
 		assertTrue("unable to set/or return our member-resource attribute", retAttr.contains(attributes.get(0)));
 
@@ -1944,7 +1944,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttributes(sess, new Resource(), member, attributes);
+		attributesManager.setAttributes(sess, member, new Resource(), attributes);
 		// shouldn't find resource
 
 	}
@@ -1959,7 +1959,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttributes(sess, resource, new Member(), attributes);
+		attributesManager.setAttributes(sess, new Member(), resource, attributes);
 		// shouldn't find member
 
 	}
@@ -1976,7 +1976,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpMemberResourceAttribute();
 		attributes.get(0).setId(0);
 		// make valid attribute not existing in DB by setting ID=0
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, member, resource, attributes);
 		// shouldn't find attribute
 
 	}
@@ -1992,7 +1992,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 
 		attributes = setUpVoAttribute();
 		// set up wrong attribute - vo instead of member-resource
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, member, resource, attributes);
 		// shouldn't set attribute
 
 	}
@@ -2008,7 +2008,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpMemberResourceAttribute();
 		attributes.get(0).setValue(1);
 		// set wrong value - integer into string
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, member, resource, attributes);
 		// shouldn't set wrong attribute
 
 	}
@@ -2023,10 +2023,10 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		attributes = setUpUserAttribute();
 
-		attributesManager.setAttributes(sess, resource, member, attributes, true);
+		attributesManager.setAttributes(sess, member, resource, attributes, true);
 
 		// return users attributes from resource member
-		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member, true);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, resource, true);
 		assertNotNull("unable to set or get member-resource(work with user) attributes", attributes);
 		assertTrue("our attribute was not set/returned", retAttr.contains(attributes.get(0)));
 
@@ -2041,7 +2041,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		attributes = setUpUserAttribute();
 
-		attributesManager.setAttributes(sess, resource, new Member(), attributes, true);
+		attributesManager.setAttributes(sess, new Member(), resource, attributes, true);
 		// shouldn't find member
 
 	}
@@ -2054,7 +2054,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		member = setUpMember();
 		attributes = setUpUserAttribute();
 
-		attributesManager.setAttributes(sess, new Resource(), member, attributes, true);
+		attributesManager.setAttributes(sess, member, new Resource(), attributes, true);
 		// shouldn't find resource
 
 	}
@@ -2071,7 +2071,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes.get(0).setId(0);
 		// make valid attribute object not existing in DB
 
-		attributesManager.setAttributes(sess, resource, member, attributes, true);
+		attributesManager.setAttributes(sess, member, resource, attributes, true);
 		// shouldn't find attribute
 
 	}
@@ -2087,7 +2087,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpUserAttribute();
 		attributes.get(0).setValue(1);
 		// set wrong value - integer into string
-		attributesManager.setAttributes(sess, resource, member, attributes, true);
+		attributesManager.setAttributes(sess, member, resource, attributes, true);
 		// shouldn't set wrong attribute
 
 	}
@@ -2915,10 +2915,10 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		map.put("C", "D");
 		Attribute memberResourceAttribute1 = setUpAttribute(LinkedHashMap.class.getName(), "testMemberResourceAttribute1", AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF, map);
 		Attribute memberResourceAttribute2 = setUpAttribute(LinkedHashMap.class.getName(), "testMemberResourceAttribute2", AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF, map);
-		attributesManager.setAttributes(sess, resource, member, new ArrayList<>(Arrays.asList(memberResourceAttribute1, memberResourceAttribute2)));
+		attributesManager.setAttributes(sess, member, resource, new ArrayList<>(Arrays.asList(memberResourceAttribute1, memberResourceAttribute2)));
 
 		List<String> attrNames = new ArrayList<>(Arrays.asList(userAttribute1.getName(), memberAttribute1.getName(), userFacilityAttribute1.getName(), memberResourceAttribute1.getName()));
-		List<Attribute> returnedAttributes = attributesManager.getAttributes(sess, resource, member, attrNames, true);
+		List<Attribute> returnedAttributes = attributesManager.getAttributes(sess, member, resource, attrNames, true);
 
 		assertTrue(returnedAttributes.size() == 4);
 		assertTrue(returnedAttributes.contains(userAttribute1));
@@ -2937,9 +2937,9 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, member, resource, attributes);
 
-		Attribute retAttr = attributesManager.getAttribute(sess, resource, member,"urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
+		Attribute retAttr = attributesManager.getAttribute(sess, member, resource, "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
 		assertNotNull("unable to get opt member resource attribute ", retAttr);
 		assertEquals("returned opt attr value is not correct", retAttr.getValue(), attributes.get(0).getValue());
 
@@ -2955,9 +2955,9 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, member, resource, attributes);
 
-		attributesManager.getAttribute(sess, new Resource(), member, "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
+		attributesManager.getAttribute(sess, member, new Resource(), "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
 		// shouldn't find resource
 
 	}
@@ -2972,9 +2972,9 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, member, resource, attributes);
 
-		attributesManager.getAttribute(sess, resource, new Member(), "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
+		attributesManager.getAttribute(sess, new Member(), resource, "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
 		// shouldn't find member
 
 	}
@@ -2988,7 +2988,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getAttribute(sess, resource, member, "urn:perun:member_resource:attribute-def:opt:nesmysl");
+		attributesManager.getAttribute(sess, member, resource, "urn:perun:member_resource:attribute-def:opt:nesmysl");
 		// shouldn't find member resource attribute "nesmysl"
 
 	}
@@ -3002,7 +3002,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getAttribute(sess, resource, member, "urn:perun:resource:attribute-def:opt:member-resource-test-attribute");
+		attributesManager.getAttribute(sess, member, resource, "urn:perun:resource:attribute-def:opt:member-resource-test-attribute");
 		// shouldn't find resource attribute instead of member-resource
 
 	}
@@ -3798,11 +3798,11 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 		attributes = setUpMemberResourceAttribute();
-		attributesManager.setAttributes(sess, resource, member, attributes);
+		attributesManager.setAttributes(sess, member, resource, attributes);
 
 		int id = attributes.get(0).getId();
 
-		Attribute retAttr = attributesManager.getAttributeById(sess, resource, member, id);
+		Attribute retAttr = attributesManager.getAttributeById(sess, member, resource, id);
 		assertNotNull("unable to get resource member attribute by id",retAttr);
 		assertEquals("returned attribute is not same as stored", retAttr, attributes.get(0));
 
@@ -3817,7 +3817,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpMemberResourceAttribute();
 		int id = attributes.get(0).getId();
 
-		attributesManager.getAttributeById(sess, new Resource(), member, id);
+		attributesManager.getAttributeById(sess, member, new Resource(), id);
 		// shouldn't find resource
 
 	}
@@ -3832,7 +3832,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpMemberResourceAttribute();
 		int id = attributes.get(0).getId();
 
-		attributesManager.getAttributeById(sess,resource, new Member(), id);
+		attributesManager.getAttributeById(sess, new Member(), resource, id);
 		// shouldn't find member
 
 	}
@@ -3846,7 +3846,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getAttributeById(sess, resource, member, 0);
+		attributesManager.getAttributeById(sess, member, resource, 0);
 		// shouldn't find attribute
 
 	}
@@ -3862,7 +3862,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpVoAttribute();
 		int id = attributes.get(0).getId();
 
-		attributesManager.getAttributeById(sess, resource, member, id);
+		attributesManager.getAttributeById(sess, member, resource, id);
 		// shouldn't return member resource attribute when ID belong to different type of attribute
 
 	}
@@ -4613,9 +4613,9 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		member = setUpMember();
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, resource, attributes.get(0));
 
-		Attribute retAttr = attributesManager.getAttribute(sess, resource, member, "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
+		Attribute retAttr = attributesManager.getAttribute(sess, member, resource, "urn:perun:member_resource:attribute-def:opt:member-resource-test-attribute");
 		assertNotNull("unable to get member-resource attribute by name", retAttr);
 		assertEquals("returned member-resource attribute is not same as stored", retAttr, attributes.get(0));
 
@@ -4629,7 +4629,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		member = setUpMember();
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttribute(sess, new Resource(), member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, new Resource(), attributes.get(0));
 		// shouldn't find resource
 
 	}
@@ -4643,7 +4643,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		attributes = setUpMemberResourceAttribute();
 
-		attributesManager.setAttribute(sess, resource, new Member(), attributes.get(0));
+		attributesManager.setAttribute(sess, new Member(), resource, attributes.get(0));
 		// shouldn't find resource
 
 	}
@@ -4660,7 +4660,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes.get(0).setId(0);
 		// make valid attribute not existing in DB by setting ID = 0
 
-		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, resource, attributes.get(0));
 		// shouldn't find attribute
 
 	}
@@ -4675,7 +4675,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		member = setUpMember();
 		attributes = setUpVoAttribute();
 
-		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, resource, attributes.get(0));
 		// shouldn't add vo attribute into member-resource
 
 	}
@@ -4691,7 +4691,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpMemberResourceAttribute();
 		attributes.get(0).setValue(1);
 
-		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, resource, attributes.get(0));
 		// shouldn't add attribute with String type and Integer value
 
 	}
@@ -5377,8 +5377,8 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						attributesManager.setAttribute(sess, resource2InVo2, b);
 						break;
 					case "member_resource": //
-						attributesManager.setAttribute(sess, resource1InVo1, member1OfUser1, a);
-						attributesManager.setAttribute(sess, resource2InVo1, member2OfUser2, b);
+						attributesManager.setAttribute(sess, member1OfUser1, resource1InVo1, a);
+						attributesManager.setAttribute(sess, member2OfUser2, resource2InVo1, b);
 						break;
 					case "member_group":
 						attributesManager.setAttribute(sess, member1OfUser1, group1InVo1, a);
@@ -5528,8 +5528,8 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 							attributesManager.setAttribute(sess, resource2InVo2, b);
 							break;
 						case "member_resource": //
-							attributesManager.setAttribute(sess, resource1InVo1, member1OfUser1, a);
-							attributesManager.setAttribute(sess, resource2InVo1, member2OfUser2, b);
+							attributesManager.setAttribute(sess, member1OfUser1, resource1InVo1, a);
+							attributesManager.setAttribute(sess, member2OfUser2, resource2InVo1, b);
 							break;
 						case "member_group":
 							attributesManager.setAttribute(sess, member1OfUser1, group1InVo1, a);
@@ -5602,8 +5602,8 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						Pair<Integer, Integer> mId_rId = BeansUtils.getSinglePair(attributesManagerBl.getPerunBeanIdsForUniqueAttributeValue(sess, b));
 						assertThat("member with duplicate value is not the one",mId_rId.getLeft(), is(member1OfUser1.getId()));
 						assertThat("resource with duplicate value is not the one",mId_rId.getRight(), is(resource1InVo1.getId()));
-						attributesManager.removeAttribute(sess, resource1InVo1, member1OfUser1, a);
-						attributesManager.setAttribute(sess, resource2InVo1, member2OfUser2, b);
+						attributesManager.removeAttribute(sess, member1OfUser1, resource1InVo1, a);
+						attributesManager.setAttribute(sess, member2OfUser2, resource2InVo1, b);
 						break;
 					case "member_group":
 						Pair<Integer,Integer> mId_gId = BeansUtils.getSinglePair(attributesManagerBl.getPerunBeanIdsForUniqueAttributeValue(sess, b));
@@ -5863,7 +5863,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpRequiredAttributes();
 		perun.getResourcesManager().assignService(sess, resource, service);
 
-		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, member);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, member, resource);
 		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
 		assertTrue("should have only 1 req member resource attribute",reqAttr.size() == 1);
 
@@ -5907,7 +5907,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getResourceRequiredAttributes(sess, new Resource(), resource,  member);
+		attributesManager.getResourceRequiredAttributes(sess, new Resource(), member, resource);
 		// shouldn't find resource
 
 	}
@@ -5921,7 +5921,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getResourceRequiredAttributes(sess, resource, new Resource(),  member);
+		attributesManager.getResourceRequiredAttributes(sess, resource, member, new Resource());
 		// shouldn't find resource
 
 	}
@@ -5944,15 +5944,15 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 
 		perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
 
-		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, resource, member);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, resource);
 		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
 		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, member);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, fakeResource);
 		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
 		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set",reqAttr.size() == 0);
 
-		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, member, fakeResource);
 		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
 		assertTrue("Should return 1 attribute (but with no value)",reqAttr.size() == 1);
 
@@ -5967,7 +5967,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getResourceRequiredAttributes(sess, resource, resource, new Member());
+		attributesManager.getResourceRequiredAttributes(sess, resource, new Member(), resource);
 		// shouldn't find member
 
 	}
@@ -5984,7 +5984,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpRequiredAttributes();
 		perun.getResourcesManager().assignService(sess, resource, service);
 
-		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, resource, member, true);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, member, resource, true);
 		assertNotNull("unable to get required member resource (work with user) attributes for its services",reqAttr);
 		assertTrue("should have more than 1 req attribute",reqAttr.size() >= 1);
 
@@ -5999,7 +5999,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getResourceRequiredAttributes(sess, new Resource(), resource, member, true);
+		attributesManager.getResourceRequiredAttributes(sess, new Resource(), member, resource, true);
 		// shouldn't find resource
 
 	}
@@ -6013,7 +6013,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getResourceRequiredAttributes(sess, resource, new Resource(), member, true);
+		attributesManager.getResourceRequiredAttributes(sess, resource, member, new Resource(), true);
 		// shouldn't find resource
 
 	}
@@ -6036,15 +6036,15 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 
 		perun.getResourcesManager().createResource(sess, fakeResource, vo, facility);
 
-		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, resource, member, true);
+		List<Attribute> reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, resource, true);
 		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
 		assertTrue("Shouldn't return attribute, when there is no service on resource",reqAttr.size() == 0);
 
-		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, fakeResource, member, true);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, fakeResource, member, fakeResource, true);
 		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
 		assertTrue("Shouldn't return attribute, when there is no service on resource and no value set",reqAttr.size() == 0);
 
-		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, fakeResource, member, true);
+		reqAttr = attributesManager.getResourceRequiredAttributes(sess, resource, member, fakeResource, true);
 		assertNotNull("unable to get required member resource attributes for its services",reqAttr);
 		assertTrue("Should return 4 attributes (but with no value)",reqAttr.size() == 4);
 		// member_resource, user_facility, user, member
@@ -6059,7 +6059,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getResourceRequiredAttributes(sess, resource, resource, new Member(), true);
+		attributesManager.getResourceRequiredAttributes(sess, resource, new Member(), resource, true);
 		// shouldn't find member
 	}
 
@@ -6792,7 +6792,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpRequiredAttributes();
 		perun.getResourcesManager().assignService(sess, resource, service);
 
-		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, member);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, member, resource);
 		assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
 		assertTrue("should have only 1 req attribute",reqAttr.size() == 1);
 
@@ -6829,7 +6829,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		member = setUpMember();
 
-		attributesManager.getRequiredAttributes(sess, new Service(), resource, member);
+		attributesManager.getRequiredAttributes(sess, new Service(), member, resource);
 		// shouldn't find service
 
 	}
@@ -6842,7 +6842,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		vo = setUpVo();
 		member = setUpMember();
 
-		attributesManager.getRequiredAttributes(sess, service, new Resource(), member);
+		attributesManager.getRequiredAttributes(sess, service, member, new Resource());
 		// shouldn't find resource
 
 	}
@@ -6858,7 +6858,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getRequiredAttributes(sess, service, resource, new Member());
+		attributesManager.getRequiredAttributes(sess, service, new Member(), resource);
 		// shouldn't find member
 
 	}
@@ -6875,7 +6875,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpRequiredAttributes();
 		perun.getResourcesManager().assignService(sess, resource, service);
 
-		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, resource, member, true);
+		List<Attribute> reqAttr = attributesManager.getRequiredAttributes(sess, service, member, resource, true);
 		assertNotNull("unable to get required resource-member attributes for one service",reqAttr);
 		assertTrue("should have at least 4 req attributes",reqAttr.size() >= 4);
 
@@ -6909,7 +6909,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		member = setUpMember();
 
-		attributesManager.getRequiredAttributes(sess, new Service(), resource, member, true);
+		attributesManager.getRequiredAttributes(sess, new Service(), member, resource, true);
 		// shouldn't find service
 
 	}
@@ -6922,7 +6922,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		vo = setUpVo();
 		member = setUpMember();
 
-		attributesManager.getRequiredAttributes(sess, service, new Resource(), member, true);
+		attributesManager.getRequiredAttributes(sess, service, member, new Resource(), true);
 		// shouldn't find resource
 
 	}
@@ -6938,7 +6938,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.getRequiredAttributes(sess, service, resource, new Member(), true);
+		attributesManager.getRequiredAttributes(sess, service, new Member(), resource, true);
 		// shouldn't find member
 
 	}
@@ -7091,7 +7091,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		vo = setUpVo();
 		group = setUpGroup();
 
-		attributesManager.getRequiredAttributes(sess, service, new Resource(), member);
+		attributesManager.getRequiredAttributes(sess, service, member, new Resource());
 		// shouldn't find resource
 
 	}
@@ -7780,11 +7780,11 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		member = setUpMember();
 		attributes = setUpMemberResourceAttribute();
-		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, resource, attributes.get(0));
 		// create member-resource and set attribute with value
-		attributesManager.removeAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.removeAttribute(sess, member, resource, attributes.get(0));
 		// remove attribute from member-resource (definition or attribute)
-		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, resource);
 		assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
 	}
@@ -7796,7 +7796,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpMemberResourceAttribute();
 		vo = setUpVo();
 		member = setUpMember();
-		attributesManager.removeAttribute(sess, new Resource(), member, attributes.get(0));
+		attributesManager.removeAttribute(sess, member, new Resource(), attributes.get(0));
 		// shouldn't find resource
 
 	}
@@ -7809,7 +7809,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		vo = setUpVo();
 		facility = setUpFacility();
 		resource = setUpResource();
-		attributesManager.removeAttribute(sess, resource, new Member(), attributes.get(0));
+		attributesManager.removeAttribute(sess, new Member(), resource, attributes.get(0));
 		// shouldn't find member
 
 	}
@@ -7824,7 +7824,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		member = setUpMember();
 		attributes = setUpMemberResourceAttribute();
 		attributes.get(0).setId(0);
-		attributesManager.removeAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.removeAttribute(sess, member, resource, attributes.get(0));
 		// shouldn't find attribute
 
 	}
@@ -7838,7 +7838,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		member = setUpMember();
 		attributes = setUpFacilityAttribute();
-		attributesManager.removeAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.removeAttribute(sess, member, resource, attributes.get(0));
 		// shouldn't find facility attribute on member-resource
 
 	}
@@ -7852,11 +7852,11 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		member = setUpMember();
 		attributes = setUpMemberResourceAttribute();
-		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, resource, attributes.get(0));
 		// create member-resource and set attribute with value
-		attributesManager.removeAttributes(sess, resource, member, attributes);
+		attributesManager.removeAttributes(sess, member, resource, attributes);
 		// remove attributes from member-resource (definition or attribute)
-		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, resource);
 		assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 
 	}
@@ -7868,7 +7868,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		attributes = setUpMemberResourceAttribute();
 		vo = setUpVo();
 		member = setUpMember();
-		attributesManager.removeAttributes(sess, new Resource(), member, attributes);
+		attributesManager.removeAttributes(sess, member, new Resource(), attributes);
 		// shouldn't find resource
 
 	}
@@ -7881,7 +7881,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		vo = setUpVo();
 		facility = setUpFacility();
 		resource = setUpResource();
-		attributesManager.removeAttributes(sess, resource, new Member(), attributes);
+		attributesManager.removeAttributes(sess, new Member(), resource, attributes);
 		// shouldn't find member
 
 	}
@@ -7896,7 +7896,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		member = setUpMember();
 		attributes = setUpResourceAttribute();
 		attributes.get(0).setId(0);
-		attributesManager.removeAttributes(sess, resource, member, attributes);
+		attributesManager.removeAttributes(sess, member, resource, attributes);
 		// shouldn't find attribute
 
 	}
@@ -7910,7 +7910,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		member = setUpMember();
 		attributes = setUpFacilityAttribute();
-		attributesManager.removeAttributes(sess, resource, member, attributes);
+		attributesManager.removeAttributes(sess, member, resource, attributes);
 		// shouldn't find facility attribute on member-resource
 
 	}
@@ -7924,11 +7924,11 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		resource = setUpResource();
 		member = setUpMember();
 		attributes = setUpMemberResourceAttribute();
-		attributesManager.setAttribute(sess, resource, member, attributes.get(0));
+		attributesManager.setAttribute(sess, member, resource, attributes.get(0));
 		// create member-resource and set attribute with value
-		attributesManager.removeAllAttributes(sess, resource, member);
+		attributesManager.removeAllAttributes(sess, member, resource);
 		// remove all attributes from member-resource (definition or attribute)
-		List<Attribute> retAttr = attributesManager.getAttributes(sess, resource, member);
+		List<Attribute> retAttr = attributesManager.getAttributes(sess, member, resource);
 		assertFalse("our member-resource shouldn't have set our attribute",retAttr.contains(attributes.get(0)));
 		// member-resource don't have core attributes ??
 
@@ -7941,7 +7941,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		vo = setUpVo();
 		member = setUpMember();
 
-		attributesManager.removeAllAttributes(sess, new Resource(), member);
+		attributesManager.removeAllAttributes(sess, member, new Resource());
 		// shouldn't find resource
 
 	}
@@ -7954,7 +7954,7 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 		facility = setUpFacility();
 		resource = setUpResource();
 
-		attributesManager.removeAllAttributes(sess, resource, new Member());
+		attributesManager.removeAllAttributes(sess, new Member(), resource);
 		// shouldn't find member
 
 	}
@@ -13923,31 +13923,31 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 
 		member1U1Res1Vo1_test_attribute = new Attribute(memberResource_test_atr_def);
 		member1U1Res1Vo1_test_attribute.setValue("member1U1Res1Vo1");
-		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo1, member1OfUser1, member1U1Res1Vo1_test_attribute);
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser1, resource1InVo1, member1U1Res1Vo1_test_attribute);
 
 		member1U1Res2Vo1_test_attribute = new Attribute(memberResource_test_atr_def);
 		member1U1Res2Vo1_test_attribute.setValue("member1U1Res2Vo1");
-		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo1, member1OfUser1, member1U1Res2Vo1_test_attribute);
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser1, resource2InVo1, member1U1Res2Vo1_test_attribute);
 
 		member1U2Res1Vo2_test_attribute = new Attribute(memberResource_test_atr_def);
 		member1U2Res1Vo2_test_attribute.setValue("member1U2Res1Vo2");
-		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo2, member1OfUser2, member1U2Res1Vo2_test_attribute);
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser2, resource1InVo2, member1U2Res1Vo2_test_attribute);
 
 		member1U2Res2Vo2_test_attribute = new Attribute(memberResource_test_atr_def);
 		member1U2Res2Vo2_test_attribute.setValue("member1U2Res2Vo2");
-		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo2, member1OfUser2, member1U2Res2Vo2_test_attribute);
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser2, resource2InVo2, member1U2Res2Vo2_test_attribute);
 
 		member1U3Res1Vo1_test_attribute = new Attribute(memberResource_test_atr_def);
 		member1U3Res1Vo1_test_attribute.setValue("member1U3Res1Vo1");
-		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo1, member1OfUser3, member1U3Res1Vo1_test_attribute);
+		perun.getAttributesManagerBl().setAttribute(sess, member1OfUser3, resource1InVo1, member1U3Res1Vo1_test_attribute);
 
 		member2U3Res1Vo2_test_attribute = new Attribute(memberResource_test_atr_def);
 		member2U3Res1Vo2_test_attribute.setValue("member2U3Res1Vo2");
-		perun.getAttributesManagerBl().setAttribute(sess, resource1InVo2, member2OfUser3, member2U3Res1Vo2_test_attribute);
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser3, resource1InVo2, member2U3Res1Vo2_test_attribute);
 
 		member2U3Res2Vo2_test_attribute = new Attribute(memberResource_test_atr_def);
 		member2U3Res2Vo2_test_attribute.setValue("member2U3Res2Vo2");
-		perun.getAttributesManagerBl().setAttribute(sess, resource2InVo2, member2OfUser3, member2U3Res2Vo2_test_attribute);
+		perun.getAttributesManagerBl().setAttribute(sess, member2OfUser3, resource2InVo2, member2U3Res2Vo2_test_attribute);
 	}
 
 	/**

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -226,7 +226,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		map.put("A", "B");
 		map.put("C", "D");
 		Attribute memberResourceAttribute1 = setUpAttribute(LinkedHashMap.class.getName(), "testMemberResourceAttribute1", AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF, map);
-		perun.getAttributesManagerBl().setAttributes(sess, resource, createdMember, new ArrayList<>(Arrays.asList(memberResourceAttribute1)));
+		perun.getAttributesManagerBl().setAttributes(sess, createdMember, resource, new ArrayList<>(Arrays.asList(memberResourceAttribute1)));
 
 		List<String> attrNames = new ArrayList<>(Arrays.asList(userAttribute1.getName(), memberAttribute1.getName(), userFacilityAttribute1.getName(), memberResourceAttribute1.getName()));
 		List<RichMember> richMembers = membersManagerEntry.getCompleteRichMembers(sess, createdGroup, resource, attrNames, Arrays.asList("INVALID", "DISABLED", "SUSPENDED", "EXPIRED"));
@@ -268,7 +268,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		map.put("C", "D");
 		Attribute memberResourceAttribute1 = setUpAttribute(LinkedHashMap.class.getName(), "testMemberResourceAttribute1", AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF, map);
 		//test of member-group attributes
-		perun.getAttributesManagerBl().setAttributes(sess, resource, createdMember, new ArrayList<>(Arrays.asList(memberResourceAttribute1)));
+		perun.getAttributesManagerBl().setAttributes(sess, createdMember, resource, new ArrayList<>(Arrays.asList(memberResourceAttribute1)));
 		Map<String, String> groupMap = new LinkedHashMap<>();
 		groupMap.put("E", "F");
 		groupMap.put("G", "H");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -212,9 +212,9 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		resourceMemberAttrDef.setType(Integer.class.getName());
 		resourceMemberAttrDef = perun.getAttributesManagerBl().createAttribute(sess, resourceMemberAttrDef);
 
-		Attribute resourceMemberAttr = perun.getAttributesManagerBl().getAttribute(sess, resource, member, resourceMemberAttrDef.getName());
+		Attribute resourceMemberAttr = perun.getAttributesManagerBl().getAttribute(sess, member, resource, resourceMemberAttrDef.getName());
 		resourceMemberAttr.setValue(1);
-		perun.getAttributesManagerBl().setAttribute(sess, resource, member, resourceMemberAttr);
+		perun.getAttributesManagerBl().setAttribute(sess, member, resource, resourceMemberAttr);
 
 		resourcesManager.copyResource(sess, resource, destinationResource, true);
 
@@ -227,7 +227,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		assertFalse("Resource tag not created for destination resource.", resourcesManager.getAllResourcesTagsForResource(sess, createdResource).isEmpty());
 
 		// resource-member attributes check
-		List<Attribute> resMembAttrs = perun.getAttributesManagerBl().getAttributes(sess, createdResource, member);
+		List<Attribute> resMembAttrs = perun.getAttributesManagerBl().getAttributes(sess, member, createdResource);
 		assertFalse("Created resource does not contain any resource-member attributes.", resMembAttrs.isEmpty());
 		assertTrue("Created resource does not contain template resource-member attribute (or copied value of attribute is wrong).",resMembAttrs.contains(resourceMemberAttr));
 	}
@@ -334,7 +334,7 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 		// shouldn't find resource
 
 	}
-	
+
 	@Test
 	public void getVo() throws Exception {
 		System.out.println(CLASS_NAME + "getVo");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBannedTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBannedTest.java
@@ -81,7 +81,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBannedTest {
 		//for message 1, 2 and 3
 		when(session.getPerunBl().getMembersManagerBl().getMemberById(any(PerunSessionImpl.class), anyInt())).thenReturn(member);
 		when(session.getPerunBl().getResourcesManagerBl().getResourceById(any(PerunSessionImpl.class), anyInt())).thenReturn(resource);
-		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Resource.class), any(Member.class), anyString())).thenReturn(isBanned);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Member.class), any(Resource.class), anyString())).thenReturn(isBanned);
 		resolvedMessages = classInstance.resolveVirtualAttributeValueChange(session, message1);
 		assertEquals(resolvedMessages.size(), 1);
 		assertEquals(resolvedMessages.get(0), isBanned.serializeToString() + " set for " + resource.serializeToString() + " and " + member.serializeToString());
@@ -112,7 +112,7 @@ public class urn_perun_member_resource_attribute_def_virt_isBannedTest {
 		//for wrong message
 		when(session.getPerunBl().getMembersManagerBl().getMemberById(any(PerunSessionImpl.class), anyInt())).thenReturn(member);
 		when(session.getPerunBl().getResourcesManagerBl().getResourceById(any(PerunSessionImpl.class), anyInt())).thenReturn(resource);
-		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Resource.class), any(Member.class), anyString())).thenReturn(isBanned);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Member.class), any(Resource.class), anyString())).thenReturn(isBanned);
 		resolvedMessages = classInstance.resolveVirtualAttributeValueChange(session, wrongMessage);
 		assertTrue(resolvedMessages.isEmpty());
 	}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -320,7 +320,7 @@ public class ApiCaller {
 	}
 
 	public Attribute getAttributeById(Resource resource, Member member, int id) throws PerunException {
-		return getAttributesManager().getAttributeById(rpcSession, resource, member, id);
+		return getAttributesManager().getAttributeById(rpcSession, member, resource, id);
 	}
 
 	public Attribute getAttributeById(Member member, Group group, int id) throws PerunException {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AttributesManagerMethod.java
@@ -288,20 +288,21 @@ public enum AttributesManagerMethod implements ManagerMethod {
 					if (parms.contains("workWithUserAttributes")) {
 						if (parms.contains("attrNames")) {
 							return ac.getAttributesManager().getAttributes(ac.getSession(),
-									ac.getResourceById(parms.readInt("resource")),
 									ac.getMemberById(parms.readInt("member")),
+									ac.getResourceById(parms.readInt("resource")),
 									parms.readList("attrNames", String.class),
 									parms.readBoolean("workWithUserAttributes"));
 						} else {
 							return ac.getAttributesManager().getAttributes(ac.getSession(),
-									ac.getResourceById(parms.readInt("resource")),
 									ac.getMemberById(parms.readInt("member")),
+									ac.getResourceById(parms.readInt("resource")),
 									parms.readBoolean("workWithUserAttributes"));
 						}
 					} else {
 						return ac.getAttributesManager().getAttributes(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")));
+								ac.getMemberById(parms.readInt("member")),
+								ac.getResourceById(parms.readInt("resource"))
+						);
 					}
 				} else if (parms.contains("group")) {
 					if (parms.contains("workWithGroupAttributes")) {
@@ -596,14 +597,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				if (parms.contains("member")) {
 					if (parms.contains("workWithUserAttributes")) {
 						ac.getAttributesManager().setAttributes(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")),
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 								parms.readList("attributes", Attribute.class),
 								parms.readBoolean("workWithUserAttributes"));
 					} else {
 						ac.getAttributesManager().setAttributes(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")),
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 								parms.readList("attributes", Attribute.class));
 					}
 				} else if (parms.contains("group")) {
@@ -864,8 +863,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				} else if (parms.contains("resource")) {
 					if (parms.contains("member")) {
 						return ac.getAttributesManager().getAttributeById(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")),
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 								parms.readInt("attributeId"));
 					} else if (parms.contains("group")) {
 						return ac.getAttributesManager().getAttributeById(ac.getSession(),
@@ -932,8 +930,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				} else if (parms.contains("resource")) {
 					if (parms.contains("member")) {
 						return ac.getAttributesManager().getAttribute(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")),
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 								parms.readString("attributeName"));
 					} else if (parms.contains("group")) {
 						return ac.getAttributesManager().getAttribute(ac.getSession(),
@@ -1223,8 +1220,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("resource")) {
 				if (parms.contains("member")) {
 					ac.getAttributesManager().setAttribute(ac.getSession(),
-							ac.getResourceById(parms.readInt("resource")),
-							ac.getMemberById(parms.readInt("member")),
+							ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 							parms.read("attribute", Attribute.class));
 				} else if (parms.contains("group")) {
 					ac.getAttributesManager().setAttribute(ac.getSession(),
@@ -1538,14 +1534,13 @@ public enum AttributesManagerMethod implements ManagerMethod {
 						if (parms.contains("workWithUserAttributes")) {
 							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 									ac.getServiceById(parms.readInt("service")),
-									ac.getResourceById(parms.readInt("resource")),
-									ac.getMemberById(parms.readInt("member")),
+									ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 									parms.readBoolean("workWithUserAttributes"));
 						} else {
 							return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
 									ac.getServiceById(parms.readInt("service")),
-									ac.getResourceById(parms.readInt("resource")),
-									ac.getMemberById(parms.readInt("member")));
+									ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource"))
+							);
 						}
 					} else {
 						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
@@ -1607,12 +1602,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				if (parms.contains("member")) {
 					if (parms.contains("workWithUserAttributes")) {
 						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")), parms.readBoolean("workWithUserAttributes"));
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
+								parms.readBoolean("workWithUserAttributes"));
 					} else {
 						return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")));
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource"))
+						);
 					}
 				} else {
 					return ac.getAttributesManager().getRequiredAttributes(ac.getSession(),
@@ -1837,14 +1832,13 @@ public enum AttributesManagerMethod implements ManagerMethod {
 						} else if (parms.contains("workWithUserAttributes")) {
 							return ac.getAttributesManager().getResourceRequiredAttributes(ac.getSession(),
 									ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
-									ac.getResourceById(parms.readInt("resource")),
-									ac.getMemberById(parms.readInt("member")),
+									ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 									parms.readBoolean("workWithUserAttributes"));
 						} else {
 							return ac.getAttributesManager().getResourceRequiredAttributes(ac.getSession(),
 									ac.getResourceById(parms.readInt("resourceToGetServicesFrom")),
-									ac.getResourceById(parms.readInt("resource")),
-									ac.getMemberById(parms.readInt("member")));
+									ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource"))
+							);
 						}
 					} else if (parms.contains("group")) {
 						if (parms.contains("workWithUserAttributes")) {
@@ -1996,8 +1990,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				} else if (parms.contains("member")) {
 					Member member = ac.getMemberById(parms.readInt("member"));
 					return ac.getAttributesManager().fillAttribute(ac.getSession(),
-							resource,
-							member,
+							member, resource,
 							ac.getAttributeById(resource, member, parms.readInt("attribute")));
 				} else {
 					return ac.getAttributesManager().fillAttribute(ac.getSession(),
@@ -2173,14 +2166,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				} else if (parms.contains("member")) {
 					if (parms.contains("workWithUserAttributes")) {
 						return ac.getAttributesManager().fillAttributes(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")),
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 								attributes,
 								parms.readBoolean("workWithUserAttributes"));
 					} else {
 						return ac.getAttributesManager().fillAttributes(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")),
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 								attributes);
 					}
 				} else {
@@ -2404,8 +2395,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("resource")) {
 				if (parms.contains("member")) {
 					ac.getAttributesManager().checkAttributeValue(ac.getSession(),
-							ac.getResourceById(parms.readInt("resource")),
-							ac.getMemberById(parms.readInt("member")),
+							ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 							parms.read("attribute", Attribute.class));
 				} else if (parms.contains("group")) {
 					ac.getAttributesManager().checkAttributeValue(ac.getSession(),
@@ -2579,14 +2569,12 @@ public enum AttributesManagerMethod implements ManagerMethod {
 				if (parms.contains("member")) {
 					if (parms.contains("workWithUserAttributes")) {
 						ac.getAttributesManager().checkAttributesValue(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")),
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 								parms.readList("attributes", Attribute.class),
 								parms.readBoolean("workWithUserAttributes"));
 					} else {
 						ac.getAttributesManager().checkAttributesValue(ac.getSession(),
-								ac.getResourceById(parms.readInt("resource")),
-								ac.getMemberById(parms.readInt("member")),
+								ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 								parms.readList("attributes", Attribute.class));
 					}
 				} else if (parms.contains("group")) {
@@ -2825,8 +2813,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("resource")) {
 				if (parms.contains("member")) {
 					ac.getAttributesManager().removeAttributes(ac.getSession(),
-							ac.getResourceById(parms.readInt("resource")),
-							ac.getMemberById(parms.readInt("member")),
+							ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 							attributes);
 				} else if (parms.contains("group")) {
 					if (parms.contains("workWithGroupAttributes")) {
@@ -3016,8 +3003,7 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("resource")) {
 				if (parms.contains("member")) {
 					ac.getAttributesManager().removeAttribute(ac.getSession(),
-							ac.getResourceById(parms.readInt("resource")),
-							ac.getMemberById(parms.readInt("member")),
+							ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource")),
 							ac.getAttributeDefinitionById(parms.readInt("attribute")));
 				} else if (parms.contains("group")) {
 					ac.getAttributesManager().removeAttribute(ac.getSession(),
@@ -3165,8 +3151,8 @@ public enum AttributesManagerMethod implements ManagerMethod {
 			} else if (parms.contains("resource")) {
 				if (parms.contains("member")) {
 					ac.getAttributesManager().removeAllAttributes(ac.getSession(),
-							ac.getResourceById(parms.readInt("resource")),
-							ac.getMemberById(parms.readInt("member")));
+							ac.getMemberById(parms.readInt("member")), ac.getResourceById(parms.readInt("resource"))
+					);
 				} else if (parms.contains("group")) {
 					if (parms.contains("workWithGroupAttributes")) {
 						ac.getAttributesManager().removeAllAttributes(ac.getSession(),


### PR DESCRIPTION
- All methods which work with member-resource attributes now have
  aligned params in their API to match the namespace.
  This will prevent future confusion and bugs when we yet pass
  params to methods with generic attribute holders.
- Fixed loading user_facility:virt:fileQuotas where attribute
  holders were mixed and caused runtime consistency exception.