### PR TITLE
DB,BASE,CORE: Removed all references for auditer_subscribers table

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -438,22 +438,6 @@ create table auditer_consumers (
 	constraint audcon_u unique(name)
 );
 
--- AUDITER_SUBSCRIBERS - registers recently processed events
-create table auditer_subscribers (
-	id integer not null,
-	name varchar(256) not null,
-	last_processed_id integer,
-	filters clob,
-	created_at timestamp default current_date not null,
-	created_by varchar(1300) default user not null,
-	modified_at timestamp default current_date not null,
-	modified_by varchar(1300) default user not null,
-	created_by_uid integer,
-	modified_by_uid integer,
-	constraint audsub_pk primary key (id),
-	constraint audsub_u unique(name)
-);
-
 -- SERVICES - provided services, their atomic form
 create table services (
 	id integer not null,
@@ -1591,7 +1575,6 @@ create table authz (
 
 create sequence attr_names_id_seq;
 create sequence auditer_consumers_id_seq;
-create sequence auditer_subscribers_id_seq;
 create sequence auditer_log_id_seq;
 create sequence auditer_log_json_id_seq;
 create sequence destinations_id_seq;

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -97,13 +97,6 @@ drop sequence exec_services_id_seq;
 drop table dispatcher_settings;
 update configurations set value='3.1.47' where property='DATABASE VERSION';
 
-3.1.47
-create table auditer_subscribers (id integer not null, name varchar(256) not null, last_processed_id integer, filters clob, created_at timestamp default statement_timestamp() not null, created_by varchar(1300) default user not null, modified_at timestamp default statement_timestamp() not null, modified_by varchar(1300) default user not null, created_by_uid integer, modified_by_uid integer, constraint audsub_pk primary key (id), constraint audsub_u unique(name) );
-create sequence auditer_subscriers_id_seq start with 10 increment by 1;
-create table auditer_log_json (id integer not null, msg text not null, actor varchar(256) not null, created_at timestamp default statement_timestamp() not null, created_by_uid integer, modified_by_uid integer, constraint audlogjson_pk primary key (id) );
-create sequence auditer_log_json_id_seq start with 10 increment by 1;
-update configurations set value='3.1.47' where property='DATABASE VERSION';
-
 3.1.46
 ALTER TABLE attr_names ADD COLUMN is_unique BOOLEAN DEFAULT FALSE NOT NULL;
 alter table member_resource_attr_values add constraint memrav_pk primary key(member_id,resource_id,attr_id);

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -444,25 +444,6 @@ create table auditer_consumers (
 	constraint audcon_u unique(name)
 );
 
--- AUDITER_SUBSCRIBERS - registers recently processed events
-create table auditer_subscribers (
-	id integer not null,
-	name nvarchar2(256) not null,
-	last_processed_id integer,
-	--filters
-	filters clob,
-	created_at date default sysdate not null,
-	created_by nvarchar2(1300) default user not null,
-	modified_at date default sysdate not null,
-	modified_by nvarchar2(1300) default user not null,
-	created_by_uid integer,
-	modified_by_uid integer,
-	constraint audsub_pk primary key (id),
-	constraint audsub_u unique(name)
-);
-
-
-
 -- SERVICES - provided services, their atomic form
 create table services (
 	id integer not null,
@@ -1601,7 +1582,6 @@ create table authz (
 
 create sequence ATTR_NAMES_ID_SEQ nocache;
 create sequence AUDITER_CONSUMERS_ID_SEQ nocache;
-create sequence AUDITER_SUBSCRIBERS_ID_SEQ nocache;
 create sequence AUDITER_LOG_ID_SEQ nocache;
 create sequence AUDITER_LOG_JSON_ID_SEQ nocache;
 create sequence DESTINATIONS_ID_SEQ nocache;

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -435,22 +435,6 @@ create table auditer_consumers (
   constraint audcon_u unique(name)
 );
 
--- AUDITER_SUBSCRIBERS - registers recently processed events
-create table auditer_subscribers(
-	id integer not null,
-	name varchar(256) not null,
-	last_processed_id integer,
-	filters clob,
-	created_at timestamp default statement_timestamp() not null,
-	created_by varchar(1300) default user not null,
-	modified_at timestamp default statement_timestamp() not null,
-	modified_by varchar(1300) default user not null,
-	created_by_uid integer,
-	modified_by_uid integer,
-	constraint audsub_pk primary key (id),
-  constraint audsub_u unique(name)
-);
-
 -- SERVICES - provided services, their atomic form
 create table services (
 	id integer not null,
@@ -1589,7 +1573,6 @@ create table authz (
 
 create sequence "attr_names_id_seq";
 create sequence "auditer_consumers_id_seq";
-create sequence "auditer_subscriers_id_seq"; --auditerSubscriber seq
 create sequence "auditer_log_id_seq";
 create sequence "auditer_log_json_id_seq"; --auditerJson seq
 create sequence "destinations_id_seq";
@@ -1860,7 +1843,6 @@ grant all on application_data to perun;
 grant all on application_reserved_logins to perun;
 grant all on auditer_log to perun;
 grant all on auditer_consumers to perun;
-grant all on auditer_subscribers to perun;
 grant all on auditer_log_json to perun;
 grant all on entityless_attr_values to perun;
 grant all on cabinet_categories to perun;

--- a/perun-db/table_order
+++ b/perun-db/table_order
@@ -30,7 +30,6 @@ authz
 hosts
 host_attr_values
 auditer_consumers
-auditer_subscribers
 security_teams_facilities
 blacklists
 resources_bans


### PR DESCRIPTION
- There was a remnant table "auditer_subscribers" of rejected
  functionality for auditer subscribers, which got into the code
  probably because of wrong rebase.
  Since it was badly defined, it was not created on any new instance
  nor it was present in the DB changelog for updates.
  Its sequence might have been created on new instances and should be
  deleted (outside our db changelog).