### PR TITLE
Removed virtual attribute value calculation from audit messages

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AttributesManagerEvents/AttributeChangedForFacility.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AttributesManagerEvents/AttributeChangedForFacility.java
@@ -1,0 +1,41 @@
+package cz.metacentrum.perun.audit.events.AttributesManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Facility;
+
+public class AttributeChangedForFacility extends AuditEvent {
+
+	private Attribute attribute;
+	private Facility facility;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public AttributeChangedForFacility() {
+	}
+
+	public AttributeChangedForFacility(Attribute attribute, Facility facility) {
+		this.attribute = attribute;
+		this.facility = facility;
+		this.message = formatMessage("%s changed for %s.", attribute, facility);
+	}
+
+	public AttributeDefinition getAttribute() {
+		return attribute;
+	}
+
+	public Facility getFacility() {
+		return facility;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AttributesManagerEvents/AttributeChangedForResourceAndMember.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AttributesManagerEvents/AttributeChangedForResourceAndMember.java
@@ -1,0 +1,47 @@
+package cz.metacentrum.perun.audit.events.AttributesManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+
+public class AttributeChangedForResourceAndMember extends AuditEvent {
+
+	private Attribute attribute;
+	private Resource resource;
+	private Member member;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public AttributeChangedForResourceAndMember() {
+	}
+
+	public AttributeChangedForResourceAndMember(Attribute attribute, Resource resource, Member member) {
+		this.attribute = attribute;
+		this.resource = resource;
+		this.member = member;
+		this.message = formatMessage("%s changed for %s and %s.", attribute, resource, member);
+	}
+
+	public Attribute getAttribute() {
+		return attribute;
+	}
+
+	public Resource getResource() {
+		return resource;
+	}
+
+	public Member getMember() {
+		return member;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AttributesManagerEvents/AttributeChangedForUser.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/AttributesManagerEvents/AttributeChangedForUser.java
@@ -1,0 +1,41 @@
+package cz.metacentrum.perun.audit.events.AttributesManagerEvents;
+
+import cz.metacentrum.perun.audit.events.AuditEvent;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.User;
+
+public class AttributeChangedForUser extends AuditEvent {
+
+	private Attribute attribute;
+	private User user;
+	private String message;
+
+	@SuppressWarnings("unused") // used by jackson mapper
+	public AttributeChangedForUser() {
+	}
+
+	public AttributeChangedForUser(Attribute attribute, User user) {
+		this.attribute = attribute;
+		this.user = user;
+		this.message = formatMessage("%s changed for %s.", attribute, user);
+	}
+
+	public AttributeDefinition getAttribute() {
+		return attribute;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return message;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_voShortNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_voShortNames.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForFacility;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForUser;
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForFacility;
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForFacility;
 import cz.metacentrum.perun.audit.events.AuditEvent;
@@ -82,13 +84,8 @@ public class urn_perun_facility_attribute_def_virt_voShortNames extends Facility
 	private List<AuditEvent> resolveEvent(PerunSessionImpl sess, Facility facility) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 		List<AuditEvent> resolvingMessages = new ArrayList<>();
 
-		Attribute attribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, NS_FACILITY_ATTR_VIRT+":voShortNames");
-		if (attribute.valueAsList() == null || attribute.valueAsList().isEmpty()){
-			AttributeDefinition attributeDefinition = new AttributeDefinition(attribute);
-			resolvingMessages.add(new AttributeRemovedForFacility(attributeDefinition, facility));
-		} else {
-			resolvingMessages.add(new AttributeSetForFacility(attribute, facility));
-		}
+		AttributeDefinition attributeDefinition = sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, NS_FACILITY_ATTR_VIRT+":voShortNames");
+		resolvingMessages.add(new AttributeChangedForFacility(new Attribute(attributeDefinition), facility));
 
 		return resolvingMessages;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBanned.java
@@ -1,7 +1,6 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForResourceAndMember;
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForResourceAndMember;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForResourceAndMember;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.audit.events.FacilityManagerEvents.BanRemovedForFacility;
 import cz.metacentrum.perun.audit.events.FacilityManagerEvents.BanSetForFacility;
@@ -21,7 +20,6 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
@@ -81,148 +79,59 @@ public class urn_perun_member_resource_attribute_def_virt_isBanned extends Membe
 		if (message == null) return resolvingMessages;
 
 		if (message instanceof BanSetForResource) {
-			return resolveBanSetForResource(perunSession, (BanSetForResource) message);
+			return resolveBanChangedForResource(perunSession, ((BanSetForResource) message).getMemberId(), ((BanSetForResource) message).getResourceId());
 
 		} else if (message instanceof BanRemovedForResource) {
-			return resolveBanRemovedForResource(perunSession, (BanRemovedForResource) message);
+			return resolveBanChangedForResource(perunSession, ((BanRemovedForResource) message).getMemberId(), ((BanRemovedForResource) message).getResourceId());
 
 		} else if (message instanceof BanUpdatedForResource) {
-			return resolveBanUpdatedForResource(perunSession, (BanUpdatedForResource) message);
+			return resolveBanChangedForResource(perunSession, ((BanUpdatedForResource) message).getMemberId(), ((BanUpdatedForResource) message).getResourceId());
 
 		} else if (message instanceof BanSetForFacility) {
-			return resolveBanSetForFacility(perunSession, (BanSetForFacility) message);
+			return resolveBanChangedForFacility(perunSession, ((BanSetForFacility) message).getUserId(), ((BanSetForFacility) message).getFacilityId());
 
 		} else if (message instanceof BanRemovedForFacility) {
-			return resolveBanRemovedForFacility(perunSession, (BanRemovedForFacility) message);
+			return resolveBanChangedForFacility(perunSession, ((BanRemovedForFacility) message).getUserId(), ((BanRemovedForFacility) message).getFacilityId());
 
 		} else if (message instanceof BanUpdatedForFacility) {
-			return resolveBanUpdatedForFacility(perunSession, (BanUpdatedForFacility) message);
+			return resolveBanChangedForFacility(perunSession, ((BanUpdatedForFacility) message).getUserId(), ((BanUpdatedForFacility) message).getFacilityId());
 		}
 
 		return resolvingMessages;
 	}
 
 
-	private List<AuditEvent> resolveBanSetForResource(PerunSessionImpl perunSession, BanSetForResource banSetForResource) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<AuditEvent> resolveBanChangedForResource(PerunSessionImpl perunSession, int memberId, int resourceId) throws InternalErrorException, AttributeNotExistsException {
 		List<AuditEvent> resolvingMessages = new ArrayList<>();
 
 		try {
-			Member member = perunSession.getPerunBl().getMembersManagerBl().getMemberById(perunSession, banSetForResource.getMemberId());
-			Resource resource = perunSession.getPerunBl().getResourcesManagerBl().getResourceById(perunSession, banSetForResource.getResourceId());
-			Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, member, resource, A_MR_V_isBanned);
-			resolvingMessages.add(new AttributeSetForResourceAndMember(attribute, resource, member));
-		} catch (MemberNotExistsException | ResourceNotExistsException | MemberResourceMismatchException e) {
+			Member member = perunSession.getPerunBl().getMembersManagerBl().getMemberById(perunSession, memberId);
+			Resource resource = perunSession.getPerunBl().getResourcesManagerBl().getResourceById(perunSession, resourceId);
+			AttributeDefinition attributeDefinition = perunSession.getPerunBl().getAttributesManagerBl().getAttributeDefinition(perunSession, A_MR_V_isBanned);
+			resolvingMessages.add(new AttributeChangedForResourceAndMember(new Attribute(attributeDefinition), resource, member));
+		} catch (MemberNotExistsException | ResourceNotExistsException e) {
 			log.error("Can't resolve virtual attribute value change for " + this.getClass().getSimpleName() + " module because of exception.", e);
 		}
 
 		return resolvingMessages;
 	}
 
-	private List<AuditEvent> resolveBanRemovedForResource(PerunSessionImpl perunSession, BanRemovedForResource banRemovedForResource) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	private List<AuditEvent> resolveBanChangedForFacility(PerunSessionImpl perunSession, int userId, int facilityId) throws InternalErrorException {
 		List<AuditEvent> resolvingMessages = new ArrayList<>();
 
 		try {
-			Member member = perunSession.getPerunBl().getMembersManagerBl().getMemberById(perunSession, banRemovedForResource.getMemberId());
-			Resource resource = perunSession.getPerunBl().getResourcesManagerBl().getResourceById(perunSession, banRemovedForResource.getResourceId());
-			Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, member, resource, A_MR_V_isBanned);
-			resolvingMessages.add(new AttributeRemovedForResourceAndMember(attribute, resource, member));
-		} catch (MemberNotExistsException | ResourceNotExistsException | MemberResourceMismatchException e) {
-			log.error("Can't resolve virtual attribute value change for " + this.getClass().getSimpleName() + " module because of exception.", e);
-		}
-
-		return resolvingMessages;
-	}
-
-	private List<AuditEvent> resolveBanUpdatedForResource(PerunSessionImpl perunSession, BanUpdatedForResource banUpdatedForResource) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
-
-		try {
-			Member member = perunSession.getPerunBl().getMembersManagerBl().getMemberById(perunSession, banUpdatedForResource.getMemberId());
-			Resource resource = perunSession.getPerunBl().getResourcesManagerBl().getResourceById(perunSession, banUpdatedForResource.getResourceId());
-			Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, member, resource, A_MR_V_isBanned);
-			resolvingMessages.add(new AttributeSetForResourceAndMember(attribute, resource, member));
-		} catch (MemberNotExistsException | ResourceNotExistsException | MemberResourceMismatchException e) {
-			log.error("Can't resolve virtual attribute value change for " + this.getClass().getSimpleName() + " module because of exception.", e);
-		}
-
-		return resolvingMessages;
-	}
-
-	private List<AuditEvent> resolveBanSetForFacility(PerunSessionImpl perunSession, BanSetForFacility banSetForFacility) throws InternalErrorException, WrongAttributeAssignmentException {
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
-
-		try {
-			User user = perunSession.getPerunBl().getUsersManagerBl().getUserById(perunSession, banSetForFacility.getUserId());
-			Facility facility = perunSession.getPerunBl().getFacilitiesManagerBl().getFacilityById(perunSession, banSetForFacility.getFacilityId());
+			User user = perunSession.getPerunBl().getUsersManagerBl().getUserById(perunSession, userId);
+			Facility facility = perunSession.getPerunBl().getFacilitiesManagerBl().getFacilityById(perunSession, facilityId);
 			List<Pair<Resource, Member>> listOfAffectedObjects = getAffectedMemberResourceObjects(perunSession, user, facility);
 
 			for (Pair<Resource, Member> affectedObjects : listOfAffectedObjects) {
 				try {
-					Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, affectedObjects.getRight(), affectedObjects.getLeft(), A_MR_V_isBanned);
-
-					resolvingMessages.add(new AttributeSetForResourceAndMember(attribute, affectedObjects.getLeft(), affectedObjects.getRight()));
+					AttributeDefinition attributeDefinition = perunSession.getPerunBl().getAttributesManagerBl().getAttributeDefinition(perunSession, A_MR_V_isBanned);
+					resolvingMessages.add(new AttributeChangedForResourceAndMember(new Attribute(attributeDefinition), affectedObjects.getLeft(), affectedObjects.getRight()));
 				} catch (AttributeNotExistsException ex) {
 					//This means that attribute isBanned not exists at all so we can skip this process
 					log.info("Virtual attribute {} not exists.", this.getClass().getSimpleName());
 					break;
-				} catch (MemberResourceMismatchException ex) {
-					throw new InternalErrorException(ex);
-				}
-			}
-		} catch (UserNotExistsException | FacilityNotExistsException e) {
-			log.error("Can't resolve virtual attribute value change for " + this.getClass().getSimpleName() + " module because of exception.", e);
-		}
-
-		return resolvingMessages;
-	}
-
-	private List<AuditEvent> resolveBanRemovedForFacility(PerunSessionImpl perunSession, BanRemovedForFacility banRemovedForFacility) throws InternalErrorException, WrongAttributeAssignmentException {
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
-
-		try {
-			User user = perunSession.getPerunBl().getUsersManagerBl().getUserById(perunSession, banRemovedForFacility.getUserId());
-			Facility facility = perunSession.getPerunBl().getFacilitiesManagerBl().getFacilityById(perunSession, banRemovedForFacility.getFacilityId());
-			List<Pair<Resource, Member>> listOfAffectedObjects = getAffectedMemberResourceObjects(perunSession, user, facility);
-
-			for(Pair<Resource, Member> affectedObjects : listOfAffectedObjects) {
-				try {
-					Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession,  affectedObjects.getRight(), affectedObjects.getLeft(), A_MR_V_isBanned);
-
-					resolvingMessages.add(new AttributeRemovedForResourceAndMember(attribute, affectedObjects.getLeft(), affectedObjects.getRight()));
-				} catch (AttributeNotExistsException ex) {
-					//This means that attribute isBanned not exists at all so we can skip this process
-					log.info("Virtual attribute {} not exists.", this.getClass().getSimpleName());
-					break;
-				} catch (MemberResourceMismatchException ex) {
-					throw new InternalErrorException(ex);
-				}
-			}
-		} catch (UserNotExistsException | FacilityNotExistsException e) {
-			log.error("Can't resolve virtual attribute value change for " + this.getClass().getSimpleName() + " module because of exception.", e);
-		}
-
-		return resolvingMessages;
-	}
-
-	private List<AuditEvent> resolveBanUpdatedForFacility(PerunSessionImpl perunSession, BanUpdatedForFacility banUpdatedForFacility) throws InternalErrorException, WrongAttributeAssignmentException {
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
-
-		try {
-			User user = perunSession.getPerunBl().getUsersManagerBl().getUserById(perunSession, banUpdatedForFacility.getUserId());
-			Facility facility = perunSession.getPerunBl().getFacilitiesManagerBl().getFacilityById(perunSession, banUpdatedForFacility.getFacilityId());
-			List<Pair<Resource, Member>> listOfAffectedObjects = getAffectedMemberResourceObjects(perunSession, user, facility);
-
-			for (Pair<Resource, Member> affectedObjects : listOfAffectedObjects) {
-				try {
-					Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, affectedObjects.getRight(), affectedObjects.getLeft(), A_MR_V_isBanned);
-
-					resolvingMessages.add(new AttributeSetForResourceAndMember(attribute, affectedObjects.getLeft(), affectedObjects.getRight()));
-				} catch (AttributeNotExistsException ex) {
-					//This means that attribute isBanned not exists at all so we can skip this process
-					log.info("Virtual attribute {} not exists.", this.getClass().getSimpleName());
-					break;
-				} catch (MemberResourceMismatchException ex) {
-					throw new InternalErrorException(ex);
 				}
 			}
 		} catch (UserNotExistsException | FacilityNotExistsException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_groupNames.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_groupNames.java
@@ -1,7 +1,6 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForUser;
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUser;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForUser;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.DirectMemberAddedToGroup;
 import cz.metacentrum.perun.audit.events.GroupManagerEvents.IndirectMemberAddedToGroup;
@@ -11,12 +10,10 @@ import cz.metacentrum.perun.audit.events.GroupManagerEvents.MemberValidatedInGro
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
-import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -30,9 +27,7 @@ import org.springframework.jdbc.core.RowMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -96,32 +91,23 @@ public class urn_perun_user_attribute_def_virt_groupNames extends UserVirtualAtt
 		if (message == null) return resolvingMessages;
 
 		if (message instanceof DirectMemberAddedToGroup) {
-			resolvingMessages.addAll(resolveEvent(sess, ((DirectMemberAddedToGroup) message).getMember()));
+			resolvingMessages.add(resolveEvent(sess, ((DirectMemberAddedToGroup) message).getMember()));
 		} else if (message instanceof IndirectMemberAddedToGroup) {
-			resolvingMessages.addAll(resolveEvent(sess, ((IndirectMemberAddedToGroup) message).getMember()));
+			resolvingMessages.add(resolveEvent(sess, ((IndirectMemberAddedToGroup) message).getMember()));
 		} else if (message instanceof MemberRemovedFromGroupTotally) {
-			resolvingMessages.addAll(resolveEvent(sess, ((MemberRemovedFromGroupTotally) message).getMember()));
+			resolvingMessages.add(resolveEvent(sess, ((MemberRemovedFromGroupTotally) message).getMember()));
 		} else if (message instanceof MemberExpiredInGroup) {
-			resolvingMessages.addAll(resolveEvent(sess, ((MemberExpiredInGroup) message).getMember()));
+			resolvingMessages.add(resolveEvent(sess, ((MemberExpiredInGroup) message).getMember()));
 		} else if (message instanceof MemberValidatedInGroup) {
-			resolvingMessages.addAll(resolveEvent(sess, ((MemberValidatedInGroup) message).getMember()));
+			resolvingMessages.add(resolveEvent(sess, ((MemberValidatedInGroup) message).getMember()));
 		}
 		return resolvingMessages;
 	}
 
-	private List<AuditEvent> resolveEvent (PerunSessionImpl sess, Member member) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
-
+	private AuditEvent resolveEvent (PerunSessionImpl sess, Member member) throws InternalErrorException, AttributeNotExistsException {
 		User user = sess.getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
-		Attribute attribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_U_V_GROUP_NAMES);
-		if (attribute.valueAsList() == null || attribute.valueAsList().isEmpty()){
-			AttributeDefinition attributeDefinition = new AttributeDefinition(attribute);
-			resolvingMessages.add(new AttributeRemovedForUser(attributeDefinition, user));
-		} else {
-			resolvingMessages.add(new AttributeSetForUser(attribute, user));
-		}
-
-		return resolvingMessages;
+		AttributeDefinition attributeDefinition = sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, A_U_V_GROUP_NAMES);
+		return new AttributeChangedForUser(new Attribute(attributeDefinition), user);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_institutionsCountries.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_institutionsCountries.java
@@ -1,8 +1,8 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForUser;
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForKey;
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForKey;
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUser;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -141,8 +141,8 @@ public class urn_perun_user_attribute_def_virt_institutionsCountries extends Use
 		//find users that are affected by the change - have schacHomeOrganization value ending in key but not ending with longerDomains
 		List<User> affectedUsers = sess.getPerunBl().getUsersManagerBl().findUsersWithExtSourceAttributeValueEnding(sess,getSourceAttributeName(), key, longerDomains);
 		for (User user : affectedUsers) {
-			Attribute attribute = am.getAttribute(sess, user, getDestinationAttributeName());
-			resolvingMessages.add(new AttributeSetForUser(attribute, user));
+			AttributeDefinition attributeDefinition = am.getAttributeDefinition(sess, getDestinationAttributeName());
+			resolvingMessages.add(new AttributeChangedForUser(new Attribute(attributeDefinition), user));
 		}
 
 		return resolvingMessages;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_kerberosLogins.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_kerberosLogins.java
@@ -1,6 +1,6 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUser;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForUser;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceAddedToUser;
 import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceRemovedFromUser;
@@ -77,26 +77,21 @@ public class urn_perun_user_attribute_def_virt_kerberosLogins extends UserVirtua
 		if (message instanceof UserExtSourceAddedToUser
 			&& ((UserExtSourceAddedToUser) message).getUserExtSource().getExtSource() instanceof ExtSourceKerberos) {
 
-			resolvingMessages.addAll(resolveEvent(perunSession, ((UserExtSourceAddedToUser) message).getUser()));
+			resolvingMessages.add(resolveEvent(perunSession, ((UserExtSourceAddedToUser) message).getUser()));
 		}
 
 		if (message instanceof UserExtSourceRemovedFromUser
 			&& ((UserExtSourceRemovedFromUser) message).getUserExtSource().getExtSource() instanceof ExtSourceKerberos) {
 
-			resolvingMessages.addAll(resolveEvent(perunSession, ((UserExtSourceRemovedFromUser) message).getUser()));
+			resolvingMessages.add(resolveEvent(perunSession, ((UserExtSourceRemovedFromUser) message).getUser()));
 		}
 
 		return resolvingMessages;
 	}
 
-	private List<AuditEvent> resolveEvent(PerunSessionImpl perunSession, User user) throws WrongAttributeAssignmentException, InternalErrorException, AttributeNotExistsException {
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
-
-		Attribute attrVirtKerberosLogins = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, user, A_U_V_KERBEROS_LOGINS);
-		//FIXME: if the attribute value is null or empty, this method should return AttributeRemovedForUser instead
-		resolvingMessages.add(new AttributeSetForUser(attrVirtKerberosLogins, user));
-
-		return resolvingMessages;
+	private AuditEvent resolveEvent(PerunSessionImpl perunSession, User user) throws InternalErrorException, AttributeNotExistsException {
+		AttributeDefinition attrVirtKerberosLoginsDefinition = perunSession.getPerunBl().getAttributesManagerBl().getAttributeDefinition(perunSession, A_U_V_KERBEROS_LOGINS);
+		return new AttributeChangedForUser(new Attribute(attrVirtKerberosLoginsDefinition), user);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
@@ -1,7 +1,6 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForUser;
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUser;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForUser;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceAddedToUser;
 import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceRemovedFromUser;
@@ -103,7 +102,7 @@ public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributes
 	}
 
 	/**
-	 * Resolve and create new auditer message about LOA attribute change based on current attribute value.
+	 * Resolve and create new auditer message about LOA attribute change.
 	 *
 	 * @param sess PerunSession
 	 * @param user User to resolve LoA messages
@@ -114,13 +113,8 @@ public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributes
 	 */
 	private AuditEvent resolveEvent(PerunSessionImpl sess, User user) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 
-		Attribute attribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_U_V_LOA);
-
-		if (attribute.getValue() == null) {
-			return new AttributeRemovedForUser(new AttributeDefinition(attribute),user);
-		} else {
-			return new AttributeSetForUser(attribute,user);
-		}
+		AttributeDefinition attributeDefinition = sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, A_U_V_LOA);
+		return new AttributeChangedForUser(new Attribute(attributeDefinition), user);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_userCertDNs.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_userCertDNs.java
@@ -1,6 +1,6 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUser;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForUser;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceAddedToUser;
 import cz.metacentrum.perun.audit.events.UserManagerEvents.UserExtSourceRemovedFromUser;
@@ -67,39 +67,18 @@ public class urn_perun_user_attribute_def_virt_userCertDNs extends UserVirtualAt
 		List<AuditEvent> resolvingMessages = new ArrayList<>();
 		if (message == null) return resolvingMessages;
 
-		if (message instanceof UserExtSourceAddedToUser) {
-			resolvingMessages.addAll(resolveUserExtSourceAddedToUser(perunSession, (UserExtSourceAddedToUser) message));
-		} else if (message instanceof UserExtSourceRemovedFromUser) {
-			resolvingMessages.addAll(resolveUserExtSourceRemovedFromUser(perunSession, (UserExtSourceRemovedFromUser) message));
+		if (message instanceof UserExtSourceAddedToUser && ((UserExtSourceAddedToUser) message).getUserExtSource().getExtSource() instanceof ExtSourceX509) {
+			resolvingMessages.add(resolveEvent(perunSession, ((UserExtSourceAddedToUser) message).getUser()));
+		} else if (message instanceof UserExtSourceRemovedFromUser && ((UserExtSourceRemovedFromUser) message).getUserExtSource().getExtSource() instanceof ExtSourceX509) {
+			resolvingMessages.add(resolveEvent(perunSession, ((UserExtSourceRemovedFromUser) message).getUser()));
 		}
 
 		return resolvingMessages;
 	}
 
-	private List<AuditEvent> resolveUserExtSourceAddedToUser(PerunSessionImpl perunSession, UserExtSourceAddedToUser userExtSourceAddedToUser) throws WrongAttributeAssignmentException, InternalErrorException, AttributeNotExistsException {
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
-
-		if (userExtSourceAddedToUser.getUserExtSource().getExtSource() instanceof ExtSourceX509) {
-			User user = userExtSourceAddedToUser.getUser();
-			Attribute attrVirtUserCertDNs = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, user, A_U_V_USER_CERT_DNS);
-			//FIXME: if the attribute value is null or empty, this method should return AttributeRemovedForUser instead
-			resolvingMessages.add(new AttributeSetForUser(attrVirtUserCertDNs, user));
-		}
-
-		return resolvingMessages;
-	}
-
-	private List<AuditEvent> resolveUserExtSourceRemovedFromUser(PerunSessionImpl perunSession, UserExtSourceRemovedFromUser userExtSourceRemovedFromUser) throws WrongAttributeAssignmentException, InternalErrorException, AttributeNotExistsException {
-		List<AuditEvent> resolvingMessages = new ArrayList<>();
-
-		if (userExtSourceRemovedFromUser.getUserExtSource().getExtSource() instanceof ExtSourceX509) {
-			User user = userExtSourceRemovedFromUser.getUser();
-			Attribute attrVirtUserCertDNs = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, user, A_U_V_USER_CERT_DNS);
-			//FIXME: if the attribute value is null or empty, this method should return AttributeRemovedForUser instead
-			resolvingMessages.add(new AttributeSetForUser(attrVirtUserCertDNs, user));
-		}
-
-		return resolvingMessages;
+	private AuditEvent resolveEvent(PerunSessionImpl perunSession, User user) throws AttributeNotExistsException, InternalErrorException {
+		AttributeDefinition attrVirtUserCertDNsDefinition = perunSession.getPerunBl().getAttributesManagerBl().getAttributeDefinition(perunSession, A_U_V_USER_CERT_DNS);
+		return new AttributeChangedForUser(new Attribute(attrVirtUserCertDNsDefinition), user);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserVirtualAttributeCollectedFromUserExtSource.java
@@ -1,10 +1,9 @@
 package cz.metacentrum.perun.core.implApi.modules.attributes;
 
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AllAttributesRemovedForUserExtSource;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForUser;
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForUes;
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForUser;
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUes;
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUser;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -219,13 +218,8 @@ public abstract class UserVirtualAttributeCollectedFromUserExtSource<T extends U
 			if (userId != null) {
 				try {
 					User user = perunSession.getPerunBl().getUsersManagerBl().getUserById(perunSession, userId);
-					Attribute attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, user, getDestinationAttributeName());
-					if (attribute.valueAsList() == null || attribute.valueAsList().isEmpty()) {
-						AttributeDefinition attributeDefinition = new AttributeDefinition(attribute);
-						resolvingMessages.add(new AttributeRemovedForUser(attributeDefinition, user));
-					} else {
-						resolvingMessages.add(new AttributeSetForUser(attribute, user));
-					}
+					AttributeDefinition attributeDefinition = perunSession.getPerunBl().getAttributesManagerBl().getAttributeDefinition(perunSession, getDestinationAttributeName());
+					resolvingMessages.add(new AttributeChangedForUser(new Attribute(attributeDefinition), user));
 				} catch (UserNotExistsException e) {
 					log.warn("User from UserExtSource doesn't exist in Perun. This occurred while parsing message: {}.", message);
 				}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBannedTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_isBannedTest.java
@@ -67,7 +67,6 @@ public class urn_perun_member_resource_attribute_def_virt_isBannedTest {
 		user = new User(1, "name", "surname", "middlename", "title", "title");
 		member = new Member(1, 1, 1, Status.VALID);
 		isBanned = new Attribute(classInstance.getAttributeDefinition());
-		isBanned.setValue(true);
 		event1 = new BanSetForResource(new BanOnResource(), member.getId(), resource.getId());
 		event2 = new BanUpdatedForResource(new BanOnResource(), member.getId(), resource.getId());
 		event3 = new BanRemovedForResource(new BanOnResource(), member.getId(), resource.getId());
@@ -86,14 +85,14 @@ public class urn_perun_member_resource_attribute_def_virt_isBannedTest {
 		//for message 1, 2 and 3
 		when(session.getPerunBl().getMembersManagerBl().getMemberById(any(PerunSessionImpl.class), anyInt())).thenReturn(member);
 		when(session.getPerunBl().getResourcesManagerBl().getResourceById(any(PerunSessionImpl.class), anyInt())).thenReturn(resource);
-		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSessionImpl.class), any(Member.class), any(Resource.class), anyString())).thenReturn(isBanned);
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(any(PerunSessionImpl.class), anyString())).thenReturn(classInstance.getAttributeDefinition());
 		resolvedEvents = classInstance.resolveVirtualAttributeValueChange(session, event1);
 		assertEquals(resolvedEvents.size(), 1);
-		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " set for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
+		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " changed for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
 		resolvedEvents = classInstance.resolveVirtualAttributeValueChange(session, event2);
-		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " set for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
+		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " changed for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
 		resolvedEvents = classInstance.resolveVirtualAttributeValueChange(session, event3);
-		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " removed for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
+		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " changed for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
 
 		//for message 4, 5 and 6
 		when(session.getPerunBl().getUsersManagerBl().getUserById(any(PerunSessionImpl.class), anyInt())).thenReturn(user);
@@ -101,11 +100,11 @@ public class urn_perun_member_resource_attribute_def_virt_isBannedTest {
 		when(session.getPerunBl().getFacilitiesManagerBl().getAssignedResources(any(PerunSessionImpl.class), any(Facility.class))).thenReturn(Collections.singletonList(resource));
 		when(session.getPerunBl().getResourcesManagerBl().getAssignedMembers(any(PerunSessionImpl.class), any(Resource.class))).thenReturn(Collections.singletonList(member));
 		resolvedEvents = classInstance.resolveVirtualAttributeValueChange(session, event4);
-		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " set for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
+		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " changed for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
 		resolvedEvents = classInstance.resolveVirtualAttributeValueChange(session, event5);
-		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " set for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
+		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " changed for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
 		resolvedEvents = classInstance.resolveVirtualAttributeValueChange(session, event6);
-		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " removed for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
+		assertEquals(resolvedEvents.get(0).getMessage(), isBanned.serializeToString() + " changed for " + resource.serializeToString() + " and " + member.serializeToString() + ".");
 	}
 
 	@Test

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest.java
@@ -3,7 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AllAttributesRemovedForUser;
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AllAttributesRemovedForUserExtSource;
-import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeRemovedForUser;
+import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeChangedForUser;
 import cz.metacentrum.perun.audit.events.AttributesManagerEvents.AttributeSetForUser;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.core.api.Attribute;
@@ -262,25 +262,24 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliationsTest {
 	public void resolveAttributeValueChangeTest() throws Exception {
 		when(session.getPerunBl().getUsersManagerBl().getUserById(session, 1)).thenReturn(user);
 		AuditEvent event = new AllAttributesRemovedForUserExtSource(ues1);
-		List<AuditEvent> auditEvents = classInstance.resolveVirtualAttributeValueChange(session, event);
+		List auditEvents = classInstance.resolveVirtualAttributeValueChange(session, event);
 
-		assertEquals(auditEvents.get(0).getClass(), AttributeSetForUser.class);
+		assertEquals(auditEvents.get(0).getClass(), AttributeChangedForUser.class);
 
 		event = new AllAttributesRemovedForUser(user);
 		auditEvents = classInstance.resolveVirtualAttributeValueChange(session, event);
-		System.out.println(auditEvents);
-		assertEquals(auditEvents.get(0).getClass(), AttributeSetForUser.class);
+		assertEquals(auditEvents.get(0).getClass(), AttributeChangedForUser.class);
 
 		Attribute attribute = new Attribute();
 		attribute.setFriendlyName("eduPersonScopedAffiliationsManuallyAssigned");
 
 		event = new AttributeSetForUser(attribute, user);
 		auditEvents = classInstance.resolveVirtualAttributeValueChange(session, event);
-		assertEquals(auditEvents.get(0).getClass(), AttributeSetForUser.class);
+		assertEquals(auditEvents.get(0).getClass(), AttributeChangedForUser.class);
 
 		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_VIRT + ":" + "eduPersonScopedAffiliations")).thenReturn(attribute);
 		auditEvents = classInstance.resolveVirtualAttributeValueChange(session, event);
-		assertEquals(auditEvents.get(0).getClass(), AttributeRemovedForUser.class);
+		assertEquals(auditEvents.get(0).getClass(), AttributeChangedForUser.class);
 	}
 
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_institutionsCountriesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_institutionsCountriesTest.java
@@ -127,8 +127,8 @@ public class urn_perun_user_attribute_def_virt_institutionsCountriesTest {
 	@Test
 	public void resolveVirtualAttributeValueChange() throws Exception {
 		setSchacHomeOrgs("muni.cz;cesnet.cz");
-		Attribute countries = classInstance.getAttributeValue(sess, user, institutionCountriesAttrDef);
-		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess,user,"urn:perun:user:attribute-def:virt:institutionsCountries"))
+		AttributeDefinition countries = classInstance.getAttributeDefinition();
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess,"urn:perun:user:attribute-def:virt:institutionsCountries"))
 			.thenReturn(countries);
 		when(sess.getPerunBl().getUsersManagerBl().getUserById(sess, userExtSource.getUserId())).thenReturn(user);
 
@@ -142,8 +142,8 @@ public class urn_perun_user_attribute_def_virt_institutionsCountriesTest {
 		setSchacHomeOrgs("muni.cz;cesnet.cz");
 		String czech_republic = "Czech Republic";
 		dnsMap.put(".cz", czech_republic);
-		Attribute countries = classInstance.getAttributeValue(sess, user, institutionCountriesAttrDef);
-		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, "urn:perun:user:attribute-def:virt:institutionsCountries"))
+		AttributeDefinition countries = classInstance.getAttributeDefinition();
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:user:attribute-def:virt:institutionsCountries"))
 			.thenReturn(countries);
 		Attribute newval = new Attribute(new urn_perun_entityless_attribute_def_def_dnsStateMapping().getAttributeDefinition());
 		newval.setValue(czech_republic);


### PR DESCRIPTION
- the calculation of virtual attribute values in audit messages was removed to speed up storing of audit messages
- added new audit event AttributeChangedForUser to substitute for AttributeSet/RemovedForUser in places where we used to decide which event to use based on virtual attribute value
- the audit messages now contains virtual attribute with null value