### PR TITLE
New way how to work with IN clause in OracleDB

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1800,7 +1800,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.51');
+insert into configurations values ('DATABASE VERSION','3.1.52');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -105,8 +105,8 @@ public interface AttributesManager {
 	String NS_UES_ATTR_OPT = "urn:perun:ues:attribute-def:opt";
 	String NS_UES_ATTR_VIRT = "urn:perun:ues:attribute-def:virt";
 
-	String ORACLE_ARRAY_OF_NUMBERS = "PERUN.TPOLECISEL";
-	String ORACLE_ARRAY_OF_STRINGS = "PERUN.TPOLEZNAKU";
+	String ORACLE_ARRAY_OF_NUMBERS = "PERUN.TARRAYOFNUMBERS";
+	String ORACLE_ARRAY_OF_STRINGS = "PERUN.TARRAYOFCHARACTERS";
 
 	String LOGIN_NAMESPACE = "login-namespace";
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -105,6 +105,9 @@ public interface AttributesManager {
 	String NS_UES_ATTR_OPT = "urn:perun:ues:attribute-def:opt";
 	String NS_UES_ATTR_VIRT = "urn:perun:ues:attribute-def:virt";
 
+	String ORACLE_ARRAY_OF_NUMBERS = "PERUN.TPOLECISEL";
+	String ORACLE_ARRAY_OF_STRINGS = "PERUN.TPOLEZNAKU";
+
 	String LOGIN_NAMESPACE = "login-namespace";
 
 	String ATTRIBUTES_REGEXP = "^[-a-zA-Z0-9]+([:][-a-zA-Z0-9]+)?$";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
@@ -1,9 +1,13 @@
 package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.DBVersion;
+import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.List;
 
 /**
@@ -14,28 +18,28 @@ import java.util.List;
 public interface DatabaseManagerBl {
 	/**
 	 * Return current database version in string (ex. 3.0.1)
-	 * 
+	 *
 	 * @return return current database version
-	 * 
+	 *
 	 * @throws InternalErrorException
 	 */
 	String getCurrentDatabaseVersion() throws InternalErrorException;
-	
+
 	/**
 	 * Get DB driver information from datasource (name-version)
-	 * 
+	 *
 	 * @return string information about database driver
-	 * 
-	 * @throws InternalErrorException 
+	 *
+	 * @throws InternalErrorException
 	 */
 	String getDatabaseDriverInformation() throws InternalErrorException;
-	
+
 	/**
 	 * Get DB information from datasource (name-version)
-	 * 
+	 *
 	 * @return string information about database
-	 * 
-	 * @throws InternalErrorException 
+	 *
+	 * @throws InternalErrorException
 	 */
 	String getDatabaseInformation() throws InternalErrorException;
 
@@ -62,6 +66,27 @@ public interface DatabaseManagerBl {
 	 */
 	List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException;
 
+	/**
+	 * Take list of perunBeans and generate an array of ids in sql database from it.
+	 *
+	 * @param perunBeans list of PerunBeans to get Ids from
+	 * @param preparedStatement database prepared statement to get working connection
+	 * @return java sql array with pre-loaded list of ids
+	 * @throws SQLException if any sql exception has been thrown
+	 * @throws InternalErrorRuntimeException if oracle method to work with an array can't be get or invoked
+	 */
+	java.sql.Array prepareOracleArrayOfNumbers(List<? extends PerunBean> perunBeans, PreparedStatement preparedStatement) throws SQLException, InternalErrorRuntimeException;
+
+	/**
+	 * Take list of String and generate an array in sql database from it.
+	 *
+	 * @param strings list of Strings to get an sql array from
+	 * @param preparedStatement database prepared statement to get working connection
+	 * @return java sql array with pre-loaded list of strings
+	 * @throws SQLException if any sql exception has been thrown
+	 * @throws InternalErrorRuntimeException if oracle method to work with an array can't be get or invoked
+	 */
+	java.sql.Array prepareOracleArrayOfStrings(List<String> strings, PreparedStatement preparedStatement) throws SQLException, InternalErrorRuntimeException;
 
 	/**
 	 * Return JDBC template for performing custom simple SQLs where jdbc is not normally available

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
@@ -68,6 +68,7 @@ public interface DatabaseManagerBl {
 
 	/**
 	 * Take list of perunBeans and generate an array of ids in sql database from it.
+	 * Implementation can be different for every type of supported DB
 	 *
 	 * @param perunBeans list of PerunBeans to get Ids from
 	 * @param preparedStatement database prepared statement to get working connection
@@ -75,10 +76,11 @@ public interface DatabaseManagerBl {
 	 * @throws SQLException if any sql exception has been thrown
 	 * @throws InternalErrorRuntimeException if oracle method to work with an array can't be get or invoked
 	 */
-	java.sql.Array prepareOracleArrayOfNumbers(List<? extends PerunBean> perunBeans, PreparedStatement preparedStatement) throws SQLException, InternalErrorRuntimeException;
+	java.sql.Array prepareSQLArrayOfNumbers(List<? extends PerunBean> perunBeans, PreparedStatement preparedStatement) throws SQLException, InternalErrorRuntimeException;
 
 	/**
 	 * Take list of String and generate an array in sql database from it.
+	 * Implementation can be different for every type of supported DB
 	 *
 	 * @param strings list of Strings to get an sql array from
 	 * @param preparedStatement database prepared statement to get working connection
@@ -86,7 +88,7 @@ public interface DatabaseManagerBl {
 	 * @throws SQLException if any sql exception has been thrown
 	 * @throws InternalErrorRuntimeException if oracle method to work with an array can't be get or invoked
 	 */
-	java.sql.Array prepareOracleArrayOfStrings(List<String> strings, PreparedStatement preparedStatement) throws SQLException, InternalErrorRuntimeException;
+	java.sql.Array prepareSQLArrayOfStrings(List<String> strings, PreparedStatement preparedStatement) throws SQLException, InternalErrorRuntimeException;
 
 	/**
 	 * Return JDBC template for performing custom simple SQLs where jdbc is not normally available

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Compatibility.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Compatibility.java
@@ -36,6 +36,19 @@ public class Compatibility {
 		}
 	}
 
+	public static String getStructureForInClause() throws InternalErrorException {
+		switch (getDbType()) {
+			case "oracle":
+				return " IN (SELECT * FROM TABLE(?)) ";
+			case "postgresql":
+				return " = ANY(?) ";
+			case "hsqldb":
+				return "  IN ( UNNEST(?) ) ";
+			default:
+				throw new InternalErrorException("unknown DB type");
+		}
+	}
+
 	public static String getTrue() throws InternalErrorException {
 		switch (getDbType()) {
 			case "oracle":

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -7,6 +7,9 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 -- this update is not supported on hsql since its used only as in-memory db
+3.1.52
+update configurations set value='3.1.52' where property='DATABASE VERSION';
+
 
 3.1.51
 alter table action_types drop constraint actiontyp_at_chk;

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -6,6 +6,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.52
+create or replace type TARRAYOFCHARACTERS is table of nvarchar2(2000);
+create or replace type TARRAYOFNUMBERS is table of number(30,0);
+update configurations set value='3.1.52' where property='DATABASE VERSION';
+
 3.1.51
 alter table action_types drop constraint actiontyp_at_chk;
 alter table action_types add constraint actiontyp_at_chk check (action_type in ('read', 'read_vo', 'read_public', 'write', 'write_vo', 'write_public'));

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,9 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.52
+update configurations set value='3.1.52' where property='DATABASE VERSION';
+
 3.1.51
 alter table action_types drop constraint actiontyp_at_chk;
 alter table action_types add constraint actiontyp_at_chk check (action_type in ('read', 'read_vo', 'read_public', 'write', 'write_vo', 'write_public'));

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.51(don't forget to update insert statement at the end of file)
+-- database version 3.1.52(don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1805,7 +1805,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.51');
+insert into configurations values ('DATABASE VERSION','3.1.52');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
@@ -1821,3 +1821,7 @@ insert into action_types (id, action_type, description) values (action_types_seq
 
 -- insert default engine on default port
 insert into engines (id, ip_address, port, last_check_in, created_at, created_by, modified_at, modified_by, status, created_by_uid, modified_by_uid) VALUES (1, '127.0.0.1', 6061, sysdate, sysdate, 'perun', sysdate, 'perun', '1', null, null);
+
+-- create array structures of numbers and characters
+create or replace type TARRAYOFCHARACTERS is table of nvarchar2(2000);
+create or replace type TARRAYOFNUMBERS is table of number(30,0);

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.51 (don't forget to update insert statement at the end of file)
+-- database version 3.1.52 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1903,7 +1903,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.51');
+insert into configurations values ('DATABASE VERSION','3.1.52');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
 - we can use database type "array" - full supported just for oracle
 - method to work with sql array was added to DatabaseManagerBl|BlImpl
 - all getRequiredAttributesForBulk methods from AttributesManagerBlImpl
 were removed and logic was added directly to the methods in impl layer
 - all getRequiredAttributes methods in AttributesManagerImpl layer were
 redesigned to work with new oracle array and if they are unable to work
 with this specific desing, they will fallback on bulk of sql queries
 with maximum of objects in SQL IN CLAUSE defined by constant in code
 - use java reflection api to prevent oracle driver be part of perun