### PR TITLE
testing on Java11 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
-dist: trusty
+dist: xenial
+jdk:
+ - openjdk8
+ - openjdk11
 notifications:
   slack:
     secure: CgeySCRL2VzY+/gohsDo5lb9LacQMFB3NjsbQeR57RvuGdemmy3kp9E/3uiHNW0KW0iuIHmcM61BIwhXIeQrSER5+pBqvDgzsc+EFEzott8QedZm0ezGEDhX5nqemmqwUJH8jEYZx/IRpza0pwz3p0tygIJhIZtlJVD7KfyXCJk=


### PR DESCRIPTION
The .travis.yml was changed to test on two JDKs in parallel - on OpenJDK 8 and on OpenJDK 11. Previously it was on Oracle JDK 8 only.  Also the operating system for the test was changed from Ubuntu 14.04 Trusty, which will expire in April 2019, to Ubuntu 16.04 Xenial that is the latest linux supported by Travis CI in this moment.