### PR TITLE
CORE: Removed dependency on opencsv, we use jackson library instead

### DIFF
--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -193,17 +193,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.opencsv</groupId>
-			<artifactId>opencsv</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
 		</dependency>
@@ -222,6 +211,11 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-csv</artifactId>
 		</dependency>
 
 		<!-- PostgreSQL driver -->

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
 		<jcip.version>1.0</jcip.version>
 		<jdom.version>1.0</jdom.version>
 		<json.version>20140107</json.version>
-		<opencsv.version>4.6</opencsv.version>
 		<oracle.version>12.2.0.1.0</oracle.version>
 		<smackx.version>3.1.0</smackx.version>
 	</properties>


### PR DESCRIPTION
- Jackson library for CSV is curated in spring-boot-starter-parent
  and by using it we don't have to manually updated version in
  dependencies, like we do for opencsv.
- Our ExtSourceCSV now uses jackson library to parse CSV files.
  Functionality is the same, just implementation changed.
  Basically we still expect CSV files to have first row as a header,
  then we read all lines and check each row if it matches query
  and if expected result limit was not passed.