### PR TITLE
CORE: Removed usage of getComplementaryObjectsForRole() for filtering

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -131,13 +131,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		if (AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
 			return getFacilitiesManagerBl().getRichFacilities(sess);
 		} else if (AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN)) {
-			// Cast complementary object to Facility
-			List<Facility> facilities = new ArrayList<>();
-			for (PerunBean facility: AuthzResolver.getComplementaryObjectsForRole(sess, Role.FACILITYADMIN, Facility.class)) {
-				facilities.add((Facility) facility);
-			}
-			//Now I create list of richFacilities from facilities
-			return getFacilitiesManagerBl().getRichFacilities(sess, facilities);
+			return getFacilitiesManagerBl().getRichFacilities(sess, getFacilitiesManagerBl().getFacilitiesWhereUserIsAdmin(sess, sess.getPerunPrincipal().getUser()));
 		} else {
 			throw new PrivilegeException(sess, "getRichFacilities");
 		}
@@ -209,12 +203,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		if (AuthzResolver.isAuthorized(sess, Role.PERUNADMIN) || AuthzResolver.isAuthorized(sess, Role.ENGINE)) {
 			return getFacilitiesManagerBl().getFacilities(sess);
 		} else if (AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN)) {
-			// Cast complementary object to Facility
-			List<Facility> facilities = new ArrayList<>();
-			for (PerunBean facility: AuthzResolver.getComplementaryObjectsForRole(sess, Role.FACILITYADMIN, Facility.class)) {
-				facilities.add((Facility) facility);
-			}
-			return facilities;
+			return getFacilitiesManagerBl().getFacilitiesWhereUserIsAdmin(sess, sess.getPerunPrincipal().getUser());
 		} else {
 			throw new PrivilegeException(sess, "getFacilities");
 		}


### PR DESCRIPTION
- In get(Rich)Facilities() we were getting each facility by its ID for
  non perun-admins. Now we use direct select for all such facilities.
- getVos() was also optimized. We can get all vos where user is
  VOADMIN at once and also all groups where is GROUPADMIN to fetch VOs
  from them. Also we don't have to repeat VO retrieval for already
  retrieved VOs.