### PR TITLE
CORE: JSON (de)serialization library jackson moved to supported version

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -105,15 +105,8 @@
 
 		<!-- OTHER -->
 		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-core-asl</artifactId>
-			<version>${jackson1.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>${jackson1.version}</version>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
 		</dependency>
 
 		<dependency>

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AuditEvent.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AuditEvent.java
@@ -1,7 +1,7 @@
 package cz.metacentrum.perun.audit.events;
 
 import cz.metacentrum.perun.core.api.PerunBean;
-import org.codehaus.jackson.annotate.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/JsonDeserializer.java
@@ -2,19 +2,20 @@ package cz.metacentrum.perun.rpc.deserializer;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import cz.metacentrum.perun.cabinet.model.*;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.registrar.model.*;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import java.io.InputStream;
@@ -96,32 +97,37 @@ public class JsonDeserializer extends Deserializer {
 	}
 
 	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
+
 	static {
-		mapper.getDeserializationConfig().addMixInAnnotations(Attribute.class, AttributeMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(AttributeDefinition.class, AttributeDefinitionMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(User.class, UserMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Member.class, MemberMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(AuditMessage.class, AuditMessageMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(PerunBean.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Candidate.class, CandidateMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(PerunException.class, PerunExceptionMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Destination.class, DestinationMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Group.class, GroupMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(UserExtSource.class, UserExtSourceMixIn.class);
 
-		mapper.getDeserializationConfig().addMixInAnnotations(Application.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ApplicationForm.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ApplicationFormItem.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ApplicationFormItemWithPrefilledValue.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ApplicationMail.class, PerunBeanMixIn.class);
+		mixinMap.put(Attribute.class, AttributeMixIn.class);
+		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
+		mixinMap.put(User.class, UserMixIn.class);
+		mixinMap.put(Member.class, MemberMixIn.class);
+		mixinMap.put(AuditMessage.class, AuditMessageMixIn.class);
+		mixinMap.put(PerunBean.class, PerunBeanMixIn.class);
+		mixinMap.put(Candidate.class, CandidateMixIn.class);
+		mixinMap.put(PerunException.class, PerunExceptionMixIn.class);
+		mixinMap.put(Destination.class, DestinationMixIn.class);
+		mixinMap.put(Group.class, GroupMixIn.class);
+		mixinMap.put(UserExtSource.class, UserExtSourceMixIn.class);
 
-		mapper.getDeserializationConfig().addMixInAnnotations(Author.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Category.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Publication.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(PublicationForGUI.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(PublicationSystem.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Thanks.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ThanksForGUI.class, PerunBeanMixIn.class);
+		mixinMap.put(Application.class, PerunBeanMixIn.class);
+		mixinMap.put(ApplicationForm.class, PerunBeanMixIn.class);
+		mixinMap.put(ApplicationFormItem.class, PerunBeanMixIn.class);
+		mixinMap.put(ApplicationFormItemWithPrefilledValue.class, PerunBeanMixIn.class);
+		mixinMap.put(ApplicationMail.class, PerunBeanMixIn.class);
+
+		mixinMap.put(Author.class, PerunBeanMixIn.class);
+		mixinMap.put(Category.class, PerunBeanMixIn.class);
+		mixinMap.put(Publication.class, PerunBeanMixIn.class);
+		mixinMap.put(PublicationForGUI.class, PerunBeanMixIn.class);
+		mixinMap.put(PublicationSystem.class, PerunBeanMixIn.class);
+		mixinMap.put(Thanks.class, PerunBeanMixIn.class);
+		mixinMap.put(ThanksForGUI.class, PerunBeanMixIn.class);
+
+		mapper.setMixIns(mixinMap);
 
 	}
 
@@ -210,14 +216,14 @@ public class JsonDeserializer extends Deserializer {
 				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as int");
 			} else {
 				try {
-					return Integer.parseInt(node.getTextValue());
+					return Integer.parseInt(node.textValue());
 				} catch (NumberFormatException ex) {
 					throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as int", ex);
 				}
 			}
 		}
 
-		return node.getIntValue();
+		return node.intValue();
 	}
 
 	@Override
@@ -241,7 +247,7 @@ public class JsonDeserializer extends Deserializer {
 			if (!value.isInt()) {
 				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as int");
 			}
-			array[i] = node.get(i).getIntValue();
+			array[i] = node.get(i).intValue();
 		}
 		return array;
 	}
@@ -274,7 +280,7 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			return mapper.readValue(node, valueType);
+			return mapper.readValue(node.traverse(), valueType);
 		} catch (IOException ex) {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as " + valueType.getSimpleName(), ex);
 		}
@@ -305,7 +311,7 @@ public class JsonDeserializer extends Deserializer {
 		try {
 			List<T> list = new ArrayList<>(node.size());
 			for (JsonNode e : node) {
-				list.add(mapper.readValue(e, valueType));
+				list.add(mapper.readValue(e.traverse(), valueType));
 			}
 			return list;
 		} catch (IOException ex) {
@@ -328,11 +334,11 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			String beanName = node.get("beanName").getTextValue();
+			String beanName = node.get("beanName").textValue();
 			if(beanName == null) {
 				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - missing beanName info");
 			}
-			return (PerunBean) mapper.readValue(node, Class.forName("cz.metacentrum.perun.core.api." + beanName));
+			return (PerunBean) mapper.readValue(node.traverse(), Class.forName("cz.metacentrum.perun.core.api." + beanName));
 		} catch (ClassNotFoundException ex) {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - class not found");
 		} catch (IOException ex) {
@@ -364,12 +370,12 @@ public class JsonDeserializer extends Deserializer {
 		try {
 			List<PerunBean> list = new ArrayList<>(node.size());
 			for (JsonNode e : node) {
-				String beanName = e.get("beanName").getTextValue();
+				String beanName = e.get("beanName").textValue();
 
 				if(beanName == null) {
 					throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as List<PerunBean> - missing beanName info");
 				}
-				list.add((PerunBean) mapper.readValue(e, Class.forName("cz.metacentrum.perun.core.api." + beanName)));
+				list.add((PerunBean) mapper.readValue(e.traverse(), Class.forName("cz.metacentrum.perun.core.api." + beanName)));
 			}
 			return list;
 		} catch (ClassNotFoundException ex) {

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializer.java
@@ -1,23 +1,25 @@
 package cz.metacentrum.perun.rpc.serializer;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.taskslib.model.Task;
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * JSON serializer.
@@ -108,15 +110,18 @@ public final class JsonSerializer implements Serializer {
 
 	public static final String CONTENT_TYPE = "application/json; charset=utf-8";
 	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
-		mapper.getSerializationConfig().addMixInAnnotations(Attribute.class, AttributeMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(AttributeDefinition.class, AttributeDefinitionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(User.class, UserMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Candidate.class, CandidateMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunException.class, PerunExceptionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunRuntimeException.class, PerunExceptionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Task.class, TaskMixIn.class);
+		mixinMap.put(Attribute.class, AttributeMixIn.class);
+		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
+		mixinMap.put(User.class, UserMixIn.class);
+		mixinMap.put(Candidate.class, CandidateMixIn.class);
+		mixinMap.put(PerunException.class, PerunExceptionMixIn.class);
+		mixinMap.put(PerunRuntimeException.class, PerunExceptionMixIn.class);
+		mixinMap.put(Task.class, TaskMixIn.class);
+
+		mapper.setMixIns(mixinMap);
 	}
 
 	private static final JsonFactory jsonFactory = new JsonFactory();

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONP.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONP.java
@@ -1,5 +1,14 @@
 package cz.metacentrum.perun.rpc.serializer;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Authorship;
 import cz.metacentrum.perun.cabinet.model.Category;
@@ -10,21 +19,14 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.taskslib.model.Task;
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * JSONP serializer.
@@ -140,22 +142,25 @@ public final class JsonSerializerJSONP implements Serializer {
 
 	public static final String CONTENT_TYPE = "text/javascript; charset=utf-8";
 	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
-		mapper.getSerializationConfig().addMixInAnnotations(Attribute.class, AttributeMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(AttributeDefinition.class, AttributeDefinitionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(User.class, UserMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Candidate.class, CandidateMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunException.class, ExceptionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunRuntimeException.class, ExceptionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunBean.class, PerunBeanMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunRequest.class, PerunRequestMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Authorship.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Author.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Category.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Publication.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Thanks.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Task.class, TaskMixIn.class);
+		mixinMap.put(Attribute.class, AttributeMixIn.class);
+		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
+		mixinMap.put(User.class, UserMixIn.class);
+		mixinMap.put(Candidate.class, CandidateMixIn.class);
+		mixinMap.put(PerunException.class, ExceptionMixIn.class);
+		mixinMap.put(PerunRuntimeException.class, ExceptionMixIn.class);
+		mixinMap.put(PerunBean.class, PerunBeanMixIn.class);
+		mixinMap.put(PerunRequest.class, PerunRequestMixIn.class);
+		mixinMap.put(Authorship.class, CabinetMixIn.class);
+		mixinMap.put(Author.class, CabinetMixIn.class);
+		mixinMap.put(Category.class, CabinetMixIn.class);
+		mixinMap.put(Publication.class, CabinetMixIn.class);
+		mixinMap.put(Thanks.class, CabinetMixIn.class);
+		mixinMap.put(Task.class, TaskMixIn.class);
+
+		mapper.setMixIns(mixinMap);
 	}
 
 	private static final JsonFactory jsonFactory = new JsonFactory();

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONSIMPLE.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/serializer/JsonSerializerJSONSIMPLE.java
@@ -1,5 +1,14 @@
 package cz.metacentrum.perun.rpc.serializer;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Authorship;
 import cz.metacentrum.perun.cabinet.model.Category;
@@ -10,19 +19,12 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.taskslib.model.Task;
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * JSON simple serializer which strips a lot of object params (used by engine).
@@ -130,22 +132,25 @@ public final class JsonSerializerJSONSIMPLE implements Serializer {
 
 	public static final String CONTENT_TYPE = "application/json; charset=utf-8";
 	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
-		mapper.getSerializationConfig().addMixInAnnotations(Attribute.class, AttributeMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(AttributeDefinition.class, AttributeDefinitionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(User.class, UserMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Candidate.class, CandidateMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunException.class, ExceptionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunRuntimeException.class, ExceptionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunBean.class, PerunBeanMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(PerunRequest.class, PerunRequestMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Authorship.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Author.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Category.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Publication.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Thanks.class, CabinetMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(Task.class, TaskMixIn.class);
+		mixinMap.put(Attribute.class, AttributeMixIn.class);
+		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
+		mixinMap.put(User.class, UserMixIn.class);
+		mixinMap.put(Candidate.class, CandidateMixIn.class);
+		mixinMap.put(PerunException.class, ExceptionMixIn.class);
+		mixinMap.put(PerunRuntimeException.class, ExceptionMixIn.class);
+		mixinMap.put(PerunBean.class, PerunBeanMixIn.class);
+		mixinMap.put(PerunRequest.class, PerunRequestMixIn.class);
+		mixinMap.put(Authorship.class, CabinetMixIn.class);
+		mixinMap.put(Author.class, CabinetMixIn.class);
+		mixinMap.put(Category.class, CabinetMixIn.class);
+		mixinMap.put(Publication.class, CabinetMixIn.class);
+		mixinMap.put(Thanks.class, CabinetMixIn.class);
+		mixinMap.put(Task.class, TaskMixIn.class);
+
+		mapper.setMixIns(mixinMap);
 	}
 
 	private static final JsonFactory jsonFactory = new JsonFactory();

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonDeserializer.java
@@ -3,9 +3,13 @@ package cz.metacentrum.perun.rpclib.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Category;
 import cz.metacentrum.perun.cabinet.model.Publication;
@@ -19,16 +23,13 @@ import cz.metacentrum.perun.registrar.model.ApplicationForm;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItem;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemWithPrefilledValue;
 import cz.metacentrum.perun.registrar.model.ApplicationMail;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.rpclib.api.Deserializer;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 
 /**
  * Deserializer that reads values from JSON content.
@@ -96,33 +97,35 @@ public class JsonDeserializer extends Deserializer {
 	}
 
 	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 	static {
-		mapper.getDeserializationConfig().addMixInAnnotations(Attribute.class, AttributeMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(AttributeDefinition.class, AttributeDefinitionMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(User.class, UserMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Member.class, MemberMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(AuditMessage.class, AuditMessageMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(PerunBean.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Candidate.class, CandidateMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(PerunException.class, PerunExceptionMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Destination.class, DestinationMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Group.class, GroupMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(UserExtSource.class, UserExtSourceMixIn.class);
+		mixinMap.put(Attribute.class, AttributeMixIn.class);
+		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
+		mixinMap.put(User.class, UserMixIn.class);
+		mixinMap.put(Member.class, MemberMixIn.class);
+		mixinMap.put(AuditMessage.class, AuditMessageMixIn.class);
+		mixinMap.put(PerunBean.class, PerunBeanMixIn.class);
+		mixinMap.put(Candidate.class, CandidateMixIn.class);
+		mixinMap.put(PerunException.class, PerunExceptionMixIn.class);
+		mixinMap.put(Destination.class, DestinationMixIn.class);
+		mixinMap.put(Group.class, GroupMixIn.class);
+		mixinMap.put(UserExtSource.class, UserExtSourceMixIn.class);
 
-		mapper.getDeserializationConfig().addMixInAnnotations(Application.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ApplicationForm.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ApplicationFormItem.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ApplicationFormItemWithPrefilledValue.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ApplicationMail.class, PerunBeanMixIn.class);
+		mixinMap.put(Application.class, PerunBeanMixIn.class);
+		mixinMap.put(ApplicationForm.class, PerunBeanMixIn.class);
+		mixinMap.put(ApplicationFormItem.class, PerunBeanMixIn.class);
+		mixinMap.put(ApplicationFormItemWithPrefilledValue.class, PerunBeanMixIn.class);
+		mixinMap.put(ApplicationMail.class, PerunBeanMixIn.class);
 
-		mapper.getDeserializationConfig().addMixInAnnotations(Author.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Category.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Publication.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(PublicationForGUI.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(PublicationSystem.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(Thanks.class, PerunBeanMixIn.class);
-		mapper.getDeserializationConfig().addMixInAnnotations(ThanksForGUI.class, PerunBeanMixIn.class);
+		mixinMap.put(Author.class, PerunBeanMixIn.class);
+		mixinMap.put(Category.class, PerunBeanMixIn.class);
+		mixinMap.put(Publication.class, PerunBeanMixIn.class);
+		mixinMap.put(PublicationForGUI.class, PerunBeanMixIn.class);
+		mixinMap.put(PublicationSystem.class, PerunBeanMixIn.class);
+		mixinMap.put(Thanks.class, PerunBeanMixIn.class);
+		mixinMap.put(ThanksForGUI.class, PerunBeanMixIn.class);
 
+		mapper.setMixIns(mixinMap);
 	}
 
 	private JsonNode root;
@@ -198,14 +201,14 @@ public class JsonDeserializer extends Deserializer {
 				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as int");
 			} else {
 				try {
-					return Integer.parseInt(node.getTextValue());
+					return Integer.parseInt(node.textValue());
 				} catch (NumberFormatException ex) {
 					throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as int", ex);
 				}
 			}
 		}
 
-		return node.getIntValue();
+		return node.intValue();
 	}
 
 	@Override
@@ -239,7 +242,7 @@ public class JsonDeserializer extends Deserializer {
 			if (!value.isInt()) {
 				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as int");
 			}
-			array[i] = node.get(i).getIntValue();
+			array[i] = node.get(i).intValue();
 		}
 		return array;
 	}
@@ -272,7 +275,7 @@ public class JsonDeserializer extends Deserializer {
 		}
 
 		try {
-			return mapper.readValue(node, valueType);
+			return mapper.readValue(node.traverse(), valueType);
 		} catch (IOException ex) {
 			throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, node.toString() + " as " + valueType.getSimpleName(), ex);
 		}
@@ -308,7 +311,7 @@ public class JsonDeserializer extends Deserializer {
 		try {
 			List<T> list = new ArrayList<>(node.size());
 			for (JsonNode e : node) {
-				list.add(mapper.readValue(e, valueType));
+				list.add(mapper.readValue(e.traverse(), valueType));
 			}
 			return list;
 		} catch (IOException ex) {

--- a/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonSerializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpclib/impl/JsonSerializer.java
@@ -2,14 +2,16 @@ package cz.metacentrum.perun.rpclib.impl;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import cz.metacentrum.perun.core.api.AuditMessage;
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -41,12 +43,15 @@ public final class JsonSerializer implements Serializer {
 	}
 
 	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final Map<Class<?>,Class<?>> mixinMap = new HashMap<>();
 
 	static {
-		mapper.getSerializationConfig().addMixInAnnotations(Attribute.class, AttributeMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(AttributeDefinition.class, AttributeDefinitionMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(User.class, UserMixIn.class);
-		mapper.getSerializationConfig().addMixInAnnotations(AuditMessage.class, AuditMessageMixIn.class);
+		mixinMap.put(Attribute.class, AttributeMixIn.class);
+		mixinMap.put(AttributeDefinition.class, AttributeDefinitionMixIn.class);
+		mixinMap.put(User.class, UserMixIn.class);
+		mixinMap.put(AuditMessage.class, AuditMessageMixIn.class);
+
+		mapper.setMixIns(mixinMap);
 	}
 	private static final JsonFactory jsonFactory = new JsonFactory();
 

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -209,11 +209,6 @@
  		</dependency>
 
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-csv</artifactId>
 		</dependency>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -8,7 +8,7 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AttributesModuleImplApi;
 import net.jcip.annotations.GuardedBy;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -7,7 +7,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
-import org.codehaus.jackson.annotate.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/GroupResourceEndpointController.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/GroupResourceEndpointController.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Endpoint controller, that returns all group resources.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/ResourceTypesEndpointController.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/ResourceTypesEndpointController.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.core.Response;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Endpoint controller, that returns all SCIM resource types.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/SchemasEndpointController.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/SchemasEndpointController.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.core.Response;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Endpoint controller, that returns schema of all resources.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/ServiceProviderConfigsEndpointController.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/ServiceProviderConfigsEndpointController.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.core.Response;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Service Provider Configuration endpoint, that returns specification

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/UserResourceEndpointController.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/endpoints/UserResourceEndpointController.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.Response;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Endpoint controller, that returns all user resources.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/AuthenticationSchemes.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/AuthenticationSchemes.java
@@ -1,6 +1,6 @@
 package cz.metacentrum.perun.scim.api.entities;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Authentication Schemes for ServiceProviderConfigs endpoint.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/EmailSCIM.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/EmailSCIM.java
@@ -1,7 +1,7 @@
 package cz.metacentrum.perun.scim.api.entities;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Email for user resources.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/GroupSCIM.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/GroupSCIM.java
@@ -1,11 +1,9 @@
 package cz.metacentrum.perun.scim.api.entities;
 
-
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.List;
-
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 /**
  * Group resource type for SCIM protocol.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/ListResponseSCIM.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/ListResponseSCIM.java
@@ -2,10 +2,10 @@ package cz.metacentrum.perun.scim.api.entities;
 
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonAutoDetect;
-import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * ListResponse type containing list of some resources, number of resources

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/MemberSCIM.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/MemberSCIM.java
@@ -1,7 +1,7 @@
 package cz.metacentrum.perun.scim.api.entities;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Member of group resource type.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/Meta.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/Meta.java
@@ -1,10 +1,9 @@
 package cz.metacentrum.perun.scim.api.entities;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.Date;
-
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 /**
  * Metadata of the resource.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/Resource.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/Resource.java
@@ -1,8 +1,8 @@
 package cz.metacentrum.perun.scim.api.entities;
 
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * All resources (user, group, ..) extend from this class, that contains resource

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/ResourceTypeSCIM.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/ResourceTypeSCIM.java
@@ -1,10 +1,9 @@
 package cz.metacentrum.perun.scim.api.entities;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
-
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 /**
  * SCIM resource type.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/SchemaSCIM.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/SchemaSCIM.java
@@ -1,8 +1,7 @@
 package cz.metacentrum.perun.scim.api.entities;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Schema of the resource.

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/ServiceProviderConfiguration.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/ServiceProviderConfiguration.java
@@ -2,8 +2,8 @@ package cz.metacentrum.perun.scim.api.entities;
 
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * SCIM Service Provider Configuration

--- a/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/UserSCIM.java
+++ b/perun-scim/src/main/java/cz/metacentrum/perun/scim/api/entities/UserSCIM.java
@@ -1,11 +1,10 @@
 package cz.metacentrum.perun.scim.api.entities;
 
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.List;
-
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 /**
  * User resource type for SCIM protocol.

--- a/perun-scim/src/test/java/cz/metacentrum/perun/scim/api/endpoints/GroupResourceEndpointControllerTest.java
+++ b/perun-scim/src/test/java/cz/metacentrum/perun/scim/api/endpoints/GroupResourceEndpointControllerTest.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.core.Response;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/perun-scim/src/test/java/cz/metacentrum/perun/scim/api/endpoints/UserResourceEndpointControllerTest.java
+++ b/perun-scim/src/test/java/cz/metacentrum/perun/scim/api/endpoints/UserResourceEndpointControllerTest.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.core.Response;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
 		<google-api-services-admin-directory.version>directory_v1-rev110-1.25.0</google-api-services-admin-directory.version>
 		<hornetq.version>2.2.21.Final</hornetq.version>
 		<netty3.version>3.2.1.Final</netty3.version><!-- needed for HornetQ -->
-		<jackson1.version>1.9.13</jackson1.version>
 		<jboss-jms-api.version>1.1.0.GA</jboss-jms-api.version>
 		<jcip.version>1.0</jcip.version>
 		<jdom.version>1.0</jdom.version>


### PR DESCRIPTION
- Removed dependency on org.codehaus.jackson:jackson-core-asl and
  replaced with com.fasterxml.jackson.core:jackson-databind.
- Fixed imports.
- Enabling/disabling ObjectMapper features has changed, also setting
  MixIn mappings has changed due to API changes in Jackson library.