### PR TITLE
Fixed regex in elixirScopedAffiliation

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirScopedAffiliation.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirScopedAffiliation.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  */
 public class urn_perun_user_attribute_def_def_elixirScopedAffiliation extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
-	private static final Pattern pattern = Pattern.compile("^[member|affiliate|faculty]+@[-A-Za-z0-9]+(\\.[-A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$");
+	private static final Pattern pattern = Pattern.compile("^(member|affiliate|faculty)@[-A-Za-z0-9]+(\\.[-A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$");
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -31,7 +31,7 @@ public class urn_perun_user_attribute_def_def_elixirScopedAffiliation extends Us
 			for (String value : values) {
 				// check each value
 				Matcher matcher = pattern.matcher(value);
-				if(!matcher.matches()) throw new WrongAttributeValueException(attribute, "Wrong format. List of \"[member|affiliate|faculty]@scope\" expected.");
+				if(!matcher.matches()) throw new WrongAttributeValueException(attribute, "Wrong format. List of \"(member|affiliate|faculty)@scope\" expected.");
 			}
 		}
 
@@ -44,7 +44,7 @@ public class urn_perun_user_attribute_def_def_elixirScopedAffiliation extends Us
 		attr.setFriendlyName("elixirScopedAffiliation");
 		attr.setDisplayName("Elixir Scoped Affiliation");
 		attr.setType(List.class.getName());
-		attr.setDescription("List of users affiliations with scope. Like: [member|affiliate|faculty]@scope");
+		attr.setDescription("List of users affiliations with scope. Like: (member|affiliate|faculty)@scope");
 		return attr;
 	}
 


### PR DESCRIPTION
* Problem: The regex in elixirScopedAffiliation module was acceptions
more strings than it should. It was caused by invalid brackets and '+'.

* Solution: Now this module should accept only strings starting with
'member', 'affiliate' or 'faculty'.