### PR TITLE
Fix module for systemUnixGroupName

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupName.java
@@ -57,6 +57,8 @@ public class urn_perun_group_resource_attribute_def_def_systemUnixGroupName exte
 			if(isSystemGroup.getValue() != null && (Integer) isSystemGroup.getValue()==1) {
 				throw new WrongReferenceAttributeValueException(attribute, "Attribute cant be null if " + group + " on " + resource + " is system unix group.");
 			}
+			
+			return;
 		}
 
 		if (groupName != null) {


### PR DESCRIPTION
 - if value is null, and there is not set attribute "isSystemUnixGroup"
 we don't want to check it more, removing of such value is ok