### PR TITLE
Add requestor to the body of the email send when error occures

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/RTMessagesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/RTMessagesManagerBlImpl.java
@@ -141,9 +141,12 @@ public class RTMessagesManagerBlImpl implements RTMessagesManagerBl {
 			// redirect all RT messages to mail address
 			SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
 			simpleMailMessage.setSubject("["+queue+"] " + subject);
-			simpleMailMessage.setText(text);
+
 			if (email != null) {
+				simpleMailMessage.setText("Requestor: " + email + "\n\n" + text);
 				simpleMailMessage.setReplyTo(email);
+			} else {
+				simpleMailMessage.setText("Requestor: UNKNOWN\n\n" + text);
 			}
 			simpleMailMessage.setFrom(BeansUtils.getCoreConfig().getMailchangeBackupFrom());
 			simpleMailMessage.setTo(BeansUtils.getCoreConfig().getRtSendToMail());


### PR DESCRIPTION
 - it is much easier to find information about requestor of the task in
 the body of the mail than just only in "ReplyTo" field