### PR TITLE
Add info about start and finish of synchronization to AuditLog

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupSyncFinished.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupSyncFinished.java
@@ -1,0 +1,39 @@
+package cz.metacentrum.perun.audit.events.GroupManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+
+public class GroupSyncFinished extends AuditEvent {
+
+	private Group group;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public GroupSyncFinished() {
+	}
+
+	public GroupSyncFinished(Group group) {
+		this.group = group;
+		this.message = formatMessage("Group synchronization for %s has been finished.", group);
+	}
+
+	public GroupSyncFinished(Group group, long startTime, long endTime) {
+		this.group = group;
+		String duration = String.valueOf(endTime - startTime);
+		this.message = formatMessage("Group synchronization for %s has been finished in %s nano seconds.", group, duration);
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	public Group getGroup() {
+		return group;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupSyncStarted.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/GroupSyncStarted.java
@@ -1,0 +1,33 @@
+package cz.metacentrum.perun.audit.events.GroupManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+
+public class GroupSyncStarted extends AuditEvent {
+
+	private Group group;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public GroupSyncStarted() {
+	}
+
+	public GroupSyncStarted(Group group) {
+		this.group = group;
+		this.message = formatMessage("Group synchronization for %s has been started.", group);
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	public Group getGroup() {
+		return group;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -12,7 +12,9 @@ import cz.metacentrum.perun.audit.events.GroupManagerEvents.GroupCreatedInVo;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.GroupDeleted;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.GroupMoved;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.GroupSyncFailed;
+import cz.metacentrum.perun.audit.events.GroupManagerEvents.GroupSyncFinished;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.GroupSyncFinishedWithErrors;
+import cz.metacentrum.perun.audit.events.GroupManagerEvents.GroupSyncStarted;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.GroupUpdated;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.IndirectMemberAddedToGroup;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.IndirectMemberRemovedFromGroup;
@@ -1449,7 +1451,9 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		ExtSource membersSource = null;
 
 		try {
-			log.debug("Group synchronization {}: started.", group);
+			long startTime = System.nanoTime();
+			getPerunBl().getAuditer().log(sess,new GroupSyncStarted(group));
+			log.debug("Group synchronization for {} has been started.", group);
 
 			//Initialization of group extSource
 			source = getGroupExtSourceForSynchronization(sess, group);
@@ -1494,7 +1498,9 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			//Remove presented members in group who are not presented in synchronized ExtSource
 			removeFormerMembersWhileSynchronization(sess, group, membersToRemove);
 
-			log.info("Group synchronization {}: ended.", group);
+			long endTime = System.nanoTime();
+			getPerunBl().getAuditer().log(sess,new GroupSyncFinished(group, startTime, endTime));
+			log.info("Group synchronization for {} has been finished.", group);
 		} finally {
 			closeExtSourcesAfterSynchronization(membersSource, source);
 		}


### PR DESCRIPTION
 - when group synchronization process is started, we log this
 information to the audit_log
 - the same for finish of synchronization
 - this info is useful for optimizations and also for processing
 information about the length of synchrinzations in the past
 to be able to validate efficiency of used optimizations