### PR TITLE
Fix of attribute module dependencies removal

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -2483,8 +2483,13 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//Remove services' required attributes
 		//TODO
 
-		AttributeDefinition attributeDef = new AttributeDefinition(attribute);
+		//Remove attribute and all it's values
+		this.deleteAllAttributeAuthz(sess, attribute);
+		getAttributesManagerImpl().deleteAttribute(sess, attribute);
+		getPerunBl().getAuditer().log(sess, new AttributeDeleted(attribute));
+
 		//Remove attribute dependencies
+		AttributeDefinition attributeDef = new AttributeDefinition(attribute);
 		synchronized (dependenciesMonitor) {
 
 			removeOppositeDependenciesForAttribute(attributeDef);
@@ -2510,11 +2515,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				log.warn("Inverse strong dependencies inconsistency. Inverse strong dependencies should contain information about {}. ", attributeDef);
 			}
 		}
-
-		//Remove attribute and all it's values
-		getPerunBl().getAuditer().log(sess,new AttributeDeleted(attribute));
-		this.deleteAllAttributeAuthz(sess, attribute);
-		getAttributesManagerImpl().deleteAttribute(sess, attribute);
 	}
 
 	/**


### PR DESCRIPTION
* Problem: during the deletion of an attribute, the old implementation
would always delete the module dependencies from relevant maps
regardless of possible failure of the DB removal. If the DB operation would
fail, the dependencies would be removed but the attribute would not
still be deleted. Next attempt of the attribute removal would fail due
to NullPointerException because the dependencies would no longer contain
the attribute's data.
* Fix: move the dependencies removal after the DB operation. That way,
the dependencies are removed only if the DB operation succeeds.
* Implemented tests that verify the correct handling of attribute
module dependencies during attribute deletion.