### PR TITLE
Added new wrappers to getData methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -140,6 +140,7 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
 	 <pre>
 	 Facility
@@ -169,7 +170,7 @@ public interface ServicesManager {
 	 * @throws FacilityNotExistsException
 	 * @throws PrivilegeException
 	 */
-	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * Generates the list of attributes per each user and per each resource. Resources are filtered by service.
@@ -178,6 +179,7 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service you will get attributes required by this service
 	 * @param facility you will get attributes for this facility, resources associated with it and users assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources. Facility second child is abstract node with no attribute and it's children are all users.
 	 <pre>
 	 Facility
@@ -206,7 +208,7 @@ public interface ServicesManager {
 	 * @throws FacilityNotExistsException
 	 * @throws PrivilegeException
 	 */
-	ServiceAttributes getFlatData(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+	ServiceAttributes getFlatData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups.
@@ -214,6 +216,7 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
@@ -288,7 +291,7 @@ public interface ServicesManager {
 		* @throws FacilityNotExistsException
 		* @throws PrivilegeException
 		*/
-		ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+		ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups in vos.
@@ -296,6 +299,7 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure.
 	 *        Facility is in the root, facility children are vos.
 	 *        Vo first child is abstract structure which children are resources.
@@ -373,7 +377,7 @@ public interface ServicesManager {
 	 * @throws PrivilegeException
 	 * @throws VoNotExistsException
 	 */
-	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException, VoNotExistsException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
+	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, VoNotExistsException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException;
 
 	/**
 	 * List packages

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/ServicesManager.java
@@ -140,7 +140,7 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
 	 <pre>
 	 Facility
@@ -179,7 +179,7 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service you will get attributes required by this service
 	 * @param facility you will get attributes for this facility, resources associated with it and users assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources. Facility second child is abstract node with no attribute and it's children are all users.
 	 <pre>
 	 Facility
@@ -216,7 +216,7 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
@@ -299,7 +299,7 @@ public interface ServicesManager {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure.
 	 *        Facility is in the root, facility children are vos.
 	 *        Vo first child is abstract structure which children are resources.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -261,6 +261,18 @@ public interface FacilitiesManagerBl {
 	List<User> getAllowedUsers(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
 
 	/**
+	 * Return all users who can use this facility and who are not expired in all groups associated to any resources of facility.
+	 * specificVo and specificService can choose concrete users
+	 * if specificVo, specificService or both are null, they do not specific (all possible results are returned)
+	 *
+	 * @param sess
+	 * @param facility
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> getAllowedUsersNotExpired(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
+
+	/**
 	 * Return all members, which are "allowed" on facility.
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -248,7 +248,7 @@ public interface FacilitiesManagerBl {
 
 	/**
 	 * Return all users who can use this facility
-	 * specificVo and specificService can choose concrete users
+	 * You can specify VO or Service you are interested in to filter resulting users (they must be members of VO and from Resource with assigned Service).
 	 * if specificVo, specificService or both are null, they do not specific (all possible results are returned)
 	 *
 	 * @param sess
@@ -261,12 +261,14 @@ public interface FacilitiesManagerBl {
 	List<User> getAllowedUsers(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException;
 
 	/**
-	 * Return all users who can use this facility and who are not expired in all groups associated to any resources of facility.
-	 * specificVo and specificService can choose concrete users
+	 * Return all users who can use this facility and who are not expired in any of groups associated with any resource
+	 * You can specify VO or Service you are interested in to filter resulting users (they must be members of VO and from Resource with assigned Service).
 	 * if specificVo, specificService or both are null, they do not specific (all possible results are returned)
 	 *
 	 * @param sess
 	 * @param facility
+	 * @param specificVo specific only those results which are in specific VO (with null, all results)
+	 * @param specificService specific only those results, which have resource with assigned specific service (if null, all results)
 	 * @return list of users
 	 * @throws InternalErrorException
 	 */

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -198,6 +198,17 @@ public interface ResourcesManagerBl {
 	List<Member> getAllowedMembers(PerunSession perunSession, Resource resource) throws InternalErrorException;
 
 	/**
+	 * Returns all members who can access the resource and who are also valid in at least one group associated to the resource.
+	 *
+	 * @param perunSession
+	 * @param resource
+	 * @return list of members assigned to the resource
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<Member> getAllowedMembersNotExpired(PerunSession perunSession, Resource resource) throws InternalErrorException;
+
+	/**
 	 * Returns all members assigned to the resource.
 	 *
 	 * @param perunSession
@@ -228,6 +239,16 @@ public interface ResourcesManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<User> getAllowedUsers(PerunSession sess, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Get all users, who can assess the resource and who are not expired in at least one group associated to the resource.
+	 *
+	 * @param sess
+	 * @param resource
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> getAllowedUsersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Assign group to a resource. Check if attributes for each member form group are valid. Fill members' attributes with missing value.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ServicesManagerBl.java
@@ -126,11 +126,12 @@ public interface ServicesManagerBl {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
 	 *
 	 * @throws InternalErrorException
 	 */
-	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException;
+	ServiceAttributes getHierarchicalData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException;
 
 	/**
 	 * Generates the list of attributes per each resource associated with the facility and filtered by service. Next it generates list of attributes
@@ -139,12 +140,13 @@ public interface ServicesManagerBl {
 	 * @param perunSession
 	 * @param service you will get attributes required by this service
 	 * @param facility you will get attributes for this facility, resources associated with it and users assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources.
 	 * 				Facility second child is abstract node with no attribute and it's children are all users.
 	 *
 	 * @throws InternalErrorException
 	 */
-	ServiceAttributes getFlatData(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException;
+	ServiceAttributes getFlatData(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException;
 
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups.
@@ -154,6 +156,7 @@ public interface ServicesManagerBl {
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
@@ -162,13 +165,14 @@ public interface ServicesManagerBl {
 	 *
 	 * @throws InternalErrorException
 	 */
-	ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException;
+	ServiceAttributes getDataWithGroups(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException;
 	/**
 	 * Generates the list of attributes per each member associated with the resources and groups.
 	 *
 	 * @param perunSession
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
 	 * @return attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first child is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
@@ -178,7 +182,7 @@ public interface ServicesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws VoNotExistsException
 	 */
-	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility) throws InternalErrorException, VoNotExistsException;
+	ServiceAttributes getDataWithVos(PerunSession perunSession, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, VoNotExistsException;
 
 	/**
 	 * List packages

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -256,6 +256,20 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
+	public List<User> getAllowedUsersNotExpired(PerunSession sess, Facility facility, Vo specificVo, Service specificService) throws InternalErrorException {
+
+		//Get all facilities resources
+		List<Resource> resources = getAssignedResources(sess, facility, specificVo, specificService);
+
+		List<User> users = new ArrayList<>();
+		for (Resource resource: resources) {
+			users.addAll(getPerunBl().getResourcesManagerBl().getAllowedUsersNotExpired(sess, resource));
+		}
+
+		return users;
+	}
+
+	@Override
 	public List<Member> getAllowedMembers(PerunSession sess, Facility facility) throws InternalErrorException {
 		return getFacilitiesManagerImpl().getAllowedMembers(sess, facility);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -261,12 +261,12 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 		//Get all facilities resources
 		List<Resource> resources = getAssignedResources(sess, facility, specificVo, specificService);
 
-		List<User> users = new ArrayList<>();
+		Set<User> users = new TreeSet<>();
 		for (Resource resource: resources) {
 			users.addAll(getPerunBl().getResourcesManagerBl().getAllowedUsersNotExpired(sess, resource));
 		}
 
-		return users;
+		return new ArrayList<>(users);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -278,6 +278,11 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	}
 
 	@Override
+	public List<User> getAllowedUsersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException {
+		return getResourcesManagerImpl().getAllowedUsersNotExpired(sess, resource);
+	}
+
+	@Override
 	public boolean isUserAssigned(PerunSession sess, User user, Resource resource) throws InternalErrorException {
 		return getResourcesManagerImpl().isUserAssigned(sess, user, resource);
 	}
@@ -306,6 +311,11 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 	@Override
 	public List<Member> getAllowedMembers(PerunSession sess, Resource resource) throws InternalErrorException {
 		return getResourcesManagerImpl().getAllowedMembers(sess, resource);
+	}
+
+	@Override
+	public List<Member> getAllowedMembersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException {
+		return getResourcesManagerImpl().getAllowedMembersNotExpired(sess, resource);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -18,6 +18,12 @@ import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServiceUpdated;
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageCreated;
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageDeleted;
 import cz.metacentrum.perun.audit.events.ServicesManagerEvents.ServicesPackageUpdated;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Destination;
@@ -162,12 +168,31 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		return resourceServiceAttributes;
 	}
 
-	private ServiceAttributes getData(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException {
+	private ServiceAttributes getData(PerunSession sess, Service service, Facility facility, Resource resource, boolean filterExpiredMembers) throws InternalErrorException {
 		ServiceAttributes resourceServiceAttributes = new ServiceAttributes();
 		resourceServiceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, resource));
 
 		List<Member> members;
 		members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
+
+		if (filterExpiredMembers) {
+			List<Member> membersToRemove = new ArrayList<>();
+			for (Member member : members) {
+				try {
+					Attribute groupStatus = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT + ":groupStatus");
+					if (groupStatus == null) {
+						throw new InternalErrorException("groupStatus is null");
+					}
+					if (groupStatus.getValue() == "EXPIRED") {
+						membersToRemove.add(member);
+					}
+				} catch (MemberResourceMismatchException | WrongAttributeAssignmentException | AttributeNotExistsException e) {
+					throw new InternalErrorException(e);
+				}
+			}
+			members.removeAll(membersToRemove);
+		}
+
 		HashMap<Member, List<Attribute>> attributes;
 
 		try {
@@ -186,7 +211,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 	}
 
-	private ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility, Resource resource) throws InternalErrorException {
+	private ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility, Resource resource, boolean filterExpiredMembers) throws InternalErrorException {
 
 		// append resource attributes
 		ServiceAttributes resourceServiceAttributes = new ServiceAttributes();
@@ -203,6 +228,22 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		ServiceAttributes membersAbstractSA = new ServiceAttributes();
 		Map<Member, ServiceAttributes> memberAttributes = new HashMap<>();
 		List<Member> members = getPerunBl().getResourcesManagerBl().getAllowedMembers(sess, resource);
+
+		if (filterExpiredMembers) {
+			List<Member> membersToRemove = new ArrayList<>();
+			for (Member member : members) {
+				try {
+					Attribute groupStatus = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT + ":groupStatus");
+					if (groupStatus.getValue() == "EXPIRED") {
+						membersToRemove.add(member);
+					}
+				} catch (MemberResourceMismatchException | WrongAttributeAssignmentException | AttributeNotExistsException e) {
+					throw new InternalErrorException(e);
+				}
+			}
+			members.removeAll(membersToRemove);
+		}
+
 		HashMap<Member, List<Attribute>> attributes;
 
 		try {
@@ -223,7 +264,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		ServiceAttributes groupsAbstractSA = new ServiceAttributes();
 		List<Group> groups = getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource);
 		for(Group group: groups) {
-			groupsAbstractSA.addChildElement(getData(sess, service, facility, resource, group, memberAttributes));
+			groupsAbstractSA.addChildElement(getData(sess, service, facility, resource, group, memberAttributes, filterExpiredMembers));
 		}
 
 		//assign abstract services attributes to resource service attributes
@@ -233,19 +274,19 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		return resourceServiceAttributes;
 	}
 
-	private ServiceAttributes getDataWithVo(PerunSession sess, Service service, Facility facility, Vo vo, List<Resource> resources) throws InternalErrorException {
+	private ServiceAttributes getDataWithVo(PerunSession sess, Service service, Facility facility, Vo vo, List<Resource> resources, boolean filterExpiredMembers) throws InternalErrorException {
 		ServiceAttributes voServiceAttributes = new ServiceAttributes();
 		voServiceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, vo));
 
 		for(Resource resource: resources) {
-			ServiceAttributes resourceServiceAttributes = getDataWithGroups(sess, service, facility, resource);
+			ServiceAttributes resourceServiceAttributes = getDataWithGroups(sess, service, facility, resource, filterExpiredMembers);
 			voServiceAttributes.addChildElement(resourceServiceAttributes);
 		}
 
 		return voServiceAttributes;
 	}
 
-	private ServiceAttributes getData(PerunSession sess, Service service, Facility facility, Resource resource, Group group, Map<Member, ServiceAttributes> memberAttributes) throws InternalErrorException {
+	private ServiceAttributes getData(PerunSession sess, Service service, Facility facility, Resource resource, Group group, Map<Member, ServiceAttributes> memberAttributes, boolean filterExpiredMembers) throws InternalErrorException {
 		ServiceAttributes groupServiceAttributes = new ServiceAttributes();
 		try {
 			// add group and group_resource attributes
@@ -258,13 +299,29 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		if (!group.getName().equals(VosManager.MEMBERS_GROUP)) {
 			List<Group> subGroups = getPerunBl().getGroupsManagerBl().getSubGroups(sess, group);
 			for(Group subGroup : subGroups) {
-				groupsSubGroupsElement.addChildElement(getData(sess, service, facility, resource, subGroup, memberAttributes));
+				groupsSubGroupsElement.addChildElement(getData(sess, service, facility, resource, subGroup, memberAttributes, filterExpiredMembers));
 			}
 		}
 
 		ServiceAttributes groupsMembersElement = new ServiceAttributes();
 		//Invalid and disabled are not allowed here
 		List<Member> members = getPerunBl().getGroupsManagerBl().getGroupMembersExceptInvalidAndDisabled(sess, group);
+
+		if (filterExpiredMembers) {
+			List<Member> membersToRemove = new ArrayList<>();
+			for (Member member : members) {
+				try {
+					Attribute groupStatus = getPerunBl().getAttributesManagerBl().getAttribute(sess, member, group, AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT + ":groupStatus");
+					if (groupStatus.getValue() == "EXPIRED") {
+						membersToRemove.add(member);
+					}
+				} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+					throw new InternalErrorException(e);
+				}
+			}
+			members.removeAll(membersToRemove);
+		}
+
 		for(Member member : members) {
 			// append also member_group attributes for each member in a group
 			// rest of member/user attributes was passed in a param if present
@@ -308,21 +365,21 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	@Override
-	public ServiceAttributes getHierarchicalData(PerunSession sess, Service service, Facility facility) throws InternalErrorException {
+	public ServiceAttributes getHierarchicalData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException {
 		ServiceAttributes serviceAttributes = new ServiceAttributes();
 		serviceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility));
 
 		List<Resource> resources = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 		resources.retainAll(getAssignedResources(sess, service));
 		for(Resource resource: resources) {
-			ServiceAttributes resourceServiceAttributes = getData(sess, service, facility, resource);
+			ServiceAttributes resourceServiceAttributes = getData(sess, service, facility, resource, filterExpiredMembers);
 			serviceAttributes.addChildElement(resourceServiceAttributes);
 		}
 		return serviceAttributes;
 	}
 
 	@Override
-	public ServiceAttributes getFlatData(PerunSession sess, Service service, Facility facility) throws InternalErrorException {
+	public ServiceAttributes getFlatData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException {
 		ServiceAttributes serviceAttributes = new ServiceAttributes();
 		serviceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility));
 
@@ -337,6 +394,21 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 		ServiceAttributes allUsersServiceAttributes = new ServiceAttributes();
 		List<User> facilityUsers = getPerunBl().getFacilitiesManagerBl().getAllowedUsers(sess, facility, null, service);
+
+		if (filterExpiredMembers) {
+			List<User> usersToRemove = new ArrayList<>();
+			for (User user : facilityUsers) {
+				try {
+					Attribute attribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, user, AttributesManager.NS_USER_FACILITY_ATTR_VIRT+ ":groupStatus");
+					if (attribute.getValue() == "EXPIRED") {
+						usersToRemove.add(user);
+					}
+				} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+					throw new InternalErrorException(e);
+				}
+			}
+			facilityUsers.removeAll(usersToRemove);
+		}
 
 		// get attributes for all users at once !
 		HashMap<User, List<Attribute>> userFacilityAttributes = getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility, facilityUsers);
@@ -359,7 +431,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	@Override
-	public ServiceAttributes getDataWithVos(PerunSession sess, Service service, Facility facility) throws InternalErrorException, VoNotExistsException {
+	public ServiceAttributes getDataWithVos(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, VoNotExistsException {
 		ServiceAttributes serviceAttributes = new ServiceAttributes();
 		serviceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility));
 
@@ -381,7 +453,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		for(Vo vo: vos) {
 			List<Resource> voResources = getPerunBl().getResourcesManagerBl().getResources(sess, vo);
 			voResources.retainAll(resources);
-			ServiceAttributes voServiceAttributes = getDataWithVo(sess, service, facility, vo, voResources);
+			ServiceAttributes voServiceAttributes = getDataWithVo(sess, service, facility, vo, voResources, filterExpiredMembers);
 			serviceAttributes.addChildElement(voServiceAttributes);
 		}
 
@@ -389,14 +461,14 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 	}
 
 	@Override
-	public ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility) throws InternalErrorException {
+	public ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException {
 		ServiceAttributes serviceAttributes = new ServiceAttributes();
 		serviceAttributes.addAttributes(getPerunBl().getAttributesManagerBl().getRequiredAttributes(sess, service, facility));
 
 		List<Resource> resources = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
 		resources.retainAll(getAssignedResources(sess, service));
 		for(Resource resource: resources) {
-			ServiceAttributes resourceServiceAttributes = getDataWithGroups(sess, service, facility, resource);
+			ServiceAttributes resourceServiceAttributes = getDataWithGroups(sess, service, facility, resource, filterExpiredMembers);
 			serviceAttributes.addChildElement(resourceServiceAttributes);
 		}
 		return serviceAttributes;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -178,7 +178,7 @@ public class ServicesManagerEntry implements ServicesManager {
 	}
 
 	@Override
-	public ServiceAttributes getHierarchicalData(PerunSession sess, Service service, Facility facility) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public ServiceAttributes getHierarchicalData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -190,11 +190,11 @@ public class ServicesManagerEntry implements ServicesManager {
 		getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
-		return getServicesManagerBl().getHierarchicalData(sess, service, facility);
+		return getServicesManagerBl().getHierarchicalData(sess, service, facility, filterExpiredMembers);
 	}
 
 	@Override
-	public ServiceAttributes getFlatData(PerunSession sess, Service service, Facility facility) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public ServiceAttributes getFlatData(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -206,11 +206,11 @@ public class ServicesManagerEntry implements ServicesManager {
 		getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
-		return getServicesManagerBl().getFlatData(sess, service, facility);
+		return getServicesManagerBl().getFlatData(sess, service, facility, filterExpiredMembers);
 	}
 
 	@Override
-	public ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public ServiceAttributes getDataWithGroups(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, FacilityNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -222,11 +222,11 @@ public class ServicesManagerEntry implements ServicesManager {
 		getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
-		return getServicesManagerBl().getDataWithGroups(sess, service, facility);
+		return getServicesManagerBl().getDataWithGroups(sess, service, facility, filterExpiredMembers);
 	}
 
 	@Override
-	public ServiceAttributes getDataWithVos(PerunSession sess, Service service, Facility facility) throws InternalErrorException, FacilityNotExistsException, VoNotExistsException, ServiceNotExistsException, PrivilegeException {
+	public ServiceAttributes getDataWithVos(PerunSession sess, Service service, Facility facility, boolean filterExpiredMembers) throws InternalErrorException, FacilityNotExistsException, VoNotExistsException, ServiceNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 
 		// Authorization
@@ -238,7 +238,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		getServicesManagerBl().checkServiceExists(sess, service);
 		getPerunBl().getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 
-		return getServicesManagerBl().getDataWithVos(sess, service, facility);
+		return getServicesManagerBl().getDataWithVos(sess, service, facility, filterExpiredMembers);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ResourcesManagerImplApi.java
@@ -356,6 +356,16 @@ public interface ResourcesManagerImplApi {
 	 */
 	List<User> getAllowedUsers(PerunSession sess, Resource resource) throws InternalErrorException;
 
+	/**
+	 * Returns all users who are allowed on the defined resource and not expired in at least one group.
+	 *
+	 * @param sess
+	 * @param resource
+	 * @return list of users
+	 * @throws InternalErrorException
+	 */
+	List<User> getAllowedUsersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException;
+
 
 	/**
 	 * Return all resources which are under the facility and has member of the user with status other than INVALID.
@@ -388,6 +398,16 @@ public interface ResourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 */
 	List<Member> getAllowedMembers(PerunSession sess, Resource resource) throws InternalErrorException;
+
+	/**
+	 * Returns all members who are allowed on the defined resource and also valid in at least one group associated to the resources.
+	 *
+	 * @param sess
+	 * @param resource
+	 * @return list of members
+	 * @throws InternalErrorException
+	 */
+	List<Member> getAllowedMembersNotExpired(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
 	 * Returns all resources where the member is assigned through the groups.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ServicesManagerEntryIntegrationTest.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichDestination;
 import cz.metacentrum.perun.core.api.Role;
@@ -1125,7 +1126,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		// get data for facility and service
 		// = should be one node (facility)
 		List<ServiceAttributes> facilities = new ArrayList<>();
-		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility));
+		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility, false));
 		assertNotNull("Unable to get hierarchical data",facilities);
 		assertTrue("Only 1 facility shoud be returned",facilities.size()==1);
 		assertNotNull("returned facility shouldn't be null",facilities.get(0));
@@ -1185,12 +1186,62 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	}
 
+	@Test
+	public void getHierarchicalDataWithoutExpiredMembers() throws Exception {
+		System.out.println(CLASS_NAME + "getHierarchicalDataWithoutExpiredMembers");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		member = setUpMember();
+		Member member2 = setUpMember();
+		group = setUpGroup();
+		perun.getGroupsManager().addMember(sess, group, member);
+		perun.getGroupsManager().addMember(sess, group, member2);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT);
+		attr.setFriendlyName("groupStatus");
+		attr.setDisplayName("Group membership status");
+		attr.setType(String.class.getName());
+
+		Attribute attribute = new Attribute(attr);
+
+		perun.getAttributesManager().createAttribute(sess, attribute);
+
+		// set element's name/id as required attributes to get some attributes for every element
+		Attribute reqFacAttr;
+		reqFacAttr = perun.getAttributesManager().getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqFacAttr);
+		Attribute reqResAttr;
+		reqResAttr = perun.getAttributesManager().getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqResAttr);
+		Attribute reqMemAttr;
+		reqMemAttr = perun.getAttributesManager().getAttribute(sess, member, "urn:perun:member:attribute-def:core:id");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
+
+		// finally assign service
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		List<ServiceAttributes> facilities2 = new ArrayList<ServiceAttributes>();
+		facilities2.add(perun.getServicesManager().getHierarchicalData(sess, service, facility, false));
+		assertEquals(2, facilities2.get(0).getChildElements().get(0).getChildElements().size());
+
+		// return only one member because the other one is expired
+		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
+		facilities.add(perun.getServicesManager().getHierarchicalData(sess, service, facility, true));
+		assertEquals(1,facilities.get(0).getChildElements().get(0).getChildElements().size());
+	}
+
 	@Test (expected=FacilityNotExistsException.class)
 	public void getHierarchicalDataWhenFacilityNotExists() throws Exception {
 		System.out.println(CLASS_NAME + "getHierarchicalDataWhenFacilityNotExists");
 
 		service = setUpService();
-		perun.getServicesManager().getHierarchicalData(sess, service, new Facility());
+		perun.getServicesManager().getHierarchicalData(sess, service, new Facility(), false);
 		// shouldn't find facility
 
 	}
@@ -1200,12 +1251,132 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		System.out.println(CLASS_NAME + "getHierarchicalDataWhenServiceNotExists");
 
 		facility = setUpFacility();
-		perun.getServicesManager().getHierarchicalData(sess, new Service(), facility);
+		perun.getServicesManager().getHierarchicalData(sess, new Service(), facility, false);
 		// shouldn't find service
 
 	}
 
-	// TODO getFlatData() - not implemented yet
+	@Test
+	public void getFlatData() throws Exception {
+		System.out.println(CLASS_NAME + "getFlatData");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		member = setUpMember();
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		group = setUpGroup();
+		perun.getGroupsManager().addMember(sess, group, member);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+
+		// set element's name/id as required attributes to get some attributes for every element
+		Attribute reqFacAttr;
+		reqFacAttr = perun.getAttributesManager().getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqFacAttr);
+		Attribute reqResAttr;
+		reqResAttr = perun.getAttributesManager().getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqResAttr);
+		Attribute reqUserAttr;
+		reqUserAttr = perun.getAttributesManager().getAttribute(sess, user, "urn:perun:user:attribute-def:core:id");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqUserAttr);
+		Attribute reqMemAttr;
+		reqMemAttr = perun.getAttributesManager().getAttribute(sess, member, "urn:perun:member:attribute-def:core:id");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
+
+		// finally assign service
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
+		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility, false));
+		assertNotNull("Unable to get flat data",facilities);
+		assertEquals("Only 1 facility should be returned", 1, facilities.size());
+		assertNotNull("returned facility shouldn't be null",facilities.get(0));
+
+		List<Attribute> facAttr = facAttr = facilities.get(0).getAttributes();
+		assertNotNull("Unable to get facility attributes required by service",facAttr);
+		assertEquals("Only 1 facility attribute should be returned", 1, facAttr.size());
+		assertTrue("Our facility required attribute not returned",facAttr.contains(reqFacAttr));
+
+		List<ServiceAttributes> facilityElements = facilities.get(0).getChildElements();
+		List<ServiceAttributes> resources = facilityElements.get(0).getChildElements();
+		assertNotNull("Unable to get facility resources",resources);
+		assertEquals("One resource should be returned", 1, resources.size());
+		assertNotNull("Our 1st resource shouldn't be null",resources.get(0));
+
+		List<Attribute> resAttr = resources.get(0).getAttributes();
+		assertNotNull("Unable to get required resource attributes",resAttr);
+		assertEquals("Required resource attribute should be returned for resource", 1, resAttr.size());
+		assertTrue("Our 1st resource required attribute not returned",resAttr.contains(reqResAttr));
+
+		List<ServiceAttributes> users = facilityElements.get(1).getChildElements();
+		assertNotNull("Unable to get facility users",users);
+		assertEquals("One user should be returned", 1, users.size());
+		assertNotNull("Our 1st user shouldn't be null",users.get(0));
+
+		List<Attribute> userAttributes = users.get(0).getAttributes();
+		assertNotNull("Unable to get required resource attributes",userAttributes);
+		assertEquals("Required resource attribute should be returned for resource", 1, userAttributes.size());
+		assertTrue("Our 1st resource required attribute not returned",userAttributes.contains(reqUserAttr));
+	}
+
+	@Test
+	public void getFlatDataWithoutExpiredUsers() throws Exception {
+		System.out.println(CLASS_NAME + "getFlatData");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		member = setUpMember();
+		Member member2 = setUpMember();
+		User user = perun.getUsersManagerBl().getUserByMember(sess, member);
+		User user2 = perun.getUsersManagerBl().getUserByMember(sess, member2);
+		group = setUpGroup();
+		perun.getGroupsManager().addMember(sess, group, member);
+		perun.getGroupsManager().addMember(sess, group, member2);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_USER_FACILITY_ATTR_VIRT);
+		attr.setFriendlyName("groupStatus");
+		attr.setDisplayName("Group membership status");
+		attr.setType(String.class.getName());
+
+		Attribute attribute = new Attribute(attr);
+
+		perun.getAttributesManager().createAttribute(sess, attribute);
+
+		// set element's name/id as required attributes to get some attributes for every element
+		Attribute reqFacAttr;
+		reqFacAttr = perun.getAttributesManager().getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqFacAttr);
+		Attribute reqResAttr;
+		reqResAttr = perun.getAttributesManager().getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqResAttr);
+		Attribute reqUserAttr;
+		reqUserAttr = perun.getAttributesManager().getAttribute(sess, user, "urn:perun:user:attribute-def:core:id");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqUserAttr);
+		Attribute reqMemAttr;
+		reqMemAttr = perun.getAttributesManager().getAttribute(sess, member, "urn:perun:member:attribute-def:core:id");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
+
+		// finally assign service
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
+		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility, false));
+		List<ServiceAttributes> facilityElements = facilities.get(0).getChildElements();
+		List<ServiceAttributes> users = facilityElements.get(1).getChildElements();
+		assertEquals("Required resource attribute should be returned for resource", 2, users.size());
+
+		facilities = new ArrayList<ServiceAttributes>();
+		facilities.add(perun.getServicesManager().getFlatData(sess, service, facility, true));
+		facilityElements = facilities.get(0).getChildElements();
+		users = facilityElements.get(1).getChildElements();
+		assertEquals("Required resource attribute should be returned for resource", 1, users.size());
+	}
 
 	@Test
 	public void getDataWithGroups() throws Exception {
@@ -1258,7 +1429,7 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		 */
 
 		List<ServiceAttributes> facilities = new ArrayList<>();
-		facilities.add(perun.getServicesManager().getDataWithGroups(sess, service, facility));
+		facilities.add(perun.getServicesManager().getDataWithGroups(sess, service, facility, false));
 		assertNotNull("Unable to get hierarchical data with groups",facilities);
 		assertTrue("Only 1 facility shoud be returned",facilities.size()==1);
 		assertNotNull("returned facility shouldn't be null",facilities.get(0));
@@ -1368,12 +1539,94 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		} // end of all resource
 	}
 
+	@Test
+	public void getDataWithGroupsWithoutExpiredMembers() throws Exception {
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		member = setUpMember();
+		Member member2 = setUpMember();
+		Member member3 = setUpMember();
+		group = setUpGroup();
+
+		Group group2 = new Group("GroupsManagerTestGroup2","testovaci2");
+		perun.getGroupsManager().createGroup(sess, vo, group2);
+
+		perun.getGroupsManager().addMember(sess, group, member);
+		perun.getGroupsManager().addMember(sess, group, member2);
+		perun.getGroupsManager().addMember(sess, group, member3);
+		perun.getGroupsManager().addMember(sess, group2, member2);
+		perun.getGroupsManager().addMember(sess, group2, member3);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource);
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT);
+		attr.setFriendlyName("groupStatus");
+		attr.setDisplayName("Group membership status");
+		attr.setType(String.class.getName());
+
+		Attribute attribute = new Attribute(attr);
+
+		perun.getAttributesManager().createAttribute(sess, attribute);
+
+		AttributeDefinition attr2 = new AttributeDefinition();
+		attr2.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
+		attr2.setFriendlyName("groupStatus");
+		attr2.setDisplayName("Group membership status");
+		attr2.setType(String.class.getName());
+
+		Attribute attribute2 = new Attribute(attr2);
+
+		perun.getAttributesManager().createAttribute(sess, attribute2);
+
+		// set element's name/id as required attributes to get some attributes for every element
+		Attribute reqFacAttr;
+		reqFacAttr = perun.getAttributesManager().getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqFacAttr);
+		Attribute reqResAttr;
+		reqResAttr = perun.getAttributesManager().getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqResAttr);
+		Attribute reqGrpAttr;
+		reqGrpAttr = perun.getAttributesManager().getAttribute(sess, group, "urn:perun:group:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqGrpAttr);
+		Attribute reqMemAttr;
+		reqMemAttr = perun.getAttributesManager().getAttribute(sess, member, "urn:perun:member:attribute-def:core:id");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
+
+		// finally assign service
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member3, group, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member3, group2, MemberGroupStatus.EXPIRED);
+
+		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
+		facilities.add(perun.getServicesManager().getDataWithGroups(sess, service, facility, true));
+		List<ServiceAttributes> resources = facilities.get(0).getChildElements();
+		List<ServiceAttributes> resourceElements = resources.get(0).getChildElements();
+		List<ServiceAttributes> groups = resourceElements.get(0).getChildElements();
+		List<ServiceAttributes> groupElements = groups.get(0).getChildElements();
+		List<ServiceAttributes> groupMembers = groupElements.get(1).getChildElements();
+		List<ServiceAttributes> members = resourceElements.get(1).getChildElements();
+
+		//group has 3 members but member2 and member3 are expired
+		assertEquals(groupMembers.size(), 1);
+
+		//group2 has 2 members but member3 is expired
+		assertEquals(groups.get(1).getChildElements().get(1).getChildElements().size(), 1);
+
+		//resource has 3 members but member3 is expired in all groups of given resource
+		assertEquals(members.size(), 2);
+	}
+
 	@Test (expected=FacilityNotExistsException.class)
 	public void getDataWithGroupsWhenFacilityNotExists() throws Exception {
 		System.out.println(CLASS_NAME + "getDataWithGroupsWhenFacilityNotExists");
 
 		service = setUpService();
-		perun.getServicesManager().getDataWithGroups(sess, service, new Facility());
+		perun.getServicesManager().getDataWithGroups(sess, service, new Facility(), false);
 		// shouldn't find facility
 
 	}
@@ -1383,9 +1636,177 @@ public class ServicesManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		System.out.println(CLASS_NAME + "getDataWithGroupsWhenServiceNotExists");
 
 		facility = setUpFacility();
-		perun.getServicesManager().getDataWithGroups(sess, new Service(), facility);
+		perun.getServicesManager().getDataWithGroups(sess, new Service(), facility, false);
 		// shouldn't find service
 
+	}
+
+	@Test
+	public void getDataWithVos() throws Exception {
+		System.out.println(CLASS_NAME + "getDataWithVos");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		member = setUpMember();
+		group = setUpGroup();
+		perun.getGroupsManager().addMember(sess, group, member);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+
+		// set element's name/id as required attributes to get some attributes for every element
+		Attribute reqFacAttr;
+		reqFacAttr = perun.getAttributesManager().getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqFacAttr);
+		Attribute reqResAttr;
+		reqResAttr = perun.getAttributesManager().getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqResAttr);
+		Attribute reqGrpAttr;
+		reqGrpAttr = perun.getAttributesManager().getAttribute(sess, group, "urn:perun:group:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqGrpAttr);
+		Attribute reqMemAttr;
+		reqMemAttr = perun.getAttributesManager().getAttribute(sess, member, "urn:perun:member:attribute-def:core:id");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
+		Attribute reqVoAttr;
+		reqVoAttr = perun.getAttributesManager().getAttribute(sess, vo, "urn:perun:vo:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqVoAttr);
+
+		// finally assign service
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
+		facilities.add(perun.getServicesManager().getDataWithVos(sess, service, facility, false));
+		assertNotNull("Unable to get data with vos",facilities);
+		assertEquals("Only 1 facility should be returned", 1, facilities.size());
+		assertNotNull("returned facility shouldn't be null",facilities.get(0));
+
+		List<Attribute> facilityAttributes = facilities.get(0).getAttributes();
+		assertNotNull("Unable to get facility attributes required by service",facilityAttributes);
+		assertEquals("Only 1 facility attribute should be returned", 1, facilityAttributes.size());
+		assertTrue("Our facility required attribute not returned",facilityAttributes.contains(reqFacAttr));
+
+		List<ServiceAttributes> vos = facilities.get(0).getChildElements();
+		assertNotNull("Unable to get vos from facility",vos);
+		assertEquals("Only 1 vo should be returned", 1, vos.size());
+		assertNotNull("returned vo shouldn't be null",vos.get(0));
+
+		List<Attribute> vosAttributes = vos.get(0).getAttributes();
+		assertNotNull("Unable to get vo attributes required by service",vosAttributes);
+		assertEquals("Only 1 vo attribute should be returned", 1, vosAttributes.size());
+		assertTrue("Our vo required attribute not returned",vosAttributes.contains(reqVoAttr));
+
+		List<ServiceAttributes> resources = vos.get(0).getChildElements();
+		assertNotNull("Unable to get resources from vo",resources);
+		assertEquals("Only 1 resource should be returned", 1, resources.size());
+		assertNotNull("returned resource shouldn't be null",resources.get(0));
+
+		List<Attribute> resourceAttributes = resources.get(0).getAttributes();
+		assertNotNull("Unable to get resource attributes required by service",resourceAttributes);
+		assertEquals("Only 1 resource attribute should be returned", 2, resourceAttributes.size());
+		assertTrue("Our resource required attribute not returned",resourceAttributes.contains(reqResAttr) && resourceAttributes.contains(reqVoAttr));
+
+		List<ServiceAttributes> resourceElements = resources.get(0).getChildElements();
+		List<ServiceAttributes> groups = resourceElements.get(0).getChildElements();
+		assertNotNull("Unable to get groups from resource",groups);
+		assertEquals("Only 1 group should be returned", 1, groups.size());
+		assertNotNull("returned group shouldn't be null",groups.get(0));
+
+		List<Attribute> groupAttributes = groups.get(0).getAttributes();
+		assertNotNull("Unable to get group attributes required by service",groupAttributes);
+		assertEquals("Only 1 group attribute should be returned", 1, groupAttributes.size());
+		assertTrue("Our group required attribute not returned",groupAttributes.contains(reqGrpAttr));
+
+		List<ServiceAttributes> members = resourceElements.get(1).getChildElements();
+		assertNotNull("Unable to get members from resource",members);
+		assertEquals("Only 1 member should be returned", 1, members.size());
+		assertNotNull("returned member shouldn't be null",members.get(0));
+
+		List<Attribute> memberAttributes = members.get(0).getAttributes();
+		assertNotNull("Unable to get member attributes required by service",memberAttributes);
+		assertEquals("Only 1 member attribute should be returned", 1, memberAttributes.size());
+		assertTrue("Our member required attribute not returned",memberAttributes.contains(reqMemAttr));
+	}
+
+	@Test
+	public void getDataWithVosWithoutExpiredMembers() throws Exception {
+		System.out.println(CLASS_NAME + "getDataWithVos");
+
+		vo = setUpVo();
+		facility = setUpFacility();
+		resource = setUpResource();
+		service = setUpService();
+		member = setUpMember();
+		Member member2 = setUpMember();
+		Member member3 = setUpMember();
+		group = setUpGroup();
+		Group group2 = new Group("GroupsManagerTestGroup2","testovaci2");
+		perun.getGroupsManager().createGroup(sess, vo, group2);
+
+		perun.getGroupsManager().addMember(sess, group, member);
+		perun.getGroupsManager().addMember(sess, group, member2);
+		perun.getGroupsManager().addMember(sess, group, member3);
+		perun.getGroupsManager().addMember(sess, group2, member2);
+		perun.getGroupsManager().addMember(sess, group2, member3);
+		perun.getResourcesManager().assignGroupToResource(sess, group, resource);
+		perun.getResourcesManager().assignGroupToResource(sess, group2, resource);
+
+		perun.getGroupsManager().setMemberGroupStatus(sess, member2, group, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member3, group, MemberGroupStatus.EXPIRED);
+		perun.getGroupsManager().setMemberGroupStatus(sess, member3, group2, MemberGroupStatus.EXPIRED);
+
+		AttributeDefinition attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_MEMBER_RESOURCE_ATTR_VIRT);
+		attr.setFriendlyName("groupStatus");
+		attr.setDisplayName("Group membership status");
+		attr.setType(String.class.getName());
+		Attribute attribute = new Attribute(attr);
+		perun.getAttributesManager().createAttribute(sess, attribute);
+
+		AttributeDefinition attr2 = new AttributeDefinition();
+		attr2.setNamespace(AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
+		attr2.setFriendlyName("groupStatus");
+		attr2.setDisplayName("Group membership status");
+		attr2.setType(String.class.getName());
+		Attribute attribute2 = new Attribute(attr2);
+		perun.getAttributesManager().createAttribute(sess, attribute2);
+
+		// set element's name/id as required attributes to get some attributes for every element
+		Attribute reqFacAttr;
+		reqFacAttr = perun.getAttributesManager().getAttribute(sess, facility, "urn:perun:facility:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqFacAttr);
+		Attribute reqResAttr;
+		reqResAttr = perun.getAttributesManager().getAttribute(sess, resource, "urn:perun:resource:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqResAttr);
+		Attribute reqGrpAttr;
+		reqGrpAttr = perun.getAttributesManager().getAttribute(sess, group, "urn:perun:group:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqGrpAttr);
+		Attribute reqMemAttr;
+		reqMemAttr = perun.getAttributesManager().getAttribute(sess, member, "urn:perun:member:attribute-def:core:id");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqMemAttr);
+		Attribute reqVoAttr;
+		reqVoAttr = perun.getAttributesManager().getAttribute(sess, vo, "urn:perun:vo:attribute-def:core:name");
+		perun.getServicesManager().addRequiredAttribute(sess, service, reqVoAttr);
+
+		// finally assign service
+		perun.getResourcesManager().assignService(sess, resource, service);
+
+		List<ServiceAttributes> facilities = new ArrayList<ServiceAttributes>();
+		facilities.add(perun.getServicesManager().getDataWithVos(sess, service, facility, true));
+		List<ServiceAttributes> vos = facilities.get(0).getChildElements();
+		List<ServiceAttributes> resources = vos.get(0).getChildElements();
+		List<ServiceAttributes> resourceElements = resources.get(0).getChildElements();
+		List<ServiceAttributes> groupMembers = resourceElements.get(0).getChildElements().get(0).getChildElements().get(1).getChildElements();
+		List<ServiceAttributes> group2Members = resourceElements.get(0).getChildElements().get(1).getChildElements().get(1).getChildElements();
+		List<ServiceAttributes> members = resourceElements.get(1).getChildElements();
+
+		//group has 3 members but member2 and member3 are expired
+		assertEquals(groupMembers.size(), 1);
+
+		//group2 has 2 members but member3 is expired
+		assertEquals(group2Members.size(), 1);
+
+		//resource has 3 members but member3 is expired in all groups of given resource
+		assertEquals(members.size(), 2);
 	}
 
 	@Test

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -149,6 +149,37 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *
 	 * @param service int Service <code>id</code>
 	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources.
+	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility childrens are resources. And resource childrens are members.
+	 <pre>
+	 Facility
+	 +---Attrs
+	 +---ChildNodes
+	 +------Resource
+	 |      +---Attrs
+	 |      +---ChildNodes
+	 |             +------Member
+	 |             |        +-------Attrs
+	 |             +------Member
+	 |             |        +-------Attrs
+	 |             +...
+	 |
+	 +------Resource
+	 |      +---Attrs
+	 |      +---ChildNodes
+	 .             +------Member
+	 .             |        +-------Attrs
+	 .             +------Member
+	 |        +-------Attrs
+	 +...
+	 </pre>
+	 *
+	 */
+	/*#
+	 * Generates the list of attributes per each member associated with the resource.
+	 *
+	 * @param service int Service <code>id</code>
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources.
 	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility childrens are resources. And resource childrens are members.
 	 <pre>
 	 Facility
@@ -178,12 +209,50 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ServiceAttributes call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getServicesManager().getHierarchicalData(ac.getSession(),
+			if (parms.contains("filterExpiredMembers")) {
+				return ac.getServicesManager().getHierarchicalData(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")));
+					ac.getFacilityById(parms.readInt("facility")),
+					parms.readBoolean("filterExpiredMembers"));
+			} else {
+				return ac.getServicesManager().getHierarchicalData(ac.getSession(),
+					ac.getServiceById(parms.readInt("service")),
+					ac.getFacilityById(parms.readInt("facility")),
+					false);
+			}
 		}
 	},
 
+	/*#
+	 * Generates the list of attributes per each user and per each resource. Never return member or member-resource attribute.
+	 *
+	 * @param service int Service <code>id</code>. You will get attributes required by this service
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @return ServiceAttributes Attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's childrens are all resources. Facility second child is abstract node with no attribute and it's childrens are all users.
+	 <pre>
+	 Facility
+	 +---Attrs
+	 +---ChildNodes
+	 +------()
+	 |      +---ChildNodes
+	 |             +------Resource
+	 |             |        +-------Attrs
+	 |             +------Resource
+	 |             |        +-------Attrs
+	 |             +...
+	 |
+	 +------()
+	 +---ChildNodes
+	 +------User
+	 |        +-------Attrs (do NOT return member, member-resource attributes)
+	 +------User
+	 |        +-------Attrs (do NOT return member, member-resource attributes)
+	 +...
+	 </pre>
+
+	 *
+	 */
 	/*#
 	 * Generates the list of attributes per each user and per each resource. Never return member or member-resource attribute.
 	 *
@@ -217,12 +286,96 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ServiceAttributes call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getServicesManager().getFlatData(ac.getSession(),
+			if (parms.contains("filterExpiredMembers")) {
+				return ac.getServicesManager().getFlatData(ac.getSession(),
+						ac.getServiceById(parms.readInt("service")),
+						ac.getFacilityById(parms.readInt("facility")),
+					parms.readBoolean("filterExpiredMembers"));
+			} else {
+				return ac.getServicesManager().getFlatData(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")));
+					ac.getFacilityById(parms.readInt("facility")),
+					false);
+			}
 		}
 	},
 
+	/*#
+	 * Generates the list of attributes per each member associated with the resources and groups.
+	 *
+	 * @param service int Service <code>id</code>. You will get attributes reuqired by this service
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @return ServiceAttributes Attributes in special structure. Facility is in the root, facility children are resources.
+	 *         Resource first chil is abstract structure which children are groups.
+	 *         Resource  second chi is abstract structure which children are members.
+	 *         Group first chil is abstract structure which children are groups.
+	 *         Group second chi is abstract structure which children are members.
+	 <pre>
+	 Facility
+	 +---Attrs                       ...................................................
+	 +---ChildNodes                  |                                                 .
+	 +------Resource                 |                                                 .
+	 |       +---Attrs               |                                                 .
+	 |       +---ChildNodes          |                                                 .
+	 |              +------()        V                                                 .
+	 |              |       +------Group                                               .
+	 |              |       |        +-------Attrs                                     .
+	 |              |       |        +-------ChildNodes                                .
+	 |              |       |                   +-------()                             .
+	 |              |       |                   |        +---ChildNodes                .
+	 |              |       |                   |               +------- GROUP (same structure as any other group)
+	 |              |       |                   |               +------- GROUP (same structure as any other group)
+	 |              |       |                   |               +...
+	 |              |       |                   +-------()
+	 |              |       |                            +---ChildNodes
+	 |              |       |                                   +------Member
+	 |              |       |                                   |        +----Attrs
+	 |              |       |                                   +------Member
+	 |              |       |                                   |        +----Attrs
+	 |              |       |                                   +...
+	 |              |       |
+	 |              |       +------Group
+	 |              |       |        +-------Attrs
+	 |              |       |        +-------ChildNodes
+	 |              |       |                   +-------()
+	 |              |       |                   |        +---ChildNodes
+	 |              |       |                   |               +------- GROUP (same structure as any other group)
+	 |              |       |                   |               +------- GROUP (same structure as any other group)
+	 |              |       |                   |               +...
+	 |              |       |                   +-------()
+	 |              |       |                            +---ChildNodes
+	 |              |       |                                   +------Member
+	 |              |       |                                   |        +----Attrs
+	 |              |       |                                   +------Member
+	 |              |       |                                   |        +----Attrs
+	 |              |       |                                   +...
+	 |              |       |
+	 |              |       +...
+	 |              |
+	 |              +------()
+	 |                      +------Member
+	 |                      |         +----Attrs
+	 |                      |
+	 |                      +------Member
+	 |                      |         +----Attrs
+	 |                      +...
+	 |
+	 +------Resource
+	 |       +---Attrs
+	 |       +---ChildNodes
+	 |              +------()
+	 |              |       +...
+	 |              |       +...
+	 |              |
+	 |              +------()
+	 |                      +...
+	 .                      +...
+	 .
+	 .
+	 </pre>
+	 *
+	 */
 	/*#
 	 * Generates the list of attributes per each member associated with the resources and groups.
 	 *
@@ -302,12 +455,98 @@ public enum ServicesManagerMethod implements ManagerMethod {
 
 		@Override
 		public ServiceAttributes call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getServicesManager().getDataWithGroups(ac.getSession(),
+			if (parms.contains("filterExpiredMembers")) {
+				return ac.getServicesManager().getDataWithGroups(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")));
+					ac.getFacilityById(parms.readInt("facility")),
+					parms.readBoolean("filterExpiredMembers"));
+			} else {
+				return ac.getServicesManager().getDataWithGroups(ac.getSession(),
+					ac.getServiceById(parms.readInt("service")),
+					ac.getFacilityById(parms.readInt("facility")),
+					false);
+			}
 		}
 	},
 
+	/*#
+	 * Generates the list of attributes per each member associated with the resources and groups in vos.
+	 *
+	 * @param service attributes required by this service you will get
+	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @return attributes in special structure.
+	 *        Facility is in the root, facility children are vos.
+	 *        Vo first child is abstract structure which children are resources.
+	 *        Resource first child is abstract structure which children are groups.
+	 *        Resource  second chi is abstract structure which children are members.
+	 *        Group first child is abstract structure which children are groups.
+	 *        Group second chi is abstract structure which children are members.
+	 <pre>
+	 Facility
+	 +---Attrs
+	 +---ChildNodes
+	        +-----Vo
+	        |      +---Attrs
+	        |      +---ChildNodes
+	        |             +-------Resource
+	        |             |       +---Attrs               |-------------------------------------------------.
+	        |             |       +---ChildNodes          |                                                 .
+	        |             |              +------()        V                                                 .
+	        |             |              |       +------Group                                               .
+	        |             |              |       |        +-------Attrs                                     .
+	        |             |              |       |        +-------ChildNodes                                .
+	        |             |              |       |                   +-------()                             .
+	        |             |              |       |                   |        +---ChildNodes                .
+	        |             |              |       |                   |               +------- GROUP (same structure as any other group)
+	        |             |              |       |                   |               +------- GROUP (same structure as any other group)
+	        |             |              |       |                   |               +...
+	        |             |              |       |                   +-------()
+	        |             |              |       |                            +---ChildNodes
+	        |             |              |       |                                   +------Member
+	        |             |              |       |                                   |        +----Attrs
+	        |             |              |       |                                   +------Member
+	        |             |              |       |                                   |        +----Attrs
+	        |             |              |       |                                   +...
+	        |             |              |       |
+	        |             |              |       +------Group
+	        |             |              |       |        +-------Attrs
+	        |             |              |       |        +-------ChildNodes
+	        |             |              |       |                   +-------()
+	        |             |              |       |                   |        +---ChildNodes
+	        |             |              |       |                   |               +------- GROUP (same structure as any other group)
+	        |             |              |       |                   |               +------- GROUP (same structure as any other group)
+	        |             |              |       |                   |               +...
+	        |             |              |       |                   +-------()
+	        |             |              |       |                            +---ChildNodes
+	        |             |              |       |                                   +------Member
+	        |             |              |       |                                   |        +----Attrs
+	        |             |              |       |                                   +------Member
+	        |             |              |       |                                   |        +----Attrs
+	        |             |              |       |                                   +...
+	        |             |              |       |
+	        |             |              |       +...
+	        |             |              |
+	        |             |              +------()
+	        |             |                      +------Member
+	        |             |                      |         +----Attrs
+	        |             |                      |
+	        |             |                      +------Member
+	        |             |                      |         +----Attrs
+	        |             |                      +...
+	        |             |
+	        |             +------Resource
+	        |             |       +---Attrs
+	        |             |       +---ChildNodes
+	        |             |              +------()
+	        |             |              |       +...
+	        |             |              |       +...
+	        |             |              |
+	        |             |              +------()
+	        |             |                      +...
+	        +-----Vo ....
+	</pre>
+	 */
 	/*#
 	 * Generates the list of attributes per each member associated with the resources and groups in vos.
 	 *
@@ -388,9 +627,17 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	getDataWithVos {
 		@Override
 		public ServiceAttributes call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getServicesManager().getDataWithVos(ac.getSession(),
+			if (parms.contains("filterExpiredMembers")) {
+				return ac.getServicesManager().getDataWithVos(ac.getSession(),
 					ac.getServiceById(parms.readInt("service")),
-					ac.getFacilityById(parms.readInt("facility")));
+					ac.getFacilityById(parms.readInt("facility")),
+					parms.readBoolean("filterExpiredMembers"));
+			} else {
+				return ac.getServicesManager().getDataWithVos(ac.getSession(),
+					ac.getServiceById(parms.readInt("service")),
+					ac.getFacilityById(parms.readInt("facility")),
+					false);
+			}
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -148,9 +148,9 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 * Generates the list of attributes per each member associated with the resource.
 	 *
 	 * @param service int Service <code>id</code>
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources.
-	 * @param filterExpiredMembers if true the method does not take expired members into account
-	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility childrens are resources. And resource childrens are members.
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources.
+	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
+	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
 	 <pre>
 	 Facility
 	 +---Attrs
@@ -179,8 +179,8 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 * Generates the list of attributes per each member associated with the resource.
 	 *
 	 * @param service int Service <code>id</code>
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources.
-	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility childrens are resources. And resource childrens are members.
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources.
+	 * @return List<ServiceAttributes> Attributes in special structure. Facility is in the root, facility children are resources. And resource children are members.
 	 <pre>
 	 Facility
 	 +---Attrs
@@ -227,9 +227,9 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 * Generates the list of attributes per each user and per each resource. Never return member or member-resource attribute.
 	 *
 	 * @param service int Service <code>id</code>. You will get attributes required by this service
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
-	 * @return ServiceAttributes Attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's childrens are all resources. Facility second child is abstract node with no attribute and it's childrens are all users.
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
+	 * @return ServiceAttributes Attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources. Facility second child is abstract node with no attribute and it's children are all users.
 	 <pre>
 	 Facility
 	 +---Attrs
@@ -257,8 +257,8 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 * Generates the list of attributes per each user and per each resource. Never return member or member-resource attribute.
 	 *
 	 * @param service int Service <code>id</code>. You will get attributes required by this service
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources
-	 * @return ServiceAttributes Attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's childrens are all resources. Facility second child is abstract node with no attribute and it's childrens are all users.
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
+	 * @return ServiceAttributes Attributes in special structure. The facility is in the root. Facility first children is abstract node which contains no attributes and it's children are all resources. Facility second child is abstract node with no attribute and it's children are all users.
 	 <pre>
 	 Facility
 	 +---Attrs
@@ -304,8 +304,8 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 * Generates the list of attributes per each member associated with the resources and groups.
 	 *
 	 * @param service int Service <code>id</code>. You will get attributes reuqired by this service
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
+	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return ServiceAttributes Attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first chil is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
@@ -380,7 +380,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 * Generates the list of attributes per each member associated with the resources and groups.
 	 *
 	 * @param service int Service <code>id</code>. You will get attributes reuqired by this service
-	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources asociated with it and members assigned to the resources
+	 * @param facility int Facility <code>id</code>. You will get attributes for this facility, resources associated with it and members assigned to the resources
 	 * @return ServiceAttributes Attributes in special structure. Facility is in the root, facility children are resources.
 	 *         Resource first chil is abstract structure which children are groups.
 	 *         Resource  second chi is abstract structure which children are members.
@@ -474,7 +474,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	 *
 	 * @param service attributes required by this service you will get
 	 * @param facility you will get attributes for this facility, vos associated with this facility by resources, resources associated with it and members assigned to the resources
-	 * @param filterExpiredMembers if true the method does not take expired members into account
+	 * @param filterExpiredMembers if true the method does not take members expired in groups into account
 	 * @return attributes in special structure.
 	 *        Facility is in the root, facility children are vos.
 	 *        Vo first child is abstract structure which children are resources.


### PR DESCRIPTION
- the methods are getHierarchicalData, getFlatData, getDataWithGroups and getDataWithVos
- if filterExpiredMembers is true methods does not return members that are expired in groups
- if member is expired in all groups that associated him to a resource, he is no longer returned in ChildNodes of that resource
- if user is expired in all groups that associated to any resource that connected him to a facility, he is no longer returned in ChildNodes of that facility