### PR TITLE
Work with expiration|valid state of member in group in LDAPc

### DIFF
--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/impl/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/impl/Utils.java
@@ -321,7 +321,7 @@ public class Utils implements cz.metacentrum.perun.ldapc.initializer.api.UtilsAp
 
 				//all DNs of valid members of the group
 				List<Member> members;
-				members = perun.getGroupsManagerBl().getGroupMembers(perunSession, group, Status.VALID);
+				members = perun.getGroupsManagerBl().getActiveGroupMembers(perunSession, group, Status.VALID);
 				writer.write(cn + '\n');
 				writer.write(perunUniqueGroupName + '\n');
 				writer.write(perunGroupId + '\n');
@@ -643,7 +643,7 @@ public class Utils implements cz.metacentrum.perun.ldapc.initializer.api.UtilsAp
 				if(member.getStatus().equals(Status.VALID)) {
 					membersOfPerunVo.add("memberOfPerunVo: " + member.getVoId());
 					List<Group> groups;
-					groups = perun.getGroupsManagerBl().getAllMemberGroups(perunSession, member);
+					groups = perun.getGroupsManagerBl().getAllGroupsWhereMemberIsActive(perunSession, member);
 					for(Group group: groups) {
 						membersOf.add("memberOf: " + "perunGroupId=" + group.getId() + ",perunVoId=" + group.getVoId() + "," + ldapBase);
 					}

--- a/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/Rpc.java
+++ b/perun-rpc-lib/src/main/java/cz/metacentrum/perun/rpclib/Rpc.java
@@ -287,6 +287,23 @@ public class Rpc {
 				throw new ConsistencyErrorException(e);
 			}
 		}
+
+		public static List<Group> getAllGroupsWhereMemberIsActive(RpcCaller rpcCaller, Member member) throws InternalErrorException, PrivilegeException, MemberNotExistsException {
+			Map<String, Object> params = new HashMap<String, Object>();
+			params.put("member", member.getId());
+
+			try {
+				return rpcCaller.call("groupsManager", "getAllGroupsWhereMemberIsActive", params).readList(Group.class);
+			} catch (MemberNotExistsException e) {
+				throw e;
+			} catch (PrivilegeException e) {
+				throw e;
+			} catch (InternalErrorException e) {
+				throw e;
+			} catch (PerunException e) {
+				throw new ConsistencyErrorException(e);
+			}
+		}
 	}
 
 	// ResourcesManager


### PR DESCRIPTION
 - members in group (members group is exception) are in LDAP only when
 they are in active state for this group. If they are inactive (expired)
 they will be removed from the group (or not added at all)
 - LDAPc-initializer will add only active members to group (attributes
 memberOf, uniqueMember in LDAP)
 - LDAPc will work with validation and expiration in the group same as
 with adding or removing from the group (workflow is similar)
 - when member is validated in the VO, he will be added to all groups
 where he is active (an always to members group)
 - when member is set to other status than valid in the VO, he will be
 removed from all groups (included members) in LDAPc
 - method getAllGroupsWhereMemberIsActive was added to rpc-lib (ldapc
 need to call this method in specific actions)