### PR TITLE
CORE: Fixed calculation expected membership expiration for GUI

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1689,10 +1689,10 @@ public class MembersManagerBlImpl implements MembersManagerBl {
             p = Pattern.compile("([0-9]+)([dmy]?)");
             m = p.matcher(gracePeriod);
             if (m.matches()) {
-				LocalDate gracePeriodDate = LocalDate.now();
+				LocalDate gracePeriodDate;
 				try {
 					Pair<Integer, TemporalUnit> fieldAmount = Utils.prepareGracePeriodDate(m);
-					gracePeriodDate = gracePeriodDate.minus(fieldAmount.getLeft(), fieldAmount.getRight());
+					gracePeriodDate = localDate.minus(fieldAmount.getLeft(), fieldAmount.getRight());
 				} catch (InternalErrorException e) {
 					throw new InternalErrorException("Wrong format of gracePeriod in VO membershipExpirationRules attribute. gracePeriod: " + gracePeriod);
 				}


### PR DESCRIPTION
- Method getNewExtendMembership() is calculating expected membership
  expiration date based on VO and LoA. Check for gracePeriod was bad,
  since it was calculated from previous gracePeriodDate value (current
  date), instead of extended localDate.
  Hence it resulted in (now.isBefore(now-gp)) which was always true,
  instead of now.isBefore(date-gp) which varies based on current date
  and VO membership settings.