### PR TITLE
CORE: Do not store message duplicates in the auditer log

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Auditer.java
@@ -404,7 +404,9 @@ public class Auditer {
 				try {
 					List<AuditEvent> auditEvents = attributesModuleImplApi.resolveVirtualAttributeValueChange((PerunSessionImpl) session, message.getEvent());
 					for (AuditEvent auditEvent : auditEvents) {
-						addedResolvedMessages.add(new AuditerMessage(session, auditEvent));
+						AuditerMessage msg = new AuditerMessage(session, auditEvent);
+						// do not store message duplicates created by this first pass through the message processing cycle
+						if (!addedResolvedMessages.contains(msg)) addedResolvedMessages.add(msg);
 					}
 				} catch (InternalErrorException | WrongAttributeAssignmentException | AttributeNotExistsException | WrongReferenceAttributeValueException ex) {
 					log.error("Error when auditer trying to resolve messages in modules.", ex);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuditerMessage.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuditerMessage.java
@@ -3,6 +3,8 @@ package cz.metacentrum.perun.core.impl;
 import cz.metacentrum.perun.audit.events.AuditEvent;
 import cz.metacentrum.perun.core.api.PerunSession;
 
+import java.util.Objects;
+
 /**
  * Wrapper for AuditEvent associating it with originating user session.
  * It is supposed to be used solely inside Auditer to store runtime state of events.
@@ -44,6 +46,20 @@ public class AuditerMessage {
 	@Override
 	public String toString() {
 		return AuditerMessage.class.getSimpleName() + ":[message='" + event.getMessage() + "']";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		AuditerMessage that = (AuditerMessage) o;
+		return Objects.equals(event, that.event) &&
+				Objects.equals(originatingSession, that.originatingSession);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(event, originatingSession);
 	}
 
 }


### PR DESCRIPTION
- Prevent storing duplicate messages in auditer log. We still resolve
  them, since our modules react on each original message, but we don't
  push them to the resulting list if it contains the same message.
  We did this in cycle detection code, but most duplicate messages
  were created by the first pass through the cycle - reacting on
  different original auditer messages with the same new message.

- Fixed cycle detection when resolving auditer messages. We didn't have
  hashCode() and equals() on the AuditerMessage. This caused all calls
  of contains() on the list to return false (it compared only object
  references, which were always different).