### PR TITLE
CORE: Do not lock resolving audit messages by attribute modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -286,20 +286,20 @@ public class Auditer {
 			return;
 		}
 
+		// Resolve all additional message from attribute modules and add them to the bulk
+		try {
+
+			//Get perun session from the first message (all sessions should be same from the same principal)
+			PerunSessionImpl session = (PerunSessionImpl) auditerMessages.get(0).getOriginatingSession();
+
+			//Check recursively all messages if they can create any resolving message
+			auditerMessages.addAll(checkRegisteredAttributesModules(session, auditerMessages, new ArrayList<>()));
+
+		} catch (Throwable ex) {
+			log.error("There is a problem with processing resolving messages! It will be forcibly skipped to prevent unexpected behavior of auditer log!", ex);
+		}
+
 		synchronized (LOCK_DB_TABLE_AUDITER_LOG) {
-
-			// Resolve all additional message from attribute modules and add them to the bulk
-			try {
-
-				//Get perun session from the first message (all sessions should be same from the same principal)
-				PerunSessionImpl session = (PerunSessionImpl) auditerMessages.get(0).getOriginatingSession();
-
-				//Check recursively all messages if they can create any resolving message
-				auditerMessages.addAll(checkRegisteredAttributesModules(session, auditerMessages, new ArrayList<>()));
-
-			} catch (Throwable ex) {
-				log.error("There is a problem with processing resolving messages! It will be forcibly skipped to prevent unexpected behavior of auditer log!", ex);
-			}
 
 			//Write all messages to the database
 			try {


### PR DESCRIPTION
- We previously "locked" all transactions before the first one resolved
  any additional audit messages (by attribute module).
  If there was a lot of messages, it could take a lot of time (resolving
  many virtual attributes value changes).
- By moving the lock after additional message resolving we allow other
  transactions to resolve messages on their own and only batch insert
  of messages is now locked to make sure our messages makes sense
  to the reader (like LDAPc).