### PR TITLE
Fixed name for the group in BBMRI registrar module

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRICollections.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRICollections.java
@@ -30,7 +30,7 @@ public class BBMRICollections implements RegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(BBMRICollections.class);
 	public static final String BIOBANK_IDS_FIELD = "Comma or new-line separated list of IDs of collections you are representing:";
-	public static final String COLLECTIONS_GROUP_NAME = "bbmriEricDirectory";
+	public static final String COLLECTIONS_GROUP_NAME = "collections:bbmriEricDirectory";
 	public static final String COLLECTION_ID_ATTR_NAME = "urn:perun:group:attribute-def:def:collectionID";
 	public static final String REPRESENTATIVES_GROUP_NAME = "representatives";
 	public static final String ADD_NEW_COLLECTIONS_GROUP_NAME = "addNewCollections";


### PR DESCRIPTION
* Old name has not been respecting hierarchy of groups
* Bug caused GroupNotExistsException when trying to approve the registration
* New name has the whole hierarchy in it