### PR TITLE
CORE: Make sure getUsersSubjects() doesn't get serialized to audit log

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourceSimpleApi.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.implApi;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
@@ -91,6 +92,7 @@ public interface ExtSourceSimpleApi {
 	 * @throws InternalErrorException
 	 * @throws ExtSourceUnsupportedOperationException
 	 */
+	@JsonIgnore
 	List<Map<String, String>> getUsersSubjects() throws InternalErrorException, ExtSourceUnsupportedOperationException;
 
 }


### PR DESCRIPTION
- New method in ExtSourceSimpleApi, getUsersSubjects() gets serialized
  to audit log, because it is a getter without params.
  Since it performs callback to the ExtSource backend, we don't want
  its response to be serialized. At best it fails to store
  UserExtSourceAddedToUser message to the log.
- Adding @JsonIgnore annotation will prevent serialization in any case.