### PR TITLE
LDAPc Bug fix: when processing audit message to group creation, VO was also created, validating member in VO instead of in Group

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/CreationEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/CreationEventProcessor.java
@@ -26,6 +26,11 @@ public class CreationEventProcessor extends AbstractEventProcessor {
 			try {
 				switch(beanFlag) {
 				case MessageBeans.GROUP_F:
+					if (beans.getParentGroup() != null) {
+						log.debug("Adding subgroup {} to group {}", beans.getGroup(), beans.getParentGroup());
+						perunGroup.addGroupAsSubGroup(beans.getGroup(), beans.getParentGroup());
+						break;
+					}
 					log.debug("Adding new group: {}", beans.getGroup());
 					perunGroup.addGroup(beans.getGroup());
 					break;
@@ -41,6 +46,9 @@ public class CreationEventProcessor extends AbstractEventProcessor {
 					break;
 					
 				case MessageBeans.VO_F:
+					if (beans.getGroup() != null) {
+						break;
+					}
 					log.debug("Adding new VO: {}", beans.getVo());
 					perunVO.addVo(beans.getVo());
 					break;

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventDispatcherImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/EventDispatcherImpl.java
@@ -308,6 +308,7 @@ public class EventDispatcherImpl implements EventDispatcher, Runnable {
 
 		//Debug information to check parsing of message.
 		MessageBeans beans = new MessageBeansImpl();
+
 		if(!listOfBeans.isEmpty()){
 			int i=0;
 			for(PerunBean p: listOfBeans) {

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/GroupEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/GroupEventProcessor.java
@@ -47,7 +47,7 @@ public class GroupEventProcessor extends AbstractEventProcessor {
 		}
 	}
 
-	public void processSubgroupAdded(String msg, MessageBeans beans) {
+	/*public void processSubgroupAdded(String msg, MessageBeans beans) {
 		if(beans.getGroup() == null || beans.getParentGroup() == null) {
 			return;
 		}
@@ -57,7 +57,7 @@ public class GroupEventProcessor extends AbstractEventProcessor {
 		} catch (NamingException | InternalErrorException e) {
 			log.error("Error adding subgroup {} to group {}: {}", beans.getGroup().getId(), beans.getParentGroup().getId(), e.getMessage());
 		}
-	}
+	}*/
 
 	public void processResourceAssigned(String msg, MessageBeans beans) {
 		if(beans.getGroup() == null || beans.getResource() == null) {

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/SimpleDispatchEventCondition.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/SimpleDispatchEventCondition.java
@@ -53,8 +53,8 @@ public class SimpleDispatchEventCondition implements DispatchEventCondition {
 	@Override
 	public boolean isApplicable(MessageBeans beans, String msg) {
 		int presentMask = beans.getPresentBeansMask();
-		
-		return (requiredBeans & presentMask) == requiredBeans; 
+
+		return requiredBeans == presentMask;
 	}
 
 	private void addFlagForBeanName(String name) throws InternalErrorException {

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -104,17 +104,19 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<property name="beansCondition">
 						<list>
 							<value>cz.metacentrum.perun.core.api.Group</value>
+							<value>cz.metacentrum.perun.core.api.Vo</value>
 						</list>
 					</property>
-					<property name="pattern" value=" created.$" />
+					<property name="pattern" value=" created in Vo:\[(.*)\]\." />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
 					<property name="beansCondition">
 						<list>
 							<value>cz.metacentrum.perun.core.api.Group</value>
+							<value>cz.metacentrum.perun.core.api.Vo</value>
 						</list>
 					</property>
-					<property name="pattern" value=" created in Vo:\[(.*)\]" />
+					<property name="pattern" value=" created in Vo:\[.*\] as subgroup of Group:\[.*\]"/>
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
 					<property name="beansCondition">
@@ -287,7 +289,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 							<value>cz.metacentrum.perun.core.api.Member</value>
 						</list>
 					</property>
-					<property name="pattern" value="  validated.$" />
+					<property name="pattern" value=" validated.$" />
 					<property name="handlerMethodName" value="processMemberAdded" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
@@ -309,15 +311,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					</property>
 					<property name="pattern" value="expired.$|disabled.$|invalidated.$|suspended #" />
 					<property name="handlerMethodName" value="processMemberRemoved" />
-				</bean>
-				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
-					<property name="beansCondition">
-						<list>
-							<value>cz.metacentrum.perun.core.api.Group</value>
-						</list>
-					</property>
-					<property name="pattern" value=" created in Vo:\[.*\] as subgroup of Group:\[.*\]" />
-					<property name="handlerMethodName" value="processSubgroupAdded" />
 				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
 					<property name="beansCondition">


### PR DESCRIPTION
When processing group creation audit message, LDAPc also attempts to create the VO in which the group was created.
I added RE that recognizes this message, and disable adding VO bean to list of beans sent to create.