### PR TITLE
BASE,CORE: Auto-create namespaced attributes

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -74,6 +74,7 @@ public class CoreConfig {
 	private boolean mailDebug;
 	private String smtpUser;
 	private String smtpPass;
+	private List<String> autocreatedNamespaces;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -585,6 +586,14 @@ public class CoreConfig {
 
 	public void setSmtpPass(String smtpPass) {
 		this.smtpPass = smtpPass;
+	}
+
+	public List<String> getAutocreatedNamespaces() {
+		return autocreatedNamespaces;
+	}
+
+	public void setAutocreatedNamespaces(List<String> autocreatedNamespaces) {
+		this.autocreatedNamespaces = autocreatedNamespaces;
 	}
 
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -58,6 +58,7 @@
 		<property name="mailDebug" value="${mail.debug}" />
 		<property name="smtpUser" value="${perun.smtp.user}" />
 		<property name="smtpPass" value="${perun.smtp.pass}" />
+		<property name="autocreatedNamespaces" value="#{'${perun.autocreatedNamespaces}'.split('\s*,\s*')}" />
 	</bean>
 
 
@@ -141,6 +142,8 @@
 				<prop key="mail.debug">false</prop>
 				<prop key="perun.smtp.user"></prop>
 				<prop key="perun.smtp.pass"></prop>
+
+				<prop key="perun.autocreatedNamespaces"></prop>
 
 			</props>
 		</property>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -54,6 +54,7 @@ import cz.metacentrum.perun.core.api.AttributeRights;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.CoreConfig;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
@@ -6882,6 +6883,71 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 		rights = new ArrayList<>();
 		attributes.put(attr, rights);
+
+		// create namespaced attributes for each namespace
+		for (String namespace : BeansUtils.getCoreConfig().getAutocreatedNamespaces()) {
+
+			// skip if empty
+			if (namespace == null || namespace.isEmpty()) continue;
+
+			// login-namespace
+			attr = new AttributeDefinition();
+			attr.setNamespace(AttributesManager.NS_USER_ATTR_DEF);
+			attr.setType(String.class.getName());
+			attr.setFriendlyName("login-namespace:"+namespace);
+			attr.setDisplayName("Login in namespace: "+namespace);
+			attr.setDescription("Logname in namespace '"+namespace+"'.");
+
+			rights = new ArrayList<>();
+			rights.add(new AttributeRights(-1, Role.SELF, Collections.singletonList(ActionType.READ)));
+			rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+			rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+			rights.add(new AttributeRights(-1, Role.FACILITYADMIN, Collections.singletonList(ActionType.READ)));
+			attributes.put(attr, rights);
+
+			// pwd-reset templates
+
+			attr = new AttributeDefinition();
+			attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+			attr.setType(String.class.getName());
+			attr.setFriendlyName("nonAuthzPwdResetConfirmMailSubject:"+namespace);
+			attr.setDisplayName("Non-Authz Pwd Reset Confirmation Mail Subject");
+			attr.setDescription("Template of PWD reset confirmation mails subject.");
+
+			rights = new ArrayList<>();
+			attributes.put(attr, rights);
+
+			attr = new AttributeDefinition();
+			attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+			attr.setType("java.lang.LargeString");
+			attr.setFriendlyName("nonAuthzPwdResetConfirmMailTemplate:"+namespace);
+			attr.setDisplayName("Non-Authz Pwd Reset Confirmation Mail Template");
+			attr.setDescription("Template of confirmation message in password reset notification.");
+
+			rights = new ArrayList<>();
+			attributes.put(attr, rights);
+
+			attr = new AttributeDefinition();
+			attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+			attr.setType(String.class.getName());
+			attr.setFriendlyName("nonAuthzPwdResetMailSubject:"+namespace);
+			attr.setDisplayName("Non-Authz Pwd Reset Mail Subject");
+			attr.setDescription("Non authz password reset mail subject for "+namespace+".");
+
+			rights = new ArrayList<>();
+			attributes.put(attr, rights);
+
+			attr = new AttributeDefinition();
+			attr.setNamespace(AttributesManager.NS_ENTITYLESS_ATTR_DEF);
+			attr.setType("java.lang.LargeString");
+			attr.setFriendlyName("nonAuthzPwdResetMailTemplate:"+namespace);
+			attr.setDisplayName("Non-Authz Pwd Reset Mail Template");
+			attr.setDescription("Non authz password reset mail template for "+namespace+".");
+
+			rights = new ArrayList<>();
+			attributes.put(attr, rights);
+
+		}
 
 		if (perunBl.isPerunReadOnly()) log.debug("Loading attributes manager init in readOnly version.");
 


### PR DESCRIPTION
- Added configuration option with list of namespaced for which
  we auto-create necessary attributes.
- We create following attributes:
  user:def:login-namespace:[namespace]
  entityless:def:nonAuthzPwdResetConfirmMailSubject:[namespace]
  entityless:def:nonAuthzPwdResetConfirmMailTemplate:[namespace]
  entityless:def:nonAuthzPwdResetMailSubject:[namespace]
  entityless:def:nonAuthzPwdResetMailTemplate:[namespace]