### PR TITLE
CORE/GUI: Allow specifying mail templates in entityless attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -1028,12 +1028,13 @@ public interface UsersManager {
 	 * @param url base URL of running perun instance passed from RPC.
 	 * @param user User to request preferred email change for
 	 * @param email new email address
+	 * @param lang Language to get confirmation mail in (optional)
 	 *
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 * @throws UserNotExistsException
 	 */
-	void requestPreferredEmailChange(PerunSession sess, String url, User user, String email) throws InternalErrorException, PrivilegeException, UserNotExistsException;
+	void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang) throws InternalErrorException, PrivilegeException, UserNotExistsException;
 
 	/**
 	 * Validate change of user's preferred email address.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -751,12 +751,13 @@ public interface UsersManager {
 	 * @param i
 	 * @param m
 	 * @param password
+	 * @param lang language to get notification in
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 * @throws LoginNotExistsException
 	 * @throws PasswordChangeFailedException
 	 */
-	void changeNonAuthzPassword(PerunSession sess, String i, String m, String password)
+	void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang)
 			throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
 
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1142,12 +1142,13 @@ public interface UsersManagerBl {
 	 * @param user     user to change password for
 	 * @param m        encrypted parameter
 	 * @param password password to set
+	 * @param lang Language to get notification in
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 * @throws LoginNotExistsException
 	 * @throws PasswordChangeFailedException
 	 */
-	void changeNonAuthzPassword(PerunSession sess, User user, String m, String password)
+	void changeNonAuthzPassword(PerunSession sess, User user, String m, String password, String lang)
 			throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1076,10 +1076,11 @@ public interface UsersManagerBl {
 	 * @param url   base URL of running perun instance passed from RPC.
 	 * @param user  User to request preferred email change for
 	 * @param email new email address
+	 * @param lang language to get confirmation mail in (optional)
 	 * @throws InternalErrorException
 	 * @throws UserNotExistsException
 	 */
-	void requestPreferredEmailChange(PerunSession sess, String url, User user, String email) throws InternalErrorException, UserNotExistsException;
+	void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang) throws InternalErrorException, UserNotExistsException;
 
 	/**
 	 * * Validate change of user's preferred email address.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1265,15 +1265,17 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void changeNonAuthzPassword(PerunSession sess, String i, String m, String password) throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
+	public void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang) throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
 
 		Utils.checkPerunSession(sess);
+
+		if (lang == null || lang.isEmpty()) lang = "en"; // fallback to english
 
 		int userId = Integer.parseInt(Utils.cipherInput(i,true));
 		// this will make also "if exists check"
 		User user = getPerunBl().getUsersManagerBl().getUserById(sess, userId);
 
-		getPerunBl().getUsersManagerBl().changeNonAuthzPassword(sess, user, m, password);
+		getPerunBl().getUsersManagerBl().changeNonAuthzPassword(sess, user, m, password, lang);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1214,7 +1214,7 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	public void requestPreferredEmailChange(PerunSession sess, String url, User user, String email) throws InternalErrorException, PrivilegeException, UserNotExistsException {
+	public void requestPreferredEmailChange(PerunSession sess, String url, User user, String email, String lang) throws InternalErrorException, PrivilegeException, UserNotExistsException {
 
 		Utils.checkPerunSession(sess);
 		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
@@ -1224,7 +1224,7 @@ public class UsersManagerEntry implements UsersManager {
 			throw new PrivilegeException(sess, "requestPreferredEmailChange");
 		}
 
-		getPerunBl().getUsersManagerBl().requestPreferredEmailChange(sess, url, user, email);
+		getPerunBl().getUsersManagerBl().requestPreferredEmailChange(sess, url, user, email, lang);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -786,8 +786,8 @@ public class Utils {
 			throw new NullPointerException("input must not be null");
 		try {
 			Mac mac = Mac.getInstance("HmacSHA256");
-			mac.init(new SecretKeySpec(BeansUtils.getCoreConfig().getMailchangeSecretKey().getBytes("UTF-8"),"HmacSHA256"));
-			byte[] macbytes = mac.doFinal(input.getBytes("UTF-8"));
+			mac.init(new SecretKeySpec(BeansUtils.getCoreConfig().getMailchangeSecretKey().getBytes(StandardCharsets.UTF_8),"HmacSHA256"));
+			byte[] macbytes = mac.doFinal(input.getBytes(StandardCharsets.UTF_8));
 			return new BigInteger(macbytes).toString(Character.MAX_RADIX);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
@@ -802,9 +802,11 @@ public class Utils {
 	 * @param url base URL of running perun instance passed from RPC
 	 * @param email new email address to send notification to
 	 * @param changeId ID of change request in DB
+	 * @param subject Template subject or null
+	 * @param content Template message or null
 	 * @throws InternalErrorException
 	 */
-	public static void sendValidationEmail(User user, String url, String email, int changeId) throws InternalErrorException {
+	public static void sendValidationEmail(User user, String url, String email, int changeId, String subject, String content) throws InternalErrorException {
 
 		// create mail sender
 		JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
@@ -817,7 +819,12 @@ public class Utils {
 
 		String instanceName = BeansUtils.getCoreConfig().getInstanceName();
 
-		message.setSubject("["+instanceName+"] New email address verification");
+		if (subject == null ||subject.isEmpty()) {
+			message.setSubject("["+instanceName+"] New email address verification");
+		} else {
+			subject = subject.replace("{instanceName}", instanceName);
+			message.setSubject(subject);
+		}
 
 		// get validation link params
 		String i = Integer.toString(changeId, Character.MAX_RADIX);
@@ -860,7 +867,12 @@ public class Utils {
 					"\n----------------------------------------------------------------" +
 					"\nPerun - Identity & Access Management System";
 
-			message.setText(text);
+			if (content == null || content.isEmpty()) {
+				message.setText(text);
+			} else {
+				content = content.replace("{link}",link);
+				message.setText(content);
+			}
 
 			mailSender.send(message);
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -961,13 +961,14 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 * @param i String first encrypted parameter
 	 * @param m String second encrypted parameter
 	 * @param password String new password
+	 * @param lang String language to get notifications in (optional).
 	 */
 	changeNonAuthzPassword {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
-			ac.getUsersManager().changeNonAuthzPassword(ac.getSession(), parms.readString("i"), parms.readString("m"), parms.readString("password"));
+			ac.getUsersManager().changeNonAuthzPassword(ac.getSession(), parms.readString("i"), parms.readString("m"), parms.readString("password"), (parms.contains("lang") ? parms.readString("lange") : null));
 
 			return null;
 		}

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1121,6 +1121,7 @@ public enum UsersManagerMethod implements ManagerMethod {
 	 *
 	 * @param user int User <code>id</code>
 	 * @param email String new email address to set
+	 * @param lang String language to get confirmation mail in (optional)
 	 */
 	requestPreferredEmailChange {
 		@Override
@@ -1135,7 +1136,8 @@ public enum UsersManagerMethod implements ManagerMethod {
 			ac.getUsersManager().requestPreferredEmailChange(ac.getSession(),
 					referer,
 					ac.getUserById(parms.readInt("user")),
-					parms.readString("email"));
+					parms.readString("email"),
+					parms.contains("lang") ? parms.readString("lang") : null);
 
 			return null;
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/RequestPreferredEmailChange.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/usersManager/RequestPreferredEmailChange.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.webgui.json.usersManager;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
@@ -120,6 +121,9 @@ public class RequestPreferredEmailChange {
 		JSONObject jsonQuery = new JSONObject();
 		jsonQuery.put("user", new JSONNumber(user.getId()));
 		jsonQuery.put("email", new JSONString(email));
+		String locale = LocaleInfo.getCurrentLocale().getLocaleName();
+		if ("default".equals(locale)) locale = "en";
+		jsonQuery.put("lang", new JSONString(locale));
 		return jsonQuery;
 	}
 


### PR DESCRIPTION
- We now allow specifying mail templates for confirmation of successful non-authenticate password reset.
- Same goes for preferred mail change request.
- We optionally consume "lang" from API to get proper template (key for entityless attribute).
- Password reset attributes are namespaced by login-namespace.
- Following entityless attributes must exist on each instance:
```
  nonAuthzPwdResetConfirmMailSubject:[namespace]
  nonAuthzPwdResetConfirmMailTemplate:[namespace]
  preferredMailChangeMailSubject
  preferredMailChangeMailTemplate
```