### PR TITLE
Save start time of successfull synchro

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -76,6 +76,8 @@ public interface GroupsManager {
 	String GROUP_SYNCHRO_TIMES_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupSynchronizationTimes";
 	// Defines the times, when the group has to be synchronized.
 	String GROUP_STRUCTURE_SYNCHRO_TIMES_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":groupStructureSynchronizationTimes";
+	// Defines timestamp with start of last successful synchronization
+	String GROUP_START_OF_LAST_SUCCESSFUL_SYNC_ATTRNAME = AttributesManager.NS_GROUP_ATTR_DEF + ":startOfLastSuccessfulSynchronization";
 
 	String GROUP_SHORT_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+$";
 	String GROUP_FULL_NAME_REGEXP = "^[-a-zA-Z.0-9_ ]+([:][-a-zA-Z.0-9_ ]+)*";

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -1389,7 +1389,7 @@ public interface GroupsManagerBl {
 	RichGroup getRichGroupByIdWithAttributesByNames(PerunSession sess, int groupId, List<String> attrNames) throws InternalErrorException, GroupNotExistsException;
 
 	/**
-	 * This method will set timestamp and exceptionMessage to group attributes for the group.
+	 * This method will set timestamp, synchronization start time and exceptionMessage to group attributes for the group.
 	 * Also log information about failed synchronization to auditer_log.
 	 *
 	 * IMPORTANT: This method runs in new transaction (because of using in synchronization of groups)
@@ -1398,12 +1398,14 @@ public interface GroupsManagerBl {
 	 *
 	 * Set timestamp to attribute "group_def_lastSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastSynchronizationState"
+	 * Set start time to attribute "group_def_startOfLastSuccessSynchronizationTimestamp"
 	 *
 	 * FailedDueToException is true means group synchronization failed completely.
 	 * FailedDueToException is false means group synchronization is ok or finished with some errors (some members were not synchronized)
 	 *
 	 * @param sess perun session
 	 * @param group the group for synchronization
+	 * @param startTime of the synchronization
 	 * @param failedDueToException if exception means fail of whole synchronization of this group or only problem with some data
 	 * @param exceptionMessage message of an exception, ok if everything is ok
 	 * @throws AttributeNotExistsException
@@ -1412,10 +1414,10 @@ public interface GroupsManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws WrongAttributeValueException
 	 */
-	void saveInformationAboutGroupSynchronizationInNewTransaction(PerunSession sess, Group group, boolean failedDueToException, String exceptionMessage) throws AttributeNotExistsException, InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeValueException;
+	void saveInformationAboutGroupSynchronizationInNewTransaction(PerunSession sess, Group group, long startTime, boolean failedDueToException, String exceptionMessage) throws AttributeNotExistsException, InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeValueException;
 
 	/**
-	 * This method will set timestamp and exceptionMessage to group attributes for the group.
+	 * This method will set timestamp, synchronization start time and exceptionMessage to group attributes for the group.
 	 * Also log information about failed synchronization to auditer_log.
 	 *
 	 * IMPORTANT: This method runs in nested transaction so it can be used in another transaction
@@ -1424,12 +1426,14 @@ public interface GroupsManagerBl {
 	 *
 	 * Set timestamp to attribute "group_def_lastSynchronizationTimestamp"
 	 * Set exception message to attribute "group_def_lastSynchronizationState"
+	 * Set start time to attribute "group_def_startOfLastSuccessSynchronizationTimestamp"
 	 *
 	 * FailedDueToException is true means group synchronization failed completely.
 	 * FailedDueToException is false means group synchronization is ok or finished with some errors (some members were not synchronized)
 	 *
 	 * @param sess perun session
 	 * @param group the group for synchronization
+	 * @param startTime of the synchronization
 	 * @param failedDueToException if exception means fail of whole synchronization of this group or only problem with some data
 	 * @param exceptionMessage message of an exception, ok if everything is ok
 	 * @throws AttributeNotExistsException
@@ -1438,7 +1442,7 @@ public interface GroupsManagerBl {
 	 * @throws WrongAttributeAssignmentException
 	 * @throws WrongAttributeValueException
 	 */
-	void saveInformationAboutGroupSynchronizationInNestedTransaction(PerunSession sess, Group group, boolean failedDueToException, String exceptionMessage) throws AttributeNotExistsException, InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeValueException;
+	void saveInformationAboutGroupSynchronizationInNestedTransaction(PerunSession sess, Group group, long startTime, boolean failedDueToException, String exceptionMessage) throws AttributeNotExistsException, InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException, WrongAttributeValueException;
 
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -6708,6 +6708,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
 		attributes.put(attr, rights);
 
+		//urn:perun:group:attribute-def:def:startOfLastSuccessfulSynchronization
+		attr = new AttributeDefinition();
+		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);
+		attr.setType(String.class.getName());
+		attr.setFriendlyName("startOfLastSuccessfulSynchronization");
+		attr.setDisplayName("Start of last successful synchronization");
+		attr.setDescription("If group is synchronized, start time of last successful synchronization will be set.");
+		//set attribute rights (with dummy id of attribute - not known yet)
+		rights = new ArrayList<>();
+		rights.add(new AttributeRights(-1, Role.VOADMIN, Collections.singletonList(ActionType.READ)));
+		rights.add(new AttributeRights(-1, Role.GROUPADMIN, Collections.singletonList(ActionType.READ)));
+		attributes.put(attr, rights);
+
 		//urn:perun:group:attribute-def:def:groupStructureSynchronizationEnabled
 		attr = new AttributeDefinition();
 		attr.setNamespace(AttributesManager.NS_GROUP_ATTR_DEF);


### PR DESCRIPTION
When group synchronization will ends up without error, start time will
be saved in the attribute startOfLastSuccessSynchronization.