### PR TITLE
Do not pass complex errors to the audit log

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupSyncFailed.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupSyncFailed.java
@@ -6,17 +6,15 @@ import cz.metacentrum.perun.core.api.Group;
 public class GroupSyncFailed extends AuditEvent {
 
 	private Group group;
-	private String originalExceptionMessage;
 	private String message;
 
 	@SuppressWarnings("unused") // used by jackson mapper
 	public GroupSyncFailed() {
 	}
 
-	public GroupSyncFailed(Group group, String originalExceptionMessage) {
+	public GroupSyncFailed(Group group) {
 		this.group = group;
-		this.originalExceptionMessage = originalExceptionMessage;
-		this.message = formatMessage( "%s synchronization failed because of %s.", group, originalExceptionMessage);
+		this.message = formatMessage( "%s synchronization failed.", group);
 	}
 
 	@Override
@@ -26,10 +24,6 @@ public class GroupSyncFailed extends AuditEvent {
 
 	public Group getGroup() {
 		return group;
-	}
-
-	public String getOriginalExceptionMessage() {
-		return originalExceptionMessage;
 	}
 
 	@Override

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupSyncFinishedWithErrors.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupSyncFinishedWithErrors.java
@@ -6,17 +6,15 @@ import cz.metacentrum.perun.core.api.Group;
 public class GroupSyncFinishedWithErrors extends AuditEvent {
 
 	private Group group;
-	private String originalExceptionMessage;
 	private String message;
 
 	@SuppressWarnings("unused") // used by jackson mapper
 	public GroupSyncFinishedWithErrors() {
 	}
 
-	public GroupSyncFinishedWithErrors(Group group, String originalExceptionMessage) {
+	public GroupSyncFinishedWithErrors(Group group) {
 		this.group = group;
-		this.originalExceptionMessage = originalExceptionMessage;
-		this.message = formatMessage("%s synchronization finished with errors: %s.", group, originalExceptionMessage);
+		this.message = formatMessage("%s synchronization finished with errors.", group);
 	}
 
 	@Override
@@ -26,10 +24,6 @@ public class GroupSyncFinishedWithErrors extends AuditEvent {
 
 	public Group getGroup() {
 		return group;
-	}
-
-	public String getOriginalExceptionMessage() {
-		return originalExceptionMessage;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -2109,11 +2109,13 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				log.error("Can't save lastSuccessSynchronizationTimestamp, because there is missing attribute with name {}",attrName);
 			}
 		} else {
-			//Log to auditer_log that synchronization failed or finished with some errors
+			//Log info about synchronization problems to audit log and to the perun system log
 			if(failedDueToException) {
-				getPerunBl().getAuditer().log(sess,new GroupSyncFailed(group, originalExceptionMessage));
+				getPerunBl().getAuditer().log(sess,new GroupSyncFailed(group));
+				log.debug("{} synchronization failed because of {}", group, originalExceptionMessage);
 			} else {
-				getPerunBl().getAuditer().log(sess, new GroupSyncFinishedWithErrors(group, originalExceptionMessage));
+				getPerunBl().getAuditer().log(sess,new GroupSyncFinishedWithErrors(group));
+				log.debug("{} synchronization finished with errors: {}", group, originalExceptionMessage);
 			}
 		}
 


### PR DESCRIPTION
 - audit log is not able to parse very complex messages like whole
 exceptions etc.
 - for this reason, we removed content of exception if group
 synchronization failed and send this information to perun log instead.
 Now only information that error occured is in the message in audit log
 and more information need to be found in specific attribute or
 in the log of the perun
 - two classes working with these messages were reworked to be able
 to send whole messages with error or partial messages without error
 itself.