### PR TITLE
GUI: Don't duplicate resources on filtering

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/resourcesManager/GetRichResources.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/resourcesManager/GetRichResources.java
@@ -321,15 +321,16 @@ public class GetRichResources implements JsonCallback, JsonCallbackTable<RichRes
 			list.addAll(fullBackup);
 		} else {
 			for (RichResource res : fullBackup){
-				// store facility by filter
+				// store resources by filter
 				if (res.getName().toLowerCase().contains(filter.toLowerCase())) {
 					list.add(res);
-				}
-				for (ResourceTag r : res.getResourceTags()) {
-					// remove " (tag)" from tag name
-					if (r.getName().contains(filter.substring(0, (filter.length() > 6) ? filter.length()-6 : filter.length()).trim())) {
-						list.add(res);
-						break;
+				} else {
+					for (ResourceTag r : res.getResourceTags()) {
+						// remove " (tag)" from tag name
+						if (r.getName().contains(filter.substring(0, (filter.length() > 6) ? filter.length()-6 : filter.length()).trim())) {
+							list.add(res);
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- Resources were duplicated in VO-Resources tabs on filtering
  when searched term matched both tag and resource name.
  Now we display single entry for each resource.