### PR TITLE
Expiration of member need to check validity of attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1212,8 +1212,10 @@ public interface MembersManagerBl {
 	 *
 	 * @throws InternalErrorException
 	 * @throws MemberNotValidYetException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws WrongAttributeValueException
 	 */
-	Member expireMember(PerunSession sess, Member member) throws InternalErrorException, MemberNotValidYetException;
+	Member expireMember(PerunSession sess, Member member) throws InternalErrorException, MemberNotValidYetException, WrongReferenceAttributeValueException, WrongAttributeValueException;
 
 	/**
 	 * Disable member.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1145,6 +1145,9 @@ public interface MembersManagerBl {
 	 * Validate all atributes for member and set member's status to VALID.
 	 * This method runs synchronously.
 	 *
+	 * Method runs in nested transaction.
+	 * As side effect, on success will change status of the object member.
+	 *
 	 * @param sess
 	 * @param member
 	 * @return membet with new status set
@@ -1170,6 +1173,8 @@ public interface MembersManagerBl {
 	/**
 	 * Set member status to invalid.
 	 *
+	 * As side effect it will change status of the object member.
+	 *
 	 * @param sess
 	 * @param member
 	 * @return member with new status set
@@ -1180,6 +1185,8 @@ public interface MembersManagerBl {
 
 	/**
 	 * Suspend member.
+	 *
+	 * As side effect it will change status of the object member.
 	 *
 	 * @param sess
 	 * @param member
@@ -1193,6 +1200,8 @@ public interface MembersManagerBl {
 	/**
 	 * Suspend member with reason for suspension.
 	 *
+	 * As side effect it will change status of the object member.
+	 *
 	 * @param sess
 	 * @param member
 	 * @param message
@@ -1205,20 +1214,26 @@ public interface MembersManagerBl {
 
 	/**
 	 * Set member's status to expired.
+	 * All attributes are validated if was in INVALID or DISABLED state before.
+	 * If validation ends with error, member keeps his old status.
+	 *
+	 * Method runs in nested transaction.
+	 * As side effect, on success will change status of the object member.
 	 *
 	 * @param sess
 	 * @param member
 	 * @return member with new status set
 	 *
 	 * @throws InternalErrorException
-	 * @throws MemberNotValidYetException
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws WrongAttributeValueException
 	 */
-	Member expireMember(PerunSession sess, Member member) throws InternalErrorException, MemberNotValidYetException, WrongReferenceAttributeValueException, WrongAttributeValueException;
+	Member expireMember(PerunSession sess, Member member) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException;
 
 	/**
 	 * Disable member.
+	 *
+	 * As side effect, on success will change status of the object member.
 	 *
 	 * @param sess
 	 * @param member

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -3071,7 +3071,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 									perunBl.getMembersManagerBl().expireMember(sess, richMember);
 									log.info("Switching member id {} to EXPIRE state, due to expiration {}.", richMember.getId(), membershipExpiration.getValue());
 									log.debug("Switching member to EXPIRE state, additional info: membership expiration date='{}', system now date='{}'", currentMembershipExpirationDate, now);
-								} catch (MemberNotValidYetException e) {
+								} catch (MemberNotValidYetException | WrongReferenceAttributeValueException | WrongAttributeValueException e) {
 									log.error("Consistency error while trying to expire member id {}, exception {}", richMember.getId(), e);
 								}
 							}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -1448,6 +1448,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 	@Override
 	public Member validateMember(PerunSession sess, Member member) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+		//this method run in nested transaction
 		if(this.haveStatus(sess, member, Status.VALID)) {
 			log.debug("Trying to validate member who is already valid. " + member);
 			return member;
@@ -1458,7 +1459,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		member.setStatus(Status.VALID);
 		getPerunBl().getAuditer().log(sess, new MemberValidated(member));
 		if(oldStatus.equals(Status.INVALID) || oldStatus.equals(Status.DISABLED)) {
-			getPerunBl().getAttributesManagerBl().doTheMagic(sess, member);
+			try {
+				getPerunBl().getAttributesManagerBl().doTheMagic(sess, member);
+			} catch (Exception ex) {
+				//return old status to object to prevent incorrect result in higher methods
+				member.setStatus(oldStatus);
+				throw ex;
+			}
 		}
 
 		return member;
@@ -1505,7 +1512,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			log.warn("Trying to suspend member who is already suspended. Suspend operation will be procesed anyway (to be shure)." + member);
 		}
 
-		if(this.haveStatus(sess, member, Status.INVALID)) throw new MemberNotValidYetException(member);
+		if(this.haveStatus(sess, member, Status.INVALID) || this.haveStatus(sess, member, Status.DISABLED)) throw new MemberNotValidYetException(member);
 		getMembersManagerImpl().setStatus(sess, member, Status.SUSPENDED);
 		member.setStatus(Status.SUSPENDED);
 		getPerunBl().getAuditer().log(sess, new MemberSuspended(member, Auditer.engineForceKeyword));
@@ -1518,7 +1525,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			log.warn("Trying to suspend member who is already suspended. Suspend operation will be procesed anyway (to be shure)." + member);
 		}
 
-		if(this.haveStatus(sess, member, Status.INVALID)) throw new MemberNotValidYetException(member);
+		if(this.haveStatus(sess, member, Status.INVALID) || this.haveStatus(sess, member, Status.DISABLED)) throw new MemberNotValidYetException(member);
 		getMembersManagerImpl().setStatus(sess, member, Status.SUSPENDED);
 		member.setStatus(Status.SUSPENDED);
 		try {
@@ -1541,13 +1548,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
-	public Member expireMember(PerunSession sess, Member member) throws InternalErrorException, MemberNotValidYetException, WrongReferenceAttributeValueException, WrongAttributeValueException {
+	public Member expireMember(PerunSession sess, Member member) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeValueException {
+		//this method run in nested transaction
 		if(this.haveStatus(sess, member, Status.EXPIRED)) {
 			log.debug("Trying to set member expired but he's already expired. " + member);
 			return member;
 		}
 
-		if(this.haveStatus(sess, member, Status.INVALID)) throw new MemberNotValidYetException(member);
 		Status oldStatus = member.getStatus();
 		getMembersManagerImpl().setStatus(sess, member, Status.EXPIRED);
 		member.setStatus(Status.EXPIRED);
@@ -1555,7 +1562,13 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 		//We need to check validity of attributes first (expired member has to have valid attributes)
 		if(oldStatus.equals(Status.INVALID) || oldStatus.equals(Status.DISABLED)) {
-			getPerunBl().getAttributesManagerBl().doTheMagic(sess, member);
+			try {
+				getPerunBl().getAttributesManagerBl().doTheMagic(sess, member);
+			} catch (Exception ex) {
+				//return old status to object to prevent incorrect result in higher methods
+				member.setStatus(oldStatus);
+				throw ex;
+			}
 		}
 
 		return member;
@@ -2441,7 +2454,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			}
 			try {
 				expireMember(sess, sponsoredMember);
-			} catch (MemberNotValidYetException | WrongReferenceAttributeValueException | WrongAttributeValueException ex) {
+			} catch (WrongReferenceAttributeValueException | WrongAttributeValueException ex) {
 				throw new InternalErrorException("cannot expire member "+sponsoredMember.getId(),ex);
 			}
 		}

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -26,6 +26,7 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.AttributesManagerImpl.updateAttribute(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl.mergeAttributeValueInNestedTransaction(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.validateMember(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.expireMember(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.MembersManagerBlImpl.createMemberSync(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.synchronizeGroup(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl.synchronizeGroupStructure(..))"/>

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -359,7 +359,7 @@ public class ExpirationNotifScheduler {
 				try {
 					perun.getMembersManagerBl().expireMember(sess, member);
 					log.info("Switching {} to EXPIRE state, due to expiration {}.", member, perun.getAttributesManagerBl().getAttribute(sess, member, "urn:perun:member:attribute-def:def:membershipExpiration").getValue());
-				} catch (MemberNotValidYetException | WrongAttributeValueException | WrongReferenceAttributeValueException e) {
+				} catch (WrongAttributeValueException | WrongReferenceAttributeValueException e) {
 					log.error("Consistency error while trying to expire member {}, exception {}", member, e);
 				}
 			}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -359,7 +359,7 @@ public class ExpirationNotifScheduler {
 				try {
 					perun.getMembersManagerBl().expireMember(sess, member);
 					log.info("Switching {} to EXPIRE state, due to expiration {}.", member, perun.getAttributesManagerBl().getAttribute(sess, member, "urn:perun:member:attribute-def:def:membershipExpiration").getValue());
-				} catch (MemberNotValidYetException e) {
+				} catch (MemberNotValidYetException | WrongAttributeValueException | WrongReferenceAttributeValueException e) {
 					log.error("Consistency error while trying to expire member {}, exception {}", member, e);
 				}
 			}


### PR DESCRIPTION
 - if member was in invalid or disabled state, his attributes need to be
 checked, because expired member in Perun is defined as "allowed" and
 his attributes need to be valid for services