### PR TITLE
LDAPc AttributeProcessors changed: values of virtual attributes are getting from Perun

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/AbstractAttributeProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/AbstractAttributeProcessor.java
@@ -9,15 +9,17 @@ import cz.metacentrum.perun.ldapc.processor.EventDispatcher.MessageBeans;
 public abstract class AbstractAttributeProcessor extends AbstractEventProcessor implements AttributeProcessor {
 
 	private int beanFlag;
-	private Pattern setPattern, removePattern, allAttrsRemovedPattern;
+	private Pattern setPattern, removePattern, allAttrsRemovedPattern, virtualAttrChangePattern;
 		
 	
-	public AbstractAttributeProcessor(int beanFlag, Pattern setPattern, Pattern removePattern, Pattern allAttrsRemovedPattern) {
+	public AbstractAttributeProcessor(int beanFlag, Pattern setPattern, Pattern removePattern, Pattern allAttrsRemovedPattern,
+									  Pattern virtualAttrChangePattern) {
 		super();
 		this.beanFlag = beanFlag;
 		this.setPattern = setPattern;
 		this.removePattern = removePattern;
 		this.allAttrsRemovedPattern = allAttrsRemovedPattern;
+		this.virtualAttrChangePattern = virtualAttrChangePattern;
 	}
 
 	@Override
@@ -34,6 +36,11 @@ public abstract class AbstractAttributeProcessor extends AbstractEventProcessor 
 			processAttributeRemoved(msg, beans);
 			return;
 		}
+		matcher = virtualAttrChangePattern.matcher(msg);
+		mask = MessageBeans.ATTRIBUTE_F | beanFlag;
+		if (matcher.find() && (beans.getPresentBeansMask() & mask) == mask) {
+			processVirtualAttributeChanged(msg, beans);
+		}
 		mask = beanFlag;
 		matcher = allAttrsRemovedPattern.matcher(msg);
 		if(matcher.find() && (beans.getPresentBeansMask() & mask) == mask) {
@@ -48,5 +55,7 @@ public abstract class AbstractAttributeProcessor extends AbstractEventProcessor 
 	public abstract void processAttributeRemoved(String msg, MessageBeans beans);
 	
 	public abstract void processAllAttributesRemoved(String msg, MessageBeans beans);
+
+	public abstract void processVirtualAttributeChanged(String msg, MessageBeans beans);
 
 }

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/FacilityAttributeProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/FacilityAttributeProcessor.java
@@ -1,18 +1,18 @@
 package cz.metacentrum.perun.ldapc.processor.impl;
 
-import java.util.List;
-import java.util.regex.Pattern;
-
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.ldapc.processor.EventDispatcher.MessageBeans;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ldap.NamingException;
 
-import cz.metacentrum.perun.core.api.Perun;
-import cz.metacentrum.perun.core.api.Resource;
-import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.ldapc.processor.EventDispatcher.MessageBeans;
+import java.util.List;
+import java.util.regex.Pattern;
 
 public class FacilityAttributeProcessor extends AbstractAttributeProcessor {
 
@@ -21,16 +21,17 @@ public class FacilityAttributeProcessor extends AbstractAttributeProcessor {
 	private static Pattern facilitySetPattern = Pattern.compile(" set for Facility:\\[(.*)\\]");
 	private static Pattern facilityRemovePattern = Pattern.compile(" removed for Facility:\\[(.*)\\]");
 	private static Pattern facilityAllAttrsRemovedPattern = Pattern.compile("All attributes removed for Facility:\\[(.*)\\]");
+	private static Pattern facilityVirtualChangePattern = Pattern.compile(" changed for Facility:\\[(.*)\\]");
 
 	public FacilityAttributeProcessor() {
-		super(MessageBeans.FACILITY_F, facilitySetPattern, facilityRemovePattern, facilityAllAttrsRemovedPattern);
+		super(MessageBeans.FACILITY_F, facilitySetPattern, facilityRemovePattern, facilityAllAttrsRemovedPattern, facilityVirtualChangePattern);
 	}
 
 	public void processAttributeSet(String msg, MessageBeans beans) {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl) ldapcManager.getPerunBl();
 
 		// ensure we have the correct beans available
-		if(beans.getAttribute() == null || beans.getFacility() == null) {
+		if (beans.getAttribute() == null || beans.getFacility() == null) {
 			return;
 		}
 		try {
@@ -38,21 +39,21 @@ public class FacilityAttributeProcessor extends AbstractAttributeProcessor {
 			perunFacility.modifyEntry(beans.getFacility(), beans.getAttribute());
 			log.debug("Getting resources assigned to facility {}", beans.getFacility().getId());
 			// List<Resource> resources = Rpc.FacilitiesManager.getAssignedResources(ldapcManager.getRpcCaller(), beans.getFacility());
-			List<Resource> resources = perun.getFacilitiesManager().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
-			for(Resource resource: resources) {
+			List<Resource> resources = perun.getFacilitiesManagerBl().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
+			for (Resource resource : resources) {
 				log.debug("Setting attribute {} for resource {}", beans.getAttribute(), resource);
 				perunResource.modifyEntry(resource, beans.getAttribute());
 			}
-		} catch (NamingException | FacilityNotExistsException | InternalErrorException | PrivilegeException e) {
-				log.error("Error setting attribute:", e);
+		} catch (NamingException | InternalErrorException e) {
+			log.error("Error setting attribute:", e);
 		}
 	}
 
 	public void processAttributeRemoved(String msg, MessageBeans beans) {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl) ldapcManager.getPerunBl();
 
 		// ensure we have the correct beans available
-		if(beans.getAttributeDef() == null || beans.getFacility() == null) {
+		if (beans.getAttributeDef() == null || beans.getFacility() == null) {
 			return;
 		}
 		try {
@@ -60,21 +61,21 @@ public class FacilityAttributeProcessor extends AbstractAttributeProcessor {
 			perunFacility.modifyEntry(beans.getFacility(), beans.getAttributeDef());
 			log.debug("Getting resources assigned to facility {}", beans.getFacility().getId());
 			// List<Resource> resources = Rpc.FacilitiesManager.getAssignedResources(ldapcManager.getRpcCaller(), beans.getFacility());
-			List<Resource> resources = perun.getFacilitiesManager().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
-			for(Resource resource: resources) {
+			List<Resource> resources = perun.getFacilitiesManagerBl().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
+			for (Resource resource : resources) {
 				log.debug("Removing attribute {} from resource {}", beans.getAttributeDef(), resource);
 				perunResource.modifyEntry(resource, beans.getAttributeDef());
 			}
-		} catch (NamingException | FacilityNotExistsException | InternalErrorException | PrivilegeException e) {
+		} catch (NamingException | InternalErrorException e) {
 			log.error("Error removing attribute:", e);
 		}
 	}
 
 	public void processAllAttributesRemoved(String msg, MessageBeans beans) {
-		Perun perun = ldapcManager.getPerunBl();
+		PerunBl perun = (PerunBl) ldapcManager.getPerunBl();
 
 		// ensure we have the correct beans available
-		if(beans.getUser() == null) {
+		if (beans.getFacility() == null) {
 			return;
 		}
 		try {
@@ -82,14 +83,38 @@ public class FacilityAttributeProcessor extends AbstractAttributeProcessor {
 			perunFacility.removeAllAttributes(beans.getFacility());
 			log.debug("Getting resources assigned to facility {}", beans.getFacility().getId());
 			// List<Resource> resources = Rpc.FacilitiesManager.getAssignedResources(ldapcManager.getRpcCaller(), beans.getFacility());
-			List<Resource> resources = perun.getFacilitiesManager().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
-			for(Resource resource: resources) {
+			List<Resource> resources = perun.getFacilitiesManagerBl().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
+			for (Resource resource : resources) {
 				log.debug("Removing all attributes from resource {}", resource);
 				perunResource.removeAllAttributes(resource);
 			}
-		} catch (NamingException | FacilityNotExistsException | InternalErrorException | PrivilegeException e) {
+		} catch (NamingException | InternalErrorException e) {
 			log.error("Error removing attributes:", e);
 		}
 	}
 
+	public void processVirtualAttributeChanged(String msg, MessageBeans beans) {
+		PerunBl perun = (PerunBl) ldapcManager.getPerunBl();
+		if (beans.getAttribute() == null || beans.getFacility() == null) {
+			return;
+		}
+		try {
+			log.debug("Getting resources assigned to facility {}", beans.getFacility().getId());
+			List<Resource> resources = perun.getFacilitiesManagerBl().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
+
+			Attribute virtAttr = perun.getAttributesManagerBl().
+				getAttribute(ldapcManager.getPerunSession(), beans.getFacility(), beans.getAttribute().getName());
+
+			log.debug("Changing virtual attribute {} for facility {}", virtAttr, beans.getFacility());
+			perunFacility.modifyEntry(beans.getFacility(), virtAttr);
+
+			for (Resource resource : resources) {
+				log.debug("Changing virtual attribute {} for resource {}", virtAttr, resource);
+				perunResource.modifyEntry(resource, virtAttr);
+			}
+		} catch (InternalErrorException | AttributeNotExistsException | WrongAttributeAssignmentException |
+			NamingException e) {
+			log.error("Error changing virtual attribute:", e);
+		}
+	}
 }

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -253,6 +253,16 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<property name="pattern" value="UserExtSource:\[.*\] removed from User:\[.*\]" />
 					<property name="handlerMethodName" value="processExtSourceRemoved" />
 				</bean>
+				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
+					<property name="beansCondition">
+						<list>
+							<value>cz.metacentrum.perun.core.api.User</value>
+							<value>cz.metacentrum.perun.core.api.Attribute</value>
+						</list>
+					</property>
+					<property name="pattern" value=" changed for User:\[.*\]"/>
+					<property name="handlerMethodName" value="processVirtualAttributeChanged"/>
+				</bean>
 			</list>
 		</property>
 	</bean>
@@ -288,6 +298,16 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					</property>
 					<property name="pattern" value="All attributes removed for Facility:\[.*\]" />
 					<property name="handlerMethodName" value="processAllAttributesRemoved" />
+				</bean>
+				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
+					<property name="beansCondition">
+						<list>
+							<value>cz.metacentrum.perun.core.api.Attribute</value>
+							<value>cz.metacentrum.perun.core.api.Facility</value>
+						</list>
+					</property>
+					<property name="pattern" value=" changed for Facility:\[.*\]"/>
+					<property name="handlerMethodName" value="processVirtualAttributeChanged"/>
 				</bean>
 			</list>
 		</property>


### PR DESCRIPTION
When LDAPc gets message about virtual attribute change (message without value) , attribute processors get value from perun and modify entry.