### PR TITLE
Convert candidate user-attributes to JSON

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -136,6 +136,12 @@
 			<artifactId>javax.mail</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>${json.version}</version>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Candidate.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import cz.metacentrum.perun.core.api.BeansUtils;
+import org.json.JSONObject;
 
 /**
  * Candidate member of a Virtual Organization.
@@ -18,6 +19,9 @@ import cz.metacentrum.perun.core.api.BeansUtils;
  * @author Martin Kuba makub@ics.muni.cz
  */
 public class Candidate extends User {
+
+	private static final String NS_USER_ATTR_CORE = "urn:perun:user:attribute-def:core:";
+	private static final String NS_USER_ATTR = "urn:perun:user:attribute-def:";
 
 	private UserExtSource userExtSource;
 	private List<UserExtSource> additionalUserExtSources;
@@ -89,6 +93,32 @@ public class Candidate extends User {
 			userExtSources.addAll(this.additionalUserExtSources);
 		}
 		return Collections.unmodifiableList(userExtSources);
+	}
+
+
+	/**
+	 * Method converts candidate's user-attributes and user core attributes to JSON object.
+	 *
+	 * @return JSONObject which contains candidate's user-attributes and user-core-attributes in JSON format
+	 */
+	public JSONObject convertAttributesToJSON() {
+		JSONObject candidateAttributes = new JSONObject();
+
+		//Convert userCoreAttributes to JSON
+		candidateAttributes.append(NS_USER_ATTR_CORE + "firstName", firstName);
+		candidateAttributes.append(NS_USER_ATTR_CORE + "lastName", lastName );
+		candidateAttributes.append(NS_USER_ATTR_CORE + "middleName", middleName);
+		candidateAttributes.append(NS_USER_ATTR_CORE + "tittleAfter", titleAfter);
+		candidateAttributes.append(NS_USER_ATTR_CORE + "tittleBefore", titleBefore);
+		candidateAttributes.append(NS_USER_ATTR_CORE + "serviceUser", isServiceUser());
+		candidateAttributes.append(NS_USER_ATTR_CORE + "sponsoredUser", isSponsoredUser());
+
+		//Convert other attributes to JSON
+		for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+			if (attribute.getKey().startsWith(NS_USER_ATTR))
+				candidateAttributes.append(attribute.getKey(), attribute.getValue());
+		}
+		return candidateAttributes;
 	}
 
 	@Override

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -208,12 +208,6 @@
 			<artifactId>google-api-services-admin-directory</artifactId>
 		</dependency>
 
-        <dependency>
- 			<groupId>org.json</groupId>
- 			<artifactId>json</artifactId>
-	        <version>${json.version}</version>
- 		</dependency>
-
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-csv</artifactId>

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/UsersManagerEntryIntegrationTest.java
@@ -30,11 +30,13 @@ import cz.metacentrum.perun.core.api.exceptions.RelationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -43,6 +45,7 @@ import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -1208,7 +1211,32 @@ public class UsersManagerEntryIntegrationTest extends AbstractPerunIntegrationTe
 
 	}
 
+	@Test
+	public void convertAttributesToJSON() {
+		System.out.println(CLASS_NAME + "convertAttributesToJSON");
 
+		Candidate candidate = new Candidate(user, userExtSource);
+		candidate.setAttributes(Collections.singletonMap(perun.getAttributesManager().NS_USER_ATTR + ":attribute", "value"));
+
+		JSONObject jsonObject = candidate.convertAttributesToJSON();
+
+		assertEquals(8, jsonObject.length());
+		assertEquals("value", jsonObject.getJSONArray(perun.getAttributesManager().NS_USER_ATTR + ":attribute").getString(0));
+		assertEquals(userFirstName, jsonObject.getJSONArray(perun.getAttributesManager().NS_USER_ATTR_CORE + ":firstName").getString(0));
+	}
+
+	@Test
+	public void convertAttributesWithNullToJSON() {
+		System.out.println(CLASS_NAME + "convertAttributesWithNullToJSON");
+
+		Candidate candidate = new Candidate(user, userExtSource);
+		candidate.setAttributes(Collections.singletonMap(perun.getAttributesManager().NS_USER_ATTR + ":attribute", null));
+
+		JSONObject jsonObject = candidate.convertAttributesToJSON();
+
+		assertEquals(8, jsonObject.length());
+		assertTrue(jsonObject.getJSONArray(perun.getAttributesManager().NS_USER_ATTR + ":attribute").isNull(0));
+	}
 
 	// PRIVATE METHODS -------------------------------------------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<jboss-jms-api.version>1.1.0.GA</jboss-jms-api.version>
 		<jcip.version>1.0</jcip.version>
 		<jdom.version>1.0</jdom.version>
-		<json.version>20140107</json.version>
+		<json.version>20190722</json.version>
 		<oracle.version>12.2.0.1.0</oracle.version>
 	</properties>
 


### PR DESCRIPTION
- Added method which converts candidate's user-attributes and
  user-core-attributes to JSON object. It will be used in User
  synchronizations.
- Added test to check if the method works correctly.
- Added json dependency to perun-base pom.xml