### PR TITLE
Edit Audit logs when deleting all attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -3899,9 +3899,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, Facility facility) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, facility);
-		getAttributesManagerImpl().removeAllAttributes(sess, facility);
+		if (getAttributesManagerImpl().removeAllAttributes(sess, facility)) {
+			getPerunBl().getAuditer().log(sess,new FacilityAllAttributesRemoved(facility));
+		}
 		log.info("{} removed all attributes from facility {}.", sess.getLogId(), facility.getId());
-		getPerunBl().getAuditer().log(sess,new FacilityAllAttributesRemoved(facility));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -3932,9 +3933,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		removeAllAttributes(sess, facility);
 		if (removeAlsoUserFacilityAttributes) {
 			List<Attribute> userFacilityAttributes = getUserFacilityAttributesForAnyUser(sess, facility);
-			getAttributesManagerImpl().removeAllUserFacilityAttributesForAnyUser(sess, facility);
+			if (getAttributesManagerImpl().removeAllUserFacilityAttributesForAnyUser(sess, facility)) {
+				getPerunBl().getAuditer().log(sess, new AllUserFacilityAttributesRemoved(facility));
+			}
 			log.info("{} removed all attributes from any user on facility {}.",sess.getLogId(), facility.getId());
-			getPerunBl().getAuditer().log(sess, new AllUserFacilityAttributesRemoved(facility));
 
 			for (Attribute attribute : userFacilityAttributes) attribute.setValue(null);
 			List<User> facilityUsers = perunBl.getFacilitiesManagerBl().getAllowedUsers(sess, facility);
@@ -4008,9 +4010,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, Host host) throws InternalErrorException, WrongAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, host);
-		getAttributesManagerImpl().removeAllAttributes(sess, host);
+		if (getAttributesManagerImpl().removeAllAttributes(sess, host)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForHost(host));
+		}
 		log.info("{} removed all attributes from host {}.", sess.getLogId(), host.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForHost(host));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4075,9 +4078,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, Vo vo) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, vo);
-		getAttributesManagerImpl().removeAllAttributes(sess, vo);
+		if (getAttributesManagerImpl().removeAllAttributes(sess, vo)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForVo(vo));
+		}
 		log.info("{} removed all attributes from vo {}.",sess.getLogId(), vo.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForVo(vo));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4140,10 +4144,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, Group group) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, group);
-		getAttributesManagerImpl().removeAllAttributes(sess, group);
-
+		if (getAttributesManagerImpl().removeAllAttributes(sess, group)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForGroup(group));
+		}
 		log.info("{} removed all attributes from group {}.",sess.getLogId(), group.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForGroup(group));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4213,14 +4217,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, resource);
-		getAttributesManagerImpl().removeAllAttributes(sess, resource);
-
+		if (getAttributesManagerImpl().removeAllAttributes(sess, resource)) {
+			getPerunBl().getAuditer().log(sess,  new AllAttributesRemovedForResource(resource));
+		}
+		log.info("{} removed all attributes from resource {}.",sess.getLogId(), resource.getId());
 		//remove all virtual attributes
 		/*for(Attribute attribute : getVirtualAttributes(sess, resource)) {
 			getAttributesManagerImpl().removeVirtualAttribute(sess, resource, attribute);
 			}*/
-		log.info("{} removed all attributes from resource {}.",sess.getLogId(), resource.getId());
-		getPerunBl().getAuditer().log(sess,  new AllAttributesRemovedForResource(resource));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4314,10 +4318,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		List<Attribute> attributes = getAttributes(sess, member, resource);
-		getAttributesManagerImpl().removeAllAttributes(sess, member, resource);
-
+		if (getAttributesManagerImpl().removeAllAttributes(sess, member, resource)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForResourceAndMember(resource, member));
+		}
 		log.info("{} removed all attributes from member {} on resource {}.",sess.getLogId(), member.getId(), resource.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForResourceAndMember(resource, member));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4406,10 +4410,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, member, group);
-		getAttributesManagerImpl().removeAllAttributes(sess, member, group);
-
+		if (getAttributesManagerImpl().removeAllAttributes(sess, member, group)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForMemberAndGroup(member, group));
+		}
 		log.info("{} removed all attributes from member {} in group {}.",sess.getLogId(), member.getId(), group.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForMemberAndGroup(member, group));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4474,9 +4478,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, Member member) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, member);
-		getAttributesManagerImpl().removeAllAttributes(sess, member);
+		if (getAttributesManagerImpl().removeAllAttributes(sess, member)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForMember(member));
+		}
 		log.info("{} removed all attributes from member {}.",sess.getLogId(), member.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForMember(member));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4551,17 +4556,18 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAllAttributes(PerunSession sess, Facility facility, User user) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, facility, user);
 		//remove all non-virtual attributes
-		getAttributesManagerImpl().removeAllAttributes(sess, facility, user);
+		boolean changed = getAttributesManagerImpl().removeAllAttributes(sess, facility, user);
 
 		//remove all virtual attributes
 		List<Attribute> virtualAttributes = getVirtualAttributes(sess, facility, user);
 		for (Attribute attribute : virtualAttributes) {
-			getAttributesManagerImpl().removeVirtualAttribute(sess, facility, user, attribute);
+			changed = getAttributesManagerImpl().removeVirtualAttribute(sess, facility, user, attribute) || changed;
 		}
 		attributes.addAll(virtualAttributes);
-
+		if (changed) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForFacilityAndUser(facility, user));
+		}
 		log.info("{} removed all attributes from user {} on facility {}.",sess.getLogId(), user.getId(), facility.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForFacilityAndUser(facility, user));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4586,10 +4592,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<RichAttribute<User, Facility>> userFacilitiesAttributes = getAttributesManagerImpl().getAllUserFacilityRichAttributes(sess, user);
 
 		//remove all non-virtual attributes
-		getAttributesManagerImpl().removeAllUserFacilityAttributes(sess, user);
-
+		if (getAttributesManagerImpl().removeAllUserFacilityAttributes(sess, user)) {
+			getPerunBl().getAuditer().log(sess, new AllUserFacilityAttributesRemovedForFacilitiesAndUser(user));
+		}
 		log.info("{} removed all attributes from user {} on all facilities.", sess.getLogId(), user.getId());
-		getPerunBl().getAuditer().log(sess, new AllUserFacilityAttributesRemovedForFacilitiesAndUser(user));
 
 		for (RichAttribute<User, Facility> richAttribute : userFacilitiesAttributes) {
 			try {
@@ -4652,10 +4658,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, User user) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, user);
-		getAttributesManagerImpl().removeAllAttributes(sess, user);
-
+		if (getAttributesManagerImpl().removeAllAttributes(sess, user)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForUser(user));
+		}
 		log.info("{} removed all attributes from  user {}.", sess.getLogId(), user.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForUser(user));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
@@ -4747,10 +4753,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	public void removeAllAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException, WrongAttributeValueException, GroupResourceMismatchException, WrongReferenceAttributeValueException {
 		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
 		List<Attribute> attributes = getAttributes(sess, resource, group);
-		getAttributesManagerImpl().removeAllAttributes(sess, resource, group);
-
+		if (getAttributesManagerImpl().removeAllAttributes(sess, resource, group)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForGroupAndResource(group, resource));
+		}
 		log.info("{} removed all attributes from group {} on resource {}.", sess.getLogId(), group.getId(), resource.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForGroupAndResource(group, resource));
 
 		//remove all virtual attributes
 		/*for(Attribute attribute : getVirtualAttributes(sess, resource)) {
@@ -4817,10 +4823,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public void removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		List<Attribute> attributes = getAttributes(sess, ues);
-		getAttributesManagerImpl().removeAllAttributes(sess, ues);
-
+		if (getAttributesManagerImpl().removeAllAttributes(sess, ues)) {
+			getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForUserExtSource(ues));
+		}
 		log.info("{} removed all attributes from user external source {}.", sess.getLogId(), ues.getId());
-		getPerunBl().getAuditer().log(sess, new AllAttributesRemovedForUserExtSource(ues));
 
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -4087,15 +4087,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Facility facility) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Facility facility) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM facility_attr_values WHERE facility_id=?", facility.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(facility.getId(), Holder.HolderType.FACILITY));
 				log.debug("All attributes values were removed from facility {}.", facility);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4113,15 +4115,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Vo vo) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Vo vo) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM vo_attr_values WHERE vo_id=?", vo.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(vo.getId(), Holder.HolderType.VO));
 				log.debug("All attributes values were removed from vo {}.", vo);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4139,15 +4143,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Group group) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Group group) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM group_attr_values WHERE group_id=?", group.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(group.getId(), Holder.HolderType.GROUP));
 				log.debug("All attributes values were removed from group {}.", group);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4165,15 +4171,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Resource resource) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Resource resource) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM resource_attr_values WHERE resource_id=?", resource.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(resource.getId(), Holder.HolderType.RESOURCE));
 				log.debug("All attributes values were removed from resource {}.", resource);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4191,15 +4199,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM member_resource_attr_values WHERE resource_id=? AND member_id=?", resource.getId(), member.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(member.getId(), Holder.HolderType.MEMBER), new Holder(resource.getId(), Holder.HolderType.RESOURCE));
 				log.debug("All attributes values were removed from member {} on resource {}.", member, resource);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4217,15 +4227,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM member_group_attr_values WHERE group_id=? AND member_id=?", group.getId(), member.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(member.getId(), Holder.HolderType.MEMBER), new Holder(group.getId(), Holder.HolderType.GROUP));
 				log.debug("All attributes values were removed from member {} in group {}.", member, group);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4243,15 +4255,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Member member) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Member member) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM member_attr_values WHERE member_id=?", member.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(member.getId(), Holder.HolderType.MEMBER));
 				log.debug("All attributes values were removed from member {}", member);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4270,39 +4284,45 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Facility facility, User user) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Facility facility, User user) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM user_facility_attr_values WHERE user_id=? AND facility_id=?", user.getId(), facility.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(user.getId(), Holder.HolderType.USER), new Holder(facility.getId(), Holder.HolderType.FACILITY));
 				log.debug("All attributes values were removed from user {} on facility {}.", user, facility);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
-	public void removeAllUserFacilityAttributesForAnyUser(PerunSession sess, Facility facility) throws InternalErrorException {
+	public boolean removeAllUserFacilityAttributesForAnyUser(PerunSession sess, Facility facility) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM user_facility_attr_values WHERE facility_id=?", facility.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(Holder.HolderType.USER, new Holder(facility.getId(), Holder.HolderType.FACILITY));
 				log.debug("All attributes values were removed from any user on facility {}.", facility);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
-	public void removeAllUserFacilityAttributes(PerunSession sess, User user) throws InternalErrorException {
+	public boolean removeAllUserFacilityAttributes(PerunSession sess, User user) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM user_facility_attr_values WHERE user_id=?", user.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(user.getId(), Holder.HolderType.USER), Holder.HolderType.FACILITY);
 				log.debug("All attributes values were removed from user {} on  all facilities.", user);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4335,15 +4355,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, User user) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, User user) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM user_attr_values WHERE user_id=?", user.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(user.getId(), Holder.HolderType.USER));
 				log.debug("All attributes values were removed from user {}.", user);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4361,15 +4383,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM group_resource_attr_values WHERE group_id=? AND resource_id=?", group.getId(), resource.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(group.getId(), Holder.HolderType.GROUP), new Holder(resource.getId(), Holder.HolderType.RESOURCE));
 				log.debug("All attributes values were removed from group {} on resource{}.", group, resource);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4387,15 +4411,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, Host host) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, Host host) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM host_attr_values WHERE host_id=?", host.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(host.getId(), Holder.HolderType.HOST));
 				log.debug("All attributes values were removed from host {}.", host);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override
@@ -4415,15 +4441,17 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException {
+	public boolean removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException {
 		try {
 			if (0 < jdbc.update("DELETE FROM user_ext_source_attr_values WHERE user_ext_source_id=?", ues.getId())) {
 				if (!CacheManager.isCacheDisabled()) perun.getCacheManager().removeAllAttributes(new Holder(ues.getId(), Holder.HolderType.UES));
 				log.debug("All attributes values were removed from user external source {}.", ues);
+				return true;
 			}
 		} catch (RuntimeException ex) {
 			throw new InternalErrorException(ex);
 		}
+		return false;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1804,9 +1804,10 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param facility remove attributes from this facility
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Facility facility) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Facility facility) throws InternalErrorException;
 
 	/**
 	 * Remove all non-virtual group-resource attribute on selected resource
@@ -1842,10 +1843,10 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param vo remove attributes from this vo
-	 *
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Vo vo) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Vo vo) throws InternalErrorException;
 
 	/**
 	 * Unset particular attribute for the group.
@@ -1863,10 +1864,10 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param group remove attributes from this group
-	 *
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Group group) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Group group) throws InternalErrorException;
 
 
 	/**
@@ -1885,10 +1886,10 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param resource remove attributes from this resource
-	 *
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Resource resource) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Unset particular member-resorce attribute for the member on the resource.
@@ -1908,10 +1909,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param member remove attributes from this member
 	 * @param resource remove attributes from this resource
-	 *
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Member member, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Unset particular attribute for the member in the group. Core attributes can't be removed this way.
@@ -1931,9 +1932,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param group remove attributes for this group
 	 * @param member remove attributes from this member
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Member member, Group group) throws InternalErrorException;
 
 	/**
 	 * Unset particular member attribute
@@ -1951,9 +1953,10 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param member
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Member member) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Member member) throws InternalErrorException;
 
 	/**
 	 * Unset particular user-facility attribute
@@ -1973,9 +1976,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param facility
 	 * @param user
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Facility facility, User user) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Facility facility, User user) throws InternalErrorException;
 
 	/**
 	 * Unset all (user-facility) <b>non-virtual</b> attributes for any user on the facility.
@@ -1984,16 +1988,17 @@ public interface AttributesManagerImplApi {
 	 * @param facility
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllUserFacilityAttributesForAnyUser(PerunSession sess, Facility facility) throws InternalErrorException;
+	boolean removeAllUserFacilityAttributesForAnyUser(PerunSession sess, Facility facility) throws InternalErrorException;
 
 	/**
 	 * Unset all (user-facility) <b>non-virtual</b> attributes for the user and <b>all facilities</b>
 	 *
 	 * @param sess perun session
 	 * @param user
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllUserFacilityAttributes(PerunSession sess, User user) throws InternalErrorException;
+	boolean removeAllUserFacilityAttributes(PerunSession sess, User user) throws InternalErrorException;
 
 	/**
 	 * Unset particular user-facility virtual attribute value.
@@ -2050,9 +2055,10 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param user
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, User user) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, User user) throws InternalErrorException;
 
 	/**
 	 * Unset particular host attribute
@@ -2069,9 +2075,10 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param host
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Host host) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Host host) throws InternalErrorException;
 
 	/**
 	 * Unset particular group_resource attribute
@@ -2091,9 +2098,10 @@ public interface AttributesManagerImplApi {
 	 * @param sess perun session
 	 * @param resource Resource
 	 * @param group Group
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, Resource resource, Group group) throws InternalErrorException;
 
 	/**
 	 * Unset particular user external source attribute
@@ -2111,9 +2119,10 @@ public interface AttributesManagerImplApi {
 	 *
 	 * @param sess perun session
 	 * @param ues
+	 * @return {@code true} if attributes was deleted or {@code false} if attributes was not deleted
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 */
-	void removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException;
+	boolean removeAllAttributes(PerunSession sess, UserExtSource ues) throws InternalErrorException;
 
 	/**
 	 * Check if attribute exists in underlaying data source.


### PR DESCRIPTION
Problem:
Auditer logs unnecessary messages. Methods (in Bl layer) that delete all attributes
always creates audit logs when they are called.
Sometimes these methods don't delete any attributes but unnecessarily log it.

Fix:
Now every methods in Impl layers that deleted all attributes returns boolean.
Return true if deleted attributes or false if no deleted attributes.
Auditer logs only when method returns true.