### PR TITLE
improve performance in ldap synchronization 

### DIFF
--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/GroupSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/GroupSynchronizer.java
@@ -29,57 +29,60 @@ public class GroupSynchronizer extends AbstractSynchronizer {
 
 	@Autowired
 	protected PerunGroup perunGroup;
-	
+
 	public void synchronizeGroups() {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		try {
 
 			log.debug("Group synchronization - getting list of VOs");
 			// List<Vo> vos = Rpc.VosManager.getVos(ldapcManager.getRpcCaller());
-			List<Vo> vos = perun.getVosManager().getVos(ldapcManager.getPerunSession());  
+			List<Vo> vos = perun.getVosManagerBl().getVos(ldapcManager.getPerunSession());
 
 			for(Vo vo : vos) {
 				// Map<String, Object> params = new HashMap<String, Object>();
 				// params.put("vo", new Integer(vo.getId()));
-				
+
 				try {
 					log.debug("Getting list of groups for VO {}", vo);
 
 					// List<Group> groups = ldapcManager.getRpcCaller().call("groupsManager",  "getAllGroups", params).readList(Group.class);
-					List<Group> groups = perun.getGroupsManager().getAllGroups(ldapcManager.getPerunSession(), vo);
+					List<Group> groups = perun.getGroupsManagerBl().getAllGroups(ldapcManager.getPerunSession(), vo);
 
 					for(Group group : groups) {
 
 						try {
 							log.debug("Synchronizing group {}", group);
-							perunGroup.synchronizeEntry(group);
+							//perunGroup.synchronizeEntry(group);
 
 							// params.clear();
 							// params.put("group", new Integer(group.getId()));
 
 							log.debug("Getting list of members for group {}", group.getId());
 							// List<Member> members = ldapcManager.getRpcCaller().call("groupsManager",  "getGroupMembers", params).readList(Member.class);
-							List<Member> members = ((PerunBl)perun).getGroupsManagerBl().getActiveGroupMembers(ldapcManager.getPerunSession(), group, Status.VALID);
+							List<Member> members = perun.getGroupsManagerBl().getActiveGroupMembers(ldapcManager.getPerunSession(), group, Status.VALID);
 							log.debug("Synchronizing {} members of group {}", members.size(), group.getId());
-							perunGroup.synchronizeMembers(group, members);
+							//perunGroup.synchronizeMembers(group, members);
 
 							log.debug("Getting list of resources assigned to group {}", group.getId());
 							// List<Resource> resources = Rpc.ResourcesManager.getAssignedResources(ldapcManager.getRpcCaller(), group);
-							List<Resource> resources = perun.getResourcesManager().getAssignedResources(ldapcManager.getPerunSession(), group);
+							List<Resource> resources = perun.getResourcesManagerBl().getAssignedResources(ldapcManager.getPerunSession(), group);
 							log.debug("Synchronizing {} resources assigned to group {}", resources.size(), group.getId());
-							perunGroup.synchronizeResources(group, resources);
+							//perunGroup.synchronizeResources(group, resources);
+							
+							perunGroup.synchronizeGroup(group, members, resources);
+							
 						} catch (PerunException e) {
 							log.error("Error synchronizing group", e);
 						}
 					}
 				} catch (PerunException e) {
 					log.error("Error synchronizing groups", e);
-				} 
+				}
 			}
-		} catch (InternalErrorException | PrivilegeException e) {
+		} catch (InternalErrorException e) {
 			log.error("Error reading list of VOs", e);
 		}
 
 	}
-	
+
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/PasswordValueTransformer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/PasswordValueTransformer.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.ldapc.beans;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import cz.metacentrum.perun.core.api.Attribute;
@@ -12,7 +13,8 @@ public class PasswordValueTransformer implements AttributeValueTransformer {
 	
 	@Override
 	public String getValue(String value, Attribute attr) {
-		return "{SASL}" + attr.getValue() + "@" + ldapProperties.getLdapLoginNamespace().toUpperCase();
+		return StringUtils.isBlank(ldapProperties.getLdapLoginNamespace()) ? 
+				null : "{SASL}" + attr.getValue() + "@" + ldapProperties.getLdapLoginNamespace().toUpperCase();
 	}
 
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/ResourceSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/ResourceSynchronizer.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.ldapc.beans;
 import java.util.ArrayList;
 import java.util.List;
 
+import cz.metacentrum.perun.core.bl.PerunBl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,8 +16,6 @@ import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.ldapc.model.PerunResource;
 
 @Component
@@ -26,34 +25,37 @@ public class ResourceSynchronizer extends AbstractSynchronizer {
 
 	@Autowired
 	protected PerunResource perunResource;
-	
+
 	public void synchronizeResources() {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		try {
 			log.debug("Resource synchronization - getting list of VOs");
 			// List<Vo> vos = Rpc.VosManager.getVos(ldapcManager.getRpcCaller());
-			List<Vo> vos = perun.getVosManager().getVos(ldapcManager.getPerunSession());
+			List<Vo> vos = perun.getVosManagerBl().getVos(ldapcManager.getPerunSession());
 			for (Vo vo : vos) {
 				// Map<String, Object> params = new HashMap <String, Object>();
 				// params.put("vo", new Integer(vo.getId()));
-				
+
 				try {
 					log.debug("Getting list of resources for VO {}", vo);
 					//List<Resource> resources = ldapcManager.getRpcCaller().call("resourceManager", "getResources", params).readList(Resource.class);
-					List<Resource> resources = perun.getResourcesManager().getResources(ldapcManager.getPerunSession(), vo);
+					List<Resource> resources = perun.getResourcesManagerBl().getResources(ldapcManager.getPerunSession(), vo);
 
-					for(Resource resource: resources) {
-						
-						try { 
+					for(Resource resource : resources) {
+
+						try {
 							log.debug("Getting list of resources for resource {}", resource.getId());
 							// Facility facility = Rpc.ResourcesManager.getFacility(ldapcManager.getRpcCaller(), resource);
-							Facility facility = perun.getResourcesManager().getFacility(ldapcManager.getPerunSession(), resource);
+							Facility facility = perun.getResourcesManagerBl().getFacility(ldapcManager.getPerunSession(), resource);
 
 							// params.clear();
 							// params.put("facility",  new Integer(facility.getId()));
 
 							log.debug("Getting list of attributes for resource {}", resource.getId());
-							List<Attribute> attrs = new ArrayList<Attribute>(); 
+							List<Attribute> attrs = new ArrayList<Attribute>();
+							/*
+							 *  replaced with single call
+							 *   
 							for(String attrName: fillPerunAttributeNames(perunResource.getPerunAttributeNames())) {
 								try {
 									//log.debug("Getting attribute {} for resource {}", attrName, resource.getId());
@@ -62,30 +64,41 @@ public class ResourceSynchronizer extends AbstractSynchronizer {
 									log.warn("No attribute {} found for resource {}: {}", attrName, resource.getId(), e.getMessage());
 								}
 							}
+							*/
+							List<String> attrNames = fillPerunAttributeNames(perunResource.getPerunAttributeNames());
+							try {
+								//log.debug("Getting attribute {} for resource {}", attrName, resource.getId());
+								attrs.addAll(perun.getAttributesManagerBl().getAttributes(ldapcManager.getPerunSession(), facility, attrNames));
+							} catch (PerunException e) {
+								log.warn("No attributes {} found for resource {}: {}", attrNames, resource.getId(), e.getMessage());
+							}
 							log.debug("Got attributes {}", attrs.toString());
 
 							log.debug("Synchronizing resource {} with {} attrs", resource, attrs.size());
-							perunResource.synchronizeEntry(resource, attrs);
+							//perunResource.synchronizeEntry(resource, attrs);
 
 							log.debug("Getting list of assigned group for resource {}", resource.getId());
-							List<Group> assignedGroups = perun.getResourcesManager().getAssignedGroups(ldapcManager.getPerunSession(), resource);
+							List<Group> assignedGroups = perun.getResourcesManagerBl().getAssignedGroups(ldapcManager.getPerunSession(), resource);
 
 							log.debug("Synchronizing {} groups for resource {}", assignedGroups.size(), resource.getId());
-							perunResource.synchronizeGroups(resource, assignedGroups);
+							//perunResource.synchronizeGroups(resource, assignedGroups);
+							
+							perunResource.synchronizeResource(resource, attrs, assignedGroups);
+							
 						} catch (PerunException e) {
 							log.error("Error synchronizing resource", e);
 						}
 					}
 
-					
+
 				} catch (PerunException e) {
 					log.error("Error synchronizing resources", e);
 				}
 			}
-		} catch (InternalErrorException | PrivilegeException e) {
+		} catch (InternalErrorException e) {
 			log.error("Error getting VO list", e);
 		}
 
 	}
-	
+
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/UserSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/UserSynchronizer.java
@@ -5,16 +5,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import cz.metacentrum.perun.core.bl.PerunBl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
 import cz.metacentrum.perun.core.api.Attribute;
-import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
@@ -22,27 +24,84 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.ldapc.model.PerunUser;
 
 @Component
-public class UserSynchronizer extends AbstractSynchronizer {
+public class UserSynchronizer extends AbstractSynchronizer implements ApplicationContextAware {
 
 	private final static Logger log = LoggerFactory.getLogger(UserSynchronizer.class);
 
-	@Autowired
-	private PerunUser perunUser;
-	
+	private ApplicationContext context;
+
+	private PerunUser[] perunUser = new PerunUser[5];
+
+	private class SyncUsersWorker implements Runnable {
+
+		public int poolIndex;
+		public User user;
+		public List<Attribute> attrs;
+		public Set<Integer> voIds;
+		public List<Group> groups;
+		List<UserExtSource> userExtSources;
+
+		public SyncUsersWorker(int poolIndex, User user, List<Attribute> attrs, Set<Integer> voIds, List<Group> groups, List<UserExtSource> userExtSources) {
+			this.poolIndex = poolIndex;
+			this.user = user;
+			this.attrs = attrs;
+			this.voIds = voIds;
+			this.groups = groups;
+			this.userExtSources = userExtSources;
+		}
+
+		public void run() {
+			try {
+				log.debug("Synchronizing user {} with {} attrs", user, attrs.size());
+				//perunUser[poolIndex].synchronizeEntry(user, attrs);
+				log.debug("Synchronizing user {} with {} VOs and {} groups", user.getId(), voIds.size(), groups.size());
+				//perunUser[poolIndex].synchronizeMembership(user, voIds, groups);
+				log.debug("Synchronizing user {} with {} extSources", user.getId(), userExtSources.size());
+				//perunUser[poolIndex].synchronizePrincipals(user, userExtSources);
+				perunUser[poolIndex].synchronizeUser(user, attrs, voIds, groups, userExtSources);
+			} catch (PerunException e) {
+				log.error("Error synchronizing user", e);
+
+			} catch (Exception e) {
+				log.error("Error synchronizing user", e);
+
+			}
+		}
+
+	}
+
+
 	public void synchronizeUsers() {
-		Perun perun = ldapcManager.getPerunBl();
+
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
+
+		ThreadPoolTaskExecutor syncExecutor = new ThreadPoolTaskExecutor();
+		int poolIndex;
+
+		for(poolIndex = 0; poolIndex < perunUser.length; poolIndex++ ) {
+			perunUser[poolIndex] = context.getBean("perunUser", PerunUser.class);
+		}
+
 		try {
+
 			log.debug("Getting list of users");
-			List<User> users = perun.getUsersManager().getUsers(ldapcManager.getPerunSession());
+			List<User> users = perun.getUsersManagerBl().getUsers(ldapcManager.getPerunSession());
+
+			syncExecutor.setCorePoolSize(5);
+			syncExecutor.setMaxPoolSize(8);
+			//syncExecutor.setQueueCapacity(30);
+			syncExecutor.initialize();
+
+			poolIndex = 0;
 
 			for(User user: users) {
 
 				log.debug("Getting list of attributes for user {}", user.getId());
-				List<Attribute> attrs = new ArrayList<Attribute>(); 
-				for(String attrName: fillPerunAttributeNames(perunUser.getPerunAttributeNames())) {
+				List<Attribute> attrs = new ArrayList<Attribute>();
+				List<String> attrNames = fillPerunAttributeNames(perunUser[poolIndex].getPerunAttributeNames());
 					try {
 						//log.debug("Getting attribute {} for user {}", attrName, user.getId());
-						Attribute attr = perun.getAttributesManager().getAttribute(ldapcManager.getPerunSession(), user, attrName);
+						attrs.addAll(perun.getAttributesManagerBl().getAttributes(ldapcManager.getPerunSession(), user, attrNames));
 						/* very chatty
 						if(attr == null) {
 							log.debug("Got null for attribute {}", attrName);
@@ -52,45 +111,59 @@ public class UserSynchronizer extends AbstractSynchronizer {
 							log.debug("Got attribute {} with value {}", attrName, attr.getValue().toString());
 						}
 						*/
-						attrs.add(attr);
 					} catch (PerunException e) {
-						log.warn("No attribute {} found for user {}: {}", attrName, user.getId(), e.getMessage());
+						log.warn("Couldn't get attributes {} for user {}: {}", attrNames, user.getId(), e.getMessage());
 					}
-				}
-				log.debug("Got attributes {}", attrs.toString());
+				log.debug("Got attributes {}", attrNames.toString());
 
 				try {
-					log.debug("Synchronizing user {} with {} attrs", user, attrs.size());
-					perunUser.synchronizeEntry(user, attrs);
-
+					//log.debug("Synchronizing user {} with {} attrs", user, attrs.size());
+					//perunUser.synchronizeEntry(user, attrs);
 
 					log.debug("Getting list of member groups for user {}", user.getId());
 					Set<Integer> voIds = new HashSet<>();
-					List<Member> members = perun.getMembersManager().getMembersByUser(ldapcManager.getPerunSession(), user);
+					List<Member> members = perun.getMembersManagerBl().getMembersByUser(ldapcManager.getPerunSession(), user);
 					List<Group> groups = new ArrayList<Group>();
 					for(Member member: members) {
 						if(member.getStatus().equals(Status.VALID)) {
 							voIds.add(member.getVoId());
-							groups.addAll(perun.getGroupsManager().getAllGroupsWhereMemberIsActive(ldapcManager.getPerunSession(), member));
+							groups.addAll(perun.getGroupsManagerBl().getAllGroupsWhereMemberIsActive(ldapcManager.getPerunSession(), member));
 						}
 					}
 
-					log.debug("Synchronizing user {} with {} VOs and {} groups", user.getId(), voIds.size(), groups.size());
-					perunUser.synchronizeMembership(user, voIds, groups);
-					
+					//log.debug("Synchronizing user {} with {} VOs and {} groups", user.getId(), voIds.size(), groups.size());
+					//perunUser.synchronizeMembership(user, voIds, groups);
+
 					log.debug("Getting list of extSources for user {}", user.getId());
-					List<UserExtSource> userExtSources = perun.getUsersManager().getUserExtSources(ldapcManager.getPerunSession(), user);
-					log.debug("Synchronizing user {} with {} extSources", user.getId(), userExtSources.size());
-					perunUser.synchronizePrincipals(user, userExtSources);
-					
+					List<UserExtSource> userExtSources = perun.getUsersManagerBl().getUserExtSources(ldapcManager.getPerunSession(), user);
+
+					//log.debug("Synchronizing user {} with {} extSources", user.getId(), userExtSources.size());
+					//perunUser.synchronizePrincipals(user, userExtSources);
+
+					syncExecutor.execute(new SyncUsersWorker(poolIndex, user, attrs, voIds, groups, userExtSources));
+
 				} catch (PerunException e) {
 					log.error("Error synchronizing user", e);
 				}
+
+				poolIndex = (poolIndex + 1) % perunUser.length;
 			}
-			
+
 		} catch (PerunException e) {
 			log.error("Error synchronizing users", e);
+		} finally {
+			syncExecutor.shutdown();
+			for(poolIndex = 0; poolIndex < perunUser.length; poolIndex++) {
+				perunUser[poolIndex] = null;
+			}
 		}
-		
+
 	}
+
+
+	@Override
+	public void setApplicationContext(ApplicationContext context) throws BeansException {
+		this.context = context;
+	}
+
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.ldapc.beans;
 
 import java.util.List;
 
+import cz.metacentrum.perun.core.bl.PerunBl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,32 +26,28 @@ public class VOSynchronizer extends AbstractSynchronizer {
 	protected PerunVO perunVO;
 
 	public void synchronizeVOs() {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		try {
 			log.debug("Getting list of VOs");
 			// List<Vo> vos = Rpc.VosManager.getVos(ldapcManager.getRpcCaller());
-			List<Vo> vos = perun.getVosManager().getVos(ldapcManager.getPerunSession());
+			List<Vo> vos = perun.getVosManagerBl().getVos(ldapcManager.getPerunSession());
 			for (Vo vo : vos) {
 				// Map<String, Object> params = new HashMap<String, Object>();
 				// params.put("vo", new Integer(vo.getId()));
 
 				try {
 					log.debug("Synchronizing VO entry {}", vo);
-					perunVO.synchronizeEntry(vo);
-					try {
-						log.debug("Getting list of VO {} members", vo.getId());
-						// List<Member> members = ldapcManager.getRpcCaller().call("membersManager", "getMembers", params).readList(Member.class);
-						List<Member> members = perun.getMembersManager().getMembers(ldapcManager.getPerunSession(), vo, Status.VALID);
-						log.debug("Synchronizing {} members of VO {}", members.size(), vo.getId());
-						perunVO.synchronizeMembers(vo, members);
-					} catch (PerunException e) {
-						log.error("Error synchronizing members for VO " + vo.getId(), e);
-					}
-				} catch (InternalErrorException e) {
-					log.error("Error synchronizing VO", e);
+					//perunVO.synchronizeEntry(vo);
+					log.debug("Getting list of VO {} members", vo.getId());
+					// List<Member> members = ldapcManager.getRpcCaller().call("membersManager", "getMembers", params).readList(Member.class);
+					List<Member> members = perun.getMembersManager().getMembers(ldapcManager.getPerunSession(), vo, Status.VALID);
+					log.debug("Synchronizing {} members of VO {}", members.size(), vo.getId());
+					perunVO.synchronizeVo(vo, members);
+				} catch (PerunException e) {
+					log.error("Error synchronizing VO " + vo.getId(), e);
 				}
 			}
-		} catch (InternalErrorException | PrivilegeException e) {
+		} catch (InternalErrorException e) {
 			log.error("Error getting list of VOs", e);
 		}
 	}

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunEntry.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunEntry.java
@@ -19,6 +19,11 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
  */
 public interface PerunEntry<T extends PerunBean> {
 
+	public interface SyncOperation {
+		public boolean isNew();
+		public DirContextOperations getEntry();
+	};
+	
 	/**
 	 * 
 	 * @param bean
@@ -75,6 +80,28 @@ public interface PerunEntry<T extends PerunBean> {
 	 */
 	void deleteEntry(T bean) throws InternalErrorException;
 
+	/**
+	 * 
+	 * @param bean
+	 * @throws InternalErrorException
+	 */
+	SyncOperation beginSynchronizeEntry(T bean) throws InternalErrorException;
+	
+	/**
+	 * 
+	 * @param bean
+	 * @param attrs
+	 * @throws InternalErrorException 
+	 */
+	SyncOperation beginSynchronizeEntry(T bean, Iterable<Attribute> attrs) throws InternalErrorException;
+	
+	/**
+	 * 
+	 * @param op
+	 * @throws InternalErrorException
+	 */
+	void commitSyncOperation(SyncOperation op) throws InternalErrorException;
+	
 	/**
 	 * 
 	 * @param bean

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunGroup.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunGroup.java
@@ -85,6 +85,8 @@ public interface PerunGroup extends PerunEntry<Group> {
 	@Deprecated
 	public List<String> getAllUniqueMembersInGroup(int groupId, int voId);
 
+	public void synchronizeGroup(Group group, List<Member> members, List<Resource> resources) throws InternalErrorException;
+	
 	public void synchronizeMembers(Group group, List<Member> members);
 
 	public void synchronizeResources(Group group, List<Resource> resources);

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunResource.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunResource.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.ldapc.model;
 
 import java.util.List;
 
+import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -31,5 +32,7 @@ public interface PerunResource extends PerunEntry<Resource> {
 	
 	public void removeGroup(Resource resource, Group group) throws InternalErrorException;
 
+	public void synchronizeResource(Resource resource, Iterable<Attribute> attrs, List<Group> assignedGroups) throws InternalErrorException;
+	
 	public void synchronizeGroups(Resource resource, List<Group> assignedGroups) throws InternalErrorException;
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunUser.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunUser.java
@@ -7,6 +7,7 @@ import javax.naming.Name;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.ModificationItem;
 
+import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
@@ -48,6 +49,7 @@ public interface PerunUser extends PerunEntry<User> {
 
 	public void removePrincipal(User user, String login) throws InternalErrorException;
 
+	public void synchronizeUser(User user, Iterable<Attribute> attrs, Set<Integer> voIds, List<Group> groups, List<UserExtSource> extSources) throws InternalErrorException;
 
 	public void synchronizeMembership(User user, Set<Integer> voIds, List<Group> groups);
 	

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunVO.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunVO.java
@@ -44,6 +44,8 @@ public interface PerunVO extends PerunEntry<Vo> {
 
 	public void removeMemberFromVO(int voId, Member member);
 
+	public void synchronizeVo(Vo vo, List<Member> members) throws InternalErrorException;
+	
 	public void synchronizeMembers(Vo vo, List<Member> members);
 
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventDispatcherImpl.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventDispatcherImpl.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.ldapc.processor.impl;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;

--- a/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
@@ -6,7 +6,7 @@
 	   xmlns:tx="http://www.springframework.org/schema/tx"
 	   xmlns:ldap="http://www.springframework.org/schema/ldap"
        xsi:schemaLocation="
-http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd
 http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
@@ -362,7 +362,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		</property>
 	</bean>
 
-	<bean id="perunUser" class="cz.metacentrum.perun.ldapc.model.impl.PerunUserImpl">
+	<bean id="perunUser" class="cz.metacentrum.perun.ldapc.model.impl.PerunUserImpl" scope="prototype">
 		<property name="attributeDescriptions">
 			<!--  this list will be added to built-in defaultAttributeDescriptions -->
 			<list>


### PR DESCRIPTION
- Use thread pool and different ldapTemplate per thread for user synchronization
- Use @Lazy to break circular dependencies
- Squash ldap updates in sync operation
- Call BL instead of Entry/API.
- Get User and Resource attributes using single call.
- Fixed setting of users surname attribute.
- Do not set userPassword when login namespace property is empty