### PR TITLE
LDAPC-ADA: Use directly BL layer of perun-core

### DIFF
--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/GroupSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/GroupSynchronizer.java
@@ -1,8 +1,6 @@
 package cz.metacentrum.perun.ldapc.beans;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,15 +9,12 @@ import org.springframework.stereotype.Component;
 
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.ldapc.model.PerunGroup;
-import cz.metacentrum.perun.ldapc.service.LdapcManager;
 import cz.metacentrum.perun.core.bl.PerunBl;
 
 @Component
@@ -29,24 +24,24 @@ public class GroupSynchronizer extends AbstractSynchronizer {
 
 	@Autowired
 	protected PerunGroup perunGroup;
-	
+
 	public void synchronizeGroups() {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		try {
 
 			log.debug("Group synchronization - getting list of VOs");
 			// List<Vo> vos = Rpc.VosManager.getVos(ldapcManager.getRpcCaller());
-			List<Vo> vos = perun.getVosManager().getVos(ldapcManager.getPerunSession());  
+			List<Vo> vos = perun.getVosManagerBl().getVos(ldapcManager.getPerunSession());
 
 			for(Vo vo : vos) {
 				// Map<String, Object> params = new HashMap<String, Object>();
 				// params.put("vo", new Integer(vo.getId()));
-				
+
 				try {
 					log.debug("Getting list of groups for VO {}", vo);
 
 					// List<Group> groups = ldapcManager.getRpcCaller().call("groupsManager",  "getAllGroups", params).readList(Group.class);
-					List<Group> groups = perun.getGroupsManager().getAllGroups(ldapcManager.getPerunSession(), vo);
+					List<Group> groups = perun.getGroupsManagerBl().getAllGroups(ldapcManager.getPerunSession(), vo);
 
 					for(Group group : groups) {
 
@@ -59,13 +54,13 @@ public class GroupSynchronizer extends AbstractSynchronizer {
 
 							log.debug("Getting list of members for group {}", group.getId());
 							// List<Member> members = ldapcManager.getRpcCaller().call("groupsManager",  "getGroupMembers", params).readList(Member.class);
-							List<Member> members = ((PerunBl)perun).getGroupsManagerBl().getActiveGroupMembers(ldapcManager.getPerunSession(), group, Status.VALID);
+							List<Member> members = (perun).getGroupsManagerBl().getActiveGroupMembers(ldapcManager.getPerunSession(), group, Status.VALID);
 							log.debug("Synchronizing {} members of group {}", members.size(), group.getId());
 							perunGroup.synchronizeMembers(group, members);
 
 							log.debug("Getting list of resources assigned to group {}", group.getId());
 							// List<Resource> resources = Rpc.ResourcesManager.getAssignedResources(ldapcManager.getRpcCaller(), group);
-							List<Resource> resources = perun.getResourcesManager().getAssignedResources(ldapcManager.getPerunSession(), group);
+							List<Resource> resources = perun.getResourcesManagerBl().getAssignedResources(ldapcManager.getPerunSession(), group);
 							log.debug("Synchronizing {} resources assigned to group {}", resources.size(), group.getId());
 							perunGroup.synchronizeResources(group, resources);
 						} catch (PerunException e) {
@@ -74,12 +69,12 @@ public class GroupSynchronizer extends AbstractSynchronizer {
 					}
 				} catch (PerunException e) {
 					log.error("Error synchronizing groups", e);
-				} 
+				}
 			}
-		} catch (InternalErrorException | PrivilegeException e) {
+		} catch (InternalErrorException e) {
 			log.error("Error reading list of VOs", e);
 		}
 
 	}
-	
+
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/ResourceSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/ResourceSynchronizer.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.ldapc.beans;
 import java.util.ArrayList;
 import java.util.List;
 
+import cz.metacentrum.perun.core.bl.PerunBl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,8 +16,6 @@ import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.ldapc.model.PerunResource;
 
 @Component
@@ -26,38 +25,38 @@ public class ResourceSynchronizer extends AbstractSynchronizer {
 
 	@Autowired
 	protected PerunResource perunResource;
-	
+
 	public void synchronizeResources() {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		try {
 			log.debug("Resource synchronization - getting list of VOs");
 			// List<Vo> vos = Rpc.VosManager.getVos(ldapcManager.getRpcCaller());
-			List<Vo> vos = perun.getVosManager().getVos(ldapcManager.getPerunSession());
+			List<Vo> vos = perun.getVosManagerBl().getVos(ldapcManager.getPerunSession());
 			for (Vo vo : vos) {
 				// Map<String, Object> params = new HashMap <String, Object>();
 				// params.put("vo", new Integer(vo.getId()));
-				
+
 				try {
 					log.debug("Getting list of resources for VO {}", vo);
 					//List<Resource> resources = ldapcManager.getRpcCaller().call("resourceManager", "getResources", params).readList(Resource.class);
-					List<Resource> resources = perun.getResourcesManager().getResources(ldapcManager.getPerunSession(), vo);
+					List<Resource> resources = perun.getResourcesManagerBl().getResources(ldapcManager.getPerunSession(), vo);
 
 					for(Resource resource: resources) {
-						
-						try { 
+
+						try {
 							log.debug("Getting list of resources for resource {}", resource.getId());
 							// Facility facility = Rpc.ResourcesManager.getFacility(ldapcManager.getRpcCaller(), resource);
-							Facility facility = perun.getResourcesManager().getFacility(ldapcManager.getPerunSession(), resource);
+							Facility facility = perun.getResourcesManagerBl().getFacility(ldapcManager.getPerunSession(), resource);
 
 							// params.clear();
 							// params.put("facility",  new Integer(facility.getId()));
 
 							log.debug("Getting list of attributes for resource {}", resource.getId());
-							List<Attribute> attrs = new ArrayList<Attribute>(); 
+							List<Attribute> attrs = new ArrayList<Attribute>();
 							for(String attrName: fillPerunAttributeNames(perunResource.getPerunAttributeNames())) {
 								try {
 									//log.debug("Getting attribute {} for resource {}", attrName, resource.getId());
-									attrs.add(perun.getAttributesManager().getAttribute(ldapcManager.getPerunSession(), facility, attrName));
+									attrs.add(perun.getAttributesManagerBl().getAttribute(ldapcManager.getPerunSession(), facility, attrName));
 								} catch (PerunException e) {
 									log.warn("No attribute {} found for resource {}: {}", attrName, resource.getId(), e.getMessage());
 								}
@@ -68,7 +67,7 @@ public class ResourceSynchronizer extends AbstractSynchronizer {
 							perunResource.synchronizeEntry(resource, attrs);
 
 							log.debug("Getting list of assigned group for resource {}", resource.getId());
-							List<Group> assignedGroups = perun.getResourcesManager().getAssignedGroups(ldapcManager.getPerunSession(), resource);
+							List<Group> assignedGroups = perun.getResourcesManagerBl().getAssignedGroups(ldapcManager.getPerunSession(), resource);
 
 							log.debug("Synchronizing {} groups for resource {}", assignedGroups.size(), resource.getId());
 							perunResource.synchronizeGroups(resource, assignedGroups);
@@ -77,15 +76,15 @@ public class ResourceSynchronizer extends AbstractSynchronizer {
 						}
 					}
 
-					
+
 				} catch (PerunException e) {
 					log.error("Error synchronizing resources", e);
 				}
 			}
-		} catch (InternalErrorException | PrivilegeException e) {
+		} catch (InternalErrorException e) {
 			log.error("Error getting VO list", e);
 		}
 
 	}
-	
+
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/UserSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/UserSynchronizer.java
@@ -5,16 +5,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import cz.metacentrum.perun.core.bl.PerunBl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import cz.metacentrum.perun.core.api.Attribute;
-import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
@@ -28,21 +27,21 @@ public class UserSynchronizer extends AbstractSynchronizer {
 
 	@Autowired
 	private PerunUser perunUser;
-	
+
 	public void synchronizeUsers() {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		try {
 			log.debug("Getting list of users");
-			List<User> users = perun.getUsersManager().getUsers(ldapcManager.getPerunSession());
+			List<User> users = perun.getUsersManagerBl().getUsers(ldapcManager.getPerunSession());
 
 			for(User user: users) {
 
 				log.debug("Getting list of attributes for user {}", user.getId());
-				List<Attribute> attrs = new ArrayList<Attribute>(); 
+				List<Attribute> attrs = new ArrayList<Attribute>();
 				for(String attrName: fillPerunAttributeNames(perunUser.getPerunAttributeNames())) {
 					try {
 						//log.debug("Getting attribute {} for user {}", attrName, user.getId());
-						Attribute attr = perun.getAttributesManager().getAttribute(ldapcManager.getPerunSession(), user, attrName);
+						Attribute attr = perun.getAttributesManagerBl().getAttribute(ldapcManager.getPerunSession(), user, attrName);
 						/* very chatty
 						if(attr == null) {
 							log.debug("Got null for attribute {}", attrName);
@@ -66,31 +65,31 @@ public class UserSynchronizer extends AbstractSynchronizer {
 
 					log.debug("Getting list of member groups for user {}", user.getId());
 					Set<Integer> voIds = new HashSet<>();
-					List<Member> members = perun.getMembersManager().getMembersByUser(ldapcManager.getPerunSession(), user);
+					List<Member> members = perun.getMembersManagerBl().getMembersByUser(ldapcManager.getPerunSession(), user);
 					List<Group> groups = new ArrayList<Group>();
 					for(Member member: members) {
 						if(member.getStatus().equals(Status.VALID)) {
 							voIds.add(member.getVoId());
-							groups.addAll(perun.getGroupsManager().getAllGroupsWhereMemberIsActive(ldapcManager.getPerunSession(), member));
+							groups.addAll(perun.getGroupsManagerBl().getAllGroupsWhereMemberIsActive(ldapcManager.getPerunSession(), member));
 						}
 					}
 
 					log.debug("Synchronizing user {} with {} VOs and {} groups", user.getId(), voIds.size(), groups.size());
 					perunUser.synchronizeMembership(user, voIds, groups);
-					
+
 					log.debug("Getting list of extSources for user {}", user.getId());
-					List<UserExtSource> userExtSources = perun.getUsersManager().getUserExtSources(ldapcManager.getPerunSession(), user);
+					List<UserExtSource> userExtSources = perun.getUsersManagerBl().getUserExtSources(ldapcManager.getPerunSession(), user);
 					log.debug("Synchronizing user {} with {} extSources", user.getId(), userExtSources.size());
 					perunUser.synchronizePrincipals(user, userExtSources);
-					
+
 				} catch (PerunException e) {
 					log.error("Error synchronizing user", e);
 				}
 			}
-			
+
 		} catch (PerunException e) {
 			log.error("Error synchronizing users", e);
 		}
-		
+
 	}
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
@@ -2,18 +2,17 @@ package cz.metacentrum.perun.ldapc.beans;
 
 import java.util.List;
 
+import cz.metacentrum.perun.core.bl.PerunBl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.ldapc.model.PerunVO;
 
 @Component
@@ -25,11 +24,11 @@ public class VOSynchronizer extends AbstractSynchronizer {
 	protected PerunVO perunVO;
 
 	public void synchronizeVOs() {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		try {
 			log.debug("Getting list of VOs");
 			// List<Vo> vos = Rpc.VosManager.getVos(ldapcManager.getRpcCaller());
-			List<Vo> vos = perun.getVosManager().getVos(ldapcManager.getPerunSession());
+			List<Vo> vos = perun.getVosManagerBl().getVos(ldapcManager.getPerunSession());
 			for (Vo vo : vos) {
 				// Map<String, Object> params = new HashMap<String, Object>();
 				// params.put("vo", new Integer(vo.getId()));
@@ -40,7 +39,7 @@ public class VOSynchronizer extends AbstractSynchronizer {
 					try {
 						log.debug("Getting list of VO {} members", vo.getId());
 						// List<Member> members = ldapcManager.getRpcCaller().call("membersManager", "getMembers", params).readList(Member.class);
-						List<Member> members = perun.getMembersManager().getMembers(ldapcManager.getPerunSession(), vo, Status.VALID);
+						List<Member> members = perun.getMembersManagerBl().getMembers(ldapcManager.getPerunSession(), vo, Status.VALID);
 						log.debug("Synchronizing {} members of VO {}", members.size(), vo.getId());
 						perunVO.synchronizeMembers(vo, members);
 					} catch (PerunException e) {
@@ -50,7 +49,7 @@ public class VOSynchronizer extends AbstractSynchronizer {
 					log.error("Error synchronizing VO", e);
 				}
 			}
-		} catch (InternalErrorException | PrivilegeException e) {
+		} catch (InternalErrorException e) {
 			log.error("Error getting list of VOs", e);
 		}
 	}


### PR DESCRIPTION
- We should call BL layer directly, otherwise nested transaction
  is created for each call to perun-core (through API layer).
- Removed unused imports.