### PR TITLE
Fixed auditer message for planned service propagation

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GeneralServiceManagerEvents/PropagationPlannedOnFacilityAndService.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GeneralServiceManagerEvents/PropagationPlannedOnFacilityAndService.java
@@ -20,7 +20,7 @@ public class PropagationPlannedOnFacilityAndService extends AuditEvent {
 	public PropagationPlannedOnFacilityAndService(Facility facility, Service service) {
 		this.facility = facility;
 		this.service = service;
-		this.message = formatMessage("propagation planned: On %s.", service);
+		this.message = formatMessage("propagation planned: On %s and %s.", facility, service);
 	}
 
 	public Facility getFacility() {


### PR DESCRIPTION
- There was forgotten facility object in auditer event
  "PropagationPlannedOnFacilityAndService" which resulted in
  disability to start propagation at all for such combination of
  facility and service.