### PR TITLE
CORE: Support multi-lang notifications for password reset

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -943,7 +943,29 @@ public class Utils {
 			if (messageTemplate == null) {
 				message.setText(textEn);
 			} else {
-				messageTemplate = messageTemplate.replace("{link}", link);
+
+				// allow enforcing per-language links
+				if (messageTemplate.contains("{link-")) {
+					Pattern pattern = Pattern.compile("\\{link-[^\\}]+\\}");
+					Matcher matcher = pattern.matcher(messageTemplate);
+					while (matcher.find()) {
+
+						// whole "{link-something}"
+						String toSubstitute = matcher.group(0);
+						String langLink = link.toString();
+
+						Pattern namespacePattern = Pattern.compile("\\-(.*?)\\}");
+						Matcher m2 = namespacePattern.matcher(toSubstitute);
+						if (m2.find()) {
+							// only language "cs", "en",...
+							String lang = m2.group(1);
+							langLink = langLink + "&locale=" + lang;
+						}
+						messageTemplate = messageTemplate.replace(toSubstitute, langLink);
+					}
+				} else {
+					messageTemplate = messageTemplate.replace("{link}", link);
+				}
 				messageTemplate = messageTemplate.replace("{displayName}", user.getDisplayName());
 				messageTemplate = messageTemplate.replace("{namespace}", namespace);
 				messageTemplate = messageTemplate.replace("{validity}", validityFormatted);


### PR DESCRIPTION
- Allow {link-[lang]} tags in notification with non-authz password
  reset request. Specified lang forces pwd-reset gui to use it.