### PR TITLE
LDAPC-ADA: Allow inclusion of Oracle driver to the build

### DIFF
--- a/perun-ldapc-ada/pom.xml
+++ b/perun-ldapc-ada/pom.xml
@@ -143,5 +143,31 @@
 
 	</dependencies>
 
+	<profiles>
+
+		<profile>
+			<!-- adds Oracle JDBC drivers if run with "mvn -Doracle=True"-->
+			<id>oracle</id>
+			<activation>
+				<property>
+					<name>oracle</name>
+					<value>True</value>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- Oracle jdbc driver -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>ojdbc8</artifactId>
+				</dependency>
+				<!-- Oracle internationalization -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>orai18n</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+
+	</profiles>
 
 </project>


### PR DESCRIPTION
- Added maven profile oracle for perun-ldapc-ada which will include
  Oracle DB drivers into shaded jar.