### PR TITLE
fix regular expressions matching audit messages 

### DIFF
--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/AbstractPerunEntry.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/AbstractPerunEntry.java
@@ -94,8 +94,12 @@ public abstract class AbstractPerunEntry<T extends PerunBean> implements Initial
 	public void modifyEntry(T bean, AttributeDefinition attr) throws InternalErrorException {
 		DirContextOperations entry = findByDN(buildDN(bean));
 		List<PerunAttribute<T>> attrDefs = findAttributeDescriptionsByPerunAttr(getAttributeDescriptions(), attr);
-		if(attrDefs.isEmpty())
-			throw new InternalErrorException("Attribute description for attribute " + attr.getName() + " not found");
+		if(attrDefs.isEmpty()) {
+			// this is not exceptional situation
+			// throw new InternalErrorException("Attribute description for attribute " + attr.getName() + " not found");
+			log.info("Attribute description for attribute {} not found, not modifying entry.", attr.getName());
+			return;
+		}
 		for(PerunAttribute<T> attrDef : attrDefs) {
 			mapToContext(bean, entry, attrDef, attr);
 		}

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/RegexpDispatchEventCondition.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/RegexpDispatchEventCondition.java
@@ -13,7 +13,7 @@ public class RegexpDispatchEventCondition extends SimpleDispatchEventCondition {
 
 	@Required
 	public void setPattern(String regexp) {
-		this.pattern = Pattern.compile(regexp, Pattern.MULTILINE | Pattern.DOTALL);
+		this.pattern = Pattern.compile(regexp, Pattern.DOTALL);
 	}
 
 	@Override

--- a/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
@@ -177,7 +177,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Attribute</value>
 						</list>
 					</property>
-					<property name="pattern" value=" set for User:\[(.|\s)*\]" />
+					<property name="pattern" value=" set for User:\[.*\]$" />
 					<property name="handlerMethodName" value="processAttributeSet" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -187,7 +187,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.AttributeDefinition</value>
 						</list>
 					</property>
-					<property name="pattern" value=" removed for User:\[(.|\s)*\]" />
+					<property name="pattern" value=" removed for User:\[.*\]$" />
 					<property name="handlerMethodName" value="processAttributeRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -196,7 +196,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.User</value>
 						</list>
 					</property>
-					<property name="pattern" value="All attributes removed for User:\[(.|\s)*\]" />
+					<property name="pattern" value="All attributes removed for User:\[.*\]$" />
 					<property name="handlerMethodName" value="processAllAttributesRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -206,7 +206,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.UserExtSource</value>
 						</list>
 					</property>
-					<property name="pattern" value="UserExtSource:\[(.|\s)*\] added to User:\[(.|\s)*\]" />
+					<property name="pattern" value="UserExtSource:\[.*\] added to User:\[.*\]$" />
 					<property name="handlerMethodName" value="processExtSourceAdded" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -216,7 +216,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.UserExtSource</value>
 						</list>
 					</property>
-					<property name="pattern" value="UserExtSource:\[(.|\s)*\] removed from User:\[(.|\s)*\]" />
+					<property name="pattern" value="UserExtSource:\[.*\] removed from User:\[.*\]$" />
 					<property name="handlerMethodName" value="processExtSourceRemoved" />
 				</bean>
 			</list>
@@ -233,7 +233,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Attribute</value>
 						</list>
 					</property>
-					<property name="pattern" value=" set for Facility:\[(.|\s)*\]" />
+					<property name="pattern" value=" set for Facility:\[.*\]$" />
 					<property name="handlerMethodName" value="processAttributeSet" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -243,7 +243,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.AttributeDefinition</value>
 						</list>
 					</property>
-					<property name="pattern" value=" removed for Facility:\[(.|\s)*\]" />
+					<property name="pattern" value=" removed for Facility:\[.*\]$" />
 					<property name="handlerMethodName" value="processAttributeRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -252,7 +252,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Facility</value>
 						</list>
 					</property>
-					<property name="pattern" value="All attributes removed for Facility:\[(.|\s)*\]" />
+					<property name="pattern" value="All attributes removed for Facility:\[.*\]$" />
 					<property name="handlerMethodName" value="processAllAttributesRemoved" />
 				</bean>
 			</list>
@@ -269,7 +269,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Member</value>
 						</list>
 					</property>
-					<property name="pattern" value=" added to Group:\[(.|\s)*\]" />
+					<property name="pattern" value=" added to Group:\[.*\]$" />
 					<property name="handlerMethodName" value="processMemberAdded" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -289,7 +289,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Member</value>
 						</list>
 					</property>
-					<property name="pattern" value=" was removed from Group:\[(.*)\] totally" />
+					<property name="pattern" value=" was removed from Group:\[.*\] totally$" />
 					<property name="handlerMethodName" value="processMemberRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -308,7 +308,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Group</value>
 						</list>
 					</property>
-					<property name="pattern" value=" created in Vo:\[(.|\s)*\] as subgroup of Group:\[(.|\s)*\]" />
+					<property name="pattern" value=" created in Vo:\[.*\] as subgroup of Group:\[.*\]$" />
 					<property name="handlerMethodName" value="processSubgroupAdded" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -318,7 +318,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Resource</value>
 						</list>
 					</property>
-					<property name="pattern" value="Group:\[(.|\s)*\] assigned to Resource:\[(.|\s)*\]" />
+					<property name="pattern" value="Group:\[.*\] assigned to Resource:\[.*\]$" />
 					<property name="handlerMethodName" value="processResourceAssigned" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -328,7 +328,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Resource</value>
 						</list>
 					</property>
-					<property name="pattern" value="Group:\[(.|\s)*\] removed from Resource:\[(.|\s)*\]" />
+					<property name="pattern" value="Group:\[.*\] removed from Resource:\[.*\]$" />
 					<property name="handlerMethodName" value="processResourceRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -337,7 +337,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Group</value>
 						</list>
 					</property>
-					<property name="pattern" value="Group:\[(.|\s)*\] was moved" />
+					<property name="pattern" value="Group:\[.*\] was moved$" />
 					<property name="handlerMethodName" value="processGroupMoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">

--- a/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
@@ -177,7 +177,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Attribute</value>
 						</list>
 					</property>
-					<property name="pattern" value=" set for User:\[.*\]$" />
+					<property name="pattern" value=" set for User:\[.*\]" />
 					<property name="handlerMethodName" value="processAttributeSet" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -187,7 +187,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.AttributeDefinition</value>
 						</list>
 					</property>
-					<property name="pattern" value=" removed for User:\[.*\]$" />
+					<property name="pattern" value=" removed for User:\[.*\]" />
 					<property name="handlerMethodName" value="processAttributeRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -196,7 +196,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.User</value>
 						</list>
 					</property>
-					<property name="pattern" value="All attributes removed for User:\[.*\]$" />
+					<property name="pattern" value="All attributes removed for User:\[.*\]" />
 					<property name="handlerMethodName" value="processAllAttributesRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -206,7 +206,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.UserExtSource</value>
 						</list>
 					</property>
-					<property name="pattern" value="UserExtSource:\[.*\] added to User:\[.*\]$" />
+					<property name="pattern" value="UserExtSource:\[.*\] added to User:\[.*\]" />
 					<property name="handlerMethodName" value="processExtSourceAdded" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -216,7 +216,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.UserExtSource</value>
 						</list>
 					</property>
-					<property name="pattern" value="UserExtSource:\[.*\] removed from User:\[.*\]$" />
+					<property name="pattern" value="UserExtSource:\[.*\] removed from User:\[.*\]" />
 					<property name="handlerMethodName" value="processExtSourceRemoved" />
 				</bean>
 			</list>
@@ -233,7 +233,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Attribute</value>
 						</list>
 					</property>
-					<property name="pattern" value=" set for Facility:\[.*\]$" />
+					<property name="pattern" value=" set for Facility:\[.*\]" />
 					<property name="handlerMethodName" value="processAttributeSet" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -243,7 +243,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.AttributeDefinition</value>
 						</list>
 					</property>
-					<property name="pattern" value=" removed for Facility:\[.*\]$" />
+					<property name="pattern" value=" removed for Facility:\[.*\]" />
 					<property name="handlerMethodName" value="processAttributeRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -252,7 +252,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Facility</value>
 						</list>
 					</property>
-					<property name="pattern" value="All attributes removed for Facility:\[.*\]$" />
+					<property name="pattern" value="All attributes removed for Facility:\[.*\]" />
 					<property name="handlerMethodName" value="processAllAttributesRemoved" />
 				</bean>
 			</list>
@@ -269,7 +269,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Member</value>
 						</list>
 					</property>
-					<property name="pattern" value=" added to Group:\[.*\]$" />
+					<property name="pattern" value=" added to Group:\[.*\]" />
 					<property name="handlerMethodName" value="processMemberAdded" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -289,7 +289,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Member</value>
 						</list>
 					</property>
-					<property name="pattern" value=" was removed from Group:\[.*\] totally$" />
+					<property name="pattern" value=" was removed from Group:\[.*\] totally" />
 					<property name="handlerMethodName" value="processMemberRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -308,7 +308,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Group</value>
 						</list>
 					</property>
-					<property name="pattern" value=" created in Vo:\[.*\] as subgroup of Group:\[.*\]$" />
+					<property name="pattern" value=" created in Vo:\[.*\] as subgroup of Group:\[.*\]" />
 					<property name="handlerMethodName" value="processSubgroupAdded" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -318,7 +318,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Resource</value>
 						</list>
 					</property>
-					<property name="pattern" value="Group:\[.*\] assigned to Resource:\[.*\]$" />
+					<property name="pattern" value="Group:\[.*\] assigned to Resource:\[.*\]" />
 					<property name="handlerMethodName" value="processResourceAssigned" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -328,7 +328,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Resource</value>
 						</list>
 					</property>
-					<property name="pattern" value="Group:\[.*\] removed from Resource:\[.*\]$" />
+					<property name="pattern" value="Group:\[.*\] removed from Resource:\[.*\]" />
 					<property name="handlerMethodName" value="processResourceRemoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -337,7 +337,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Group</value>
 						</list>
 					</property>
-					<property name="pattern" value="Group:\[.*\] was moved$" />
+					<property name="pattern" value="Group:\[.*\] was moved" />
 					<property name="handlerMethodName" value="processGroupMoved" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">


### PR DESCRIPTION
fix regular expressions matching audit messages with exponential complexity
  - this caused apparent hangups of perun-ldapc-ada on longer audit messages
add $ to RE matching audit messages
do not throw exception when processing attribute not describe in LDAP defs
  - audit messages concerning attributes not reflected in LDAP are ignored just with log message