### PR TITLE
REGISTRAR: Ignore AlreadyMemberException in BBMRI modules

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -1442,7 +1442,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			app = registrarManager.approveApplicationInternal(sess, appId);
 		} catch (AlreadyMemberException ex) {
 			// case when user joined identity after sending initial application and former user was already member of VO
-			throw new RegistrarException("User is already member of your VO/group with ID:"+ex.getMember().getId()+" (user joined his identities after sending new application). You can reject this application and re-validate old member to keep old data (e.g. login,email).", ex);
+			throw new RegistrarException("User is already member (with ID: "+ex.getMember().getId()+") of your VO/group. (user joined his identities after sending new application). You can reject this application and re-validate old member to keep old data (e.g. login,email).", ex);
 		} catch (MemberNotExistsException ex) {
 			throw new RegistrarException("To approve application user must already be member of VO.", ex);
 		} catch (NotGroupMemberException ex) {

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRICollections.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRICollections.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.registrar.modules;
 
 import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -77,7 +78,11 @@ public class BBMRICollections implements RegistrarModule {
 				log.debug("For collection ID " + collectionID + " there is no group in Perun.");
 			} else {
 				// add user to the group
-				perun.getGroupsManager().addMember(session, group, member);
+				try {
+					perun.getGroupsManager().addMember(session, group, member);
+				} catch (AlreadyMemberException ex) {
+					// ignore
+				}
 			}
 		}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRINetworks.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRINetworks.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -86,7 +87,11 @@ public class BBMRINetworks implements RegistrarModule {
 			if (group == null) {
 				log.debug("For network ID: " + networkID + " there is no group in Perun.");
 			} else {
-				perun.getGroupsManager().addMember(session, group, member);
+				try {
+					perun.getGroupsManager().addMember(session, group, member);
+				} catch (AlreadyMemberException ex) {
+					// ignore
+				}
 			}
 		}
 


### PR DESCRIPTION
- When user is supposed to be added to proper collection
  or network, then we can ignore the stat, that he is already
  a member of such group.
- Rephrased exception message if user is already a member of VO/Group.