### PR TITLE
CORE: Allow Facility managers to read/write User attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -454,7 +454,12 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 				if (isAuthorized(sess, Role.GROUPADMIN, voElement)) return true;
 			}
 		}
-//			if (roles.containsKey(Role.FACILITYADMIN)) ; //Not allowed
+		if (roles.containsKey(Role.FACILITYADMIN)) {
+			List<Facility> facilities = perunBl.getFacilitiesManagerBl().getAssignedFacilities(sess, user);
+			for (Facility facility : facilities) {
+				if (isAuthorized(sess, Role.FACILITYADMIN, facility)) return true;
+			}
+		}
 
 		return false;
 	}


### PR DESCRIPTION
- Previously facility managers couldn't read or write any of user
  attributes.
- Now we allow facility manager to read and write User attributes if
  User is assigned to any facility of such manager and if attribute
  itself is set to allow facility manager role.