### PR TITLE
CORE: Fixed setting authz for newly created vo/group

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -189,11 +189,10 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		getPerunBl().getAuditer().log(sess, new GroupCreatedInVo(group, vo));
 		group.setVoId(vo.getId());
 
-
-		//set creator as group admin unless he already have authz right on the group (he is VO admin)
+		//set creator as group admin unless he already have authz right on the group (he is VO admin or this is "members" group of VO)
 		User user = sess.getPerunPrincipal().getUser();
 		if(user != null) {   //user can be null in tests
-			if(!AuthzResolverBlImpl.isAuthorized(sess, Role.VOADMIN, vo)) {
+			if(!AuthzResolverBlImpl.isAuthorized(sess, Role.VOADMIN, vo) && !VosManager.MEMBERS_GROUP.equals(group.getName())) {
 				try {
 					AuthzResolverBlImpl.setRole(sess, user, group, Role.GROUPADMIN);
 				} catch (AlreadyAdminException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -186,6 +186,17 @@ public class VosManagerBlImpl implements VosManagerBl {
 		vo = getVosManagerImpl().createVo(sess, vo);
 		getPerunBl().getAuditer().log(sess, new VoCreated(vo));
 
+		//set creator as VO manager
+		if (sess.getPerunPrincipal().getUser() != null) {
+			try {
+				addAdmin(sess, vo, sess.getPerunPrincipal().getUser());
+			} catch (AlreadyAdminException ex) {
+				throw new ConsistencyErrorException("Add manager to newly created VO failed because there is a particular manager already assigned", ex);
+			}
+		} else {
+			log.error("Can't set VO manager during creating of the VO. User from perunSession is null. {} {}", vo, sess);
+		}
+
 		try {
 			// Create group containing VO members
 			Group members = new Group(VosManager.MEMBERS_GROUP, VosManager.MEMBERS_GROUP_DESCRIPTION + " for VO " + vo.getName());
@@ -197,17 +208,6 @@ public class VosManagerBlImpl implements VosManagerBl {
 
 		// create empty application form
 		getVosManagerImpl().createApplicationForm(sess, vo);
-
-		//set creator as VO manager
-		if (sess.getPerunPrincipal().getUser() != null) {
-			try {
-				addAdmin(sess, vo, sess.getPerunPrincipal().getUser());
-			} catch (AlreadyAdminException ex) {
-				throw new ConsistencyErrorException("Add manager to newly created VO failed because there is a particular manager already assigned", ex);
-			}
-		} else {
-			log.error("Can't set VO manager during creating of the VO. User from perunSession is null. {} {}", vo, sess);
-		}
 
 		log.info("Vo {} created", vo);
 


### PR DESCRIPTION
- When we create new VO, it`s creator is always set as group manager of
  "members" group, because we assigned vo manager role after creating
  such group.
- Now we assign vo manager role before to make sure that unnecessary
  role is not assigned (we don't want to manage managers on "members"
  group).
  Also we prevent it by checking created group name on reserved
  keyword "members" together with user vo manager status.