### PR TITLE
LDAPC: Support user:def:elixirBonaFideStatus

### DIFF
--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunAttribute.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunAttribute.java
@@ -8,7 +8,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 public interface PerunAttribute<T extends PerunBean> {
 
 	public interface PerunAttributeNames {
-	
+
 		//PERUN ATTRIBUTES NAMES
 		public static final String perunAttrPreferredMail = "preferredMail";
 		public static final String perunAttrMail = "mail";
@@ -23,7 +23,7 @@ public interface PerunAttribute<T extends PerunBean> {
 		public static final String perunAttrClientID = "OIDCClientID";
 		public static final String perunAttrGroupNames = "groupNames";
 		public static final String perunAttrInstitutionsCountries = "institutionsCountries";
-	
+
 		//LDAP ATTRIBUTES NAMES
 		public static final String ldapAttrAssignedToResourceId = "assignedToResourceId";
 		public static final String ldapAttrAssignedGroupId = "assignedGroupId";
@@ -63,7 +63,7 @@ public interface PerunAttribute<T extends PerunBean> {
 		public static final String ldapAttrIsSponsoredUser = "isSponsoredUser";
 		public static final String ldapAttrGroupNames = perunAttrGroupNames;
 		public static final String ldapAttrInstitutionsCountries = perunAttrInstitutionsCountries;
-	
+
 		//LDAP OBJECT CLASSES
 		public static final String objectClassTop = "top";
 		public static final String objectClassPerunResource = "perunResource";
@@ -76,10 +76,10 @@ public interface PerunAttribute<T extends PerunBean> {
 		public static final String objectClassPerunUser = "perunUser";
 		public static final String objectClassTenOperEntry = "tenOperEntry";
 		public static final String objectClassInetUser = "inetUser";
-	
+
 		//LDAP ORGANIZATION UNITS
 		public static final String organizationalUnitPeople = "ou=People";
-	
+
 	}
 
 	interface SingleValueExtractor<T> {
@@ -95,15 +95,15 @@ public interface PerunAttribute<T extends PerunBean> {
 
 	public static final boolean MULTIVALUED = true;
 	public static final boolean SINGLE = false;
-	
+
 	public boolean isRequired();
 
 	public boolean isMultiValued();
 
 	public String getName();
-	
+
 	public String getName(AttributeDefinition attr);
-	
+
 	public String getBaseName();
 
 	public boolean hasValue(T bean, Attribute... attributes) throws InternalErrorException;

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
@@ -563,7 +563,7 @@ public class EventProcessorImpl implements Runnable {
 						ldapConnector.updateUsersAttributeInLDAP(String.valueOf(this.user.getId()), ldapAttrUserCertDNs, subjectsArray);
 					}
 
-				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":" + perunAttrBonaFideStatus)) {
+				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_DEF + ":" + perunAttrBonaFideStatus)) {
 					if(this.attribute.getValue() != null) {
 						updateUserAttribute(ldapAttrBonaFideStatus, (String) attribute.getValue(), LdapOperation.REPLACE_ATTRIBUTE, this.user);
 					} else {
@@ -662,7 +662,7 @@ public class EventProcessorImpl implements Runnable {
 						updateUserAttribute(ldapAttrInstitutionsCountries, null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
 					}
 
-				} else if(this.attributeDef.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":" + perunAttrBonaFideStatus)) {
+				} else if(this.attributeDef.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_DEF + ":" + perunAttrBonaFideStatus)) {
 					if(ldapConnector.userAttributeExist(this.user, ldapAttrBonaFideStatus)) {
 						updateUserAttribute(ldapAttrBonaFideStatus, null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
 					}

--- a/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
@@ -80,7 +80,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 			</list>
 		</property>
 	</bean>
-	
+
 	<bean id="creationEventProcessor" class="cz.metacentrum.perun.ldapc.processor.impl.CreationEventProcessor">
 		<property name="dispatchConditions">
 			<list>
@@ -127,7 +127,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 			</list>
 		</property>
 	</bean>
-	
+
 	<bean id="updateEventProcessor" class="cz.metacentrum.perun.ldapc.processor.impl.UpdateEventProcessor">
 		<property name="dispatchConditions">
 			<list>
@@ -166,7 +166,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 			</list>
 		</property>
 	</bean>
-	
+
 	<bean id="userAttributeEventProcessor" class="cz.metacentrum.perun.ldapc.processor.impl.UserAttributeProcessor">
 		<property name="dispatchConditions">
 			<list>
@@ -344,7 +344,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="preferredMail" />
 							<property name="namespace" value="urn:perun:user:attribute-def:def" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="mail" />
@@ -354,7 +354,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="preferredMail" />
 							<property name="namespace" value="urn:perun:user:attribute-def:def" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="o" />
@@ -364,7 +364,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="organization" />
 							<property name="namespace" value="urn:perun:user:attribute-def:def" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="telephoneNumber" />
@@ -374,7 +374,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="phone" />
 							<property name="namespace" value="urn:perun:user:attribute-def:def" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="userCertificateSubject" />
@@ -390,13 +390,13 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 											<bean class="cz.metacentrum.perun.ldapc.beans.RegexpSubst">
 												<property name="find" value="^[0-9]+[:]" />
 												<property name="replace" value="" />
-											</bean>	
+											</bean>
 										</list>
 									</property>
 								</bean>
 							</property>
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="schacHomeOrganizations" />
@@ -406,7 +406,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="schacHomeOrganizations" />
 							<property name="namespace" value="urn:perun:user:attribute-def:virt" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="eduPersonScopedAffiliations" />
@@ -416,7 +416,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="eduPersonScopedAffiliations" />
 							<property name="namespace" value="urn:perun:user:attribute-def:virt" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="groupNames" />
@@ -426,7 +426,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="groupNames" />
 							<property name="namespace" value="urn:perun:user:attribute-def:virt" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="schacHomeOrganizations" />
@@ -436,7 +436,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="schacHomeOrganizations" />
 							<property name="namespace" value="urn:perun:user:attribute-def:virt" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="institutionsCountries" />
@@ -446,7 +446,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="institutionsCountries" />
 							<property name="namespace" value="urn:perun:user:attribute-def:virt" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="libraryIDs" />
@@ -456,7 +456,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="libraryIDs" />
 							<property name="namespace" value="urn:perun:user:attribute-def:def" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="uidNumber;x-ns-" />
@@ -467,7 +467,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="namespace" value="urn:perun:user:attribute-def:def:uid-namespace" />
 							<property name="name" value="" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="login;x-ns-" />
@@ -478,7 +478,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="namespace" value="urn:perun:user:attribute-def:def:login-namespace" />
 							<property name="name" value="" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="userPassword" />
@@ -492,17 +492,17 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 								<bean class="cz.metacentrum.perun.ldapc.beans.PasswordValueTransformer" />
 							</property>
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="bonaFideStatus" />
 					<property name="required" value="false" />
 					<property name="singleValueExtractor">
 						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
-							<property name="namespace" value="urn:perun:user:attribute-def:virt" />
+							<property name="namespace" value="urn:perun:user:attribute-def:def" />
 							<property name="name" value="elixirBonaFideStatus" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 			</list>
 		</property>
@@ -520,7 +520,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="entityID" />
 							<property name="namespace" value="urn:perun:facility:attribute-def:def" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="OIDCClientID" />
@@ -530,7 +530,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<property name="name" value="OIDCClientID" />
 							<property name="namespace" value="urn:perun:facility:attribute-def:def" />
 						</bean>
-					</property> 
+					</property>
 				</bean>
 			</list>
 		</property>
@@ -538,10 +538,10 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 
 	<bean id="perunGroup" class="cz.metacentrum.perun.ldapc.model.impl.PerunGroupImpl">
 	</bean>
-		
+
 	<bean id="perunVO" class="cz.metacentrum.perun.ldapc.model.impl.PerunVOImpl">
 	</bean>
-		
+
     <bean id="ldapProperties" class="cz.metacentrum.perun.ldapc.beans.LdapProperties">
         <constructor-arg name="ldapConsumerName" index="0" value="${ldap.consumerName}" />
         <constructor-arg name="ldapBase" index="1" value="${ldap.base}" />
@@ -549,16 +549,16 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
     </bean>
 
     <!-- These beans are for define ldapTemplate -->
-	<ldap:context-source 
+	<ldap:context-source
 		url="${ldap.url}"
 		base="${ldap.base}"
-		username="${ldap.userDn}" 
+		username="${ldap.userDn}"
 		password="${ldap.password}">
 		<ldap:pooling />
 	</ldap:context-source>
-	
+
 	<ldap:ldap-template />
 
 	<import resource="file:${perun.conf.custom}/perun-ldapc-attributes.xml" />
-	
+
 </beans>

--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/impl/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/impl/Utils.java
@@ -474,7 +474,7 @@ public class Utils implements cz.metacentrum.perun.ldapc.initializer.api.UtilsAp
 			String bonaFideStatus = "bonaFideStatus: ";
 			Attribute attrBonaFideStatus = null;
 			try {
-				attrBonaFideStatus = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_VIRT + ":elixirBonaFideStatus");
+				attrBonaFideStatus = perun.getAttributesManagerBl().getAttribute(perunSession, user, AttributesManager.NS_USER_ATTR_DEF + ":elixirBonaFideStatus");
 			} catch (AttributeNotExistsException | WrongAttributeAssignmentException ex) {
 				log.error("Bona fide status attribute is missing or it's assignment is wrong. Attribute was skipped.", ex);
 			}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
@@ -565,7 +565,7 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 						ldapConnector.updateUsersAttributeInLDAP(String.valueOf(this.user.getId()), ldapAttrUserCertDNs, subjectsArray);
 					}
 
-				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":" + perunAttrBonaFideStatus)) {
+				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_DEF + ":" + perunAttrBonaFideStatus)) {
 					if(this.attribute.getValue() != null) {
 						updateUserAttribute(ldapAttrBonaFideStatus, (String) attribute.getValue(), LdapOperation.REPLACE_ATTRIBUTE, this.user);
 					} else {
@@ -664,7 +664,7 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 						updateUserAttribute(ldapAttrInstitutionsCountries, null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
 					}
 
-				} else if(this.attributeDef.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":" + perunAttrBonaFideStatus)) {
+				} else if(this.attributeDef.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_DEF + ":" + perunAttrBonaFideStatus)) {
 					if(ldapConnector.userAttributeExist(this.user, ldapAttrBonaFideStatus)) {
 						updateUserAttribute(ldapAttrBonaFideStatus, null, LdapOperation.REMOVE_ATTRIBUTE, this.user);
 					}


### PR DESCRIPTION
- "virt" version of attribute was removed from the sources and
  replaced by the "def" version, hence LDAPc must read audit messages
  of the new attribute instead.
- Same goes for ldapc-initializer.
- Same goes for new LDAPC (perun-ldapc-ada)