### PR TITLE
CORE: Support resolving value change in user:virt:loa attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -618,14 +618,15 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	@Override
 	public UserExtSource updateUserExtSource(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException, UserExtSourceExistsException {
+		UserExtSource updatedUes = getUsersManagerImpl().updateUserExtSource(sess, userExtSource);
 		getPerunBl().getAuditer().log(sess, new UserExtSourceUpdated(userExtSource));
-		return getUsersManagerImpl().updateUserExtSource(sess, userExtSource);
+		return updatedUes;
 	}
 
 	@Override
 	public void updateUserExtSourceLastAccess(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException {
-		getPerunBl().getAuditer().log(sess, new UserExtSourceUpdated(userExtSource));
 		getUsersManagerImpl().updateUserExtSourceLastAccess(sess, userExtSource);
+		getPerunBl().getAuditer().log(sess, new UserExtSourceUpdated(userExtSource));
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -624,6 +624,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	@Override
 	public void updateUserExtSourceLastAccess(PerunSession sess, UserExtSource userExtSource) throws InternalErrorException {
+		getPerunBl().getAuditer().log(sess, new UserExtSourceUpdated(userExtSource));
 		getUsersManagerImpl().updateUserExtSourceLastAccess(sess, userExtSource);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
@@ -1,16 +1,27 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForUser;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUser;
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceAddedToUser;
+import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceRemovedFromUser;
+import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceUpdated;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -21,6 +32,8 @@ import java.util.List;
  * @author Pavel Vyskocil vyskocilpavel@muni.cz
  */
 public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributesModuleAbstract implements UserVirtualAttributesModuleImplApi {
+
+	private static final String A_U_V_LOA = AttributesManager.NS_USER_ATTR_VIRT + ":" + "loa";
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
@@ -49,6 +62,53 @@ public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributes
 		attr.setType(String.class.getName());
 		attr.setDescription("The highest value of LoA from all user's userExtSources.");
 		return attr;
+	}
+
+	@Override
+	public List<AuditEvent> resolveVirtualAttributeValueChange(PerunSessionImpl sess, AuditEvent message) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+
+		List<AuditEvent> resolvingMessages = new ArrayList<>();
+		if (message == null) return resolvingMessages;
+
+		if (message instanceof UserExtSourceAddedToUser) {
+			resolvingMessages.addAll(resolveEvent(sess, ((UserExtSourceAddedToUser) message).getUser()));
+		} else if (message instanceof UserExtSourceRemovedFromUser) {
+			resolvingMessages.addAll(resolveEvent(sess, ((UserExtSourceRemovedFromUser) message).getUser()));
+		} else if (message instanceof UserExtSourceUpdated) {
+			try {
+				resolvingMessages.addAll(resolveEvent(sess, sess.getPerunBl().getUsersManagerBl().getUserById(
+						sess, ((UserExtSourceUpdated) message).getUserExtSource().getUserId())));
+			} catch (UserNotExistsException e) {
+				throw new ConsistencyErrorException("User associated with updated UserExtSource no longer exists while resolving virtual attribute value change.", e);
+			}
+		}
+		return resolvingMessages;
+
+	}
+
+	/**
+	 * Resolve and create new auditer messages about LOA attribute change based on current attribute value.
+	 *
+	 * @param sess PerunSession
+	 * @param user User to resolve LoA messages
+	 * @return List of new messages or empty list
+	 * @throws InternalErrorException
+	 * @throws AttributeNotExistsException
+	 * @throws WrongAttributeAssignmentException
+	 */
+	private List<AuditEvent> resolveEvent(PerunSessionImpl sess, User user) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+
+		List<AuditEvent> resolvingMessages = new ArrayList<>();
+		Attribute attribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_U_V_LOA);
+
+		if (attribute.getValue() == null) {
+			resolvingMessages.add(new AttributeRemovedForUser(new AttributeDefinition(attribute),user));
+		} else {
+			resolvingMessages.add(new AttributeSetForUser(attribute,user));
+		}
+
+		return resolvingMessages;
+
 	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
@@ -71,12 +71,12 @@ public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributes
 		if (message == null) return resolvingMessages;
 
 		if (message instanceof UserExtSourceAddedToUser) {
-			resolvingMessages.addAll(resolveEvent(sess, ((UserExtSourceAddedToUser) message).getUser()));
+			resolvingMessages.add(resolveEvent(sess, ((UserExtSourceAddedToUser) message).getUser()));
 		} else if (message instanceof UserExtSourceRemovedFromUser) {
-			resolvingMessages.addAll(resolveEvent(sess, ((UserExtSourceRemovedFromUser) message).getUser()));
+			resolvingMessages.add(resolveEvent(sess, ((UserExtSourceRemovedFromUser) message).getUser()));
 		} else if (message instanceof UserExtSourceUpdated) {
 			try {
-				resolvingMessages.addAll(resolveEvent(sess, sess.getPerunBl().getUsersManagerBl().getUserById(
+				resolvingMessages.add(resolveEvent(sess, sess.getPerunBl().getUsersManagerBl().getUserById(
 						sess, ((UserExtSourceUpdated) message).getUserExtSource().getUserId())));
 			} catch (UserNotExistsException e) {
 				throw new ConsistencyErrorException("User associated with updated UserExtSource no longer exists while resolving virtual attribute value change.", e);
@@ -87,7 +87,7 @@ public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributes
 	}
 
 	/**
-	 * Resolve and create new auditer messages about LOA attribute change based on current attribute value.
+	 * Resolve and create new auditer message about LOA attribute change based on current attribute value.
 	 *
 	 * @param sess PerunSession
 	 * @param user User to resolve LoA messages
@@ -96,18 +96,15 @@ public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributes
 	 * @throws AttributeNotExistsException
 	 * @throws WrongAttributeAssignmentException
 	 */
-	private List<AuditEvent> resolveEvent(PerunSessionImpl sess, User user) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private AuditEvent resolveEvent(PerunSessionImpl sess, User user) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
 		Attribute attribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_U_V_LOA);
 
 		if (attribute.getValue() == null) {
-			resolvingMessages.add(new AttributeRemovedForUser(new AttributeDefinition(attribute),user));
+			return new AttributeRemovedForUser(new AttributeDefinition(attribute),user);
 		} else {
-			resolvingMessages.add(new AttributeSetForUser(attribute,user));
+			return new AttributeSetForUser(attribute,user);
 		}
-
-		return resolvingMessages;
 
 	}
 


### PR DESCRIPTION
- Since we will push user:virt:loa attribute to the LDAP, we must
  resolve its value changes from other auditer messages
  (changes to the user ext source).
- Update of lastSeen timestamp for UserExtSource must also emit
  UserExtSourceUpdated auditer message, since attribute module takes
  value only from UESes user used in a last year.