### PR TITLE
Fixed auditing of null VOs in member expiration messages

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -141,7 +141,7 @@ public class ExpirationNotifScheduler {
 					if (didntSubmitExtensionApplication(m)) {
 						// still didn't apply for extension
 
-						expirationPeriod.getExpirationAuditAction().callOn(getPerun().getAuditer(), sess, m, vosMap.get(m.getId()));
+						expirationPeriod.getExpirationAuditAction().callOn(getPerun().getAuditer(), sess, m, vosMap.get(m.getVoId()));
 					} else {
 						log.debug("{} not notified about expiration, has submitted - pending application.", m);
 					}


### PR DESCRIPTION
* BUG: There is used member's id instead of id of his vo.