### PR TITLE
Group structure synchronization split

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -136,6 +136,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+
 /**
  * GroupsManager business logic
  *
@@ -1656,9 +1657,9 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		updateExistingGroupsWhileSynchronization(sess, baseGroup, groupsToUpdate, skippedGroups);
 		removeFormerGroupsWhileSynchronization(sess, baseGroup, groupsToRemove, skippedGroups);
 
-		log.info("Group structure synchronization {}: ended.", baseGroup);
+		setUpSynchronizationAttributesForAllSubGroups(sess, baseGroup, source);
 
-		synchronizeSubGroupsMembers(sess, baseGroup, source);
+		log.info("Group structure synchronization {}: ended.", baseGroup);
 
 		return skippedGroups;
 	}
@@ -3359,7 +3360,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	/**
-	 * Synchronize members for all subgroups of given base group
+	 * Set up attributes, which are necessary for members synchronization,for all subgroups of given base group.
 	 *
 	 * Method used by group structure synchronization
 	 *
@@ -3372,23 +3373,24 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	 * @throws WrongAttributeValueException
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	private void synchronizeSubGroupsMembers(PerunSession sess, Group baseGroup, ExtSource source) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
-		List<Group> groupsForMemberSynchronization = getAllSubGroups(sess, baseGroup);
+	private void setUpSynchronizationAttributesForAllSubGroups(PerunSession sess, Group baseGroup, ExtSource source) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		Attribute baseMembersQuery = getPerunBl().getAttributesManagerBl().getAttribute(sess, baseGroup, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 
-		Attribute membersQueryAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, baseGroup, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
-		Attribute baseMemberExtsource = getPerunBl().getAttributesManagerBl().getAttribute(sess, baseGroup, GroupsManager.GROUPMEMBERSEXTSOURCE_ATTRNAME);
-
-		if (membersQueryAttribute.getValue() == null) {
+		if (baseMembersQuery.getValue() == null) {
 			throw new WrongAttributeValueException("Group members query attribute is not set for base group " + baseGroup + "!");
 		}
 
-		//Order subGroups from (leaf groups are first)
-		groupsForMemberSynchronization.sort((g1, g2) -> {
-			int g1size = g1.getName().split(":").length;
-			int g2size = g2.getName().split(":").length;
+		Attribute membersQueryAttribute = new Attribute(getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME));
+		Attribute baseMemberExtsource = getPerunBl().getAttributesManagerBl().getAttribute(sess, baseGroup, GroupsManager.GROUPMEMBERSEXTSOURCE_ATTRNAME);
+		Attribute lightWeightSynchronization = getPerunBl().getAttributesManagerBl().getAttribute(sess, baseGroup, GroupsManager.GROUPLIGHTWEIGHTSYNCHRONIZATION_ATTRNAME);
+		Attribute synchronizationInterval = getPerunBl().getAttributesManagerBl().getAttribute(sess, baseGroup, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
+		Attribute extSourceNameAttr = new Attribute(getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPEXTSOURCE_ATTRNAME));
+		Attribute synchroEnabled = new Attribute(getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPSYNCHROENABLED_ATTRNAME));
 
-			return g1size - g2size;
-		});
+		extSourceNameAttr.setValue(source.getName());
+		synchroEnabled.setValue("true");
+
+		List<Group> groupsForMemberSynchronization = getAllSubGroups(sess, baseGroup);
 
 		//for each group set attributes for members synchronization, synchronize them and save the result
 		for (Group group: groupsForMemberSynchronization) {
@@ -3399,54 +3401,14 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				} catch (ExtSourceAlreadyAssignedException e) {
 					log.info("ExtSource already assigned to group: {}", group);
 				}
-				Attribute extSourceNameAttr = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPEXTSOURCE_ATTRNAME);
-				extSourceNameAttr.setValue(source.getName());
 				getPerunBl().getAttributesManagerBl().setAttribute(sess, group, extSourceNameAttr);
 			}
 
-			Attribute membersQueryForGroup = getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
-			membersQueryForGroup.setValue(membersQueryAttribute.getValue().toString().replace("?", group.getShortName()));
-			getPerunBl().getAttributesManagerBl().setAttribute(sess, group, membersQueryForGroup);
+			membersQueryAttribute.setValue(baseMembersQuery.getValue().toString().replace("?", group.getShortName()));
 
-			Attribute groupMemberExtsource = getPerunBl().getAttributesManagerBl().getAttribute(sess, baseGroup, GroupsManager.GROUPMEMBERSEXTSOURCE_ATTRNAME);
-			groupMemberExtsource.setValue(baseMemberExtsource.getValue());
-			getPerunBl().getAttributesManagerBl().setAttribute(sess, group, groupMemberExtsource);
-
-			synchronizeMembersAndSaveResult(sess, group);
+			getPerunBl().getAttributesManagerBl().setAttributes(sess, group, Arrays.asList(baseMemberExtsource, lightWeightSynchronization, synchronizationInterval, synchroEnabled, membersQueryAttribute));
 		}
 
-	}
-
-	/**
-	 * Synchronize members under group and save information about it
-	 *
-	 * Method used by group structure synchronization
-	 *
-	 * @param sess perun session
-	 * @param group under which will be members synchronized
-	 */
-	private void synchronizeMembersAndSaveResult(PerunSession sess, Group group) {
-		String exceptionMessage = null;
-		String skippedMembersMessage = null;
-		boolean failedDueToException = false;
-		try {
-			List<String> skippedMembers = perunBl.getGroupsManagerBl().synchronizeGroup(sess, group);
-			skippedMembersMessage = prepareSkippedObjectsMessage(skippedMembers, "members");
-			exceptionMessage = skippedMembersMessage;
-
-		} catch (Exception e) {
-			failedDueToException = true;
-			exceptionMessage = "Cannot synchronize group ";
-			log.error(exceptionMessage + group, e);
-			exceptionMessage += "due to exception: " + e.getClass().getName() + " => " + e.getMessage();
-		} finally {
-			try {
-				perunBl.getGroupsManagerBl().saveInformationAboutGroupSynchronizationInNestedTransaction(sess, group, failedDueToException, exceptionMessage);
-			} catch (Exception ex) {
-				log.error("When synchronization group " + group + ", exception was thrown.", ex);
-				log.info("Info about exception from synchronization: " + skippedMembersMessage);
-			}
-		}
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -69,6 +69,10 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 				if (requiredAttribute.getValue() == null) {
 					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
 				}
+				requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
+				if (requiredAttribute.getValue() == null) {
+					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
+				}
 			} catch (AttributeNotExistsException e) {
 				throw new ConsistencyErrorException(e);
 			}
@@ -82,6 +86,7 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 		dependencies.add(GroupsManager.GROUPSQUERY_ATTRNAME);
 		dependencies.add(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 		dependencies.add(GroupsManager.GROUPEXTSOURCE_ATTRNAME);
+		dependencies.add(GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
 		return dependencies;
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
@@ -38,11 +38,6 @@ public class urn_perun_group_attribute_def_def_synchronizationEnabled extends Gr
 		}
 			try {
 				if (attrValue.equals("true")) {
-
-					if(sess.getPerunBl().getGroupsManagerBl().isGroupInStructureSynchronizationTree(sess, group)) {
-						throw new InternalErrorException("There is already enabled group structure synchronization for this group or one of the parent groups.");
-					}
-
 					Attribute requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
 					if (requiredAttribute.getValue() == null) {
 						throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
@@ -112,13 +112,12 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup testGroup = new TestGroup("createdGroup", baseGroup.getShortName(), "group is child of base group");
 		List<Map<String, String>> subjects = Collections.singletonList(testGroup.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		// tested method
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
 		// asserts
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 
@@ -135,11 +134,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup testGroup = new TestGroup("createdGroup", null, "group without parent");
 		List<Map<String, String>> subjects = Collections.singletonList(testGroup.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 
@@ -156,11 +154,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup testGroup = new TestGroup("createdGroup", "nonExistingParent", "group's parent does not exist");
 		List<Map<String, String>> subjects = Collections.singletonList(testGroup.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 
@@ -178,11 +175,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup testGroupB = new TestGroup("groupB", baseGroup.getShortName(), "description of group B");
 		List<Map<String, String>> subjects = Arrays.asList(testGroupA.toMap(), testGroupB.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 
@@ -197,7 +193,6 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup testGroupB = new TestGroup("groupB", "groupA", "description of group B");
 		List<Map<String, String>> subjects = Arrays.asList(testGroupB.toMap(), testGroupA.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
@@ -225,13 +220,12 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup testGroup = new TestGroup("createdGroup", subGroup.getShortName(), "child of subgroup (baseGroup -> subGroup -> [this group])");
 		subjects.add(testGroup.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		// tested method
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
 		// assertions
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, subGroup);
 
@@ -255,11 +249,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		List<Map<String, String>> complexGroupTree = makeComplexGroupTreeSample(childOfBaseGroup.getShortName());
 		subjects.addAll(complexGroupTree);
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		// assert structure
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
@@ -283,11 +276,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 
 		List<Map<String, String>> subjects = new ArrayList<>();
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 
@@ -308,13 +300,12 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup subBaseTestGroup = new TestGroup("subGroup", baseGroup.getShortName(), "child of base group");
 		List<Map<String, String>> subjects = Collections.singletonList(subBaseTestGroup.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		// tested method
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
 		// asserts
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 
@@ -339,11 +330,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup leafTestGroup = new TestGroup("leafGroup", subBaseGroup.getShortName(), "leaf group");
 		List<Map<String, String>> subjects = Arrays.asList(subBaseTestGroup.toMap(), leafTestGroup.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 
@@ -370,11 +360,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup modifiedSubBaseTestGroup = new TestGroup("modified", baseGroup.getShortName(), "child of base group");
 		List<Map<String, String>> subjects = Collections.singletonList(modifiedSubBaseTestGroup.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 		assertTrue("Base group should have exactly one child!", 1 == subGroups.size());
@@ -392,11 +381,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup modifiedSubBaseTestGroup = new TestGroup("group1", baseGroup.getShortName(), "modified");
 		List<Map<String, String>> subjects = Collections.singletonList(modifiedSubBaseTestGroup.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 		assertTrue("Base group should have exactly one child!", 1 == subGroups.size());
@@ -418,11 +406,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		final TestGroup testGroupB = new TestGroup("groupB", groupA.getShortName(), "group B");
 		List<Map<String, String>> subjects = Arrays.asList(testGroupA.toMap(), testGroupB.toMap());
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 		assertTrue("Base group should have exactly one child!",1 == subGroups.size());
@@ -450,11 +437,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 
 		List<Map<String, String>> subjects = new ArrayList<>();
 		when(essa.getSubjectGroups(anyMap())).thenReturn(subjects);
-		when(essa.getGroupSubjects(anyMap())).thenReturn(Collections.emptyList());
 
 		List<String> skipped = groupsManagerBl.synchronizeGroupStructure(sess, baseGroup);
 
-		assertTrue("No users should be skipped!", skipped.isEmpty());
+		assertTrue("No groups should be skipped!", skipped.isEmpty());
 
 		List<Group> subGroups = groupsManagerBl.getSubGroups(sess, baseGroup);
 
@@ -487,6 +473,10 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		Attribute membersQuery = new Attribute(((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME));
 		membersQuery.setValue("SELECT * from members where groupName='?';");
 		attributesManagerBl.setAttribute(sess, baseGroup, membersQuery);
+
+		Attribute interval = new Attribute(((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME));
+		interval.setValue("1");
+		attributesManagerBl.setAttribute(sess, baseGroup, interval);
 
 		// create test Group in database
 		assertNotNull("unable to create testing Group",returnedGroup);


### PR DESCRIPTION
Members synchronization is not part of the structure synchronization
anymore. Structure synchronization just sets up members synchronization
attributes instead of that. Synchronization of members is then run
separately.