### PR TITLE
Fix of generating inverse strong dependencies

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -7145,7 +7145,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		inverseDependencies = generateInverseDependencies(dependencies);
 
 		//Second create inversion map for strong dependencies
-		inverseStrongDependencies = generateInverseDependencies(inverseStrongDependencies);
+		inverseStrongDependencies = generateInverseDependencies(strongDependencies);
 
 		log.debug("InverseDependencies and InverseStrongDependencies was filled successfully.");
 


### PR DESCRIPTION
* Problem: the inverse strong dependencies were not generated properly
because of a typo. There was a wrong object given to the method
responsible for generating inverse dependencies. As a result, the
inverseDependencies map contained only empty sets for each attribute.
This problem could cause some dependencies not being checked while
setting an attribute's value.

* Solution was to give the method for generating the inverse
dependencies the correct object - strongDependencies.