### PR TITLE
LDAPC: We must handle both data types in user:virt:loa

### DIFF
--- a/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/impl/Utils.java
+++ b/perun-ldapc-initializer/src/main/java/cz/metacentrum/perun/ldapc/initializer/impl/Utils.java
@@ -502,8 +502,21 @@ public class Utils implements cz.metacentrum.perun.ldapc.initializer.api.UtilsAp
 			} catch (AttributeNotExistsException | WrongAttributeAssignmentException ex) {
 				log.error("LoA attribute is missing or it's assignment is wrong. Attribute was skipped.", ex);
 			}
-			if(attrLoA == null || attrLoA.getValue() == null || ((String) attrLoA.getValue()).isEmpty()) loa = null;
-			else loa+= (String) attrLoA.getValue();
+			if (attrLoA == null || attrLoA.getValue() == null) {
+				loa = null;
+			} else {
+				// we don't have unified type of loa attr value !!
+				if (attrLoA.getValue() instanceof String) {
+					if (!((String) attrLoA.getValue()).isEmpty()) {
+						loa += (String) attrLoA.getValue();
+					} else {
+						loa = null;
+					}
+				} else {
+					// integer expected
+					loa += String.valueOf(attrLoA.getValue());
+				}
+			}
 			if(loa != null) writer.write(loa + '\n');
 
 			//all certificates subjects

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventProcessorImpl.java
@@ -589,7 +589,8 @@ public class EventProcessorImpl implements EventProcessor, Runnable {
 					}
 				} else if(this.attribute.getName().equals(cz.metacentrum.perun.core.api.AttributesManager.NS_USER_ATTR_VIRT + ":" + perunAttrLoA)) {
 					if(this.attribute.getValue() != null) {
-						updateUserAttribute(ldapAttrLoA, (String) attribute.getValue(), LdapOperation.REPLACE_ATTRIBUTE, this.user);
+						// we are not consistent in data type of LoA (Integer vs. String)
+						updateUserAttribute(ldapAttrLoA, String.valueOf(attribute.getValue()), LdapOperation.REPLACE_ATTRIBUTE, this.user);
 					} else {
 						if(ldapConnector.userAttributeExist(this.user, ldapAttrLoA)) {
 							updateUserAttribute(ldapAttrLoA, null, LdapOperation.REMOVE_ATTRIBUTE, this.user);


### PR DESCRIPTION
- Old LDAPc and LDAP initializer must also handle both data types
  when reading auditer log and filling LDAP.