### PR TITLE
EduPersonScopedAffiliations

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
@@ -6,9 +6,16 @@ import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetFor
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributeCollectedFromUserExtSource;
@@ -22,9 +29,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
- * All affiliations collected from UserExtSources attributes and eduPersonScopedAffiliationsManuallyAssigned.
+ * All affiliations collected from:
+ *  - UserExtSources attributes
+ *  - urn:perun:user:attribute-def:def:eduPersonScopedAffiliationsManuallyAssigned
+ *  - urn:perun:group:attribute-def:def:groupAffiliations
  *
  * @author Martin Kuba makub@ics.muni.cz
  * @author Dominik Frantisek Bucik <bucik@ics.muni.cz>
@@ -33,6 +44,13 @@ import java.util.Set;
 public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations extends UserVirtualAttributeCollectedFromUserExtSource {
 
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+	private final Pattern userAllAttrsRemovedPattern = Pattern.compile("All attributes removed for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern userEPSAMASetPattern = Pattern.compile("Attribute:\\[(.*)friendlyName=<" + getSecondarySourceAttributeFriendlyName() +">(.*)] set for User:\\[(.*)]", Pattern.DOTALL);
+	private final Pattern userEPSAMARemovePattern = Pattern.compile("AttributeDefinition:\\[(.*)friendlyName=<" + getSecondarySourceAttributeFriendlyName() + ">(.*)] removed for User:\\[(.*)]", Pattern.DOTALL);
+
+	// format has to match the format in Perun-wui setAffiliation miniapp (method createAssignedAffiliationsAttribute)
+	private final String VALIDITY_DATE_FORMAT = "yyyy-MM-dd";
 
 	@Override
 	public String getSourceAttributeFriendlyName() {
@@ -55,6 +73,22 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations exten
 		return AttributesManager.NS_USER_ATTR_DEF + ":" + getSecondarySourceAttributeFriendlyName();
 	}
 
+	/**
+	 * Get friendly name of tertiary source attribute
+	 * @return friendly name of tertiary source attribute
+	 */
+	public String getTertiarySourceAttributeFriendlyName() {
+		return "groupAffiliations";
+	}
+
+	/**
+	 * Get name of tertiary source attribute
+	 * @return name of secondary source attribute
+	 */
+	public String getTertiarySourceAttributeName() {
+		return AttributesManager.NS_GROUP_ATTR_DEF + ":" + getTertiarySourceAttributeFriendlyName();
+	}
+
 	@Override
 	public String getDestinationAttributeFriendlyName() {
 		return "eduPersonScopedAffiliations";
@@ -70,15 +104,32 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations exten
 		//for values use set because of avoiding duplicities
 		Set<String> valuesWithoutDuplicities = new HashSet<>(attribute.valueAsList());
 
+		valuesWithoutDuplicities.addAll(getAffiliationsManuallyAssigned(sess, user));
+		valuesWithoutDuplicities.addAll(getAffiliationsFromGroups(sess, user));
+
+		//convert set to list (values in list will be without duplicities)
+		destinationAttribute.setValue(new ArrayList<>(valuesWithoutDuplicities));
+		return destinationAttribute;
+	}
+
+	/**
+	 * Collect manually assigned affiliations
+	 * @param sess Perun session
+	 * @param user User for whom the values should be collected
+	 * @return Set of collected affiliations
+	 * @throws InternalErrorException When some error occurs, see exception cause for details.
+	 */
+	private Set<String> getAffiliationsManuallyAssigned(PerunSessionImpl sess, User user) throws InternalErrorException {
+		Set<String> result = new HashSet<>();
+
 		Attribute manualEPSAAttr = null;
 		try {
-			//get value from urn:perun:user:attribute-def:def:eduPersonScopedAffiliationsManuallyAssigned
 			manualEPSAAttr = sess.getPerunBl().getAttributesManagerBl()
-					.getAttribute(sess, user, getSecondarySourceAttributeName());
+				.getAttribute(sess, user, getSecondarySourceAttributeName());
 		} catch (WrongAttributeAssignmentException e) {
 			throw new InternalErrorException("Wrong assignment of " + getSecondarySourceAttributeFriendlyName() + " for user " + user.getId(), e);
 		} catch (AttributeNotExistsException e) {
-			log.debug("Attribute " + getSecondarySourceAttributeFriendlyName() + " of user " + user.getId() + "does not exist, values will be skipped", e);
+			log.debug("Attribute " + getSecondarySourceAttributeFriendlyName() + " of user " + user.getId() + " does not exist, values will be skipped", e);
 		}
 
 		if (manualEPSAAttr != null) {
@@ -86,22 +137,79 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations exten
 			if (value != null) {
 
 				LocalDate now = LocalDate.now();
-				// format has to match the format in Perun-wui setAffiliation miniapp
-				// (method createAssignedAffiliationsAttribute)
-				DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+				DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern(VALIDITY_DATE_FORMAT);
 				for (Map.Entry<String, String> entry: value.entrySet()) {
 					LocalDate expiration = LocalDate.parse(entry.getValue(), dateFormat);
 
 					if (! now.isAfter(expiration)) {
-						valuesWithoutDuplicities.add(entry.getKey());
+						result.add(entry.getKey());
 					}
 				}
 			}
 		}
 
-		//convert set to list (values in list will be without duplicities)
-		destinationAttribute.setValue(new ArrayList<>(valuesWithoutDuplicities));
-		return destinationAttribute;
+		return result;
+	}
+
+	/**
+	 * Collect affiliations from perun Groups
+	 * @param sess Perun session
+	 * @param user User for whom the values should be collected
+	 * @return Set of collected affiliations
+	 * @throws InternalErrorException When some error occurs, see exception cause for details.
+	 */
+	private Set<String> getAffiliationsFromGroups(PerunSessionImpl sess, User user) throws InternalErrorException {
+		Set<String> result = new HashSet<>();
+
+		List<Member> userVoMembers = sess.getPerunBl().getMembersManagerBl().getMembersByUser(sess, user);
+		List<Member> validVoMembers = new ArrayList<>();
+		if (userVoMembers != null && !userVoMembers.isEmpty()) {
+			for (Member member: userVoMembers) {
+				if (member.getStatus() == Status.VALID) {
+					validVoMembers.add(member);
+				}
+			}
+		}
+
+		List<Member> groupMembers = new ArrayList<>();
+		List<Group> groupsForAttrCheck = new ArrayList<>();
+		for (Member member : validVoMembers) {
+			List<Group> groups = sess.getPerunBl().getGroupsManagerBl().getMemberGroups(sess, member);
+			if (groups == null || groups.isEmpty()) {
+				continue;
+			}
+
+			for (Group group: groups) {
+				try {
+					Member groupMember = sess.getPerunBl().getGroupsManagerBl().getGroupMemberById(sess, group, member.getId());
+					if (member.getGroupStatus() == MemberGroupStatus.VALID) {
+						groupsForAttrCheck.add(group);
+					}
+				} catch (NotGroupMemberException e) {
+					log.debug("User: " + user.getId() + " is not a member of group: " + group.getId() + ", skipping");
+				}
+			}
+		}
+
+		for (Group group: groupsForAttrCheck) {
+			try {
+				Attribute groupAffiliations = sess.getPerunBl().getAttributesManager()
+					.getAttribute(sess, group, getTertiarySourceAttributeName());
+				if (groupAffiliations != null && groupAffiliations.valueAsList() != null) {
+					result.addAll(groupAffiliations.valueAsList());
+				}
+			} catch (GroupNotExistsException e) {
+				throw new InternalErrorException("Group with ID: " + group.getId() + " does not exist");
+			} catch (PrivilegeException e) {
+				throw new InternalErrorException("Unauthorized access to the group " + group.getId());
+			} catch (WrongAttributeAssignmentException e) {
+				throw new InternalErrorException("Wrong assignment of " + getTertiarySourceAttributeFriendlyName() + " for user " + user.getId(), e);
+			} catch (AttributeNotExistsException e) {
+				log.debug("Attribute " + getTertiarySourceAttributeFriendlyName() + " of group " + group.getId() + " does not exist, values will be skipped", e);
+			}
+		}
+
+		return result;
 	}
 
 	@Override
@@ -122,7 +230,7 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations exten
 			}
 		});
 		handleIdentifiers.add(auditEvent -> {
-			if (auditEvent instanceof AttributeRemovedForUser &&((AttributeRemovedForUser) auditEvent).getAttribute().getFriendlyName().equals(getSecondarySourceAttributeFriendlyName())) {
+			if (auditEvent instanceof AttributeRemovedForUser && ((AttributeRemovedForUser) auditEvent).getAttribute().getFriendlyName().equals(getSecondarySourceAttributeFriendlyName())) {
 				return ((AttributeRemovedForUser) auditEvent).getUser().getId();
 			} else {
 				return null;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest.java
@@ -9,6 +9,10 @@ import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
@@ -17,6 +21,7 @@ import org.junit.Test;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -30,7 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Test module for urn:perun:user:attribute-def:def:eduPersonScopedAffiliationsManuallyAssigned
+ * Test module for urn:perun:user:attribute-def:virt:eduPersonScopedAffiliations
  *
  * @author Martin Kuba makub@ics.muni.cz
  * @author Dominik Frantisek Bucik <bucik@ics.muni.cz>
@@ -44,17 +49,32 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest {
 	private UserExtSource ues2;
 	private Attribute uesAtt1;
 	private Attribute uesAtt2;
-	private Attribute userAtt;
-	private final String VALUE1 = "member@somewhere.edu";
-	private final String VALUE2 = "affiliate@company.com";
-	private final String VALUE3 = "library-walk-in@company.com";
-	private final String KEY1 = "member@somewhere.org";
-	private final String KEY2 = "affiliate@somewhere.edu";
+	private Attribute userAtt1;
+	private final String VALUE1 = "11aff11@somewhere.edu";
+	private final String VALUE2 = "22aff22@somewhere.edu";
+	private final String VALUE3 = "33aff33@somewhere.edu";
+	private final String VALUE4 = "44aff44@somewhere.edu";
+	private final String VALUE5 = "55aff55@somewhere.edu";
+	private final String VALUE6 = "66aff66@somewhere.edu";
+	private final String VALUE7 = "77aff77@somewhere.edu";
+
 	private LocalDate valid;
 	private LocalDate invalid;
+	private Member validMember;
+	private Member expiredMember;
+	private Member groupMember1;
+	private Member groupMember2;
+	private int gId1 = 1;
+	private int gId2 = 2;
+	private Group group1;
+	private Group group2;
+	private Attribute groupAtt1;
 
 	@Before
 	public void setVariables() {
+		classInstance = new urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+
 		valid = LocalDate.now();
 		invalid = valid.minusDays(1);
 		DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -70,35 +90,73 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest {
 		uesAtt1.setValue(VALUE1);
 		uesAtt2.setValue(VALUE2+";"+VALUE3);
 
-		userAtt = new Attribute();
-		Map<String, String> MAP_VALUE = new LinkedHashMap<>();
-		MAP_VALUE.put(KEY1, valid.format(dateFormat));
-		MAP_VALUE.put(KEY2, invalid.format(dateFormat));
-		userAtt.setValue(MAP_VALUE);
+		userAtt1 = new Attribute();
+		Map<String, String> mapValue = new LinkedHashMap<>();
+		mapValue.put(VALUE6, valid.format(dateFormat));
+		mapValue.put(VALUE7, invalid.format(dateFormat));
+		userAtt1.setValue(mapValue);
 
-		classInstance = new urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations();
-		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		group1 = new Group(gId1, "G1", "G1_DSC", null, null, null, null, null, null);
+		group2 = new Group(gId2, "G2", "G2_DSC", null, null, null, null, null, null);
+
+		validMember = new Member(1, 1, 1, Status.VALID);
+		expiredMember = new Member(2, 1, 1, Status.EXPIRED);
+
+		groupMember1 = new Member(1, 1, 1, Status.VALID);
+		groupMember1.setSourceGroupId(gId1);
+		groupMember1.putGroupStatus(gId1, MemberGroupStatus.VALID);
+
+		groupMember2 = new Member(1, 1, 1, Status.VALID);
+		groupMember2.setSourceGroupId(gId2);
+		groupMember2.putGroupStatus(gId2, MemberGroupStatus.EXPIRED);
+
+		groupAtt1 = new Attribute();
+		List<String> arrListValue = new ArrayList<>();
+		arrListValue.add(VALUE4);
+		arrListValue.add(VALUE5);
+		groupAtt1.setValue(arrListValue);
 	}
 
 	@Test
-	public void getAttributeValueFromBothSources() throws Exception {
+	public void getAttributeValueFromAllSources() throws Exception {
 		urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations classInstance = new urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations();
 		PerunSessionImpl session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
 
-		when(session.getPerunBl().getUsersManagerBl().getUserExtSources(session, user)).thenReturn(
-				Arrays.asList(ues1, ues2)
-		);
-
-		String sourceAttributeName = classInstance.getSourceAttributeName();
+		String primarySourceAttributeName = classInstance.getSourceAttributeName();
 		String secondarySourceAttrName = classInstance.getSecondarySourceAttributeName();
-		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, ues1, sourceAttributeName)).thenReturn(
+		String tertiarySourceAttrName = classInstance.getTertiarySourceAttributeName();
+
+		// USER_EXT_SOURCE
+		when(session.getPerunBl().getUsersManagerBl().getUserExtSources(session, user)).thenReturn(
+			Arrays.asList(ues1, ues2)
+		);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, ues1, primarySourceAttributeName)).thenReturn(
 				uesAtt1
 		);
-		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, ues2, sourceAttributeName)).thenReturn(
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, ues2, primarySourceAttributeName)).thenReturn(
 				uesAtt2
 		);
+
+		// MANUALLY_ASSIGNED_AFFILIATIONS
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, secondarySourceAttrName)).thenReturn(
-				userAtt
+				userAtt1
+		);
+
+		// AFFILIATIONS_FROM_GROUP
+		when(session.getPerunBl().getMembersManagerBl().getMembersByUser(session, user)).thenReturn(
+				Arrays.asList(validMember, expiredMember)
+		);
+		when(session.getPerunBl().getGroupsManagerBl().getMemberGroups(session, validMember)).thenReturn(
+				Arrays.asList(group1, group2)
+		);
+		when(session.getPerunBl().getGroupsManagerBl().getGroupMemberById(session, group1, validMember.getId())).thenReturn(
+				groupMember1
+		);
+		when(session.getPerunBl().getGroupsManagerBl().getGroupMemberById(session, group2, validMember.getId())).thenReturn(
+				groupMember2
+		);
+		when(session.getPerunBl().getAttributesManager().getAttribute(session, group1, tertiarySourceAttrName)).thenReturn(
+				groupAtt1
 		);
 
 		Attribute receivedAttr = classInstance.getAttributeValue(session, user, classInstance.getAttributeDefinition());
@@ -108,7 +166,42 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest {
 		@SuppressWarnings("unchecked")
 		List<String> actual = (List<String>) receivedAttr.getValue();
 		Collections.sort(actual);
-		List<String> expected = Arrays.asList(VALUE1, VALUE2, VALUE3, KEY1);
+		List<String> expected = Arrays.asList(VALUE1, VALUE2, VALUE3, VALUE4, VALUE5, VALUE6);
+		Collections.sort(expected);
+		assertEquals("collected values are incorrect", expected, actual);
+	}
+
+	@Test
+	public void getAttributeValueOnlyGroupAffiliations() throws Exception {
+		urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations classInstance = new urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations();
+		PerunSessionImpl session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+
+		when(session.getPerunBl().getMembersManagerBl().getMembersByUser(session, user)).thenReturn(
+			Arrays.asList(validMember, expiredMember)
+		);
+		when(session.getPerunBl().getGroupsManagerBl().getMemberGroups(session, validMember)).thenReturn(
+			Arrays.asList(group1, group2)
+		);
+		when(session.getPerunBl().getGroupsManagerBl().getGroupMemberById(session, group1, validMember.getId())).thenReturn(
+			groupMember1
+		);
+		when(session.getPerunBl().getGroupsManagerBl().getGroupMemberById(session, group2, validMember.getId())).thenReturn(
+			groupMember2
+		);
+
+		String tertiarySourceAttrName = classInstance.getTertiarySourceAttributeName();
+		when(session.getPerunBl().getAttributesManager().getAttribute(session, group1, tertiarySourceAttrName)).thenReturn(
+			groupAtt1
+		);
+
+		Attribute receivedAttr = classInstance.getAttributeValue(session, user, classInstance.getAttributeDefinition());
+		assertTrue(receivedAttr.getValue() instanceof List);
+		assertEquals("destination attribute name wrong",classInstance.getDestinationAttributeFriendlyName(),receivedAttr.getFriendlyName());
+
+		@SuppressWarnings("unchecked")
+		List<String> actual = (List<String>) receivedAttr.getValue();
+		Collections.sort(actual);
+		List<String> expected = Arrays.asList(VALUE4, VALUE5);
 		Collections.sort(expected);
 		assertEquals("collected values are incorrect", expected, actual);
 	}
@@ -142,7 +235,6 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest {
 		assertEquals("collected values are incorrect", expected, actual);
 	}
 
-	@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 	@Test
 	public void getAttributeValueOnlyFromEduPersonScopedAffiliationsManuallyAssigned() throws Exception {
 		urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations classInstance = new urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations();
@@ -150,7 +242,7 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest {
 
 		String secondarySourceAttrName = classInstance.getSecondarySourceAttributeName();
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, secondarySourceAttrName)).thenReturn(
-				userAtt
+			userAtt1
 		);
 
 		Attribute receivedAttr = classInstance.getAttributeValue(session, user, classInstance.getAttributeDefinition());
@@ -160,7 +252,8 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest {
 		@SuppressWarnings("unchecked")
 		List<String> actual = (List<String>) receivedAttr.getValue();
 		Collections.sort(actual);
-		List<String> expected = Arrays.asList(KEY1);
+		List<String> expected = new ArrayList<>();
+		expected.add(VALUE6);
 		Collections.sort(expected);
 		assertEquals("collected values are incorrect", expected, actual);
 	}


### PR DESCRIPTION
* Added new way of collecting the EPSA attribute values. The module checks all memberships of user in groups. For valid memberships in groups (and valid also in parent VO) the attribute urn:perun:group:attribute-def:def:groupAffiliations is looked for. Found attribute values are added to the result.
* Added tests for attribute module