### PR TITLE
GUI: Remove unnecessary ending & from URLs

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributes.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributes.java
@@ -232,7 +232,9 @@ public class GetAttributes implements JsonCallback, JsonCallbackTable<Attribute>
 		for (Map.Entry<String, Integer> attr : this.ids.entrySet()) {
 			params += attr.getKey() + "=" + attr.getValue() + "&";
 		}
-
+		if (params.endsWith("&")) {
+			params = params.substring(0, params.length()-1);
+		}
 		JsonClient js = new JsonClient();
 		js.retrieveData(GetAttributes.JSON_URL, params, this);
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesDefinitionWithRights.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesDefinitionWithRights.java
@@ -164,6 +164,9 @@ public class GetAttributesDefinitionWithRights implements JsonCallback, JsonCall
 		for (Map.Entry<String, Integer> attr : this.ids.entrySet()) {
 			params += attr.getKey() + "=" + attr.getValue() + "&";
 		}
+		if (params.endsWith("&")) {
+			params = params.substring(0, params.length()-1);
+		}
 		js.retrieveData(JSON_URL, params, this);
 	}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesV2.java
@@ -242,7 +242,9 @@ public class GetAttributesV2 implements JsonCallback, JsonCallbackTable<Attribut
 		for (Map.Entry<String, Integer> attr : this.ids.entrySet()) {
 			params += attr.getKey() + "=" + attr.getValue() + "&";
 		}
-
+		if (params.endsWith("&")) {
+			params = params.substring(0, params.length()-1);
+		}
 		JsonClient js = new JsonClient();
 		js.retrieveData(GetAttributesV2.JSON_URL, params, this);
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetListOfAttributes.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetListOfAttributes.java
@@ -108,6 +108,10 @@ public class GetListOfAttributes implements JsonCallback {
 
 		}
 
+		if (params.endsWith("&")) {
+			params = params.substring(0, params.length()-1);
+		}
+
 		JsonClient js = new JsonClient();
 		js.retrieveData(JSON_URL, params, this);
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetRequiredAttributes.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetRequiredAttributes.java
@@ -93,6 +93,9 @@ public class GetRequiredAttributes implements JsonCallback, JsonCallbackTable<At
 		for (Map.Entry<String, Integer> attr : this.ids.entrySet()) {
 			params += attr.getKey() + "=" + attr.getValue() + "&";
 		}
+		if (params.endsWith("&")) {
+			params = params.substring(0, params.length()-1);
+		}
 		JsonClient js = new JsonClient();
 		js.retrieveData(GetRequiredAttributes.JSON_URL, params, this);
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetRequiredAttributesV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetRequiredAttributesV2.java
@@ -130,6 +130,9 @@ public class GetRequiredAttributesV2 implements JsonCallback, JsonCallbackTable<
 				params += "services[]=" + s.getId() + "&";
 			}
 		}
+		if (params.endsWith("&")) {
+			params = params.substring(0, params.length()-1);
+		}
 		JsonClient js = new JsonClient();
 		js.retrieveData(GetRequiredAttributesV2.JSON_URL, params, this);
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetResourceRequiredAttributes.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetResourceRequiredAttributes.java
@@ -87,6 +87,9 @@ public class GetResourceRequiredAttributes implements JsonCallback, JsonCallback
 		for (Map.Entry<String, Integer> attr : this.ids.entrySet()) {
 			params += attr.getKey() + "=" + attr.getValue() + "&";
 		}
+		if (params.endsWith("&")) {
+			params = params.substring(0, params.length()-1);
+		}
 		JsonClient js = new JsonClient();
 		js.retrieveData(JSON_URL, params, this);
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetResourceRequiredAttributesV2.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetResourceRequiredAttributesV2.java
@@ -95,6 +95,9 @@ public class GetResourceRequiredAttributesV2 implements JsonCallback, JsonCallba
 		for (Map.Entry<String, Integer> attr : this.ids.entrySet()) {
 			params += attr.getKey() + "=" + attr.getValue() + "&";
 		}
+		if (params.endsWith("&")) {
+			params = params.substring(0, params.length()-1);
+		}
 		JsonClient js = new JsonClient();
 		js.retrieveData(GetResourceRequiredAttributesV2.JSON_URL, params, this);
 	}


### PR DESCRIPTION
- When we ask for attributes, we generate URL from many params
  and it wrongly ended with unnecessary &.