### PR TITLE
Membership expiration extension fix

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -3416,7 +3416,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				Calendar gracePeriodCalendar = Calendar.getInstance();
 				Pair<Integer, Integer> fieldAmount;
 				try {
-					fieldAmount = Utils.extendGracePeriodCalendar(gracePeriodCalendar, m, calendar, extensionInNextYear);
+					fieldAmount = Utils.extendGracePeriodCalendar(gracePeriodCalendar, m, calendar);
 				} catch (InternalErrorException e) {
 					throw new InternalErrorException("Wrong format of gracePeriod in group membershipExpirationRules attribute. gracePeriod: " + gracePeriod);
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1634,7 +1634,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
             if (m.matches()) {
 				Calendar gracePeriodCalendar = Calendar.getInstance();
 				try {
-					Utils.extendGracePeriodCalendar(gracePeriodCalendar, m, calendar, extensionInNextYear);
+					Utils.extendGracePeriodCalendar(gracePeriodCalendar, m, calendar);
 				} catch (InternalErrorException e) {
 					throw new InternalErrorException("Wrong format of gracePeriod in VO membershipExpirationRules attribute. gracePeriod: " + gracePeriod);
 				}
@@ -2083,7 +2083,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 						Calendar gracePeriodCalendar = Calendar.getInstance();
 						Pair<Integer, Integer> fieldAmount;
 						try {
-							fieldAmount = Utils.extendGracePeriodCalendar(gracePeriodCalendar, m, calendar, extensionInNextYear);
+							fieldAmount = Utils.extendGracePeriodCalendar(gracePeriodCalendar, m, calendar);
 						} catch (InternalErrorException e) {
 							throw new InternalErrorException("Wrong format of gracePeriod in VO membershipExpirationRules attribute. gracePeriod: " + gracePeriod);
 						}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1418,11 +1418,10 @@ public class Utils {
 	 * @param gracePeriodCalendar grace period calendar
 	 * @param matcher matcher
 	 * @param extensionCalendar extension calendar
-	 * @param extensionInNextYear is extension next year
 	 * @return pair of field(Calendar.YEAR, Calendar.MONTH, Calendar.DAY_OF_MONTH) and amount
 	 * @throws InternalErrorException when given matcher contains invalid data
 	 */
-	public static Pair<Integer, Integer> extendGracePeriodCalendar(Calendar gracePeriodCalendar, Matcher matcher, Calendar extensionCalendar, boolean extensionInNextYear) throws InternalErrorException {
+	public static Pair<Integer, Integer> extendGracePeriodCalendar(Calendar gracePeriodCalendar, Matcher matcher, Calendar extensionCalendar) throws InternalErrorException {
 		if (!matcher.matches()) {
 			return null;
 		}
@@ -1434,9 +1433,6 @@ public class Utils {
 		int month = extensionCalendar.get(Calendar.MONTH);
 		int day = extensionCalendar.get(Calendar.DAY_OF_MONTH);
 		gracePeriodCalendar.set(year, month, day);
-		if (extensionInNextYear) {
-			gracePeriodCalendar.add(Calendar.YEAR, 1);
-		}
 
 		int field;
 		String dmyString = matcher.group(2);


### PR DESCRIPTION
There was an error introduced in
0a6a4f8 which broke expiration
extension with fixed date (i.e. account is extended to fixed date in the
future).

When the extension date were in next year (not current year) and user
was within the grace period, which means he should get one extra year in
his extension, he doesn't get the extra year. Which usually means he got
the same expiration date which he already had.

Problem is hidden in method extendCalendarByStaticDate which have a side
effect of changing the date from parameter to the date of the extension.
This will caused that "gracePeriodCalendar" date computed by
extendGracePeriodCalendar method is prolonged by one extra year, which
shouldn't happen.

For example today is 1.12.2000, extension date is 1.2. and grace period
is 3 months. extendCalendarByStaticDate changes the date in parameter to
1.2.2001 and extendGracePeriodCalendar sets gracePeriodCalendar to
1.11.2001 (that is 1.2.2002 (the extra year which shouldn't be there)
subtract 3 months grace period).

As a result of this extendGracePeriodCalendar seems to be OK and
therefore there is no extra year added to extension date is is should
be.

This commit fixes the addition of one extra year to
extendGracePeriodCalendar which will fix the described issue.