### PR TITLE
Remove status SUSPEND from member in core

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/MemberUnsuspended.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/MembersManagerEvents/MemberUnsuspended.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.audit.events.MembersManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.audit.events.EngineForceEvent;
+import cz.metacentrum.perun.core.api.Member;
+
+public class MemberUnsuspended extends AuditEvent implements EngineForceEvent {
+
+	private Member member;
+	private String engineForceKeyword;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public MemberUnsuspended() {
+	}
+
+	public MemberUnsuspended(Member member, String engineForceKeyword) {
+		this.member = member;
+		this.engineForceKeyword = engineForceKeyword;
+		this.message = formatMessage("%s unsuspended #%s.", member, engineForceKeyword);
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	public Member getMember() {
+		return member;
+	}
+
+	public String getEngineForceKeyword() {
+		return engineForceKeyword;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Status.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Status.java
@@ -7,7 +7,7 @@ import java.util.Map;
 public enum Status {
 	VALID  (0),
 				 INVALID (1),    //just created object, where some information (e.g. attribute)  is missing
-				 SUSPENDED (2),  //security issue
+				 //SUSPENDED (2),  //security issue, this status was replaced by suspension logic
 				 EXPIRED (3),
 				 DISABLED (4);   //use this status instead of deleting the entity
 

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.55 (don't forget to update insert statement at the end of file)
+-- database version 3.1.56 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1773,7 +1773,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.55');
+insert into configurations values ('DATABASE VERSION','3.1.56');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-cli/setMemberStatus
+++ b/perun-cli/setMemberStatus
@@ -13,7 +13,7 @@ sub help {
 	--------------------------------------
 	Available options:
 	--memberId        | -m member id
-	--status          | -s VALID/INVALID/SUSPENDED/EXPIRED/DISABLED
+	--status          | -s VALID/INVALID/EXPIRED/DISABLED
 	--batch           | -b batch
 	--help            | -h prints this help
 

--- a/perun-cli/suspendMemberTo
+++ b/perun-cli/suspendMemberTo
@@ -14,19 +14,20 @@ sub help {
 	Available options:
 	--memberId        | -m member id
 	--date            | -d date in format yyyy-mm-dd
+	--reason          | -r reason for suspension
 	--batch           | -b batch
 	--help            | -h prints this help
 
 	};
 }
 
-my ($memberId, $date);
+my ($memberId, $date, $reason);
 our $batch;
 GetOptions ("help|h" => sub {
 		print help();
 		exit 0;
 	}, "batch|b"     => \$batch,
-	"memberId|m=i"   => \$memberId, "date|d=s" => \$date) || die help();
+	"memberId|m=i"   => \$memberId, "date|d=s" => \$date, "reason|r=s" => \$reason) || die help();
 
 # Check options
 unless (defined($memberId)) { die "ERROR: memberId is required \n";}
@@ -35,6 +36,10 @@ unless (defined($date)) { die "ERROR: date to which will be member suspended is 
 my $agent = Perun::Agent->new();
 my $membersAgent = $agent->getMembersAgent;
 
-$membersAgent->suspendMemberTo( member => $memberId, suspendedTo => $date );
+if($reason) {
+	$membersAgent->suspendMemberTo( member => $memberId, suspendedTo => $date, message => $reason );
+else {
+	$membersAgent->suspendMemberTo( member => $memberId, suspendedTo => $date );
+}
 
 printMessage("Member with id $memberId was suspended to $date.", $batch);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -988,7 +988,24 @@ public interface MembersManager {
 	void suspendMemberTo(PerunSession sess, Member member, Date suspendedTo) throws InternalErrorException, MemberNotExistsException, PrivilegeException;
 
 	/**
+	 * Set date to which will be member suspended in his VO.
+	 * Also set reason of this suspension to the member attribute.
+	 *
+	 * For almost unlimited time please use time in the far future.
+	 *
+	 * @param sess
+	 * @param member member who will be suspended
+	 * @param message reason of suspension
+	 * @param suspendedTo date to which will be member suspended (after this date, he will not be affected by suspension any more)
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 * @throws MemberNotExistsException if member not exists in Perun
+	 */
+	void suspendMemberTo(PerunSession sess, Member member, Date suspendedTo, String message) throws InternalErrorException, MemberNotExistsException, PrivilegeException;
+
+	/**
 	 * Remove suspend state from Member - remove date to which member should be considered as suspended in the VO.
+	 * Also remove message with reason for suspension.
 	 *
 	 * WARNING: this will remove the date even if it is in the past (so member is no longer considered as suspended)
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1113,7 +1113,22 @@ public interface MembersManagerBl {
 	void suspendMemberTo(PerunSession sess, Member member, Date suspendedTo) throws InternalErrorException;
 
 	/**
+	 * Set date to which will be member suspended in his VO.
+	 * Also set reason of this suspension to the member attribute.
+	 *
+	 * For almost unlimited time please use time in the far future.
+	 *
+	 * @param sess
+	 * @param member member who will be suspended
+	 * @param message reason of suspension
+	 * @param suspendedTo date to which will be member suspended (after this date, he will not be affected by suspension any more)
+	 * @throws InternalErrorException
+	 */
+	void suspendMemberTo(PerunSession sess, Member member, Date suspendedTo, String message) throws InternalErrorException;
+
+	/**
 	 * Remove suspend state from Member - remove date to which member should be considered as suspended in the VO.
+	 * Also remove message with reason for suspension.
 	 *
 	 * WARNING: this method will always succeed if member exists, because it will set date for suspension to null
 	 *
@@ -1205,35 +1220,6 @@ public interface MembersManagerBl {
 	 * @throws InternalErrorException
 	 */
 	Member invalidateMember(PerunSession sess, Member member) throws InternalErrorException;
-
-	/**
-	 * Suspend member.
-	 *
-	 * As side effect it will change status of the object member.
-	 *
-	 * @param sess
-	 * @param member
-	 * @return member with new status set
-	 *
-	 * @throws InternalErrorException
-	 * @throws MemberNotValidYetException
-	 */
-	Member suspendMember(PerunSession sess, Member member) throws InternalErrorException, MemberNotValidYetException;
-
-	/**
-	 * Suspend member with reason for suspension.
-	 *
-	 * As side effect it will change status of the object member.
-	 *
-	 * @param sess
-	 * @param member
-	 * @param message
-	 * @return member with new status set
-	 *
-	 * @throws InternalErrorException
-	 * @throws MemberNotValidYetException
-	 */
-	Member suspendMember(PerunSession sess, Member member, String message) throws InternalErrorException, MemberNotValidYetException;
 
 	/**
 	 * Set member's status to expired.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1049,6 +1049,22 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
+	public void suspendMemberTo(PerunSession sess, Member member, Date suspendedTo, String message) throws InternalErrorException, MemberNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
+		Utils.notNull(suspendedTo, "suspendedTo");
+		Utils.notNull(suspendedTo, "message");
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, member)) {
+			throw new PrivilegeException(sess, "suspendMemberTo");
+		}
+
+		getMembersManagerBl().checkMemberExists(sess, member);
+
+		membersManagerBl.suspendMemberTo(sess, member, suspendedTo, message);
+	}
+
+	@Override
 	public void unsuspendMember(PerunSession sess, Member member) throws InternalErrorException, MemberNotExistsException, MemberNotSuspendedException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -8,6 +8,11 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.56
+update members set suspended_to=to_date('2999-01-01', 'YYYY-MM-DD') where status='2';
+update members set status='0' where status='2';
+update configurations set value='3.1.56' where property='DATABASE VERSION';
+
 3.1.55
 drop sequence "auditer_log_json_id_seq";
 alter table auditer_log rename to auditer_log_old;

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -6,6 +6,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.56
+update members set suspended_to=to_date('2999-01-01', 'YYYY-MM-DD') where status='2';
+update members set status='0' where status='2';
+update configurations set value='3.1.56' where property='DATABASE VERSION';
+
 3.1.55
 drop sequence auditer_log_json_id_seq;
 alter table auditer_log rename to auditer_log_old;

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,11 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.56
+update members set suspended_to=to_date('2999-01-01', 'YYYY-MM-DD') where status='2';
+update members set status='0' where status='2';
+update configurations set value='3.1.56' where property='DATABASE VERSION';
+
 3.1.55
 drop sequence "auditer_log_json_id_seq";
 alter table auditer_log rename to auditer_log_old;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -230,7 +230,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		perun.getAttributesManagerBl().setAttributes(sess, createdMember, resource, new ArrayList<>(Collections.singletonList(memberResourceAttribute1)));
 
 		List<String> attrNames = new ArrayList<>(Arrays.asList(userAttribute1.getName(), memberAttribute1.getName(), userFacilityAttribute1.getName(), memberResourceAttribute1.getName()));
-		List<RichMember> richMembers = membersManagerEntry.getCompleteRichMembers(sess, createdGroup, resource, attrNames, Arrays.asList("INVALID", "DISABLED", "SUSPENDED", "EXPIRED"));
+		List<RichMember> richMembers = membersManagerEntry.getCompleteRichMembers(sess, createdGroup, resource, attrNames, Arrays.asList("INVALID", "DISABLED", "EXPIRED"));
 		assertTrue(richMembers.isEmpty());
 		richMembers = membersManagerEntry.getCompleteRichMembers(sess, createdGroup, resource, attrNames, Collections.singletonList("VALID"));
 
@@ -638,7 +638,7 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 	public void getMembersCountByStatus() throws Exception {
 		System.out.println(CLASS_NAME + "getMembersCountByStatus");
 
-		final int count = membersManagerEntry.getMembersCount(sess, createdVo, Status.SUSPENDED);
+		final int count = membersManagerEntry.getMembersCount(sess, createdVo, Status.EXPIRED);
 		assertTrue("testing VO should have 0 members with SUSPENDED status", count == 0);
 		final int count2 = membersManagerEntry.getMembersCount(sess, createdVo, Status.VALID);
 		assertTrue("testing VO should have 1 member with VALID status", count2 == 1);

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.55 (don't forget to update insert statement at the end of file)
+-- database version 3.1.56 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1775,7 +1775,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.55');
+insert into configurations values ('DATABASE VERSION','3.1.56');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.55 (don't forget to update insert statement at the end of file)
+-- database version 3.1.56 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1873,7 +1873,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.55');
+insert into configurations values ('DATABASE VERSION','3.1.56');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -307,7 +307,6 @@ public class ExpirationNotifScheduler {
 		// Only members with following statuses will be notified
 		List<Status> allowedStatuses = new ArrayList<>();
 		allowedStatuses.add(Status.VALID);
-		allowedStatuses.add(Status.SUSPENDED);
 
 		Map<Integer, Vo> vosMap = new HashMap<>();
 		for (Vo vo : vos) {
@@ -560,7 +559,6 @@ public class ExpirationNotifScheduler {
 		// Only members with following statuses will be notified
 		List<Status> allowedStatuses = new ArrayList<>();
 		allowedStatuses.add(Status.VALID);
-		allowedStatuses.add(Status.SUSPENDED);
 		// in opposite to vo expiration we want to notify about incoming group expirations even when user is expired in VO
 		allowedStatuses.add(Status.EXPIRED);
 

--- a/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
+++ b/perun-registrar-lib/src/test/java/cz/metacentrum/perun/registrar/ExpirationNotifSchedulerTest.java
@@ -133,13 +133,10 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 		// set statuses synchronizer should ignore
 		perun.getMembersManager().setStatus(session, member2, Status.DISABLED);
 		perun.getMembersManager().setStatus(session, member3, Status.INVALID);
-		perun.getMembersManager().setStatus(session, member4, Status.SUSPENDED);
 		perun.getMembersManager().setStatus(session, member7, Status.DISABLED);
 		perun.getMembersManager().setStatus(session, member8, Status.INVALID);
-		perun.getMembersManager().setStatus(session, member9, Status.SUSPENDED);
 		perun.getMembersManager().setStatus(session, member12, Status.DISABLED);
 		perun.getMembersManager().setStatus(session, member13, Status.INVALID);
-		perun.getMembersManager().setStatus(session, member14, Status.SUSPENDED);
 
 		// set status synchronizer should keep
 		perun.getMembersManager().setStatus(session, member5, Status.EXPIRED);  // expiration today
@@ -160,9 +157,6 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 		Member returnedMember3 = perun.getMembersManager().getMemberById(session, member3.getId());
 		assertEquals("Member3 should be kept invalid!", returnedMember3.getStatus(), Status.INVALID);
 
-		Member returnedMember4 = perun.getMembersManager().getMemberById(session, member4.getId());
-		assertEquals("Member4 should be kept suspended!", returnedMember4.getStatus(), Status.SUSPENDED);
-
 		Member returnedMember5 = perun.getMembersManager().getMemberById(session, member5.getId());
 		assertEquals("Member5 should be kept expired!", returnedMember5.getStatus(), Status.EXPIRED);
 
@@ -175,9 +169,6 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 		Member returnedMember8 = perun.getMembersManager().getMemberById(session, member8.getId());
 		assertEquals("Member8 should be kept invalid!", returnedMember8.getStatus(), Status.INVALID);
 
-		Member returnedMember9 = perun.getMembersManager().getMemberById(session, member9.getId());
-		assertEquals("Member9 should be kept suspended!", returnedMember9.getStatus(), Status.SUSPENDED);
-
 		Member returnedMember10 = perun.getMembersManager().getMemberById(session, member10.getId());
 		assertEquals("Member10 should be kept valid!", returnedMember10.getStatus(), Status.VALID);
 
@@ -189,9 +180,6 @@ public class ExpirationNotifSchedulerTest extends RegistrarBaseIntegrationTest {
 
 		Member returnedMember13 = perun.getMembersManager().getMemberById(session, member13.getId());
 		assertEquals("Member13 should be kept invalid!", returnedMember13.getStatus(), Status.INVALID);
-
-		Member returnedMember14 = perun.getMembersManager().getMemberById(session, member14.getId());
-		assertEquals("Member14 should be kept suspended!", returnedMember14.getStatus(), Status.SUSPENDED);
 
 		Member returnedMember15 = perun.getMembersManager().getMemberById(session, member15.getId());
 		assertEquals("Member15 should be kept expired!", returnedMember15.getStatus(), Status.EXPIRED);

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -497,7 +497,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Returns all members of a VO.
 	 *
 	 * @param vo int VO <code>id</code>
-	 * @param status String VALID | INVALID | SUSPENDED | EXPIRED | DISABLED
+	 * @param status String VALID | INVALID | EXPIRED | DISABLED
 	 * @return List<Member> VO members
 	 */
 	getMembers {
@@ -521,7 +521,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Returns all members of a VO with additional information.
 	 *
 	 * @param vo int VO <code>id</code>
-	 * @param status String VALID | INVALID | SUSPENDED | EXPIRED | DISABLED
+	 * @param status String VALID | INVALID | EXPIRED | DISABLED
 	 * @return List<RichMember> VO members
 	 */
 	getRichMembers {
@@ -546,7 +546,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 *
  	 * @param vo int Vo <code>id</code>
  	 * @param attrsNames List<String> Attribute names
- 	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+ 	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | EXPIRED | DISABLED)
  	 * @return List<RichMember> List of richMembers with specific attributes from Vo
  	 */
 	/*#
@@ -568,7 +568,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 *
  	 * @param group int Group <code>id</code>
  	 * @param attrsNames List<String> Attribute names
- 	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+ 	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | EXPIRED | DISABLED)
  	 * @param lookingInParentGroup boolean If true, look up in a parent group
  	 * @return List<RichMember> List of richMembers with specific attributes from group
  	 */
@@ -594,7 +594,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param group int Group <code>id</code>
 	 * @param resource int Resource <code>id</code>
 	 * @param attrsNames List<String> Attribute names
-	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+	 * @param allowedStatuses List<String> Allowed statuses (VALID | INVALID | EXPIRED | DISABLED)
 	 * @return List<RichMember> List of richMembers with selected specific attributes
 	 */
 	getCompleteRichMembers {
@@ -706,7 +706,7 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 * Get all RichMembers of VO with specified status. RichMember object contains user, member, userExtSources and member/user attributes.
  	 *
  	 * @param vo int Vo <code>id</code>
- 	 * @param status String Status (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+ 	 * @param status String Status (VALID | INVALID | EXPIRED | DISABLED)
  	 * @return List<RichMember> List of RichMembers with all member/user attributes, empty list if there are no members in VO with specified status
  	 */
 	/*#
@@ -792,7 +792,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Returns count of VO members with specified status.
 	 *
 	 * @param vo int VO <code>id</code>
-	 * @param status String Status (VALID | INVALID | SUSPENDED | EXPIRED | DISABLED)
+	 * @param status String Status (VALID | INVALID | EXPIRED | DISABLED)
 	 * @return int Members count
 	 */
 	/*#
@@ -1061,8 +1061,8 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Set membership status of a member.
 	 *
 	 * @param member int Member <code>id</code>
-	 * @param status String VALID | INVALID | SUSPENDED | EXPIRED | DISABLED
-	 * @exampleParam status "SUSPENDED"
+	 * @param status String VALID | INVALID | EXPIRED | DISABLED
+	 * @exampleParam status "EXPIRED"
 	 * @param message String reason for suspension
 	 * @return Member Member with status after change
 	 */
@@ -1070,8 +1070,8 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * Set membership status of a member.
 	 *
 	 * @param member int Member <code>id</code>
-	 * @param status String VALID | INVALID | SUSPENDED | EXPIRED | DISABLED
-	 * @exampleParam status "SUSPENDED"
+	 * @param status String VALID | INVALID | EXPIRED | DISABLED
+	 * @exampleParam status "EXPIRED"
 	 * @return Member Member with status after change
 	 */
 	setStatus {
@@ -1095,6 +1095,16 @@ public enum MembersManagerMethod implements ManagerMethod {
 	 * @param member int Member <code>id</code>
 	 * @param suspendedTo String date in format yyyy-MM-dd to which member will be suspended
 	 */
+	/*#
+	 * Set date to which will be member suspended in his VO.
+	 * Also set message as reason of suspension to the member attribute.
+	 *
+	 * For almost unlimited time please use time in the far future.
+	 *
+	 * @param member int Member <code>id</code>
+	 * @param suspendedTo String date in format yyyy-MM-dd to which member will be suspended
+	 * @param message String reason of suspension
+	 */
 	suspendMemberTo {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
@@ -1109,7 +1119,11 @@ public enum MembersManagerMethod implements ManagerMethod {
 				throw new RpcException(RpcException.Type.CANNOT_DESERIALIZE_VALUE, "SuspendedTo is not in correct format yyyy-MM-dd and can't be parser correctly!");
 			}
 
-			ac.getMembersManager().suspendMemberTo(ac.getSession(), ac.getMemberById(parms.readInt("member")), suspendedTo);
+			if(parms.contains("message")) {
+				ac.getMembersManager().suspendMemberTo(ac.getSession(), ac.getMemberById(parms.readInt("member")), suspendedTo);
+			} else {
+				ac.getMembersManager().suspendMemberTo(ac.getSession(), ac.getMemberById(parms.readInt("member")), suspendedTo, parms.readString("message"));
+			}
 
 			return null;
 		}
@@ -1117,6 +1131,7 @@ public enum MembersManagerMethod implements ManagerMethod {
 
 	/*#
 	 * Remove suspend state from Member - remove date to which member should be considered as suspended in the VO.
+	 * Also remove message about reason of suspension.
 	 *
 	 * WARNING: this will remove the date even if it is in the past (so member is no longer considered as suspended)
 	 *

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/StatisticsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/perunadmintabs/StatisticsTabItem.java
@@ -102,11 +102,10 @@ public class StatisticsTabItem implements TabItem, TabItemWithUrl {
 		vosTable.setWidget(0, 1, new HTML("<strong>" + "Members" + "</strong>"));
 		vosTable.setWidget(0, 2, new HTML("<strong>" + "Valid members" + "</strong>"));
 		vosTable.setWidget(0, 3, new HTML("<strong>" + "Invalid members" + "</strong>"));
-		vosTable.setWidget(0, 4, new HTML("<strong>" + "Suspended members" + "</strong>"));
-		vosTable.setWidget(0, 5, new HTML("<strong>" + "Expired members" + "</strong>"));
-		vosTable.setWidget(0, 6, new HTML("<strong>" + "Disabled members" + "</strong>"));
-		vosTable.setWidget(0, 7, new HTML("<strong>" + "Groups" + "</strong>"));
-		vosTable.setWidget(0, 8, new HTML("<strong>" + "Resources" + "</strong>"));
+		vosTable.setWidget(0, 4, new HTML("<strong>" + "Expired members" + "</strong>"));
+		vosTable.setWidget(0, 5, new HTML("<strong>" + "Disabled members" + "</strong>"));
+		vosTable.setWidget(0, 6, new HTML("<strong>" + "Groups" + "</strong>"));
+		vosTable.setWidget(0, 7, new HTML("<strong>" + "Resources" + "</strong>"));
 
 		// vos events - adds the VOs to the table and calls how many members the VO has
 		JsonCallbackEvents vosEvents = new JsonCallbackEvents(){
@@ -129,9 +128,6 @@ public class StatisticsTabItem implements TabItem, TabItemWithUrl {
 					GetMembersCount countInvalidMembers = new GetMembersCount(vo.getId(), PerunStatus.INVALID);
 					countInvalidMembers.retrieveData();
 
-					GetMembersCount countSuspendedMembers = new GetMembersCount(vo.getId(), PerunStatus.SUSPENDED);
-					countSuspendedMembers.retrieveData();
-
 					GetMembersCount countExpiredMembers = new GetMembersCount(vo.getId(), PerunStatus.EXPIRED);
 					countExpiredMembers.retrieveData();
 
@@ -150,11 +146,10 @@ public class StatisticsTabItem implements TabItem, TabItemWithUrl {
 					vosTable.setWidget(i + 1, 1, countMembers.getMembersCountHyperlink());
 					vosTable.setWidget(i + 1, 2, countValidMembers.getMembersCountHyperlink());
 					vosTable.setWidget(i + 1, 3, countInvalidMembers.getMembersCountHyperlink());
-					vosTable.setWidget(i + 1, 4, countSuspendedMembers.getMembersCountHyperlink());
-					vosTable.setWidget(i + 1, 5, countExpiredMembers.getMembersCountHyperlink());
-					vosTable.setWidget(i + 1, 6, countDisabledMembers.getMembersCountHyperlink());
-					vosTable.setWidget(i + 1, 7, countGroups.getGroupsCountHyperlink());
-					vosTable.setWidget(i + 1, 8, countResources.getResourcesCountHyperlink());
+					vosTable.setWidget(i + 1, 4, countExpiredMembers.getMembersCountHyperlink());
+					vosTable.setWidget(i + 1, 5, countDisabledMembers.getMembersCountHyperlink());
+					vosTable.setWidget(i + 1, 6, countGroups.getGroupsCountHyperlink());
+					vosTable.setWidget(i + 1, 7, countResources.getResourcesCountHyperlink());
 
 				}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoOverviewTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/vostabs/VoOverviewTabItem.java
@@ -216,7 +216,6 @@ public class VoOverviewTabItem implements TabItem {
 		final GetMembersCount countMembers = new GetMembersCount(vo.getId(), null);
 		final GetMembersCount countValidMembers = new GetMembersCount(vo.getId(), PerunStatus.VALID);
 		final GetMembersCount countInvalidMembers = new GetMembersCount(vo.getId(), PerunStatus.INVALID);
-		final GetMembersCount countSuspendedMembers = new GetMembersCount(vo.getId(), PerunStatus.SUSPENDED);
 		final GetMembersCount countExpiredMembers = new GetMembersCount(vo.getId(), PerunStatus.EXPIRED);
 		final GetMembersCount countDisabledMembers = new GetMembersCount(vo.getId(), PerunStatus.DISABLED);
 
@@ -245,7 +244,6 @@ public class VoOverviewTabItem implements TabItem {
 					countMembers.retrieveData();
 					countValidMembers.retrieveData();
 					countInvalidMembers.retrieveData();
-					countSuspendedMembers.retrieveData();
 					countExpiredMembers.retrieveData();
 					countDisabledMembers.retrieveData();
 
@@ -263,18 +261,16 @@ public class VoOverviewTabItem implements TabItem {
 		vosTable.setWidget(1, 1, countValidMembers.getMembersCountLabel());
 		vosTable.setWidget(2, 0, new HTML(" - invalid"));
 		vosTable.setWidget(2, 1, countInvalidMembers.getMembersCountLabel());
-		vosTable.setWidget(3, 0, new HTML(" - suspended"));
-		vosTable.setWidget(3, 1, countSuspendedMembers.getMembersCountLabel());
-		vosTable.setWidget(4, 0, new HTML(" - expired"));
-		vosTable.setWidget(4, 1, countExpiredMembers.getMembersCountLabel());
-		vosTable.setWidget(5, 0, new HTML(" - disabled"));
-		vosTable.setWidget(5, 1, countDisabledMembers.getMembersCountLabel());
+		vosTable.setWidget(3, 0, new HTML(" - expired"));
+		vosTable.setWidget(3, 1, countExpiredMembers.getMembersCountLabel());
+		vosTable.setWidget(4, 0, new HTML(" - disabled"));
+		vosTable.setWidget(4, 1, countDisabledMembers.getMembersCountLabel());
 
-		vosTable.setWidget(6, 0, new HTML("<strong>" + "Resources" + "</strong>"));
-		vosTable.setWidget(6, 1, countResources.getResourcesCountLabel());
+		vosTable.setWidget(5, 0, new HTML("<strong>" + "Resources" + "</strong>"));
+		vosTable.setWidget(5, 1, countResources.getResourcesCountLabel());
 
-		vosTable.setWidget(7, 0, new HTML("<strong>" + "Groups" + "</strong>"));
-		vosTable.setWidget(7, 1, countGroups.getGroupsCountLabel());
+		vosTable.setWidget(6, 0, new HTML("<strong>" + "Groups" + "</strong>"));
+		vosTable.setWidget(6, 1, countGroups.getGroupsCountLabel());
 
 		vp2.add(statistics);
 


### PR DESCRIPTION
 - status suspend was removed from object Status
 - sql with needed changes were added to changelogs for all databases
 - object Status.SUSPENDED was removed from all parts where it was used
 before (expect services which need to be changed separately), methods
 used for suspension this way were also removed
 - some logic was removed from registrar
 - some logic was removed from gui
 - new method "suspendMemberTo" with reason of suspension was created
 and used also in entry and RPC
 - new event for unsuspending member was added

WARNING: this part of change has impact on services and other
funcionality which is using status SUSPEND and should be merged only
together with all other changes in separate commits.