### PR TITLE
Fixed deleting group when the group was ResourceSelfService of resource

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -408,6 +408,15 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			}
 		}
 
+		List<Resource> resourcesWhereGroupIsResourceSelfService = getGroupsManagerImpl().getResourcesWhereGroupIsResourceSelfService(sess, group);
+		for (Resource resource : resourcesWhereGroupIsResourceSelfService) {
+			try {
+				perunBl.getResourcesManagerBl().removeResourceSelfServiceGroup(sess, resource, group);
+			} catch (GroupNotAdminException e) {
+				log.warn("Can't unset group {} as admin of resource {} due to group not admin exception {}.", group, resource, e);
+			}
+		}
+
 		List<SecurityTeam> securityTeamsWhereGroupIsAdmin = getGroupsManagerImpl().getSecurityTeamsWhereGroupIsAdmin(sess, group);
 		for (SecurityTeam securityTeam : securityTeamsWhereGroupIsAdmin) {
 			try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -974,6 +974,17 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
+	public List<Resource> getResourcesWhereGroupIsResourceSelfService(PerunSession session, Group group) throws InternalErrorException {
+		try {
+			return jdbc.query("select " + ResourcesManagerImpl.resourceMappingSelectQuery + " from authz join resources " +
+					"on authz.resource_id=resources.id where authorized_group_id=? and authz.role_id=(select id from roles where name='resourceselfservice')",
+				ResourcesManagerImpl.RESOURCE_MAPPER, group.getId());
+		}  catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
 	public List<SecurityTeam> getSecurityTeamsWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException {
 		try {
 			return jdbc.query("select " + SecurityTeamsManagerImpl.securityTeamMappingSelectQuery + " from authz join security_teams " +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -737,6 +737,16 @@ public interface GroupsManagerImplApi {
 	List<Resource> getResourcesWhereGroupIsAdmin(PerunSession session, Group group) throws InternalErrorException;
 
 	/**
+	 * Returns all resources where given group si RESOURCESELFSERVICE.
+	 *
+	 * @param session session
+	 * @param group group
+	 * @return list of all resources where given group is RESOURCESELFSERVICE
+	 * @throws InternalErrorException
+	 */
+	List<Resource> getResourcesWhereGroupIsResourceSelfService(PerunSession session, Group group) throws InternalErrorException;
+
+	/**
 	 * Returns all security teams where given group si SECURITYADMIN.
 	 *
 	 * @param session session


### PR DESCRIPTION
Added new method to find all resources where group is ResourceSelfService.
deleteAnyGroup method now unsets ResourceSelfService role of group before deleting it.