### PR TITLE
Tools for managin SpecificUsers

### DIFF
--- a/perun-cli/Perun/UsersAgent.pm
+++ b/perun-cli/Perun/UsersAgent.pm
@@ -163,4 +163,24 @@ sub moveUserExtSource
 	return Perun::Common::callManagerMethod('moveUserExtSource', 'null', @_);
 }
 
+sub setSpecificUser
+{
+	return Perun::Common::callManagerMethod('setSpecificUser', 'null', @_);
+}
+
+sub unsetSpecificUser
+{
+	return Perun::Common::callManagerMethod('unsetSpecificUser', 'null', @_);
+}
+
+sub addSpecificUserOwner
+{
+	return Perun::Common::callManagerMethod('addSpecificUserOwner', 'null', @_);
+}
+
+sub removeSpecificUserOwner
+{
+	return Perun::Common::callManagerMethod('removeSpecificUserOwner', 'null', @_);
+}
+
 1;

--- a/perun-cli/addSpecificUserOwner
+++ b/perun-cli/addSpecificUserOwner
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::Agent;
+use Perun::Common qw(printMessage);
+
+sub help {
+	return qq{
+	Adds next owner to specific User. User id and owner id is required.
+	--------------------------------------
+	Available options:
+	--userId       | -u user id
+	--owner        | -o owner Id
+	--batch        | -b batch
+	--help         | -h prints this help
+
+	};
+}
+
+my ($userId, $ownerId, $batch);
+GetOptions ("help|h"  => sub {
+		print help();
+		exit 0;
+	}, "batch|b"        => \$batch,
+	"userId|u=i"        => \$userId, 
+	"owner|o=i"         => \$ownerId) || die help();
+
+# Check options
+unless (defined($userId)) { die "ERROR: userId is required \n";}
+unless (defined($ownerId)) { die "ERROR: ownerId is required \n";}
+
+my $agent = Perun::Agent->new();
+my $usersAgent = $agent->getUsersAgent;
+
+$usersAgent->addSpecificUserOwner( specificUser => $userId, user => $ownerId );
+
+printMessage("Next owner $ownerId added to Specific user $userId successfully.", $batch);

--- a/perun-cli/getSpecificUsersByUser
+++ b/perun-cli/getSpecificUsersByUser
@@ -1,0 +1,44 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Text::ASCIITable;
+use Perun::Agent;
+use Perun::Common qw(printMessage printTable getSortingFunction);
+
+sub help {
+	return qq{
+	Lists Specific users assigned to User. User id is required.
+	--------------------------------------
+	Available options:
+	--userId       | -u user id
+	--batch        | -b batch
+	--help         | -h prints this help
+
+	};
+}
+
+my ($userId, $ownerId, $batch);
+GetOptions ("help|h"  => sub {
+		print help();
+		exit 0;
+	}, "batch|b"        => \$batch,
+	"userId|u=i"        => \$userId ) || die help();
+
+# Check options
+unless (defined($userId)) { die "ERROR: userId is required \n";}
+
+my $agent = Perun::Agent->new();
+my $usersAgent = $agent->getUsersAgent;
+
+my @users=$usersAgent->getSpecificUsersByUser( user => $userId );
+unless (@users) {
+	printMessage "No users found", $batch;
+	exit 0;
+}
+
+
+#output
+my $sortingFunction = getSortingFunction("getSortingName", 1);
+printTable($sortingFunction, @users);

--- a/perun-cli/getUsersBySpecificUser
+++ b/perun-cli/getUsersBySpecificUser
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Text::ASCIITable;
+use Perun::Agent;
+use Perun::Common qw(printMessage printTable getSortingFunction);
+
+sub help {
+	return qq{
+	Lists users assigned to Specific user. Specific user id is required.
+	--------------------------------------
+	Available options:
+	--specUserId   | -u specific user id
+	--batch        | -b batch
+	--help         | -h prints this help
+
+	};
+}
+
+my ($specUserId, $batch);
+GetOptions ("help|h"  => sub {
+		print help();
+		exit 0;
+	}, "batch|b"        => \$batch,
+	"specUserId|u=i"    => \$specUserId ) || die help();
+
+# Check options
+unless (defined($specUserId)) { die "ERROR: userId is required \n";}
+
+my $agent = Perun::Agent->new();
+my $usersAgent = $agent->getUsersAgent;
+
+my @users=$usersAgent->getUsersBySpecificUser( specificUser => $specUserId );
+
+unless (@users) {
+	printMessage "No users found", $batch;
+	exit 0;
+}
+
+#output
+my $sortingFunction = getSortingFunction("getSortingName", 1);
+printTable($sortingFunction, @users);
+

--- a/perun-cli/removeSpecificUserOwner
+++ b/perun-cli/removeSpecificUserOwner
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::Agent;
+use Perun::Common qw(printMessage);
+
+sub help {
+	return qq{
+	Removes given owner from specific User. User id and owner id is required.
+	--------------------------------------
+	Available options:
+	--userId       | -u user id
+	--owner        | -o owner Id
+	--batch        | -b batch
+	--help         | -h prints this help
+
+	};
+}
+
+my ($userId, $ownerId, $batch);
+GetOptions ("help|h"  => sub {
+		print help();
+		exit 0;
+	}, "batch|b"        => \$batch,
+	"userId|u=i"        => \$userId, 
+	"owner|o=i"         => \$ownerId) || die help();
+
+# Check options
+unless (defined($userId)) { die "ERROR: userId is required \n";}
+unless (defined($ownerId)) { die "ERROR: ownerId is required \n";}
+
+my $agent = Perun::Agent->new();
+my $usersAgent = $agent->getUsersAgent;
+
+$usersAgent->removeSpecificUserOwner( specificUser => $userId, user => $ownerId );
+
+printMessage("Given owner $ownerId removed from Specific user $userId successfully.", $batch);

--- a/perun-cli/setSpecificUser
+++ b/perun-cli/setSpecificUser
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::Agent;
+use Perun::Common qw(printMessage);
+
+sub help {
+	return qq{
+	Sets specific User. User id is required.
+	--------------------------------------
+	Available options:
+	--userId       | -u user id
+	--specUserType | -t type of specific user (service/sponsored)
+	--owner        | -o owner Id
+	--batch        | -b batch
+	--help         | -h prints this help
+
+	};
+}
+
+my ($userId, $ownerId, $specUsrType, $batch);
+GetOptions ("help|h"  => sub {
+		print help();
+		exit 0;
+	}, "batch|b"        => \$batch,
+	"userId|u=i"        => \$userId, 
+	"owner|o=i"         => \$ownerId,
+	"specUserType|t=s"  => \$specUsrType ) || die help();
+
+# Check options
+unless (defined($userId)) { die "ERROR: userId is required \n";}
+
+my $agent = Perun::Agent->new();
+my $usersAgent = $agent->getUsersAgent;
+
+$usersAgent->setSpecificUser( specificUser => $userId, owner => $ownerId, specificUserType => $specUsrType );
+
+printMessage("Specific user Id:$userId successfully set", $batch);

--- a/perun-cli/unsetSpecificUser
+++ b/perun-cli/unsetSpecificUser
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Getopt::Long qw(:config no_ignore_case);
+use Perun::Agent;
+use Perun::Common qw(printMessage);
+
+sub help {
+	return qq{
+	Unsets specific User. User id is required.
+	--------------------------------------
+	Available options:
+	--userId       | -u specific user id
+	--specUserType | -t type of specific user (SERVICE/SPONSORED)
+	--batch        | -b batch
+	--help         | -h prints this help
+
+	};
+}
+
+my ($userId, $specUsrType, $batch);
+GetOptions ("help|h"  => sub {
+		print help();
+		exit 0;
+	}, "batch|b"        => \$batch,
+	"userId|u=i"        => \$userId, 
+	"specUserType|t=s"  => \$specUsrType ) || die help();
+
+# Check options
+unless (defined($userId)) { die "ERROR: specificUserId is required \n";}
+
+my $agent = Perun::Agent->new();
+my $usersAgent = $agent->getUsersAgent;
+
+$usersAgent->unsetSpecificUser( specificUser => $userId, specificUserType => $specUsrType );
+
+printMessage("Specific user Id: $userId successfully unset", $batch);


### PR DESCRIPTION
addSpecificUserOwner - Adds next owner to specific User.
getUsersBySpecificUser - Lists Specific users assigned to User.
setSpecificUser - Sets specific User.
getSpecificUsersByUser  - Lists users assigned to Specific user.
removeSpecificUserOwner - Removes given owner from specific User.
unsetSpecificUser - Unsets specific User.
updated Perun/UsersAgent.pm - new methods setSpecificUser, unsetSpecificUser,
addSpecificUserOwner, removeSpecificUserOwner added