### PR TITLE
Add new method to get rich groups by resource and member

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -633,7 +633,10 @@ public interface GroupsManager {
 	 *
 	 * @param sess
 	 * @param resource resource to get assigned groups for
-	 * @param attrNames If empty, return all non-empty attributes. If not empty, return all selected attributes in allowed namespaces.
+	 * @param attrNames list of selected attribute names,
+	 *                  if it is null, return all possible non-empty attributes,
+	 *                  empty list in attrNames means - no attributes needed
+	 * @return list of RichGroup objects with specific attributes specified by object Resource and object Member.
 	 * @return
 	 * @throws InternalErrorException
 	 * @throws ResourceNotExistsException
@@ -651,10 +654,10 @@ public interface GroupsManager {
 	 * @param sess
 	 * @param member member used for filtering returned groups (groups have to contain this member to be returned)
 	 * @param resource resource to get assigned groups for
-	 * @param attrNames If empty, return all non-empty attributes. If not empty, return all selected attributes in allowed namespaces.
-	 *
+	 * @param attrNames list of selected attribute names,
+	 *                  if it is null, return all possible non-empty attributes,
+	 *                  empty list in attrNames means - no attributes needed
 	 * @return list of RichGroup objects with specific attributes specified by object Resource and object Member
-	 *
 	 * @throws InternalErrorException
 	 * @throws MemberNotExistsException
 	 * @throws ResourceNotExistsException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -642,6 +642,27 @@ public interface GroupsManager {
 	List<RichGroup> getRichGroupsAssignedToResourceWithAttributesByNames(PerunSession sess, Resource resource, List<String> attrNames) throws InternalErrorException, ResourceNotExistsException, PrivilegeException;
 
 	/**
+	 * Get list of all richGroups with selected attributes assigned to the resource filtered by specific member.
+	 * Allowed namespaces of attributes are group, group-resource, member-group
+	 *
+	 * Last step is filtration of attributes:
+	 * Attributes are filtered by rights of user in session. User get only those selected attributes he has rights to read.
+	 *
+	 * @param sess
+	 * @param member member used for filtering returned groups (groups have to contain this member to be returned)
+	 * @param resource resource to get assigned groups for
+	 * @param attrNames If empty, return all non-empty attributes. If not empty, return all selected attributes in allowed namespaces.
+	 *
+	 * @return list of RichGroup objects with specific attributes specified by object Resource and object Member
+	 *
+	 * @throws InternalErrorException
+	 * @throws MemberNotExistsException
+	 * @throws ResourceNotExistsException
+	 * @throws PrivilegeException
+	 */
+	List<RichGroup> getRichGroupsAssignedToResourceWithAttributesByNames(PerunSession sess, Member member, Resource resource, List<String> attrNames) throws InternalErrorException, ResourceNotExistsException, PrivilegeException, MemberNotExistsException;
+
+	/**
 	 * Gets list of all user administrators of this group.
 	 * If some group is administrator of the given group, all members are included in the list.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -36,6 +36,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.GroupStructureSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.GroupSynchronizationAlreadyRunningException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
 import cz.metacentrum.perun.core.api.exceptions.ParentGroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
@@ -1188,6 +1189,27 @@ public interface GroupsManagerBl {
 	List<RichGroup> filterOnlyAllowedAttributes(PerunSession sess, List<RichGroup> richGroups, Resource resource, boolean useContext) throws InternalErrorException;
 
 	/**
+	 * For list of richGroups filter all their group attributes and remove all which principal has no access to.
+	 * Context usage is safe even for groups from different VOs.
+	 *
+	 * Context means same "combination of authz role for a group"+"attribute_urn (name)". Since privileges are resolved by roles on group and attribute type.
+	 *
+	 * if useContext is true: every attribute is unique in a context of authz roles combination and its URN. So for each combination of
+	 * users authz roles granted for the group, attributes with same URN has same privilege.
+	 *
+	 * if useContext is false: every attribute is unique in context of group, which means every attribute for more groups need to be check separately,
+	 * because for example groups can be from different vos where user has different authz (better authorization check, worse performance)
+	 *
+	 * @param sess
+	 * @param richGroups
+	 * @param member optional member param used for context
+	 * @param resource optional resource param used for context
+	 * @return list of RichGroups with only allowed attributes
+	 * @throws InternalErrorException
+	 */
+	List<RichGroup> filterOnlyAllowedAttributes(PerunSession sess, List<RichGroup> richGroups, Member member, Resource resource, boolean useContext) throws InternalErrorException;
+
+	/**
 	 * This method takes group and creates RichGroup containing all attributes
 	 *
 	 * @param sess
@@ -1257,6 +1279,24 @@ public interface GroupsManagerBl {
 	List<RichGroup> convertGroupsToRichGroupsWithAttributes(PerunSession sess, Resource resource, List<Group> groups, List<String> attrNames) throws InternalErrorException, GroupResourceMismatchException;
 
 	/**
+	 * This method takes list of groups, resource, member and list of attrNames and then creates list of RichGroups containing
+	 * all selected group, group-resource and member-group attributes filtered by list (attributes from other
+	 * namespaces are skipped without any warning).
+	 * If attribute with correct namespace is in the list, it will be return even with empty value (if no value exists).
+	 *
+	 * @param sess
+	 * @param member member to get member-resource and member-group attributes for
+	 * @param resource resource to get group-resource and member-resource attributes for
+	 * @param groups to convert to richGroups and get group-resource and member-group attributes for
+	 * @param attrNames list of selected attributes (even with empty values), if it is empty, return all possible non-empty attributes
+	 * @return list of RichGroups with selected attributes
+	 * @throws InternalErrorException
+	 * @throws GroupResourceMismatchException if group is not assigned to resource
+	 * @throws MemberResourceMismatchException if member is not assigned to group
+	 */
+	List<RichGroup> convertGroupsToRichGroupsWithAttributes(PerunSession sess, Member member, Resource resource, List<Group> groups, List<String> attrNames) throws InternalErrorException, GroupResourceMismatchException, MemberResourceMismatchException;
+
+	/**
 	 * Get all RichGroups with selected attributes assigned to the resource.
 	 *
 	 * @param sess
@@ -1266,6 +1306,24 @@ public interface GroupsManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<RichGroup> getRichGroupsWithAttributesAssignedToResource(PerunSession sess, Resource resource, List<String> attrNames) throws InternalErrorException;
+
+	/**
+	 * Get list of all richGroups with selected attributes assigned to the resource filtered by specific member.
+	 * Allowed namespaces of attributes are group, group-resource, member-group and member-resource.
+	 *
+	 * Last step is filtration of attributes:
+	 * Attributes are filtered by rights of user in session. User get only those selected attributes he has rights to read.
+	 *
+	 * @param sess
+	 * @param member member used for filtering returned groups (groups have to contain this member to be returned)
+	 * @param resource resource to get assigned groups for
+	 * @param attrNames If empty, return all non-empty attributes. If not empty, return all selected attributes in allowed namespaces.
+	 *
+	 * @return list of RichGroup objects with specific attributes specified by object Resource and object Member
+	 *
+	 * @throws InternalErrorException
+	 */
+	List<RichGroup> getRichGroupsWithAttributesAssignedToResource(PerunSession sess, Member member, Resource resource, List<String> attrNames) throws InternalErrorException;
 
 	/**
 	 * Return all RichGroups for specified member, containing selected attributes.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -1271,7 +1271,9 @@ public interface GroupsManagerBl {
 	 * @param sess
 	 * @param resource
 	 * @param groups
-	 * @param attrNames list of selected attributes (even with empty values), if it is empty, return all possible non-empty attributes
+	 * @param attrNames list of selected attribute names,
+	 *                  if it is null, return all possible non-empty attributes,
+	 *                  empty list in attrNames means - no attributes needed
 	 * @return list of RichGroups with selected attributes
 	 * @throws InternalErrorException
 	 * @throws GroupResourceMismatchException
@@ -1288,7 +1290,9 @@ public interface GroupsManagerBl {
 	 * @param member member to get member-resource and member-group attributes for
 	 * @param resource resource to get group-resource and member-resource attributes for
 	 * @param groups to convert to richGroups and get group-resource and member-group attributes for
-	 * @param attrNames list of selected attributes (even with empty values), if it is empty, return all possible non-empty attributes
+	 * @param attrNames list of selected attribute names,
+	 *                  if it is null, return all possible non-empty attributes,
+	 *                  empty list in attrNames means - no attributes needed
 	 * @return list of RichGroups with selected attributes
 	 * @throws InternalErrorException
 	 * @throws GroupResourceMismatchException if group is not assigned to resource
@@ -1301,7 +1305,9 @@ public interface GroupsManagerBl {
 	 *
 	 * @param sess
 	 * @param resource the resource to get assigned groups from it
-	 * @param attrNames list of selected attributes (even with empty values), if it is empty, return all possible non-empty attributes
+	 * @param attrNames list of selected attribute names,
+	 *                  if it is null, return all possible non-empty attributes,
+	 *                  empty list in attrNames means - no attributes needed
 	 * @return list of RichGroups with selected attributes assigned to the resource
 	 * @throws InternalErrorException
 	 */
@@ -1317,10 +1323,10 @@ public interface GroupsManagerBl {
 	 * @param sess
 	 * @param member member used for filtering returned groups (groups have to contain this member to be returned)
 	 * @param resource resource to get assigned groups for
-	 * @param attrNames If empty, return all non-empty attributes. If not empty, return all selected attributes in allowed namespaces.
-	 *
+	 * @param attrNames list of selected attribute names,
+	 *                  if it is null, return all possible non-empty attributes,
+	 *                  empty list in attrNames means - no attributes needed
 	 * @return list of RichGroup objects with specific attributes specified by object Resource and object Member
-	 *
 	 * @throws InternalErrorException
 	 */
 	List<RichGroup> getRichGroupsWithAttributesAssignedToResource(PerunSession sess, Member member, Resource resource, List<String> attrNames) throws InternalErrorException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1202,6 +1202,25 @@ public class GroupsManagerEntry implements GroupsManager {
 		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, resource, true);
 	}
 
+	@Override
+	public List<RichGroup> getRichGroupsAssignedToResourceWithAttributesByNames(PerunSession sess, Member member, Resource resource, List<String> attrNames) throws InternalErrorException, ResourceNotExistsException, PrivilegeException, MemberNotExistsException {
+		Utils.checkPerunSession(sess);
+		this.getPerunBl().getResourcesManagerBl().checkResourceExists(sess, resource);
+		this.getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);
+
+		Facility facility = getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, resource) &&
+			!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, resource) &&
+			!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+			throw new PrivilegeException(sess, "getRichGroupsAssignedToResourceWithAttributesByNames");
+		}
+
+		List<RichGroup> richGroups = getGroupsManagerBl().getRichGroupsWithAttributesAssignedToResource(sess, member, resource, attrNames);
+
+		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, member, resource, true);
+	}
+
 	public List<RichGroup> getMemberRichGroupsWithAttributesByNames(PerunSession sess, Member member, List<String> attrNames) throws InternalErrorException, MemberNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		this.getPerunBl().getMembersManagerBl().checkMemberExists(sess, member);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -684,6 +684,20 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 	/*#
 	 **
+	 * Get list of all richGroups with selected attributes assigned to the resource filtered by specific member.
+	 * Allowed namespaces of attributes are group, group-resource and member-group.
+	 *
+	 * Last step is filtration of attributes:
+	 * Attributes are filtered by rights of user in session. User get only those selected attributes he has rights to read.
+	 *
+	 * @param member int Member <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @param attrNames List<String> names of attributes
+	 * @return List<RichGroup> groups with attributes
+	 *
+	 */
+	/*#
+	 **
 	 * Get list of all richGroups with selected attributes assigned to resource.
 	 * Allowed namespaces of attributes are group and group-resource.
 	 *
@@ -699,9 +713,17 @@ public enum GroupsManagerMethod implements ManagerMethod {
 
 		@Override
 		public List<RichGroup> call(ApiCaller ac, Deserializer parms) throws PerunException {
-			return ac.getGroupsManager().getRichGroupsAssignedToResourceWithAttributesByNames(ac.getSession(),
+
+			if(parms.contains("member")) {
+				return ac.getGroupsManager().getRichGroupsAssignedToResourceWithAttributesByNames(ac.getSession(),
+					ac.getMemberById(parms.readInt("member")),
 					ac.getResourceById(parms.readInt("resource")),
 					parms.readList("attrNames", String.class));
+			} else {
+				return ac.getGroupsManager().getRichGroupsAssignedToResourceWithAttributesByNames(ac.getSession(),
+					ac.getResourceById(parms.readInt("resource")),
+					parms.readList("attrNames", String.class));
+			}
 		}
 	},
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -683,46 +683,65 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 **
+	 *
+	 * Get list of all richGroups with all attributes assigned to the resource filtered by specific member.
+	 * Allowed namespaces of attributes are group, group-resource and member-group.
+	 *
+	 * @param member int Member <code>id</code>
+	 * @param resource int Resource <code>id</code>
+	 * @return List<RichGroup> groups with all group, group-resource and member-group attributes (non-empty)
+	 */
+	/*#
+	 *
 	 * Get list of all richGroups with selected attributes assigned to the resource filtered by specific member.
 	 * Allowed namespaces of attributes are group, group-resource and member-group.
 	 *
-	 * Last step is filtration of attributes:
-	 * Attributes are filtered by rights of user in session. User get only those selected attributes he has rights to read.
+	 * You will get only attributes which you are authorized to read. You must specify names of requested attributes
+	 * by their URNs in attrNames. Empty list means no attributes to return.
 	 *
 	 * @param member int Member <code>id</code>
 	 * @param resource int Resource <code>id</code>
 	 * @param attrNames List<String> names of attributes
 	 * @return List<RichGroup> groups with attributes
-	 *
 	 */
 	/*#
-	 **
+	 *
+	 * Get list of all richGroups with all attributes assigned to resource.
+	 * Allowed namespaces of attributes are group and group-resource.
+	 *
+	 * @param resource int Resource <code>id</code>
+	 * @return List<RichGroup> groups with all group and group-resource attributes (non-empty)
+	 */
+	/*#
+	 *
 	 * Get list of all richGroups with selected attributes assigned to resource.
 	 * Allowed namespaces of attributes are group and group-resource.
 	 *
-	 * Last step is filtration of attributes:
-	 * Attributes are filtered by rights of user in session. User get only those selected attributes he has rights to read.
+	 * You will get only attributes which you are authorized to read. You must specify names of requested attributes
+	 * by their URNs in attrNames.
 	 *
 	 * @param resource int Resource <code>id</code>
 	 * @param attrNames List<String> names of attributes
 	 * @return List<RichGroup> groups with attributes
-	 *
 	 */
 	getRichGroupsAssignedToResourceWithAttributesByNames {
 
 		@Override
 		public List<RichGroup> call(ApiCaller ac, Deserializer parms) throws PerunException {
+			List<String> attrNames = null;
+			if(parms.contains("attrNames")) {
+				attrNames = parms.readList("attrNames", String.class);
+			}
 
 			if(parms.contains("member")) {
 				return ac.getGroupsManager().getRichGroupsAssignedToResourceWithAttributesByNames(ac.getSession(),
 					ac.getMemberById(parms.readInt("member")),
 					ac.getResourceById(parms.readInt("resource")),
-					parms.readList("attrNames", String.class));
+					attrNames);
 			} else {
 				return ac.getGroupsManager().getRichGroupsAssignedToResourceWithAttributesByNames(ac.getSession(),
 					ac.getResourceById(parms.readInt("resource")),
-					parms.readList("attrNames", String.class));
+					attrNames);
 			}
 		}
 	},


### PR DESCRIPTION
 - we already have method to get richGroups with attributes by object
 Resource (assigned to the group) but we also want to filter these
 groups by specific member (return groups where member has membership,
 remove others from the list). For this reason, new method with also
 Member object in the parameters was added.
 - add this new method to RPC, Entry layer and BL layer
 - add test for this new method
 - as side effect, method filterOnlyAllowedAttributes now also can
 filter member-group attributes. There are also small changes in the
 names of variable and order of processing this filtering method, but
 these changes are only cosmetic.