### PR TITLE
CORE: Determine user:virt:loa data type dynamically

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
@@ -49,7 +49,15 @@ public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributes
 			if(maxLoa < e.getLoa()) maxLoa = e.getLoa();
 		}
 		Attribute attribute = new Attribute(attributeDefinition);
-		attribute.setValue(maxLoa.toString());
+
+		// since we are not consistent of which data type LoA is between instances,
+		// we must determine it from attribute definition
+		if (String.class.getName().equals(attribute.getType())) {
+			attribute.setValue(maxLoa.toString());
+		} else {
+			attribute.setValue(maxLoa);
+		}
+
 		return attribute;
 	}
 


### PR DESCRIPTION
- Since we are not consistent in data type for user:virt:loa
  between instances, we must determine proper data type based
  on passed AttributeDefinition.