### PR TITLE
New methods to get only active or inactive members of any group

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -273,7 +273,37 @@ public interface GroupsManager {
 	 * @throws PrivilegeException insufficient permission
 	 * @throws GroupNotExistsException when group does not exist
 	 */
-	List<Member> getGroupDirectMembers(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;;
+	List<Member> getGroupDirectMembers(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
+
+	/**
+	 * Return all members of the group who are active (valid) in the group.
+	 *
+	 * Do not return expired members of the group.
+	 *
+	 * @param sess perun session
+	 * @param group to get members from
+	 * @return list of active (valid) members
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException insufficient permission
+	 * @throws GroupNotExistsException when group does not exist
+	 */
+	List<Member> getActiveGroupMembers(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
+
+	/**
+	 * Return all members of the group who are inactive (expired) in the group.
+	 *
+	 * Do not return active members of the group.
+	 *
+	 * @param sess perun session
+	 * @param group to get members from
+	 * @return list of inactive (expired) members
+	 *
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException insufficient permission
+	 * @throws GroupNotExistsException when group does not exist
+	 */
+	List<Member> getInactiveGroupMembers(PerunSession perunSession, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException;
 
 	/**
 	 * Return group members with specified vo membership status.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -375,6 +375,30 @@ public interface GroupsManagerBl {
 	List<Member> getGroupDirectMembers(PerunSession perunSession, Group group) throws InternalErrorException;
 
 	/**
+	 * Return all members of the group who are active (valid) in the group.
+	 *
+	 * Do not return expired members of the group.
+	 *
+	 * @param sess perun session
+	 * @param group to get members from
+	 * @return list of active (valid) members
+	 * @throws InternalErrorException
+	 */
+	List<Member> getActiveGroupMembers(PerunSession perunSession, Group group) throws InternalErrorException;
+
+	/**
+	 * Return all members of the group who are inactive (expired) in the group.
+	 *
+	 * Do not return active members of the group.
+	 *
+	 * @param sess perun session
+	 * @param group to get members from
+	 * @return list of inactive (expired) members
+	 * @throws InternalErrorException
+	 */
+	List<Member> getInactiveGroupMembers(PerunSession perunSession, Group group) throws InternalErrorException;
+
+	/**
 	 * Return only valid, suspended, expired and disabled group members.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -999,6 +999,16 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
+	public List<Member> getActiveGroupMembers(PerunSession sess, Group group) throws InternalErrorException {
+		return filterMembersByStatusInGroup(getGroupMembers(sess, group), MemberGroupStatus.VALID);
+	}
+
+	@Override
+	public List<Member> getInactiveGroupMembers(PerunSession sess, Group group) throws InternalErrorException {
+		return filterMembersByStatusInGroup(getGroupMembers(sess, group), MemberGroupStatus.EXPIRED);
+	}
+
+	@Override
 	public List<Member> getGroupMembers(PerunSession sess, Group group, Status status) throws InternalErrorException {
 		if (status == null) {
 			return this.getGroupMembers(sess, group);
@@ -3700,5 +3710,23 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		return false;
 
+	}
+
+	/**
+	 * Return list of members with allowedStatus filtered from input array list membersToFilter.
+	 *
+	 * @param membersToFilter list of members to filter
+	 * @param allowedStatus allowed status to filter by
+	 * @return list of members with filtered status in group
+	 * @throws InternalErrorException if allowed status is null
+	 */
+	private List<Member> filterMembersByStatusInGroup(List<Member> membersToFilter, MemberGroupStatus allowedStatus) throws InternalErrorException {
+		if (allowedStatus == null) throw new InternalErrorException("Allowed status can't be null.");
+		List<Member> filteredMembers = new ArrayList<>();
+		if (membersToFilter == null || membersToFilter.isEmpty()) return filteredMembers;
+		for(Member member: membersToFilter) {
+			if (allowedStatus.equals(member.getGroupStatus())) filteredMembers.add(member);
+		}
+		return filteredMembers;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -303,6 +303,36 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
+	public List<Member> getActiveGroupMembers(PerunSession sess, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getGroupsManagerBl().checkGroupExists(sess, group);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
+			&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, group)
+			&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
+			throw new PrivilegeException(sess, "getActiveGroupMembers");
+		}
+
+		return getGroupsManagerBl().getActiveGroupMembers(sess, group);
+	}
+
+	@Override
+	public List<Member> getInactiveGroupMembers(PerunSession sess, Group group) throws InternalErrorException, PrivilegeException, GroupNotExistsException {
+		Utils.checkPerunSession(sess);
+		getGroupsManagerBl().checkGroupExists(sess, group);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group)
+			&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, group)
+			&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group)) {
+			throw new PrivilegeException(sess, "getInactiveGroupMembers");
+		}
+
+		return getGroupsManagerBl().getInactiveGroupMembers(sess, group);
+	}
+
+	@Override
 	public List<Member> getGroupMembers(PerunSession sess, Group group, Status status) throws InternalErrorException, PrivilegeException, GroupNotExistsException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, group);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -3987,6 +3987,97 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		assertEquals("Found invalid member.", foundMembers.get(0), expectedRichMember);
 	}
 
+	@Test
+	public void getActiveGroupMembers() throws Exception {
+		System.out.println(CLASS_NAME + "getActiveGroupMembers");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+		Member m2 = setUpMemberWithDifferentParam(vo, 1);
+		Member m3 = setUpMemberWithDifferentParam(vo, 2);
+
+		groupsManagerBl.addMember(sess, g1, m1);
+		groupsManagerBl.addMember(sess, g2, m2);
+		groupsManagerBl.addMember(sess, g1, m3);
+		groupsManagerBl.addMember(sess, g2, m3);
+
+		groupsManagerBl.expireMemberInGroup(sess, m2, g2);
+		groupsManagerBl.expireMemberInGroup(sess, m3, g1);
+
+		List<Member> activeMembers = groupsManagerBl.getActiveGroupMembers(sess, g1);
+		assertTrue(activeMembers.contains(m1));
+		assertFalse(activeMembers.contains(m2));
+		assertTrue(activeMembers.contains(m3));
+	}
+
+	@Test
+	public void getInactiveGroupMembers() throws Exception {
+		System.out.println(CLASS_NAME + "getInactiveGroupMembers");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+		Member m2 = setUpMemberWithDifferentParam(vo, 1);
+		Member m3 = setUpMemberWithDifferentParam(vo, 2);
+
+		groupsManagerBl.addMember(sess, g1, m1);
+		groupsManagerBl.addMember(sess, g2, m2);
+		groupsManagerBl.addMember(sess, g1, m3);
+		groupsManagerBl.addMember(sess, g2, m3);
+
+		groupsManagerBl.expireMemberInGroup(sess, m2, g2);
+		groupsManagerBl.expireMemberInGroup(sess, m3, g1);
+
+		List<Member> inactiveMembers = groupsManagerBl.getInactiveGroupMembers(sess, g1);
+		assertFalse(inactiveMembers.contains(m1));
+		assertTrue(inactiveMembers.contains(m2));
+		assertFalse(inactiveMembers.contains(m3));
+	}
+
+	@Test
+	public void allMembersEqualsInactivePlusActiveMembersInGroup() throws Exception {
+		System.out.println(CLASS_NAME + "allMembersEqualsInactivePlusActiveMembersInGroup");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+		Member m2 = setUpMemberWithDifferentParam(vo, 1);
+		Member m3 = setUpMemberWithDifferentParam(vo, 2);
+
+		groupsManagerBl.addMember(sess, g1, m1);
+		groupsManagerBl.addMember(sess, g2, m2);
+		groupsManagerBl.addMember(sess, g1, m3);
+		groupsManagerBl.addMember(sess, g2, m3);
+
+		groupsManagerBl.expireMemberInGroup(sess, m2, g2);
+		groupsManagerBl.expireMemberInGroup(sess, m3, g1);
+
+		List<Member> inactiveAndActiveMembers = groupsManagerBl.getActiveGroupMembers(sess, g1);
+		inactiveAndActiveMembers.addAll(groupsManagerBl.getInactiveGroupMembers(sess, g1));
+		List<Member> allMembers = groupsManagerBl.getGroupMembers(sess, g1);
+
+		Collections.sort(allMembers);
+		Collections.sort(inactiveAndActiveMembers);
+		
+		assertEquals(allMembers, inactiveAndActiveMembers);
+	}
+
 	// PRIVATE METHODS -------------------------------------------------------------
 
 	private Vo setUpVo() throws Exception {

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -1038,7 +1038,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * Returns full list of member's RichGroups containing selected attributes.
 	 *
 	 * "members" group is not included!
-	 * 
+	 *
 	 * @param member int <code>id</code> of member
 	 * @param attrNames List<String> if attrNames is null method will return RichGroups containing all attributes
 	 * @return List<RichGroup> RichGroups containing selected attributes
@@ -1135,6 +1135,43 @@ public enum GroupsManagerMethod implements ManagerMethod {
 			return ac.getGroupsManager().getAllMemberGroups(ac.getSession(),
 					ac.getMemberById(parms.readInt("member")));
 		}
+	},
+
+	/*#
+	 * Return all members of the group who are active (valid) in the group.
+	 *
+	 * Do not return expired members of the group.
+	 *
+	 * @param group int <code>id</code> of group
+	 * @return List<Member> list of active (valid) members of the group
+	 */
+	getActiveGroupMembers {
+
+		@Override
+		public List<Member> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getGroupsManager().getActiveGroupMembers(ac.getSession(),
+				ac.getGroupById(parms.readInt("group")));
+		}
+	},
+
+	/*#
+	 * Return all members of the group who are inactive (expired) in the group.
+	 *
+	 * Do not return active members of the group.
+	 *
+	 * @param group int <code>id</code> of group
+	 * @return List<Member> list of inactive (expired) members of the group
+	 */
+	getInactiveGroupMembers {
+
+		@Override
+		public List<Member> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getGroupsManager().getInactiveGroupMembers(ac.getSession(),
+				ac.getGroupById(parms.readInt("group")));
+		}
+
 	},
 
 	/*#


### PR DESCRIPTION
 - active members of group are members with at least 1 valid
 sourceGroupStatus (direct or indirect) in the group
 - inactive members of group are members with no valid sourceGroupStatus
 (direct or indirect) in the group and at least 1 expired
 sourceGroupStatus in the group
 - there are two new methods to get such active or inactive member of
 the group
 - tests were added to check if these methods work correctly