### PR TITLE
CORE: Implemented logic for group membership expiration notifications

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/GroupMembershipExpirationInDays.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/GroupMembershipExpirationInDays.java
@@ -1,0 +1,46 @@
+package cz.metacentrum.perun.audit.events.ExpirationNotifScheduler;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+
+public class GroupMembershipExpirationInDays extends AuditEvent {
+
+	private Member member;
+	private int daysToExpiration;
+	private Group group;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public GroupMembershipExpirationInDays() {
+	}
+
+	public GroupMembershipExpirationInDays(Member member, int daysToExpiration, Group group) {
+		this.member = member;
+		this.daysToExpiration = daysToExpiration;
+		this.group = group;
+		this.message = formatMessage("%s will expire in %d days in %s.", member, daysToExpiration, group);
+	}
+
+	public Member getMember() {
+		return member;
+	}
+
+	public int getDaysToExpiration() {
+		return daysToExpiration;
+	}
+
+	public Group getGroup() {
+		return group;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/GroupMembershipExpirationInMonthNotification.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/GroupMembershipExpirationInMonthNotification.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.audit.events.ExpirationNotifScheduler;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+
+public class GroupMembershipExpirationInMonthNotification extends AuditEvent {
+
+	private Member member;
+	private Group group;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public GroupMembershipExpirationInMonthNotification() {
+	}
+
+	public GroupMembershipExpirationInMonthNotification(Member member, Group group) {
+		this.member = member;
+		this.group = group;
+		this.message = formatMessage("%s will expire in a month in %s.", member, group);
+	}
+
+	public Member getMember() {
+		return member;
+	}
+
+	public Group getGroup() {
+		return group;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/GroupMembershipExpired.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/ExpirationNotifScheduler/GroupMembershipExpired.java
@@ -1,0 +1,46 @@
+package cz.metacentrum.perun.audit.events.ExpirationNotifScheduler;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+
+public class GroupMembershipExpired extends AuditEvent {
+
+	private Member member;
+	private int daysAfterExpiration;
+	private Group group;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public GroupMembershipExpired() {
+	}
+
+	public GroupMembershipExpired(Member member, int daysAfterExpiration, Group group) {
+		this.member = member;
+		this.daysAfterExpiration = daysAfterExpiration;
+		this.group = group;
+		this.message = formatMessage("%s has expired %d days ago in %s.", member, daysAfterExpiration, group);
+	}
+
+	public Member getMember() {
+		return member;
+	}
+
+	public int getDaysAfterExpiration() {
+		return daysAfterExpiration;
+	}
+
+	public Group getGroup() {
+		return group;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/Searcher.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/Searcher.java
@@ -165,6 +165,9 @@ public interface Searcher {
 	 * Method returns members with its expiration status for given group.
 	 * Method ignores current member state, just compares expiration date!
 	 *
+	 * Method returns also indirect members of group with expiration set (by accident probably),
+	 * but we manage status only for direct members !!
+	 *
 	 * @param sess Perun session
 	 * @param operator One of "=", "<", ">", "<=", ">=". If null, "=" is anticipated.
 	 * @param date Date to compare expiration with (if null, current date is used).

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
@@ -97,6 +97,9 @@ public interface SearcherBl {
 	 * Method returns members with its expiration status for given group.
 	 * Method ignores current member state, just compares expiration date!
 	 *
+	 * Method returns also indirect members of group with expiration set (by accident probably),
+	 * but we manage status only for direct members !!
+	 *
 	 * @param sess Perun session
 	 * @param operator One of "=", "<", ">", "<=", ">=". If null, "=" is anticipated.
 	 * @param date Date to compare expiration with (if null, current date is used).

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
@@ -274,12 +275,12 @@ public class SearcherImpl implements SearcherImplApi {
 		}
 
 		try {
-			AttributeDefinition def = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:member_group:attribute-def:def:membershipExpiration");
+			AttributeDefinition def = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_MEMBER_GROUP_ATTR_DEF + ":groupMembershipExpiration");
 
-			String query = "select distinct " + MembersManagerImpl.memberMappingSelectQuery + " from members left join member_group_attr_values val on " +
+			String query = "select distinct " + MembersManagerImpl.groupsMembersMappingSelectQuery + " from members left join groups_members on members.id=groups_members.member_id and groups_members.group_id=? left join member_group_attr_values val on " +
 					"val.member_id=members.id and val.attr_id=? where val.group_id=? and TO_DATE(val.attr_value, 'YYYY-MM-DD')"+operator+compareDate;
 
-			return jdbcTemplate.query(query, MembersManagerImpl.MEMBER_MAPPER, def.getId(), group.getId());
+			return jdbcTemplate.query(query, MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, group.getId(), def.getId(), group.getId());
 
 		} catch (Exception e) {
 			throw new InternalErrorException(e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpiration.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpiration.java
@@ -52,7 +52,8 @@ public class urn_perun_member_group_attribute_def_def_groupMembershipExpiration 
 
 		// find out members status in given group
 		MemberGroupStatus status = session.getPerunBl().getGroupsManagerBl().getDirectMemberGroupStatus(session, member, group);
-		if(value != null && status.equals(MemberGroupStatus.EXPIRED)) {
+		// status is null if member is not direct at the time -> changing value doesn't affect indirect membership
+		if(value != null && MemberGroupStatus.EXPIRED.equals(status)) {
 			Date expirationDate;
 			try {
 				expirationDate = BeansUtils.getDateFormatterWithoutTime().parse(value);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
@@ -277,6 +277,25 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 		assertTrue("Member with expiration yesterday was not found for >= yesterday.", perun.getSearcher().getMembersByGroupExpiration(sess, group, ">=", calendar).contains(member2));
 		assertTrue("Member with expiration today was found for = yesterday.", !perun.getSearcher().getMembersByGroupExpiration(sess, group, "=", calendar).contains(member1));
 		assertTrue("Member with expiration yesterday was found for > yesterday.", !perun.getSearcher().getMembersByGroupExpiration(sess, group, ">", calendar).contains(member2));
+
+		// check sub-group logic if it resolve correct status for members
+
+		Group subGroup = new Group("subgroup", "subgroup of test group");
+		perun.getGroupsManager().createGroup(sess, group, subGroup);
+		perun.getGroupsManager().addMember(sess, subGroup, member1);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, group, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, subGroup, MemberGroupStatus.EXPIRED);
+		List<Member> mems = perun.getSearcher().getMembersByGroupExpiration(sess, group, ">", calendar);
+		assertEquals("Should have found single member", mems.size(), 1);
+		assertTrue("Member1 not found between soon to be expired in a group", mems.contains(member1));
+		assertEquals("Member soon to be expired in a group hadn't have a correct status", MemberGroupStatus.EXPIRED, mems.get(0).getGroupStatus());
+
+		perun.getGroupsManager().setMemberGroupStatus(sess, member1, group, MemberGroupStatus.VALID);
+		mems = perun.getSearcher().getMembersByGroupExpiration(sess, group, ">", calendar);
+		assertEquals("Should have found single member", mems.size(), 1);
+		assertTrue("Member1 not found between soon to be expired in a group", mems.contains(member1));
+		assertEquals("Member soon to be expired in a group hadn't have a correct status", MemberGroupStatus.VALID, mems.get(0).getGroupStatus());
+
 	}
 
 	@Test

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/SearcherEntryIntegrationTest.java
@@ -251,7 +251,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 		// setup required attribute if not exists
 		try {
-			perun.getAttributesManager().getAttributeDefinition(sess, "urn:perun:member_group:attribute-def:def:membershipExpiration");
+			perun.getAttributesManager().getAttributeDefinition(sess, "urn:perun:member_group:attribute-def:def:groupMembershipExpiration");
 		} catch (AttributeNotExistsException ex) {
 			setUpGroupMembershipExpirationAttribute();
 		}
@@ -263,11 +263,11 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 		String yesterday = BeansUtils.getDateFormatterWithoutTime().format(calendar.getTime());
 
 		// set attributes
-		Attribute attribute = new Attribute(perun.getAttributesManager().getAttributeDefinition(sess, "urn:perun:member_group:attribute-def:def:membershipExpiration"));
+		Attribute attribute = new Attribute(perun.getAttributesManager().getAttributeDefinition(sess, "urn:perun:member_group:attribute-def:def:groupMembershipExpiration"));
 		attribute.setValue(today);
 		perun.getAttributesManager().setAttribute(sess, member1, group, attribute);
 
-		Attribute attribute2 = new Attribute(perun.getAttributesManager().getAttributeDefinition(sess, "urn:perun:member_group:attribute-def:def:membershipExpiration"));
+		Attribute attribute2 = new Attribute(perun.getAttributesManager().getAttributeDefinition(sess, "urn:perun:member_group:attribute-def:def:groupMembershipExpiration"));
 		attribute2.setValue(yesterday);
 		perun.getAttributesManager().setAttribute(sess, member2, group, attribute2);
 
@@ -963,7 +963,7 @@ public class SearcherEntryIntegrationTest extends AbstractPerunIntegrationTest {
 
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_DEF);
-		attr.setFriendlyName("membershipExpiration");
+		attr.setFriendlyName("groupMembershipExpiration");
 		attr.setType(String.class.getName());
 		attr.setDisplayName("Group membership expiration");
 		attr.setDescription("When the member expires in group, format YYYY-MM-DD.");

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
@@ -34,7 +34,7 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 	private final static String CLASS_NAME = "ExpirationNotifSchedulerTest.";
 
 	private final static String EXPIRATION_URN = "urn:perun:member:attribute-def:def:membershipExpiration";
-	private final static String GROUP_EXPIRATION_URN = "urn:perun:member_group:attribute-def:def:membershipExpiration";
+	private final static String GROUP_EXPIRATION_URN = "urn:perun:member_group:attribute-def:def:groupMembershipExpiration";
 	private ExtSource extSource = new ExtSource(0, "testExtSource", ExtSourcesManager.EXTSOURCE_INTERNAL);
 	private Vo vo = new Vo(0, "SynchronizerTestVo", "SyncTestVo");
 
@@ -390,7 +390,7 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 
 		AttributeDefinition attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_DEF);
-		attr.setFriendlyName("membershipExpiration");
+		attr.setFriendlyName("groupMembershipExpiration");
 		attr.setType(String.class.getName());
 		attr.setDisplayName("Group membership expiration");
 		attr.setDescription("When the member expires in group, format YYYY-MM-DD.");


### PR DESCRIPTION
- Fixed groupMembershipExpiration module, which failed on null pointer
  if user was not direct member of a group.
- Added auditer messages about incoming and recent membership group
  expiration. Format is same but VO is replaced for Group.
- Added new methods in ExpirationNotifScheduler which process incoming
  and recent group membership expiration and submits proper audit
  messages into auditer log.
- Fixed vo membership expiration notification for cases when member
  can't extend, we always send MONTH type of notification. Now we
  each type.
- Getting members by expiration in group was previously ok with
  just VO members, but they are missing their correct member_group
  status in related group. This add necessary logic to get also correct
  member_group status of a member.
- Overall differences between VO and Group membership expiration
  resolving are:

  - EXPIRED (in vo) members are always notified about group expiration,
    since they can usually extend both memberships at once.
  - We always resolve DIRECT membership status. Notifications for
    indirect relations are not send.