### PR TITLE
CORE: Fixed attribute authz in conversion of Members to RichMembers

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1324,12 +1324,13 @@ public interface MembersManagerBl {
 	 *
 	 * @param sess
 	 * @param richMembers list of richMembers for which attributes need to be filtered
+	 * @param group
 	 * @param useContext true or false means using context or not using context (more above in javadoc)
 	 *
 	 * @return list of richMembers with only allowed attributes
 	 * @throws InternalErrorException
 	 */
-	List<RichMember> filterOnlyAllowedAttributes(PerunSession sess, List<RichMember> richMembers, boolean useContext) throws InternalErrorException;
+	List<RichMember> filterOnlyAllowedAttributes(PerunSession sess, List<RichMember> richMembers, Group group, boolean useContext) throws InternalErrorException;
 
 	/**
 	 * Send mail to user's preferred email address with link for non-authz password reset.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1957,7 +1957,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 						if(canRead) {
 							boolean isWritable = false;
 							if (groupAttr.getNamespace().startsWith(AttributesManager.NS_GROUP_RESOURCE_ATTR)) {
-								isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, groupAttr, rg, resource);
+								isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, groupAttr, rg, resource);
 							} else if (groupAttr.getNamespace().startsWith(AttributesManager.NS_GROUP_ATTR)) {
 								isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, groupAttr, rg, null);
 							}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1739,7 +1739,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
-	public List<RichMember> filterOnlyAllowedAttributes(PerunSession sess, List<RichMember> richMembers, boolean useContext) throws InternalErrorException {
+	public List<RichMember> filterOnlyAllowedAttributes(PerunSession sess, List<RichMember> richMembers, Group group, boolean useContext) throws InternalErrorException {
 		//If no context should be used - every attribute is unique in context of member (for every member test access rights for all attributes again)
 		if(!useContext) return filterOnlyAllowedAttributes(sess, richMembers);
 
@@ -1773,8 +1773,19 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 						}
 					//if not, get information about authz rights and set record to contextMap
 					} else {
-						if(AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, membAttr, rm)) {
-							boolean isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, membAttr, rm);
+						boolean canRead = false;
+						if (membAttr.getNamespace().startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) {
+							canRead = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, membAttr, rm, group);
+						} else if (membAttr.getNamespace().startsWith(AttributesManager.NS_MEMBER_ATTR)) {
+							canRead = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.READ, membAttr, rm);
+						}
+						if(canRead) {
+							boolean isWritable = false;
+							if (membAttr.getNamespace().startsWith(AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
+								isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, membAttr, rm, group);
+							} else if (membAttr.getNamespace().startsWith(AttributesManager.NS_MEMBER_ATTR)) {
+								isWritable = AuthzResolver.isAuthorizedForAttribute(sess, ActionType.WRITE, membAttr, rm);
+							}
 							membAttr.setWritable(isWritable);
 							allowedMemberAttributes.add(membAttr);
 							contextMap.put(membAttr.getFriendlyName(), isWritable);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -329,7 +329,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "getGroupRichMembers");
 				}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembers(sess, group), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembers(sess, group), group, true);
 	}
 
 	@Override
@@ -344,7 +344,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "getGroupDirectRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupDirectRichMembers(sess, group), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupDirectRichMembers(sess, group), group, true);
 	}
 
 	@Override
@@ -359,7 +359,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "getGroupRichMembers");
 				}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembers(sess, group, status), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembers(sess, group, status), group, true);
 	}
 
 	@Override
@@ -374,7 +374,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "getGroupRichMembersWithAttributes");
 				}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembersWithAttributes(sess, group), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembersWithAttributes(sess, group), group, true);
 	}
 
 	@Override
@@ -388,7 +388,7 @@ public class GroupsManagerEntry implements GroupsManager {
 				&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
 			throw new PrivilegeException(sess, "getGroupRichMembersWithAttributes");
 				}
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembersWithAttributes(sess, group, status), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getGroupRichMembersWithAttributes(sess, group, status), group, true);
 	}
 
 	@Override
@@ -864,7 +864,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "getParentGroupRichMembers for " + group.getName());
 				}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getParentGroupRichMembers(sess, group), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getParentGroupRichMembers(sess, group), group, true);
 	}
 
 	@Override
@@ -879,7 +879,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "getParentGroupRichMembers for " + group.getName());
 				}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getParentGroupRichMembersWithAttributes(sess, group), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getGroupsManagerBl().getParentGroupRichMembersWithAttributes(sess, group), group, true);
 	}
 
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -455,7 +455,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getRichMemberWithAttributes");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, vo, attrsDef), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, vo, attrsDef), null, true);
 	}
 
 	@Override
@@ -471,7 +471,7 @@ public class MembersManagerEntry implements MembersManager {
 
 		getPerunBl().getGroupsManagerBl().checkGroupExists(sess, group);
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, allowedStatuses, group), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, allowedStatuses, group), group, true);
 	}
 
 	@Override
@@ -487,7 +487,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getRichMembersWithAttributesByNames");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributesByNames(sess, vo, attrsNames), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributesByNames(sess, vo, attrsNames), null, true);
 	}
 
 	@Override
@@ -503,7 +503,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, vo, attrsNames), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, vo, attrsNames), null, true);
 	}
 
 	@Override
@@ -519,7 +519,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, vo, attrsNames, allowedStatuses), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, vo, attrsNames, allowedStatuses), null, true);
 	}
 
 	@Override
@@ -535,7 +535,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, group, attrsNames, lookingInParentGroup), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, group, attrsNames, lookingInParentGroup), group, true);
 	}
 
 	@Override
@@ -567,7 +567,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, group, attrsNames, allowedStatuses, lookingInParentGroup), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getCompleteRichMembers(sess, group, attrsNames, allowedStatuses, lookingInParentGroup), group, true);
 	}
 
 	@Override
@@ -583,7 +583,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, vo, attrsNames, searchString), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, vo, attrsNames, searchString), null, true);
 	}
 
 	@Override
@@ -599,7 +599,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, vo, attrsNames, allowedStatuses, searchString), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, vo, attrsNames, allowedStatuses, searchString), null, true);
 	}
 
 	@Override
@@ -639,7 +639,7 @@ public class MembersManagerEntry implements MembersManager {
 			richMemberIter.remove();
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, richMembers, false);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, richMembers, null, false);
 	}
 
 	@Override
@@ -655,7 +655,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, group, attrsNames, searchString, lookingInParentGroup), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, group, attrsNames, searchString, lookingInParentGroup), group, true);
 	}
 
 	@Override
@@ -671,7 +671,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, group, attrsNames, allowedStatuses, searchString, lookingInParentGroup), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, group, attrsNames, allowedStatuses, searchString, lookingInParentGroup), group, true);
 	}
 
 	@Override
@@ -687,7 +687,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getRichMembersWithAttributesByNames");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributesByNames(sess, group, attrsNames), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributesByNames(sess, group, attrsNames), group, true);
 	}
 
 	@Override
@@ -703,7 +703,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getRichMemberWithAttributes");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, group, attrsDef), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, group, attrsDef), group, true);
 	}
 
 	@Override
@@ -719,7 +719,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "getRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembers(sess, group), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembers(sess, group), group, true);
 	}
 
 	@Override
@@ -735,7 +735,7 @@ public class MembersManagerEntry implements MembersManager {
 
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembers(sess, vo), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembers(sess, vo), null, true);
 	}
 
 	@Override
@@ -751,7 +751,7 @@ public class MembersManagerEntry implements MembersManager {
 
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembers(sess, vo, status), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembers(sess, vo, status), null, true);
 	}
 
 	@Override
@@ -767,7 +767,7 @@ public class MembersManagerEntry implements MembersManager {
 
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, vo), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, vo), null, true);
 	}
 
 	@Override
@@ -783,7 +783,7 @@ public class MembersManagerEntry implements MembersManager {
 
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, vo, status), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().getRichMembersWithAttributes(sess, vo, status), null, true);
 	}
 
 	@Override
@@ -894,7 +894,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findRichMembersInGroup");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersWithAttributesInGroup(sess, group, searchString), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersWithAttributesInGroup(sess, group, searchString), group, true);
 	}
 
 	@Override
@@ -925,7 +925,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findRichMembersInParentGroup");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersWithAttributesInParentGroup(sess, group, searchString), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersWithAttributesInParentGroup(sess, group, searchString), group, true);
 	}
 
 	@Override
@@ -940,7 +940,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findRichMembersInVo");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersInVo(sess, vo, searchString), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersInVo(sess, vo, searchString), null, true);
 	}
 
 	@Override
@@ -955,7 +955,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findRichMembersWithAttributesInVo");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersWithAttributesInVo(sess, vo, searchString), true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersWithAttributesInVo(sess, vo, searchString), null, true);
 	}
 
 	@Override


### PR DESCRIPTION
- Since we retrieve also member_group attributes with RichMembers in
  some cases, we need to differentiate calls isAuthorizedForAttribute()
  by respective namespace.
- Fixed also WRITE recognition on group_resource attributes for
  RichGroups.