### PR TITLE
CORE: Use MemberGroupAttributeRowMapper in getRequiredAttributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3165,7 +3165,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 							"join service_required_attrs on id=service_required_attrs.attr_id and service_required_attrs.service_id=? " +
 							"left join member_group_attr_values mem_gr on id=mem_gr.attr_id and mem_gr.group_id=? and member_id=? " +
 							"where namespace in (?,?,?)",
-					new SingleBeanAttributeRowMapper<>(sess, this, member), service.getId(), group.getId(), member.getId(), AttributesManager.NS_MEMBER_GROUP_ATTR_DEF, AttributesManager.NS_MEMBER_GROUP_ATTR_OPT, AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
+					new MemberGroupAttributeRowMapper(sess, this, member, group), service.getId(), group.getId(), member.getId(), AttributesManager.NS_MEMBER_GROUP_ATTR_DEF, AttributesManager.NS_MEMBER_GROUP_ATTR_OPT, AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_groupStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_groupStatus.java
@@ -63,7 +63,7 @@ public class urn_perun_member_group_attribute_def_virt_groupStatus extends Membe
 		attr.setFriendlyName("groupStatus");
 		attr.setDisplayName("Group membership status");
 		attr.setType(String.class.getName());
-		attr.setDescription("Whether member is ACTIVE or EXPIRED in a group.");
+		attr.setDescription("Whether member is VALID or EXPIRED in a group.");
 		return attr;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_groupStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_groupStatus.java
@@ -59,7 +59,7 @@ public class urn_perun_member_resource_attribute_def_virt_groupStatus extends Me
         attr.setFriendlyName("groupStatus");
         attr.setDisplayName("Group membership status");
         attr.setType(String.class.getName());
-        attr.setDescription("Whether member is ACTIVE or EXPIRED in all groups assigned to the resource.");
+        attr.setDescription("Whether member is VALID or EXPIRED in all groups assigned to the resource.");
         return attr;
     }
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_groupStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_groupStatus.java
@@ -53,7 +53,7 @@ public class urn_perun_user_facility_attribute_def_virt_groupStatus extends User
 		attr.setFriendlyName("groupStatus");
 		attr.setDisplayName("Group membership status");
 		attr.setType(String.class.getName());
-		attr.setDescription("Whether user is ACTIVE or EXPIRED in all groups assigned to the facility.");
+		attr.setDescription("Whether user is VALID or EXPIRED in all groups assigned to the facility.");
 		return attr;
 	}
 }


### PR DESCRIPTION
- We wrongly used SingleBeanAttributeRowMapper with member for
  member_group attributes while getting set of required attributes.
  It failed on inner attribute authz and type check. Now we correctly
  use MemberGroupAttributeRowMapper.
- Fixed name of group status in attributes descriptions from ACTIVE
  to correct VALID.