### PR TITLE
Fixed typo in lastSuccessGroupStructureSynchronizationTimestamp

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -6793,7 +6793,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
 		attr.setType(String.class.getName());
-		attr.setFriendlyName("lastSuccessGroupStructuresSynchronizationTimestamp");
+		attr.setFriendlyName("lastSuccessGroupStructureSynchronizationTimestamp");
 		attr.setDisplayName("Last successful group structure synchronization timestamp");
 		attr.setDescription("If group structure is synchronized, there will be timestamp of last successful synchronization.");
 		//set attribute rights (with dummy id of attribute - not known yet)


### PR DESCRIPTION


- This attribute had extra "s" in name which was causing errors in structured synchronizations.