### PR TITLE
Separation of checkAttributeSyntax from checkAttributeSemantics

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_mail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_mail.java
@@ -27,14 +27,16 @@ public class urn_perun_member_attribute_def_def_mail extends MemberAttributesMod
 	private static final String A_M_mail = AttributesManager.NS_MEMBER_ATTR_DEF + ":mail";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Attribute attribute) throws WrongAttributeValueException {
-		String attributeValue;
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
 
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Member mail can't be null.");
-		else attributeValue = (String) attribute.getValue();
-
-		Matcher emailMatcher = Utils.emailPattern.matcher(attributeValue);
+		Matcher emailMatcher = Utils.emailPattern.matcher(attribute.valueAsString());
 		if(!emailMatcher.find()) throw new WrongAttributeValueException(attribute, "Email is not in correct form.");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Member mail can't be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_membershipExpiration.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_membershipExpiration.java
@@ -28,9 +28,9 @@ public class urn_perun_member_attribute_def_def_membershipExpiration extends Mem
 	 * matches with regular expression yyyy-MM-dd
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Attribute attribute) throws WrongAttributeValueException {
 
-		String membershipExpTime = (String) attribute.getValue();
+		String membershipExpTime = attribute.valueAsString();
 
 		if(membershipExpTime == null) return; // NULL is ok
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_phone.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_phone.java
@@ -29,21 +29,21 @@ public class urn_perun_member_attribute_def_def_phone extends MemberAttributesMo
 	//Example of correct number "+420123456789"
 	private static final Pattern pattern = Pattern.compile("^[+][0-9]{4,16}$");
 
-	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Attribute attribute) throws WrongAttributeValueException {
-
-		// null attribute
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "User attribute phone cannot be null.");
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
 
 		// wrong type of the attribute
 		if (!(attribute.getValue() instanceof String)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: String");
 
-		String phone = attribute.valueAsString();
-
-		Matcher matcher = pattern.matcher(phone);
+		Matcher matcher = pattern.matcher(attribute.valueAsString());
 		if (!matcher.matches()) {
 			throw new WrongAttributeValueException(attribute, "Phone is not in correct format!");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "User attribute phone cannot be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_virt_loa.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_virt_loa.java
@@ -8,7 +8,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.MemberVirtualAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.MemberVirtualAttributesModuleImplApi;
@@ -22,8 +22,9 @@ import java.util.List;
 public class urn_perun_member_attribute_def_virt_loa extends MemberVirtualAttributesModuleAbstract implements MemberVirtualAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
-		if(!attribute.equals(getAttributeValue(sess, member, attribute))) throw new WrongAttributeValueException(attribute, member, "Attribute value is not the highest value from member's UserExtSources Loas.");
+	public void checkAttributeSemantics(PerunSessionImpl sess, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		Attribute currentAttribute = getAttributeValue(sess, member, attribute);
+		if(!attribute.equals(currentAttribute)) throw new WrongReferenceAttributeValueException(attribute, currentAttribute, member, null, member, null, "Attribute value is not the highest value from member's UserExtSources Loas.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberAttributesModuleAbstract.java
@@ -24,7 +24,7 @@ public abstract class MemberAttributesModuleAbstract extends AttributesModuleAbs
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberAttributesModuleImplApi.java
@@ -38,13 +38,10 @@ public interface MemberAttributesModuleImplApi extends AttributesModuleImplApi{
 	 *
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
-	 * @throws WrongReferenceAttributeValueException if an referenced attribute against
-	 *         the parameter is to be compared is not available
-	 * @throws WrongReferenceAttributeValueException
-	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongReferenceAttributeValueException if the attribute value has wrong/illegal semantics
+	 * @throws WrongAttributeAssignmentException if attribute does not belong to appropriate entity
 	 */
-	void checkAttributeSemantics(PerunSessionImpl session, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void checkAttributeSemantics(PerunSessionImpl session, Member member, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Tries to fill an attribute to the specified member.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_mailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_mailTest.java
@@ -1,0 +1,58 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests attribute module.
+ */
+public class urn_perun_member_attribute_def_def_mailTest {
+
+	private urn_perun_member_attribute_def_def_mail classInstance;
+	private PerunSessionImpl session;
+	private Attribute attributeToCheck;
+	private Member member;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_member_attribute_def_def_mail();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		session = mock(PerunSessionImpl.class);
+		member = mock(Member.class);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNull() throws Exception {
+		System.out.println("testCheckNull()");
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSemantics(session, member, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckEmailSyntax() throws Exception {
+		System.out.println("testCheckEmailSyntax()");
+		attributeToCheck.setValue("a/-+");
+		classInstance.checkAttributeSyntax(session, member, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("my@example.com");
+		classInstance.checkAttributeSemantics(session, member, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("my@example.com");
+		classInstance.checkAttributeSyntax(session, member, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_membershipExpirationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_membershipExpirationTest.java
@@ -31,10 +31,10 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 
 	@Test
 	public void testCheckAttributeReturnNull() throws Exception {
-		System.out.println("testCheckAttriubuteReturnNull()");
+		System.out.println("testCheckAttributeReturnNull()");
 		attributeToCheck.setValue(null);
 
-		classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+		classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 	}
 
 	@Test
@@ -42,7 +42,7 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		System.out.println("testCheckAttributeCommonValue()");
 		attributeToCheck.setValue("2001-12-25");
 
-		classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+		classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 	}
 
 	@Test
@@ -50,7 +50,7 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		System.out.println("testCheckAttributeLowBorderValue()");
 		attributeToCheck.setValue("1000-01-01");
 
-		classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+		classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 	}
 
 	@Test
@@ -58,14 +58,14 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		System.out.println("testCheckAttributeHighBorderValue()");
 		attributeToCheck.setValue("9999-12-31");
 
-		classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+		classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
 		public void testCheckAttributeWrongMonths() throws Exception {
 			System.out.println("testCheckAttributeWrongMonth()");
 			attributeToCheck.setValue("1500-15-25");
-			classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+			classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 
 		}
 
@@ -73,7 +73,7 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		public void testCheckAttributeWrongYears() throws Exception {
 			System.out.println("testCheckAttributeWrongYear()");
 			attributeToCheck.setValue("500-10-25");
-			classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+			classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 
 		}
 
@@ -81,7 +81,7 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		public void testCheckAttributeWrongDays() throws Exception {
 			System.out.println("testCheckAttributeWrongDay()");
 			attributeToCheck.setValue("1500-10-32");
-			classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+			classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 
 		}
 
@@ -89,7 +89,7 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		public void testCheckAttributeWrongMonthWithBadDaysValueTime() throws Exception {
 			System.out.println("testCheckAttributeWrongMonthWithBadDaysValueTime()");
 			attributeToCheck.setValue("3595-11-31");
-			classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+			classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 
 		}
 
@@ -97,7 +97,7 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		public void testCheckAttributeWrongCharInDate() throws Exception {
 			System.out.println("testCheckAttributeWrongCharsInDate()");
 			attributeToCheck.setValue("3595-11-31s");
-			classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+			classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 
 		}
 
@@ -105,7 +105,7 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		public void testCheckAttributeWrongCharsBetweenDate() throws Exception {
 			System.out.println("testCheckAttributeWrongCharsBetweenDate()");
 			attributeToCheck.setValue("3595.11.31");
-			classInstance.checkAttributeSemantics(session, new Member(), attributeToCheck);
+			classInstance.checkAttributeSyntax(session, new Member(), attributeToCheck);
 
 		}
 
@@ -114,6 +114,6 @@ public class urn_perun_member_attribute_def_def_membershipExpirationTest {
 		System.out.println("testCheckAttriubuteReturnNull()");
 		Attribute attribute = classInstance.fillAttribute(session, new Member(), classInstance.getAttributeDefinition());
 		assertNull("Test", attribute.getValue());
-		classInstance.checkAttributeSemantics(session, new Member(), attribute);
+		classInstance.checkAttributeSyntax(session, new Member(), attribute);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_phoneTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_def_phoneTest.java
@@ -1,0 +1,66 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import com.google.common.collect.Lists;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests attribute module.
+ */
+public class urn_perun_member_attribute_def_def_phoneTest {
+
+	private urn_perun_member_attribute_def_def_phone classInstance;
+	private PerunSessionImpl session;
+	private Attribute attributeToCheck;
+	private Member member;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_member_attribute_def_def_phone();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		session = mock(PerunSessionImpl.class);
+		member = mock(Member.class);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNull() throws Exception {
+		System.out.println("testCheckNull()");
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSemantics(session, member, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckType() throws Exception {
+		System.out.println("testCheckType()");
+		attributeToCheck.setValue(Lists.newArrayList("+420123456789"));
+		classInstance.checkAttributeSyntax(session, member, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckEmailSyntax() throws Exception {
+		System.out.println("testCheckEmailSyntax()");
+		attributeToCheck.setValue("a/-+");
+		classInstance.checkAttributeSyntax(session, member, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("+420123456789");
+		classInstance.checkAttributeSemantics(session, member, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("+420123456789");
+		classInstance.checkAttributeSyntax(session, member, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_virt_loaTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_attribute_def_virt_loaTest.java
@@ -1,0 +1,60 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests attribute module.
+ */
+public class urn_perun_member_attribute_def_virt_loaTest {
+
+	private urn_perun_member_attribute_def_virt_loa classInstance;
+	private PerunSessionImpl session;
+	private Attribute attributeToCheck;
+	private Member member;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_member_attribute_def_virt_loa();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		attributeToCheck.setId(101);
+		session = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		UsersManagerBl um = mock(UsersManagerBl.class);
+		User user = mock(User.class);
+		member = mock(Member.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+		when(session.getPerunBl().getUsersManagerBl()).thenReturn(um);
+		when(session.getPerunBl().getUsersManagerBl().getUserById(session, member.getUserId())).thenReturn(user);
+		UserExtSource userExtSource = mock(UserExtSource.class);
+		when(userExtSource.getLoa()).thenReturn(1);
+		when(session.getPerunBl().getUsersManagerBl().getActiveUserExtSources(session, user)).thenReturn(Collections.singletonList(userExtSource));
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNotHighestValue() throws Exception {
+		System.out.println("testCheckNotHighestValue()");
+		attributeToCheck.setValue("0");
+		classInstance.checkAttributeSemantics(session, member, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("1");
+		classInstance.checkAttributeSemantics(session, member, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in member attribute modules
- also added test for checks