### PR TITLE
UTILS: Check for account existence before validation in KDC

### DIFF
--- a/perun-utils/password-manager/perun.passwordManager
+++ b/perun-utils/password-manager/perun.passwordManager
@@ -326,30 +326,54 @@ function reserve_random() {
 function validate() {
 	case $TYPE in
 	KERBEROS_HEIMDAL)
-		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
+		RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM get ${USERLOGIN}@${REALM} 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
+			logger "Perun-PasswordValidate: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
-		if [ $RET_CODE -ne 0 ]; then
-			logger "Perun-PasswordValidate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
-			exit 4
+		# if RET was not empty, then entry exist
+		if [ "$RET" ]; then
+			RET=$(timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.heimdal --principal=$ADMINPRINCIPAL --keytab=$KEYTAB --realm=$REALM modify --expiration-time="never" ${USERLOGIN}@${REALM} 2>&1)
+			RET_CODE=$?
+			if [ $RET_CODE -eq 124 ]; then
+				logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
+				exit $RET_CODE
+			fi
+			if [ $RET_CODE -ne 0 ]; then
+				logger "Perun-PasswordValidate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
+				exit 4
+			fi
+			logger "Perun-PasswordValidate: successfully validated login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
+		else
+			# RET was empty, silently skipping
+			logger "Perun-PasswordValidate: doing nothing because entry $LOGINNAMESPACE:$USERLOGIN in $REALM doesn't exist."
 		fi
-		logger "Perun-PasswordValidate: successfully validated login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 		;;
 	KERBEROS_MIT)
-		RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+		RET=$(printf "getprinc %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>/dev/null)
 		RET_CODE=$?
 		if [ $RET_CODE -eq 124 ]; then
-			logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
+			logger "Perun-PasswordValidate: check for existence timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
 			exit $RET_CODE
 		fi
-		if [ $RET_CODE -ne 0 ]; then
-			logger "Perun-PasswordValidate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
-			exit 4
+		# if RET was not empty, then entry exist
+		if [ "$RET" ]; then
+			RET=$(printf "modprinc -expire never %s\n" "${USERLOGIN}@${REALM}" | timeout -k $TIMEOUT_KILL $TIMEOUT /usr/bin/kadmin.mit -p $ADMINPRINCIPAL -k -t $KEYTAB -r $REALM 2>&1)
+			RET_CODE=$?
+			if [ $RET_CODE -eq 124 ]; then
+				logger "Perun-PasswordValidate: setting expiration time to never timed out for $LOGINNAMESPACE:$USERLOGIN in $REALM (Warning: this error can mask original error 124 from KDC!, reason: $RET.)"
+				exit $RET_CODE
+			fi
+			if [ $RET_CODE -ne 0 ]; then
+				logger "Perun-PasswordValidate: setting expiration time to never for $LOGINNAMESPACE:$USERLOGIN in $REALM failed, reason: $RET."
+				exit 4
+			fi
+			logger "Perun-PasswordValidate: successfully validated login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
+		else
+			# RET was empty, silently skipping
+			logger "Perun-PasswordValidate: doing nothing because entry $LOGINNAMESPACE:$USERLOGIN in $REALM doesn't exist."
 		fi
-		logger "Perun-PasswordValidate: successfully validated login for $LOGINNAMESPACE:$USERLOGIN in $REALM."
 		;;
 	esac
 }


### PR DESCRIPTION
- Fixed case when user tried to validate non-existing entry in KDC.
  We silently skipped this in deployed versions of password manager.
  This commit puts this change to cvs.