### PR TITLE
CORE: Use share mail sending configuration for whole Perun

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -162,6 +162,11 @@
 			<artifactId>flying-saucer-pdf</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -67,6 +67,13 @@ public class CoreConfig {
 	private String userExtSourcesPersistent;
 	private List<String> allowedCorsDomains;
 	private String pdfFontPath;
+	private String smtpHost;
+	private int smtpPort;
+	private boolean smtpAuth;
+	private boolean smtpStartTls;
+	private boolean mailDebug;
+	private String smtpUser;
+	private String smtpPass;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -523,4 +530,61 @@ public class CoreConfig {
 	public void setPdfFontPath(String pdfFontPath) {
 		this.pdfFontPath = pdfFontPath;
 	}
+
+	public String getSmtpHost() {
+		return smtpHost;
+	}
+
+	public void setSmtpHost(String smtpHost) {
+		this.smtpHost = smtpHost;
+	}
+
+	public int getSmtpPort() {
+		return smtpPort;
+	}
+
+	public void setSmtpPort(int smtpPort) {
+		this.smtpPort = smtpPort;
+	}
+
+	public boolean isSmtpAuth() {
+		return smtpAuth;
+	}
+
+	public void setSmtpAuth(boolean smtpAuth) {
+		this.smtpAuth = smtpAuth;
+	}
+
+	public boolean isSmtpStartTls() {
+		return smtpStartTls;
+	}
+
+	public void setSmtpStartTls(boolean smtpStartTls) {
+		this.smtpStartTls = smtpStartTls;
+	}
+
+	public boolean isMailDebug() {
+		return mailDebug;
+	}
+
+	public void setMailDebug(boolean mailDebug) {
+		this.mailDebug = mailDebug;
+	}
+
+	public String getSmtpUser() {
+		return smtpUser;
+	}
+
+	public void setSmtpUser(String smtpUser) {
+		this.smtpUser = smtpUser;
+	}
+
+	public String getSmtpPass() {
+		return smtpPass;
+	}
+
+	public void setSmtpPass(String smtpPass) {
+		this.smtpPass = smtpPass;
+	}
+
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -51,6 +51,13 @@
 		<property name="allowedCorsDomains" value="#{'${perun.allowedCorsDomains}'.split('\s*,\s*')}" />
 		<property name="cacheEnabled" value="${perun.cacheEnabled}" />
 		<property name="pdfFontPath" value="${perun.pdfFontPath}" />
+		<property name="smtpHost" value="${mail.smtp.host}" />
+		<property name="smtpPort" value="${mail.smtp.port}" />
+		<property name="smtpAuth" value="${mail.smtp.auth}" />
+		<property name="smtpStartTls" value="${mail.smtp.starttls.enable}" />
+		<property name="mailDebug" value="${mail.debug}" />
+		<property name="smtpUser" value="${perun.smtp.user}" />
+		<property name="smtpPass" value="${perun.smtp.pass}" />
 	</bean>
 
 
@@ -127,6 +134,14 @@
 				<prop key="perun.oidc.i4.extsource.name">https://login.elixir-czech.org/idp/</prop>
 				<prop key="perun.oidc.i4.extsource.type">cz.metacentrum.perun.core.impl.ExtSourceIdp</prop>
 
+				<prop key="mail.smtp.host">localhost</prop>
+				<prop key="mail.smtp.port">25</prop>
+				<prop key="mail.smtp.auth">false</prop>
+				<prop key="mail.smtp.starttls.enable">false</prop>
+				<prop key="mail.debug">false</prop>
+				<prop key="perun.smtp.user"></prop>
+				<prop key="perun.smtp.pass"></prop>
+
 			</props>
 		</property>
 	</bean>
@@ -148,7 +163,10 @@
 	<!-- active in Spring profile "default", packs default properties and few others as a bean -->
 	<beans profile="default">
 		<bean id="coreProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-			<property name="properties" ref="defaultCoreProperties"/>
+			<property name="properties" ref="defaultCoreProperties" />
+			<!-- Following file should be present only in test resources !! -->
+			<property name="location" value="classpath:perun-tests.properties" />
+			<property name="ignoreResourceNotFound" value="true" />
 		</bean>
 	</beans>
 

--- a/perun-base/src/test/resources/perun-tests.properties
+++ b/perun-base/src/test/resources/perun-tests.properties
@@ -1,0 +1,8 @@
+# These properties override "default" in the context properties, but can be overridden by the actual files in "production" profile
+mail.smtp.host=localhost
+mail.smtp.port=8086
+mail.smtp.auth=false
+mail.smtp.starttls.enable=false
+mail.debug=false
+perun.smtp.user=
+perun.smtp.pass=

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -166,11 +166,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.sun.mail</groupId>
-			<artifactId>javax.mail</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>jdom</groupId>
 			<artifactId>jdom</artifactId>
 		</dependency>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -14,6 +14,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 import javax.crypto.Cipher;
@@ -900,8 +901,7 @@ public class Utils {
 	public static void sendPasswordResetEmail(User user, String email, String namespace, String url, int id, String messageTemplate, String subject) throws InternalErrorException {
 
 		// create mail sender
-		JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-		mailSender.setHost("localhost");
+		JavaMailSender mailSender = BeansUtils.getDefaultMailSender();
 
 		// create message
 		SimpleMailMessage message = new SimpleMailMessage();
@@ -1013,8 +1013,7 @@ public class Utils {
 	public static void sendPasswordResetConfirmationEmail(User user, String email, String namespace, String subject, String content) throws InternalErrorException {
 
 		// create mail sender
-		JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-		mailSender.setHost("localhost");
+		JavaMailSender mailSender = BeansUtils.getDefaultMailSender();
 
 		// create message
 		SimpleMailMessage message = new SimpleMailMessage();

--- a/perun-notification/src/main/resources/perun-notification.xml
+++ b/perun-notification/src/main/resources/perun-notification.xml
@@ -61,15 +61,9 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<bean id="propertiesBean" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 			<property name="properties">
 				<props>
-					<prop key="notif.mailSmtpAuth">false</prop>
-					<prop key="notif.username"></prop>
-					<prop key="notif.password"></prop>
-					<prop key="notif.smtpHost">localhost</prop>
-					<prop key="notif.port">8086</prop>
 					<prop key="notif.emailFrom">perun@localhost</prop>
 					<prop key="notif.fromText">perun@localhost test message</prop>
 					<prop key="notif.sendMessages">true</prop>
-					<prop key="notif.starttls">false</prop>
 					<prop key="notif.jabber.jabberServer">jabber.org</prop>
 					<prop key="notif.jabber.port">5222</prop>
 					<prop key="notif.jabber.serviceName">jabber.org</prop>

--- a/perun-notification/src/test/java/cz/metacentrum/perun/notif/AbstractTest.java
+++ b/perun-notification/src/test/java/cz/metacentrum/perun/notif/AbstractTest.java
@@ -37,15 +37,15 @@ public class AbstractTest {
 	protected PerunBl perun;
 
 	protected PerunSession sess;
-	
+
 	protected static SimpleSmtpServer smtpServer;
-	
+
 	@Autowired
 	protected PerunNotifNotificationManager manager;
-	
+
 	@Autowired
 	protected SchedulingManagerImpl schedulingManager;
-	
+
 	@Autowired
 	private ApplicationContext appContext;
 
@@ -77,7 +77,7 @@ public class AbstractTest {
 		final PerunPrincipal pp = new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
 		sess = perun.getPerunSession(pp, new PerunClient());
 	}
-	
+
 	@After
 	public void stopSmtpServer() {
 		if (smtpServer != null) {
@@ -90,7 +90,7 @@ public class AbstractTest {
 	public void dummyTest() {
 		System.out.println("Dummy test to prevent: NoRunnableMethodsException");
 	}
-	
+
 	public Connection getConnection() throws SQLException {
 		// classic Autowire dataSource does not work
 		return ((SimpleDriverDataSource) appContext.getBean("dataSource")).getConnection();

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -34,7 +34,6 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.transaction.annotation.Transactional;
 
 import cz.metacentrum.perun.core.bl.PerunBl;
@@ -92,15 +91,6 @@ public class MailManagerImpl implements MailManager {
 		this.jdbc =  new JdbcPerunTemplate(dataSource);
 	}
 
-	public void setMailSender(MailSender mailSender) {
-		this.mailSender = mailSender;
-		boolean auth = Boolean.parseBoolean(registrarProperties.getProperty("mail.smtp.auth", "false"));
-		if (auth) {
-			((JavaMailSenderImpl)mailSender).setUsername(registrarProperties.getProperty("registrar.smtp.user"));
-			((JavaMailSenderImpl)mailSender).setPassword(registrarProperties.getProperty("registrar.smtp.pass"));
-		}
-	}
-
 	/**
 	 * Init method, instantiate PerunSession
 	 *
@@ -118,6 +108,7 @@ public class MailManagerImpl implements MailManager {
 		this.membersManager = perun.getMembersManager();
 		this.usersManager = perun.getUsersManager();
 		this.groupsManager = perun.getGroupsManager();
+		this.mailSender = BeansUtils.getDefaultMailSender();
 
 	}
 

--- a/perun-registrar-lib/src/main/resources/perun-registrar-lib.xml
+++ b/perun-registrar-lib/src/main/resources/perun-registrar-lib.xml
@@ -21,11 +21,6 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 	<!-- Scans for @Repository, @Service and @Component -->
 	<context:component-scan base-package="cz.metacentrum.perun.registrar"/>
 
-	<!-- for sending emails -->
-	<bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
-		<property name="javaMailProperties" ref="registrarProperties"/>
-	</bean>
-
 	<bean id="registrarManager" class="cz.metacentrum.perun.registrar.impl.RegistrarManagerImpl" init-method="initialize">
 		<property name="dataSource" ref="dataSource"/>
 		<property name="registrarManager" ref="registrarManager"/>
@@ -33,7 +28,6 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 
 	<bean id="mailManager" class="cz.metacentrum.perun.registrar.impl.MailManagerImpl" init-method="initialize">
 		<property name="dataSource" ref="dataSource"/>
-		<property name="mailSender" ref="mailSender" />
 	</bean>
 
 	<bean id="consolidatorManager" class="cz.metacentrum.perun.registrar.impl.ConsolidatorManagerImpl" init-method="initialize">
@@ -68,15 +62,6 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 					<prop key="backupFrom">perun@localhost</prop>
 					<prop key="backupTo">perun@localhost</prop>
 					<prop key="fedAuthz">fed</prop>
-					<!-- MAIL SENDING PROPERTIES -->
-					<prop key="mail.smtp.host">localhost</prop>
-					<prop key="mail.smtp.port">25</prop>
-					<prop key="mail.smtp.auth">false</prop>
-					<prop key="mail.smtp.starttls.enable">false</prop>
-					<prop key="mail.debug">false</prop>
-					<!-- user / password if "mail.smtp.auth" is true -->
-					<prop key="registrar.smtp.user"></prop>
-					<prop key="registrar.smtp.pass"></prop>
 				</props>
 			</property>
 		</bean>


### PR DESCRIPTION
- Necessary properties moved to the perun.properties and can be read
  from CoreConfig class.
- BeansUtils now have method to return initialized JavaMailSender.
- Registrar and Core are using shared config now (core previously
  was on localhost:25 config only).
- Notification module reads properties from shared config too instead
  of perun-notif.properties.