### PR TITLE
LDAPC: Fixed regex for userPassword attribute

### DIFF
--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -527,7 +527,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<property name="required" value="false" />
 					<property name="singleValueExtractor">
 						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
-							<property name="nameRegexp" value="urn:perun:user:attribute-def:def:login-namespace:${ldap.loginNamespace}" />
+							<property name="nameRegexp" value="^urn:perun:user:attribute-def:def:login-namespace:${ldap.loginNamespace}$" />
 							<property name="namespace" value="urn:perun:user:attribute-def:def:login-namespace" />
 							<property name="name" value="${ldap.loginNamespace}" />
 							<property name="valueTransformer">


### PR DESCRIPTION
- Regex matcher for userPassword attribute was too open and matched
  any attribute with the same prefix. We now match beginning and
  ending of expected attribute URN.