### PR TITLE
LDAPC: Fill also displayName attribute to the LDAP

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunAttribute.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunAttribute.java
@@ -45,6 +45,7 @@ public interface PerunAttribute<T extends PerunBean> {
 		public static final String ldapAttrUserPassword = "userPassword";
 		public static final String ldapAttrSurname = "sn";
 		public static final String ldapAttrGivenName = "givenName";
+		public static final String ldapAttrDisplayName = "displayName";
 		public static final String ldapAttrEntityID = perunAttrEntityID;
 		public static final String ldapAttrClientID = perunAttrClientID;
 		public static final String ldapAttrObjectClass = "objectClass";

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunUserImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunUserImpl.java
@@ -39,7 +39,9 @@ public class PerunUserImpl extends AbstractPerunEntry<User> implements PerunUser
 		return Arrays.asList(
 				PerunAttribute.PerunAttributeNames.ldapAttrSurname,
 				PerunAttribute.PerunAttributeNames.ldapAttrCommonName,
-				PerunAttribute.PerunAttributeNames.ldapAttrGivenName);
+				PerunAttribute.PerunAttributeNames.ldapAttrGivenName,
+				PerunAttribute.PerunAttributeNames.ldapAttrDisplayName
+		);
 	}
 
 	@Override
@@ -74,6 +76,18 @@ public class PerunUserImpl extends AbstractPerunEntry<User> implements PerunUser
 							return commonName;
 						}
 						),
+				new PerunAttributeDesc<>(
+						PerunAttribute.PerunAttributeNames.ldapAttrDisplayName,
+						PerunAttribute.OPTIONAL,
+						(PerunAttribute.SingleValueExtractor<User>)(user, attrs) -> {
+							String displayName = user.getDisplayName();
+							if (StringUtils.isBlank(displayName)) {
+								return null;
+							} else {
+								return displayName;
+							}
+						}
+				),
 				new PerunAttributeDesc<>(
 						PerunAttribute.PerunAttributeNames.ldapAttrPerunUserId,
 						PerunAttribute.REQUIRED,
@@ -131,7 +145,7 @@ public class PerunUserImpl extends AbstractPerunEntry<User> implements PerunUser
 		}
 		entry.setAttributeValues(PerunAttribute.PerunAttributeNames.ldapAttrMemberOf, memberOfNames.toArray());
 	}
-	
+
 	protected void doSynchronizePrincipals(DirContextOperations entry, List<UserExtSource> extSources) {
 		entry.setAttributeValues(PerunAttribute.PerunAttributeNames.ldapAttrEduPersonPrincipalNames,
 				extSources.stream()
@@ -143,7 +157,7 @@ public class PerunUserImpl extends AbstractPerunEntry<User> implements PerunUser
 					.toArray(String[]::new)
 					);
 	}
-	
+
 	@Override
 	public void synchronizeUser(User user, Iterable<Attribute> attrs, Set<Integer> voIds, List<Group> groups, List<UserExtSource> extSources) throws InternalErrorException {
 		SyncOperation syncOp = beginSynchronizeEntry(user, attrs);


### PR DESCRIPTION
- Added support for displayName attribute for User object. It will be
  updated by default when user is created or updated.
- It will contains whole users name, including academic titles.
- It will be used on MU primarily, but we can generally deploy it
  and use it if necessary.
- Since LDAP attribute displayName is a part of inetOrgPerson schema,
  we don't have to update our own schema.