### PR TITLE
Added WrongAttributeSemanticsException and WrongAttributeSyntaxException

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/WrongAttributeSemanticsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/WrongAttributeSemanticsException.java
@@ -1,0 +1,54 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Attribute;
+
+/**
+ * Attribute's value has incorrect semantics.
+ *
+ * @author Metodej Klang
+ */
+public class WrongAttributeSemanticsException extends WrongAttributeValueException {
+	public WrongAttributeSemanticsException(String message) {
+		super(message);
+	}
+
+	public WrongAttributeSemanticsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public WrongAttributeSemanticsException(Throwable cause) {
+		super(cause);
+	}
+
+	public WrongAttributeSemanticsException(Attribute attribute) {
+		super(attribute);
+	}
+
+	public WrongAttributeSemanticsException(Attribute attribute, Object attributeHolder, Object attributeHolderSecondary, String message) {
+		super(attribute, attributeHolder, attributeHolderSecondary, message);
+	}
+
+	public WrongAttributeSemanticsException(Attribute attribute, Object attributeHolder, Object attributeHolderSecondary) {
+		super(attribute, attributeHolder, attributeHolderSecondary);
+	}
+
+	public WrongAttributeSemanticsException(Attribute attribute, Object attributeHolder, String message) {
+		super(attribute, attributeHolder, message);
+	}
+
+	public WrongAttributeSemanticsException(Attribute attribute, Object attributeHolder, String message, Throwable cause) {
+		super(attribute, attributeHolder, message, cause);
+	}
+
+	public WrongAttributeSemanticsException(Attribute attribute, Throwable cause) {
+		super(attribute, cause);
+	}
+
+	public WrongAttributeSemanticsException(Attribute attribute, String message) {
+		super(attribute, message);
+	}
+
+	public WrongAttributeSemanticsException(Attribute attribute, String message, Throwable cause) {
+		super(attribute, message, cause);
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/WrongAttributeSyntaxException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/WrongAttributeSyntaxException.java
@@ -1,0 +1,54 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+import cz.metacentrum.perun.core.api.Attribute;
+
+/**
+ * Attribute's value has incorrect syntax.
+ *
+ * @author Metodej Klang
+ */
+public class WrongAttributeSyntaxException extends WrongAttributeValueException {
+	public WrongAttributeSyntaxException(String message) {
+		super(message);
+	}
+
+	public WrongAttributeSyntaxException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public WrongAttributeSyntaxException(Throwable cause) {
+		super(cause);
+	}
+
+	public WrongAttributeSyntaxException(Attribute attribute) {
+		super(attribute);
+	}
+
+	public WrongAttributeSyntaxException(Attribute attribute, Object attributeHolder, Object attributeHolderSecondary, String message) {
+		super(attribute, attributeHolder, attributeHolderSecondary, message);
+	}
+
+	public WrongAttributeSyntaxException(Attribute attribute, Object attributeHolder, Object attributeHolderSecondary) {
+		super(attribute, attributeHolder, attributeHolderSecondary);
+	}
+
+	public WrongAttributeSyntaxException(Attribute attribute, Object attributeHolder, String message) {
+		super(attribute, attributeHolder, message);
+	}
+
+	public WrongAttributeSyntaxException(Attribute attribute, Object attributeHolder, String message, Throwable cause) {
+		super(attribute, attributeHolder, message, cause);
+	}
+
+	public WrongAttributeSyntaxException(Attribute attribute, Throwable cause) {
+		super(attribute, cause);
+	}
+
+	public WrongAttributeSyntaxException(Attribute attribute, String message) {
+		super(attribute, message);
+	}
+
+	public WrongAttributeSyntaxException(Attribute attribute, String message, Throwable cause) {
+		super(attribute, message, cause);
+	}
+}


### PR DESCRIPTION
- new exceptions extend WrongAttributeValueException
- these exceptions will be used in new logic to differentiate whether wrong attribute value is due to semantics or syntax error