### PR TITLE
Utils: Added timeout for kerberos password manager

### DIFF
--- a/perun-utils/password-manager/perun.passwordManager
+++ b/perun-utils/password-manager/perun.passwordManager
@@ -57,7 +57,7 @@ function change() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM passwd --password="${PASSWORD}" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -69,7 +69,7 @@ function change() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" --pw-expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -84,7 +84,7 @@ function change() {
 		RET=$(printf "cpw -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -96,7 +96,7 @@ function change() {
 		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -118,14 +118,14 @@ function reserve() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ "$RET" ]; then
 			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 			RET_CODE=$?
 			if [ $RET_CODE -eq 124 ]; then
-				logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 				exit $RET_CODE
 			fi
 			if [ $RET_CODE -ne 0 ]; then
@@ -143,7 +143,7 @@ function reserve() {
 			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add --password="${PASSWORD}" --use-defaults ${USERLOGIN}@${REALM} 2>&1)
 			RET_CODE=$?
 			if [ $RET_CODE -eq 124 ]; then
-				logger "Perun-PasswordReserve: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				logger "Perun-PasswordReserve: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 				exit $RET_CODE
 			fi
 		fi
@@ -157,7 +157,7 @@ function reserve() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -171,14 +171,14 @@ function reserve() {
 		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ "$RET" ]; then
 			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 			RET_CODE=$?
 			if [ $RET_CODE -eq 124 ]; then
-				logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 				exit $RET_CODE
 			fi
 			if [ $RET_CODE -ne 0 ]; then
@@ -196,7 +196,7 @@ function reserve() {
 			RET=$(printf "addprinc -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 			RET_CODE=$?
 			if [ $RET_CODE -eq 124 ]; then
-				logger "Perun-PasswordReserve: setting new password for timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				logger "Perun-PasswordReserve: setting new password for timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 				exit $RET_CODE
 			fi
 		fi
@@ -210,7 +210,7 @@ function reserve() {
 		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -231,14 +231,14 @@ function reserve_random() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ "$RET" ]; then
 			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 			RET_CODE=$?
 			if [ $RET_CODE -eq 124 ]; then
-				logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 				exit $RET_CODE
 			fi
 			if [ $RET_CODE -ne 0 ]; then
@@ -251,7 +251,7 @@ function reserve_random() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add -r --use-defaults ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -263,7 +263,7 @@ function reserve_random() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -277,14 +277,14 @@ function reserve_random() {
 		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ "$RET" ]; then
 			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 			RET_CODE=$?
 			if [ $RET_CODE -eq 124 ]; then
-				logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 				exit $RET_CODE
 			fi
 			if [ $RET_CODE -ne 0 ]; then
@@ -297,7 +297,7 @@ function reserve_random() {
 		RET=$(printf "addprinc -randkey %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -309,7 +309,7 @@ function reserve_random() {
 		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -329,7 +329,7 @@ function validate() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -342,7 +342,7 @@ function validate() {
 		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -362,7 +362,7 @@ function delete() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -375,7 +375,7 @@ function delete() {
 		RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
@@ -396,7 +396,7 @@ case $LOGINNAMESPACE in
 		KEYTAB=/pathtokeytab
 		ADMINPRINCIPAL=pwchange/principal
 		;;
-	namespace1)
+	namespace2)
 		TYPE=KERBEROS_MIT
 		REALM=REALM2
 		KEYTAB=/pathtokeytab

--- a/perun-utils/password-manager/perun.passwordManager
+++ b/perun-utils/password-manager/perun.passwordManager
@@ -57,8 +57,8 @@ function change() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM passwd --password="${PASSWORD}" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: setting new password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -69,8 +69,8 @@ function change() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" --pw-expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -84,8 +84,8 @@ function change() {
 		RET=$(printf "cpw -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: setting new password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -96,8 +96,8 @@ function change() {
 		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -118,16 +118,16 @@ function reserve() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ "$RET" ]; then
 			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 			RET_CODE=$?
-		  if [ $RET_CODE -eq 124 ]; then
-		    logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		    exit $RET_CODE
-		  fi
+			if [ $RET_CODE -eq 124 ]; then
+				logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				exit $RET_CODE
+			fi
 			if [ $RET_CODE -ne 0 ]; then
 				logger "Perun-PasswordReserve: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
@@ -141,11 +141,11 @@ function reserve() {
 			exit 4
 		else
 			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add --password="${PASSWORD}" --use-defaults ${USERLOGIN}@${REALM} 2>&1)
-		  RET_CODE=$?
-		  if [ $RET_CODE -eq 124 ]; then
-		    logger "Perun-PasswordReserve: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		    exit $RET_CODE
-		  fi
+			RET_CODE=$?
+			if [ $RET_CODE -eq 124 ]; then
+				logger "Perun-PasswordReserve: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				exit $RET_CODE
+			fi
 		fi
 
 		if [ $RET_CODE -ne 0 ]; then
@@ -157,8 +157,8 @@ function reserve() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -171,16 +171,16 @@ function reserve() {
 		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ "$RET" ]; then
 			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 			RET_CODE=$?
 			if [ $RET_CODE -eq 124 ]; then
-		    logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		    exit $RET_CODE
-		  fi
+				logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				exit $RET_CODE
+			fi
 			if [ $RET_CODE -ne 0 ]; then
 				logger "Perun-PasswordReserve: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
@@ -196,9 +196,9 @@ function reserve() {
 			RET=$(printf "addprinc -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 			RET_CODE=$?
 			if [ $RET_CODE -eq 124 ]; then
-		    logger "Perun-PasswordReserve: setting new password for timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		    exit $RET_CODE
-		  fi
+				logger "Perun-PasswordReserve: setting new password for timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				exit $RET_CODE
+			fi
 		fi
 
 		if [ $RET_CODE -ne 0 ]; then
@@ -210,8 +210,8 @@ function reserve() {
 		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -231,16 +231,16 @@ function reserve_random() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ "$RET" ]; then
 			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 			RET_CODE=$?
-		  if [ $RET_CODE -eq 124 ]; then
-		    logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		    exit $RET_CODE
-		  fi
+			if [ $RET_CODE -eq 124 ]; then
+				logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				exit $RET_CODE
+			fi
 			if [ $RET_CODE -ne 0 ]; then
 				logger "Perun-PasswordReserveRandom: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
@@ -249,10 +249,10 @@ function reserve_random() {
 		fi
 
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add -r --use-defaults ${USERLOGIN}@${REALM} 2>&1)
-    RET_CODE=$?
+		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting new random password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -263,8 +263,8 @@ function reserve_random() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -277,16 +277,16 @@ function reserve_random() {
 		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ "$RET" ]; then
 			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-		  RET_CODE=$?
-		  if [ $RET_CODE -eq 124 ]; then
-		    logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		    exit $RET_CODE
-		  fi
+			RET_CODE=$?
+			if [ $RET_CODE -eq 124 ]; then
+				logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+				exit $RET_CODE
+			fi
 			if [ $RET_CODE -ne 0 ]; then
 				logger "Perun-PasswordReserveRandom: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
@@ -295,10 +295,10 @@ function reserve_random() {
 		fi
 
 		RET=$(printf "addprinc -randkey %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-    RET_CODE=$?
+		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting new random password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -309,8 +309,8 @@ function reserve_random() {
 		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -329,8 +329,8 @@ function validate() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordValidate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -342,8 +342,8 @@ function validate() {
 		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordValidate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -362,8 +362,8 @@ function delete() {
 		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordDelete: removing the password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -375,8 +375,8 @@ function delete() {
 		RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-		  logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
-		  exit $RET_CODE
+			logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+			exit $RET_CODE
 		fi
 		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordDelete: removing the password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."

--- a/perun-utils/password-manager/perun.passwordManager
+++ b/perun-utils/password-manager/perun.passwordManager
@@ -45,14 +45,14 @@ function change() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
 		# Change password
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM passwd --password="${PASSWORD}" ${USERLOGIN}@${REALM} 2>&1`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM passwd --password="${PASSWORD}" ${USERLOGIN}@${REALM} 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordChange: setting new password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 3
 		fi
 
 		# Set password expiration to never - for sure:-)
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" --pw-expiration-time="never" ${USERLOGIN}@${REALM} 2>&1`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" --pw-expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordChange: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
@@ -62,14 +62,14 @@ function change() {
 		;;
 	KERBEROS_MIT)
 		# Change password
-		RET=`printf "cpw -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+		RET=$(printf "cpw -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordChange: setting new password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 3
 		fi
 
 		# Set principal expiration to never - this can be useful when the principal has been suspended for password leakage
-		RET=`printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordChange: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
@@ -86,9 +86,9 @@ function reserve() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
 		# Check if the principal already exists, if yes, just remove it and create a new one = self-repair
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
 		if [ "$RET" ]; then
-			RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1`
+			RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 			if [ $? -ne 0 ]; then
 				logger "Perun-PasswordReserve: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
@@ -101,7 +101,7 @@ function reserve() {
 			logger "Perun-PasswordReserve: empty password provided for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 			exit 4
 		else
-			RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add --password="${PASSWORD}" --use-defaults ${USERLOGIN}@${REALM} 2>&1`
+			RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add --password="${PASSWORD}" --use-defaults ${USERLOGIN}@${REALM} 2>&1)
 		fi
 
 		if [ $? -ne 0 ]; then
@@ -110,7 +110,7 @@ function reserve() {
 		fi
 
 		# Set expiration to 1.1.1970
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
@@ -119,9 +119,9 @@ function reserve() {
 		;;
 	KERBEROS_MIT)
 		# Check if the principal already exists, if yes, just remove it and create a new one = self-repair
-		RET=`printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null`
+		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
 		if [ "$RET" ]; then
-			RET=`printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 			if [ $? -ne 0 ]; then
 				logger "Perun-PasswordReserve: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
@@ -134,7 +134,7 @@ function reserve() {
 			logger "Perun-PasswordReserve: empty password provided for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 			exit 4
 		else
-			RET=`printf "addprinc -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+			RET=$(printf "addprinc -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		fi
 
 		if [ $? -ne 0 ]; then
@@ -143,7 +143,7 @@ function reserve() {
 		fi
 
 		# Set expiration to 1.1.1970
-		RET=`printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
@@ -159,9 +159,9 @@ function reserve_random() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
 		 # Check if the principal already exists, if yes, just remove it and create a new one = self-repair
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
 		if [ "$RET" ]; then
-			RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1`
+			RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 			if [ $? -ne 0 ]; then
 				logger "Perun-PasswordReserveRandom: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
@@ -169,7 +169,7 @@ function reserve_random() {
 			logger "Perun-PasswordReserveRandom: WARNING old entry $LOGINNAMESPACE:$USERLOGIN in $REALM which shouldn't be there was removed."
 		fi
 
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add -r --use-defaults ${USERLOGIN}@${REALM} 2>&1`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add -r --use-defaults ${USERLOGIN}@${REALM} 2>&1)
 
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting new random password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -177,7 +177,7 @@ function reserve_random() {
 		fi
 
 		# Set expiration to 1.1.1970
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
@@ -186,9 +186,9 @@ function reserve_random() {
 		;;
 	KERBEROS_MIT)
 		 # Check if the principal already exists, if yes, just remove it and create a new one = self-repair
-		RET=`printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null`
+		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
 		if [ "$RET" ]; then
-			RET=`printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 			if [ $? -ne 0 ]; then
 				logger "Perun-PasswordReserveRandom: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
@@ -196,7 +196,7 @@ function reserve_random() {
 			logger "Perun-PasswordReserveRandom: WARNING old entry $LOGINNAMESPACE:$USERLOGIN in $REALM which shouldn't be there was removed."
 		fi
 
-		RET=`printf "addprinc -randkey %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+		RET=$(printf "addprinc -randkey %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting new random password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
@@ -204,7 +204,7 @@ function reserve_random() {
 		fi
 
 		# Set expiration to 1.1.1970
-		RET=`printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
@@ -219,7 +219,7 @@ function reserve_random() {
 function validate() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" ${USERLOGIN}@${REALM} 2>&1`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordCreate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
@@ -227,7 +227,7 @@ function validate() {
 		logger "Perun-PasswordValidate: successfully validated login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 		;;
 	KERBEROS_MIT)
-		RET=`printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordCreate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
@@ -242,7 +242,7 @@ function validate() {
 function delete() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
-		RET=`/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1`
+		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordDelete: removing the password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 5
@@ -250,7 +250,7 @@ function delete() {
 		logger "Perun-PasswordDelete: successfully deleted login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 		;;
 	KERBEROS_MIT)
-		RET=`printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1`
+		RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
 		if [ $? -ne 0 ]; then
 			logger "Perun-PasswordDelete: removing the password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 5

--- a/perun-utils/password-manager/perun.passwordManager
+++ b/perun-utils/password-manager/perun.passwordManager
@@ -19,6 +19,9 @@ USERLOGIN=$3
 
 PATH=$PATH:/usr/sbin
 
+TIMEOUT="15" # wait 15 sec for callback to KDC
+TIMEOUT_KILL="15" # kill process after additional 15 sec, resultin in 30s real timeout
+
 # Below is an example for managing Kerberos KDC for login-namespace called einfra.
 
 # Check if the password is OK
@@ -28,8 +31,14 @@ function check() {
 	KERBEROS_HEIMDAL|KERBEROS_MIT)
 		TMP_FILE=/tmp/perun.passwd.check
 		# Check old password
-		echo -n "$PASSWORD" | kinit -c ${TMP_FILE} --password-file=STDIN ${USERLOGIN}@${REALM}
-		if [ $? -ne 0 ]; then
+		echo -n "$PASSWORD" | timeout -k $TIMEOUT_KILL $TIMEOUT kinit -c ${TMP_FILE} --password-file=STDIN ${USERLOGIN}@${REALM}
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+			logger "Perun-PasswordChange: password check timed out for $LOGINNAMESPACE:$USERLOGIN (Warning: this error can mask original error 124 from KDC!)"
+			rm -f ${TMP_FILE}
+			exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: old password doesn't match for $LOGINNAMESPACE:$USERLOGIN"
 			rm -f ${TMP_FILE}
 			exit 1
@@ -45,15 +54,25 @@ function change() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
 		# Change password
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM passwd --password="${PASSWORD}" ${USERLOGIN}@${REALM} 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM passwd --password="${PASSWORD}" ${USERLOGIN}@${REALM} 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: setting new password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 3
 		fi
 
 		# Set password expiration to never - for sure:-)
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" --pw-expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" --pw-expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
@@ -62,15 +81,25 @@ function change() {
 		;;
 	KERBEROS_MIT)
 		# Change password
-		RET=$(printf "cpw -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(printf "cpw -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordChange: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: setting new password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 3
 		fi
 
 		# Set principal expiration to never - this can be useful when the principal has been suspended for password leakage
-		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordChange: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordChange: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
@@ -86,10 +115,20 @@ function reserve() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
 		# Check if the principal already exists, if yes, just remove it and create a new one = self-repair
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
 		if [ "$RET" ]; then
-			RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
-			if [ $? -ne 0 ]; then
+			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
+			RET_CODE=$?
+		  if [ $RET_CODE -eq 124 ]; then
+		    logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		    exit $RET_CODE
+		  fi
+			if [ $RET_CODE -ne 0 ]; then
 				logger "Perun-PasswordReserve: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
 			fi
@@ -101,17 +140,27 @@ function reserve() {
 			logger "Perun-PasswordReserve: empty password provided for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 			exit 4
 		else
-			RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add --password="${PASSWORD}" --use-defaults ${USERLOGIN}@${REALM} 2>&1)
+			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add --password="${PASSWORD}" --use-defaults ${USERLOGIN}@${REALM} 2>&1)
+		  RET_CODE=$?
+		  if [ $RET_CODE -eq 124 ]; then
+		    logger "Perun-PasswordReserve: setting new password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		    exit $RET_CODE
+		  fi
 		fi
 
-		if [ $? -ne 0 ]; then
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserve: setting new password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
 
 		# Set expiration to 1.1.1970
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
@@ -119,10 +168,20 @@ function reserve() {
 		;;
 	KERBEROS_MIT)
 		# Check if the principal already exists, if yes, just remove it and create a new one = self-repair
-		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
+		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserve: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
 		if [ "$RET" ]; then
-			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-			if [ $? -ne 0 ]; then
+			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+			RET_CODE=$?
+			if [ $RET_CODE -eq 124 ]; then
+		    logger "Perun-PasswordReserve: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		    exit $RET_CODE
+		  fi
+			if [ $RET_CODE -ne 0 ]; then
 				logger "Perun-PasswordReserve: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
 			fi
@@ -134,17 +193,27 @@ function reserve() {
 			logger "Perun-PasswordReserve: empty password provided for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 			exit 4
 		else
-			RET=$(printf "addprinc -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+			RET=$(printf "addprinc -pw \"%s\" %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+			RET_CODE=$?
+			if [ $RET_CODE -eq 124 ]; then
+		    logger "Perun-PasswordReserve: setting new password for timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		    exit $RET_CODE
+		  fi
 		fi
 
-		if [ $? -ne 0 ]; then
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserve: setting new password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
 
 		# Set expiration to 1.1.1970
-		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserve: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
@@ -159,26 +228,45 @@ function reserve_random() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
 		 # Check if the principal already exists, if yes, just remove it and create a new one = self-repair
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
 		if [ "$RET" ]; then
-			RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
-			if [ $? -ne 0 ]; then
+			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
+			RET_CODE=$?
+		  if [ $RET_CODE -eq 124 ]; then
+		    logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		    exit $RET_CODE
+		  fi
+			if [ $RET_CODE -ne 0 ]; then
 				logger "Perun-PasswordReserveRandom: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
 			fi
 			logger "Perun-PasswordReserveRandom: WARNING old entry $LOGINNAMESPACE:$USERLOGIN in $REALM which shouldn't be there was removed."
 		fi
 
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add -r --use-defaults ${USERLOGIN}@${REALM} 2>&1)
-
-		if [ $? -ne 0 ]; then
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM add -r --use-defaults ${USERLOGIN}@${REALM} 2>&1)
+    RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting new random password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
 
 		# Set expiration to 1.1.1970
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="1970-01-01" ${USERLOGIN}@${REALM} 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
@@ -186,26 +274,45 @@ function reserve_random() {
 		;;
 	KERBEROS_MIT)
 		 # Check if the principal already exists, if yes, just remove it and create a new one = self-repair
-		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
+		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserveRandom: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
 		if [ "$RET" ]; then
-			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-			if [ $? -ne 0 ]; then
+			RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+		  RET_CODE=$?
+		  if [ $RET_CODE -eq 124 ]; then
+		    logger "Perun-PasswordReserveRandom: removing old entry timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		    exit $RET_CODE
+		  fi
+			if [ $RET_CODE -ne 0 ]; then
 				logger "Perun-PasswordReserveRandom: removing old entry $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 				exit 4
 			fi
 			logger "Perun-PasswordReserveRandom: WARNING old entry $LOGINNAMESPACE:$USERLOGIN in $REALM which shouldn't be there was removed."
 		fi
 
-		RET=$(printf "addprinc -randkey %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-
-		if [ $? -ne 0 ]; then
+		RET=$(printf "addprinc -randkey %s\n" "${PASSWORD}" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+    RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserveRandom: setting new random password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting new random password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
 
 		# Set expiration to 1.1.1970
-		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(printf "modprinc -expire \"01/01/1970 00:00:01 UTC\" %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordReserveRandom: setting expiration time to 1.1.1970 for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
@@ -219,17 +326,27 @@ function reserve_random() {
 function validate() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
-		if [ $? -ne 0 ]; then
-			logger "Perun-PasswordCreate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
+			logger "Perun-PasswordValidate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
 		logger "Perun-PasswordValidate: successfully validated login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 		;;
 	KERBEROS_MIT)
-		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-		if [ $? -ne 0 ]; then
-			logger "Perun-PasswordCreate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
+		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
+			logger "Perun-PasswordValidate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 4
 		fi
 		logger "Perun-PasswordValidate: successfully validated login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
@@ -242,16 +359,26 @@ function validate() {
 function delete() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
-		RET=$(/usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM del ${USERLOGIN}@${REALM} 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordDelete: removing the password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 5
 		fi
 		logger "Perun-PasswordDelete: successfully deleted login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 		;;
 	KERBEROS_MIT)
-		RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
-		if [ $? -ne 0 ]; then
+		RET=$(printf "delprinc -force %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+		RET_CODE=$?
+		if [ $RET_CODE -eq 124 ]; then
+		  logger "Perun-PasswordDelete: removing the password timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!)"
+		  exit $RET_CODE
+		fi
+		if [ $RET_CODE -ne 0 ]; then
 			logger "Perun-PasswordDelete: removing the password for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
 			exit 5
 		fi


### PR DESCRIPTION
- We will wait 15 seconds for the KDC response and kill the process
  after another 15 seconds. If timeout occur, we exist script with
  error code 124.
- Use $(...) notation instead of legacy backticks. This prevents possible
  issues with escaping and nesting of commands. Full rationale at:
  https://github.com/koalaman/shellcheck/wiki/SC2006