### PR TITLE
REGISTRAR: Support custom configuration of SMTP

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -34,6 +34,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.transaction.annotation.Transactional;
 
 import cz.metacentrum.perun.core.bl.PerunBl;
@@ -93,6 +94,11 @@ public class MailManagerImpl implements MailManager {
 
 	public void setMailSender(MailSender mailSender) {
 		this.mailSender = mailSender;
+		boolean auth = Boolean.parseBoolean(registrarProperties.getProperty("mail.smtp.auth", "false"));
+		if (auth) {
+			((JavaMailSenderImpl)mailSender).setUsername(registrarProperties.getProperty("registrar.smtp.user"));
+			((JavaMailSenderImpl)mailSender).setPassword(registrarProperties.getProperty("registrar.smtp.pass"));
+		}
 	}
 
 	/**

--- a/perun-registrar-lib/src/main/resources/perun-registrar-lib.xml
+++ b/perun-registrar-lib/src/main/resources/perun-registrar-lib.xml
@@ -23,7 +23,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 
 	<!-- for sending emails -->
 	<bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
-		<property name="host" value="localhost"/>
+		<property name="javaMailProperties" ref="registrarProperties"/>
 	</bean>
 
 	<bean id="registrarManager" class="cz.metacentrum.perun.registrar.impl.RegistrarManagerImpl" init-method="initialize">
@@ -68,6 +68,15 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 					<prop key="backupFrom">perun@localhost</prop>
 					<prop key="backupTo">perun@localhost</prop>
 					<prop key="fedAuthz">fed</prop>
+					<!-- MAIL SENDING PROPERTIES -->
+					<prop key="mail.smtp.host">localhost</prop>
+					<prop key="mail.smtp.port">25</prop>
+					<prop key="mail.smtp.auth">false</prop>
+					<prop key="mail.smtp.starttls.enable">false</prop>
+					<prop key="mail.debug">false</prop>
+					<!-- user / password if "mail.smtp.auth" is true -->
+					<prop key="registrar.smtp.user"></prop>
+					<prop key="registrar.smtp.pass"></prop>
 				</props>
 			</property>
 		</bean>


### PR DESCRIPTION
- From now on we can specify necessary SMTP properties, if we wish
  to use other SMTP server than localhost on port 25.