### PR TITLE
CORE: Fixed order of params and names in attribute modules 

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -557,7 +557,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 			try {
 				UserFacilityVirtualAttributesModuleImplApi attributeModule = attributesManagerImpl.getFacilityUserVirtualAttributeModule(sess, attribute);
-				return attributeModule.getAttributeValue((PerunSessionImpl) sess, (Facility) attributeHolder2, (User) attributeHolder, attribute);
+				return attributeModule.getAttributeValue((PerunSessionImpl) sess, (User) attributeHolder, (Facility) attributeHolder2, attribute);
 			} catch (InternalErrorException ex) {
 				throw new InternalErrorRuntimeException(ex);
 			}
@@ -625,7 +625,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 			try {
 				GroupResourceVirtualAttributesModuleImplApi attributeModule = attributesManagerImpl.getResourceGroupVirtualAttributeModule(sess, attribute);
-				return attributeModule.getAttributeValue((PerunSessionImpl) sess, (Resource) attributeHolder2, (Group) attributeHolder, attribute);
+				return attributeModule.getAttributeValue((PerunSessionImpl) sess, (Group) attributeHolder, (Resource) attributeHolder2, attribute);
 			} catch (InternalErrorException ex) {
 				throw new InternalErrorRuntimeException(ex);
 			}
@@ -2667,12 +2667,12 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public boolean setVirtualAttribute(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
-		return getFacilityUserVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, facility, user, attribute);
+		return getFacilityUserVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, user, facility, attribute);
 	}
 
 	@Override
 	public boolean setVirtualAttribute(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
-		return getResourceGroupVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, resource, group, attribute);
+		return getResourceGroupVirtualAttributeModule(sess, attribute).setAttributeValue((PerunSessionImpl) sess, group, resource, attribute);
 	}
 
 	@Override
@@ -3636,7 +3636,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		}
 
 		try {
-			return attributeModule.fillAttribute((PerunSessionImpl) sess, facility, user, attribute);
+			return attributeModule.fillAttribute((PerunSessionImpl) sess, user, facility, attribute);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3678,7 +3678,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			return attribute;
 		}
 		try {
-			return attributeModule.fillAttribute((PerunSessionImpl) sess, resource, group, attribute);
+			return attributeModule.fillAttribute((PerunSessionImpl) sess, group, resource, attribute);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3816,7 +3816,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		GroupResourceAttributesModuleImplApi resourceGroupModule = getResourceGroupAttributeModule(sess, attribute);
 		if (resourceGroupModule == null) return; //facility module doesn't exists
 		try {
-			resourceGroupModule.changedAttributeHook((PerunSessionImpl) sess, resource, group, attribute);
+			resourceGroupModule.changedAttributeHook((PerunSessionImpl) sess, group, resource, attribute);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3864,7 +3864,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		UserFacilityAttributesModuleImplApi facilityUserModule = getFacilityUserAttributeModule(sess, attribute);
 		if (facilityUserModule == null) return; //facility module doesn't exists
 		try {
-			facilityUserModule.changedAttributeHook((PerunSessionImpl) sess, facility, user, attribute);
+			facilityUserModule.changedAttributeHook((PerunSessionImpl) sess, user, facility, attribute);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -3966,7 +3966,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		UserFacilityAttributesModuleImplApi attributeModule = getFacilityUserAttributeModule(sess, attribute);
 		if (attributeModule == null) return;
 		try {
-			attributeModule.checkAttributeValue((PerunSessionImpl) sess, facility, user, attribute);
+			attributeModule.checkAttributeValue((PerunSessionImpl) sess, user, facility, attribute);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -4021,7 +4021,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		GroupResourceAttributesModuleImplApi attributeModule = getResourceGroupAttributeModule(sess, attribute);
 		if (attributeModule == null) return;
 		try {
-			attributeModule.checkAttributeValue((PerunSessionImpl) sess, resource, group, attribute);
+			attributeModule.checkAttributeValue((PerunSessionImpl) sess, group, resource, attribute);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new InternalErrorException(ex);
 		}
@@ -4307,7 +4307,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public boolean removeVirtualAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
-		return getFacilityUserVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, facility, user, attribute);
+		return getFacilityUserVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, user, facility, attribute);
 	}
 
 	@Override
@@ -4317,7 +4317,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public boolean removeVirtualAttribute(PerunSession sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		return getResourceGroupVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, resource, group, attribute);
+		return getResourceGroupVirtualAttributeModule(sess, attribute).removeAttributeValue((PerunSessionImpl) sess, group, resource, attribute);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -32,8 +32,8 @@ import cz.metacentrum.perun.core.implApi.AttributesManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupVirtualAttributesModuleImplApi;
@@ -43,10 +43,10 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.MemberGroupAttribute
 import cz.metacentrum.perun.core.implApi.modules.attributes.MemberGroupVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.MemberVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleImplApi;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceVirtualAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserExtSourceAttributesModuleImplApi;
@@ -556,7 +556,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				throw new ConsistencyErrorRuntimeException("Second attribute holder of user_facility attribute isn't facility");
 
 			try {
-				FacilityUserVirtualAttributesModuleImplApi attributeModule = attributesManagerImpl.getFacilityUserVirtualAttributeModule(sess, attribute);
+				UserFacilityVirtualAttributesModuleImplApi attributeModule = attributesManagerImpl.getFacilityUserVirtualAttributeModule(sess, attribute);
 				return attributeModule.getAttributeValue((PerunSessionImpl) sess, (Facility) attributeHolder2, (User) attributeHolder, attribute);
 			} catch (InternalErrorException ex) {
 				throw new InternalErrorRuntimeException(ex);
@@ -624,7 +624,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				throw new ConsistencyErrorRuntimeException("Second attribute holder of group-resource attribute isn't resource");
 
 			try {
-				ResourceGroupVirtualAttributesModuleImplApi attributeModule = attributesManagerImpl.getResourceGroupVirtualAttributeModule(sess, attribute);
+				GroupResourceVirtualAttributesModuleImplApi attributeModule = attributesManagerImpl.getResourceGroupVirtualAttributeModule(sess, attribute);
 				return attributeModule.getAttributeValue((PerunSessionImpl) sess, (Resource) attributeHolder2, (Group) attributeHolder, attribute);
 			} catch (InternalErrorException ex) {
 				throw new InternalErrorRuntimeException(ex);
@@ -637,7 +637,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				throw new ConsistencyErrorRuntimeException("Second attribute holder of member_resource attribute isn't Resource");
 
 			try {
-				ResourceMemberVirtualAttributesModuleImplApi attributeModule = attributesManagerImpl.getResourceMemberVirtualAttributeModule(sess, attribute);
+				MemberResourceVirtualAttributesModuleImplApi attributeModule = attributesManagerImpl.getResourceMemberVirtualAttributeModule(sess, attribute);
 				return attributeModule.getAttributeValue((PerunSessionImpl) sess, (Member) attributeHolder, (Resource) attributeHolder2, attribute);
 			} catch (InternalErrorException ex) {
 				throw new InternalErrorRuntimeException(ex);
@@ -3597,7 +3597,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public Attribute fillAttribute(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException {
 		//Use attributes module
-		ResourceMemberAttributesModuleImplApi attributeModule = getResourceMemberAttributeModule(sess, attribute);
+		MemberResourceAttributesModuleImplApi attributeModule = getResourceMemberAttributeModule(sess, attribute);
 		if (attributeModule == null) {
 			log.debug("Attribute wasn't filled. There is no module for: {}.", attribute.getName());
 			return attribute;
@@ -3629,7 +3629,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public Attribute fillAttribute(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException {
 		//Use attributes module
-		FacilityUserAttributesModuleImplApi attributeModule = getFacilityUserAttributeModule(sess, attribute);
+		UserFacilityAttributesModuleImplApi attributeModule = getFacilityUserAttributeModule(sess, attribute);
 		if (attributeModule == null) {
 			log.debug("Attribute wasn't filled. There is no module for: {}.", attribute.getName());
 			return attribute;
@@ -3672,7 +3672,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public Attribute fillAttribute(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException {
-		ResourceGroupAttributesModuleImplApi attributeModule = getResourceGroupAttributeModule(sess, attribute);
+		GroupResourceAttributesModuleImplApi attributeModule = getResourceGroupAttributeModule(sess, attribute);
 		if (attributeModule == null) {
 			log.debug("Attribute wasn't filled. There is no module for: {}.", attribute.getName());
 			return attribute;
@@ -3813,7 +3813,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public void changedAttributeHook(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//Call attribute module
-		ResourceGroupAttributesModuleImplApi resourceGroupModule = getResourceGroupAttributeModule(sess, attribute);
+		GroupResourceAttributesModuleImplApi resourceGroupModule = getResourceGroupAttributeModule(sess, attribute);
 		if (resourceGroupModule == null) return; //facility module doesn't exists
 		try {
 			resourceGroupModule.changedAttributeHook((PerunSessionImpl) sess, resource, group, attribute);
@@ -3837,7 +3837,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public void changedAttributeHook(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//Call attribute module
-		ResourceMemberAttributesModuleImplApi resourceMemberGroupModule = getResourceMemberAttributeModule(sess, attribute);
+		MemberResourceAttributesModuleImplApi resourceMemberGroupModule = getResourceMemberAttributeModule(sess, attribute);
 		if (resourceMemberGroupModule == null) return; //facility module doesn't exists
 		try {
 			resourceMemberGroupModule.changedAttributeHook((PerunSessionImpl) sess, member, resource, attribute);
@@ -3861,7 +3861,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public void changedAttributeHook(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//Call attribute module
-		FacilityUserAttributesModuleImplApi facilityUserModule = getFacilityUserAttributeModule(sess, attribute);
+		UserFacilityAttributesModuleImplApi facilityUserModule = getFacilityUserAttributeModule(sess, attribute);
 		if (facilityUserModule == null) return; //facility module doesn't exists
 		try {
 			facilityUserModule.changedAttributeHook((PerunSessionImpl) sess, facility, user, attribute);
@@ -3940,7 +3940,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	@Override
 	public void checkAttributeValue(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//Call attribute module
-		ResourceMemberAttributesModuleImplApi resourceMemberGroupModule = getResourceMemberAttributeModule(sess, attribute);
+		MemberResourceAttributesModuleImplApi resourceMemberGroupModule = getResourceMemberAttributeModule(sess, attribute);
 		if (resourceMemberGroupModule == null) return; //facility module doesn't exists
 		try {
 			resourceMemberGroupModule.checkAttributeValue((PerunSessionImpl) sess, member, resource, attribute);
@@ -3963,7 +3963,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSession sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException {
-		FacilityUserAttributesModuleImplApi attributeModule = getFacilityUserAttributeModule(sess, attribute);
+		UserFacilityAttributesModuleImplApi attributeModule = getFacilityUserAttributeModule(sess, attribute);
 		if (attributeModule == null) return;
 		try {
 			attributeModule.checkAttributeValue((PerunSessionImpl) sess, facility, user, attribute);
@@ -4018,7 +4018,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		ResourceGroupAttributesModuleImplApi attributeModule = getResourceGroupAttributeModule(sess, attribute);
+		GroupResourceAttributesModuleImplApi attributeModule = getResourceGroupAttributeModule(sess, attribute);
 		if (attributeModule == null) return;
 		try {
 			attributeModule.checkAttributeValue((PerunSessionImpl) sess, resource, group, attribute);
@@ -4751,12 +4751,12 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 * @return instance resource member attribute module
 	 * null if the module doesn't exists
 	 */
-	private ResourceMemberAttributesModuleImplApi getResourceMemberAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
+	private MemberResourceAttributesModuleImplApi getResourceMemberAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
 		if (attributeModule == null) return null;
 
-		if (attributeModule instanceof ResourceMemberAttributesModuleImplApi) {
-			return (ResourceMemberAttributesModuleImplApi) attributeModule;
+		if (attributeModule instanceof MemberResourceAttributesModuleImplApi) {
+			return (MemberResourceAttributesModuleImplApi) attributeModule;
 		} else {
 			throw new WrongModuleTypeException("Required attribute module isn't FacilityAttributesModule");
 		}
@@ -4883,12 +4883,12 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 * @param attribute attribute for which you get the module
 	 * @return instance user-facility attribute module, null if the module doesn't exists
 	 */
-	private FacilityUserAttributesModuleImplApi getFacilityUserAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
+	private UserFacilityAttributesModuleImplApi getFacilityUserAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
 		if (attributeModule == null) return null;
 
-		if (attributeModule instanceof FacilityUserAttributesModuleImplApi) {
-			return (FacilityUserAttributesModuleImplApi) attributeModule;
+		if (attributeModule instanceof UserFacilityAttributesModuleImplApi) {
+			return (UserFacilityAttributesModuleImplApi) attributeModule;
 		} else {
 			throw new InternalErrorException("Required attribute module isn't FacilityUserAttributesModule");
 		}
@@ -4900,13 +4900,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 * @param attribute attribute for which you get the module
 	 * @return instance user-facility attribute module, null if the module doesn't exists
 	 */
-	private FacilityUserVirtualAttributesModuleImplApi getFacilityUserVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
+	private UserFacilityVirtualAttributesModuleImplApi getFacilityUserVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
 		if (attributeModule == null)
 			throw new ModuleNotExistsException("Virtual attribute module for " + attribute + " doesn't exists.");
 
-		if (attributeModule instanceof FacilityUserVirtualAttributesModuleImplApi) {
-			return (FacilityUserVirtualAttributesModuleImplApi) attributeModule;
+		if (attributeModule instanceof UserFacilityVirtualAttributesModuleImplApi) {
+			return (UserFacilityVirtualAttributesModuleImplApi) attributeModule;
 		} else {
 			throw new WrongModuleTypeException("Required attribute module isn't FacilityUserVirtualAttributesModule");
 		}
@@ -4969,11 +4969,11 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 * @param attribute attribute for which you get the module
 	 * @return instance resource attribute module, null if the module doesn't exists
 	 */
-	private ResourceGroupAttributesModuleImplApi getResourceGroupAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
+	private GroupResourceAttributesModuleImplApi getResourceGroupAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
 		if (attributeModule == null) return null;
-		if (attributeModule instanceof ResourceGroupAttributesModuleImplApi) {
-			return (ResourceGroupAttributesModuleImplApi) attributeModule;
+		if (attributeModule instanceof GroupResourceAttributesModuleImplApi) {
+			return (GroupResourceAttributesModuleImplApi) attributeModule;
 
 		} else {
 			throw new InternalErrorException("Required attribute module isn't ResourceGroupAttributesModule");
@@ -5003,12 +5003,12 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 * @param attribute attribute for which you get the module
 	 * @return instance group-resource attribute module, null if the module doesn't exists
 	 */
-	ResourceGroupVirtualAttributesModuleImplApi getResourceGroupVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
+	GroupResourceVirtualAttributesModuleImplApi getResourceGroupVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
 		if (attributeModule == null) return null;
 
-		if (attributeModule instanceof ResourceGroupVirtualAttributesModuleImplApi) {
-			return (ResourceGroupVirtualAttributesModuleImplApi) attributeModule;
+		if (attributeModule instanceof GroupResourceVirtualAttributesModuleImplApi) {
+			return (GroupResourceVirtualAttributesModuleImplApi) attributeModule;
 		} else {
 			throw new InternalErrorException("Required attribute module isn't ResourceGroupVirtualAttributesModule");
 		}
@@ -5020,12 +5020,12 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 * @param attribute attribute for which you get the module
 	 * @return instance member-resource attribute module, null if the module doesn't exists
 	 */
-	ResourceMemberVirtualAttributesModuleImplApi getResourceMemberVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
+	MemberResourceVirtualAttributesModuleImplApi getResourceMemberVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
 		if (attributeModule == null) return null;
 
-		if (attributeModule instanceof ResourceMemberVirtualAttributesModuleImplApi) {
-			return (ResourceMemberVirtualAttributesModuleImplApi) attributeModule;
+		if (attributeModule instanceof MemberResourceVirtualAttributesModuleImplApi) {
+			return (MemberResourceVirtualAttributesModuleImplApi) attributeModule;
 		} else {
 			throw new InternalErrorException("Required attribute module isn't ResourceMemberVirtualAttributesModule");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adName.java
@@ -12,8 +12,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  *
  * @author Michal Stava  stavamichal@gmail.com
  */
-public class urn_perun_group_resource_attribute_def_def_adName extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_adName extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final String A_R_D_AD_OU_NAME = AttributesManager.NS_RESOURCE_ATTR_DEF + ":adOuName";
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adName.java
@@ -38,7 +38,7 @@ public class urn_perun_group_resource_attribute_def_def_adName extends GroupReso
 	private static final Pattern pattern = Pattern.compile("(\\w|-|\\.)*");
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String attributeValue;
 
 		//Attribute can be null

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_drupalGroupType.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_drupalGroupType.java
@@ -25,7 +25,7 @@ public class urn_perun_group_resource_attribute_def_def_drupalGroupType extends 
 	private final static org.slf4j.Logger log = LoggerFactory.getLogger(urn_perun_group_resource_attribute_def_def_drupalGroupType.class);
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String attributeValue = null;
 
 		if(attribute.getValue() == null) {
@@ -41,7 +41,7 @@ public class urn_perun_group_resource_attribute_def_def_drupalGroupType extends 
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl session, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl session, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute filledAttribute = new Attribute(attribute);
 
 		String attributeValue = (String) filledAttribute.getValue();
@@ -49,7 +49,7 @@ public class urn_perun_group_resource_attribute_def_def_drupalGroupType extends 
 			filledAttribute.setValue("public");
 		} else {
 			try {
-				checkAttributeValue(session, resource, group, filledAttribute);
+				checkAttributeValue(session, group, resource, filledAttribute);
 			} catch (WrongAttributeValueException ex) {
 				log.error("Type of drupal group can be either 'public' or 'private'.", ex);
 			} catch (WrongReferenceAttributeValueException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_drupalGroupType.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_drupalGroupType.java
@@ -10,10 +10,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -22,10 +20,10 @@ import org.slf4j.LoggerFactory;
  * @author Sona Mastrakova <sona.mastrakova@gmail.com>
  * @date 16.10.2015
  */
-public class urn_perun_group_resource_attribute_def_def_drupalGroupType extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_drupalGroupType extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private final static org.slf4j.Logger log = LoggerFactory.getLogger(urn_perun_group_resource_attribute_def_def_drupalGroupType.class);
-	
+
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String attributeValue = null;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_freeipaGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_freeipaGroupName.java
@@ -34,7 +34,7 @@ public class urn_perun_group_resource_attribute_def_def_freeipaGroupName extends
 	private static final String A_GR_freeipaGroupName = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":freeipaGroupName";
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 		//prepare group name and check its format
 		String groupName = (String) attribute.getValue();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_freeipaGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_freeipaGroupName.java
@@ -14,10 +14,9 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -29,7 +28,7 @@ import java.util.regex.Pattern;
  * @author Peter Balcirak <peter.balcirak@gmail.com>
  * @date 16.5.2016
  */
-public class urn_perun_group_resource_attribute_def_def_freeipaGroupName extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_freeipaGroupName extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final Pattern pattern = Pattern.compile("^[a-zA-Z0-9_.][a-zA-Z0-9_.-]{0,252}[a-zA-Z0-9_.$-]?$");
 	private static final String A_GR_freeipaGroupName = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":freeipaGroupName";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isSystemUnixGroup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isSystemUnixGroup.java
@@ -4,9 +4,7 @@ import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
-import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -17,15 +15,15 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 import java.util.ArrayList;
 
 /**
  *
  * @author Michal Stava email:&lt;stavamichal@gmail.com&gt;
  */
-public class urn_perun_group_resource_attribute_def_def_isSystemUnixGroup extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_isSystemUnixGroup extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final String A_GR_systemUnixGroupName = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGroupName";
 	private static final String A_GR_systemUnixGID = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGID";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isSystemUnixGroup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isSystemUnixGroup.java
@@ -29,12 +29,12 @@ public class urn_perun_group_resource_attribute_def_def_isSystemUnixGroup extend
 	private static final String A_GR_systemUnixGID = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGID";
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		return new Attribute(attributeDefinition);
 	}
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
 
 		Integer isSystemUnixGroup = (Integer) attribute.getValue();
 		if(isSystemUnixGroup == null) return; //isSystemUnixGroup can be null. It is equivalent to 0.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu.java
@@ -55,7 +55,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu ex
 	static final String ADNAME_ATTRIBUTE = NAMESPACE + ":adName";
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		log.trace("checkAttributeValue(resource={},group={},attribute={})", resource, group, attribute);
 		ArrayList<String> emails;
 		//get values
@@ -112,7 +112,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu ex
 	 * Prefills value created by joining value of urn:perun:group_resource:attribute-def:def:adName with "@group.muni.cz"
 	 */
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attrDef) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attrDef) throws InternalErrorException, WrongAttributeAssignmentException {
 		if (!NAMESPACE.equals(attrDef.getNamespace())) throw new WrongAttributeAssignmentException(attrDef);
 		try {
 			Attribute result = new Attribute(attrDef);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu.java
@@ -16,8 +16,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.AttributesManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ import static cz.metacentrum.perun.core.impl.Utils.hasDuplicate;
  * @author Martin Kuba &lt;makub@ics.muni.cz>
  */
 @SuppressWarnings("unused")
-public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_group_resource_attribute_def_def_o365EmailAddresses_mu.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimit.java
@@ -13,10 +13,9 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -28,7 +27,7 @@ import java.math.BigDecimal;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_group_resource_attribute_def_def_projectDataLimit extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_projectDataLimit extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final String A_GR_projectDataQuota = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectDataQuota";
 	private static final Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimit.java
@@ -43,7 +43,7 @@ public class urn_perun_group_resource_attribute_def_def_projectDataLimit extends
 	long E = P * 1024;
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrProjectDataQuota = null;
 		String projectDataQuota = null;
 		String projectDataLimit = null;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuota.java
@@ -43,7 +43,7 @@ public class urn_perun_group_resource_attribute_def_def_projectDataQuota extends
 	long E = P * 1024;
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrProjectDataLimit = null;
 		String projectDataQuota = null;
 		String projectDataLimit = null;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuota.java
@@ -13,10 +13,9 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -28,7 +27,7 @@ import java.math.BigDecimal;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_group_resource_attribute_def_def_projectDataQuota extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_projectDataQuota extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final String A_GR_projectDataLimit = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectDataLimit";
 	private static final Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
@@ -158,7 +157,7 @@ public class urn_perun_group_resource_attribute_def_def_projectDataQuota extends
 		attr.setNamespace(AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF);
 		attr.setFriendlyName("projectDataQuota");
 		attr.setDisplayName("Project soft data quota.");
-		attr.setType(String.class.getName());		
+		attr.setType(String.class.getName());
 		attr.setDescription("Project soft quota including units (M, G, T, ...), G is default.");
 		return attr;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissions.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissions.java
@@ -10,8 +10,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
  * @author Michal Stava <stavamichal@gmail.com>
  * @date 25.2.2014
  */
-public class urn_perun_group_resource_attribute_def_def_projectDirPermissions extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_projectDirPermissions extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final Pattern pattern = Pattern.compile("^[01234567]{3}$");
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissions.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissions.java
@@ -27,7 +27,7 @@ public class urn_perun_group_resource_attribute_def_def_projectDirPermissions ex
 	private static final Pattern pattern = Pattern.compile("^[01234567]{3}$");
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Integer permissions = (Integer) attribute.getValue();
 		//Permissions can be null (if null, it means DEFAULT 750)
 		if (permissions == null) return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectName.java
@@ -35,7 +35,7 @@ public class urn_perun_group_resource_attribute_def_def_projectName extends Grou
 	private static final Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9]+$");
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String name = (String) attribute.getValue();
 		if (name == null) return;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectName.java
@@ -14,13 +14,11 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,7 +28,7 @@ import java.util.regex.Pattern;
  * @author Michal Stava <stavamichal@gmail.com>
  * @date 25.2.2014
  */
-public class urn_perun_group_resource_attribute_def_def_projectName extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_projectName extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final String A_R_projectsBasePath = AttributesManager.NS_RESOURCE_ATTR_DEF + ":projectsBasePath";
 	private static final String A_GR_projectName = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectName";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
@@ -5,7 +5,6 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -15,13 +14,11 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
-import java.util.ArrayList;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
+
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,7 +28,7 @@ import java.util.regex.Pattern;
  * @author Michal Stava <stavamichal@gmail.com>
  * @date 25.2.2014
  */
-public class urn_perun_group_resource_attribute_def_def_projectOwnerLogin extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_projectOwnerLogin extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final String A_UF_V_login = AttributesManager.NS_USER_FACILITY_ATTR_VIRT + ":login";
 	private static final Pattern pattern = Pattern.compile("^[a-zA-Z0-9][-A-z0-9_.@/]*$");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
@@ -34,7 +34,7 @@ public class urn_perun_group_resource_attribute_def_def_projectOwnerLogin extend
 	private static final Pattern pattern = Pattern.compile("^[a-zA-Z0-9][-A-z0-9_.@/]*$");
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String ownerLogin = (String) attribute.getValue();
 		if (ownerLogin == null) return;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGID.java
@@ -18,15 +18,15 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 import java.util.ArrayList;
 
 /**
  *
  * @author Michal Stava email:&lt;stavamichal@gmail.com&gt;
  */
-public class urn_perun_group_resource_attribute_def_def_systemUnixGID extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_systemUnixGID extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final String A_GR_systemUnixGroupName = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGroupName";
 	private static final String A_GR_systemIsUnixGroup = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":isSystemUnixGroup";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGID.java
@@ -32,12 +32,12 @@ public class urn_perun_group_resource_attribute_def_def_systemUnixGID extends Gr
 	private static final String A_GR_systemIsUnixGroup = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":isSystemUnixGroup";
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		return new Attribute(attributeDefinition);
 	}
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
 		Integer gid = (Integer) attribute.getValue();
 
 		//Gid should not be null if is system unix group or if less than 1

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupName.java
@@ -11,8 +11,8 @@ import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.*;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  *
  * @author Michal Stava email:&lt;stavamichal@gmail.com&gt;
  */
-public class urn_perun_group_resource_attribute_def_def_systemUnixGroupName extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_systemUnixGroupName extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private static final String A_GR_systemUnixGID = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGID";
 	private static final String A_GR_systemIsUnixGroup = AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":isSystemUnixGroup";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupName.java
@@ -28,12 +28,12 @@ public class urn_perun_group_resource_attribute_def_def_systemUnixGroupName exte
 	private static final Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9]*$");
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		return new Attribute(attributeDefinition);
 	}
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
 
 		String groupName = (String) attribute.getValue();
 		Attribute isSystemGroup = new Attribute();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsGroupName.java
@@ -22,7 +22,7 @@ public class urn_perun_group_resource_attribute_def_def_vomsGroupName extends Gr
     private static final Pattern pattern = Pattern.compile("^[^<>&=]*$");
 
     @Override
-    public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+    public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
         String vomsGroupName;
 
         if(attribute.getValue() == null) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsGroupName.java
@@ -7,8 +7,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  *
  * @author Vladimir Mecko vladimir.mecko@gmail.com
  */
-public class urn_perun_group_resource_attribute_def_def_vomsGroupName extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_vomsGroupName extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
     private static final Pattern pattern = Pattern.compile("^[^<>&=]*$");
 
     @Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsRoles.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsRoles.java
@@ -6,8 +6,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
  *
  * @author Vladimir Mecko vladimir.mecko@gmail.com
  */
-public class urn_perun_group_resource_attribute_def_def_vomsRoles extends ResourceGroupAttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_def_vomsRoles extends GroupResourceAttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	private final Pattern pattern = Pattern.compile("^[^<>&]*$");
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsRoles.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsRoles.java
@@ -25,7 +25,7 @@ public class urn_perun_group_resource_attribute_def_def_vomsRoles extends GroupR
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		if(attribute.getValue() == null) {
 			return;
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
@@ -16,15 +16,15 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtualAttributesModuleImplApi;
 
 /**
  * Module to resolve correct group name in G-suite (google groups) based on its domain.
  *
  * @author Michal Stava &lt;stavamichal@gmail.com&gt;
  */
-public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends ResourceGroupVirtualAttributesModuleAbstract implements ResourceGroupVirtualAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
@@ -27,7 +27,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtual
 public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getGoogleGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 		// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
 		String namespace = ((String) googleGroupNameNamespaceAttribute.getValue()).replaceAll("\\.", "-");
@@ -49,7 +49,7 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		Attribute googleGroupNameNamespaceAttribute;
@@ -84,7 +84,7 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 	}
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		Attribute googleGroupNameNamespaceAttribute;
@@ -108,7 +108,7 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 	}
 
 	@Override
-	public boolean setAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getGoogleGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 
 		try {
@@ -127,7 +127,7 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 	}
 
 	@Override
-	public boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		return false;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
@@ -1,7 +1,6 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
@@ -17,14 +16,14 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtualAttributesModuleImplApi;
 
 /**
  *
  * @author Slavek Licehammer &lt;glory@ics.muni.cz&gt;
  */
-public class urn_perun_group_resource_attribute_def_virt_unixGID extends ResourceGroupVirtualAttributesModuleAbstract implements ResourceGroupVirtualAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
@@ -26,7 +26,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtual
 public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute unixGIDNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGIDNamespaceAttributeWithNotNullValue(sess, resource);
 		Attribute gidAttribute;
 		try {
@@ -45,7 +45,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupRe
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		Attribute unixGIDNamespaceAttribute;
@@ -78,7 +78,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupRe
 	}
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		Attribute unixGIDNamespaceAttribute;
@@ -100,7 +100,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupRe
 	}
 
 	@Override
-	public boolean setAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		Attribute unixGIDNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGIDNamespaceAttributeWithNotNullValue(sess, resource);
 
 		try {
@@ -117,7 +117,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupRe
 	}
 
 	@Override
-	public boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		return false;
 		/* This method remove attribute for Group not only GroupResource (we dont want it)
 			 Attribute unixGIDNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGIDNamespaceAttributeWithNotNullValue(sess, resource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
@@ -26,7 +26,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtual
 public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute unixGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 		Attribute groupNameAttribute;
 		try {
@@ -46,7 +46,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends G
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		Attribute unixGroupNameNamespaceAttribute;
@@ -79,7 +79,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends G
 	}
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		Attribute unixGroupNameNamespaceAttribute;
@@ -101,7 +101,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends G
 	}
 
 	@Override
-	public boolean setAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		Attribute unixGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 
 		try {
@@ -118,7 +118,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends G
 	}
 
 	@Override
-	public boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		return false;
 		/* This method remove attribute for Group not only GroupResource (we dont want it)
 			 Attribute unixGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGroupNameNamespaceAttributeWithNotNullValue(sess, resource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
@@ -1,7 +1,6 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import cz.metacentrum.perun.core.api.Attribute;
@@ -17,14 +16,14 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceGroupVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceVirtualAttributesModuleImplApi;
 
 /**
  *
  * @author Slavek Licehammer &lt;glory@ics.muni.cz&gt;
  */
-public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends ResourceGroupVirtualAttributesModuleAbstract implements ResourceGroupVirtualAttributesModuleImplApi {
+public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
@@ -13,8 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_def_dataLimit extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_def_dataLimit extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultDataLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit";
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuota.java
@@ -13,8 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_def_dataQuota extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_def_dataQuota extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultDataLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit";
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
@@ -14,8 +14,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import java.util.Map;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_def_dataQuotas extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_def_dataQuotas extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	public static final String A_R_maxUserDataQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserDataQuotas";
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotasOverride.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotasOverride.java
@@ -10,8 +10,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
 
 import java.util.LinkedHashMap;
 
@@ -21,7 +21,7 @@ import java.util.LinkedHashMap;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_def_dataQuotasOverride extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_def_dataQuotasOverride extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotas.java
@@ -14,8 +14,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import java.util.Map;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_def_fileQuotas extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_def_fileQuotas extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	public static final String A_R_maxUserFileQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserFileQuotas";
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotasOverride.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotasOverride.java
@@ -10,8 +10,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
 
 import java.util.LinkedHashMap;
 
@@ -21,7 +21,7 @@ import java.util.LinkedHashMap;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_def_fileQuotasOverride extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_def_fileQuotasOverride extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimit.java
@@ -13,8 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +22,7 @@ import java.util.List;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_def_filesLimit extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_def_filesLimit extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultFilesLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesLimit";
 	private static final String A_R_defaultFilesQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesQuota";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuota.java
@@ -13,8 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +22,7 @@ import java.util.List;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_def_filesQuota extends ResourceMemberAttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_def_filesQuota extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultFilesLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesLimit";
 	private static final String A_R_defaultFilesQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesQuota";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_dataQuotas.java
@@ -13,7 +13,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceVirtualAttributesModuleAbstract;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import java.util.Map;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_virt_dataQuotas extends ResourceMemberVirtualAttributesModuleAbstract {
+public class urn_perun_member_resource_attribute_def_virt_dataQuotas extends MemberResourceVirtualAttributesModuleAbstract {
 	public static final String A_R_defaultDataQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuotas";
 	public static final String A_MR_dataQuotas = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuotas";
 	public static final String A_MR_dataQuotasOverride = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuotasOverride";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_fileQuotas.java
@@ -13,7 +13,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceVirtualAttributesModuleAbstract;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import java.util.Map;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_member_resource_attribute_def_virt_fileQuotas extends ResourceMemberVirtualAttributesModuleAbstract {
+public class urn_perun_member_resource_attribute_def_virt_fileQuotas extends MemberResourceVirtualAttributesModuleAbstract {
 	public static final String A_R_defaultFileQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFileQuotas";
 	public static final String A_MR_fileQuotas = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":fileQuotas";
 	public static final String A_MR_fileQuotasOverride = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":fileQuotasOverride";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
@@ -18,8 +18,8 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceMemberVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceVirtualAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Michal Stava
  */
-public class urn_perun_member_resource_attribute_def_virt_isBanned extends ResourceMemberVirtualAttributesModuleAbstract implements ResourceMemberVirtualAttributesModuleImplApi {
+public class urn_perun_member_resource_attribute_def_virt_isBanned extends MemberResourceVirtualAttributesModuleAbstract implements MemberResourceVirtualAttributesModuleImplApi {
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_member_resource_attribute_def_virt_isBanned.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTime.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTime.java
@@ -20,15 +20,14 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
-import java.util.HashMap;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
 
 /**
  *
  * @author Milan Halenar <255818@mail.muni.cz>
  */
-public class urn_perun_user_facility_attribute_def_def_accountExpirationTime extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_def_accountExpirationTime extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	private static final String A_F_D_accountExpirationTime = AttributesManager.NS_FACILITY_ATTR_DEF + ":accountExpirationTime";
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTime.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTime.java
@@ -32,7 +32,7 @@ public class urn_perun_user_facility_attribute_def_def_accountExpirationTime ext
 	private static final String A_F_D_accountExpirationTime = AttributesManager.NS_FACILITY_ATTR_DEF + ":accountExpirationTime";
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Integer accExpTime = (Integer) attribute.getValue();
 
 		if (accExpTime == null) {
@@ -55,7 +55,7 @@ public class urn_perun_user_facility_attribute_def_def_accountExpirationTime ext
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl perunSession, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute ret = new Attribute(attribute);
 		List<Integer> resourcesExpTimes = new ArrayList<Integer>();
 		Integer resourceExpTime = null;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGID.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class urn_perun_user_facility_attribute_def_def_basicDefaultGID extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
 		Attribute namespaceAttribute;
 			try {
 				namespaceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGID-namespace");
@@ -61,7 +61,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGID extends U
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		List<Resource> allowedResources = sess.getPerunBl().getUsersManagerBl().getAllowedResources(sess, facility, user);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGID.java
@@ -13,8 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +22,7 @@ import java.util.List;
 	*
 	* @author Jakub Peschel <410368@mail.muni.cz>
 	*/
-public class urn_perun_user_facility_attribute_def_def_basicDefaultGID extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_def_basicDefaultGID extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_defaultUnixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_defaultUnixGID.java
@@ -32,7 +32,7 @@ public class urn_perun_user_facility_attribute_def_def_defaultUnixGID extends Us
 	 * TODO Known issues: Can't detect if unixGid is not set on all resources and groups where user is allowed. This will be reported as WrongAttributeValueException, but it should be WrongReferenceAttributeValueException
 	 */
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
 		Integer gid = (Integer) attribute.getValue();
 		if(gid == null) return;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_defaultUnixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_defaultUnixGID.java
@@ -16,15 +16,15 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
 import java.util.ArrayList;
 
 /**
  *
  * @author Slavek Licehammer &lt;glory@ics.muni.cz&gt;
  */
-public class urn_perun_user_facility_attribute_def_def_defaultUnixGID extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_def_defaultUnixGID extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	/**
 	 * Checks the new default GID of the user at the specified facility. The new GID must be equals to any of resource unixGID attribute where resource is from speciafie facility (and user must have acces to this resource) or from groupResource:unixGID attribute (groups if from the resources and user have acess to them)

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPoint.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPoint.java
@@ -21,15 +21,15 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
 
 /**
  *
  * @author Milan Halenar <255818@mail.muni.cz>
  * @date 27.4.2011
  */
-public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$*");
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPoint.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPoint.java
@@ -34,7 +34,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends Us
 	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$*");
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl session, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 		List<Resource> usersResources = null;
 		usersResources = session.getPerunBl().getUsersManagerBl().getAllowedResources(session, facility, user);
@@ -66,7 +66,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends Us
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl session, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl session, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute returnAttribute = new Attribute(attribute);
 		List<Resource> usersResources = null;
 		usersResources = session.getPerunBl().getUsersManagerBl().getAllowedResources(session, facility, user);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_o365AccountExtension.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_o365AccountExtension.java
@@ -19,7 +19,7 @@ import java.util.Date;
 public class urn_perun_user_facility_attribute_def_def_o365AccountExtension extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		String o365AccExtTime = (String) attribute.getValue();
 
 		if(o365AccExtTime == null) return; //null is allowed value

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_o365AccountExtension.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_o365AccountExtension.java
@@ -6,8 +6,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
 
 import java.text.ParseException;
 import java.util.Date;
@@ -16,7 +16,7 @@ import java.util.Date;
  *
  * @author V. Mecko vladimir.mecko@gmail.com
  */
-public class urn_perun_user_facility_attribute_def_def_o365AccountExtension extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_def_o365AccountExtension extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell.java
@@ -33,7 +33,7 @@ public class urn_perun_user_facility_attribute_def_def_shell extends UserFacilit
 	 * in allowed shells and also need to have correct format.
 	 */
 	@Override
-	public void checkAttributeValue(PerunSessionImpl session, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeAssignmentException {
 		String shell = (String) attribute.getValue();
 
 		if (shell == null) return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell.java
@@ -15,8 +15,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
 
 /**
  * Checks and fills shell for a specified user at the particular facility.
@@ -24,7 +24,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttribut
  * @date 28.4.2011 20:51:05
  * @author Lukáš Pravda   <luky.pravda@gmail.com>
  */
-public class urn_perun_user_facility_attribute_def_def_shell extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_def_shell extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	/**
 	 * Checks an attribute with shell for the user at the specified facility. There

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
@@ -27,7 +27,7 @@ public class urn_perun_user_facility_attribute_def_def_shell_passwd_scp extends 
 	private static final Pattern pattern = Pattern.compile("^(/[-_.a-zA-Z0-9]+)+$");
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		String shell = (String) attribute.getValue();
 
 		if(shell == null) throw new WrongAttributeValueException(attribute, "Value can't be null");
@@ -36,7 +36,7 @@ public class urn_perun_user_facility_attribute_def_def_shell_passwd_scp extends 
 	}
 
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute attribute = new Attribute(attributeDefinition);
 		try {
 			Attribute shellOnFacilityAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":" + attributeDefinition.getFriendlyName());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
@@ -12,8 +12,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
  *
  * @author Slavek Licehammer &lt;glory@ics.muni.cz&gt;
  */
-public class urn_perun_user_facility_attribute_def_def_shell_passwd_scp extends FacilityUserAttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_def_shell_passwd_scp extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	private static final Pattern pattern = Pattern.compile("^(/[-_.a-zA-Z0-9]+)+$");
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UID.java
@@ -33,7 +33,7 @@ public class urn_perun_user_facility_attribute_def_virt_UID extends UserFacility
 	 * existing user and the new user is allowed.
 	 */
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
 		try {
 			Attribute uidNamespaceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":uid-namespace");
 
@@ -56,7 +56,7 @@ public class urn_perun_user_facility_attribute_def_virt_UID extends UserFacility
 	 * in range (minUID, maxUID) is returned.
 	 */
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		try {
 			Attribute uidNamespaceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":uid-namespace");
 
@@ -79,7 +79,7 @@ public class urn_perun_user_facility_attribute_def_virt_UID extends UserFacility
 	 * Gets the value of the attribute f:uid-namespace and then finds the value of the attribute u:uid-namespace:[uid-namespace]
 	 */
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attr = new Attribute(attributeDefinition);
 
 		Attribute uidAttribute = null;
@@ -105,7 +105,7 @@ public class urn_perun_user_facility_attribute_def_virt_UID extends UserFacility
 	}
 
 	@Override
-	public boolean setAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		AttributeDefinition userUidAttributeDefinition;
 		try {
 			// Get the f:uid-namespace attribute

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UID.java
@@ -14,10 +14,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserAttributesModuleImplApi;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +25,7 @@ import java.util.List;
  * @date 22.4.2011 10:43:48
  * @author Lukáš Pravda   <luky.pravda@gmail.com>
  */
-public class urn_perun_user_facility_attribute_def_virt_UID extends FacilityUserVirtualAttributesModuleAbstract implements FacilityUserVirtualAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_virt_UID extends UserFacilityVirtualAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 	/**
 	 * Checks the new UID of the user at the specified facility. The new UID must

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_blacklisted.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_blacklisted.java
@@ -14,7 +14,7 @@ import java.util.List;
  */
 public class urn_perun_user_facility_attribute_def_virt_blacklisted extends UserFacilityVirtualAttributesModuleAbstract {
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		List<SecurityTeam> securityTeams = sess.getPerunBl().getFacilitiesManagerBl().getAssignedSecurityTeams(sess, facility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_blacklisted.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_blacklisted.java
@@ -3,7 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleAbstract;
 
 import java.util.List;
 
@@ -12,7 +12,7 @@ import java.util.List;
  *
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
  */
-public class urn_perun_user_facility_attribute_def_virt_blacklisted extends FacilityUserVirtualAttributesModuleAbstract {
+public class urn_perun_user_facility_attribute_def_virt_blacklisted extends UserFacilityVirtualAttributesModuleAbstract {
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_dataQuotas.java
@@ -18,7 +18,7 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleAbstract;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,7 +35,7 @@ import java.util.Map;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_user_facility_attribute_def_virt_dataQuotas extends FacilityUserVirtualAttributesModuleAbstract {
+public class urn_perun_user_facility_attribute_def_virt_dataQuotas extends UserFacilityVirtualAttributesModuleAbstract {
 	public static final String A_MR_V_dataQuotas = AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT + ":dataQuotas";
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_dataQuotas.java
@@ -39,7 +39,7 @@ public class urn_perun_user_facility_attribute_def_virt_dataQuotas extends UserF
 	public static final String A_MR_V_dataQuotas = AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT + ":dataQuotas";
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		//merge attribute settings for every allowed resource

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGID.java
@@ -16,8 +16,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.Map;
  *
  * @author Jakub Peschel <410368@mail.muni.cz>
  */
-public class urn_perun_user_facility_attribute_def_virt_defaultUnixGID extends FacilityUserVirtualAttributesModuleAbstract implements FacilityUserVirtualAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_virt_defaultUnixGID extends UserFacilityVirtualAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGID.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class urn_perun_user_facility_attribute_def_virt_defaultUnixGID extends UserFacilityVirtualAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attr = new Attribute(attributeDefinition);
 		try {
 			//first phase: if attribute UF:D:defaultUnixGID is set, it has top priority
@@ -107,7 +107,7 @@ public class urn_perun_user_facility_attribute_def_virt_defaultUnixGID extends U
 	}
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, facility, "Attribute can't be null.");
 		try {
 			Attribute defaultUnixGID = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, facility, user, AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":defaultUnixGID");
@@ -119,7 +119,7 @@ public class urn_perun_user_facility_attribute_def_virt_defaultUnixGID extends U
 	}
 
 	@Override
-	public boolean setAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		try {
 			Attribute attributeToSet = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, user, AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":defaultUnixGID");
 			attributeToSet.setValue(attribute.getValue());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_fileQuotas.java
@@ -39,7 +39,7 @@ public class urn_perun_user_facility_attribute_def_virt_fileQuotas extends UserF
 	public static final String A_MR_V_fileQuotas = AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT + ":fileQuotas";
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attribute = new Attribute(attributeDefinition);
 
 		//merge attribute settings for every allowed resource

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_fileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_fileQuotas.java
@@ -18,7 +18,7 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleAbstract;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,7 +35,7 @@ import java.util.Map;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class urn_perun_user_facility_attribute_def_virt_fileQuotas extends FacilityUserVirtualAttributesModuleAbstract {
+public class urn_perun_user_facility_attribute_def_virt_fileQuotas extends UserFacilityVirtualAttributesModuleAbstract {
 	public static final String A_MR_V_fileQuotas = AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT + ":fileQuotas";
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_login.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_login.java
@@ -13,8 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +24,7 @@ import java.util.List;
  * @date 22.4.2011 10:43:48
  * @author Lukáš Pravda   <luky.pravda@gmail.com>
  */
-public class urn_perun_user_facility_attribute_def_virt_login extends FacilityUserVirtualAttributesModuleAbstract implements FacilityUserVirtualAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_virt_login extends UserFacilityVirtualAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 	/**
 	 * Calls checkAttribute on u:login-namespace:[login-namespace]

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_login.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_login.java
@@ -30,7 +30,7 @@ public class urn_perun_user_facility_attribute_def_virt_login extends UserFacili
 	 * Calls checkAttribute on u:login-namespace:[login-namespace]
 	 */
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
 		try  {
 			Attribute loginNamespaceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":login-namespace");
 			Attribute loginAttribute = null;
@@ -52,7 +52,7 @@ public class urn_perun_user_facility_attribute_def_virt_login extends UserFacili
 	 * Calls fillAttribute on u:login-namespace:[login-namespace]
 	 */
 	@Override
-	public Attribute fillAttribute(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		Attribute virtLoginAttribute = new Attribute(attributeDefinition);
 
 		try {
@@ -78,7 +78,7 @@ public class urn_perun_user_facility_attribute_def_virt_login extends UserFacili
 	 * Gets the value of the attribute f:login-namespace and then finds the value of the attribute u:login-namespace:[login-namespace]
 	 */
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attr = new Attribute(attributeDefinition);
 
 		Attribute loginAttribute = null;
@@ -104,7 +104,7 @@ public class urn_perun_user_facility_attribute_def_virt_login extends UserFacili
 	}
 
 	@Override
-	public boolean setAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		AttributeDefinition userLoginAttributeDefinition;
 		try {
 			// Get the f:login-namespace attribute

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName.java
@@ -13,8 +13,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +25,7 @@ import java.util.List;
  * @date 12.8.2014
  * @author Michal Stava   <stavamichal@gmail.com>
  */
-public class urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName extends FacilityUserVirtualAttributesModuleAbstract implements FacilityUserVirtualAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName extends UserFacilityVirtualAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 	private static final String A_FACILITY_DEF_UNIX_GROUPNAME_NAMESPACE = AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGroupName-namespace";
 	private static final String A_USER_DEF_PREFERRED_UNIX_GROUPNAME_NAMESPACE = AttributesManager.NS_USER_ATTR_DEF + ":preferredUnixGroupName-namespace:";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName.java
@@ -31,7 +31,7 @@ public class urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName e
 	private static final String A_USER_DEF_PREFERRED_UNIX_GROUPNAME_NAMESPACE = AttributesManager.NS_USER_ATTR_DEF + ":preferredUnixGroupName-namespace:";
 
 	@Override
-	public void checkAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
 		try {
 			Attribute facilityGroupNameNamespaceAttr = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, A_FACILITY_DEF_UNIX_GROUPNAME_NAMESPACE);
 			if(facilityGroupNameNamespaceAttr.getValue() == null) {
@@ -50,7 +50,7 @@ public class urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName e
 	}
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attr = new Attribute(attributeDefinition);
 		Attribute preferredGroupNameAttribute = null;
 
@@ -73,7 +73,7 @@ public class urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName e
 	}
 
 	@Override
-	public boolean setAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		AttributeDefinition userPreferredGroupNameDefinition;
 		try {
 			Attribute facilityGroupNameNamespaceAttr = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, A_FACILITY_DEF_UNIX_GROUPNAME_NAMESPACE);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_shell.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_shell.java
@@ -28,7 +28,7 @@ import java.util.Set;
 public class urn_perun_user_facility_attribute_def_virt_shell extends UserFacilityVirtualAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 	@Override
-	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl sess, User user, Facility facility, AttributeDefinition attributeDefinition) throws InternalErrorException {
 		Attribute attr = new Attribute(attributeDefinition);
 		try {
 			Attribute attribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, user, AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":shell");
@@ -77,7 +77,7 @@ public class urn_perun_user_facility_attribute_def_virt_shell extends UserFacili
 	}
 
 	@Override
-	public boolean setAttributeValue(PerunSessionImpl sess, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		try {
 			Attribute attributeToSet = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, user, AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":shell");
 			return  sess.getPerunBl().getAttributesManagerBl().setAttributeWithoutCheck(sess, facility, user, attributeToSet);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_shell.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_shell.java
@@ -14,8 +14,8 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityUserVirtualAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualAttributesModuleImplApi;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.Set;
  *
  *@author Jakub Peschel <410368@mail.muni.cz>
  */
-public class urn_perun_user_facility_attribute_def_virt_shell extends FacilityUserVirtualAttributesModuleAbstract implements FacilityUserVirtualAttributesModuleImplApi {
+public class urn_perun_user_facility_attribute_def_virt_shell extends UserFacilityVirtualAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 	@Override
 	public Attribute getAttributeValue(PerunSessionImpl sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleAbstract.java
@@ -21,15 +21,15 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
  */
 public abstract class GroupResourceAttributesModuleAbstract extends AttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
-	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 	}
 
-	public Attribute fillAttribute(PerunSessionImpl session, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl session, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		return new Attribute(attribute);
 	}
 
-	public void changedAttributeHook(PerunSessionImpl session, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public void changedAttributeHook(PerunSessionImpl session, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleAbstract.java
@@ -4,14 +4,11 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Group;
-import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Abstract class for Resource Group Attributes modules.
@@ -22,7 +19,7 @@ import java.util.List;
  * @author Michal Stava <stavamichal@gmail.com>
  *
  */
-public abstract class ResourceGroupAttributesModuleAbstract extends AttributesModuleAbstract implements ResourceGroupAttributesModuleImplApi{
+public abstract class GroupResourceAttributesModuleAbstract extends AttributesModuleAbstract implements GroupResourceAttributesModuleImplApi {
 
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleImplApi.java
@@ -23,8 +23,8 @@ public interface GroupResourceAttributesModuleImplApi extends AttributesModuleIm
 	 * Checks if value of this facility attribute is valid.
 	 *
 	 * @param perunSession perun session
-	 * @param resource resource for which you want to check validity of attribute
 	 * @param group group
+	 * @param resource resource for which you want to check validity of attribute
 	 * @param attribute attribute to check
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
@@ -32,28 +32,28 @@ public interface GroupResourceAttributesModuleImplApi extends AttributesModuleIm
 	 * @throws WrongAttributeAssignmentException
 	 */
 
-	void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void checkAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * This method MAY fill an attribute at the specified resource.
 	 *
 	 * @param perunSession perun session
-	 * @param resource resource for which you want to check validity of attribute
 	 * @param group group
+	 * @param resource resource for which you want to check validity of attribute
 	 * @param attribute attribute to fill in
 	 * @return
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeAssignmentException
 	 */
-	Attribute fillAttribute(PerunSessionImpl perunSession, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException,WrongAttributeAssignmentException;
+	Attribute fillAttribute(PerunSessionImpl perunSession, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException,WrongAttributeAssignmentException;
+
 	/**
 	 * If you need to do some further work with other modules, this method do that
-	 *
 	 * @param session session
-	 * @param resource the resource
 	 * @param group the group
+	 * @param resource the resource
 	 * @param attribute the attribute
 	 */
-	void changedAttributeHook(PerunSessionImpl session, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+	void changedAttributeHook(PerunSessionImpl session, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleImplApi.java
@@ -17,7 +17,7 @@ import java.util.List;
  *
  * @author Milan Halenar <mhalenar@gmail.com>
  */
-public interface ResourceGroupAttributesModuleImplApi extends AttributesModuleImplApi{
+public interface GroupResourceAttributesModuleImplApi extends AttributesModuleImplApi{
 
 	/**
 	 * Checks if value of this facility attribute is valid.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceVirtualAttributesModuleAbstract.java
@@ -23,15 +23,15 @@ import java.util.List;
 public abstract class GroupResourceVirtualAttributesModuleAbstract extends GroupResourceAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 
-	public Attribute getAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException {
 		return new Attribute(attribute);
 	}
 
-	public boolean setAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		return false;
 	}
 
-	public boolean removeAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public boolean removeAttributeValue(PerunSessionImpl perunSession, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		return false;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceVirtualAttributesModuleAbstract.java
@@ -20,7 +20,7 @@ import java.util.List;
  *
  * @author Michal Stava <stavamichal@gmail.com>
  */
-public abstract class ResourceGroupVirtualAttributesModuleAbstract extends ResourceGroupAttributesModuleAbstract implements ResourceGroupVirtualAttributesModuleImplApi{
+public abstract class GroupResourceVirtualAttributesModuleAbstract extends GroupResourceAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 
 	public Attribute getAttributeValue(PerunSessionImpl perunSession, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceVirtualAttributesModuleImplApi.java
@@ -2,55 +2,56 @@ package cz.metacentrum.perun.core.implApi.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
-import cz.metacentrum.perun.core.api.Facility;
-import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
 /**
  * This interface serves as a template for virtual attributes.
  *
- * @author Michal Prochazka <michalp@ics.muni.cz>
+ * @author Slavek Licehammer <glory@ics.muni.cz>
  */
-public interface FacilityUserVirtualAttributesModuleImplApi extends FacilityUserAttributesModuleImplApi, VirtualAttributesModuleImplApi{
+public interface GroupResourceVirtualAttributesModuleImplApi extends GroupResourceAttributesModuleImplApi, VirtualAttributesModuleImplApi {
 
 	/**
 	 * This method will return computed value.
 	 *
-	 * @param perunSession perun session
-	 * @param facility facility which is needed for computing the value
-	 * @param user user which is needed for computing the value
+	 * @param sess perun session
+	 * @param resource resource which is needed for computing the value
+	 * @param group group which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	Attribute getAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
+	Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Method sets attributes' values which are dependent on this virtual attribute.
 	 *
-	 * @param perunSession
-	 * @param facility facility which is needed for computing the value
-	 * @param user user which is needed for computing the value
+	 * @param sess
+	 * @param resource resource which is needed for computing the value
+	 * @param group group which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return true if attribute was really changed
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean setAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+	boolean setAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Currently do nothing.
 	 *
-	 * @param perunSession
-	 * @param facility facility which is needed for computing the value
-	 * @param user user which is needed for computing the value
+	 * @param sess
+	 * @param resource resource which is needed for computing the value
+	 * @param group group which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceVirtualAttributesModuleImplApi.java
@@ -20,38 +20,38 @@ public interface GroupResourceVirtualAttributesModuleImplApi extends GroupResour
 	 * This method will return computed value.
 	 *
 	 * @param sess perun session
-	 * @param resource resource which is needed for computing the value
 	 * @param group group which is needed for computing the value
+	 * @param resource resource which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException;
+	Attribute getAttributeValue(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Method sets attributes' values which are dependent on this virtual attribute.
 	 *
 	 * @param sess
-	 * @param resource resource which is needed for computing the value
 	 * @param group group which is needed for computing the value
+	 * @param resource resource which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return true if attribute was really changed
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean setAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+	boolean setAttributeValue(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Currently do nothing.
 	 *
 	 * @param sess
-	 * @param resource resource which is needed for computing the value
 	 * @param group group which is needed for computing the value
+	 * @param resource resource which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean removeAttributeValue(PerunSessionImpl sess, Group group, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleAbstract.java
@@ -19,7 +19,7 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
  * @author Michal Stava <stavamichal@gmail.com>
  *
  */
-public abstract class ResourceMemberAttributesModuleAbstract extends AttributesModuleAbstract implements ResourceMemberAttributesModuleImplApi {
+public abstract class MemberResourceAttributesModuleAbstract extends AttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleImplApi.java
@@ -18,7 +18,7 @@ import java.util.List;
  *
  * @author Lukáš Pravda <luky.pravda@gmail.com>
  */
-public interface ResourceMemberAttributesModuleImplApi extends AttributesModuleImplApi{
+public interface MemberResourceAttributesModuleImplApi extends AttributesModuleImplApi{
 
 	/**
 	 * This method checks Member's attributes at a specified resource.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceVirtualAttributesModuleAbstract.java
@@ -20,7 +20,7 @@ import java.util.List;
  *
  * @author Michal Stava <stavamichal@gmail.com>
  */
-public abstract class ResourceMemberVirtualAttributesModuleAbstract extends ResourceMemberAttributesModuleAbstract implements ResourceMemberVirtualAttributesModuleImplApi{
+public abstract class MemberResourceVirtualAttributesModuleAbstract extends MemberResourceAttributesModuleAbstract implements MemberResourceVirtualAttributesModuleImplApi {
 
 
 	public Attribute getAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceVirtualAttributesModuleImplApi.java
@@ -2,7 +2,7 @@ package cz.metacentrum.perun.core.implApi.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
-import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
@@ -12,46 +12,46 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 /**
  * This interface serves as a template for virtual attributes.
  *
- * @author Slavek Licehammer <glory@ics.muni.cz>
+ * @author Michal Stava
  */
-public interface ResourceGroupVirtualAttributesModuleImplApi extends ResourceGroupAttributesModuleImplApi, VirtualAttributesModuleImplApi {
+public interface MemberResourceVirtualAttributesModuleImplApi extends MemberResourceAttributesModuleImplApi, VirtualAttributesModuleImplApi {
 
 	/**
 	 * This method will return computed value.
 	 *
 	 * @param sess perun session
+	 * @param member member which is needed for computing the value
 	 * @param resource resource which is needed for computing the value
-	 * @param group group which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	Attribute getAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException;
+	Attribute getAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Method sets attributes' values which are dependent on this virtual attribute.
 	 *
 	 * @param sess
+	 * @param member member which is needed for computing the value
 	 * @param resource resource which is needed for computing the value
-	 * @param group group which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return true if attribute was really changed
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean setAttributeValue(PerunSessionImpl sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+	boolean setAttributeValue(PerunSessionImpl sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Currently do nothing.
 	 *
 	 * @param sess
+	 * @param member member which is needed for computing the value
 	 * @param resource resource which is needed for computing the value
-	 * @param group group which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean removeAttributeValue(PerunSessionImpl sess, Resource resource, Group group, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean removeAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityAttributesModuleAbstract.java
@@ -20,15 +20,15 @@ import cz.metacentrum.perun.core.impl.PerunSessionImpl;
  */
 public abstract class UserFacilityAttributesModuleAbstract extends AttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
-	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
 
 	}
 
-	public Attribute fillAttribute(PerunSessionImpl session, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public Attribute fillAttribute(PerunSessionImpl session, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException {
 		return new Attribute(attribute);
 	}
 
-	public void changedAttributeHook(PerunSessionImpl session, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public void changedAttributeHook(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityAttributesModuleAbstract.java
@@ -4,14 +4,11 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.Role;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Abstract class for Facility User Attributes modules.
@@ -21,7 +18,7 @@ import java.util.List;
  * @author Michal Stava <stavamichal@gmail.com>
  *
  */
-public abstract class FacilityUserAttributesModuleAbstract extends AttributesModuleAbstract implements FacilityUserAttributesModuleImplApi {
+public abstract class UserFacilityAttributesModuleAbstract extends AttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	public void checkAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityAttributesModuleImplApi.java
@@ -15,7 +15,7 @@ import java.util.List;
 /**
  * @author Lukáš Pravda <luky.pravda@gmail.com>
  */
-public interface FacilityUserAttributesModuleImplApi extends AttributesModuleImplApi{
+public interface UserFacilityAttributesModuleImplApi extends AttributesModuleImplApi{
 
 	/**
 	 * Checks if assigned attribute in relationship between those two

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityAttributesModuleImplApi.java
@@ -22,8 +22,8 @@ public interface UserFacilityAttributesModuleImplApi extends AttributesModuleImp
 	 * entities has a correct value.
 	 *
 	 * @param session Perun session
-	 * @param facility Facility to be used by a user.
 	 * @param user User of the facility.
+	 * @param facility Facility to be used by a user.
 	 * @param attribute Attribute in relationship between facility and user.
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
@@ -32,15 +32,15 @@ public interface UserFacilityAttributesModuleImplApi extends AttributesModuleImp
 	 *         the parameter is to be compared is not available
 	 * @throws WrongAttributeAssignmentException
 	 */
-	void checkAttributeValue(PerunSessionImpl session, Facility facility, User user, Attribute attribute) throws  InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributeValue(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws  InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 
 	/**
 	 * Tries to fill an attribute in the relationship between a facility and
 	 * user
 	 *
 	 * @param session Perun Session
-	 * @param facility Facility to be used by user.
 	 * @param user User of the facility
+	 * @param facility Facility to be used by user.
 	 * @param attribute Attribute in relationship between facility and user to be filled in.
 	 * @return Attribute which MAY be filled in
 	 *
@@ -48,15 +48,14 @@ public interface UserFacilityAttributesModuleImplApi extends AttributesModuleImp
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeAssignmentException
 	 */
-	Attribute fillAttribute(PerunSessionImpl session, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
+	Attribute fillAttribute(PerunSessionImpl session, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException;
 
 	/**
 	 * If you need to do some further work with other modules, this method do that
-	 *
 	 * @param session session
-	 * @param facility the facility
 	 * @param user the user
+	 * @param facility the facility
 	 * @param attribute the attribute
 	 */
-	void changedAttributeHook(PerunSessionImpl session, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+	void changedAttributeHook(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityVirtualAttributesModuleAbstract.java
@@ -23,15 +23,15 @@ import java.util.List;
 public abstract class UserFacilityVirtualAttributesModuleAbstract extends UserFacilityAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 
-	public Attribute getAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
+	public Attribute getAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException {
 		return new Attribute(attribute);
 	}
 
-	public boolean setAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+	public boolean setAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		return false;
 	}
 
-	public boolean removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {
+	public boolean removeAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException {
 		return false;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityVirtualAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityVirtualAttributesModuleAbstract.java
@@ -20,7 +20,7 @@ import java.util.List;
  * @author Michal Stava <stavamichal@gmail.com>
  *
  */
-public abstract class FacilityUserVirtualAttributesModuleAbstract extends FacilityUserAttributesModuleAbstract implements FacilityUserVirtualAttributesModuleImplApi{
+public abstract class UserFacilityVirtualAttributesModuleAbstract extends UserFacilityAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 
 	public Attribute getAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityVirtualAttributesModuleImplApi.java
@@ -2,56 +2,55 @@ package cz.metacentrum.perun.core.implApi.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
-import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
 /**
  * This interface serves as a template for virtual attributes.
  *
- * @author Michal Stava
+ * @author Michal Prochazka <michalp@ics.muni.cz>
  */
-public interface ResourceMemberVirtualAttributesModuleImplApi extends ResourceMemberAttributesModuleImplApi, VirtualAttributesModuleImplApi {
+public interface UserFacilityVirtualAttributesModuleImplApi extends UserFacilityAttributesModuleImplApi, VirtualAttributesModuleImplApi{
 
 	/**
 	 * This method will return computed value.
 	 *
-	 * @param sess perun session
-	 * @param member member which is needed for computing the value
-	 * @param resource resource which is needed for computing the value
+	 * @param perunSession perun session
+	 * @param facility facility which is needed for computing the value
+	 * @param user user which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	Attribute getAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException;
+	Attribute getAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Method sets attributes' values which are dependent on this virtual attribute.
 	 *
-	 * @param sess
-	 * @param member member which is needed for computing the value
-	 * @param resource resource which is needed for computing the value
+	 * @param perunSession
+	 * @param facility facility which is needed for computing the value
+	 * @param user user which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return true if attribute was really changed
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean setAttributeValue(PerunSessionImpl sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+	boolean setAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Currently do nothing.
 	 *
-	 * @param sess
-	 * @param member member which is needed for computing the value
-	 * @param resource resource which is needed for computing the value
+	 * @param perunSession
+	 * @param facility facility which is needed for computing the value
+	 * @param user user which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean removeAttributeValue(PerunSessionImpl sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	boolean removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityVirtualAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserFacilityVirtualAttributesModuleImplApi.java
@@ -19,38 +19,38 @@ public interface UserFacilityVirtualAttributesModuleImplApi extends UserFacility
 	 * This method will return computed value.
 	 *
 	 * @param perunSession perun session
-	 * @param facility facility which is needed for computing the value
 	 * @param user user which is needed for computing the value
+	 * @param facility facility which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	Attribute getAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
+	Attribute getAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException;
 
 	/**
 	 * Method sets attributes' values which are dependent on this virtual attribute.
 	 *
 	 * @param perunSession
-	 * @param facility facility which is needed for computing the value
 	 * @param user user which is needed for computing the value
+	 * @param facility facility which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return true if attribute was really changed
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean setAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
+	boolean setAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Currently do nothing.
 	 *
 	 * @param perunSession
-	 * @param facility facility which is needed for computing the value
 	 * @param user user which is needed for computing the value
+	 * @param facility facility which is needed for computing the value
 	 * @param attribute attribute to operate on
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
 	 */
-	boolean removeAttributeValue(PerunSessionImpl perunSession, Facility facility, User user, AttributeDefinition attribute) throws InternalErrorException;
+	boolean removeAttributeValue(PerunSessionImpl perunSession, User user, Facility facility, AttributeDefinition attribute) throws InternalErrorException;
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTest.java
@@ -67,7 +67,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 	@Test
 	public void fillAttribute() throws Exception {
 		System.out.println("fillAttribute()");
-		Attribute attribute = classInstance.fillAttribute(session, resource, group, classInstance.getAttributeDefinition());
+		Attribute attribute = classInstance.fillAttribute(session, group, resource, classInstance.getAttributeDefinition());
 		Object attributeValue = attribute.getValue();
 		assertThat(attributeValue, is(notNullValue()));
 		List<String> expectedValue = new ArrayList<>();
@@ -79,7 +79,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 				.thenReturn(Sets.newHashSet(new Pair<>(group.getId(),resource.getId())));
 		when(am.getPerunBeanIdsForUniqueAttributeValue(eq(session), argThat(new BeanAttributeMatcher("member"))))
 				.thenReturn(Sets.newHashSet());
-		classInstance.checkAttributeValue(session, resource, group, attribute);
+		classInstance.checkAttributeValue(session, group, resource, attribute);
 	}
 
 
@@ -87,28 +87,28 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 	public void testCheckType() throws Exception {
 		System.out.println("testCheckType()");
 		attributeToCheck.setValue("AAA");
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
 	public void testCheckEmailSyntax() throws Exception {
 		System.out.println("testCheckEmailSyntax()");
 		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "a/-+"));
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
 	public void testCheckDuplicates() throws Exception {
 		System.out.println("testCheckDuplicates()");
 		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "aaa@bbb.com", "my@example.com"));
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
 	public void testCheckValueExistIfAdNameSetWithNull() throws Exception {
 		System.out.println("testCheckValueExistIfAdNameSetWithNull()");
 		attributeToCheck.setValue(null);
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 
 	@Test
@@ -117,7 +117,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 		attributeToCheck.setValue(null);
 		when(adNameAttr.getValue()).thenReturn(null);
 		when(am.getPerunBeanIdsForUniqueAttributeValue(eq(session),any(Attribute.class))).thenReturn(Sets.newHashSet());
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 
 
@@ -125,7 +125,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 	public void testCheckValueExistIfAdNameSet() throws Exception {
 		System.out.println("testCheckValueExistIfAdNameSet()");
 		attributeToCheck.setValue(Lists.newArrayList());
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 
 	@Test
@@ -134,9 +134,9 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 		when(adNameAttr.getValue()).thenReturn(null);
 		when(am.getPerunBeanIdsForUniqueAttributeValue(eq(session),any(Attribute.class))).thenReturn(Sets.newHashSet());
 		attributeToCheck.setValue(Lists.newArrayList());
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 		attributeToCheck.setValue(Lists.newArrayList("my@example.com"));
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 
 	@Test
@@ -147,7 +147,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 				.thenReturn(Sets.newHashSet(new Pair<>(group.getId(),resource.getId())));
 		when(am.getPerunBeanIdsForUniqueAttributeValue(eq(session), argThat(new BeanAttributeMatcher("member"))))
 				.thenReturn(Sets.newHashSet());
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
@@ -158,6 +158,6 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 				.thenReturn(Sets.newHashSet(new Pair<>(1000,2000)));
 		when(am.getPerunBeanIdsForUniqueAttributeValue(eq(session), argThat(new BeanAttributeMatcher("member"))))
 				.thenReturn(Sets.newHashSet());
-		classInstance.checkAttributeValue(session, resource, group, attributeToCheck);
+		classInstance.checkAttributeValue(session, group, resource, attributeToCheck);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTimeTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTimeTest.java
@@ -51,7 +51,7 @@ public class urn_perun_user_facility_attribute_def_def_accountExpirationTimeTest
 				setValue(1500);
 			}
 		});
-		classInstance.checkAttributeValue(session, new Facility(), new User(), attributeToCheck);
+		classInstance.checkAttributeValue(session, new User(), new Facility(), attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
@@ -64,7 +64,7 @@ public class urn_perun_user_facility_attribute_def_def_accountExpirationTimeTest
 					setValue(999);
 				}
 			});
-			classInstance.checkAttributeValue(session, new Facility(), new User(), attributeToCheck);
+			classInstance.checkAttributeValue(session, new User(), new Facility(), attributeToCheck);
 			fail("Assigning lower accountExpirationTime than the time set at facility should throw exception.");
 
 		}
@@ -88,7 +88,7 @@ public class urn_perun_user_facility_attribute_def_def_accountExpirationTimeTest
 				setValue(1001);
 			}
 		});
-		attributeToCheck = classInstance.fillAttribute(session, new Facility(), new User(), attributeToCheck);
+		attributeToCheck = classInstance.fillAttribute(session, new User(), new Facility(), attributeToCheck);
 		assertEquals("Filled attribute should be the lowest from all resource and facility values", 999,attributeToCheck.getValue());
 	}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest.java
@@ -71,7 +71,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest {
 				when(session.getPerunBl().getUsersManagerBl().getAllowedResources(any(PerunSessionImpl.class), any(Facility.class), any(User.class))).thenReturn(allowedResources);
 				when(session.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(any(PerunSessionImpl.class), any(Attribute.class))).thenReturn(allowedResourcesWithSameGid);
 
-				classInstance.checkAttributeValue(session, facility, user, basic);
+				classInstance.checkAttributeValue(session, user, facility, basic);
 		}
 
 		@Test
@@ -90,7 +90,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest {
 				when(session.getPerunBl().getUsersManagerBl().getAllowedResources(any(PerunSessionImpl.class), any(Facility.class), any(User.class))).thenReturn(allowedResources);
 				when(session.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(any(PerunSessionImpl.class), any(Attribute.class))).thenReturn(allowedResourcesWithSameGid);
 
-				classInstance.checkAttributeValue(session, facility, user, basic);
+				classInstance.checkAttributeValue(session, user, facility, basic);
 		}
 
 		@Test(expected = WrongAttributeValueException.class)
@@ -107,7 +107,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest {
 				when(session.getPerunBl().getUsersManagerBl().getAllowedResources(any(PerunSessionImpl.class), any(Facility.class), any(User.class))).thenReturn(allowedResources);
 				when(session.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(any(PerunSessionImpl.class), any(Attribute.class))).thenReturn(allowedResourcesWithSameGid);
 
-				classInstance.checkAttributeValue(session, facility, user, basic);
+				classInstance.checkAttributeValue(session, user, facility, basic);
 		}
 
 		@Test(expected = WrongAttributeValueException.class)
@@ -124,7 +124,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest {
 				when(session.getPerunBl().getUsersManagerBl().getAllowedResources(any(PerunSessionImpl.class), any(Facility.class), any(User.class))).thenReturn(allowedResources);
 				when(session.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(any(PerunSessionImpl.class), any(Attribute.class))).thenReturn(allowedResourcesWithSameGid);
 
-				classInstance.checkAttributeValue(session, facility, user, basic);
+				classInstance.checkAttributeValue(session, user, facility, basic);
 		}
 
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPointTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPointTest.java
@@ -91,7 +91,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 		});
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfMntPts);
 
-		classInstance.checkAttributeValue(session, facility, user, attributeToCheck);
+		classInstance.checkAttributeValue(session, user, facility, attributeToCheck);
 	}
 
 	/**
@@ -116,7 +116,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 		});
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfMntPts);
 
-		Attribute filledAttribute = classInstance.fillAttribute(session, facility, user, new AttributeDefinition());
+		Attribute filledAttribute = classInstance.fillAttribute(session, user, facility, new AttributeDefinition());
 		assertTrue("A different homeMountPoint was filled than those available", ( listOfMntPts.getValue()).equals(filledAttribute.getValue()));
 	}
 
@@ -131,7 +131,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 		when(session.getPerunBl().getUsersManagerBl().getAllowedResources(any(PerunSession.class), any(Facility.class), any(User.class))).thenReturn(new ArrayList<Resource>());
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfMntPts);
 
-		Attribute atr = classInstance.fillAttribute(session, facility, user, new AttributeDefinition());
+		Attribute atr = classInstance.fillAttribute(session, user, facility, new AttributeDefinition());
 
 		assertNull("User's homeMountPoint was filled even they don't have an account there.", atr.getValue());
 	}
@@ -146,7 +146,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 			Attribute atr = new Attribute();
 			atr.setValue(("/mnt/mnt1"));
 
-			classInstance.checkAttributeValue(session, facility, user, atr);
+			classInstance.checkAttributeValue(session, user, facility, atr);
 
 		}
 
@@ -172,7 +172,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 			});
 			when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfMntPts);
 
-			classInstance.checkAttributeValue(session, facility, user, new Attribute());
+			classInstance.checkAttributeValue(session, user, facility, new Attribute());
 			fail("Empty attribute should have thrown an exception");
 
 		}
@@ -202,7 +202,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 			});
 			when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfMntPts);
 
-			classInstance.checkAttributeValue(session, facility, user, attributeToCheck);
+			classInstance.checkAttributeValue(session, user, facility, attributeToCheck);
 			fail("Wrong homeMountPoint format should have thrown an exception");
 		}
 
@@ -227,7 +227,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 			});
 			when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfMntPts);
 
-			classInstance.checkAttributeValue(session, facility, user, attributeToCheck) ;
+			classInstance.checkAttributeValue(session, user, facility, attributeToCheck) ;
 			fail("Wrong homeMountPoint format should have thrown an exception");
 		}
 
@@ -252,7 +252,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 			Attribute attributeToCheck = new Attribute();
 			attributeToCheck.setValue("/mnt/mnt1/");
 
-			classInstance.checkAttributeValue(session, facility, user, attributeToCheck);
+			classInstance.checkAttributeValue(session, user, facility, attributeToCheck);
 			fail("Wrong homeMountPoint format should have thrown an exception");
 		}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shellTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shellTest.java
@@ -81,7 +81,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(PerunSession.class), any(Facility.class))).thenReturn(new ArrayList<Resource>(){{add(resource);}});
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), eq(AttributesManager.NS_RESOURCE_ATTR_DEF + ":shells"))).thenReturn(listOfShells);
 
-		classInstance.checkAttributeValue(session, facility, user, attributeToCheck);
+		classInstance.checkAttributeValue(session, user, facility, attributeToCheck);
 	}
 
 
@@ -96,7 +96,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 		Attribute atr = new Attribute();
 		atr.setValue(("/bin/bash"));
 
-		classInstance.checkAttributeValue(session, facility, user, atr);
+		classInstance.checkAttributeValue(session, user, facility, atr);
 
 	}
 
@@ -111,7 +111,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(PerunSession.class), any(Facility.class))).thenReturn(new ArrayList<Resource>(){{add(resource);}});
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfShells);
 
-		classInstance.checkAttributeValue(session, facility, user, new Attribute());
+		classInstance.checkAttributeValue(session, user, facility, new Attribute());
 	}
 
 	/**
@@ -129,7 +129,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(PerunSession.class), any(Facility.class))).thenReturn(new ArrayList<Resource>(){{add(resource);}});
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfShells);
 
-		classInstance.checkAttributeValue(session, facility, user, attributeToCheck);
+		classInstance.checkAttributeValue(session, user, facility, attributeToCheck);
 		fail("Wrong shell format should have thrown an exception");
 	}
 
@@ -144,7 +144,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(PerunSession.class), any(Facility.class))).thenReturn(new ArrayList<Resource>(){{add(resource);}});
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfShells);
 
-		classInstance.checkAttributeValue(session, facility, user, attributeToCheck);
+		classInstance.checkAttributeValue(session, user, facility, attributeToCheck);
 		fail("Wrong shell format should have thrown an exception");
 	}
 
@@ -159,7 +159,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 		Attribute attributeToCheck = new Attribute();
 		attributeToCheck.setValue("/bin/bash/");
 
-		classInstance.checkAttributeValue(session, facility, user, attributeToCheck);
+		classInstance.checkAttributeValue(session, user, facility, attributeToCheck);
 		fail("Wrong shell format should have thrown an exception");
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest.java
@@ -114,7 +114,7 @@ public class urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest {
 				//UF:D:basicDefaultGID attr
 				when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Facility.class), any(User.class), eq(AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":basicDefaultGID"))).thenReturn(basicDefaultGID);
 
-				Attribute testAttr = classInstance.getAttributeValue(session, facility, user, attrDef);
+				Attribute testAttr = classInstance.getAttributeValue(session, user, facility, attrDef);
 				assertEquals(testAttr,dDefaultUnixGid);
 		}
 
@@ -150,7 +150,7 @@ public class urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest {
 				//UF:D:basicDefaultGID attr
 				when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Facility.class), any(User.class), eq(AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":basicDefaultGID"))).thenReturn(basicDefaultGID);
 
-				Attribute testAttr = classInstance.getAttributeValue(session, facility, user, attrDef);
+				Attribute testAttr = classInstance.getAttributeValue(session, user, facility, attrDef);
 				assertEquals(testAttr, new Attribute(attrDef));
 		}
 
@@ -190,7 +190,7 @@ public class urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest {
 				//UF:D:basicDefaultGID attr
 				when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Facility.class), any(User.class), eq(AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":basicDefaultGID"))).thenReturn(basicDefaultGID);
 
-				Attribute testAttr = classInstance.getAttributeValue(session, facility, user, attrDef);
+				Attribute testAttr = classInstance.getAttributeValue(session, user, facility, attrDef);
 				assertEquals(testAttr, prefferedUnixGroupNameSelectedValueGID);
 		}
 
@@ -227,7 +227,7 @@ public class urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest {
 				//UF:D:basicDefaultGID attr
 				when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Facility.class), any(User.class), eq(AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":basicDefaultGID"))).thenReturn(basicDefaultGID);
 
-				Attribute testAttr = classInstance.getAttributeValue(session, facility, user, attrDef);
+				Attribute testAttr = classInstance.getAttributeValue(session, user, facility, attrDef);
 				assertEquals(testAttr, basicDefaultGID);
 		}
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_shellTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_shellTest.java
@@ -82,7 +82,7 @@ public class urn_perun_user_facility_attribute_def_virt_shellTest {
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Resource.class), eq(AttributesManager.NS_RESOURCE_ATTR_DEF + ":shells")).getValue()).thenReturn(resourceShell);
 		when(session.getPerunBl().getUsersManagerBl().getAllowedResources(any(PerunSessionImpl.class), any(Facility.class), any(User.class))).thenReturn(resourceList);
 
-		Attribute testAttr = classInstance.getAttributeValue(session, facility, user, session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_USER_FACILITY_ATTR_VIRT + "shell"));
+		Attribute testAttr = classInstance.getAttributeValue(session, user, facility, session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_USER_FACILITY_ATTR_VIRT + "shell"));
 		assertEquals("/mnt/bash2", (String)testAttr.getValue());
 
 	}


### PR DESCRIPTION
- Renamed all modules classes to match attribute namespace they represents.
  Eg. user_facility namespace had switched entity names in module class name.
- Switched order of api params in all methods of attribute modules to match the
  namespace they represents. Eg. group_resource had Resource as first param
  and Group as second.