### PR TITLE
CORE,GUI: Fixed adding new members to the group from candidates

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -34,6 +34,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.LoginNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
@@ -823,19 +824,23 @@ public class VosManagerBlImpl implements VosManagerBl {
 		// try to find member for MemberCandidates with not null RichUser
 		for (MemberCandidate memberCandidate : memberCandidates) {
 			if (memberCandidate.getRichUser() != null) {
+				Member member = null;
 				try {
-					Member member = getPerunBl().getMembersManagerBl().getMemberByUser(sess, vo, memberCandidate.getRichUser());
 
+					member = getPerunBl().getMembersManagerBl().getMemberByUser(sess, vo, memberCandidate.getRichUser());
 					if (group != null) {
-						// check if member is in group
-						if (getPerunBl().getGroupsManagerBl().isGroupMember(sess, group, member)) {
-							member.setSourceGroupId(group.getId());
-						}
+						member = getPerunBl().getGroupsManagerBl().getGroupMemberById(sess, group, member.getId());
 					}
-					memberCandidate.setMember(member);
+
 				} catch (MemberNotExistsException ignored) {
-					// no matching member was found
+					// no matching VO member was found
+				} catch (NotGroupMemberException e) {
+					// not matching Group member was found
 				}
+
+				// put null or matching member
+				memberCandidate.setMember(member);
+
 			}
 		}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/vosManager/GetCompleteCandidates.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/vosManager/GetCompleteCandidates.java
@@ -220,7 +220,12 @@ public class GetCompleteCandidates implements JsonCallback, JsonCallbackTable<Me
 				if (groupId == 0) {
 					if (candidate.getMember() != null) return "Member of VO";
 				} else {
-					if (candidate.getMember() != null && candidate.getMember().getSourceGroupId() != 0) return "Member of Group";
+					if (candidate.getMember() != null &&
+							candidate.getMember().getSourceGroupId() != 0 &&
+							"DIRECT".equalsIgnoreCase( candidate.getMember().getMembershipType())) return "Member of Group";
+					if (candidate.getMember() != null &&
+							candidate.getMember().getSourceGroupId() != 0 &&
+							"INDIRECT".equalsIgnoreCase( candidate.getMember().getMembershipType())) return "Indirect member of Group";
 					if (candidate.getMember() != null) return "Member of VO";
 				}
 				return "";

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunCheckboxCell.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/cells/PerunCheckboxCell.java
@@ -187,9 +187,12 @@ public class PerunCheckboxCell<T extends JavaScriptObject> extends AbstractEdita
 			}
 		}
 
-		// member candidate is member or member of group (faked as editable)
+		// member candidate is member of VO or member of Group (editable property is faked as "groupId == 0")
 		if (((GeneralObject)value).getObjectType().equalsIgnoreCase("MemberCandidate")) {
-			if(((MemberCandidate)value).getMember() != null && ((MemberCandidate)value).getMember().getSourceGroupId() != 0 && !editable){
+			if(((MemberCandidate)value).getMember() != null &&
+					(((MemberCandidate)value).getMember().getSourceGroupId() != 0 &&
+							((MemberCandidate)value).getMember().getMembershipType().equalsIgnoreCase("DIRECT"))
+					&& !editable){
 				sb.append(INPUT_DISABLED);
 				return;
 			} else if(((MemberCandidate)value).getMember() != null && editable){


### PR DESCRIPTION
- When member was indirect in the group, we couldn't add him as direct
  from GUI.
- Now we properly resolve group membership for each MemberCandidate on
  the server side and GUI properly detects direct and indirect
  membership types for disabling/enabling selection in table.