### PR TITLE
CORE: Allow reporting to RT to be redirected to mail

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -63,6 +63,7 @@ public class CoreConfig {
 	private String rtServiceuserPassword;
 	private String rtServiceuserUsername;
 	private String rtUrl;
+	private String rtSendToMail;
 	private String smsProgram;
 	private String userExtSourcesPersistent;
 	private List<String> allowedCorsDomains;
@@ -601,4 +602,11 @@ public class CoreConfig {
 		this.autocreatedNamespaces = autocreatedNamespaces;
 	}
 
+	public void setRtSendToMail(String rtSendToMail) {
+		this.rtSendToMail = rtSendToMail;
+	}
+
+	public String getRtSendToMail() {
+		return rtSendToMail;
+	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -59,6 +59,7 @@
 		<property name="smtpUser" value="${perun.smtp.user}" />
 		<property name="smtpPass" value="${perun.smtp.pass}" />
 		<property name="autocreatedNamespaces" value="#{'${perun.autocreatedNamespaces}'.split('\s*,\s*')}" />
+		<property name="rtSendToMail" value="${perun.rt.sendToMail}" />
 	</bean>
 
 
@@ -96,6 +97,7 @@
 				<prop key="perun.rt.defaultQueue">perun</prop>
 				<prop key="perun.rt.serviceuser.username">perunv3-rt</prop>
 				<prop key="perun.rt.serviceuser.password">password</prop>
+				<prop key="perun.rt.sendToMail" />
 				<prop key="perun.passwordManager.program">/usr/local/bin/perun.passwordManager</prop>
 				<prop key="perun.alternativePasswordManager.program">/usr/local/bin/perun.altPasswordManager</prop>
 				<prop key="perun.recaptcha.privatekey"/>


### PR DESCRIPTION
* Added new config option "perun.rt.sendToMail" into perun.properties.
  If set, it will cause all RT messages (error reporting) to be
  redirected to its value (mail address).
* Updated RTMessagesManager to allow sending of report to mail
  addresses instead of contacting RT API.