### PR TITLE
GUI: Changed Date to LocalDateTime in Task object

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/LocalDateTime.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/LocalDateTime.java
@@ -1,0 +1,71 @@
+package cz.metacentrum.perun.webgui.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class LocalDateTime extends JavaScriptObject {
+
+	protected LocalDateTime() {
+	}
+
+	// {"year":2019,"month":"MARCH","monthValue":3,"dayOfMonth":28,"hour":6,"minute":16,"second":6,"nano":0,"dayOfWeek":"THURSDAY","dayOfYear":87,"chronology":{"calendarType":"iso8601","id":"ISO"}}
+
+	public final native int getYear() /*-{
+		return this.year;
+	}-*/;
+
+	public final native String getMonthName() /*-{
+		return this.month;
+	}-*/;
+
+	public final native int getMonthValue() /*-{
+		return this.monthValue;
+	}-*/;
+
+	public final native int getDayOfMonth() /*-{
+		return this.dayOfMonth;
+	}-*/;
+
+	public final native int getHour() /*-{
+		return this.hour;
+	}-*/;
+
+	public final native int getMinute() /*-{
+		return this.minute;
+	}-*/;
+
+	public final native int getSecond() /*-{
+		return this.second;
+	}-*/;
+
+	public final native int getNano() /*-{
+		return this.nano;
+	}-*/;
+
+	public final native String getDayOfWeek() /*-{
+		return this.dayOfWeek;
+	}-*/;
+
+	public final native int getDayOfYear() /*-{
+		return this.dayOfYear;
+	}-*/;
+
+	public final native String getChronologyId() /*-{
+		return this.chronology.id;
+	}-*/;
+
+	public final native String getChronologyCalendarType() /*-{
+		return this.chronology.calendarType;
+	}-*/;
+
+	public final String printValue() {
+
+		return getYear() + " " +
+				getMonthName().substring(0,1) + getMonthName().substring(1,3).toLowerCase() +
+				" " + ((getDayOfMonth() < 10) ? "0" : "") + getDayOfMonth() +
+				" " + ((getHour() < 10) ? "0" : "") + getHour() +
+				":" + ((getMinute() < 10) ? "0" : "") + getMinute() +
+				":" + ((getSecond() < 10) ? "0" : "")+ getSecond();
+
+	}
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ServiceState.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/ServiceState.java
@@ -37,28 +37,28 @@ public class ServiceState extends JavaScriptObject {
 	}-*/;
 
 	public final String getStartTime() {
-		if (getStartTimeNative() != 0) {
-			return DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM).format(new Date((long)getStartTimeNative()));
+		if (getStartTimeNative() != null) {
+			return getStartTimeNative().printValue();
 		} else {
 			return "Not yet";
 		}
 	}
 
-	public final native double getStartTimeNative() /*-{
-		if (!(this.startTime)) { return 0; }
+	public final native LocalDateTime getStartTimeNative() /*-{
+		if (!(this.startTime)) { return null; }
 		return this.startTime;
 	}-*/;
 
 	public final String getEndTime() {
-		if (getEndTimeNative() != 0) {
-			return DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM).format(new Date((long)getEndTimeNative()));
+		if (getEndTimeNative() != null) {
+			return getEndTimeNative().printValue();
 		} else {
 			return "Not yet";
 		}
 	}
 
-	public final native double getEndTimeNative() /*-{
-		if (!(this.endTime)) { return 0; }
+	public final native LocalDateTime getEndTimeNative() /*-{
+		if (!(this.endTime)) { return null; }
 		return this.endTime;
 	}-*/;
 
@@ -67,16 +67,16 @@ public class ServiceState extends JavaScriptObject {
 	}-*/;
 
 	public final String getSchedule() {
-		if (getScheduleNative() != 0) {
-			return DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM).format(new Date((long)getScheduleNative()));
+		if (getScheduleNative() != null) {
+			return getScheduleNative().printValue();
 		} else {
 			return "Not yet";
 		}
 	}
 
-	public final native double getScheduleNative() /*-{
-		if (!(this.scheduled)) { return 0; }
-		return this.scheduled;
+	public final native LocalDateTime getScheduleNative() /*-{
+		if (!(this.schedule)) { return null; }
+		return this.schedule;
 	}-*/;
 
 	/**
@@ -95,7 +95,7 @@ public class ServiceState extends JavaScriptObject {
 	}-*/;
 
 	public final native String getHasDestinations() /*-{
-		return (this.hasDestinations == true) ? "" : "Service has no destinations defined.";
+		return (this.hasDestinations === true) ? "" : "Service has no destinations defined.";
 	}-*/;
 
 	/**

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Task.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/model/Task.java
@@ -1,9 +1,6 @@
 package cz.metacentrum.perun.webgui.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.i18n.client.DateTimeFormat;
-
-import java.sql.Date;
 
 /**
  * Overlay type for Task object from Perun
@@ -24,28 +21,28 @@ public class Task extends JavaScriptObject {
 	}-*/;
 
 	public final String getStartTime() {
-		if (getStartTimeNative() != 0) {
-			return DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM).format(new Date((long)getStartTimeNative()));
+		if (getStartTimeNative() != null) {
+			return getStartTimeNative().printValue();
 		} else {
 			return "Not yet";
 		}
 	}
 
-	public final native double getStartTimeNative() /*-{
-		if (!(this.startTime)) { return 0; }
+	public final native LocalDateTime getStartTimeNative() /*-{
+		if (!(this.startTime)) { return null; }
 		return this.startTime;
 	}-*/;
 
 	public final String getEndTime() {
-		if (getEndTimeNative() != 0) {
-			return DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM).format(new Date((long)getEndTimeNative()));
+		if (getEndTimeNative() != null) {
+			return getEndTimeNative().printValue();
 		} else {
 			return "Not yet";
 		}
 	}
 
-	public final native double getEndTimeNative() /*-{
-		if (!(this.endTime)) { return 0; }
+	public final native LocalDateTime getEndTimeNative() /*-{
+		if (!(this.endTime)) { return null; }
 		return this.endTime;
 	}-*/;
 
@@ -58,15 +55,15 @@ public class Task extends JavaScriptObject {
 	}-*/;
 
 	public final String getSchedule() {
-		if (getScheduleNative() != 0) {
-			return DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM).format(new Date((long)getScheduleNative()));
+		if (getScheduleNative() != null) {
+			return getScheduleNative().printValue();
 		} else {
 			return "Not yet";
 		}
 	}
 
-	public final native double getScheduleNative() /*-{
-		if (!(this.schedule)) { return 0; }
+	public final native LocalDateTime getScheduleNative() /*-{
+		if (!(this.schedule)) { return null; }
 		return this.schedule;
 	}-*/;
 


### PR DESCRIPTION
- We changed Task property data types from Date to LocalDateTime, which
  is not present in GWT and must be replaced with our own class
  extending JavaScriptObject.
- Read date/time properties in Task using this new object.
- This change is related to pull-request #2180 and shouldn't be merged
  without it.