### PR TITLE
Facility LDAP class implementation

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/FacilityCreated.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/FacilityCreated.java
@@ -16,7 +16,7 @@ public class FacilityCreated extends AuditEvent implements EngineIgnoreEvent {
 
 	public FacilityCreated(Facility facility) {
 		this.facility = facility;
-		this.message = formatMessage("Facility created %s.",facility);
+		this.message = formatMessage("%s created.",facility);
 	}
 
 	public Facility getFacility() {

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/FacilityDeleted.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/FacilityDeleted.java
@@ -14,7 +14,7 @@ public class FacilityDeleted extends AuditEvent {
 
 	public FacilityDeleted(Facility facility) {
 		this.facility = facility;
-		this.message = formatMessage("Facility deleted %s.", facility);
+		this.message = formatMessage("%s deleted.", facility);
 	}
 
 	public Facility getFacility() {

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/FacilitySynchronizer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/FacilitySynchronizer.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.ldapc.beans;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.naming.Name;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.ldapc.model.PerunFacility;
+
+
+@Component
+public class FacilitySynchronizer extends AbstractSynchronizer {
+
+	private final static Logger log = LoggerFactory.getLogger(FacilitySynchronizer.class);
+
+	@Autowired
+	protected PerunFacility perunFacility;
+
+	public void synchronizeFacilities() {
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
+		Set<Name> presentFacilities = new HashSet<Name>();
+
+		try {
+			log.debug("Getting list of facilities");
+
+			List<Facility> facilities = perun.getFacilitiesManagerBl().getFacilities(ldapcManager.getPerunSession());
+
+			for(Facility facility : facilities) {
+
+				presentFacilities.add(perunFacility.getEntryDN(String.valueOf(facility.getId())));
+						
+				try {
+					log.debug("Synchronizing facility {}", facility);
+
+					log.debug("Getting list of attributes for facility {}", facility.getId());
+					List<Attribute> attrs = new ArrayList<Attribute>();
+					List<String> attrNames = fillPerunAttributeNames(perunFacility.getPerunAttributeNames());
+					try {
+						//log.debug("Getting attribute {} for resource {}", attrName, resource.getId());
+						attrs.addAll(perun.getAttributesManagerBl().getAttributes(ldapcManager.getPerunSession(), facility, attrNames));
+					} catch (PerunException e) {
+						log.warn("No attributes {} found for facility {}: {}", attrNames, facility.getId(), e.getMessage());
+					}
+					log.debug("Got attributes {}", attrs.toString());
+
+					perunFacility.synchronizeFacility(facility, attrs);
+							
+				} catch (PerunException e) {
+					log.error("Error synchronizing facility", e);
+				}
+			}
+
+			try {
+				removeOldEntries(perunFacility, presentFacilities, log);
+			} catch (InternalErrorException e) {
+				log.error("Error removing old facility entries", e);
+			}
+		
+		} catch (PerunException e) {
+			log.error("Error reading list of facilities", e);
+		}
+
+	
+	}
+	
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunAttribute.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunAttribute.java
@@ -64,11 +64,13 @@ public interface PerunAttribute<T extends PerunBean> {
 		public static final String ldapAttrIsSponsoredUser = "isSponsoredUser";
 		public static final String ldapAttrGroupNames = perunAttrGroupNames;
 		public static final String ldapAttrInstitutionsCountries = perunAttrInstitutionsCountries;
+		public static final String ldapAttrPerunFacilityDn = "perunFacilityDn";
 
 		//LDAP OBJECT CLASSES
 		public static final String objectClassTop = "top";
 		public static final String objectClassPerunResource = "perunResource";
 		public static final String objectClassPerunGroup = "perunGroup";
+		public static final String objectClassPerunFacility = "perunFacility";
 		public static final String objectClassOrganization = "organization";
 		public static final String objectClassPerunVO = "perunVO";
 		public static final String objectClassPerson = "person";

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunFacility.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunFacility.java
@@ -1,0 +1,18 @@
+package cz.metacentrum.perun.ldapc.model;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+
+public interface PerunFacility extends PerunEntry<Facility> {
+	
+	public void addFacility(Facility facility)  throws InternalErrorException;
+	
+	public void deleteFacility(Facility facility) throws InternalErrorException;
+	
+	public void updateFacility(Facility facility) throws InternalErrorException; 
+
+	public void synchronizeFacility(Facility facility, Iterable<Attribute> attrs) throws InternalErrorException; 
+
+}
+	

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunFacilityImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunFacilityImpl.java
@@ -1,0 +1,96 @@
+package cz.metacentrum.perun.ldapc.model.impl;
+
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.naming.Name;
+
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.support.LdapNameBuilder;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.ldapc.model.PerunAttribute;
+import cz.metacentrum.perun.ldapc.model.PerunFacility;
+
+public class PerunFacilityImpl extends AbstractPerunEntry<Facility> implements PerunFacility {
+
+	@Override
+	protected List<String> getDefaultUpdatableAttributes() {
+		return Arrays.asList(
+				PerunAttribute.PerunAttributeNames.ldapAttrCommonName,
+				PerunAttribute.PerunAttributeNames.ldapAttrDescription);
+	}
+
+	@Override
+	protected List<PerunAttribute<Facility>> getDefaultAttributeDescriptions() {
+		return Arrays.asList(
+				new PerunAttributeDesc<>(
+						PerunAttribute.PerunAttributeNames.ldapAttrCommonName, 
+						PerunAttribute.REQUIRED, 
+						(PerunAttribute.SingleValueExtractor<Facility>)(facility, attrs) -> facility.getName()
+						),
+				new PerunAttributeDesc<>(
+						PerunAttribute.PerunAttributeNames.ldapAttrPerunFacilityId, 
+						PerunAttribute.REQUIRED, 
+						(PerunAttribute.SingleValueExtractor<Facility>)(facility, attrs) -> String.valueOf(facility.getId())
+						),
+				new PerunAttributeDesc<>(
+						PerunAttribute.PerunAttributeNames.ldapAttrDescription, 
+						PerunAttribute.OPTIONAL, 
+						(PerunAttribute.SingleValueExtractor<Facility>)(facility, attrs) -> facility.getDescription()
+						)
+				);
+	}
+
+	@Override
+	public void addFacility(Facility facility) throws InternalErrorException {
+		addEntry(facility);
+	}
+
+	@Override
+	public void deleteFacility(Facility facility) throws InternalErrorException {
+		deleteEntry(facility);
+	}
+
+	@Override
+	public void updateFacility(Facility facility) throws InternalErrorException {
+		modifyEntry(facility);
+	}
+
+	@Override
+	public void synchronizeFacility(Facility facility, Iterable<Attribute> attrs) throws InternalErrorException {
+		synchronizeEntry(facility, attrs);
+	}
+
+	@Override
+	public Name getEntryDN(String... id) {
+		return LdapNameBuilder.newInstance()
+				.add(PerunAttribute.PerunAttributeNames.ldapAttrPerunFacilityId, id[0])
+				.build();
+	}
+
+	@Override
+	protected Name buildDN(Facility bean) {
+		return getEntryDN(String.valueOf(bean.getId()));
+	}
+
+	@Override
+	protected void mapToContext(Facility bean, DirContextOperations context) throws InternalErrorException {
+		context.setAttributeValue("objectclass", PerunAttribute.PerunAttributeNames.objectClassPerunFacility);
+		mapToContext(bean, context, getAttributeDescriptions());
+	}
+
+	@Override
+	public List<Name> listEntries() throws InternalErrorException {
+		return ldapTemplate.search(query().
+				where("objectclass").is(PerunAttribute.PerunAttributeNames.objectClassPerunFacility),
+				getNameMapper());
+	}
+
+
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunResourceImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunResourceImpl.java
@@ -20,7 +20,9 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.ldapc.beans.LdapProperties;
 import cz.metacentrum.perun.ldapc.model.PerunAttribute;
+import cz.metacentrum.perun.ldapc.model.PerunFacility;
 import cz.metacentrum.perun.ldapc.model.PerunGroup;
 import cz.metacentrum.perun.ldapc.model.PerunResource;
 
@@ -30,6 +32,10 @@ public class PerunResourceImpl extends AbstractPerunEntry<Resource> implements P
 
 	@Autowired
 	private PerunGroup perunGroup;
+	@Autowired
+	private PerunFacility perunFacility;
+	@Autowired
+	private LdapProperties LdapProperties;
 	
 	@Override
 	protected List<String> getDefaultUpdatableAttributes() {
@@ -65,6 +71,12 @@ public class PerunResourceImpl extends AbstractPerunEntry<Resource> implements P
 						PerunAttribute.PerunAttributeNames.ldapAttrDescription, 
 						PerunAttribute.OPTIONAL, 
 						(PerunAttribute.SingleValueExtractor<Resource>)(resource, attrs) -> resource.getDescription()
+						),
+				new PerunAttributeDesc<>(
+						PerunAttribute.PerunAttributeNames.ldapAttrPerunFacilityDn, 
+						PerunAttribute.OPTIONAL, 
+						(PerunAttribute.SingleValueExtractor<Resource>)(resource, attrs) -> perunFacility.getEntryDN(String.valueOf(resource.getFacilityId())).toString() 
+															+ "," + ldapProperties.getLdapBase()
 						)
 				);
 	}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/AbstractEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/AbstractEventProcessor.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 
+import cz.metacentrum.perun.ldapc.model.PerunFacility;
 import cz.metacentrum.perun.ldapc.model.PerunGroup;
 import cz.metacentrum.perun.ldapc.model.PerunResource;
 import cz.metacentrum.perun.ldapc.model.PerunUser;
@@ -30,6 +31,8 @@ public abstract class AbstractEventProcessor implements EventProcessor, Initiali
 	protected PerunGroup perunGroup;
 	@Autowired
 	protected PerunResource perunResource;
+	@Autowired
+	protected PerunFacility perunFacility;
 	@Autowired
 	protected PerunUser perunUser;
 	@Autowired

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/CreationEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/CreationEventProcessor.java
@@ -40,6 +40,11 @@ public class CreationEventProcessor extends AbstractEventProcessor {
 					perunResource.addResource(beans.getResource(), getFacilityEntityIdValue(beans.getResource().getFacilityId()));
 					break;
 					
+				case MessageBeans.FACILITY_F:
+					log.debug("Adding new facility: {}", beans.getFacility());
+					perunFacility.addFacility(beans.getFacility());
+					break;
+					
 				case MessageBeans.USER_F:
 					log.debug("Adding new user: {}", beans.getUser());
 					perunUser.addUser(beans.getUser());

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/DeletionEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/DeletionEventProcessor.java
@@ -26,6 +26,11 @@ public class DeletionEventProcessor extends AbstractEventProcessor {
 					perunResource.deleteResource(beans.getResource());
 					break;
 					
+				case MessageBeans.FACILITY_F:
+					log.debug("Removing facility {}", beans.getFacility());
+					perunFacility.deleteFacility(beans.getFacility());
+					break;
+					
 				case MessageBeans.USER_F:
 					log.debug("Removing user {}", beans.getUser());
 					perunUser.deleteUser(beans.getUser());

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/FacilityAttributeProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/FacilityAttributeProcessor.java
@@ -34,6 +34,8 @@ public class FacilityAttributeProcessor extends AbstractAttributeProcessor {
 			return;
 		}
 		try {
+			log.debug("Setting attribute {} for facility {}", beans.getAttribute(), beans.getFacility());
+			perunFacility.modifyEntry(beans.getFacility(), beans.getAttribute());
 			log.debug("Getting resources assigned to facility {}", beans.getFacility().getId());
 			// List<Resource> resources = Rpc.FacilitiesManager.getAssignedResources(ldapcManager.getRpcCaller(), beans.getFacility());
 			List<Resource> resources = perun.getFacilitiesManager().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
@@ -54,6 +56,8 @@ public class FacilityAttributeProcessor extends AbstractAttributeProcessor {
 			return;
 		}
 		try {
+			log.debug("Removing attribute {} from facility {}", beans.getAttributeDef(), beans.getFacility());
+			perunFacility.modifyEntry(beans.getFacility(), beans.getAttributeDef());
 			log.debug("Getting resources assigned to facility {}", beans.getFacility().getId());
 			// List<Resource> resources = Rpc.FacilitiesManager.getAssignedResources(ldapcManager.getRpcCaller(), beans.getFacility());
 			List<Resource> resources = perun.getFacilitiesManager().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());
@@ -74,6 +78,8 @@ public class FacilityAttributeProcessor extends AbstractAttributeProcessor {
 			return;
 		}
 		try {
+			log.debug("Removing all attributes from facility {}", beans.getFacility());
+			perunFacility.removeAllAttributes(beans.getFacility());
 			log.debug("Getting resources assigned to facility {}", beans.getFacility().getId());
 			// List<Resource> resources = Rpc.FacilitiesManager.getAssignedResources(ldapcManager.getRpcCaller(), beans.getFacility());
 			List<Resource> resources = perun.getFacilitiesManager().getAssignedResources(ldapcManager.getPerunSession(), beans.getFacility());

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/UpdateEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/UpdateEventProcessor.java
@@ -26,6 +26,11 @@ public class UpdateEventProcessor extends AbstractEventProcessor {
 					perunResource.updateResource(beans.getResource());
 					break;
 					
+				case MessageBeans.FACILITY_F:
+					log.debug("Updating facility {}", beans.getFacility());
+					perunFacility.updateFacility(beans.getFacility());
+					break;
+					
 				case MessageBeans.USER_F:
 					log.debug("Updating user {}", beans.getUser());
 					perunUser.updateUser(beans.getUser());

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/impl/LdapcManagerImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/impl/LdapcManagerImpl.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.ldapc.beans.FacilitySynchronizer;
 import cz.metacentrum.perun.ldapc.beans.GroupSynchronizer;
 import cz.metacentrum.perun.ldapc.beans.LdapProperties;
 import cz.metacentrum.perun.ldapc.beans.ResourceSynchronizer;
@@ -28,6 +29,8 @@ public class LdapcManagerImpl implements LdapcManager {
 	private EventDispatcher eventDispatcher;
 	@Autowired
 	private VOSynchronizer voSynchronizer;
+	@Autowired
+	private FacilitySynchronizer facilitySynchronizer;
 	@Autowired
 	private ResourceSynchronizer resourceSynchronizer;
 	@Autowired
@@ -58,6 +61,7 @@ public class LdapcManagerImpl implements LdapcManager {
 	public void synchronize() {
 		try {
 			voSynchronizer.synchronizeVOs();
+			facilitySynchronizer.synchronizeFacilities();
 			userSynchronizer.synchronizeUsers();
 			resourceSynchronizer.synchronizeResources();
 			groupSynchronizer.synchronizeGroups();

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -48,6 +48,14 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
 					<property name="beansCondition">
 						<list>
+							<value>cz.metacentrum.perun.core.api.Facility</value>
+						</list>
+					</property>
+					<property name="pattern" value=" deleted.$" />
+				</bean>
+				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
+					<property name="beansCondition">
+						<list>
 							<value>cz.metacentrum.perun.core.api.Resource</value>
 						</list>
 					</property>
@@ -92,6 +100,14 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	<bean id="creationEventProcessor" class="cz.metacentrum.perun.ldapc.processor.impl.CreationEventProcessor">
 		<property name="dispatchConditions">
 			<list>
+				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
+					<property name="beansCondition">
+						<list>
+							<value>cz.metacentrum.perun.core.api.Facility</value>
+						</list>
+					</property>
+					<property name="pattern" value=" created.$" />
+				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
 					<property name="beansCondition">
 						<list>
@@ -141,6 +157,14 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	<bean id="updateEventProcessor" class="cz.metacentrum.perun.ldapc.processor.impl.UpdateEventProcessor">
 		<property name="dispatchConditions">
 			<list>
+				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
+					<property name="beansCondition">
+						<list>
+							<value>cz.metacentrum.perun.core.api.Facility</value>
+						</list>
+					</property>
+					<property name="pattern" value=" updated.$" />
+				</bean>
 				<bean class="cz.metacentrum.perun.ldapc.processor.impl.RegexpDispatchEventCondition">
 					<property name="beansCondition">
 						<list>
@@ -598,6 +622,36 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		</property>
 	</bean>
 
+	<bean id="perunFacility" class="cz.metacentrum.perun.ldapc.model.impl.PerunFacilityImpl">
+		<property name="attributeDescriptions">
+			<!--  this list will be added to built-in defaultAttributeDescriptions -->
+			<list>
+				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
+					<property name="name" value="OIDCClientID" />
+					<property name="required" value="false" />
+					<property name="singleValueExtractor">
+						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
+							<property name="name" value="OIDCClientID" />
+							<property name="namespace" value="urn:perun:facility:attribute-def:def" />
+						</bean>
+					</property>
+				</bean>
+				<!-- not used (yet) 
+				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
+					<property name="name" value="OIDCCheckGroupMembership" />
+					<property name="required" value="false" />
+					<property name="singleValueExtractor">
+						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
+							<property name="name" value="OIDCCheckGroupMembership" />
+							<property name="namespace" value="urn:perun:facility:attribute-def:def" />
+						</bean>
+					</property>
+				</bean>
+ 				-->
+			</list>
+		</property>
+	</bean>
+	
 	<bean id="perunGroup" class="cz.metacentrum.perun.ldapc.model.impl.PerunGroupImpl">
 	</bean>
 

--- a/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
+++ b/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
@@ -29,11 +29,14 @@ olcAttributeTypes: {24}( 1.3.6.1.4.1.8057.2.80.28 NAME 'institutionsCountries' D
 olcAttributeTypes: {25}( 1.3.6.1.4.1.8057.2.80.29 NAME 'isCesnetEligible' DESC 'isCesnetEligible' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: {26}( 1.3.6.1.4.1.8057.2.80.30 NAME 'loa' DESC 'Level of authority' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: {27}( 1.3.6.1.4.1.8057.2.80.31 NAME 'internalUserIdentifiers' DESC 'All identifiers collected from UserExtSource attribute additionalIdentifiers' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {28}( 1.3.6.1.4.1.8057.2.80.32 NAME 'perunFacilityDn' DESC 'DN of Facility the resource belongs to' EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE )
+olcAttributeTypes: {29}( 1.3.6.1.4.1.8057.2.80.33 NAME 'OIDCCheckGroupMembership' DESC '???' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 -
 replace: olcObjectClasses
 olcObjectClasses: {0}( 1.3.6.1.4.1.8057.2.80.4 NAME 'perunUser' DESC 'User managed by Perun' SUP inetOrgPerson STRUCTURAL MUST ( perunUserId $ isServiceUser  $ isSponsoredUser ) MAY ( preferredMail $ userCertificateSubject $ uidNumber $ login $ eduPersonPrincipalNames $ userPassword $ memberOfPerunVo $ libraryIDs $ schacHomeOrganizations $ eduPersonScopedAffiliations $ bonaFideStatus $ groupNames $ institutionsCountries $ isCesnetEligible $ loa $ internalUserIdentifiers ) )
 olcObjectClasses: {1}( 1.3.6.1.4.1.8057.2.80.5 NAME 'perunGroup' DESC 'Group managed by Perun' SUP top  STRUCTURAL MUST ( cn $ perunGroupId $ perunVoId $ perunUniqueGroupName ) MAY ( uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ perunParentGroup $ perunParentGroupId $ assignedToResourceId ) )
-olcObjectClasses: {2}( 1.3.6.1.4.1.8057.2.80.15 NAME 'perunResource' DESC 'Resource managed by Perun' SUP top STRUCTURAL MUST ( cn $  perunResourceId $ perunVoId $ perunFacilityId ) MAY (uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ assignedGroupId  $ entityID $ OIDCClientID))
+olcObjectClasses: {2}( 1.3.6.1.4.1.8057.2.80.15 NAME 'perunResource' DESC 'Resource managed by Perun' SUP top STRUCTURAL MUST ( cn $  perunResourceId $ perunVoId $ perunFacilityId ) MAY (uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ assignedGroupId  $ entityID $ OIDCClientID $ perunFacilityDn ))
 olcObjectClasses: {3}( 1.3.6.1.4.1.8057.2.80.6 NAME 'perunVO' DESC 'VO managed by Perun' SUP organization STRUCTURAL MUST perunVoId MAY uniqueMember )
+olcObjectClasses: {4}( 1.3.6.1.4.1.8057.2.80.34 NAME 'perunFacility' DESC 'Facility managed by Perun' SUP top STRUCTURAL MUST ( cn $ perunFacilityId ) MAY ( description $ OIDCClientID $ OIDCCheckGroupMembership ) )
 -
 


### PR DESCRIPTION
Introduce Facility class into LDAPc:
- add related attribute and objectclass definition to LDAP schema
- add facility model class with perun bean attribute descriptions
- add facility bean for model with additional attributes
- add facility synchronizer class
- hook up facility related audit log events

Pre-existing attributes related to facility model that are being stored in resource entries continue to do so, in addition to storing them in facility entries. 