### PR TITLE
New method getUserExtSourceByUniqueAttributeValue

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -441,6 +441,50 @@ public interface UsersManagerBl {
 	UserExtSource getUserExtSourceById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException;
 
 	/**
+	 * Return userExtSource for specific attribute definition (specified by id) and unique value.
+	 * If not found, throw and exception.
+	 *
+	 * It looks for exactly one value of the specific attribute type:
+	 * - Integer -> exactly match
+	 * - String -> exactly match
+	 * - Map -> exactly match of "key=value"
+	 * - ArrayList -> exactly match of one of the value
+	 *
+	 * @param sess
+	 * @param attrId attribute id used for founding attribute definition which has to exists, be unique and in userExtSource namespace
+	 * @param uniqueValue value used for searching
+	 *
+	 * @return userExtSource found by attribute id and it's unique value
+	 *
+	 * @throws InternalErrorException if attrId or uniqueValue is in incorrect format
+	 * @throws UserExtSourceNotExistsException if userExtSource can't be found
+	 * @throws AttributeNotExistsException if attribute can't be found by it's id
+	 */
+	UserExtSource getUserExtSourceByUniqueAttributeValue(PerunSession sess, int attrId, String uniqueValue) throws InternalErrorException, AttributeNotExistsException, UserExtSourceNotExistsException;
+
+	/**
+	 * Return userExtSource for specific attribute definition (specified by id) and unique value.
+	 * If not found, throw and exception.
+	 *
+	 * It looks for exactly one value of the specific attribute type:
+	 * - Integer -> exactly match
+	 * - String -> exactly match
+	 * - Map -> exactly match of "key=value"
+	 * - ArrayList -> exactly match of one of the value
+	 *
+	 * @param sess
+	 * @param attrName attribute name used for founding attribute definition which has to exists, be unique and in userExtSource namespace
+	 * @param uniqueValue value used for searching
+	 *
+	 * @return userExtSource found by attribute name and it's unique value
+	 *
+	 * @throws InternalErrorException if attrName or uniqueValue is in incorrect format
+	 * @throws UserExtSourceNotExistsException if userExtSource can't be found
+	 * @throws AttributeNotExistsException if attribute can't be found by it's name
+	 */
+	UserExtSource getUserExtSourceByUniqueAttributeValue(PerunSession sess, String attrName, String uniqueValue) throws InternalErrorException, AttributeNotExistsException, UserExtSourceNotExistsException;
+
+	/**
 	 * Get all users userExtSources with last_access not older than (now - m),
 	 * where 'm' is number of months defined in CONSTANT in UsersManagerImpl.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -640,6 +640,49 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	}
 
 	@Override
+	public UserExtSource getUserExtSourceByUniqueAttributeValue(PerunSession sess, int attrId, String uniqueValue) throws InternalErrorException, AttributeNotExistsException, UserExtSourceNotExistsException {
+		if(attrId <= 0) throw new InternalErrorException("Unexpected attribute Id with zero or negative value.");
+		AttributeDefinition attrDef = perunBl.getAttributesManagerBl().getAttributeDefinitionById(sess, attrId);
+		return getUserExtSourceByUniqueAttributeValue(sess, attrDef, uniqueValue);
+
+	}
+
+	@Override
+	public UserExtSource getUserExtSourceByUniqueAttributeValue(PerunSession sess, String attrName, String uniqueValue) throws InternalErrorException, AttributeNotExistsException, UserExtSourceNotExistsException {
+		if(attrName == null || attrName.isEmpty()) throw new InternalErrorException("Can't find attribute, because it's name is missing.");
+		AttributeDefinition attrDef = perunBl.getAttributesManagerBl().getAttributeDefinition(sess, attrName);
+
+		return getUserExtSourceByUniqueAttributeValue(sess, attrDef, uniqueValue);
+	}
+
+	/**
+	 * Return userExtSource for specific attribute definition and unique value.
+	 * If not found, throw and exception.
+	 *
+	 * It looks for exactly one value of the specific attribute type:
+	 * - Integer -> exactly match
+	 * - String -> exactly match
+	 * - Map -> exactly match of "key=value"
+	 * - ArrayList -> exactly match of one of the value
+	 *
+	 * @param sess
+	 * @param attrDef attribute definition we are looking for, has to be unique and in userExtSource namespace
+	 * @param uniqueValue value used for searching
+	 *
+	 * @return userExtSource found by attribute definition and it's unique value
+	 *
+	 * @throws InternalErrorException if attributeDefinition or uniqueValue is in incorrect format
+	 * @throws UserExtSourceNotExistsException if userExtSource can't be found
+	 */
+	private UserExtSource getUserExtSourceByUniqueAttributeValue(PerunSession sess, AttributeDefinition attrDef, String uniqueValue) throws InternalErrorException, UserExtSourceNotExistsException {
+		if(!attrDef.getNamespace().startsWith(AttributesManager.NS_UES_ATTR)) throw new InternalErrorException("Attribute definition has to be from 'ues' namespace: " + attrDef);
+		if(!attrDef.isUnique()) throw new InternalErrorException("Attribute definition has to be unique: " + attrDef);
+		if(uniqueValue == null || uniqueValue.isEmpty()) throw new InternalErrorException("Can't find userExtSource by empty value!");
+
+		return usersManagerImpl.getUserExtSourceByUniqueAttributeValue(sess, attrDef.getId(), uniqueValue);
+	}
+
+	@Override
 	public List<UserExtSource> getAllUserExtSourcesByTypeAndLogin(PerunSession sess, String extType, String extLogin) throws InternalErrorException {
 		return getUsersManagerImpl().getAllUserExtSourcesByTypeAndLogin(sess, extType, extLogin);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -620,6 +620,20 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	@Override
+	public UserExtSource getUserExtSourceByUniqueAttributeValue(PerunSession sess, int attrId, String uniqueValue) throws InternalErrorException, UserExtSourceNotExistsException {
+		try {
+			return jdbc.queryForObject("select " + userExtSourceMappingSelectQuery + "," + ExtSourcesManagerImpl.extSourceMappingSelectQuery +
+				" from user_ext_sources left join ext_sources on user_ext_sources.ext_sources_id=ext_sources.id " +
+				" left join user_ext_source_attr_u_values on user_ext_source_attr_u_values.user_ext_source_id=user_ext_sources.id" +
+				" where user_ext_source_attr_u_values.attr_id=? and user_ext_source_attr_u_values.attr_value=?", USEREXTSOURCE_MAPPER, attrId, uniqueValue);
+		} catch (EmptyResultDataAccessException e) {
+			throw new UserExtSourceNotExistsException(e);
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
 	public List<UserExtSource> getUserExtSources(PerunSession sess, User user) throws InternalErrorException {
 		try {
 			return jdbc.query("SELECT " + userExtSourceMappingSelectQuery + "," + ExtSourcesManagerImpl.extSourceMappingSelectQuery +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -309,6 +309,27 @@ public interface UsersManagerImplApi {
 	UserExtSource getUserExtSourceById(PerunSession sess, int id) throws InternalErrorException, UserExtSourceNotExistsException;
 
 	/**
+	 * Return userExtSource for specific attribute id and unique value.
+	 * If not found, throw and exception.
+	 *
+	 * It looks for exactly one value of the specific attribute type:
+	 * - Integer -> exactly match
+	 * - String -> exactly match
+	 * - Map -> exactly match of "key=value"
+	 * - ArrayList -> exactly match of one of the value
+	 *
+	 * @param sess
+	 * @param attrId attribute id we are looking for
+	 * @param uniqueValue value used for searching
+	 *
+	 * @return userExtSource found by attribute id and it's unique value
+	 *
+	 * @throws InternalErrorException if Runtime exception has been thrown
+	 * @throws UserExtSourceNotExistsException if userExtSource can't be found
+	 */
+	UserExtSource getUserExtSourceByUniqueAttributeValue(PerunSession sess, int attrId, String uniqueValue) throws InternalErrorException, UserExtSourceNotExistsException;
+
+	/**
 	 * Get List of user ext sources by user
 	 *
 	 * @param sess session

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -36,7 +36,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
@@ -605,6 +607,86 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 		usersManager.getUserExtSourceById(sess, 0);
 		// shouldn't find ext source
 
+	}
+
+	@Test
+	public void getUserExtSourceByListValue() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByListValue");
+
+		List<String> listValue = new ArrayList<>();
+		listValue.add("A-VALUE");
+		listValue.add("B-VALUE");
+		listValue.add("C-VALUE");
+
+		Attribute attribute = createUserExtSourceAttribute("testAttribute", ArrayList.class.getName(), listValue, true);
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource, attribute);
+
+		for(String value : listValue) {
+			UserExtSource returnedUserExtSource = perun.getUsersManagerBl().getUserExtSourceByUniqueAttributeValue(sess, attribute.getId(), value);
+			assertEquals(userExtSource, returnedUserExtSource);
+		}
+	}
+
+	@Test
+	public void getUserExtSourceByMapValue() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByMapValue");
+
+		Map<String, String> mapValue = new LinkedHashMap<>();
+		mapValue.put("A-KEY", "A-VALUE");
+		mapValue.put("B-KEY", "B-VALUE");
+		mapValue.put("C-KEY", "C-VALUE");
+
+		Attribute attribute = createUserExtSourceAttribute("testAttribute", LinkedHashMap.class.getName(), mapValue, true);
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource, attribute);
+
+		for(String key : mapValue.keySet()) {
+			String uniqueValue = key + "=" + mapValue.get(key);
+			UserExtSource returnedUserExtSource = perun.getUsersManagerBl().getUserExtSourceByUniqueAttributeValue(sess, attribute.getId(), uniqueValue);
+			assertEquals(userExtSource, returnedUserExtSource);
+		}
+	}
+
+	@Test
+	public void getUserExtSourceByStringValue() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByStringValue");
+
+		Attribute attribute = createUserExtSourceAttribute("testAttribute", String.class.getName(), "testValue", true);
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource, attribute);
+
+		UserExtSource returnedUserExtSource = perun.getUsersManagerBl().getUserExtSourceByUniqueAttributeValue(sess, attribute.getId(), attribute.valueAsString());
+		assertEquals(userExtSource, returnedUserExtSource);
+	}
+
+	@Test
+	public void getUserExtSourceByIntegerValue() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByIntegerValue");
+
+		Attribute attribute = createUserExtSourceAttribute("testAttribute", Integer.class.getName(), 77, true);
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource, attribute);
+
+		UserExtSource returnedUserExtSource = perun.getUsersManagerBl().getUserExtSourceByUniqueAttributeValue(sess, attribute.getId(), attribute.valueAsInteger().toString());
+		assertEquals(userExtSource, returnedUserExtSource);
+	}
+
+	@Test
+	public void getUserExtSourceByBooleanValue() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByBooleanValue");
+
+		Attribute attribute = createUserExtSourceAttribute("testAttribute", Boolean.class.getName(), true, true);
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource, attribute);
+
+		UserExtSource returnedUserExtSource = perun.getUsersManagerBl().getUserExtSourceByUniqueAttributeValue(sess, attribute.getId(), attribute.valueAsBoolean().toString());
+		assertEquals(userExtSource, returnedUserExtSource);
+	}
+
+	@Test (expected=InternalErrorException.class)
+	public void getUserExtSourceByNonUniqueAttribute() throws Exception {
+		System.out.println(CLASS_NAME + "getUserExtSourceByNonUniqueAttribute");
+
+		Attribute attribute = createUserExtSourceAttribute("testAttribute");
+		perun.getAttributesManagerBl().setAttribute(sess, userExtSource, attribute);
+
+		perun.getUsersManagerBl().getUserExtSourceByUniqueAttributeValue(sess, attribute.getId(), attribute.valueAsString());
 	}
 
 	@Test (expected=UserExtSourceNotExistsException.class)
@@ -1321,14 +1403,19 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 	}
 
 	private Attribute createUserExtSourceAttribute(String name) throws Exception {
+		return this.createUserExtSourceAttribute(name, String.class.getName(), "Testing value", false);
+	}
+
+	private Attribute createUserExtSourceAttribute(String name, String type, Object value, boolean unique) throws Exception {
 		AttributeDefinition attrDef = new AttributeDefinition();
 		attrDef.setNamespace(AttributesManager.NS_UES_ATTR_DEF);
 		attrDef.setDescription(name);
 		attrDef.setFriendlyName(name);
-		attrDef.setType(String.class.getName());
+		attrDef.setType(type);
+		attrDef.setUnique(unique);
 		attrDef = perun.getAttributesManagerBl().createAttribute(sess, attrDef);
 		Attribute attribute = new Attribute(attrDef);
-		attribute.setValue("Testing value");
+		attribute.setValue(value);
 		return attribute;
 	}
 }


### PR DESCRIPTION
 - we want to find userExtSource by value of its attribute
 - if attribute is type of Map, we need to look for combination
 'key=value' and if it is array, we need to look for one of his values,
 for this reason implementation can work only with unique attributes
 - logic will be just a part of bussiness logic, we don't need to call
 this method from outside yet
 - two implementations were created: one using attribute Id, one using
 attribute name, both checking existence of such unique userExtSource
 attribute
 - add tests for all values of attributes