### PR TITLE
Change all usage of BeansUtils.prepareInSQLClause()

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -782,16 +782,6 @@ public interface GroupsManagerBl {
 	List<Group> getGroups(PerunSession sess, Vo vo) throws InternalErrorException;
 
 	/**
-	 * Get groups by theirs Id.
-	 *
-	 * @param sess
-	 * @param groupsIds
-	 * @return list of groups
-	 * @throws InternalErrorException
-	 */
-	List<Group> getGroupsByIds(PerunSession sess, List<Integer> groupsIds) throws InternalErrorException;
-
-	/**
 	 * @param sess
 	 * @param vo
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -415,16 +415,6 @@ public interface ResourcesManagerBl {
 	List<RichResource> getRichResources(PerunSession perunSession, Vo vo) throws InternalErrorException;
 
 	/**
-	 * Get list of resources by theirs IDs.
-	 *
-	 * @param sess
-	 * @param resourcesIds
-	 * @return list of resources
-	 * @throws InternalErrorException
-	 */
-	List<Resource> getResourcesByIds(PerunSession sess, List<Integer> resourcesIds) throws InternalErrorException;
-
-	/**
 	 * Get all VO resources count.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/DatabaseManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/DatabaseManagerBlImpl.java
@@ -1,28 +1,16 @@
 package cz.metacentrum.perun.core.blImpl;
 
-import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.DBVersion;
-import cz.metacentrum.perun.core.api.Perun;
-import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
 import cz.metacentrum.perun.core.bl.DatabaseManagerBl;
 import cz.metacentrum.perun.core.impl.Compatibility;
 import cz.metacentrum.perun.core.implApi.DatabaseManagerImplApi;
-import java.beans.Beans;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.sql.Connection;
-import java.sql.JDBCType;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Database manager can work with database version and upgraded state of perun DB.
@@ -35,7 +23,6 @@ public class DatabaseManagerBlImpl implements DatabaseManagerBl {
 	public static final String ORACLE_CHANGELOG = "oracleChangelog.txt";
 	public static final String POSTGRES_CHANGELOG = "postgresChangelog.txt";
 	public static final String HSQLDB_CHANGELOG = "hsqldbChangelog.txt";
-	public static final String NAME_OF_ORACLE_ARRAY_METHOD = "createOracleArray";
 	private final DatabaseManagerImplApi databaseManagerImpl;
 
 	public DatabaseManagerBlImpl(DatabaseManagerImplApi databaseManagerImpl) {
@@ -122,39 +109,6 @@ public class DatabaseManagerBlImpl implements DatabaseManagerBl {
 			}
 		}
 		log.debug("Initialize manager ends!");
-	}
-
-	public java.sql.Array prepareSQLArrayOfNumbers(List<? extends PerunBean> perunBeans, PreparedStatement preparedStatement) throws SQLException, InternalErrorRuntimeException {
-		Connection connection = preparedStatement.getConnection().unwrap(Connection.class);
-		if(Compatibility.isOracle()) {
-			int[] arrayOfBeansIds = perunBeans.stream().mapToInt(PerunBean::getId).toArray();
-			try {
-				Method createOracleArrayMethod = connection.getClass().getMethod(NAME_OF_ORACLE_ARRAY_METHOD, String.class, Object.class);
-				createOracleArrayMethod.setAccessible(true);
-				return (java.sql.Array) createOracleArrayMethod.invoke(connection, AttributesManager.ORACLE_ARRAY_OF_NUMBERS, arrayOfBeansIds);
-			} catch (Exception ex) {
-				throw new InternalErrorRuntimeException("Can't access to method " + NAME_OF_ORACLE_ARRAY_METHOD, ex);
-			}
-		} else {
-			Integer[] arrayOfBeansIds = perunBeans.stream().map(PerunBean::getId).toArray(Integer[]::new);
-			return connection.createArrayOf(JDBCType.INTEGER.name(), arrayOfBeansIds);
-		}
-	}
-
-	public java.sql.Array prepareSQLArrayOfStrings(List<String> strings, PreparedStatement preparedStatement) throws SQLException, InternalErrorRuntimeException {
-		String[] arrayOfStrings = strings.stream().toArray(String[]::new);
-		Connection connection = preparedStatement.getConnection().unwrap(Connection.class);
-		if(Compatibility.isOracle()) {
-			try {
-				Method createOracleArrayMethod = connection.getClass().getMethod(NAME_OF_ORACLE_ARRAY_METHOD, String.class, Object.class);
-				createOracleArrayMethod.setAccessible(true);
-				return (java.sql.Array) createOracleArrayMethod.invoke(connection, AttributesManager.ORACLE_ARRAY_OF_STRINGS, arrayOfStrings);
-			} catch (Exception ex) {
-				throw new InternalErrorRuntimeException("Can't access to method " + NAME_OF_ORACLE_ARRAY_METHOD, ex);
-			}
-		} else {
-			return connection.createArrayOf(JDBCType.VARCHAR.name(), arrayOfStrings);
-		}
 	}
 
 	public DatabaseManagerImplApi getDatabaseManagerImpl() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1322,11 +1322,6 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
-	public List<Group> getGroupsByIds(PerunSession sess, List<Integer> groupsIds) throws InternalErrorException {
-		return getGroupsManagerImpl().getGroupsByIds(sess, groupsIds);
-	}
-
-	@Override
 	public int getGroupsCount(PerunSession sess, Vo vo) throws InternalErrorException {
 		return getGroupsManagerImpl().getGroupsCount(sess, vo);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -587,11 +587,6 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
-	public List<Resource> getResourcesByIds(PerunSession sess, List<Integer> resourcesIds) throws InternalErrorException {
-		return getResourcesManagerImpl().getResourcesByIds(sess, resourcesIds);
-	}
-
-	@Override
 	public int getResourcesCount(PerunSession sess, Vo vo) throws InternalErrorException {
 		return getResourcesManagerImpl().getResourcesCount(sess, vo);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -28,7 +28,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.*;
 import cz.metacentrum.perun.core.api.exceptions.rt.ConsistencyErrorRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
+import cz.metacentrum.perun.core.bl.DatabaseManagerBl;
 import cz.metacentrum.perun.core.implApi.AttributesManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleImplApi;
@@ -3422,7 +3422,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				"JOIN members ON members.id " + Compatibility.getStructureForInClause() +
 				"LEFT JOIN member_resource_attr_values mem ON attr_names.id=mem.attr_id AND mem.resource_id=? " +
 				"AND mem.member_id=members.id WHERE namespace IN (?,?,?)", (PreparedStatementCallback<HashMap<Member, List<Attribute>>>) preparedStatement -> {
-					Array sqlArray = ((PerunBlImpl)perun).getDatabaseManagerBl().prepareSQLArrayOfNumbers(members, preparedStatement);
+					Array sqlArray = DatabaseManagerBl.prepareSQLArrayOfNumbers(members, preparedStatement);
 					preparedStatement.setInt(1, service.getId());
 					preparedStatement.setArray(2, sqlArray);
 					preparedStatement.setInt(3, resource.getId());
@@ -3457,7 +3457,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				"JOIN members ON members.id " + Compatibility.getStructureForInClause() +
 				"LEFT JOIN member_attr_values mem ON attr_names.id=mem.attr_id " +
 				"AND mem.member_id=members.id WHERE namespace IN (?,?,?,?)", (PreparedStatementCallback<HashMap<Member, List<Attribute>>>) preparedStatement -> {
-				Array sqlArray = ((PerunBlImpl) perun).getDatabaseManagerBl().prepareSQLArrayOfNumbers(members, preparedStatement);
+				Array sqlArray = DatabaseManagerBl.prepareSQLArrayOfNumbers(members, preparedStatement);
 				preparedStatement.setInt(1, service.getId());
 				preparedStatement.setArray(2, sqlArray);
 				preparedStatement.setString(3, AttributesManager.NS_MEMBER_ATTR_CORE);
@@ -3492,7 +3492,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				"JOIN users ON users.id " + Compatibility.getStructureForInClause() +
 				"LEFT JOIN user_facility_attr_values usr_fac ON attr_names.id=usr_fac.attr_id AND facility_id=? AND user_id=users.id " +
 				"WHERE namespace IN (?,?,?)", (PreparedStatementCallback<HashMap<User, List<Attribute>>>) preparedStatement -> {
-					Array sqlArray = ((PerunBlImpl)perun).getDatabaseManagerBl().prepareSQLArrayOfNumbers(users, preparedStatement);
+					Array sqlArray = DatabaseManagerBl.prepareSQLArrayOfNumbers(users, preparedStatement);
 					preparedStatement.setInt(1, service.getId());
 					preparedStatement.setArray(2, sqlArray);
 					preparedStatement.setInt(3, facility.getId());
@@ -3527,7 +3527,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 				"JOIN users ON users.id " + Compatibility.getStructureForInClause() +
 				"LEFT JOIN user_attr_values usr ON attr_names.id=usr.attr_id AND user_id=users.id " +
 				"WHERE namespace IN (?,?,?,?)", (PreparedStatementCallback<HashMap<User, List<Attribute>>>) preparedStatement -> {
-				Array sqlArray = ((PerunBlImpl) perun).getDatabaseManagerBl().prepareSQLArrayOfNumbers(users, preparedStatement);
+				Array sqlArray = DatabaseManagerBl.prepareSQLArrayOfNumbers(users, preparedStatement);
 				preparedStatement.setInt(1, service.getId());
 				preparedStatement.setArray(2, sqlArray);
 				preparedStatement.setString(3, AttributesManager.NS_USER_ATTR_CORE);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -525,23 +525,6 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
-	public List<Group> getGroupsByIds(PerunSession sess, List<Integer> groupsIds) throws InternalErrorException {
-		// If groupsIds are empty, we can immediately return empty result
-		if (groupsIds.size() == 0) {
-			return new ArrayList<Group>();
-		}
-
-		try {
-			return this.namedParameterJdbcTemplate.query("select " + groupMappingSelectQuery + " from groups where " + BeansUtils.prepareInSQLClause(groupsIds, "groups.id"),
-					GROUP_MAPPER);
-		} catch(EmptyResultDataAccessException ex) {
-			return new ArrayList<Group>();
-		} catch(RuntimeException ex) {
-			throw new InternalErrorException(ex);
-		}
-	}
-
-	@Override
 	public List<Group> getAllMemberGroups(PerunSession sess, Member member) throws InternalErrorException {
 		try {
 			return jdbc.query("select distinct " + groupMappingSelectQuery + " from groups_members join groups on groups_members.group_id = groups.id " +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -589,21 +589,6 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	}
 
 	@Override
-	public List<Resource> getResourcesByIds(PerunSession sess, List<Integer> resourcesIds) throws InternalErrorException {
-		if (resourcesIds.size() == 0) {
-			return new ArrayList<Resource>();
-		}
-
-		try {
-			return this.namedParameterJdbcTemplate.query("select " + resourceMappingSelectQuery + "  from resources where " +
-					BeansUtils.prepareInSQLClause(resourcesIds, "resources.id"),
-					RESOURCE_MAPPER);
-		} catch(RuntimeException ex) {
-			throw new InternalErrorException(ex);
-		}
-	}
-
-	@Override
 	public Resource updateResource(PerunSession sess, Resource resource) throws InternalErrorException {
 		try {
 			Map<String, Object> map = jdbc.queryForMap("select name, dsc from resources where id=?", resource.getId());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -189,18 +189,6 @@ public interface GroupsManagerImplApi {
 	void removeMember(PerunSession perunSession, Group group, Member member) throws InternalErrorException, NotGroupMemberException;
 
 	/**
-	 * Return groups by theirs id.
-	 *
-	 * @param perunSession
-	 * @param groupsIds list of group ids
-	 *
-	 * @return list groups
-	 *
-	 * @throws InternalErrorException
-	 */
-	List<Group> getGroupsByIds(PerunSession perunSession, List<Integer> groupsIds) throws InternalErrorException;
-
-	/**
 	 * Return list of assigned groups on the resource.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -316,16 +316,6 @@ public interface ResourcesManagerImplApi {
 	List<RichResource> getRichResources(PerunSession perunSession, Vo vo) throws InternalErrorException;
 
 	/**
-	 * Get list of resources by theirs IDs.
-	 *
-	 * @param sess
-	 * @param resourcesIds
-	 * @return list of resources
-	 * @throws InternalErrorException
-	 */
-	List<Resource> getResourcesByIds(PerunSession sess, List<Integer> resourcesIds) throws InternalErrorException;
-
-	/**
 	 * Get all VO resources count.
 	 *
 	 * @param perunSession

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -3983,25 +3983,6 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 	}
 
 	@Test
-	public void getGroupsByIds() throws Exception {
-		System.out.println(CLASS_NAME + "getGroupsByIds");
-
-		vo = setUpVo();
-		List ids = new ArrayList();
-		List groups = new ArrayList();
-
-		for (int i = 1; i < 1002; i++) {
-			Group group = new Group("GroupsManagerTestGroup" + i,"testovaci" + i);
-			groupsManager.createGroup(sess, vo, group);
-			ids.add(group.getId());
-			groups.add(group);
-		}
-
-		assertEquals(groups, groupsManagerBl.getGroupsByIds(sess, ids));
-
-	}
-
-	@Test
 	public void getGroupDirectMembers() throws Exception {
 		System.out.println(CLASS_NAME + "getGroupDirectMembers");
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntryIntegrationTest.java
@@ -1624,28 +1624,6 @@ public class ResourcesManagerEntryIntegrationTest extends AbstractPerunIntegrati
 	}
 
 	@Test
-	public void getResourcesByIds() throws Exception {
-		System.out.println(CLASS_NAME + "getResourcesByIds");
-
-		vo = setUpVo();
-		facility = setUpFacility();
-		List ids = new ArrayList();
-		List resources = new ArrayList();
-
-		for (int i = 1; i < 1002; i++) {
-			Resource resource = new Resource();
-			resource.setName("ResourcesManagerTestResource" + i);
-			resource.setDescription("Testovaci" + i);
-			resourcesManager.createResource(sess, resource, vo, facility);
-			ids.add(resource.getId());
-			resources.add(resource);
-		}
-
-		assertEquals(resources, perun.getResourcesManagerBl().getResourcesByIds(sess, ids));
-
-	}
-
-	@Test
 	public void addResourceSelfServiceUser() throws Exception {
 		System.out.println(CLASS_NAME + "addResourceSelfServiceGroup");
 

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/PerunNotifPoolMessageDao.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/dao/PerunNotifPoolMessageDao.java
@@ -32,7 +32,7 @@ public interface PerunNotifPoolMessageDao {
 	 *
 	 * @return templateId = list<PoolMessage>
 	 */
-	public Map<Integer, List<PoolMessage>> getAllPoolMessagesForProcessing();
+	public Map<Integer, List<PoolMessage>> getAllPoolMessagesForProcessing() throws InternalErrorException;
 
 	/**
 	 * Sets all created to now for all pool messages. Is used after start of
@@ -45,5 +45,5 @@ public interface PerunNotifPoolMessageDao {
 	 *
 	 * @param proccessedIds
 	 */
-	public void removeAllPoolMessages(Set<Integer> proccessedIds);
+	public void removeAllPoolMessages(Set<Integer> proccessedIds) throws InternalErrorException;
 }

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManager.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManager.java
@@ -35,5 +35,5 @@ public interface PerunNotifPoolMessageManager {
 	 * keyAttributes and checks conditionals set in templates whether sent
 	 * notification or not. Procesed messages are removed from db.
 	 */
-	public void processPerunNotifPoolMessagesFromDb();
+	public void processPerunNotifPoolMessagesFromDb() throws InternalErrorException;
 }

--- a/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManagerImpl.java
+++ b/perun-notification/src/main/java/cz/metacentrum/perun/notif/managers/PerunNotifPoolMessageManagerImpl.java
@@ -406,7 +406,7 @@ public class PerunNotifPoolMessageManagerImpl implements PerunNotifPoolMessageMa
 	}
 
 	@Override
-	public void processPerunNotifPoolMessagesFromDb() {
+	public void processPerunNotifPoolMessagesFromDb() throws InternalErrorException {
 
 		//in format templateId = list<PoolMessage>
 		Map<Integer, List<PoolMessage>> poolMessages = perunNotifPoolMessageDao.getAllPoolMessagesForProcessing();


### PR DESCRIPTION
Methods removeAllPoolMessages in PerunNotifPoolMessageDaoImpl and getUsersByIds in UsersManagerImpl now use sql arrays instead of BeansUtils.prepareInSQLClause().
Methods getGroupsByIds in GroupsManagerImpl and getResourcesByIds in ResourcesManagerImpl were removed because they were not used.