### PR TITLE
include only valid members of VO in perun-ldapc-ada

### DIFF
--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Perun;
+import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
@@ -42,7 +43,7 @@ public class VOSynchronizer extends AbstractSynchronizer {
 					try {
 						log.debug("Getting list of VO {} members", vo.getId());
 						// List<Member> members = ldapcManager.getRpcCaller().call("membersManager", "getMembers", params).readList(Member.class);
-						List<Member> members = perun.getMembersManager().getMembers(ldapcManager.getPerunSession(), vo);
+						List<Member> members = perun.getMembersManager().getMembers(ldapcManager.getPerunSession(), vo, Status.VALID);
 						log.debug("Synchronizing {} members of VO {}", members.size(), vo.getId());
 						perunVO.synchronizeMembers(vo, members);
 					} catch (PerunException e) {


### PR DESCRIPTION
- adds Status.VALID parameter to getMembers() call to get only valid VO members when synchronizing