### PR TITLE
CORE, RPC: Added getGroupsWhereUserIsActive() methods to the UsersManager

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -1149,4 +1149,51 @@ public interface UsersManager {
 	 * @return String representing HTML with data about new generated password
 	 */
 	String changePasswordRandom(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PrivilegeException, PasswordOperationTimeoutException, LoginNotExistsException, PasswordChangeFailedException;
+
+	/**
+	 * Return all groups where user is active (has VALID status in VO and Group together)
+	 * for specified user and resource
+	 *
+	 * @param sess PerunSession
+	 * @param resource Only groups assigned to this resource might be returned
+	 * @param user Only groups where this user is VALID member might be returned
+	 * @return List of groups where user is active (is a VALID vo and group member) on specified resource
+	 */
+	List<Group> getGroupsWhereUserIsActive(PerunSession sess, Resource resource, User user) throws PrivilegeException, InternalErrorException;
+
+	/**
+	 * Return all RichGroups where user is active (has VALID status in VO and Group together)
+	 * for specified user and resource with specified group attributes by their names (URNs).
+	 *
+	 * @param sess PerunSession
+	 * @param resource Only groups assigned to this resource might be returned
+	 * @param user Only groups where this user is VALID member might be returned
+	 * @param attrNames Names (URNs) of group attributes to get with each returned group
+	 * @return List of groups where user is active (is a VALID vo and group member) on specified resource
+	 */
+	List<RichGroup> getRichGroupsWhereUserIsActive(PerunSession sess, Resource resource, User user, List<String> attrNames) throws PrivilegeException, InternalErrorException, MemberNotExistsException;
+
+	/**
+	 * Return all groups where user is active (has VALID status in VO and Group together)
+	 * for specified user and facility
+	 *
+	 * @param sess PerunSession
+	 * @param facility Only groups assigned to this facility (all its resources) might be returned
+	 * @param user Only groups where this user is VALID member might be returned
+	 * @return List of groups where user is active (is a VALID vo and group member) on specified facility
+	 */
+	List<Group> getGroupsWhereUserIsActive(PerunSession sess, Facility facility, User user) throws PrivilegeException, InternalErrorException;
+
+	/**
+	 * Return all groups where user is active (has VALID status in VO and Group together)
+	 * for specified user and resource
+	 *
+	 * @param sess PerunSession
+	 * @param facility Only groups assigned to this facility (all its resources) might be returned
+	 * @param user Only groups where this user is VALID member might be returned
+	 * @param attrNames Names (URNs) of group attributes to get with each returned group
+	 * @return List of groups where user is active (is a VALID vo and group member) on specified facility
+	 */
+	List<RichGroup> getRichGroupsWhereUserIsActive(PerunSession sess, Facility facility, User user, List<String> attrNames) throws PrivilegeException, InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -1230,4 +1230,27 @@ public interface UsersManagerBl {
 	 * @throws PasswordChangeFailedException     password change failed
 	 */
 	String changePasswordRandom(PerunSession session, User user, String loginNamespace) throws PasswordOperationTimeoutException, LoginNotExistsException, InternalErrorException, PasswordChangeFailedException;
+
+	/**
+	 * Return all groups where user is active (has VALID status in VO and Group together)
+	 * for specified user and resource
+	 *
+	 * @param sess PerunSession
+	 * @param resource Only groups assigned to this resource might be returned
+	 * @param user Only groups where this user is VALID member might be returned
+	 * @return List of groups where user is active (is a VALID vo and group member) on specified resource
+	 */
+	List<Group> getGroupsWhereUserIsActive(PerunSession sess, Resource resource, User user) throws InternalErrorException;
+
+	/**
+	 * Return all groups where user is active (has VALID status in VO and Group together)
+	 * for specified user and facility
+	 *
+	 * @param sess PerunSession
+	 * @param facility Only groups assigned to this facility (all its resources) might be returned
+	 * @param user Only groups where this user is VALID member might be returned
+	 * @return List of groups where user is active (is a VALID vo and group member) on specified facility
+	 */
+	List<Group> getGroupsWhereUserIsActive(PerunSession sess, Facility facility, User user) throws InternalErrorException;
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -323,7 +323,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 
 		//Authrorization
 		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility)) {
-			throw new PrivilegeException(perunSession, "getAllowedGroups");
+			throw new PrivilegeException(perunSession, "getGroupsWhereUserIsActive");
 		}
 
 		getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -1341,4 +1341,56 @@ public class UsersManagerEntry implements UsersManager {
 
 		return usersManagerBl.changePasswordRandom(sess, user, loginNamespace);
 	}
+
+	@Override
+	public List<Group> getGroupsWhereUserIsActive(PerunSession sess, Resource resource, User user) throws PrivilegeException, InternalErrorException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) &&
+				!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, resource)) {
+			throw new PrivilegeException("getGroupsWhereUserIsActive");
+		}
+
+		return perunBl.getUsersManagerBl().getGroupsWhereUserIsActive(sess, resource, user);
+	}
+
+	@Override
+	public List<RichGroup> getRichGroupsWhereUserIsActive(PerunSession sess, Resource resource, User user, List<String> attrNames) throws PrivilegeException, InternalErrorException, MemberNotExistsException {
+
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) &&
+				!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, resource)) {
+			throw new PrivilegeException("getRichGroupsWhereUserIsActive");
+		}
+
+		return perunBl.getGroupsManagerBl().filterOnlyAllowedAttributes(sess,
+				perunBl.getGroupsManagerBl().convertGroupsToRichGroupsWithAttributes(sess,
+						perunBl.getUsersManagerBl().getGroupsWhereUserIsActive(sess, resource, user), attrNames), null, true);
+
+	}
+
+	@Override
+	public List<Group> getGroupsWhereUserIsActive(PerunSession sess, Facility facility, User user) throws PrivilegeException, InternalErrorException {
+		Utils.checkPerunSession(sess);
+
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException("getGroupsWhereUserIsActive");
+		}
+
+		return perunBl.getUsersManagerBl().getGroupsWhereUserIsActive(sess, facility, user);
+	}
+
+	@Override
+	public List<RichGroup> getRichGroupsWhereUserIsActive(PerunSession sess, Facility facility, User user, List<String> attrNames) throws PrivilegeException, InternalErrorException {
+
+		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException("getRichGroupsWhereUserIsActive");
+		}
+
+		return perunBl.getGroupsManagerBl().filterOnlyAllowedAttributes(sess,
+				perunBl.getGroupsManagerBl().convertGroupsToRichGroupsWithAttributes(sess,
+						perunBl.getUsersManagerBl().getGroupsWhereUserIsActive(sess, facility, user), attrNames), null, true);
+
+
+	}
+
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1309,5 +1309,83 @@ public enum UsersManagerMethod implements ManagerMethod {
 				ac.getUserById(parms.readInt("userId")),
 				parms.readString("loginNamespace"));
 		}
+	},
+
+	/*#
+	 * Get list of groups of user on specified resource where use is active,
+	 * that means User is a VALID in the VO and the Group and groups are assigned to the resource.
+	 *
+	 * @param resource Integer ID of Resource
+	 * @param user Integer ID of User
+	 *
+	 * @return List<Group> Groups where User is active
+	 */
+	/*#
+	 * Get list of groups of user on specified resource where use is active,
+	 * that means User is a VALID in the VO and the Group and groups are assigned to the facility.
+	 *
+	 * @param facility Integer ID of Facility
+	 * @param user Integer ID of User
+	 *
+	 * @return List<Group> Groups where User is active
+	 */
+	getGroupsWhereUserIsActive {
+		@Override
+		public List<Group> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			if (parms.contains("resource")) {
+				return ac.getUsersManager().getGroupsWhereUserIsActive(ac.getSession(),
+						ac.getResourceById(parms.readInt("resource")),
+						ac.getUserById(parms.readInt("user")));
+			} else {
+				return ac.getUsersManager().getGroupsWhereUserIsActive(ac.getSession(),
+						ac.getFacilityById(parms.readInt("facility")),
+						ac.getUserById(parms.readInt("user")));
+			}
+
+
+		}
+	},
+
+	/*#
+	 * Get list of rich groups of user on specified resource with group attributes specified by the list of their names.
+	 * Groups where user is active are returned, that means groups, where User is a VALID in the VO and the Group and
+	 * groups are assigned to the resource.
+	 *
+	 * @param resource Integer ID of Resource
+	 * @param user Integer ID of User
+	 * @param attrNames List<String> Attribute names (list of their URNs)
+	 *
+	 * @return List<RichGroup> Groups where User is active
+	 */
+	/*#
+	 * Get list of rich groups of user on specified resource with group attributes specified by the list of their names.
+	 * Groups where user is active are returned, that means groups, where User is a VALID in the VO and the Group and
+	 * groups are assigned to the facility.
+	 *
+	 * @param facility Integer ID of Facility
+	 * @param user Integer ID of User
+	 * @param attrNames List<String> Attribute names (list of their URNs)
+	 *
+	 * @return List<RichGroup> Groups where User is active
+	 */
+	getRichGroupsWhereUserIsActive {
+		@Override
+		public List<RichGroup> call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			if (parms.contains("resource")) {
+				return ac.getUsersManager().getRichGroupsWhereUserIsActive(ac.getSession(),
+						ac.getResourceById(parms.readInt("resource")),
+						ac.getUserById(parms.readInt("user")),
+						parms.readList("attrNames", String.class));
+			} else {
+				return ac.getUsersManager().getRichGroupsWhereUserIsActive(ac.getSession(),
+						ac.getFacilityById(parms.readInt("facility")),
+						ac.getUserById(parms.readInt("user")),
+						parms.readList("attrNames", String.class));
+			}
+
+		}
 	}
+
 }


### PR DESCRIPTION
- For the purpose of the proxy IdP we added method to get list of
  Groups (or RichGroups with attributes by names) where User is
  "active" for specified user and facility/resource.
- "Active" in this case means that user is member of related VO
  with VALID status and also is VALID in each such Group.
  Groups where member is EXPIRED are excluded from active set.
- Methods were added to the Core and RPC with proper javadoc.
- Test added for new methods.