### PR TITLE
(Un)SetRole privileges

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/impl/Privileges.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/impl/Privileges.java
@@ -1,0 +1,134 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.api.Role;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static cz.metacentrum.perun.core.api.Role.CABINETADMIN;
+import static cz.metacentrum.perun.core.api.Role.FACILITYADMIN;
+import static cz.metacentrum.perun.core.api.Role.GROUPADMIN;
+import static cz.metacentrum.perun.core.api.Role.PERUNADMIN;
+import static cz.metacentrum.perun.core.api.Role.PERUNOBSERVER;
+import static cz.metacentrum.perun.core.api.Role.RESOURCEADMIN;
+import static cz.metacentrum.perun.core.api.Role.RESOURCESELFSERVICE;
+import static cz.metacentrum.perun.core.api.Role.SECURITYADMIN;
+import static cz.metacentrum.perun.core.api.Role.SPONSOR;
+import static cz.metacentrum.perun.core.api.Role.TOPGROUPCREATOR;
+import static cz.metacentrum.perun.core.api.Role.VOADMIN;
+import static cz.metacentrum.perun.core.api.Role.VOOBSERVER;
+
+/**
+ * This class defines role setting privileges.
+ *
+ * This class contains information about which roles can set given role.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class Privileges {
+
+	private static Map<Role, Set<Role>> rolePrivileges = new HashMap<>();
+
+	static {
+		initialize();
+	}
+
+	private static void initialize() {
+		role(FACILITYADMIN).canBeManagedBy(
+			FACILITYADMIN
+		);
+
+		role(GROUPADMIN).canBeManagedBy(
+			GROUPADMIN,
+			VOADMIN
+		);
+
+		role(PERUNADMIN).canBeManagedBy(
+			PERUNADMIN
+		);
+
+		role(RESOURCEADMIN).canBeManagedBy(
+			RESOURCEADMIN,
+			VOADMIN
+		);
+
+		role(RESOURCESELFSERVICE).canBeManagedBy(
+			RESOURCEADMIN,
+			VOADMIN
+		);
+
+		role(SPONSOR).canBeManagedBy(
+			VOADMIN
+		);
+
+		role(TOPGROUPCREATOR).canBeManagedBy(
+			VOADMIN
+		);
+
+		role(VOADMIN).canBeManagedBy(
+			VOADMIN
+		);
+
+		role(VOOBSERVER).canBeManagedBy(
+			VOOBSERVER,
+			VOADMIN
+		);
+
+		role(PERUNOBSERVER).canBeManagedBy(
+			PERUNOBSERVER
+		);
+
+		role(SECURITYADMIN).canBeManagedBy(
+			SECURITYADMIN
+		);
+
+		role(CABINETADMIN).canBeManagedBy(
+			CABINETADMIN
+		);
+	}
+
+	/**
+	 * Returns roles which are allowed to set given role.
+	 *
+	 * @param role role
+	 * @return set of roles which can set the given role, null if no configuration is set for given role
+	 */
+	public static Set<Role> getRolesWhichCanManageRole(Role role) {
+		return rolePrivileges.get(role);
+	}
+	/**
+	 * Helper method for fluent code.
+	 */
+	private static RoleSet role(Role role) {
+		return new RoleSet(role);
+	}
+
+	/**
+	 * Helper class for fluent code.
+	 *
+	 * Represents state of privileges configuration.
+	 */
+	private static class RoleSet {
+		private Role role;
+
+		private RoleSet(Role role) {
+			this.role = role;
+		}
+
+		/**
+		 * Defines which role can set previously specified role.
+		 *
+		 * @param allowedRoles roles that are allowed to set the previously specified role.
+		 */
+		private void canBeManagedBy(Role... allowedRoles) {
+			if (!rolePrivileges.containsKey(role)) {
+				rolePrivileges.put(role, new HashSet<>());
+			}
+			for (Role allowedRole : allowedRoles) {
+				rolePrivileges.get(role).add(allowedRole);
+			}
+		}
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -16,9 +16,11 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.AuthzRoles;
+import cz.metacentrum.perun.core.impl.Privileges;
 import cz.metacentrum.perun.core.impl.Utils;
 
 import java.util.List;
+import java.util.Set;
 
 public class AuthzResolver {
 
@@ -446,6 +448,19 @@ public class AuthzResolver {
 	}
 
 	/**
+	 * Check if principal is allowed to manage the given role to the given object.
+	 *
+	 * @param sess session
+	 * @param complementaryObject complementary object
+	 * @param role role
+	 * @return true, if the current principal can unset the given role for the given object, false otherwise
+	 * @throws InternalErrorException internal error
+	 */
+	public static boolean isAuthorizedToManageRole(PerunSession sess, PerunBean complementaryObject, Role role) throws InternalErrorException {
+		return hasOneOfTheRolesForObject(sess, complementaryObject, Privileges.getRolesWhichCanManageRole(role));
+	}
+
+	/**
 	 * Set role for user and <b>all</b> complementary objects.
 	 *
 	 * If some complementary object is wrong for the role, throw an exception.
@@ -457,11 +472,9 @@ public class AuthzResolver {
 	 * @param complementaryObjects objects for which role will be set
 	 */
 	public static void setRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, PrivilegeException, UserNotExistsException, AlreadyAdminException {
-		Utils.notNull(role, "role");
-		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
-
-		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
-		AuthzResolverBlImpl.setRole(sess, user, role, complementaryObjects);
+		for (PerunBean complementaryObject : complementaryObjects) {
+			setRole(sess, user, complementaryObject, role);
+		}
 	}
 
 	/**
@@ -478,8 +491,10 @@ public class AuthzResolver {
 	public static void setRole(PerunSession sess, User user, PerunBean complementaryObject, Role role) throws  InternalErrorException, PrivilegeException, UserNotExistsException, AlreadyAdminException {
 		Utils.notNull(role, "role");
 		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
+		if(!isAuthorizedToManageRole(sess, complementaryObject, role)) {
+			throw new PrivilegeException("You are not privileged to use this method setRole.");
+		}
 
-		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
 		AuthzResolverBlImpl.setRole(sess, user,complementaryObject, role);
 	}
 
@@ -495,11 +510,9 @@ public class AuthzResolver {
 	 * @param complementaryObjects objects for which role will be set
 	 */
 	public static void setRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, PrivilegeException, GroupNotExistsException, AlreadyAdminException {
-		Utils.notNull(role, "role");
-		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
-
-		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
-		AuthzResolverBlImpl.setRole(sess, authorizedGroup, role, complementaryObjects);
+		for (PerunBean complementaryObject : complementaryObjects) {
+			setRole(sess, authorizedGroup, complementaryObject, role);
+		}
 	}
 
 	/**
@@ -517,7 +530,10 @@ public class AuthzResolver {
 		Utils.notNull(role, "role");
 		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
 
-		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
+		if(!isAuthorizedToManageRole(sess, complementaryObject, role)) {
+			throw new PrivilegeException("You are not privileged to use this method setRole.");
+		}
+
 		AuthzResolverBlImpl.setRole(sess, authorizedGroup, complementaryObject, role);
 	}
 
@@ -533,11 +549,9 @@ public class AuthzResolver {
 	 * @param complementaryObjects objects for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, User user, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, PrivilegeException, UserNotExistsException, UserNotAdminException {
-		Utils.notNull(role, "role");
-		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
-
-		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method unsetRole.");
-		AuthzResolverBlImpl.unsetRole(sess, user, role, complementaryObjects);
+		for (PerunBean complementaryObject : complementaryObjects) {
+			unsetRole(sess, user, complementaryObject, role);
+		}
 	}
 
 	/**
@@ -555,7 +569,9 @@ public class AuthzResolver {
 		Utils.notNull(role, "role");
 		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
 
-		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method unsetRole.");
+		if (!isAuthorizedToManageRole(sess, complementaryObject, role)) {
+			throw new PrivilegeException("You are not privileged to change the given role for the given object.");
+		}
 		AuthzResolverBlImpl.unsetRole(sess, user, complementaryObject, role);
 	}
 
@@ -571,11 +587,9 @@ public class AuthzResolver {
 	 * @param complementaryObjects objects for which role will be unset
 	 */
 	public static void unsetRole(PerunSession sess, Group authorizedGroup, Role role, List<PerunBean> complementaryObjects) throws InternalErrorException, PrivilegeException, GroupNotExistsException, GroupNotAdminException {
-		Utils.notNull(role, "role");
-		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
-
-		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
-		AuthzResolverBlImpl.unsetRole(sess, authorizedGroup, role, complementaryObjects);
+		for (PerunBean complementaryObject : complementaryObjects) {
+			unsetRole(sess, authorizedGroup, complementaryObject, role);
+		}
 	}
 
 	/**
@@ -593,7 +607,9 @@ public class AuthzResolver {
 		Utils.notNull(role, "role");
 		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, authorizedGroup);
 
-		if(!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method setRole.");
+		if (!isAuthorizedToManageRole(sess, complementaryObject, role)) {
+			throw new PrivilegeException("You are not privileged to change the given role for the given object.");
+		}
 		AuthzResolverBlImpl.unsetRole(sess, authorizedGroup, complementaryObject, role);
 	}
 
@@ -729,5 +745,26 @@ public class AuthzResolver {
 	 */
 	public static void refreshAuthz(PerunSession sess) throws InternalErrorException {
 		AuthzResolverBlImpl.refreshAuthz(sess);
+	}
+
+	/**
+	 * This methods verifies if the current principal has one of the given roles for the given object.
+	 *
+	 * @param sess session
+	 * @param complementaryObject complementary object
+	 * @param allowedRoles set of roles which are tested
+	 * @return true, if the principal is authorized, false otherwise
+	 * @throws InternalErrorException internal error
+	 */
+	public static boolean hasOneOfTheRolesForObject(PerunSession sess, PerunBean complementaryObject, Set<Role> allowedRoles) throws InternalErrorException {
+		if (allowedRoles == null) {
+			throw new InternalErrorException("Unsupported role.");
+		}
+		for (Role allowedRole : allowedRoles) {
+			if (isAuthorized(sess, allowedRole, complementaryObject)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/PrivilegesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/PrivilegesTest.java
@@ -1,0 +1,21 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.api.Role;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class PrivilegesTest {
+
+	@Test
+	public void testGetRolesWhichCanManageRole() {
+		Set<Role> allowedRoles = Privileges.getRolesWhichCanManageRole(Role.GROUPADMIN);
+
+		assertThat(allowedRoles).containsOnly(Role.GROUPADMIN, Role.VOADMIN);
+	}
+}


### PR DESCRIPTION
* The old implementation of the (un)setRole methods were allowed only
for PerunAdmins. But it makes sence to allow this method be called by
other users who are e.g. VoAdmins.
* The new implementation tests if the current principal has one of the
needed roles for given object to change the desired role.
* Created class named Privileges which is responsible for configuration
of which roles can (un)set other roles.