### PR TITLE
Fixed javadoc for sendPasswordResetLinkEmail

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1097,9 +1097,9 @@ public interface MembersManager {
 	 *
 	 * @param sess PerunSession
 	 * @param member Member to get user to send link mail to
-	 * @param namespace namespace to change password in (member must have login in)
+	 * @param namespace namespace to change password in (member must have login in it)
 	 * @param url base URL of Perun instance
-	 * @param mailAttributeUrn urn of the auttribute with stored mail
+	 * @param mailAttributeUrn urn of the attribute with stored mail
 	 * @param language language of the message
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException If not VO admin of member

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -1246,8 +1246,9 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Correct authz information is stored in link's URL.
 	 *
 	 * @param member int Member to get user to send link mail to
-	 * @param namespace String Namespace to change password in (member must have login in)
-	 * @param url String Base URL of Perun instance
+	 * @param namespace String Namespace to change password in (member must have login in it)
+	 * @param emailAttributeURN urn of the attribute with stored mail
+	 * @param language language of the message
 	 */
 	sendPasswordResetLinkEmail {
 		@Override


### PR DESCRIPTION
Javadoc for RPC contained different parameters then are used and
required.
Fixed typos in javadoc.