### PR TITLE
GUI: Fixed various litle bugs

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesDefinition.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetAttributesDefinition.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.webgui.json.attributesManager;
 
 import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.cell.client.TextInputCell;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.cellview.client.CellTable;
@@ -314,7 +315,7 @@ public class GetAttributesDefinition implements JsonCallback, JsonCallbackTable<
 	public void removeFromBackupTable(AttributeDefinition object) {
 		fullBackup.remove(object);
 		list.remove(object);
-		selectionModel.getSelectedSet().remove(object);
+		selectionModel.setSelected(object, false);
 		oracle.clear();
 		for (AttributeDefinition def : fullBackup) {
 			oracle.add(def.getFriendlyName());

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetServiceRequiredAttributes.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/attributesManager/GetServiceRequiredAttributes.java
@@ -252,6 +252,7 @@ public class GetServiceRequiredAttributes implements JsonCallback, JsonCallbackT
 	public void clearTable(){
 		loaderImage.loadingStart();
 		list.clear();
+		fullBackup.clear();
 		selectionModel.clear();
 		oracle.clear();
 		dataProvider.flush();

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/ApplicationDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/ApplicationDetailTabItem.java
@@ -62,6 +62,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl {
 	private TabItem tab;
 	private Application app = null;
 	private int row = 0;
+	private boolean refreshParent = false;
 
 	/**
 	 * Creates a tab instance
@@ -93,7 +94,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl {
 
 	@Override
 	public boolean isRefreshParentOnClose() {
-		return true;
+		return refreshParent;
 	}
 
 	@Override
@@ -198,6 +199,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl {
 							public void onFinished(JavaScriptObject jso) {
 								app = jso.cast();
 								draw();
+								refreshParent = true;
 							}
 						}));
 						request.verifyApplication(appId);
@@ -218,6 +220,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl {
 					HandleApplication request = new HandleApplication(JsonCallbackEvents.disableButtonEvents(approve, new JsonCallbackEvents(){
 						@Override
 						public void onFinished(JavaScriptObject jso) {
+							refreshParent = true;
 							session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 						}
 					}));
@@ -246,6 +249,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl {
 							HandleApplication request = new HandleApplication(JsonCallbackEvents.disableButtonEvents(reject, new JsonCallbackEvents(){
 								@Override
 								public void onFinished(JavaScriptObject jso) {
+									refreshParent = true;
 									session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 								}
 							}));
@@ -269,6 +273,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl {
 					HandleApplication request = new HandleApplication(JsonCallbackEvents.disableButtonEvents(delete, new JsonCallbackEvents(){
 						@Override
 						public void onFinished(JavaScriptObject jso) {
+							refreshParent = true;
 							session.getTabManager().closeTab(tab, isRefreshParentOnClose());
 						}
 					}));

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServiceRequiredAttributesTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/servicestabs/ServiceRequiredAttributesTabItem.java
@@ -108,6 +108,8 @@ public class ServiceRequiredAttributesTabItem implements TabItem, TabItemWithUrl
 		TabMenu menu = new TabMenu();
 		menu.addWidget(UiElements.getRefreshButton(this));
 
+		final ExtendedSuggestBox box = new ExtendedSuggestBox(servReqAttr.getOracle());
+
 		// custom event
 		final JsonCallbackEvents events = JsonCallbackEvents.refreshTableEvents(servReqAttr);
 
@@ -129,7 +131,13 @@ public class ServiceRequiredAttributesTabItem implements TabItem, TabItemWithUrl
 						// TODO - SHOULD HAVE ONLY ONE CALLBACK TO CORE
 						for (int i=0; i<attrsForRemoving.size(); i++ ) {
 							if (i == attrsForRemoving.size()-1) {
-								RemoveRequiredAttribute request = new RemoveRequiredAttribute(JsonCallbackEvents.disableButtonEvents(removeButton, events));
+								RemoveRequiredAttribute request = new RemoveRequiredAttribute(JsonCallbackEvents.disableButtonEvents(removeButton, JsonCallbackEvents.mergeEvents(events, new JsonCallbackEvents() {
+									@Override
+									public void onFinished(JavaScriptObject jso) {
+										// clear filter since filter ignores next call for some reason
+										box.getSuggestBox().setText("");
+									}
+								})));
 								request.removeRequiredAttribute(serviceId, attrsForRemoving.get(i).getId());
 							} else {
 								RemoveRequiredAttribute request = new RemoveRequiredAttribute(JsonCallbackEvents.disableButtonEvents(removeButton));
@@ -144,7 +152,6 @@ public class ServiceRequiredAttributesTabItem implements TabItem, TabItemWithUrl
 
 		menu.addWidget(removeButton);
 
-		final ExtendedSuggestBox box = new ExtendedSuggestBox(servReqAttr.getOracle());
 		menu.addFilterWidget(box, new PerunSearchEvent() {
 			@Override
 			public void searchFor(String text) {


### PR DESCRIPTION
- Fixed attribute definition removal, when removed attribute was kept between selected and sent with next action.
- Remove deleted required attributes from full backup, so they don't return to the table after next filter event.
- If application was not modified, do not refresh parent tab, where we could have filtered result (it discards them).