### PR TITLE
CORE: Fixed attribute authz in conversion of Groups to RichGroups

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -1037,10 +1037,11 @@ public interface GroupsManagerBl {
 	 *
 	 * @param sess
 	 * @param richGroups
+	 * @param resource optional resource param used for context
 	 * @return list of RichGroups with only allowed attributes
 	 * @throws InternalErrorException
 	 */
-	List<RichGroup> filterOnlyAllowedAttributes(PerunSession sess, List<RichGroup> richGroups, boolean useContext) throws InternalErrorException;
+	List<RichGroup> filterOnlyAllowedAttributes(PerunSession sess, List<RichGroup> richGroups, Resource resource, boolean useContext) throws InternalErrorException;
 
 	/**
 	 * This method takes group and creates RichGroup containing all attributes

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1912,7 +1912,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
-	public List<RichGroup> filterOnlyAllowedAttributes(PerunSession sess, List<RichGroup> richGroups, boolean useContext) throws InternalErrorException {
+	public List<RichGroup> filterOnlyAllowedAttributes(PerunSession sess, List<RichGroup> richGroups, Resource resource, boolean useContext) throws InternalErrorException {
 
 		//If no context should be used - every attribute is unique in context of group (for every group test access rights for all attributes again)
 		if(!useContext) return filterOnlyAllowedAttributes(sess, richGroups);
@@ -1948,8 +1948,19 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 						// no READ for attribute
 					} else {
 						//if not, get information about authz rights and set record to contextMap
-						if(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, groupAttr, rg)) {
-							boolean isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, groupAttr, rg);
+						boolean canRead = false;
+						if (groupAttr.getNamespace().startsWith(AttributesManager.NS_GROUP_RESOURCE_ATTR)) {
+							canRead = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, groupAttr, rg, resource);
+						} else if (groupAttr.getNamespace().startsWith(AttributesManager.NS_GROUP_ATTR)) {
+							canRead = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, groupAttr, rg, null);
+						}
+						if(canRead) {
+							boolean isWritable = false;
+							if (groupAttr.getNamespace().startsWith(AttributesManager.NS_GROUP_RESOURCE_ATTR)) {
+								isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, groupAttr, rg, resource);
+							} else if (groupAttr.getNamespace().startsWith(AttributesManager.NS_GROUP_ATTR)) {
+								isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, groupAttr, rg, null);
+							}
 							groupAttr.setWritable(isWritable);
 							allowedGroupAttributes.add(groupAttr);
 							contextMap.put(key + groupAttr.getName(), isWritable);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -348,7 +348,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		if(specificService != null) getPerunBl().getServicesManagerBl().checkServiceExists(perunSession, specificService);
 
 		List<RichGroup> richGroups = getFacilitiesManagerBl().getAllowedRichGroupsWithAttributes(perunSession, facility, specificVo, specificService, attrNames);
-		return getPerunBl().getGroupsManagerBl().filterOnlyAllowedAttributes(perunSession, richGroups, true);
+		return getPerunBl().getGroupsManagerBl().filterOnlyAllowedAttributes(perunSession, richGroups, null, true);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1026,7 +1026,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 		List<RichGroup> richGroups = getGroupsManagerBl().getRichGroupsWithAttributesAssignedToResource(sess, resource, attrNames);
 
-		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, true);
+		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, resource, true);
 	}
 
 	@Override
@@ -1055,7 +1055,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			}
 		}
 
-		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, true);
+		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, null, true);
 	}
 
 	@Override
@@ -1083,7 +1083,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			}
 		}
 
-		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, true);
+		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, null, true);
 	}
 
 	@Override
@@ -1111,7 +1111,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			}
 		}
 
-		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, true);
+		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, null, true);
 	}
 
 	@Override


### PR DESCRIPTION
- Since we retrieve also group_resource attributes with RichGroups in
  some cases, we need to differentiate calls isAuthorizedForAttribute()
  by respective namespace.