### PR TITLE
Added queryTimeout for database operations

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -39,6 +39,7 @@ public class CoreConfig {
 	private int groupMaxConcurrentGroupsStructuresToSynchronize;
 	private int mailchangeValidationWindow;
 	private int pwdresetValidationWindow;
+	private int queryTimeout;
 	private List<String> admins;
 	private List<String> enginePrincipals;
 	private List<String> generatedLoginNamespaces;
@@ -613,5 +614,13 @@ public class CoreConfig {
 
 	public String getRtSendToMail() {
 		return rtSendToMail;
+	}
+
+	public int getQueryTimeout() {
+		return queryTimeout;
+	}
+
+	public void setQueryTimeout(int queryTimeout) {
+		this.queryTimeout = queryTimeout;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -60,6 +60,7 @@
 		<property name="smtpPass" value="${perun.smtp.pass}" />
 		<property name="autocreatedNamespaces" value="#{'${perun.autocreatedNamespaces}'.split('\s*,\s*')}" />
 		<property name="rtSendToMail" value="${perun.rt.sendToMail}" />
+		<property name="queryTimeout" value="${perun.queryTimeout}" />
 	</bean>
 
 
@@ -120,6 +121,7 @@
 				<prop key="perun.instanceName">LOCAL</prop>
 				<prop key="perun.allowedCorsDomains"></prop>
 				<prop key="perun.cacheEnabled">false</prop>
+				<prop key="perun.queryTimeout">-1</prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/AuthorshipManagerDaoImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/AuthorshipManagerDaoImpl.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.cabinet.bl.ErrorCodes;
 import cz.metacentrum.perun.cabinet.dao.AuthorshipManagerDao;
 import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Authorship;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.impl.Compatibility;
@@ -98,6 +99,7 @@ public class AuthorshipManagerDaoImpl implements AuthorshipManagerDao {
 
 	public AuthorshipManagerDaoImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	// methods ----------------------

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/CategoryManagerDaoImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/CategoryManagerDaoImpl.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.cabinet.bl.CabinetException;
 import cz.metacentrum.perun.cabinet.bl.ErrorCodes;
 import cz.metacentrum.perun.cabinet.dao.CategoryManagerDao;
 import cz.metacentrum.perun.cabinet.model.Category;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -33,6 +34,7 @@ public class CategoryManagerDaoImpl implements CategoryManagerDao {
 
 	public CategoryManagerDaoImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	private final static String CATEGORY_SELECT_QUERY = "cabinet_categories.id as category_id, " +

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/PublicationManagerDaoImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/PublicationManagerDaoImpl.java
@@ -16,6 +16,7 @@ import cz.metacentrum.perun.cabinet.model.Author;
 import cz.metacentrum.perun.cabinet.model.Publication;
 import cz.metacentrum.perun.cabinet.model.PublicationForGUI;
 import cz.metacentrum.perun.cabinet.model.ThanksForGUI;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -50,6 +51,8 @@ public class PublicationManagerDaoImpl implements PublicationManagerDao {
 	public PublicationManagerDaoImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		this.namedParameterJdbcTemplate.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	private final static String PUBLICATION_SELECT_QUERY = "cabinet_publications.id as publication_id, " +

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/PublicationSystemManagerDaoImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/PublicationSystemManagerDaoImpl.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.cabinet.dao.PublicationSystemManagerDao;
 import cz.metacentrum.perun.cabinet.model.PublicationSystem;
 import cz.metacentrum.perun.cabinet.bl.CabinetException;
 import cz.metacentrum.perun.cabinet.bl.ErrorCodes;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -30,6 +31,7 @@ public class PublicationSystemManagerDaoImpl implements PublicationSystemManager
 
 	public PublicationSystemManagerDaoImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	private final static String PUBLICATION_SYSTEM_SELECT_QUERY = "cabinet_publication_systems.id as ps_id, " +

--- a/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/ThanksManagerDaoImpl.java
+++ b/perun-cabinet/src/main/java/cz/metacentrum/perun/cabinet/dao/impl/ThanksManagerDaoImpl.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.cabinet.bl.ErrorCodes;
 import cz.metacentrum.perun.cabinet.dao.ThanksManagerDao;
 import cz.metacentrum.perun.cabinet.model.Thanks;
 import cz.metacentrum.perun.cabinet.model.ThanksForGUI;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.impl.Compatibility;
@@ -32,6 +33,7 @@ public class ThanksManagerDaoImpl implements ThanksManagerDao {
 
 	public ThanksManagerDaoImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	private final static String THANKS_SELECT_QUERY = "cabinet_thanks.id as thanks_id, " +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -194,6 +194,8 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	public AttributesManagerImpl(DataSource perunPool) {
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(perunPool);
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.namedParameterJdbcTemplate.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	protected final static String attributeDefinitionMappingSelectQuery =

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -73,6 +74,7 @@ public class Auditer {
 
 	public void setPerunPool(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -107,6 +107,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 
 	public AuthzResolverImpl(DataSource perunPool) {
 		jdbc = new JdbcPerunTemplate(perunPool);
+		jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/CacheManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/CacheManager.java
@@ -84,6 +84,7 @@ public class CacheManager implements CacheManagerApi {
 
 	public void setPerunPool(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	public void stopCacheManager() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/DatabaseManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/DatabaseManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -34,6 +35,7 @@ public class DatabaseManagerImpl implements DatabaseManagerImplApi {
 
 	public DatabaseManagerImpl(DataSource perunPool) {
 		jdbc = new JdbcPerunTemplate(perunPool);
+		jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcesManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Group;
@@ -82,6 +83,7 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 
 	public ExtSourcesManagerImpl(DataSource perunPool) {
 		jdbc = new JdbcPerunTemplate(perunPool);
+		jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	public void setSelf(ExtSourcesManagerImplApi self) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -226,6 +226,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 
 	public FacilitiesManagerImpl(DataSource perunPool) {
 		jdbc = new JdbcPerunTemplate(perunPool);
+		jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/GroupsManagerImpl.java
@@ -99,6 +99,8 @@ public class GroupsManagerImpl implements GroupsManagerImplApi {
 	public GroupsManagerImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		this.namedParameterJdbcTemplate.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
@@ -93,6 +94,8 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 	public MembersManagerImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		this.namedParameterJdbcTemplate.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/OwnersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/OwnersManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Owner;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
@@ -40,6 +41,7 @@ public class OwnersManagerImpl implements OwnersManagerImplApi {
 	 */
 	public OwnersManagerImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	protected static final RowMapper<Owner> OWNER_MAPPER = (resultSet, i) -> {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -172,6 +172,8 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 	public ResourcesManagerImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		this.namedParameterJdbcTemplate.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 
 		// Initialize resources manager
 		this.initialize();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -42,6 +42,8 @@ public class SearcherImpl implements SearcherImplApi {
 	public SearcherImpl(DataSource perunPool) {
 		jdbc = new NamedParameterJdbcTemplate(perunPool);
 		jdbcTemplate = new JdbcPerunTemplate(perunPool);
+		jdbc.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		jdbcTemplate.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SecurityTeamsManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -48,6 +49,7 @@ public class SecurityTeamsManagerImpl implements SecurityTeamsManagerImplApi {
 	 */
 	public SecurityTeamsManagerImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Destination;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -48,6 +49,7 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 
 	public ServicesManagerImpl(DataSource perunPool) {
 		jdbc = new JdbcPerunTemplate(perunPool);
+		jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	public final static String serviceMappingSelectQuery = " services.id as services_id, services.name as services_name, " +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -161,6 +161,8 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	public UsersManagerImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
 		this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		this.namedParameterJdbcTemplate.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/VosManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/VosManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -65,6 +66,7 @@ public class VosManagerImpl implements VosManagerImplApi {
 	 */
 	public VosManagerImpl(DataSource perunPool) {
 		this.jdbc = new JdbcPerunTemplate(perunPool);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskDaoJdbc.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskDaoJdbc.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.taskslib.dao.jdbc;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Service;
@@ -16,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
 
@@ -33,6 +35,12 @@ import java.util.List;
 public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 
 	private static final Logger log = LoggerFactory.getLogger(TaskDaoJdbc.class);
+
+	private JdbcTemplate getMyJdbcTemplate() {
+		// jdbc template cannot be null
+		this.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		return this.getJdbcTemplate();
+	}
 
 	/**
 	 * Method create formatter with default settings for perun timestamps and set lenient on false
@@ -123,14 +131,13 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		return new Pair<>(task, engineID);
 	};
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public int scheduleNewTask(Task task, int engineID) {
 		int newTaskId = 0;
 		try {
-			newTaskId = Utils.getNewId(this.getJdbcTemplate(), "tasks_id_seq");
+			newTaskId = Utils.getNewId(getMyJdbcTemplate(), "tasks_id_seq");
 			// jdbc template cannot be null
-			this.getJdbcTemplate().update(
+			getMyJdbcTemplate().update(
 						"insert into tasks(id, service_id, facility_id, schedule, recurrence, delay, status, engine_id) values (?,?,?, " + Compatibility.toDate("?","'DD-MM-YYYY HH24:MI:SS'") + ",?,?,?,?)",
 						newTaskId, task.getServiceId(), task.getFacilityId(), task.getSchedule().format(getDateTimeFormatter()), task.getRecurrence(), task.getDelay(), task.getStatus().toString(), engineID < 0 ? null : engineID);
 			log.debug("Added task with ID {}", newTaskId);
@@ -144,14 +151,13 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		return 0;
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public int insertTask(Task task, int engineID) {
 		int newTaskId = 0;
 		try {
 			newTaskId = task.getId();
 			// jdbc template cannot be null
-			this.getJdbcTemplate().update(
+			getMyJdbcTemplate().update(
 					"insert into tasks(id, service_id, facility_id, schedule, recurrence, delay, status, engine_id) values (?,?,?,to_date(?,'DD-MM-YYYY HH24:MI:SS'),?,?,?,?)",
 					newTaskId, task.getServiceId(), task.getFacilityId(), task.getSchedule().format(getDateTimeFormatter()), task.getRecurrence(), task.getDelay(), task.getStatus().toString(), engineID < 0 ? null : engineID);
 			return newTaskId;
@@ -167,12 +173,11 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		return getTask(service.getId(), facility.getId());
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public Task getTask(int serviceId, int facilityId) {
 		try {
 			// jdbc template cannot be null
-			return this.getJdbcTemplate().queryForObject(
+			return getMyJdbcTemplate().queryForObject(
 						"select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 						", " + ServicesManagerImpl.serviceMappingSelectQuery + " from tasks left join services on tasks.service_id = services.id and tasks.service_id=?" +
 						"left join facilities on facilities.id = tasks.facility_id and tasks.facility_id = ?",
@@ -187,12 +192,11 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		return getTask(service.getId(), facility.getId(), engineID);
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public Task getTask(int serviceId, int facilityId, int engineID) {
 		try {
 			// jdbc template cannot be null
-			return this.getJdbcTemplate().queryForObject(
+			return getMyJdbcTemplate().queryForObject(
 						"select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 						", " + ServicesManagerImpl.serviceMappingSelectQuery + " from tasks left join services on tasks.service_id = services.id " +
 						"left join facilities on facilities.id = tasks.facility_id " +
@@ -204,12 +208,11 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		}
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public List<Task> listAllTasksForFacility(int facilityId) {
 		try {
 			// jdbc template cannot be null
-			return this.getJdbcTemplate().query(
+			return getMyJdbcTemplate().query(
 					"select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 					", " + ServicesManagerImpl.serviceMappingSelectQuery + " from tasks left join services on tasks.service_id = services.id " +
 					"left join facilities on facilities.id = tasks.facility_id where facilities.id = ?",
@@ -219,12 +222,11 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		}
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public Task getTaskById(int id) {
 		try {
 			// jdbc template cannot be null
-			return this.getJdbcTemplate().queryForObject(
+			return getMyJdbcTemplate().queryForObject(
 					"select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 					", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
 					"left join facilities on facilities.id = tasks.facility_id where tasks.id = ?",
@@ -234,12 +236,11 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		}
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public Task getTaskById(int id, int engineID) {
 		try {
 			// jdbc template cannot be null
-			return this.getJdbcTemplate().queryForObject(
+			return getMyJdbcTemplate().queryForObject(
 					"select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 					", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
 					"left join facilities on facilities.id = tasks.facility_id where tasks.id = ? and tasks.engine_id " + (engineID < 0 ? "is null" : "= ?"),
@@ -249,68 +250,61 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		}
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public List<Task> listAllTasks() {
 		// jdbc template cannot be null
-		return this.getJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
+		return getMyJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 				", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
 				"left join facilities on facilities.id = tasks.facility_id", TASK_ROWMAPPER);
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public List<Task> listAllTasks(int engineID) {
 		// jdbc template cannot be null
-		return this.getJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
+		return getMyJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 				", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
 				"left join facilities on facilities.id = tasks.facility_id left where tasks.engine_id " + (engineID < 0 ? "is null" : "= ?"),
 				engineID < 0 ? new Integer[] { } : new Integer[] { engineID }, TASK_ROWMAPPER);
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public List<Pair<Task, Integer>> listAllTasksAndClients() {
 		// jdbc template cannot be null
-		return this.getJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
+		return getMyJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 				", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
 				"left join facilities on facilities.id = tasks.facility_id", TASK_CLIENT_ROWMAPPER);
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public List<Task> listAllTasksInState(Task.TaskStatus state) {
 		String textState = state.toString().toUpperCase();
 		// jdbc template cannot be null
-		return this.getJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
+		return getMyJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 				", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
 				"left join facilities on facilities.id = tasks.facility_id left where tasks.status = ?",
 				TASK_ROWMAPPER, textState);
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public List<Task> listAllTasksInState(Task.TaskStatus state, int engineID) {
 		String textState = state.toString().toUpperCase();
 		// jdbc template cannot be null
-		return this.getJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
+		return getMyJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 				", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
 				"left join facilities on facilities.id = tasks.facility_id where tasks.status = ? and tasks.engine_id " + (engineID < 0 ? "is null" : "= ?"),
 				engineID < 0 ? new Object[] { textState } : new Object[] { textState, engineID }, TASK_ROWMAPPER);
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public List<Task> listAllTasksNotInState(Task.TaskStatus state, int engineID) {
 		String textState = state.toString().toUpperCase();
 		// jdbc template cannot be null
-		return this.getJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
+		return getMyJdbcTemplate().query("select " + taskMappingSelectQuery + ", " + FacilitiesManagerImpl.facilityMappingSelectQuery +
 				", " + ServicesManagerImpl.serviceMappingSelectQuery  + " from tasks left join services on tasks.service_id = services.id " +
 				"left join facilities on facilities.id = tasks.facility_id where tasks.status != ? and tasks.engine_id " + (engineID < 0 ? "is null" : "= ?"),
 				engineID < 0 ? new Object[] { textState } : new Object[] { textState, engineID }, TASK_ROWMAPPER);
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public void updateTask(Task task, int engineID) {
 		String scheduled = null;
@@ -327,14 +321,13 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		}
 
 		// jdbc template cannot be null
-		this.getJdbcTemplate().update(
+		getMyJdbcTemplate().update(
 				"update tasks set service_id = ?, facility_id = ?, schedule = " + Compatibility.toDate("?","'DD-MM-YYYY HH24:MI:SS'") + ", recurrence = ?, delay = ?, "
 				+ "status = ?, start_time = " + Compatibility.toDate("?","'DD-MM-YYYY HH24:MI:SS'") + ", end_time = " + Compatibility.toDate("?","'DD-MM-YYYY HH24:MI:SS'") + " where id = ? and engine_id " + (engineID < 0 ? "is null" : "= ?"), task.getServiceId(),
 				task.getFacilityId(), scheduled, task.getRecurrence(), task.getDelay(), task.getStatus().toString(), startTime, endTime, task.getId(),
 				engineID < 0 ? null : engineID);
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public void updateTask(Task task) {
 		String scheduled = null;
@@ -351,31 +344,29 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		}
 
 		// jdbc template cannot be null
-		this.getJdbcTemplate().update(
+		getMyJdbcTemplate().update(
 				"update tasks set service_id = ?, facility_id = ?, schedule = " + Compatibility.toDate("?","'DD-MM-YYYY HH24:MI:SS'") + ", recurrence = ?, delay = ?, "
 				+ "status = ?, start_time = " + Compatibility.toDate("?","'DD-MM-YYYY HH24:MI:SS'") + ", end_time = " + Compatibility.toDate("?","'DD-MM-YYYY HH24:MI:SS'") + " where id = ?", task.getServiceId(),
 				task.getFacilityId(), scheduled, task.getRecurrence(), task.getDelay(), task.getStatus().toString(), startTime, endTime, task.getId());
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public void updateTaskEngine(Task task, int engineID) throws InternalErrorException {
 		try {
 			// jdbc template cannot be null
-			this.getJdbcTemplate().update(
+			getMyJdbcTemplate().update(
 				"update tasks set engine_id = ? where id = ?", engineID < 0 ? null : engineID, task.getId());
 		} catch(Exception e) {
 			throw new InternalErrorException("Error updating engine id", e);
 		}
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public boolean isThereSuchTask(Service service, Facility facility, int engineID) {
 		// jdbc template cannot be null
-		this.getJdbcTemplate().update("select id from services where id = ?", service.getId());
+		getMyJdbcTemplate().update("select id from services where id = ?", service.getId());
 
-		List<Integer> tasks = this.getJdbcTemplate().queryForList("select id from tasks where service_id = ? and facility_id = ? and engine_id " + (engineID < 0 ? "is null" : "= ?"),
+		List<Integer> tasks = getMyJdbcTemplate().queryForList("select id from tasks where service_id = ? and facility_id = ? and engine_id " + (engineID < 0 ? "is null" : "= ?"),
 				engineID < 0 ? new Integer[] { service.getId(), facility.getId() }
 					: new Integer[] { service.getId(), facility.getId(),  engineID }, Integer.class);
 		if (tasks.size() == 0) {
@@ -391,8 +382,7 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		//this.getJdbcTemplate().update("select id from services where id = ? for update", service.getId());
 
 		// jdbc template cannot be null
-		@SuppressWarnings("ConstantConditions")
-		List<Integer> tasks = this.getJdbcTemplate().queryForList("select id from tasks where service_id = ? and facility_id = ?",
+		List<Integer> tasks = getMyJdbcTemplate().queryForList("select id from tasks where service_id = ? and facility_id = ?",
 				new Integer[] { service.getId(), facility.getId() }, Integer.class);
 		if (tasks.size() == 0) {
 			return false;
@@ -402,45 +392,40 @@ public class TaskDaoJdbc extends JdbcDaoSupport implements TaskDao {
 		return true;
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public void removeTask(Service service, Facility facility, int engineID) {
 		// jdbc template cannot be null
-		this.getJdbcTemplate().update("delete from tasks where service_id = ? and facility_id = ? and engine_id " + (engineID < 0 ? "is null" : "= ?"),
+		getMyJdbcTemplate().update("delete from tasks where service_id = ? and facility_id = ? and engine_id " + (engineID < 0 ? "is null" : "= ?"),
 				engineID < 0 ? new Object[] { service.getId(), facility.getId() }
 					: new Object[] { service.getId(), facility.getId(), engineID });
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public void removeTask(Service service, Facility facility) {
 		// jdbc template cannot be null
-		this.getJdbcTemplate().update("delete from tasks where service_id = ? and facility_id = ?", service.getId(), facility.getId());
+		getMyJdbcTemplate().update("delete from tasks where service_id = ? and facility_id = ?", service.getId(), facility.getId());
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public void removeTask(int id, int engineID) {
 		if(engineID < 0) {
 			// jdbc template cannot be null
-			this.getJdbcTemplate().update("delete from tasks where id = ? and engine_id is null", id);
+			getMyJdbcTemplate().update("delete from tasks where id = ? and engine_id is null", id);
 		} else {
 			// jdbc template cannot be null
-			this.getJdbcTemplate().update("delete from tasks where id = ? and engine_id = ?", id, engineID);
+			getMyJdbcTemplate().update("delete from tasks where id = ? and engine_id = ?", id, engineID);
 		}
 	}
 
-	@SuppressWarnings("ConstantConditions")
 	@Override
 	public void removeTask(int id) {
 		// jdbc template cannot be null
-		this.getJdbcTemplate().update("delete from tasks where id = ?", id);
+		getMyJdbcTemplate().update("delete from tasks where id = ?", id);
 	}
 
 	private int queryForInt(String sql, Object... args) throws DataAccessException {
 		// jdbc template cannot be null
-		@SuppressWarnings("ConstantConditions")
-		Integer i = getJdbcTemplate().queryForObject(sql, args, Integer.class);
+		Integer i = getMyJdbcTemplate().queryForObject(sql, args, Integer.class);
 		return (i != null ? i : 0);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskResultDaoJdbc.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/taskslib/dao/jdbc/TaskResultDaoJdbc.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.taskslib.dao.jdbc;
 
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.impl.Compatibility;
 import cz.metacentrum.perun.core.impl.ServicesManagerImpl;
@@ -68,6 +69,7 @@ public class TaskResultDaoJdbc extends JdbcDaoSupport implements TaskResultDao {
 		if (this.namedParameterJdbcTemplate == null && this.getDataSource() != null) {
 			this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(this.getDataSource());
 		}
+		this.namedParameterJdbcTemplate.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 		return this.namedParameterJdbcTemplate;
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
@@ -52,6 +52,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 
 	public void setDataSource(DataSource dataSource) {
 		this.jdbc = new JdbcPerunTemplate(dataSource);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	protected void initialize() throws PerunException {

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.audit.events.ExpirationNotifScheduler.MembershipExpi
 import cz.metacentrum.perun.audit.events.ExpirationNotifScheduler.MembershipExpired;
 
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
@@ -61,6 +62,7 @@ public class ExpirationNotifScheduler {
 	@Autowired
 	public void setDataSource(DataSource dataSource) {
 		this.jdbc = new JdbcPerunTemplate(dataSource);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	public PerunBl getPerun() {

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -89,6 +89,7 @@ public class MailManagerImpl implements MailManager {
 
 	public void setDataSource(DataSource dataSource) {
 		this.jdbc =  new JdbcPerunTemplate(dataSource);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	/**

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -169,6 +169,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	public void setDataSource(DataSource dataSource) {
 		this.jdbc = new JdbcPerunTemplate(dataSource);
 		this.namedJdbc = new NamedParameterJdbcTemplate(jdbc);
+		this.jdbc.setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
+		this.namedJdbc.getJdbcTemplate().setQueryTimeout(BeansUtils.getCoreConfig().getQueryTimeout());
 	}
 
 	public void setRegistrarManager(RegistrarManager registrarManager) {


### PR DESCRIPTION
- added new attribute queryTimeout to CoreConfig representing maximal time query can last
- value is stored in perun.properties as perun.queryTimeout, default value is set to -1 which is also the general default value