### PR TITLE
Fix email validation confirmation message

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/WebGui.java
@@ -539,7 +539,7 @@ public class WebGui implements EntryPoint, ValueChangeHandler<String> {
 						body.clear();
 						FlexTable ft = new FlexTable();
 						ft.setSize("100%", "300px");
-						ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.acceptIcon())+"<h2>"+ "The email address: <i>"+ SafeHtmlUtils.fromString(over.getString())+"</i></h2><h2>was verified and set as your preferred email.</h2>");
+						ft.setHTML(0, 0, new Image(LargeIcons.INSTANCE.acceptIcon())+"<h2>"+ "The email address: <i>"+ (SafeHtmlUtils.fromString(over.getString())).asString() +"</i></h2><h2>was verified and set as your preferred email.</h2>");
 						ft.getFlexCellFormatter().setHorizontalAlignment(0, 0, HasHorizontalAlignment.ALIGN_CENTER);
 						ft.getFlexCellFormatter().setVerticalAlignment(0, 0, HasVerticalAlignment.ALIGN_MIDDLE);
 						body.add(ft);


### PR DESCRIPTION
The email address in the message was prefixed by string "safe: ". That
was caused by wrong usage of SafeHtml class. You need to use "asString"
method to get the output. In this case was used toString which returns
result with the "safe: " prefix.

Previous message example:
The email address: safe: "some@email.com"
was verified and set as your preferred email.

New message format:
The email address: some@email.com
was verified and set as your preferred email.