### PR TITLE
Throw better exception for integrity in DB when updating Facility

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/FacilitiesManager.java
@@ -229,8 +229,13 @@ public interface FacilitiesManager {
 	 *
 	 * @param facility to update
 	 * @return updated facility
+	 *
+	 * @throws FacilityExistsException
+	 * @throws FacilityNotExistsException
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
 	 */
-	Facility updateFacility(PerunSession perunSession, Facility facility) throws FacilityNotExistsException, InternalErrorException, PrivilegeException;
+	Facility updateFacility(PerunSession perunSession, Facility facility) throws FacilityNotExistsException, FacilityExistsException, InternalErrorException, PrivilegeException;
 
 	/**
 	 * Returns list of all facilities owned by the owner.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -360,8 +360,9 @@ public interface FacilitiesManagerBl {
 	 * @return updated facility
 	 *
 	 * @throws InternalErrorException
+	 * @throws FacilityExistsException
 	 */
-	Facility updateFacility(PerunSession perunSession, Facility facility) throws InternalErrorException;
+	Facility updateFacility(PerunSession perunSession, Facility facility) throws InternalErrorException, FacilityExistsException;
 
 	/**
 	 * Returns list of all facilities owned by the owner.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -388,7 +388,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
-	public Facility updateFacility(PerunSession sess, Facility facility) throws InternalErrorException {
+	public Facility updateFacility(PerunSession sess, Facility facility) throws InternalErrorException, FacilityExistsException {
 		//check facility name, it can contain only a-zA-Z.0-9_-
 		if (!facility.getName().matches("^[ a-zA-Z.0-9_-]+$")) {
 			throw new InternalErrorException(new IllegalArgumentException("Wrong facility name, facility name can contain only a-Z0-9.-_ and space characters"));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -437,7 +437,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 	}
 
 	@Override
-	public Facility updateFacility(PerunSession sess, Facility facility) throws FacilityNotExistsException, InternalErrorException, PrivilegeException {
+	public Facility updateFacility(PerunSession sess, Facility facility) throws FacilityNotExistsException, FacilityExistsException, InternalErrorException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		getFacilitiesManagerBl().checkFacilityExists(sess, facility);
 		Utils.notNull(facility, "facility");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.HostAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.HostNotExistsException;
@@ -36,6 +37,7 @@ import cz.metacentrum.perun.core.implApi.FacilitiesManagerImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -269,7 +271,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	}
 
 	@Override
-	public Facility updateFacility(PerunSession sess, Facility facility) throws InternalErrorException {
+	public Facility updateFacility(PerunSession sess, Facility facility) throws InternalErrorException, FacilityExistsException {
 
 		// Get the facility stored in the DB
 		Facility dbFacility;
@@ -287,6 +289,8 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 								Compatibility.getSysdate() + " where id=?",
 						facility.getName(), facility.getDescription(), sess.getPerunPrincipal().getActor(),
 						sess.getPerunPrincipal().getUserId(), facility.getId());
+			} catch (DataIntegrityViolationException e) {
+				throw new FacilityExistsException("The name must be unique and it's already occupied.", e);
 			} catch (RuntimeException e) {
 				throw new InternalErrorException(e);
 			}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.HostAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.HostNotExistsException;
@@ -243,8 +244,9 @@ public interface FacilitiesManagerImplApi {
 	 * @param facility
 	 *
 	 * @throws InternalErrorException
+	 * @throws FacilityExistsException if the name of facility has been already used for different Facility
 	 */
-	Facility updateFacility(PerunSession perunSession, Facility facility) throws InternalErrorException;
+	Facility updateFacility(PerunSession perunSession, Facility facility) throws InternalErrorException, FacilityExistsException;
 
 	/**
 	 * Deletes all facility owners.
@@ -723,12 +725,12 @@ public interface FacilitiesManagerImplApi {
 
 	/**
 	 * Get true if any ban for user and facility exists.
-	 * 
+	 *
 	 * @param sess
 	 * @param userId id of user
 	 * @param facilityId id of facility
 	 * @return true if ban exists
-	 * @throws InternalErrorException 
+	 * @throws InternalErrorException
 	 */
 	boolean banExists(PerunSession sess, int userId, int facilityId) throws InternalErrorException;
 
@@ -744,11 +746,11 @@ public interface FacilitiesManagerImplApi {
 
 	/**
 	 * Set ban for user on facility
-	 * 
+	 *
 	 * @param sess
 	 * @param banOnFacility the ban
 	 * @return ban on facility
-	 * @throws InternalErrorException 
+	 * @throws InternalErrorException
 	 */
 	BanOnFacility setBan(PerunSession sess, BanOnFacility banOnFacility) throws InternalErrorException;
 


### PR DESCRIPTION
 - if updated Facility has the same name as other Facility,
 DataViolationException is thrown and we need to change that to
 FacilityExistsException instead of InternalErrorException