### PR TITLE
CORE: Removed duplicate condition in getAssignedFacilities() authz

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -474,7 +474,6 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOADMIN, group) &&
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, group) &&
-				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, group) &&
 				!AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, group) &&
 				!AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			throw new PrivilegeException(sess, "getAssignedFacilities");


### PR DESCRIPTION
- There was unnecessary duplication of check on VO_OBSERVER role
  in FacilitiesManager method getAssignedFacilities()