### PR TITLE
LDAPc Bug:removing data in sync after exception

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/VOSynchronizer.java
@@ -1,23 +1,23 @@
 package cz.metacentrum.perun.ldapc.beans;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import javax.naming.Name;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Status;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.ldapc.model.PerunVO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.naming.Name;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Component
 public class VOSynchronizer extends AbstractSynchronizer {
@@ -27,20 +27,21 @@ public class VOSynchronizer extends AbstractSynchronizer {
 	@Autowired
 	protected PerunVO perunVO;
 
-	public void synchronizeVOs() {
+	public void synchronizeVOs() throws InternalErrorException {
 		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
+		boolean shouldWriteExceptionLog = true;
 		try {
 			log.debug("Getting list of VOs");
 			// List<Vo> vos = Rpc.VosManager.getVos(ldapcManager.getRpcCaller());
 			List<Vo> vos = perun.getVosManagerBl().getVos(ldapcManager.getPerunSession());
 			Set<Name> presentVos = new HashSet<Name>(vos.size());
-			
+
 			for (Vo vo : vos) {
 				// Map<String, Object> params = new HashMap<String, Object>();
 				// params.put("vo", new Integer(vo.getId()));
-				
+
 				presentVos.add(perunVO.getEntryDN(String.valueOf(vo.getId())));
-				
+
 				try {
 					log.debug("Synchronizing VO entry {}", vo);
 					//perunVO.synchronizeEntry(vo);
@@ -51,18 +52,25 @@ public class VOSynchronizer extends AbstractSynchronizer {
 					perunVO.synchronizeVo(vo, members);
 				} catch (PerunException e) {
 					log.error("Error synchronizing VO " + vo.getId(), e);
+					shouldWriteExceptionLog = false;
+					throw new InternalErrorException(e);
 				}
 			}
-			
+
 			// search VO entries in LDAP and remove the ones not present in Perun
 			try {
 				removeOldEntries(perunVO, presentVos, log);
 			} catch (InternalErrorException e) {
 				log.error("Error removing old VO entries", e);
+				shouldWriteExceptionLog = false;
+				throw new InternalErrorException(e);
 			}
-			
+
 		} catch (InternalErrorException e) {
-			log.error("Error getting list of VOs", e);
+			if (shouldWriteExceptionLog) {
+				log.error("Error getting list of VOs", e);
+			}
+			throw new InternalErrorException(e);
 		}
 	}
 }

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/LdapcManager.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/LdapcManager.java
@@ -17,7 +17,7 @@ public interface LdapcManager {
 	 */
 	void stopProcessingEvents();
 
-	void synchronize();
+	void synchronize() throws InternalErrorException;
 
 	public Perun getPerunBl();
 

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/impl/LdapcManagerImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/impl/LdapcManagerImpl.java
@@ -1,16 +1,12 @@
 package cz.metacentrum.perun.ldapc.service.impl;
 
-import cz.metacentrum.perun.core.bl.PerunBl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.ldapc.beans.FacilitySynchronizer;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.ldapc.beans.GroupSynchronizer;
 import cz.metacentrum.perun.ldapc.beans.LdapProperties;
 import cz.metacentrum.perun.ldapc.beans.ResourceSynchronizer;
@@ -18,6 +14,9 @@ import cz.metacentrum.perun.ldapc.beans.UserSynchronizer;
 import cz.metacentrum.perun.ldapc.beans.VOSynchronizer;
 import cz.metacentrum.perun.ldapc.processor.EventDispatcher;
 import cz.metacentrum.perun.ldapc.service.LdapcManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @org.springframework.stereotype.Service(value = "ldapcManager")
 public class LdapcManagerImpl implements LdapcManager {
@@ -58,7 +57,7 @@ public class LdapcManagerImpl implements LdapcManager {
 		System.out.println("Event processor thread interrupted.");
 	}
 
-	public void synchronize() {
+	public void synchronize() throws InternalErrorException {
 		try {
 			voSynchronizer.synchronizeVOs();
 			facilitySynchronizer.synchronizeFacilities();
@@ -70,6 +69,7 @@ public class LdapcManagerImpl implements LdapcManager {
 			((PerunBl)getPerunBl()).getAuditMessagesManagerBl().setLastProcessedId(perunSession, ldapProperties.getLdapConsumerName(), lastProcessedMessageId);
 		} catch (Exception  e) {
 			log.error("Error synchronizing to LDAP", e);
+			throw new InternalErrorException(e);
 		}
 	}
 


### PR DESCRIPTION
When LDAPc sync is getting data and exception is thrown, resource list is empty or not complete and items which are supposed to remain are deleted. (same problem is with attributes)
I added some control variables and edited several try-catch blocks to fix this bug.