### PR TITLE
Delete log from PerunException and PerunRuntimeException

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PerunException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PerunException.java
@@ -11,17 +11,14 @@ import org.slf4j.LoggerFactory;
 public abstract class PerunException extends Exception {
 	static final long serialVersionUID = 0;
 
-	private final static Logger log = LoggerFactory.getLogger(PerunException.class);
+	private final static Logger log = LoggerFactory.getLogger("ultimate_logger");
 	private String errorId = Long.toHexString(System.currentTimeMillis());
 
 	public PerunException() {
 		super();
 
 		if (!(this instanceof InternalErrorException)) {
-			log.warn("Exception {}: {}.", errorId, this);
-			if (log.isDebugEnabled()) {
-				log.debug("Exception detail:", this);
-			}
+			log.debug("Exception {}: {}.", errorId, this);
 		}
 	}
 
@@ -29,31 +26,26 @@ public abstract class PerunException extends Exception {
 		super(message);
 
 		if (!(this instanceof InternalErrorException)) {
-			log.warn("Exception {}: {}.", errorId, this);
-			if (log.isDebugEnabled()) {
-				log.debug("Exception detail:", this);
-			}
+			log.debug("Exception {}: {}.", errorId, this);
 		}
+
 	}
 
 	public PerunException(String message, Throwable cause) {
 		super(message, cause);
 
 		if (!(this instanceof InternalErrorException)) {
-			log.warn("Exception {}: {}.", errorId, this);
-			if (log.isDebugEnabled()) {
-				log.debug("Exception detail:", this);
-			}
+			log.debug("Exception {}: {}.", errorId, this);
 		}
+
 	}
 
 	public PerunException(Throwable cause) {
+
 		super(cause!=null?cause.getMessage():null,cause);
+
 		if (!(this instanceof InternalErrorException)) {
-			log.warn("Exception {}: {}.", errorId, this);
-			if (log.isDebugEnabled()) {
-				log.debug("Exception detail:", this);
-			}
+			log.debug("Exception {}: {}.", errorId, this);
 		}
 	}
 

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/rt/PerunRuntimeException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/rt/PerunRuntimeException.java
@@ -7,29 +7,25 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 
 public abstract class PerunRuntimeException extends RuntimeException {
 	static final long serialVersionUID = 0;
-	private final static Logger log = LoggerFactory.getLogger(PerunException.class);
+	private final static Logger log = LoggerFactory.getLogger("ultimate_logger");
 
 	private String errorId = Long.toHexString(System.currentTimeMillis());
 
 	public PerunRuntimeException() {
+
 		super();
 
 		if (!(this instanceof InternalErrorRuntimeException)) {
-			log.warn("Runtime Exception {}: {}.", errorId, this);
-			if (log.isDebugEnabled()) {
-				log.debug("Runtime Exception detail:", this);
-			}
+			log.debug("Runtime Exception {}: {}.", errorId, this);
 		}
 	}
 
 	public PerunRuntimeException(String err) {
+
 		super(err);
 
 		if (!(this instanceof InternalErrorRuntimeException)) {
-			log.warn("Runtime Exception {}: {}.", errorId, this);
-			if (log.isDebugEnabled()) {
-				log.debug("Runtime Exception detail:", this);
-			}
+			log.debug("Runtime Exception {}: {}.", errorId, this);
 		}
 	}
 
@@ -37,10 +33,7 @@ public abstract class PerunRuntimeException extends RuntimeException {
 		super(cause!=null?cause.getMessage():null, cause);
 
 		if (!(this instanceof InternalErrorRuntimeException)) {
-			log.warn("Runtime Exception {}: {}.", errorId, this);
-			if (log.isDebugEnabled()) {
-				log.debug("Runtime Exception detail:", this);
-			}
+			log.debug("Runtime Exception {}: {}.", errorId, this);
 		}
 	}
 
@@ -48,10 +41,7 @@ public abstract class PerunRuntimeException extends RuntimeException {
 		super(err, cause);
 
 		if (!(this instanceof InternalErrorRuntimeException)) {
-			log.warn("Runtime Exception {}: {}.", errorId, this);
-			if (log.isDebugEnabled()) {
-				log.debug("Runtime Exception detail:", this);
-			}
+			log.debug("Runtime Exception {}: {}.", errorId, this);
 		}
 	}
 

--- a/perun-base/src/main/resources/logback-default.xml
+++ b/perun-base/src/main/resources/logback-default.xml
@@ -134,6 +134,22 @@
 	<logger name="cz.metacentrum.perun.core.impl.PerunTransactionManager" level="error"/>
 	<logger name="cz.metacentrum.perun.core.impl.PerunBasicDataSource" level="error"/>
 
+	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-ultimate">
+        <file>${LOGDIR}perun-ultimate.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-ultimate.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
+			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
+		</rollingPolicy>
+    	<encoder>
+			<pattern>${ENCODER_PATTERN}</pattern>
+		</encoder>
+    </appender>
+	<logger name="ultimate_logger" level="debug" additivity="false">
+		<appender-ref ref="perun-ultimate"/>
+    </logger>
+
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-eventProcessor">
 		<file>${LOGDIR}perun-dispatcher-eventProcessor.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -738,15 +738,18 @@ public class Api extends HttpServlet {
 			if (!isJsonp) {
 				resp.setStatus(400);
 			}
+			log.warn("Perun exception {}: {}.", pex.getErrorId(), pex);
 			ser.writePerunException(pex);
 		} catch (PerunRuntimeException prex) {
 			// If the output is JSONP, it cannot send the HTTP 400 code, because the web browser wouldn't accept this
 			if (!isJsonp) {
 				resp.setStatus(400);
 			}
+			log.warn("PerunRuntime exception {}: {}.", prex.getErrorId(), prex);
 			ser.writePerunRuntimeException(prex);
 		} catch (IOException ioex) { //IOException gets logged and is rethrown
 			//noinspection ThrowableNotThrown
+			log.warn("IO exception {}: {}.", Long.toHexString(System.currentTimeMillis()), ioex);
 			new RpcException(RpcException.Type.UNCATCHED_EXCEPTION, ioex);
 			throw ioex;
 		} catch (Exception ex) {
@@ -754,6 +757,7 @@ public class Api extends HttpServlet {
 			if (!isJsonp) {
 				resp.setStatus(500);
 			}
+			log.warn("Perun exception {}: {}.", Long.toHexString(System.currentTimeMillis()), ex);
 			ser.writePerunException(new RpcException(RpcException.Type.UNCATCHED_EXCEPTION, ex));
 		} finally {
 			if (!isGet && !isPut && perunRequest != null) {


### PR DESCRIPTION
Problem:
Some methods are use Exception as return value and every Exception extends from PerunException where is in constructor logs error message.
We don't want to log Exception that is processed in the code.

Fix:
I removed log from PerunException and PerunRuntimeException and add log exception to Api.java. Here is catched every exception that going out.