### PR TITLE
upgraded to Spring Boot Starter parent 2.1.2 / Spring 5.1.4

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -150,20 +150,16 @@
 		<dependency>
 			<groupId>org.infinispan</groupId>
 			<artifactId>infinispan-core</artifactId>
-			<version>9.4.2.Final</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.infinispan</groupId>
 			<artifactId>infinispan-query</artifactId>
-			<version>9.4.2.Final</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.xhtmlrenderer/flying-saucer-pdf -->
 		<dependency>
 			<groupId>org.xhtmlrenderer</groupId>
 			<artifactId>flying-saucer-pdf</artifactId>
-			<version>${flying-saucer-pdf.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/perun-scim/pom.xml
+++ b/perun-scim/pom.xml
@@ -97,16 +97,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.ws.rs</groupId>
-			<artifactId>javax.ws.rs-api</artifactId>
-			<version>${javax.ws.rs-api.version}</version>
-			<type>jar</type>
-		</dependency>
-
-		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-common</artifactId>
-			<version>${jersey-common.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.1.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/>
 	</parent>
 
@@ -84,8 +84,6 @@
 		<recaptcha4j.version>0.0.7</recaptcha4j.version>
 		<smackx.version>3.1.0</smackx.version>
 		<taglibs-standard.version>1.2.5</taglibs-standard.version>
-		<javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
-		<jersey-common.version>2.23.2</jersey-common.version>
 	</properties>
 
 	<!-- DEFAULT MAVEN BUILD SETTINGS
@@ -433,6 +431,19 @@
 				<groupId>org.jboss.javaee</groupId>
 				<artifactId>jboss-jms-api</artifactId>
 				<version>${jboss-jms-api.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.xhtmlrenderer</groupId>
+				<artifactId>flying-saucer-pdf</artifactId>
+				<version>${flying-saucer-pdf.version}</version>
+				<exclusions>
+					<exclusion>
+						<!-- problem with double-dependency on bcmail-jdk14 versions 1.46 and 1.60 in the same time -->
+						<artifactId>bctsp-jdk14</artifactId>
+						<groupId>org.bouncycastle</groupId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
- routine update
- also removed direct dependency of perun-scim on javax.ws.rs-api, it is already transitive dependency of jersey-common
- fixed dependency of flying-saucer-pdf on two different versions of bcmail-jdk14 by excluding bctsp-jdk14 (Bouncy Castle implementation of Time-Stamp Protocol)