### PR TITLE
getUsersSubjects in extSources

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -146,6 +146,11 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
         return null;
     }
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
     @Override
     public void close() throws ExtSourceUnsupportedOperationException {
         throw new ExtSourceUnsupportedOperationException("Using this method is not supported for CSV.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
@@ -109,6 +109,11 @@ public class ExtSourceEGISSO extends ExtSourceLdap implements ExtSourceApi {
 		return subjects;
 	}
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
 	protected Map<String,String> processResultToSubject(SearchResult sr) throws InternalErrorException {
 		if(sr == null) throw new InternalErrorException("SearchResult is empty so cannot be proceed.");
 		Map<String,String> subject = new HashMap<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
@@ -219,6 +219,11 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 	}
 
 	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
 	public void close() throws ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException("Using this method is not supported for Google Groups.");
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -62,6 +62,11 @@ public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 		return this.querySource(queryForGroup, null, 0);
 	}
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
 	protected List<Map<String,String>> querySource(String query, String searchString, int maxResults) throws InternalErrorException {
 
 		// Get the URL, if query was provided it has precedence over url attribute defined in extSource

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
@@ -50,4 +50,9 @@ public class ExtSourceIdp extends ExtSource implements ExtSourceSimpleApi {
 	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
+
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
@@ -50,4 +50,9 @@ public class ExtSourceInternal extends ExtSource implements ExtSourceSimpleApi {
 	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
+
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
@@ -50,4 +50,9 @@ public class ExtSourceKerberos extends ExtSource implements ExtSourceSimpleApi {
 	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
+
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -163,6 +163,11 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		}
 	}
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
 	protected void initContext() throws InternalErrorException {
 		// Load mapping between LDAP attributes and Perun attributes
 		Hashtable<String,String> env = new Hashtable<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -118,6 +118,11 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 		return subjectsFromGroup;
 	}
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
 	private List<Map<String, String>> convertRichUsersToListOfSubjects(List<RichUser> richUsers) throws InternalErrorException {
 		List<Map<String, String>> listOfSubjects = new ArrayList<>();
 		for(RichUser ru: richUsers) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
@@ -83,6 +83,11 @@ public class ExtSourceREMS extends ExtSourceSqlComplex implements ExtSourceApi {
 		throw new ExtSourceUnsupportedOperationException();
 	}
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
 	/**
 	 * Filters subjects that does not have a corresponding user in Perun by ues REMS
 	 * or by additionalueses in format: {extSourceName}|{extSourceClass}|{eppn}|0.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -109,6 +109,17 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 		return this.querySource(sqlQueryForGroup, null, 0);
 	}
 
+	@Override
+	public List<Map<String,String>> getUsersSubjects() throws InternalErrorException, ExtSourceUnsupportedOperationException{
+		String query = getAttributes().get("usersQuery");
+
+		if (query == null) {
+			throw new InternalErrorException("usersQuery attribute is required");
+		}
+
+		return this.querySource(query, null, 0);
+	}
+
 	protected List<Map<String,String>> querySource(String query, String searchString, int maxResults) throws InternalErrorException {
 		log.debug("Searching for '{}' in external source 'url:{}'", searchString, getAttributes().get("url"));
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
@@ -127,6 +127,11 @@ public class ExtSourceUnity extends ExtSource implements ExtSourceApi {
         return jsonParsingGroups(queryForGroup);
     }
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
     @Override
     public void close() {
         throw new UnsupportedOperationException("Using this method is not supported for Unity");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
@@ -158,6 +158,11 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
         return subjects;
     }
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
     @Override
     public void close() throws ExtSourceUnsupportedOperationException {
         throw new ExtSourceUnsupportedOperationException(

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
@@ -50,4 +50,9 @@ public class ExtSourceX509 extends ExtSource implements ExtSourceSimpleApi {
 	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
 	}
+
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -149,6 +149,11 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 		return xpathParsing(queryForGroup, 0);
 	}
 
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
 	protected void prepareEnvironment() throws InternalErrorException {
 		//Get file or uri of xml
 		file = getAttributes().get("file");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
@@ -84,4 +84,13 @@ public interface ExtSourceSimpleApi {
 	 */
 	List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException;
 
+	/**
+	 * Get the list of subjects from the external source.
+	 *
+	 * @return list of maps, which contains attr_name-&gt;attr_value, e.g. firstName-&gt;Michal
+	 * @throws InternalErrorException
+	 * @throws ExtSourceUnsupportedOperationException
+	 */
+	List<Map<String, String>> getUsersSubjects() throws InternalErrorException, ExtSourceUnsupportedOperationException;
+
 }


### PR DESCRIPTION
This method is needed for ExtSource synchronization which will be
implemented later. ExtSourceSql contains working implementation but
other extSources throw ExtSourceUnsupportedOperationException for now.