### PR TITLE
CORE: Hide group status of members of "members" group in tables

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/FindCompleteRichMembers.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/membersManager/FindCompleteRichMembers.java
@@ -66,6 +66,7 @@ public class FindCompleteRichMembers implements JsonCallbackSearchFor, JsonCallb
 	private AjaxLoaderImage loaderImage = new AjaxLoaderImage(true, WidgetTranslation.INSTANCE.emptySearchForMembers());
 
 	private ArrayList<PerunStatus> allowedStatuses = new ArrayList<PerunStatus>();
+	private boolean hideGroupStatusColumn = true;
 
 	/**
 	 * Creates a new instance of the method
@@ -86,6 +87,9 @@ public class FindCompleteRichMembers implements JsonCallbackSearchFor, JsonCallb
 			this.attributes = attributes;
 		}
 		allowedStatuses.addAll(Arrays.asList(PerunStatus.values()));
+		if (entity.equals(PerunEntity.GROUP)) {
+			hideGroupStatusColumn = false;
+		}
 	}
 
 	/**
@@ -261,7 +265,7 @@ public class FindCompleteRichMembers implements JsonCallbackSearchFor, JsonCallb
 		columnProvider.addIdColumn(authz, 110);
 		columnProvider.addUserIdColumn(authz, 110);
 		columnProvider.addStatusColumn(authz, 20);
-		if (entity.equals(PerunEntity.GROUP)) {
+		if (!hideGroupStatusColumn) {
 			columnProvider.addGroupStatusColumn(authz, entityId,120);
 		}
 		columnProvider.addNameColumn(authz);
@@ -440,6 +444,10 @@ public class FindCompleteRichMembers implements JsonCallbackSearchFor, JsonCallb
 
 	public void setIndirectCheckable(boolean checkable) {
 		this.indirectCheckable = checkable;
+	}
+
+	public void setHideGroupStatusColumn(boolean hideGroupStatusColumn) {
+		this.hideGroupStatusColumn = hideGroupStatusColumn;
 	}
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
@@ -131,6 +131,7 @@ public class GroupMembersTabItem implements TabItem, TabItemWithUrl {
 		final FindCompleteRichMembers findMembers = new FindCompleteRichMembers(PerunEntity.GROUP, groupId, "", null);
 		members.excludeDisabled(!wasDisabled);
 		members.setIndirectCheckable(false);
+		findMembers.setHideGroupStatusColumn("members".equals(group.getName()));
 		findMembers.setIndirectCheckable(false);
 
 		final CustomButton searchButton = TabMenu.getPredefinedButton(ButtonType.SEARCH, ButtonTranslation.INSTANCE.searchMemberInGroup());


### PR DESCRIPTION
- We do not allow setting group status for the members of "members"
  group in API, hence do not display that column in table in GUI.