### PR TITLE
Support for post-processing paging for method returning list of objects

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/ApiCaller.java
@@ -475,4 +475,41 @@ public class ApiCaller {
 	public Object call(String managerName, String methodName, Deserializer parms) throws PerunException {
 		return PerunManager.call(managerName, methodName, this, parms);
 	}
+
+	/**
+	 * Returns a view of the portion of this list between the specified fromIndex, inclusive, and toIndex, inclusive.
+	 *
+	 * If list of objects is null or empty, it will return empty list as sublist.
+	 * If fromIndex is lower than 0, it will be set to 0.
+	 * If toIndex is bigger than size of an input array, it will be set to the size of an array.
+	 * If fromIndex and toIndex are same, it will return array with exactly 1 object on this position.
+	 * If fromIndex is bigger than toIndex, it will return empty array.
+	 *
+	 * @param listOfObjects original list of objects from which we will get the sublist view by indexes
+	 * @param fromIndex index of the object from original list, which will be the first object in the sublist view (included)
+	 * @param toIndex index of the object from original list, which will be the last object in the sublist view (included)
+	 *
+	 * @return a view of the portion of the listOfObjects between fromIndex and toIndex (both inclusive), for example
+	 * if fromIndex=0 and toIndex=10 it will return view on first 11 objects of the input list if they exist. If
+	 * there are only 6 objects, it will return view on all these objects.
+	 */
+	public <E> List<E> getSublist(List<E> listOfObjects, int fromIndex, int toIndex) {
+		//if list if empty or null, return empty list of objects (there is no sublist to be find)
+		if(listOfObjects == null || listOfObjects.isEmpty()) return new ArrayList<>();
+
+		//toIndex should be included in the subList, so we will work with toIndex+1
+		toIndex = toIndex + 1;
+
+		//From index can't be lower than 0
+		if(fromIndex<0) fromIndex = 0;
+
+		//To index can't be bigger than size of an array
+		if(toIndex>listOfObjects.size()) toIndex = listOfObjects.size();
+
+		//To index can't be lower than from index
+		if(toIndex<fromIndex) toIndex = fromIndex;
+
+		return listOfObjects.subList(fromIndex, toIndex);
+
+	}
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -930,7 +930,41 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Returns all RichGroups containing selected attributes
+	 * Returns sub-list of all RichGroups, each containing selected attributes, starting at fromIndex (included)
+	 * and ending at the size of the original list.
+	 *
+	 * Example: [1,2,3,4], fromIndex=1 => [2,3,4]
+	 *
+	 * @param vo int <code>id</code> of vo
+	 * @param fromIndex int begin index of returned subList, included
+	 * @param attrNames List<String> if attrNames is null method will return RichGroups containing all attributes
+	 * @return List<RichGroup> RichGroups containing selected attributes
+	 */
+	/*#
+	 * Returns sub-list of all RichGroups, each containing selected attributes, starting at first index of the original
+	 * list (included) and ending at the toIndex (included).
+	 *
+	 * Example: [1,2,3,4], toIndex=2 => [1,2,3]
+	 *
+	 * @param vo int <code>id</code> of vo
+	 * @param toIndex int end index of returned subList, included
+	 * @param attrNames List<String> if attrNames is null method will return RichGroups containing all attributes
+	 * @return List<RichGroup> RichGroups containing selected attributes
+	 */
+	/*#
+	 * Returns sub-list of all RichGroups, each containing selected attributes, starting at fromIndex (included)
+	 * and ending at the toIndex (included).
+	 *
+	 * Example: [1,2,3,4], fromIndex=1, toIndex=2 => [2,3]
+	 *
+	 * @param vo int <code>id</code> of vo
+	 * @param fromIndex int begin index of returned subList, included
+	 * @param toIndex int end index of returned subList, included
+	 * @param attrNames List<String> if attrNames is null method will return RichGroups containing all attributes
+	 * @return List<RichGroup> RichGroups containing selected attributes
+	 */
+	/*#
+	 * Returns full list of all RichGroups containing selected attributes.
 	 *
 	 * @param vo int <code>id</code> of vo
 	 * @param attrNames List<String> if attrNames is null method will return RichGroups containing all attributes
@@ -941,9 +975,22 @@ public enum GroupsManagerMethod implements ManagerMethod {
 		@Override
 		public List<RichGroup> call(ApiCaller ac, Deserializer parms) throws PerunException {
 
-			return ac.getGroupsManager().getAllRichGroupsWithAttributesByNames(ac.getSession(),
-					ac.getVoById(parms.readInt("vo")),
-					parms.readList("attrNames", String.class));
+			List<RichGroup> listOfRichGroups = ac.getGroupsManager().getAllRichGroupsWithAttributesByNames(ac.getSession(),
+				ac.getVoById(parms.readInt("vo")),
+				parms.readList("attrNames", String.class));
+
+			if(listOfRichGroups == null) listOfRichGroups = new ArrayList<>();
+
+			if (parms.contains("fromIndex") && parms.contains("toIndex")) {
+				return ac.getSublist(listOfRichGroups, parms.readInt("fromIndex"), parms.readInt("toIndex"));
+			} else if (parms.contains("fromIndex")) {
+				int toIndex = listOfRichGroups.size();
+				return ac.getSublist(listOfRichGroups, parms.readInt("fromIndex"), toIndex);
+			} else if (parms.contains("toIndex")) {
+				return ac.getSublist(listOfRichGroups, 0, parms.readInt("toIndex"));
+			} else {
+				return listOfRichGroups;
+			}
 		}
 	},
 


### PR DESCRIPTION
 - new utility method for rpc getSublist, which is able to return
 subList of existing list as the view defined by it's lower index
 (fromIndex) and it's higher index (toIndex), both included
 - use this new method for processing of existing method
 getAllRichGroupsWithAttributesByNames to be able to get just defined
 part of the output