### PR TITLE
Avoid of setting old quotas if new quotas are enabled on facility

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -3491,9 +3491,10 @@ public interface AttributesManagerBl {
 	 * @return {@code true} if attribute was changed (deleted) or {@code false} if attribute was not present in a first place
 	 * @throws WrongAttributeAssignmentException if attribute isn't member-resource attribute or if it is core attribute
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongReferenceAttributeValueException if there is problem with removing value because of actual value of referenced attribute
 	 * @throws MemberResourceMismatchException
 	 */
-	boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException;
+	boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Unset all attributes for the member-group without check of value.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -4271,7 +4271,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, MemberResourceMismatchException {
+	public boolean removeAttributeWithoutCheck(PerunSession sess, Member member, Resource resource, AttributeDefinition attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
 		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_MEMBER_RESOURCE_ATTR);
 		if (getAttributesManagerImpl().isCoreAttribute(sess, attribute))

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3822,7 +3822,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void changedAttributeHook(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException {
+	public void changedAttributeHook(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		//Call attribute module
 		MemberResourceAttributesModuleImplApi resourceMemberGroupModule = getResourceMemberAttributeModule(sess, attribute);
 		if (resourceMemberGroupModule == null) return; //facility module doesn't exists

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -31,6 +32,7 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Membe
 	private static final String A_R_defaultDataLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit";
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";
 	private static final String A_MR_dataQuota = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuota";
+	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 	private static final Pattern numberPattern = Pattern.compile("[0-9]+([.,])?[0-9]*");
 	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
 	final long K = 1024;
@@ -176,6 +178,25 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Membe
 
 			if (limitNumber.compareTo(quotaNumber) < 0) {
 				throw new WrongReferenceAttributeValueException(attribute, attrDataQuota, resource, member, resource, null, attribute + " must be more than or equals to " + attrDataQuota);
+			}
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		//if this is setting of the new attribute value, check if old quota attributes are supported on the facility
+		if(attribute.getValue() != null) {
+			try {
+				Facility facility = session.getPerunBl().getResourcesManagerBl().getFacility(session, resource);
+				Attribute readyForNewQuotasAttribute = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, A_F_readyForNewQuotas);
+				//You shouldn't be allowed to set old quota attributes if facility is set for new quotas attributes (to prevent wrong setting of quotas)
+				if(readyForNewQuotasAttribute != null && readyForNewQuotasAttribute.valueAsBoolean()) {
+					throw new WrongReferenceAttributeValueException(attribute, readyForNewQuotasAttribute, member, resource, facility, null, "For this facility the new quotas attributes are used! You are trying to set the old ones.");
+				}
+			} catch (AttributeNotExistsException ex) {
+				//if attribute not exists, it is the same like it was set on false, which is ok
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuota.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -31,6 +32,7 @@ public class urn_perun_member_resource_attribute_def_def_dataQuota extends Membe
 	private static final String A_R_defaultDataLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit";
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";
 	private static final String A_MR_dataLimit = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataLimit";
+	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 	private static final Pattern numberPattern = Pattern.compile("[0-9]+([.,])?[0-9]*");
 	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
 	final long K = 1024;
@@ -177,6 +179,25 @@ public class urn_perun_member_resource_attribute_def_def_dataQuota extends Membe
 
 			if (limitNumber.compareTo(quotaNumber) < 0) {
 				throw new WrongReferenceAttributeValueException(attribute, attrDataLimit, resource, member, resource, null, attribute + " must be less than or equals to " + attrDataLimit);
+			}
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		//if this is setting of the new attribute value, check if old quota attributes are supported on the facility
+		if(attribute.getValue() != null) {
+			try {
+				Facility facility = session.getPerunBl().getResourcesManagerBl().getFacility(session, resource);
+				Attribute readyForNewQuotasAttribute = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, A_F_readyForNewQuotas);
+				//You shouldn't be allowed to set old quota attributes if facility is set for new quotas attributes (to prevent wrong setting of quotas)
+				if(readyForNewQuotasAttribute != null && readyForNewQuotasAttribute.valueAsBoolean()) {
+					throw new WrongReferenceAttributeValueException(attribute, readyForNewQuotasAttribute, member, resource, facility, null, "For this facility the new quotas attributes are used! You are trying to set the old ones.");
+				}
+			} catch (AttributeNotExistsException ex) {
+				//if attribute not exists, it is the same like it was set on false, which is ok
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimit.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -28,6 +29,7 @@ public class urn_perun_member_resource_attribute_def_def_filesLimit extends Memb
 	private static final String A_R_defaultFilesLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesLimit";
 	private static final String A_R_defaultFilesQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesQuota";
 	private static final String A_MR_filesQuota = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":filesQuota";
+	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -79,6 +81,25 @@ public class urn_perun_member_resource_attribute_def_def_filesLimit extends Memb
 			if(filesLimit != null && filesLimit != 0) throw new WrongReferenceAttributeValueException(attribute, attrFilesQuota, resource, member, resource, null, "Try to set limited limit, but there is still set unlimited Quota.");
 		} else if(filesLimit != null && filesLimit != 0)  {
 			if(filesLimit < filesQuota) throw new WrongReferenceAttributeValueException(attribute, attrFilesQuota, resource, member, resource, null, attribute + " must be more than or equals to " + attrFilesQuota);
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		//if this is setting of the new attribute value, check if old quota attributes are supported on the facility
+		if(attribute.getValue() != null) {
+			try {
+				Facility facility = session.getPerunBl().getResourcesManagerBl().getFacility(session, resource);
+				Attribute readyForNewQuotasAttribute = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, A_F_readyForNewQuotas);
+				//You shouldn't be allowed to set old quota attributes if facility is set for new quotas attributes (to prevent wrong setting of quotas)
+				if(readyForNewQuotasAttribute != null && readyForNewQuotasAttribute.valueAsBoolean()) {
+					throw new WrongReferenceAttributeValueException(attribute, readyForNewQuotasAttribute, member, resource, facility, null, "For this facility the new quotas attributes are used! You are trying to set the old ones.");
+				}
+			} catch (AttributeNotExistsException ex) {
+				//if attribute not exists, it is the same like it was set on false, which is ok
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuota.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
@@ -28,6 +29,7 @@ public class urn_perun_member_resource_attribute_def_def_filesQuota extends Memb
 	private static final String A_R_defaultFilesLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesLimit";
 	private static final String A_R_defaultFilesQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesQuota";
 	private static final String A_MR_filesLimit = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":filesLimit";
+	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -79,6 +81,25 @@ public class urn_perun_member_resource_attribute_def_def_filesQuota extends Memb
 			if(filesLimit != null && filesLimit != 0) throw new WrongReferenceAttributeValueException(attribute, attrFilesLimit, resource, member, resource, null, "Try to set unlimited quota, but limit is still " + filesLimit);
 		} else if(filesLimit != null && filesLimit != 0) {
 			if(filesLimit < filesQuota) throw new WrongReferenceAttributeValueException(attribute, attrFilesLimit, resource, member, resource, null, attribute + " must be less than or equal to " + attrFilesLimit);
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		//if this is setting of the new attribute value, check if old quota attributes are supported on the facility
+		if(attribute.getValue() != null) {
+			try {
+				Facility facility = session.getPerunBl().getResourcesManagerBl().getFacility(session, resource);
+				Attribute readyForNewQuotasAttribute = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, A_F_readyForNewQuotas);
+				//You shouldn't be allowed to set old quota attributes if facility is set for new quotas attributes (to prevent wrong setting of quotas)
+				if(readyForNewQuotasAttribute != null && readyForNewQuotasAttribute.valueAsBoolean()) {
+					throw new WrongReferenceAttributeValueException(attribute, readyForNewQuotasAttribute, member, resource, facility, null, "For this facility the new quotas attributes are used! You are trying to set the old ones.");
+				}
+			} catch (AttributeNotExistsException ex) {
+				//if attribute not exists, it is the same like it was set on false, which is ok
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataLimit.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
@@ -27,6 +28,7 @@ import java.util.regex.Pattern;
 public class urn_perun_resource_attribute_def_def_defaultDataLimit extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";
+	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 	private static final Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
 	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
 	private static final Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
@@ -165,6 +167,25 @@ public class urn_perun_resource_attribute_def_def_defaultDataLimit extends Resou
 
 			if (limitNumber.compareTo(quotaNumber) < 0) {
 				throw new WrongReferenceAttributeValueException(attribute, attrDefaultDataQuota, resource, null, resource, null, attribute + " must be more than or equals to " + attrDefaultDataQuota);
+			}
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		//if this is setting of the new attribute value, check if old quota attributes are supported on the facility
+		if(attribute.getValue() != null) {
+			try {
+				Facility facility = session.getPerunBl().getResourcesManagerBl().getFacility(session, resource);
+				Attribute readyForNewQuotasAttribute = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, A_F_readyForNewQuotas);
+				//You shouldn't be allowed to set old quota attributes if facility is set for new quotas attributes (to prevent wrong setting of quotas)
+				if(readyForNewQuotasAttribute != null && readyForNewQuotasAttribute.valueAsBoolean()) {
+					throw new WrongReferenceAttributeValueException(attribute, readyForNewQuotasAttribute, resource, null, facility, null, "For this facility the new quotas attributes are used! You are trying to set the old ones.");
+				}
+			} catch (AttributeNotExistsException ex) {
+				//if attribute not exists, it is the same like it was set on false, which is ok
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuota.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
@@ -27,6 +28,7 @@ import java.util.regex.Pattern;
 public class urn_perun_resource_attribute_def_def_defaultDataQuota extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultDataLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit";
+	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 	private static final Pattern numberPattern = Pattern.compile("[0-9]+[.]?[0-9]*");
 	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
 	private static final Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
@@ -165,6 +167,25 @@ public class urn_perun_resource_attribute_def_def_defaultDataQuota extends Resou
 
 			if (limitNumber.compareTo(quotaNumber) < 0) {
 				throw new WrongReferenceAttributeValueException(attribute, attrDefaultDataLimit, resource, null, resource, null, attribute + " must be less than or equals to " + defaultDataLimit);
+			}
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		//if this is setting of the new attribute value, check if old quota attributes are supported on the facility
+		if(attribute.getValue() != null) {
+			try {
+				Facility facility = session.getPerunBl().getResourcesManagerBl().getFacility(session, resource);
+				Attribute readyForNewQuotasAttribute = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, A_F_readyForNewQuotas);
+				//You shouldn't be allowed to set old quota attributes if facility is set for new quotas attributes (to prevent wrong setting of quotas)
+				if(readyForNewQuotasAttribute != null && readyForNewQuotasAttribute.valueAsBoolean()) {
+					throw new WrongReferenceAttributeValueException(attribute, readyForNewQuotasAttribute, resource, null, facility, null, "For this facility the new quotas attributes are used! You are trying to set the old ones.");
+				}
+			} catch (AttributeNotExistsException ex) {
+				//if attribute not exists, it is the same like it was set on false, which is ok
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesLimit.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
@@ -24,6 +25,7 @@ import java.util.List;
 public class urn_perun_resource_attribute_def_def_defaultFilesLimit extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultFilesQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesQuota";
+	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -55,6 +57,25 @@ public class urn_perun_resource_attribute_def_def_defaultFilesLimit extends Reso
 			if(defaultFilesLimit != null && defaultFilesLimit != 0) throw new WrongReferenceAttributeValueException(attribute, attrDefaultFilesQuota, resource, null, resource, null, "Try to set limited limit, but there is still set unlimited Quota.");
 		} else if(defaultFilesLimit != null && defaultFilesLimit != 0) {
 			if(defaultFilesLimit < defaultFilesQuota) throw new WrongReferenceAttributeValueException(attribute, attrDefaultFilesQuota, resource, null, resource, null, attribute + " must be more than or equals to " + attrDefaultFilesQuota);
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		//if this is setting of the new attribute value, check if old quota attributes are supported on the facility
+		if(attribute.getValue() != null) {
+			try {
+				Facility facility = session.getPerunBl().getResourcesManagerBl().getFacility(session, resource);
+				Attribute readyForNewQuotasAttribute = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, A_F_readyForNewQuotas);
+				//You shouldn't be allowed to set old quota attributes if facility is set for new quotas attributes (to prevent wrong setting of quotas)
+				if(readyForNewQuotasAttribute != null && readyForNewQuotasAttribute.valueAsBoolean()) {
+					throw new WrongReferenceAttributeValueException(attribute, readyForNewQuotasAttribute, resource, null, facility, null, "For this facility the new quotas attributes are used! You are trying to set the old ones.");
+				}
+			} catch (AttributeNotExistsException ex) {
+				//if attribute not exists, it is the same like it was set on false, which is ok
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesQuota.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
@@ -24,6 +25,7 @@ import java.util.List;
 public class urn_perun_resource_attribute_def_def_defaultFilesQuota extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	private static final String A_R_defaultFilesLimit = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesLimit";
+	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 
 	@Override
 	public void checkAttributeValue(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
@@ -55,6 +57,25 @@ public class urn_perun_resource_attribute_def_def_defaultFilesQuota extends Reso
 			if(defaultFilesLimit != null && defaultFilesLimit != 0) throw new WrongReferenceAttributeValueException(attribute, attrDefaultFilesLimit, resource, null, resource, null, "Try to set unlimited quota, but limit is still " + defaultFilesLimit);
 		}else if(defaultFilesLimit != null && defaultFilesLimit != 0) {
 			if(defaultFilesLimit < defaultFilesQuota) throw new WrongReferenceAttributeValueException(attribute, attrDefaultFilesLimit, resource, null, resource, null, attribute + " must be less than or equals " + attrDefaultFilesLimit);
+		}
+	}
+
+	@Override
+	public void changedAttributeHook(PerunSessionImpl session, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		//if this is setting of the new attribute value, check if old quota attributes are supported on the facility
+		if(attribute.getValue() != null) {
+			try {
+				Facility facility = session.getPerunBl().getResourcesManagerBl().getFacility(session, resource);
+				Attribute readyForNewQuotasAttribute = session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, A_F_readyForNewQuotas);
+				//You shouldn't be allowed to set old quota attributes if facility is set for new quotas attributes (to prevent wrong setting of quotas)
+				if(readyForNewQuotasAttribute != null && readyForNewQuotasAttribute.valueAsBoolean()) {
+					throw new WrongReferenceAttributeValueException(attribute, readyForNewQuotasAttribute, resource, null, facility, null, "For this facility the new quotas attributes are used! You are trying to set the old ones.");
+				}
+			} catch (AttributeNotExistsException ex) {
+				//if attribute not exists, it is the same like it was set on false, which is ok
+			} catch (WrongAttributeAssignmentException ex) {
+				throw new InternalErrorException(ex);
+			}
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1560,8 +1560,9 @@ public interface AttributesManagerImplApi {
 	 * @param resource
 	 * @param attribute
 	 * @throws InternalErrorException
+	 * @throws WrongReferenceAttributeValueException
 	 */
-	void changedAttributeHook(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException;
+	void changedAttributeHook(PerunSession sess, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * If you need to do some further work with other modules, this method do that

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleAbstract.java
@@ -29,7 +29,7 @@ public abstract class MemberResourceAttributesModuleAbstract extends AttributesM
 		return new Attribute(attribute);
 	}
 
-	public void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) {
+	public void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleImplApi.java
@@ -54,6 +54,8 @@ public interface MemberResourceAttributesModuleImplApi extends AttributesModuleI
 	 * @param member the member
 	 * @param resource the resource
 	 * @param attribute the attribute
+	 * @throws InternalErrorException if there is any internal error
+	 * @throws WrongReferenceAttributeValueException if there is problem to process the change hook because of the value of referenced attribute
 	 */
-	void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute);
+	void changedAttributeHook(PerunSessionImpl session, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 }


### PR DESCRIPTION
 - there is an attribute on facility which says if there are used new
 quotas attributes (for whole facility) or the old ones are still used
 (especially for service fs_home). This changes will prevent to set old
 attributes on all resources of such facility if new quotas are enabled
 there.
 - changes were made to "changeAttributeHook" because only there is
 possible to let checking of the attribute same, but disallowed of
 changing value to different one and also allowed removing of the value.
 For these reasons necessarily exceptions were added where needed.
 - to all affected attribute modules were added logic to check this
 situation and throw an exception if setting of the new value is
 disallowed (defined by setting on facility)