### PR TITLE
CORE: Extend exception message in user:def:uid_namespace module

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_uid_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_uid_namespace.java
@@ -75,7 +75,7 @@ public class urn_perun_user_attribute_def_def_uid_namespace extends UserAttribut
 		usersWithUid.remove(user); //remove self
 		if (!usersWithUid.isEmpty()) {
 			if(usersWithUid.size() > 1) throw new ConsistencyErrorException("FATAL ERROR: Duplicated UID detected." +  attribute + " " + usersWithUid);
-			throw new WrongAttributeValueException(attribute, "This UID " + attribute.getValue() + " is already occupied by" + usersWithUid.get(0)  + ".");
+			throw new WrongAttributeValueException(attribute, "UID " + attribute.getValue() + " is already occupied by " + usersWithUid.get(0)  + ". We can't set it for " + user + ".");
 		}
 	}
 


### PR DESCRIPTION
- We want to know, for which User we tried to set already existing UID.