### PR TITLE
GUI: Close button on overlay tabs call inner closeTab()

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/PageNotFoundTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/PageNotFoundTabItem.java
@@ -31,6 +31,16 @@ public class PageNotFoundTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/TabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/TabItem.java
@@ -76,4 +76,17 @@ public interface TabItem{
 	 */
 	public boolean isPrepared();
 
+	/**
+	 * Whether tab should refresh parent on close. This is just a hint, it can be overridden in
+	 * button action implementation (like events to close tab on action finish, where refreshing parent is default).
+	 *
+	 * @return TRUE refresh / FALSE dont refresh
+	 */
+	public boolean isRefreshParentOnClose();
+
+	/**
+	 * Performs tab specific action on closing
+	 */
+	public void onClose();
+
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionDetailTabItem.java
@@ -86,6 +86,16 @@ public class AttributeDefinitionDetailTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(def.getName());
@@ -307,7 +317,7 @@ public class AttributeDefinitionDetailTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/AttributeDefinitionsTabItem.java
@@ -67,6 +67,16 @@ public class AttributeDefinitionsTabItem implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// create main panel for content

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/CreateAttributeDefinitionTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/CreateAttributeDefinitionTabItem.java
@@ -3,7 +3,6 @@ package cz.metacentrum.perun.webgui.tabs.attributestabs;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
@@ -73,6 +72,16 @@ public class CreateAttributeDefinitionTabItem implements TabItem {
 
 	public boolean isPrepared(){
 		return true;
+	}
+
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
 	}
 
 	public Widget draw() {
@@ -260,7 +269,7 @@ public class CreateAttributeDefinitionTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/SetNewAttributeTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/attributestabs/SetNewAttributeTabItem.java
@@ -81,6 +81,16 @@ public class SetNewAttributeTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel mainTab = new VerticalPanel();
@@ -340,7 +350,7 @@ public class SetNewAttributeTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 		menu.addWidget(helper);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AddAuthorTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AddAuthorTabItem.java
@@ -100,6 +100,17 @@ public class AddAuthorTabItem implements TabItem, TabItemWithUrl {
 		return !(publication == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+		// trigger refresh of sub-tab via event
+		if (events != null) events.onFinished(null);
+	}
+
 	public Widget draw() {
 
 
@@ -171,9 +182,7 @@ public class AddAuthorTabItem implements TabItem, TabItemWithUrl {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				// trigger refresh of sub-tab via event
-				events.onFinished(null);
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AddPublicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AddPublicationsTabItem.java
@@ -97,6 +97,16 @@ public class AddPublicationsTabItem implements TabItem, TabItemWithUrl, TabItemW
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		tab = this; // save this tab for reloading

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AllAuthorsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AllAuthorsTabItem.java
@@ -55,6 +55,16 @@ public class AllAuthorsTabItem implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 
 	public Widget draw() {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AllCategoriesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AllCategoriesTabItem.java
@@ -59,6 +59,16 @@ public class AllCategoriesTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AllPublicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/AllPublicationsTabItem.java
@@ -79,6 +79,16 @@ public class AllPublicationsTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/CreateCategoryTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/CreateCategoryTabItem.java
@@ -47,6 +47,16 @@ public class CreateCategoryTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		final VerticalPanel vp = new VerticalPanel();
@@ -112,7 +122,7 @@ public class CreateCategoryTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/CreateThanksTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/CreateThanksTabItem.java
@@ -100,6 +100,16 @@ public class CreateThanksTabItem implements TabItem, TabItemWithUrl{
 		return !(publication == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL
@@ -156,7 +166,7 @@ public class CreateThanksTabItem implements TabItem, TabItemWithUrl{
 			public void onClick(ClickEvent event) {
 				// trigger refresh of sub-tab via event
 				events.onFinished(null);
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/PublicationDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/PublicationDetailTabItem.java
@@ -102,6 +102,16 @@ public class PublicationDetailTabItem implements TabItem, TabItemWithUrl {
 		return !(publication == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// show only part of title

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/PublicationSystemsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/PublicationSystemsTabItem.java
@@ -46,6 +46,16 @@ public class PublicationSystemsTabItem implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// main panel

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/PublicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/PublicationsTabItem.java
@@ -58,6 +58,16 @@ public class PublicationsTabItem implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/UsersPublicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/cabinettabs/UsersPublicationsTabItem.java
@@ -103,6 +103,16 @@ public class UsersPublicationsTabItem implements TabItem, TabItemWithUrl{
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(user.getFullNameWithTitles().trim()) + ": Publications");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/entitylessattributestabs/EntitylessAttributeEditKeyTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/entitylessattributestabs/EntitylessAttributeEditKeyTabItem.java
@@ -258,6 +258,16 @@ public class EntitylessAttributeEditKeyTabItem implements TabItem, TabItemWithUr
 	}
 
 	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/entitylessattributestabs/EntitylessAttributesDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/entitylessattributestabs/EntitylessAttributesDetailTabItem.java
@@ -84,6 +84,16 @@ public class EntitylessAttributesDetailTabItem implements TabItem {
 	}
 
 	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
+	@Override
 	public Widget draw() {
 
 		titleWidget.setText(def.getName());
@@ -291,7 +301,7 @@ public class EntitylessAttributesDetailTabItem implements TabItem {
 		menu.addWidget(updateButton);
 
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", event ->
-			session.getTabManager().closeTab(tab, false)));
+			session.getTabManager().closeTab(tab, isRefreshParentOnClose())));
 
 		CustomButton showKeys = new CustomButton();
 		showKeys.setText("show keys");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityDestinationTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityDestinationTabItem.java
@@ -74,6 +74,16 @@ public class AddFacilityDestinationTabItem implements TabItem {
 		return (facility != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add destination");
@@ -351,7 +361,7 @@ public class AddFacilityDestinationTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerGroupTabItem.java
@@ -96,6 +96,16 @@ public class AddFacilityManagerGroupTabItem implements TabItem {
 		return facility != null;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+		if (refreshEvents != null) refreshEvents.onFinished(null);
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add manager group");
@@ -156,8 +166,8 @@ public class AddFacilityManagerGroupTabItem implements TabItem {
 		tabMenu.addWidget(1, TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				if (refreshEvents != null) refreshEvents.onFinished(null);
-				session.getTabManager().closeTab(tab, false);
+				//if (refreshEvents != null) refreshEvents.onFinished(null);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 
@@ -209,9 +219,7 @@ public class AddFacilityManagerGroupTabItem implements TabItem {
 						if (i == list.size() - 1) {
 							AddAdmin request = new AddAdmin(JsonCallbackEvents.disableButtonEvents(addButton, new JsonCallbackEvents(){
 								public void onFinished(JavaScriptObject jso) {
-									// close tab and refresh table
-									if (refreshEvents != null) refreshEvents.onFinished(null);
-									session.getTabManager().closeTab(tab, false);
+									session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 								}
 							}));
 							request.addFacilityAdminGroup(facility, list.get(i));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityManagerTabItem.java
@@ -91,6 +91,16 @@ public class AddFacilityManagerTabItem implements TabItem {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add manager");
@@ -172,7 +182,7 @@ public class AddFacilityManagerTabItem implements TabItem {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityOwnerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityOwnerTabItem.java
@@ -66,6 +66,16 @@ public class AddFacilityOwnerTabItem implements TabItem {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// TITLE
@@ -110,7 +120,7 @@ public class AddFacilityOwnerTabItem implements TabItem {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddHostsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddHostsTabItem.java
@@ -74,6 +74,16 @@ public class AddHostsTabItem implements TabItem {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(facility.getName())+": add hosts");
@@ -124,7 +134,7 @@ public class AddHostsTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AssignSecurityTeamTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AssignSecurityTeamTabItem.java
@@ -66,6 +66,16 @@ public class AssignSecurityTeamTabItem implements TabItem {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// TITLE
@@ -119,7 +129,7 @@ public class AssignSecurityTeamTabItem implements TabItem {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/CreateFacilityTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/CreateFacilityTabItem.java
@@ -126,6 +126,16 @@ public class CreateFacilityTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+		if (eventsOnClose != null) eventsOnClose.onFinished(null);
+	}
+
 	public Widget draw() {
 
 		final TabItemWithUrl tab = this;
@@ -235,7 +245,6 @@ public class CreateFacilityTabItem implements TabItem, TabItemWithUrl {
 					UiElements.generateAlert("Confirmation", "Do you really want to exit create facility wizard ?", new ClickHandler() {
 						@Override
 						public void onClick(ClickEvent clickEvent) {
-							eventsOnClose.onFinished(null);
 							session.getTabManager().closeTab(tab);
 						}
 					});
@@ -1369,7 +1378,6 @@ public class CreateFacilityTabItem implements TabItem, TabItemWithUrl {
 			finish.addClickHandler(new ClickHandler() {
 				@Override
 				public void onClick(ClickEvent clickEvent) {
-					eventsOnClose.onFinished(null);
 					session.getTabManager().closeTab(tab);
 				}
 			});

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/DestinationResultsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/DestinationResultsTabItem.java
@@ -122,6 +122,16 @@ public class DestinationResultsTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Tasks results: "+destination);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/EditFacilityDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/EditFacilityDetailsTabItem.java
@@ -64,6 +64,16 @@ public class EditFacilityDetailsTabItem implements TabItem {
 		return (facility != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget = new Label("Edit facility");
@@ -124,7 +134,7 @@ public class EditFacilityDetailsTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitiesPropagationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitiesPropagationsTabItem.java
@@ -69,6 +69,16 @@ public class FacilitiesPropagationsTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		mainrow = 0;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitiesSelectTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitiesSelectTabItem.java
@@ -61,6 +61,16 @@ public class FacilitiesSelectTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityAllowedGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityAllowedGroupsTabItem.java
@@ -91,6 +91,16 @@ public class FacilityAllowedGroupsTabItem implements TabItem, TabItemWithUrl {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// set title

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityBlacklistTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityBlacklistTabItem.java
@@ -70,6 +70,16 @@ public class FacilityBlacklistTabItem implements TabItem, TabItemWithUrl {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Creates a tab instance
 	 * @param facility

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityDestinationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityDestinationsTabItem.java
@@ -84,6 +84,16 @@ public class FacilityDestinationsTabItem implements TabItem, TabItemWithUrl{
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// set title

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityDetailTabItem.java
@@ -99,6 +99,16 @@ public class FacilityDetailTabItem implements TabItem, TabItemWithUrl{
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(facility.getName()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityHostsSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityHostsSettingsTabItem.java
@@ -86,6 +86,16 @@ public class FacilityHostsSettingsTabItem implements TabItem, TabItemWithUrl {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Creates a tab instance
 	 * @param facility

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityHostsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityHostsTabItem.java
@@ -78,6 +78,16 @@ public class FacilityHostsTabItem implements TabItem, TabItemWithUrl{
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Creates a tab instance
 	 * @param facility

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityManagersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityManagersTabItem.java
@@ -94,6 +94,16 @@ public class FacilityManagersTabItem implements TabItem, TabItemWithUrl{
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// set title

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityOwnersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityOwnersTabItem.java
@@ -82,6 +82,16 @@ public class FacilityOwnersTabItem implements TabItem, TabItemWithUrl{
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// TITLE

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityResourcesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityResourcesTabItem.java
@@ -85,6 +85,16 @@ public class FacilityResourcesTabItem implements TabItem, TabItemWithUrl{
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// set title

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitySecurityTeamsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitySecurityTeamsTabItem.java
@@ -72,6 +72,16 @@ public class FacilitySecurityTeamsTabItem implements TabItem, TabItemWithUrl {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Creates a tab instance
 	 * @param facility

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitySettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilitySettingsTabItem.java
@@ -111,6 +111,16 @@ public class FacilitySettingsTabItem implements TabItem, TabItemWithUrl {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public void hideServicesSwitch(boolean hide) {
 		this.hide = hide;
 		lastCheckBoxValue = !hide;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityStatusTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/FacilityStatusTabItem.java
@@ -86,6 +86,16 @@ public class FacilityStatusTabItem implements TabItem, TabItemWithUrl {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// title

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsForDestinationTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsForDestinationTabItem.java
@@ -158,6 +158,16 @@ public class TaskResultsForDestinationTabItem implements TabItem, TabItemWithUrl
 	}
 
 	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/TaskResultsTabItem.java
@@ -82,6 +82,16 @@ public class TaskResultsTabItem implements TabItem, TabItemWithUrl{
 		return !(task == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Tasks results: "+task.getService().getName());

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupExtSourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupExtSourceTabItem.java
@@ -67,7 +67,7 @@ public class AddGroupExtSourceTabItem implements TabItem, TabItemWithUrl{
 	/**
 	 * Creates a tab instance
 	 *
-	 * @param voId ID of Vo to have ext source added
+	 * @param groupId ID of Group to have ext source added
 	 */
 	public AddGroupExtSourceTabItem(int groupId){
 		this.groupId = groupId;
@@ -93,6 +93,16 @@ public class AddGroupExtSourceTabItem implements TabItem, TabItemWithUrl{
 
 	public boolean isPrepared(){
 		return !(group == null);
+	}
+
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
 	}
 
 	public Widget draw() {
@@ -169,7 +179,7 @@ public class AddGroupExtSourceTabItem implements TabItem, TabItemWithUrl{
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerGroupTabItem.java
@@ -95,6 +95,16 @@ public class AddGroupManagerGroupTabItem implements TabItem {
 		return group != null;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+		if (refreshEvents != null) refreshEvents.onFinished(null);
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add manager group");
@@ -156,8 +166,7 @@ public class AddGroupManagerGroupTabItem implements TabItem {
 		tabMenu.addWidget(2, TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				if (refreshEvents != null) refreshEvents.onFinished(null);
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 
@@ -209,9 +218,7 @@ public class AddGroupManagerGroupTabItem implements TabItem {
 						if (i == list.size() - 1) {
 							AddAdmin request = new AddAdmin(JsonCallbackEvents.disableButtonEvents(addButton, new JsonCallbackEvents(){
 								public void onFinished(JavaScriptObject jso) {
-									// close tab and refresh table
-									if (refreshEvents != null) refreshEvents.onFinished(null);
-									session.getTabManager().closeTab(tab, false);
+									session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 								}
 							}));
 							request.addGroupAdminGroup(group, list.get(i));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupManagerTabItem.java
@@ -95,6 +95,16 @@ public class AddGroupManagerTabItem implements TabItem {
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add manager");
@@ -188,7 +198,7 @@ public class AddGroupManagerTabItem implements TabItem {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupUnionTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AddGroupUnionTabItem.java
@@ -149,7 +149,7 @@ public class AddGroupUnionTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 
@@ -256,6 +256,16 @@ public class AddGroupUnionTabItem implements TabItem {
 	@Override
 	public boolean isPrepared() {
 		return !(group == null);
+	}
+
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
 	}
 
 	public final static String URL = "add-grp-union";

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AssignGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/AssignGroupTabItem.java
@@ -75,6 +75,16 @@ public class AssignGroupTabItem implements TabItem {
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// set tab name
@@ -144,7 +154,7 @@ public class AssignGroupTabItem implements TabItem {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
 				// fixme - probably should be button for finish and close
-				session.getTabManager().closeTab(tab, true);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/CreateGroupTabItem.java
@@ -86,6 +86,16 @@ public class CreateGroupTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -221,7 +231,7 @@ public class CreateGroupTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/EditGroupDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/EditGroupDetailsTabItem.java
@@ -64,6 +64,16 @@ public class EditGroupDetailsTabItem implements TabItem {
 		return (group != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget = new Label("Edit group");
@@ -139,7 +149,7 @@ public class EditGroupDetailsTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupApplicationFormSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupApplicationFormSettingsTabItem.java
@@ -92,6 +92,16 @@ public class GroupApplicationFormSettingsTabItem implements TabItem, TabItemWith
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupApplicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupApplicationsTabItem.java
@@ -93,6 +93,16 @@ public class GroupApplicationsTabItem implements TabItem, TabItemWithUrl {
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// request

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupDetailTabItem.java
@@ -87,6 +87,16 @@ public class GroupDetailTabItem implements TabItem, TabItemWithUrl{
 		return (group != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(group.getName()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupExtSourcesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupExtSourcesTabItem.java
@@ -87,6 +87,16 @@ public class GroupExtSourcesTabItem implements TabItem, TabItemWithUrl {
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(group.getName())+": "+"ext sources");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupManagersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupManagersTabItem.java
@@ -93,6 +93,15 @@ public class GroupManagersTabItem implements TabItem, TabItemWithUrl{
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
 
 	public Widget draw() {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
@@ -107,6 +107,16 @@ public class GroupMembersTabItem implements TabItem, TabItemWithUrl {
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// SET TAB NAME

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupRelationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupRelationsTabItem.java
@@ -286,6 +286,16 @@ public class GroupRelationsTabItem implements TabItem, TabItemWithUrl {
 	}
 
 	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
+	@Override
 	public boolean equals(Object o) {
 
 		if (this == o)

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupResourceRequiredAttributesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupResourceRequiredAttributesTabItem.java
@@ -105,6 +105,16 @@ public class GroupResourceRequiredAttributesTabItem implements TabItem, TabItemW
 		return !(group == null || resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 
 	public Widget draw() {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupResourcesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupResourcesTabItem.java
@@ -86,6 +86,16 @@ public class GroupResourcesTabItem implements TabItem, TabItemWithUrl{
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// set title

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupSettingsTabItem.java
@@ -102,6 +102,16 @@ public class GroupSettingsTabItem implements TabItem, TabItemWithUrl {
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(group.getName()) + ": settings");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupsResourceRequiredAttributesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupsResourceRequiredAttributesTabItem.java
@@ -87,6 +87,16 @@ public class GroupsResourceRequiredAttributesTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		if (groups == null || groups.get(0) == null) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupsTabItem.java
@@ -94,6 +94,16 @@ public class GroupsTabItem implements TabItem, TabItemWithUrl {
 		return ((voId != 0 && vo != null) || (voId == 0 && vo == null));
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// main panel
@@ -135,7 +145,7 @@ public class GroupsTabItem implements TabItem, TabItemWithUrl {
 			public void update(int index, RichGroup group, String value) {
 				session.getTabManager().addTab(new GroupDetailTabItem(group));
 				// close group selection tab when group is selected
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/MoveGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/MoveGroupsTabItem.java
@@ -83,6 +83,16 @@ public class MoveGroupsTabItem implements TabItem {
 		return ((this.vo != null) || (this.group != null)) && (this.groups != null) && (!this.groups.isEmpty());
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -226,7 +236,7 @@ public class MoveGroupsTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/SubgroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/SubgroupsTabItem.java
@@ -88,6 +88,16 @@ public class SubgroupsTabItem implements TabItem, TabItemWithUrl{
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 
 	public Widget draw() {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToGroupTabItem.java
@@ -116,6 +116,16 @@ public class AddMemberToGroupTabItem implements TabItem, TabItemWithUrl {
 		return !(group == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add member(s)");
@@ -495,7 +505,7 @@ public class AddMemberToGroupTabItem implements TabItem, TabItemWithUrl {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
 				// with refresh if somebody was added
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToResourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToResourceTabItem.java
@@ -93,6 +93,16 @@ public class AddMemberToResourceTabItem implements TabItem  {
 		return (vo != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Start tab at stage two with 1 member selected for adding
 	 *
@@ -477,7 +487,7 @@ public class AddMemberToResourceTabItem implements TabItem  {
 			CustomButton finish = TabMenu.getPredefinedButton(ButtonType.FINISH, "Close the tab", new ClickHandler() {
 				@Override
 				public void onClick(ClickEvent clickEvent) {
-					session.getTabManager().closeTab(tab, false);
+					session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 				}
 			});
 			finish.setImageAlign(true);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/AddMemberToVoTabItem.java
@@ -86,6 +86,16 @@ public class AddMemberToVoTabItem implements TabItem, TabItemWithUrl {
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Constructor
 	 *
@@ -192,7 +202,7 @@ public class AddMemberToVoTabItem implements TabItem, TabItemWithUrl {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeGroupStatusTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeGroupStatusTabItem.java
@@ -63,6 +63,16 @@ public class ChangeGroupStatusTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Change group member status");
@@ -119,7 +129,7 @@ public class ChangeGroupStatusTabItem implements TabItem {
 					@Override
 					public void onFinished(JavaScriptObject jso) {
 						// close without refresh
-						session.getTabManager().closeTab(tab, false);
+						session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 					}
 				})));
 				request.setStatus(lb.getValue(lb.getSelectedIndex()));
@@ -130,7 +140,7 @@ public class ChangeGroupStatusTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, ButtonTranslation.INSTANCE.cancelButton(), new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeStatusTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/ChangeStatusTabItem.java
@@ -54,6 +54,16 @@ public class ChangeStatusTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Change member status");
@@ -129,7 +139,7 @@ public class ChangeStatusTabItem implements TabItem {
 					@Override
 					public void onFinished(JavaScriptObject jso) {
 						// close without refresh
-						session.getTabManager().closeTab(tab, false);
+						session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 					}
 				})), messageArea.getText());
 				request.setStatus(lb.getValue(lb.getSelectedIndex()));
@@ -140,7 +150,7 @@ public class ChangeStatusTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, ButtonTranslation.INSTANCE.cancelButton(), new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/CreateServiceMemberInVoTabItem.java
@@ -83,6 +83,16 @@ public class CreateServiceMemberInVoTabItem implements TabItem, TabItemWithUrl {
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Constructor
 	 *

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberAddToGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberAddToGroupTabItem.java
@@ -57,6 +57,16 @@ public class MemberAddToGroupTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Add to group(s)");
@@ -112,7 +122,7 @@ public class MemberAddToGroupTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberApplicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberApplicationsTabItem.java
@@ -59,6 +59,16 @@ public class MemberApplicationsTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(member.getUser().getFullNameWithTitles().trim()) + ": applications");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberDetailTabItem.java
@@ -91,6 +91,16 @@ public class MemberDetailTabItem implements TabItem, TabItemWithUrl {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(member.getUser().getFullNameWithTitles().trim()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberGroupsTabItem.java
@@ -57,6 +57,16 @@ public class MemberGroupsTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(member.getUser().getFullNameWithTitles().trim()) + ": groups");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberOverviewTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberOverviewTabItem.java
@@ -57,6 +57,16 @@ public class MemberOverviewTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(member.getUser().getFullNameWithTitles().trim()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberResourcesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberResourcesTabItem.java
@@ -48,6 +48,16 @@ public class MemberResourcesTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(member.getUser().getFullNameWithTitles().trim()) + ": resources");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberServiceUsersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberServiceUsersTabItem.java
@@ -44,6 +44,16 @@ public class MemberServiceUsersTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		if (member.getUser().isServiceUser()) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberSettingsTabItem.java
@@ -76,6 +76,16 @@ public class MemberSettingsTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(member.getUser().getFullNameWithTitles().trim())+ ": Settings");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberSponsoredUsersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberSponsoredUsersTabItem.java
@@ -49,6 +49,16 @@ public class MemberSponsoredUsersTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		if (member.getUser().isSponsoredUser()) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MembershipExpirationTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MembershipExpirationTabItem.java
@@ -62,6 +62,16 @@ public class MembershipExpirationTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Set membership expiration");
@@ -162,7 +172,7 @@ public class MembershipExpirationTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, ButtonTranslation.INSTANCE.cancelButton(), new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/SendPasswordResetRequestTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/SendPasswordResetRequestTabItem.java
@@ -69,6 +69,16 @@ public class SendPasswordResetRequestTabItem implements TabItem {
 		return !(member == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Send password reset request");
@@ -167,7 +177,7 @@ public class SendPasswordResetRequestTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, ButtonTranslation.INSTANCE.cancelButton(), new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/AuditLogTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/AuditLogTabItem.java
@@ -57,6 +57,16 @@ public class AuditLogTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// page main tab

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/CreateOwnerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/CreateOwnerTabItem.java
@@ -51,6 +51,16 @@ public class CreateOwnerTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -128,7 +138,7 @@ public class CreateOwnerTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/ExtSourcesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/ExtSourcesTabItem.java
@@ -57,6 +57,16 @@ public class ExtSourcesTabItem implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// create main panel for content

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/FacilitiesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/FacilitiesTabItem.java
@@ -63,6 +63,16 @@ public class FacilitiesTabItem implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/OwnersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/OwnersTabItem.java
@@ -60,6 +60,16 @@ public class OwnersTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// tab content

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/PropagationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/PropagationsTabItem.java
@@ -69,6 +69,16 @@ public class PropagationsTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		mainrow = 0;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/SearcherTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/SearcherTabItem.java
@@ -79,6 +79,16 @@ public class SearcherTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// main widget panel

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/StatisticsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/StatisticsTabItem.java
@@ -58,6 +58,16 @@ public class StatisticsTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// PAGE CONTENTS

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/VosTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/VosTabItem.java
@@ -64,6 +64,16 @@ public class VosTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/ApplicationDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/ApplicationDetailTabItem.java
@@ -40,7 +40,7 @@ import java.util.Map;
  *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
+public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl {
 
 	/**
 	 * Perun web session
@@ -89,6 +89,16 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 
 	public boolean isPrepared(){
 		return (app != null);
+	}
+
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return true;
+	}
+
+	@Override
+	public void onClose() {
+
 	}
 
 	public Widget draw() {
@@ -208,7 +218,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 					HandleApplication request = new HandleApplication(JsonCallbackEvents.disableButtonEvents(approve, new JsonCallbackEvents(){
 						@Override
 						public void onFinished(JavaScriptObject jso) {
-							session.getTabManager().closeTab(tab, true);
+							session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 						}
 					}));
 					request.approveApplication(app);
@@ -236,7 +246,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 							HandleApplication request = new HandleApplication(JsonCallbackEvents.disableButtonEvents(reject, new JsonCallbackEvents(){
 								@Override
 								public void onFinished(JavaScriptObject jso) {
-									session.getTabManager().closeTab(tab, true);
+									session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 								}
 							}));
 							request.rejectApplication(appId, reason.getText());
@@ -259,7 +269,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 					HandleApplication request = new HandleApplication(JsonCallbackEvents.disableButtonEvents(delete, new JsonCallbackEvents(){
 						@Override
 						public void onFinished(JavaScriptObject jso) {
-							session.getTabManager().closeTab(tab, true);
+							session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 						}
 					}));
 					request.deleteApplication(appId);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CopyFormTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CopyFormTabItem.java
@@ -72,6 +72,16 @@ public class CopyFormTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		final FlexTable content = new FlexTable();
@@ -234,7 +244,7 @@ public class CopyFormTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CopyMailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CopyMailsTabItem.java
@@ -72,6 +72,16 @@ public class CopyMailsTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		final FlexTable content = new FlexTable();
@@ -230,7 +240,7 @@ public class CopyMailsTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateFormItemTabItem.java
@@ -96,6 +96,16 @@ public class CreateFormItemTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// vertical panel
@@ -232,7 +242,7 @@ public class CreateFormItemTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/CreateMailTabItem.java
@@ -135,6 +135,16 @@ public class CreateMailTabItem implements TabItem {
 		}
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Returns message texarea
 	 *
@@ -469,7 +479,7 @@ public class CreateMailTabItem implements TabItem {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
@@ -109,6 +109,16 @@ public class EditFormItemTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Returns flex table with settings for the language
 	 *
@@ -717,13 +727,13 @@ public class EditFormItemTabItem implements TabItem {
 				saveItem();
 				events.onFinished(item);
 				// do not reload content from RPC !!
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailFooterTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailFooterTabItem.java
@@ -77,6 +77,16 @@ public class EditMailFooterTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		final FlexTable content = new FlexTable();
@@ -181,7 +191,7 @@ public class EditMailFooterTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditMailTabItem.java
@@ -93,6 +93,16 @@ public class EditMailTabItem implements TabItem, TabItemWithUrl {
 		return (appMail != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	/**
 	 * Returns message texarea
 	 *
@@ -392,7 +402,7 @@ public class EditMailTabItem implements TabItem, TabItemWithUrl {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/MailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/MailsTabItem.java
@@ -133,6 +133,16 @@ public class MailsTabItem implements TabItem, TabItemWithUrl {
 
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		final GetApplicationMails mailsRequest;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/PreviewFormTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/PreviewFormTabItem.java
@@ -63,6 +63,16 @@ public class PreviewFormTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		if (form.getGroup() != null) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/AssignGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/AssignGroupTabItem.java
@@ -82,6 +82,16 @@ public class AssignGroupTabItem implements TabItem {
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Assign group");
@@ -148,7 +158,7 @@ public class AssignGroupTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/AssignServiceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/AssignServiceTabItem.java
@@ -80,6 +80,16 @@ public class AssignServiceTabItem implements TabItem {
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Assign service");
@@ -144,7 +154,7 @@ public class AssignServiceTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/AssignTagTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/AssignTagTabItem.java
@@ -77,6 +77,16 @@ public class AssignTagTabItem implements TabItem {
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add tag");
@@ -115,7 +125,7 @@ public class AssignTagTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/CreateFacilityResourceManageServicesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/CreateFacilityResourceManageServicesTabItem.java
@@ -103,6 +103,16 @@ public class CreateFacilityResourceManageServicesTabItem implements TabItem {
 		return (facility != null && resource != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return true;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Create resource: Assign and configure services");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/CreateFacilityResourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/CreateFacilityResourceTabItem.java
@@ -81,6 +81,16 @@ public class CreateFacilityResourceTabItem implements TabItem {
 		return !(facility == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Create resource");
@@ -196,7 +206,7 @@ public class CreateFacilityResourceTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/EditResourceDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/EditResourceDetailsTabItem.java
@@ -63,6 +63,16 @@ public class EditResourceDetailsTabItem implements TabItem {
 		return (resource != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget = new Label("Edit resource");
@@ -120,7 +130,7 @@ public class EditResourceDetailsTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ManageGroupsBeforeAssigning.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ManageGroupsBeforeAssigning.java
@@ -108,6 +108,16 @@ public class ManageGroupsBeforeAssigning implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		final VerticalPanel vp = new VerticalPanel();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceAssignedGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceAssignedGroupsTabItem.java
@@ -85,6 +85,16 @@ public class ResourceAssignedGroupsTabItem implements TabItem, TabItemWithUrl{
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(resource.getName()) + ": manage assigned groups");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceAssignedServicesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceAssignedServicesTabItem.java
@@ -85,6 +85,16 @@ public class ResourceAssignedServicesTabItem implements TabItem, TabItemWithUrl{
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(resource.getName()) + ": manage assigned services");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceDetailTabItem.java
@@ -91,6 +91,16 @@ public class ResourceDetailTabItem implements TabItem, TabItemWithUrl {
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(resource.getName()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceGroupSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceGroupSettingsTabItem.java
@@ -89,6 +89,16 @@ public class ResourceGroupSettingsTabItem implements TabItem, TabItemWithUrl {
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(resource.getName()) + ": group settings");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceMemberSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceMemberSettingsTabItem.java
@@ -92,6 +92,16 @@ public class ResourceMemberSettingsTabItem implements TabItem, TabItemWithUrl {
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(resource.getName()) + ": member settings");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceSettingsTabItem.java
@@ -119,6 +119,16 @@ public class ResourceSettingsTabItem implements TabItem, TabItemWithUrl {
 		return (resource != null && serviceId == 0) || (resource != null && service != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		if (service != null) {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceTagsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/resourcestabs/ResourceTagsTabItem.java
@@ -82,6 +82,16 @@ public class ResourceTagsTabItem implements TabItem, TabItemWithUrl{
 		return !(resource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(resource.getName()) + ": manage assigned tags");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/AddSecurityTeamManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/AddSecurityTeamManagerTabItem.java
@@ -98,6 +98,16 @@ public class AddSecurityTeamManagerTabItem implements TabItem {
 		return securityTeam != null;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add member");
@@ -153,7 +163,7 @@ public class AddSecurityTeamManagerTabItem implements TabItem {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/AddUserToBlacklistTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/AddUserToBlacklistTabItem.java
@@ -100,6 +100,16 @@ public class AddUserToBlacklistTabItem implements TabItem {
 		return securityTeam != null;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add to blacklist");
@@ -155,7 +165,7 @@ public class AddUserToBlacklistTabItem implements TabItem {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/CreateSecurityTeamTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/CreateSecurityTeamTabItem.java
@@ -53,6 +53,16 @@ public class CreateSecurityTeamTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -114,7 +124,7 @@ public class CreateSecurityTeamTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/EditSecurityTeamDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/EditSecurityTeamDetailsTabItem.java
@@ -61,6 +61,16 @@ public class EditSecurityTeamDetailsTabItem implements TabItem {
 		return (team != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget = new Label("Edit Security Team");
@@ -118,7 +128,7 @@ public class EditSecurityTeamDetailsTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamBlacklistTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamBlacklistTabItem.java
@@ -83,6 +83,16 @@ public class SecurityTeamBlacklistTabItem implements TabItem, TabItemWithUrl {
 		return securityTeam != null;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL
@@ -155,7 +165,7 @@ public class SecurityTeamBlacklistTabItem implements TabItem, TabItemWithUrl {
 				@Override
 				public void update(int i, Pair<User,String> pair, String string) {
 					session.getTabManager().addTab(new UserDetailTabItem(pair.getLeft()));
-					session.getTabManager().closeTab(tab, false);
+					session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 				}
 			});
 		} else {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamDetailTabItem.java
@@ -85,6 +85,16 @@ public class SecurityTeamDetailTabItem implements TabItem, TabItemWithUrl{
 		return !(securityTeam == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(securityTeam.getName()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamMembersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamMembersTabItem.java
@@ -81,6 +81,16 @@ public class SecurityTeamMembersTabItem implements TabItem, TabItemWithUrl {
 		return securityTeam != null;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL
@@ -145,7 +155,7 @@ public class SecurityTeamMembersTabItem implements TabItem, TabItemWithUrl {
 				@Override
 				public void update(int i, User user, String string) {
 					session.getTabManager().addTab(new UserDetailTabItem(user));
-					session.getTabManager().closeTab(tab, false);
+					session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 				}
 			});
 		} else {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamSelectTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/securitytabs/SecurityTeamSelectTabItem.java
@@ -56,6 +56,16 @@ public class SecurityTeamSelectTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL
@@ -129,7 +139,7 @@ public class SecurityTeamSelectTabItem implements TabItem, TabItemWithUrl {
 			@Override
 			public void update(int i, SecurityTeam securityTeam, String string) {
 				session.getTabManager().addTab(new SecurityTeamDetailTabItem(securityTeam));
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/AddRequiredAttributesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/AddRequiredAttributesTabItem.java
@@ -83,6 +83,16 @@ public class AddRequiredAttributesTabItem implements TabItem {
 		return (service != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add required attributes");
@@ -140,7 +150,7 @@ public class AddRequiredAttributesTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/CreateServicePackageTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/CreateServicePackageTabItem.java
@@ -48,6 +48,16 @@ public class CreateServicePackageTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -121,7 +131,7 @@ public class CreateServicePackageTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/CreateServiceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/CreateServiceTabItem.java
@@ -53,6 +53,16 @@ public class CreateServiceTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -185,7 +195,7 @@ public class CreateServiceTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/EditServiceDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/EditServiceDetailsTabItem.java
@@ -70,6 +70,16 @@ public class EditServiceDetailsTabItem implements TabItem {
 		return (service != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget = new Label("Edit service");
@@ -188,7 +198,7 @@ public class EditServiceDetailsTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServiceDestinationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServiceDestinationsTabItem.java
@@ -96,6 +96,16 @@ public class ServiceDestinationsTabItem implements TabItem, TabItemWithUrl{
 		return !(service == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText("Service destinations");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServiceDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServiceDetailTabItem.java
@@ -91,6 +91,16 @@ public class ServiceDetailTabItem implements TabItem, TabItemWithUrl{
 		return !(service == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw(){
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(service.getName()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServicePackageDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServicePackageDetailTabItem.java
@@ -80,6 +80,16 @@ public class ServicePackageDetailTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(servicesPackage.getName()) + ": assigned services");
@@ -191,7 +201,7 @@ public class ServicePackageDetailTabItem implements TabItem, TabItemWithUrl {
 		CustomButton close = TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				session.getTabManager().closeTab(tab);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServicePackagesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServicePackagesTabItem.java
@@ -61,6 +61,16 @@ public class ServicePackagesTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// create widget for the whole page

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServiceRequiredAttributesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServiceRequiredAttributesTabItem.java
@@ -83,6 +83,15 @@ public class ServiceRequiredAttributesTabItem implements TabItem, TabItemWithUrl
 		return !(service == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
 
 
 	public Widget draw() {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServicesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServicesTabItem.java
@@ -62,6 +62,16 @@ public class ServicesTabItem implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// create widget for the whole page

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestAttributeTableTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestAttributeTableTabItem.java
@@ -53,6 +53,16 @@ public class TestAttributeTableTabItem implements TabItem, TabItemWithUrl{
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		PerunAttributeTableWidget.SaveEvent saveEvent = new PerunAttributeTableWidget.SaveEvent() {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestDataGridAttributesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestDataGridAttributesTabItem.java
@@ -71,6 +71,16 @@ public class TestDataGridAttributesTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		//contentWidget.setSize("100%", "100%");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestDataGridTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestDataGridTabItem.java
@@ -74,6 +74,16 @@ public class TestDataGridTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		//contentWidget.setSize("100%", "100%");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestJSONParserTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestJSONParserTabItem.java
@@ -6,13 +6,11 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.UiElements;
 import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
-import cz.metacentrum.perun.webgui.json.rtMessagesManager.SendMessageToRt;
 import cz.metacentrum.perun.webgui.model.BasicOverlayType;
 import cz.metacentrum.perun.webgui.tabs.TabItem;
 import cz.metacentrum.perun.webgui.tabs.TabItemWithUrl;
@@ -50,6 +48,16 @@ public class TestJSONParserTabItem implements TabItem, TabItemWithUrl {
 
 	public boolean isPrepared(){
 		return true;
+	}
+
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
 	}
 
 	public Widget draw() {

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestRtReportingTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/testtabs/TestRtReportingTabItem.java
@@ -54,6 +54,16 @@ public class TestRtReportingTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		Button sendMessageButton = new Button("Send to RT");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/AddLoginTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/AddLoginTabItem.java
@@ -97,6 +97,16 @@ public class AddLoginTabItem implements TabItem {
 		return (user != null && usersLogins != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add login");
@@ -167,7 +177,7 @@ public class AddLoginTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/AddUserExtSourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/AddUserExtSourceTabItem.java
@@ -90,6 +90,16 @@ public class AddUserExtSourceTabItem implements TabItem, TabItemWithUrl {
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add ext. identity");
@@ -189,7 +199,7 @@ public class AddUserExtSourceTabItem implements TabItem, TabItemWithUrl {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				session.getTabManager().closeTab(tab);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/ConnectServiceIdentityTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/ConnectServiceIdentityTabItem.java
@@ -85,6 +85,16 @@ public class ConnectServiceIdentityTabItem implements TabItem, TabItemWithUrl {
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return true;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Connect identity");
@@ -124,7 +134,7 @@ public class ConnectServiceIdentityTabItem implements TabItem, TabItemWithUrl {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			public void onClick(ClickEvent clickEvent) {
 				// close tab and refresh
-				session.getTabManager().closeTab(tab, true);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/EditUserDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/EditUserDetailsTabItem.java
@@ -63,6 +63,16 @@ public class EditUserDetailsTabItem implements TabItem {
 		return (user != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget = new Label("Edit user");
@@ -137,7 +147,7 @@ public class EditUserDetailsTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/IdentitySelectorTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/IdentitySelectorTabItem.java
@@ -43,6 +43,16 @@ public class IdentitySelectorTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		final TabItem tab = this;
@@ -69,7 +79,7 @@ public class IdentitySelectorTabItem implements TabItem, TabItemWithUrl {
 			@Override
 			public void onClick(ClickEvent event) {
 				session.getTabManager().addTab(new SelfDetailTabItem(session.getUser()));
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 		baseLayout.setWidget(2, 0, new Image(LargeIcons.INSTANCE.userGrayIcon()));
@@ -121,7 +131,7 @@ public class IdentitySelectorTabItem implements TabItem, TabItemWithUrl {
 								@Override
 								public void onClick(ClickEvent event) {
 									session.getTabManager().addTab(new SelfDetailTabItem(u2));
-									session.getTabManager().closeTab(tab, false);
+									session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 								}
 							});
 							innerTable.setWidget(row, 1, userName);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/InviteUserTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/InviteUserTabItem.java
@@ -69,6 +69,16 @@ public class InviteUserTabItem implements TabItem {
 		return (vo != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -169,7 +179,7 @@ public class InviteUserTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/RequestQuotaChangeTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/RequestQuotaChangeTabItem.java
@@ -73,6 +73,16 @@ public class RequestQuotaChangeTabItem implements TabItem {
 		return (user != null && resource != null && quotaType != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		new GetEntityById(PerunEntity.VIRTUAL_ORGANIZATION, resource.getVoId(), new JsonCallbackEvents(){
@@ -180,7 +190,7 @@ public class RequestQuotaChangeTabItem implements TabItem {
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfApplicationDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfApplicationDetailTabItem.java
@@ -73,6 +73,16 @@ public class SelfApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 		return !(application == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(user.getFullNameWithTitles().trim())+ ": Application detail");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfApplicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfApplicationsTabItem.java
@@ -87,6 +87,16 @@ public class SelfApplicationsTabItem implements TabItem, TabItemWithUrl{
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(user.getFullNameWithTitles().trim())+ ": Applications");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfAuthenticationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfAuthenticationsTabItem.java
@@ -84,6 +84,16 @@ public class SelfAuthenticationsTabItem implements TabItem, TabItemWithUrl {
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(user.getFullNameWithTitles().trim())+": Authentication");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfDetailTabItem.java
@@ -85,6 +85,16 @@ public class SelfDetailTabItem implements TabItem, TabItemWithUrl {
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(user.getFullNameWithTitles().trim()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPasswordTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPasswordTabItem.java
@@ -127,6 +127,16 @@ public class SelfPasswordTabItem implements TabItem, TabItemWithUrl{
 		return (user != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		String actionText = "Change";
@@ -443,7 +453,7 @@ public class SelfPasswordTabItem implements TabItem, TabItemWithUrl{
 			menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 				@Override
 				public void onClick(ClickEvent event) {
-					session.getTabManager().closeTab(tab, false);
+					session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 				}
 			}));
 		}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPersonalTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfPersonalTabItem.java
@@ -82,6 +82,16 @@ public class SelfPersonalTabItem implements TabItem {
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// content

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfResourcesSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfResourcesSettingsTabItem.java
@@ -159,6 +159,16 @@ public class SelfResourcesSettingsTabItem implements TabItem, TabItemWithUrl, Ta
 
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(user.getFullNameWithTitles().trim()) + ": Resources settings");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfServiceUsersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfServiceUsersTabItem.java
@@ -331,6 +331,16 @@ public class SelfServiceUsersTabItem implements TabItem, TabItemWithUrl {
 	}
 
 	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
+	@Override
 	public int hashCode() {
 		final int prime = 1259;
 		int result = 432;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfSponsoredUsersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfSponsoredUsersTabItem.java
@@ -188,6 +188,16 @@ public class SelfSponsoredUsersTabItem implements TabItem, TabItemWithUrl {
 	}
 
 	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
+	@Override
 	public int hashCode() {
 		final int prime = 1259;
 		int result = 432;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfVosTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfVosTabItem.java
@@ -84,6 +84,16 @@ public class SelfVosTabItem implements TabItem, TabItemWithUrl {
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(user.getFullNameWithTitles().trim())+": VO settings");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/ShellChangeTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/ShellChangeTabItem.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * @author Vaclav Mach <374430@mail.muni.cz>
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-public class ShellChangeTabItem implements TabItem{
+public class ShellChangeTabItem implements TabItem {
 
 	private PerunWebSession session = PerunWebSession.getInstance();
 
@@ -62,6 +62,16 @@ public class ShellChangeTabItem implements TabItem{
 
 	public boolean isPrepared(){
 		return (userId != 0 && resource != null);
+	}
+
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
 	}
 
 	public Widget draw() {
@@ -147,7 +157,7 @@ public class ShellChangeTabItem implements TabItem{
 						// refresh only what's necessary
 						events.onFinished(jso);
 						// don't refresh underlaying tab
-						session.getTabManager().closeTab(tab, false);
+						session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 					}
 				}));
 				request.setAttribute(ids, a);
@@ -180,7 +190,7 @@ public class ShellChangeTabItem implements TabItem{
 						// refresh only what's necessary
 						events.onFinished(jso);
 						// don't refresh underlaying tab
-						session.getTabManager().closeTab(tab, false);
+						session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 					}
 				}));
 				ArrayList<Attribute> list = new ArrayList<Attribute>();
@@ -194,7 +204,7 @@ public class ShellChangeTabItem implements TabItem{
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserDetailTabItem.java
@@ -115,6 +115,16 @@ public class UserDetailTabItem implements TabItem, TabItemWithUrl {
 		return !(user == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 
 	public Widget draw() {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserExtSourceDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserExtSourceDetailTabItem.java
@@ -84,6 +84,16 @@ public class UserExtSourceDetailTabItem implements TabItem, TabItemWithUrl {
 		return !(userExtSource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(userExtSource.getLogin().trim()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserExtSourceSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UserExtSourceSettingsTabItem.java
@@ -88,6 +88,16 @@ public class UserExtSourceSettingsTabItem implements TabItem, TabItemWithUrl {
 		return !(userExtSource == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(userExtSource.getLogin().trim()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UsersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/UsersTabItem.java
@@ -70,6 +70,16 @@ public class UsersTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		CustomButton searchButton = new CustomButton("Search", ButtonTranslation.INSTANCE.searchUsers(), SmallIcons.INSTANCE.findIcon());

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoExtSourceTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoExtSourceTabItem.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * @author Pavel Zlamal <256627@mail.muni.cz>
  * @author Vaclav Mach <374430@mail.muni.cz>
  */
-public class AddVoExtSourceTabItem implements TabItem, TabItemWithUrl{
+public class AddVoExtSourceTabItem implements TabItem, TabItemWithUrl {
 
 	/**
 	 * Perun web session
@@ -92,6 +92,16 @@ public class AddVoExtSourceTabItem implements TabItem, TabItemWithUrl{
 
 	public boolean isPrepared(){
 		return !(vo == null);
+	}
+
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
 	}
 
 	public Widget draw() {
@@ -170,7 +180,7 @@ public class AddVoExtSourceTabItem implements TabItem, TabItemWithUrl{
 		menu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerGroupTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerGroupTabItem.java
@@ -95,6 +95,16 @@ public class AddVoManagerGroupTabItem implements TabItem {
 		return vo != null;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+		if (refreshEvents != null) refreshEvents.onFinished(null);
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add manager group");
@@ -157,8 +167,7 @@ public class AddVoManagerGroupTabItem implements TabItem {
 		tabMenu.addWidget(1, TabMenu.getPredefinedButton(ButtonType.CANCEL, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				if (refreshEvents != null) refreshEvents.onFinished(null);
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 
@@ -208,9 +217,7 @@ public class AddVoManagerGroupTabItem implements TabItem {
 						if (i == list.size() - 1) {
 							AddAdmin request = new AddAdmin(JsonCallbackEvents.disableButtonEvents(addButton, new JsonCallbackEvents(){
 								public void onFinished(JavaScriptObject jso) {
-									// close tab and refresh table
-									if (refreshEvents != null) refreshEvents.onFinished(null);
-									session.getTabManager().closeTab(tab, false);
+									session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 								}
 							}));
 							request.addVoAdminGroup(vo, list.get(i));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/AddVoManagerTabItem.java
@@ -95,6 +95,16 @@ public class AddVoManagerTabItem implements TabItem {
 		return vo != null;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return !alreadyAddedList.isEmpty();
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText("Add manager");
@@ -150,7 +160,7 @@ public class AddVoManagerTabItem implements TabItem {
 		tabMenu.addWidget(TabMenu.getPredefinedButton(ButtonType.CLOSE, "", new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, !alreadyAddedList.isEmpty());
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		}));
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/CreateVoResourceTagTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/CreateVoResourceTagTabItem.java
@@ -56,6 +56,16 @@ public class CreateVoResourceTagTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -107,7 +117,7 @@ public class CreateVoResourceTagTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/CreateVoTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/CreateVoTabItem.java
@@ -55,6 +55,16 @@ public class CreateVoTabItem implements TabItem {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		VerticalPanel vp = new VerticalPanel();
@@ -133,7 +143,7 @@ public class CreateVoTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/EditVoDetailsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/EditVoDetailsTabItem.java
@@ -63,6 +63,16 @@ public class EditVoDetailsTabItem implements TabItem {
 		return (vo != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget = new Label("Edit VO name");
@@ -116,7 +126,7 @@ public class EditVoDetailsTabItem implements TabItem {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
-				session.getTabManager().closeTab(tab, false);
+				session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 			}
 		});
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoApplicationFormSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoApplicationFormSettingsTabItem.java
@@ -93,6 +93,16 @@ public class VoApplicationFormSettingsTabItem implements TabItem, TabItemWithUrl
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoApplicationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoApplicationsTabItem.java
@@ -95,6 +95,16 @@ public class VoApplicationsTabItem implements TabItem, TabItemWithUrl{
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// request

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoDetailTabItem.java
@@ -89,6 +89,16 @@ public class VoDetailTabItem implements TabItem, TabItemWithUrl{
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(vo.getName()));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoExtSourcesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoExtSourcesTabItem.java
@@ -85,6 +85,16 @@ public class VoExtSourcesTabItem implements TabItem, TabItemWithUrl{
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(vo.getName())+": "+"ext sources");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoGroupsTabItem.java
@@ -89,6 +89,16 @@ public class VoGroupsTabItem implements TabItem, TabItemWithUrl{
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		this.titleWidget.setText(Utils.getStrippedStringWithEllipsis(vo.getName())+": "+"groups");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoManagersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoManagersTabItem.java
@@ -95,6 +95,16 @@ public class VoManagersTabItem implements TabItem, TabItemWithUrl {
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 
 	public Widget draw() {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoMembersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoMembersTabItem.java
@@ -100,6 +100,16 @@ public class VoMembersTabItem implements TabItem, TabItemWithUrl {
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// SET TAB NAME

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoOverviewTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoOverviewTabItem.java
@@ -90,6 +90,16 @@ public class VoOverviewTabItem implements TabItem {
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	private void setLabels() {
 		this.titleWidget.setText(vo.getName());
 		this.voNameLabel.setText(vo.getName());

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoResourcesPropagationsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoResourcesPropagationsTabItem.java
@@ -86,6 +86,16 @@ public class VoResourcesPropagationsTabItem implements TabItem, TabItemWithUrl {
 		return (vo != null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		mainrow = 0;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoResourcesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoResourcesTabItem.java
@@ -88,6 +88,16 @@ public class VoResourcesTabItem implements TabItem, TabItemWithUrl{
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// set title

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoResourcesTagsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoResourcesTagsTabItem.java
@@ -86,6 +86,16 @@ public class VoResourcesTagsTabItem implements TabItem, TabItemWithUrl{
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 
 	public Widget draw() {
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoSettingsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoSettingsTabItem.java
@@ -90,6 +90,16 @@ public class VoSettingsTabItem implements TabItem, TabItemWithUrl {
 		return !(vo == null);
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		titleWidget.setText(Utils.getStrippedStringWithEllipsis(vo.getName())+": settings");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VosSelectTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VosSelectTabItem.java
@@ -58,6 +58,16 @@ public class VosSelectTabItem implements TabItem, TabItemWithUrl {
 		return true;
 	}
 
+	@Override
+	public boolean isRefreshParentOnClose() {
+		return false;
+	}
+
+	@Override
+	public void onClose() {
+
+	}
+
 	public Widget draw() {
 
 		// MAIN PANEL


### PR DESCRIPTION
- We no longer simply move overlay tab outside of the view, but
  properly call closeTab() on it even from "X" close button.
- Each TabItem can now specify actions in onClose() and whether
  it wants to refresh the parent tab.