### PR TITLE
CORE: Removed group_member condition in getAllowed like methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -312,9 +312,8 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 		try  {
 			return jdbc.query("select distinct " + UsersManagerImpl.userMappingSelectQuery + " from groups_resources join groups on groups_resources.group_id=groups.id" +
 					" join groups_members on groups.id=groups_members.group_id join members on groups_members.member_id=members.id join users on " +
-					" users.id=members.user_id where groups_resources.resource_id=? and members.status!=? and members.status!=? and groups_members.status=?",
-					UsersManagerImpl.USER_MAPPER, resource.getId(),	String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()),
-					String.valueOf(MemberGroupStatus.VALID.getCode()));
+					" users.id=members.user_id where groups_resources.resource_id=? and members.status!=? and members.status!=?",
+					UsersManagerImpl.USER_MAPPER, resource.getId(),	String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<User>();
 		} catch (RuntimeException e) {
@@ -329,8 +328,8 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 					" left outer join groups_resources on groups_resources.resource_id=resources.id" +
 					" left outer join groups_members on groups_members.group_id=groups_resources.group_id" +
 					" left outer join members on members.id=groups_members.member_id" +
-					" where facilities.id=? and members.user_id=? and members.status!=? and groups_members.status=?",
-					RESOURCE_MAPPER, facility.getId(), user.getId(), String.valueOf(Status.INVALID.getCode()), String.valueOf(MemberGroupStatus.VALID.getCode()));
+					" where facilities.id=? and members.user_id=? and members.status!=?",
+					RESOURCE_MAPPER, facility.getId(), user.getId(), String.valueOf(Status.INVALID.getCode()));
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<Resource>();
 		}	catch (RuntimeException e) {
@@ -343,8 +342,8 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 		try  {
 			return jdbc.query("select distinct " + MembersManagerImpl.memberMappingSelectQuery + " from groups_resources join groups on groups_resources.group_id=groups.id" +
 					" join groups_members on groups.id=groups_members.group_id join members on groups_members.member_id=members.id " +
-					" where groups_resources.resource_id=? and members.status!=? and members.status!=? and groups_members.status=?", MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, resource.getId(),
-					String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()), String.valueOf(MemberGroupStatus.VALID.getCode()));
+					" where groups_resources.resource_id=? and members.status!=? and members.status!=?", MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, resource.getId(),
+					String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<Member>();
 		} catch (RuntimeException e) {


### PR DESCRIPTION
- Since there is a wrong column used in select and we don't want to
  limit "allowed" members by their group status, this commit removes
  such condition from the code.
- We will solve this condition by specific member_group,
  member_resource and user_facility virtual attributes.