### PR TITLE
Prevent large attributes to be unique

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2329,6 +2329,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			if (!Arrays.asList("def","opt").contains(attribute.getNamespace().split(":")[4])) {
 				throw new InternalErrorException("only 'def' and 'opt' attributes can be unique");
 			}
+			if(attribute.getType().equals(BeansUtils.largeStringClassName) ||
+					attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
+				throw new InternalErrorException("large attributes cannot be marked unique");
+			}
 		}
 
 		attribute = getAttributesManagerImpl().createAttribute(sess, attribute);
@@ -7331,6 +7335,10 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		if(attrDef.getNamespace().startsWith(NS_ENTITYLESS_ATTR)) throw new InternalErrorException("entityless atributes cannot be converted to unique");
 		if(!Arrays.asList("def","opt").contains(attrDef.getNamespace().split(":")[4])) {
 			throw new InternalErrorException("only 'def' and 'opt' attributes can be converted to unique");
+		}
+		if(attrDef.getType().equals(BeansUtils.largeStringClassName) ||
+			attrDef.getType().equals(BeansUtils.largeArrayListClassName)) {
+			throw new InternalErrorException("large attributes cannot be marked unique");
 		}
 		log.info("converting attribute {} to unique",attrDef.getName());
 		attrDef.setUnique(true);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/AttributesManagerEntryIntegrationTestAbstract.java
@@ -5294,6 +5294,11 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 			if (bean.equals("entityless")) continue;
 
 			for (String type : AttributesManagerImpl.ATTRIBUTE_TYPES) {
+				//large string and large array are unsupported types for uniqueness
+				if(type.equals(BeansUtils.largeStringClassName) || type.equals(BeansUtils.largeArrayListClassName)) {
+					continue;
+				}
+
 				log.debug("conversion to unique bean {} type {}", bean, type);
 				String namespace = AttributesManagerImpl.BEANS_TO_NAMESPACES_MAP.get(bean) + ":def";
 				String friendlyName = "test-conv-attr" + (counter++);
@@ -5316,7 +5321,6 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 				Attribute b = new Attribute(attributeDefinition);
 				switch (type) {
 					case "java.lang.String":
-					case BeansUtils.largeStringClassName:
 						a.setValue("string1");
 						b.setValue("string2");
 						break;
@@ -5329,7 +5333,6 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						b.setValue(Boolean.TRUE);
 						break;
 					case "java.util.ArrayList":
-					case BeansUtils.largeArrayListClassName:
 						a.setValue(new ArrayList<>(Arrays.asList("value1","value2")));
 						b.setValue(new ArrayList<>(Arrays.asList("value3","value4")));
 						break;
@@ -5445,6 +5448,11 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 			if (bean.equals("entityless")) continue;
 
 			for(String type: AttributesManagerImpl.ATTRIBUTE_TYPES) {
+				//large string and large array are unsupported types for uniqueness
+				if(type.equals(BeansUtils.largeStringClassName) || type.equals(BeansUtils.largeArrayListClassName)) {
+					continue;
+				}
+
 				log.debug(" uniqueness check bean {} type {}", bean, type);
 				String namespace = AttributesManagerImpl.BEANS_TO_NAMESPACES_MAP.get(bean) + ":def";
 				String friendlyName = "test-attr"+(counter++);
@@ -5466,7 +5474,6 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 				Attribute b = new Attribute(attributeDefinition);
 				switch (type) {
 					case "java.lang.String":
-					case BeansUtils.largeStringClassName:
 						a.setValue("samestring");
 						b.setValue("samestring");
 						break;
@@ -5479,7 +5486,6 @@ public class AttributesManagerEntryIntegrationTestAbstract extends AbstractPerun
 						b.setValue(Boolean.TRUE);
 						break;
 					case "java.util.ArrayList":
-					case BeansUtils.largeArrayListClassName:
 						a.setValue(Lists.newArrayList("value1","value2"));
 						b.setValue(Lists.newArrayList("value3","value2"));
 						break;


### PR DESCRIPTION
 - because there is a limitation of the field in database for one value
 of unique attribute, we need to prevent large attributes to become
 unique