### PR TITLE
New methods to work with member and his groups

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -872,6 +872,48 @@ public interface GroupsManager {
 	List<Group> getAllMemberGroups(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException;
 
 	/**
+	 * Returns all member's groups where member is in active state (is valid there)
+	 * Excluded members group.
+	 *
+	 * @param sess perun session
+	 * @param member member to get groups for
+	 * @return list of groups where member is in active state (valid)
+	 *
+	 * @throws MemberNotExistsException member in parameter not exists in perun
+	 * @throws PrivilegeException user is not privileged to call this method
+	 * @throws InternalErrorException
+	 */
+	List<Group> getGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException;
+
+	/**
+	 * Returns all member's groups where member is in inactive state (it is not valid and it is expired there)
+	 * Excluded members group.
+	 *
+	 * @param sess perun session
+	 * @param member member to get groups for
+	 * @return list of groups where member is in inactive state (expired)
+	 *
+	 * @throws MemberNotExistsException member in parameter not exists in perun
+	 * @throws PrivilegeException user is not privileged to call this method
+	 * @throws InternalErrorException
+	 */
+	List<Group> getGroupsWhereMemberIsInactive(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException;
+
+	/**
+	 * Returns all member's groups where member is in active state (is valid there)
+	 * Included members group.
+	 *
+	 * @param sess perun session
+	 * @param member member to get groups for
+	 * @return list of groups where member is in active state (valid)
+	 *
+	 * @throws MemberNotExistsException member in parameter not exists in perun
+	 * @throws PrivilegeException user is not privileged to call this method
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAllGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException;
+
+	/**
 	 * Return all RichGroups for specified member, containing selected attributes.
 	 * "members" group is not included.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -387,6 +387,19 @@ public interface GroupsManagerBl {
 	List<Member> getActiveGroupMembers(PerunSession perunSession, Group group) throws InternalErrorException;
 
 	/**
+	 * Return all members of the group who are active (valid) in the group and have specific status in the Vo.
+	 *
+	 * Do not return expired members of the group.
+	 *
+	 * @param sess perun session
+	 * @param group to get members from
+	 * @param status to get only members with this specific status in the Vo
+	 * @return list of active (valid) members with specific status in the Vo
+	 * @throws InternalErrorException
+	 */
+	List<Member> getActiveGroupMembers(PerunSession sess, Group group, Status status) throws InternalErrorException;
+
+	/**
 	 * Return all members of the group who are inactive (expired) in the group.
 	 *
 	 * Do not return active members of the group.
@@ -397,6 +410,33 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Member> getInactiveGroupMembers(PerunSession perunSession, Group group) throws InternalErrorException;
+
+	/**
+	 * Return all members of the group who are inactive (expired) in the group and have specific status in the Vo.
+	 *
+	 * Do not return active members of the group.
+	 *
+	 * @param sess perun session
+	 * @param group to get members from
+	 * @param status to get only members with this specific status in the Vo
+	 * @return list of inactive (expired) members with specific status in the Vo
+	 * @throws InternalErrorException
+	 */
+	List<Member> getInactiveGroupMembers(PerunSession sess, Group group, Status status) throws InternalErrorException;
+
+	/**
+	 * Return all members of the group who has specific status in the group and also specific status in the Vo.
+	 *
+	 * For example: All members with valid status in the Vo and also valid status in the group.
+	 *
+	 * @param sess perun session
+	 * @param group to get members from
+	 * @param statusInGroup to get only members with this specific status in the group
+	 * @param status to get only members with this specific status in the Vo
+	 * @return list of members with specific status in group and specific status in the Vo
+	 * @throws InternalErrorException
+	 */
+	List<Member> getGroupMembers(PerunSession sess, Group group, MemberGroupStatus statusInGroup, Status status) throws InternalErrorException;
 
 	/**
 	 * Return only valid, suspended, expired and disabled group members.
@@ -958,6 +998,40 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<Group> getAllMemberGroups(PerunSession sess, Member member) throws InternalErrorException;
+
+	/**
+	 * Returns all member's groups where member is in active state (is valid there)
+	 * Excluded members group.
+	 *
+	 * @param sess perun session
+	 * @param member member to get groups for
+	 * @return list of groups where member is in active state (valid)
+	 * @throws InternalErrorException
+	 */
+	List<Group> getGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException;
+
+	/**
+	 * Returns all member's groups where member is in inactive state (it is not valid and it is expired there)
+	 * Excluded members group.
+	 *
+	 * @param sess perun session
+	 * @param member member to get groups for
+	 * @return list of groups where member is in inactive state (expired)
+	 * @throws InternalErrorException
+	 */
+	List<Group> getGroupsWhereMemberIsInactive(PerunSession sess, Member member) throws InternalErrorException;
+
+	/**
+	 * Returns all member's groups where member is in active state (is valid there)
+	 * Included members group.
+	 *
+	 * @param sess perun session
+	 * @param member member to get groups for
+	 * @return list of groups where member is in active state (valid)
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAllGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException;
+
 
 	/**
 	 * Returns all groups which have set the attribute with the value. Searching only def and opt attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -999,8 +999,23 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
+	public List<Member> getGroupMembers(PerunSession sess, Group group, MemberGroupStatus statusInGroup, Status status) throws InternalErrorException {
+		return filterMembersByStatusInGroup(getGroupMembers(sess, group, status), statusInGroup);
+	}
+
+	@Override
+	public List<Member> getActiveGroupMembers(PerunSession sess, Group group, Status status) throws InternalErrorException {
+		return filterMembersByStatusInGroup(getGroupMembers(sess, group, status), MemberGroupStatus.VALID);
+	}
+
+	@Override
 	public List<Member> getActiveGroupMembers(PerunSession sess, Group group) throws InternalErrorException {
 		return filterMembersByStatusInGroup(getGroupMembers(sess, group), MemberGroupStatus.VALID);
+	}
+
+	@Override
+	public List<Member> getInactiveGroupMembers(PerunSession sess, Group group, Status status) throws InternalErrorException {
+		return filterMembersByStatusInGroup(getGroupMembers(sess, group, status), MemberGroupStatus.EXPIRED);
 	}
 
 	@Override
@@ -1394,6 +1409,29 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	@Override
 	public List<Group> getAllMemberGroups(PerunSession sess, Member member) throws InternalErrorException {
 		return getGroupsManagerImpl().getAllMemberGroups(sess, member);
+	}
+
+	@Override
+	public List<Group> getGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException {
+		List<Group> groupsWhereMemberIsActive = this.getAllGroupsWhereMemberIsActive(sess, member);
+		groupsWhereMemberIsActive.removeIf(g -> VosManager.MEMBERS_GROUP.equals(g.getName()));
+		return groupsWhereMemberIsActive;
+	}
+
+	@Override
+	public List<Group> getGroupsWhereMemberIsInactive(PerunSession sess, Member member) throws InternalErrorException {
+		//IMPORTANT: this is the easiest way but also more time consuming - this code can be optimize if needed
+		List<Group> membersGroups = this.getMemberGroups(sess, member);
+		List<Group> activeMembersGroup = this.getGroupsWhereMemberIsActive(sess, member);
+		//Inactive are groups where member has no active state (all-active=inactive)
+		membersGroups.removeAll(activeMembersGroup);
+
+		return membersGroups;
+	}
+
+	@Override
+	public List<Group> getAllGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException {
+		return getGroupsManagerImpl().getAllGroupsWhereMemberIsActive(sess, member);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1042,6 +1042,57 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
+	public List<Group> getGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+
+		Vo vo = getPerunBl().getMembersManagerBl().getMemberVo(sess, member);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo)
+			&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo)
+			&& !AuthzResolver.isAuthorized(sess, Role.SELF, member)) {
+			throw new PrivilegeException(sess, "getGroupsWhereMemberIsActive");
+		}
+
+		return getGroupsManagerBl().getGroupsWhereMemberIsActive(sess, member);
+	}
+
+	@Override
+	public List<Group> getGroupsWhereMemberIsInactive(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+
+		Vo vo = getPerunBl().getMembersManagerBl().getMemberVo(sess, member);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo)
+			&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo)
+			&& !AuthzResolver.isAuthorized(sess, Role.SELF, member)) {
+			throw new PrivilegeException(sess, "getGroupsWhereMemberIsInactive");
+		}
+
+		return getGroupsManagerBl().getGroupsWhereMemberIsInactive(sess, member);
+	}
+
+	@Override
+	public List<Group> getAllGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException {
+		Utils.checkPerunSession(sess);
+		getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+
+		Vo vo = getPerunBl().getMembersManagerBl().getMemberVo(sess, member);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo)
+			&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo)
+			&& !AuthzResolver.isAuthorized(sess, Role.SELF, member)) {
+			throw new PrivilegeException(sess, "getAllGroupsWhereMemberIsActive");
+		}
+
+		return getGroupsManagerBl().getAllGroupsWhereMemberIsActive(sess, member);
+	}
+
+	@Override
 	public List<RichGroup> getRichGroupsAssignedToResourceWithAttributesByNames(PerunSession sess, Resource resource, List<String> attrNames) throws InternalErrorException, ResourceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		this.getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -538,6 +538,19 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	}
 
 	@Override
+	public List<Group> getAllGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException {
+		try {
+			return jdbc.query("select distinct " + groupMappingSelectQuery + " from groups_members join groups on groups_members.group_id = groups.id " +
+					" where groups_members.member_id=? and groups_members.source_group_status=?",
+				GROUP_MAPPER, member.getId(), MemberGroupStatus.VALID.getCode());
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
 	public List<Group> getGroupsByAttribute(PerunSession sess, Attribute attribute) throws InternalErrorException {
 		try {
 			return jdbc.query("select " + groupMappingSelectQuery + " from groups " +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -259,6 +259,17 @@ public interface GroupsManagerImplApi {
 	List<Group> getAllMemberGroups(PerunSession sess, Member member) throws InternalErrorException;
 
 	/**
+	 * Returns all member's groups where member is in active state (is valid there)
+	 * Included members group.
+	 *
+	 * @param sess perun session
+	 * @param member member to get groups for
+	 * @return list of groups where member is in active state (valid)
+	 * @throws InternalErrorException
+	 */
+	List<Group> getAllGroupsWhereMemberIsActive(PerunSession sess, Member member) throws InternalErrorException;
+
+	/**
 	 * Return group members.
 	 *
 	 * @param sess

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -34,6 +34,7 @@ import cz.metacentrum.perun.core.api.MembershipType;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichGroup;
 import cz.metacentrum.perun.core.api.RichMember;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.Vo;
@@ -4074,8 +4075,197 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 		Collections.sort(allMembers);
 		Collections.sort(inactiveAndActiveMembers);
-		
+
 		assertEquals(allMembers, inactiveAndActiveMembers);
+	}
+
+	@Test
+	public void getValidGroupMembersInGroupAndInVo() throws Exception {
+		System.out.println(CLASS_NAME + "getValidGroupMembersInGroupAndInVo");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+		Member m2 = setUpMemberWithDifferentParam(vo, 1);
+		Member m3 = setUpMemberWithDifferentParam(vo, 2);
+
+		groupsManagerBl.addMember(sess, g1, m1);
+		groupsManagerBl.addMember(sess, g2, m2);
+		groupsManagerBl.addMember(sess, g1, m3);
+		groupsManagerBl.addMember(sess, g2, m3);
+
+		groupsManagerBl.expireMemberInGroup(sess, m2, g2);
+		groupsManagerBl.expireMemberInGroup(sess, m3, g1);
+		perun.getMembersManagerBl().expireMember(sess, m1);
+
+		List<Member> filteredMembers = groupsManagerBl.getGroupMembers(sess, g1, MemberGroupStatus.VALID, Status.VALID);
+		assertFalse(filteredMembers.contains(m1));
+		assertFalse(filteredMembers.contains(m2));
+		assertTrue(filteredMembers.contains(m3));
+	}
+
+	@Test
+	public void getValidGroupMembersInGroupAndExpiredInVo() throws Exception {
+		System.out.println(CLASS_NAME + "getValidGroupMembersInGroupAndExpiredInVo");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+		Member m2 = setUpMemberWithDifferentParam(vo, 1);
+		Member m3 = setUpMemberWithDifferentParam(vo, 2);
+
+		groupsManagerBl.addMember(sess, g1, m1);
+		groupsManagerBl.addMember(sess, g2, m2);
+		groupsManagerBl.addMember(sess, g1, m3);
+		groupsManagerBl.addMember(sess, g2, m3);
+
+		groupsManagerBl.expireMemberInGroup(sess, m2, g2);
+		groupsManagerBl.expireMemberInGroup(sess, m3, g1);
+		perun.getMembersManagerBl().expireMember(sess, m1);
+
+		List<Member> filteredMembers = groupsManagerBl.getGroupMembers(sess, g1, MemberGroupStatus.VALID, Status.EXPIRED);
+		assertTrue(filteredMembers.contains(m1));
+		assertFalse(filteredMembers.contains(m2));
+		assertFalse(filteredMembers.contains(m3));
+	}
+
+	@Test
+	public void getExpiredGroupMembersInGroupAndVo() throws Exception {
+		System.out.println(CLASS_NAME + "getExpiredGroupMembersInGroupAndVo");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+		Member m2 = setUpMemberWithDifferentParam(vo, 1);
+		Member m3 = setUpMemberWithDifferentParam(vo, 2);
+
+		groupsManagerBl.addMember(sess, g1, m1);
+		groupsManagerBl.addMember(sess, g2, m2);
+		groupsManagerBl.addMember(sess, g1, m3);
+		groupsManagerBl.addMember(sess, g2, m3);
+
+		groupsManagerBl.expireMemberInGroup(sess, m2, g2);
+		groupsManagerBl.expireMemberInGroup(sess, m1, g1);
+		perun.getMembersManagerBl().expireMember(sess, m1);
+
+		List<Member> filteredMembers = groupsManagerBl.getGroupMembers(sess, g1, MemberGroupStatus.EXPIRED, Status.EXPIRED);
+		assertTrue(filteredMembers.contains(m1));
+		assertFalse(filteredMembers.contains(m2));
+		assertFalse(filteredMembers.contains(m3));
+	}
+
+	@Test
+	public void getAllGroupsWhereMemberIsActive() throws Exception {
+		System.out.println(CLASS_NAME + "getAllGroupsWhereMemberIsActive");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		Group g3 = new Group("G3", "G3");
+		Group g4 = new Group("G4", "G4");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+		g3 = groupsManagerBl.createGroup(sess, g2, g3);
+		g4 = groupsManagerBl.createGroup(sess, vo, g4);
+		Group membersGroup = perun.getGroupsManagerBl().getGroupByName(sess, vo, VosManager.MEMBERS_GROUP);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+
+		groupsManagerBl.addMember(sess, g2, m1);
+		groupsManagerBl.addMember(sess, g3, m1);
+		groupsManagerBl.addMember(sess, g4, m1);
+
+		groupsManagerBl.expireMemberInGroup(sess, m1, g3);
+
+		List<Group> activeGroups = groupsManagerBl.getAllGroupsWhereMemberIsActive(sess, m1);
+
+		assertTrue(activeGroups.contains(g1));
+		assertTrue(activeGroups.contains(g2));
+		assertFalse(activeGroups.contains(g3));
+		assertTrue(activeGroups.contains(g4));
+		assertTrue(activeGroups.contains(membersGroup));
+	}
+
+	@Test
+	public void getGroupsWhereMemberIsActive() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsWhereMemberIsActive");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		Group g3 = new Group("G3", "G3");
+		Group g4 = new Group("G4", "G4");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+		g3 = groupsManagerBl.createGroup(sess, g2, g3);
+		g4 = groupsManagerBl.createGroup(sess, vo, g4);
+		Group membersGroup = perun.getGroupsManagerBl().getGroupByName(sess, vo, VosManager.MEMBERS_GROUP);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+
+		groupsManagerBl.addMember(sess, g2, m1);
+		groupsManagerBl.addMember(sess, g3, m1);
+		groupsManagerBl.addMember(sess, g4, m1);
+
+		groupsManagerBl.expireMemberInGroup(sess, m1, g3);
+
+		List<Group> activeGroups = groupsManagerBl.getGroupsWhereMemberIsActive(sess, m1);
+
+		assertTrue(activeGroups.contains(g1));
+		assertTrue(activeGroups.contains(g2));
+		assertFalse(activeGroups.contains(g3));
+		assertTrue(activeGroups.contains(g4));
+		assertFalse(activeGroups.contains(membersGroup));
+	}
+
+	@Test
+	public void getGroupsWhereMemberIsInactive() throws Exception {
+		System.out.println(CLASS_NAME + "getGroupsWhereMemberIsInactive");
+
+		vo = setUpVo();
+
+		Group g1 = new Group("G1", "G1");
+		Group g2 = new Group("G2", "G2");
+		Group g3 = new Group("G3", "G3");
+		Group g4 = new Group("G4", "G4");
+		g1 = groupsManagerBl.createGroup(sess, vo, g1);
+		g2 = groupsManagerBl.createGroup(sess, g1, g2);
+		g3 = groupsManagerBl.createGroup(sess, g2, g3);
+		g4 = groupsManagerBl.createGroup(sess, vo, g4);
+		Group membersGroup = perun.getGroupsManagerBl().getGroupByName(sess, vo, VosManager.MEMBERS_GROUP);
+
+		Member m1 = setUpMemberWithDifferentParam(vo, 0);
+
+		groupsManagerBl.addMember(sess, g2, m1);
+		groupsManagerBl.addMember(sess, g3, m1);
+		groupsManagerBl.addMember(sess, g4, m1);
+
+		groupsManagerBl.expireMemberInGroup(sess, m1, g3);
+
+		List<Group> activeGroups = groupsManagerBl.getGroupsWhereMemberIsInactive(sess, m1);
+
+		assertFalse(activeGroups.contains(g1));
+		assertFalse(activeGroups.contains(g2));
+		assertTrue(activeGroups.contains(g3));
+		assertFalse(activeGroups.contains(g4));
+		assertFalse(activeGroups.contains(membersGroup));
 	}
 
 	// PRIVATE METHODS -------------------------------------------------------------

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -1138,6 +1138,54 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
+	 * Returns all member's groups where member is in active state (is valid there)
+	 * Excluded members group.
+	 *
+	 * @param member int <code>id</code> of member
+	 * @return List<Group> Groups where member is in active state (valid)
+	 */
+	getGroupsWhereMemberIsActive {
+		@Override
+		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getGroupsManager().getGroupsWhereMemberIsActive(ac.getSession(),
+				ac.getMemberById(parms.readInt("member")));
+		}
+	},
+
+	/*#
+	 * Returns all member's groups where member is in inactive state (it is not valid and it is expired there)
+	 * Excluded members group.
+	 *
+	 * @param member int <code>id</code> of member
+	 * @return List<Group> Groups where member is in inactive state (expired)
+	 */
+	getGroupsWhereMemberIsInactive {
+		@Override
+		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getGroupsManager().getGroupsWhereMemberIsInactive(ac.getSession(),
+				ac.getMemberById(parms.readInt("member")));
+		}
+	},
+
+	/**
+	 * Returns all member's groups where member is in active state (is valid there)
+	 * Included members group.
+	 *
+	 * @param member int <code>id</code> of member
+	 * @return List<Group> All groups where member is in active state (valid)
+	 */
+	getAllGroupsWhereMemberIsActive {
+		@Override
+		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getGroupsManager().getAllGroupsWhereMemberIsActive(ac.getSession(),
+				ac.getMemberById(parms.readInt("member")));
+		}
+	},
+
+	/*#
 	 * Return all members of the group who are active (valid) in the group.
 	 *
 	 * Do not return expired members of the group.


### PR DESCRIPTION
 - we need to be able to identify all groups where member is in active
 or inactive state (valid or expired) with or without members group, for
 this purpose there are 3 new methods - getGroupsWhereMemberIsActive,
 getGroupsWhereMemberIsInactive and getAllGroupsWhereMemberIsActive
 - also simple tests for these 3 methods were added
 - these 3 methods were also added to Entry and RPC (we want to call
 them using Perun RPC API)

 - we need to be able to filter not only state of members in group by
 MemberGroupStatus, but also by Vo Status of members. For this reason 3
 new methods were created - getActiveGroupMembers with filter on Status
 in Vo, getInactiveGroupMembers with filter on Status in Vo and the
 complex method getGroupMembers with filter on Status in Vo and also
 with filter on status in Group.
 - we don't need to use these methods from outside of perun so they do
 not exist in Entry and RPC layers
 - simple tests for these 3 methods were added