### PR TITLE
remove old entries from LDAP during synchronization in ldapc

### DIFF
--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/AbstractSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/AbstractSynchronizer.java
@@ -2,11 +2,17 @@ package cz.metacentrum.perun.ldapc.beans;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import javax.naming.Name;
+
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.ldapc.model.PerunEntry;
+import cz.metacentrum.perun.ldapc.model.impl.AbstractPerunEntry;
 import cz.metacentrum.perun.ldapc.service.LdapcManager;
 
 public abstract class AbstractSynchronizer {
@@ -25,5 +31,16 @@ public abstract class AbstractSynchronizer {
 			}
 		}
 		return result;
+	}
+
+	protected void removeOldEntries(PerunEntry<?> perunEntry, Set<Name> presentEntries, Logger log) throws InternalErrorException {
+		List<Name> ldapEntries = perunEntry.listEntries();
+		log.debug("Checking for old entries: {} present, {} active", ldapEntries.size(), presentEntries.size());
+		for (Name name : ldapEntries) {
+			if(!presentEntries.contains(name)) {
+				log.debug("Removing entry {} which is not present anymore", name);
+				perunEntry.deleteEntry(name);
+			}
+		}
 	}
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
@@ -1,20 +1,22 @@
 package cz.metacentrum.perun.ldapc.beans;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
-import cz.metacentrum.perun.core.bl.PerunBl;
+import javax.naming.Name;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.ldapc.model.PerunVO;
 
 @Component
@@ -31,10 +33,14 @@ public class VOSynchronizer extends AbstractSynchronizer {
 			log.debug("Getting list of VOs");
 			// List<Vo> vos = Rpc.VosManager.getVos(ldapcManager.getRpcCaller());
 			List<Vo> vos = perun.getVosManagerBl().getVos(ldapcManager.getPerunSession());
+			Set<Name> presentVos = new HashSet<Name>(vos.size());
+			
 			for (Vo vo : vos) {
 				// Map<String, Object> params = new HashMap<String, Object>();
 				// params.put("vo", new Integer(vo.getId()));
-
+				
+				presentVos.add(perunVO.getEntryDN(String.valueOf(vo.getId())));
+				
 				try {
 					log.debug("Synchronizing VO entry {}", vo);
 					//perunVO.synchronizeEntry(vo);
@@ -47,6 +53,14 @@ public class VOSynchronizer extends AbstractSynchronizer {
 					log.error("Error synchronizing VO " + vo.getId(), e);
 				}
 			}
+			
+			// search VO entries in LDAP and remove the ones not present in Perun
+			try {
+				removeOldEntries(perunVO, presentVos, log);
+			} catch (InternalErrorException e) {
+				log.error("Error removing old VO entries", e);
+			}
+			
 		} catch (InternalErrorException e) {
 			log.error("Error getting list of VOs", e);
 		}

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunEntry.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/PerunEntry.java
@@ -82,6 +82,18 @@ public interface PerunEntry<T extends PerunBean> {
 
 	/**
 	 * 
+	 */
+	void deleteEntry(Name dn) throws InternalErrorException;
+	
+	/**
+	 * 
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	List<Name> listEntries() throws InternalErrorException;
+	
+	/**
+	 * 
 	 * @param bean
 	 * @throws InternalErrorException
 	 */

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/AbstractPerunEntry.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/AbstractPerunEntry.java
@@ -140,11 +140,7 @@ public abstract class AbstractPerunEntry<T extends PerunBean> implements Initial
 	 */
 	@Override
 	public void deleteEntry(T bean) throws InternalErrorException {
-		try {
-			ldapTemplate.unbind(buildDN(bean));
-		} catch (NameNotFoundException e) {
-			throw new InternalErrorException(e);
-		}
+		deleteEntry(buildDN(bean));
 	}
 	
 
@@ -446,4 +442,5 @@ public abstract class AbstractPerunEntry<T extends PerunBean> implements Initial
 			}
 		};
 	}
+
 } 

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunGroupImpl.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunGroupImpl.java
@@ -1,6 +1,8 @@
 package cz.metacentrum.perun.ldapc.model.impl;
 
 
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -262,4 +264,13 @@ public class PerunGroupImpl extends AbstractPerunEntry<Group> implements PerunGr
 		}
 		return false;
 	}
+
+	@Override
+	public List<Name> listEntries() throws InternalErrorException {
+		return ldapTemplate.search(query().
+				where("objectclass").is(PerunAttribute.PerunAttributeNames.objectClassPerunGroup),
+				getNameMapper());
+	}
+
+
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunResourceImpl.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunResourceImpl.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.ldapc.model.impl;
 
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -151,6 +153,13 @@ public class PerunResourceImpl extends AbstractPerunEntry<Resource> implements P
 	protected void mapToContext(Resource bean, DirContextOperations context) throws InternalErrorException {
 		context.setAttributeValue("objectclass", PerunAttribute.PerunAttributeNames.objectClassPerunResource);
 		mapToContext(bean, context, getAttributeDescriptions());
+	}
+
+	@Override
+	public List<Name> listEntries() throws InternalErrorException {
+		return ldapTemplate.search(query().
+				where("objectclass").is(PerunAttribute.PerunAttributeNames.objectClassPerunResource),
+				getNameMapper());
 	}
 
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunUserImpl.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunUserImpl.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.ldapc.model.impl;
 
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -195,5 +197,13 @@ public class PerunUserImpl extends AbstractPerunEntry<User> implements PerunUser
 				.add(PerunAttribute.PerunAttributeNames.ldapAttrPerunUserId, userId[0])
 				.build();
 	}
+
+	@Override
+	public List<Name> listEntries() throws InternalErrorException {
+		return ldapTemplate.search(query().
+				where("objectclass").is(PerunAttribute.PerunAttributeNames.objectClassPerson),
+				getNameMapper());
+	}
+
 
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunVOImpl.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunVOImpl.java
@@ -152,4 +152,18 @@ public class PerunVOImpl extends AbstractPerunEntry<Vo> implements PerunVO {
 				getNameMapper());
 	}
 
+	@Override
+	public void deleteEntry(Name dn) throws InternalErrorException {
+		// first find and remove entries in subtree
+		List<Name> subentries = ldapTemplate.search(query()
+				.base(dn)
+				.where("objectclass").like("*"),
+				getNameMapper());
+		for(Name entrydn : subentries) {
+			ldapTemplate.unbind(entrydn);
+		}
+		// then remove this entry
+		super.deleteEntry(dn);
+	}
+
 }

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunVOImpl.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunVOImpl.java
@@ -157,7 +157,7 @@ public class PerunVOImpl extends AbstractPerunEntry<Vo> implements PerunVO {
 		// first find and remove entries in subtree
 		List<Name> subentries = ldapTemplate.search(query()
 				.base(dn)
-				.where("objectclass").like("*"),
+				.where("objectclass").not().is(PerunAttribute.PerunAttributeNames.objectClassPerunVO),
 				getNameMapper());
 		for(Name entrydn : subentries) {
 			ldapTemplate.unbind(entrydn);

--- a/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunVOImpl.java
+++ b/perun-ldapc-ada/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunVOImpl.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.support.LdapNameBuilder;
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
 
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Vo;
@@ -142,6 +143,13 @@ public class PerunVOImpl extends AbstractPerunEntry<Vo> implements PerunVO {
 		return LdapNameBuilder.newInstance()
 				.add(PerunAttribute.PerunAttributeNames.ldapAttrPerunVoId, voId[0])
 				.build();
+	}
+
+	@Override
+	public List<Name> listEntries() throws InternalErrorException {
+		return ldapTemplate.search(query().
+				where("objectclass").is(PerunAttribute.PerunAttributeNames.objectClassPerunVO),
+				getNameMapper());
 	}
 
 }

--- a/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc-ada/src/main/resources/perun-ldapc.xml
@@ -56,6 +56,14 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
 					<property name="beansCondition">
 						<list>
+							<value>cz.metacentrum.perun.core.api.Resource</value>
+						</list>
+					</property>
+					<property name="pattern" value=" deleted.#Facility" />
+				</bean>
+				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
+					<property name="beansCondition">
+						<list>
 							<value>cz.metacentrum.perun.core.api.Group</value>
 						</list>
 					</property>


### PR DESCRIPTION
search and remove old (not in Perun anymore) entries 
wait for workers end before shutting down pool