### PR TITLE
CORE: Group admin should be allowed to get member by user

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -348,6 +348,7 @@ public class MembersManagerEntry implements MembersManager {
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo) &&
+				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.SELF, user)) {
 			throw new PrivilegeException(sess, "getMemberByUser");
 		}


### PR DESCRIPTION
- We allow group admins to get all vo members, so we should
  allow it for a single member too.
- This fixes problem with group extension applications, which group
  admins are currently not allowed to approve.