### PR TITLE
Removed synchronization interval requirements

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled.java
@@ -50,12 +50,7 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 					throw new WrongReferenceAttributeValueException(attribute, attrSynchronizeEnabled);
 				}
 
-				Attribute requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME);
-				if (requiredAttribute.getValue() == null) {
-					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
-				}
-
-				requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSQUERY_ATTRNAME);
+				Attribute requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSQUERY_ATTRNAME);
 				if (requiredAttribute.getValue() == null) {
 					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
 				}
@@ -69,10 +64,6 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 				if (requiredAttribute.getValue() == null) {
 					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
 				}
-				requiredAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
-				if (requiredAttribute.getValue() == null) {
-					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
-				}
 			} catch (AttributeNotExistsException e) {
 				throw new ConsistencyErrorException(e);
 			}
@@ -82,7 +73,6 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnab
 	@Override
 	public List<String> getDependencies() {
 		List<String> dependencies = new ArrayList<>();
-		dependencies.add(GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME);
 		dependencies.add(GroupsManager.GROUPSQUERY_ATTRNAME);
 		dependencies.add(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 		dependencies.add(GroupsManager.GROUPEXTSOURCE_ATTRNAME);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
@@ -38,12 +38,7 @@ public class urn_perun_group_attribute_def_def_synchronizationEnabled extends Gr
 		}
 			try {
 				if (attrValue.equals("true")) {
-					Attribute requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
-					if (requiredAttribute.getValue() == null) {
-						throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
-					}
-
-					requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+					Attribute requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 					if (requiredAttribute.getValue() == null) {
 						throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
 					}


### PR DESCRIPTION
Problem: Interval for group and group strucute synchronizations was
	 required in order to enable these synchronizations. In fact, it is not
	 necessary, because when the interval is not set, default interval, which is set in the configuration, will
	 be taken instead.
Change:  Requirement for synchronization interval was removed from
	 modules synchronizationEnabled and groupStructureSynchronizationEnabled.
Result:  Synchronizations can be set without attribute
	 synchronizationInterval/groupStructureSynchronizationInterval.