### PR TITLE
Add new util method to RPC to get system time in miliseconds

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -82,6 +82,7 @@ public class Api extends HttpServlet {
 	private final static String PERUNREQUESTSURL = "getPendingRequests";
 	private final static String PERUNSTATUS = "getPerunStatus";
 	private final static String PERUNSTATISTICS = "getPerunStatistics";
+	private final static String PERUNSYSTEMTIME = "getPerunSystemTimeInMillis";
 	private final static String VOOTMANAGER = "vootManager";
 	private final static String SCIMMANAGER = "scimManager";
 	private final static int timeToLiveWhenDone = 60 * 1000; // in milisec, if requests is done more than this time, remove it from list
@@ -674,6 +675,10 @@ public class Api extends HttpServlet {
 
 				out.close();
 				return;
+			} else if ("utils".equals(manager) && PERUNSYSTEMTIME.equals(method)) {
+				long systemTimeInMillis = System.currentTimeMillis();
+				ser.write(systemTimeInMillis);
+				out.close();
 			}
 
 			// In case of GET requests (read ones) set changing state to false


### PR DESCRIPTION
 - we need to be able synchronize time for external servers to be able
 to correctly comunicate with perun, for this reason Perun can return
 it's actual system time by this util method