### PR TITLE
Change behavior of user virt module groupNames

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_groupNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_groupNames.java
@@ -5,7 +5,9 @@ import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetFor
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.DirectMemberAddedToGroup;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.IndirectMemberAddedToGroup;
+import cz.metacentrum.perun.audit.events.GroupManagerEvents.MemberExpiredInGroup;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.MemberRemovedFromGroupTotally;
+import cz.metacentrum.perun.audit.events.GroupManagerEvents.MemberValidatedInGroup;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
@@ -47,7 +49,7 @@ public class urn_perun_user_attribute_def_virt_groupNames extends UserVirtualAtt
 			Vo vo = sess.getPerunBl().getMembersManagerBl().getMemberVo(sess, member);
 			voNames.add(vo.getShortName());
 
-			List<Group> groups = sess.getPerunBl().getGroupsManagerBl().getMemberGroups(sess, member);
+			List<Group> groups = sess.getPerunBl().getGroupsManagerBl().getGroupsWhereMemberIsActive(sess, member);
 			for (Group group : groups) {
 				groupNames.add(vo.getShortName() +":"+ group.getName());
 			}
@@ -69,6 +71,10 @@ public class urn_perun_user_attribute_def_virt_groupNames extends UserVirtualAtt
 			resolvingMessages.addAll(resolveEvent(sess, ((IndirectMemberAddedToGroup) message).getMember()));
 		} else if (message instanceof MemberRemovedFromGroupTotally) {
 			resolvingMessages.addAll(resolveEvent(sess, ((MemberRemovedFromGroupTotally) message).getMember()));
+		} else if (message instanceof MemberExpiredInGroup) {
+			resolvingMessages.addAll(resolveEvent(sess, ((MemberExpiredInGroup) message).getMember()));
+		} else if (message instanceof MemberValidatedInGroup) {
+			resolvingMessages.addAll(resolveEvent(sess, ((MemberValidatedInGroup) message).getMember()));
 		}
 		return resolvingMessages;
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_groupNamesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_groupNamesTest.java
@@ -74,10 +74,10 @@ public class urn_perun_user_attribute_def_virt_groupNamesTest {
                 Arrays.asList(member1, member2)
         );
 
-        when(session.getPerunBl().getGroupsManagerBl().getMemberGroups(session, member1)).thenReturn(
+        when(session.getPerunBl().getGroupsManagerBl().getGroupsWhereMemberIsActive(session, member1)).thenReturn(
                 Collections.singletonList(group1)
         );
-        when(session.getPerunBl().getGroupsManagerBl().getMemberGroups(session, member2)).thenReturn(
+        when(session.getPerunBl().getGroupsManagerBl().getGroupsWhereMemberIsActive(session, member2)).thenReturn(
                 Collections.singletonList(group2)
         );
 


### PR DESCRIPTION
 - in attribute groupNames there should be only active groups (groups
 where member is in valid state) so behavior of getValue method was
 changed to respect this
 - attribute need to react on messages with the change of member status
 in the group (valid -> expired and vice versa), so two new messages were
 added to resolveVirtualAttributeValueChange