### PR TITLE
CORE, GUI, CLI: Support new windows destinations

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/Destination.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/Destination.java
@@ -1,7 +1,5 @@
 package cz.metacentrum.perun.core.api;
 
-import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
-
 /**
  * Destination where services are propagated.
  *
@@ -16,6 +14,8 @@ public class Destination extends Auditable implements Comparable<PerunBean> {
 	public final static String DESTINATIONUSERHOSTTYPE = "user@host";
 	public final static String DESTINATIONUSERHOSTPORTTYPE = "user@host:port";
 	public final static String DESTINATIONSERVICESPECIFICTYPE = "service-specific";
+	public final static String DESTINATIONWINDOWS = "user@host-windows";
+	public final static String DESTINATIONWINDOWSPROXY = "host-windows-proxy";
 
 	public static final String PROPAGATIONTYPE_PARALLEL = "PARALLEL";
 	public static final String PROPAGATIONTYPE_SERIAL = "SERIAL";
@@ -79,7 +79,7 @@ public class Destination extends Auditable implements Comparable<PerunBean> {
 
 	/**
 	 * 	Gets the propagation type for this instance.
-	 * 
+	 *
 	 *  @return The propagation type, either "PARALLEL", "SERIAL" or "DUMMY"
 	 */
 	public String getPropagationType() {
@@ -90,7 +90,8 @@ public class Destination extends Auditable implements Comparable<PerunBean> {
 	 * Gets the hostname from destination
 	 * e.g. if destination is type user@host then return host
 	 * e.g. if destination is type user@host:port then return host
-	 * if destination is other type then those two, return destination without changes
+	 * e.g. if destination is type user@host-windows then return host-windows
+	 * if destination is other type then these three, return destination without changes
 	 *
 	 * if there is no chars @ and :, return not changed type
 	 * if type is null, return this destination without changes
@@ -102,7 +103,7 @@ public class Destination extends Auditable implements Comparable<PerunBean> {
 		if(this.destination == null) return this.destination;
 		if(this.type == null) return this.destination;
 
-		if(this.type.equals(DESTINATIONUSERHOSTPORTTYPE) || this.type.equals(DESTINATIONUSERHOSTTYPE)) {
+		if(this.type.equals(DESTINATIONUSERHOSTPORTTYPE) || this.type.equals(DESTINATIONUSERHOSTTYPE) || this.type.equals(DESTINATIONWINDOWS)) {
 			int startIndex = this.destination.indexOf('@');
 			int endIndex = this.destination.indexOf(':');
 			if(startIndex == -1) return this.destination;

--- a/perun-cli/addFacilityDestination
+++ b/perun-cli/addFacilityDestination
@@ -15,7 +15,7 @@ sub help {
 	--facilityName | -F facility name
 	--serviceId    | -s service id
 	--destination  | -D destination string
-	--type         | -t destination type (host/email/url)
+	--type         | -t destination type (host/user\@host/user\@host:port/user\@host-windows/host-windows-proxy/email/semail/url/service-specific)
 	--batch        | -b batch
 	--help         | -h prints this help
 

--- a/perun-cli/createFacilityLike
+++ b/perun-cli/createFacilityLike
@@ -18,7 +18,7 @@ sub help {
 	--fromNumber     | -o numbering of nodes starts from
 	--toNumber       | -d numbering of nodes ends to
 	--specialNodes   | -p list of special node names
-	--skipFacCretion | -s skip creation of facility
+	--skipFacCreation | -s skip creation of facility
 	--batch          | -b batch
 	--help           | -h prints this help
 
@@ -32,10 +32,10 @@ GetOptions ("help|h"   => sub {
 		print help();
 		exit 0;
 	}, "batch|b"       => \$batch,
-	"likeFacility|l=s" => \$likeFacility, 
+	"likeFacility|l=s" => \$likeFacility,
 	"facilityDsc|D=s" => \$facilityDescription,
 	"nodeName|n=s"     => \$nodeName,
-	"fromNumber|o=i"   => \$fromNumber, 
+	"fromNumber|o=i"   => \$fromNumber,
 	"toNumber|d=i" => \$toNumber,
 	'specialNodes|p=s@{0,}' => \@specnodes,
 	"skipFacCreation|s" => \$skipFac,
@@ -91,7 +91,7 @@ unless ($skipFac) {
 	}
 
 	$facilitiesAgent->addHosts( facility => $facilityId, hostnames => \@hosts );
-	
+
 	printMessage("Hosts '@hosts' successfully added on the facility Id:$facilityId", $batch);
 
 	# pridani special nodes
@@ -137,7 +137,7 @@ foreach my $resourceO (@resourcesO) {
 	$resourceName =~ s/$likeFacility/$facilityName/;
 	$resource->setName( $resourceName );
 	my $resourceDescription=$resourceO->getDescription;
-	$resourceDescription =~ s/$likeFacility/$facilityName/; 
+	$resourceDescription =~ s/$likeFacility/$facilityName/;
 	$resource->setDescription( $resourceDescription);
 #	$resource->setVoId($voId);
 #	$resource->setFacilityId($facilityId);

--- a/perun-cli/removeFacilityDestination
+++ b/perun-cli/removeFacilityDestination
@@ -15,7 +15,7 @@ sub help {
 	--facilityName | -F facility name
 	--serviceId    | -s service id
 	--destination  | -D destination
-	--type         | -t destination type
+	--type         | -t destination type (host/user\@host/user\@host:port/user\@host-windows/host-windows-proxy/email/semail/url/service-specific)
 	--batch        | -b batch
 	--help         | -h prints this help
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -456,7 +456,9 @@ public class ServicesManagerEntry implements ServicesManager {
 		List<Facility> facilitiesByDestination = new ArrayList<>();
 		if(destination.getType().equals(Destination.DESTINATIONHOSTTYPE) ||
 				destination.getType().equals(Destination.DESTINATIONUSERHOSTTYPE) ||
-				destination.getType().equals(Destination.DESTINATIONUSERHOSTPORTTYPE)) {
+				destination.getType().equals(Destination.DESTINATIONUSERHOSTPORTTYPE) ||
+				destination.getType().equals(Destination.DESTINATIONWINDOWS) ||
+				destination.getType().equals(Destination.DESTINATIONWINDOWSPROXY)) {
 			facilitiesByHostname = getPerunBl().getFacilitiesManagerBl().getFacilitiesByHostName(perunSession, destination.getHostNameFromDestination());
 			if(facilitiesByHostname.isEmpty()) facilitiesByDestination = getPerunBl().getFacilitiesManagerBl().getFacilitiesByDestination(perunSession, destination.getHostNameFromDestination());
 
@@ -509,7 +511,9 @@ public class ServicesManagerEntry implements ServicesManager {
 		List<Facility> facilitiesByDestination = new ArrayList<>();
 		if(destination.getType().equals(Destination.DESTINATIONHOSTTYPE) ||
 				destination.getType().equals(Destination.DESTINATIONUSERHOSTTYPE) ||
-				destination.getType().equals(Destination.DESTINATIONUSERHOSTPORTTYPE)) {
+				destination.getType().equals(Destination.DESTINATIONUSERHOSTPORTTYPE) ||
+				destination.getType().equals(Destination.DESTINATIONWINDOWS) ||
+				destination.getType().equals(Destination.DESTINATIONWINDOWSPROXY)) {
 			facilitiesByHostname = getPerunBl().getFacilitiesManagerBl().getFacilitiesByHostName(sess, destination.getHostNameFromDestination());
 			if(facilitiesByHostname.isEmpty()) facilitiesByDestination = getPerunBl().getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination.getHostNameFromDestination());
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1091,7 +1091,9 @@ public class Utils {
 				&& (!Objects.equals(destinationType, Destination.DESTINATIONURLTYPE))
 				&& (!Objects.equals(destinationType, Destination.DESTINATIONUSERHOSTTYPE))
 				&& (!Objects.equals(destinationType, Destination.DESTINATIONUSERHOSTPORTTYPE))
-				&& (!Objects.equals(destinationType, Destination.DESTINATIONSERVICESPECIFICTYPE)))) {
+				&& (!Objects.equals(destinationType, Destination.DESTINATIONSERVICESPECIFICTYPE))
+				&& (!Objects.equals(destinationType, Destination.DESTINATIONWINDOWS))
+				&& (!Objects.equals(destinationType, Destination.DESTINATIONWINDOWSPROXY)))) {
 			throw new WrongPatternException("Destination type " + destinationType + " is not supported.");
 		}
 	}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityDestinationTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/facilitiestabs/AddFacilityDestinationTabItem.java
@@ -101,6 +101,8 @@ public class AddFacilityDestinationTabItem implements TabItem {
 		type.addItem("HOST","host");
 		type.addItem("USER@HOST", "user@host");
 		type.addItem("USER@HOST:PORT", "user@host:port");
+		type.addItem("USER@HOST-WINDOWS","user@host-windows");
+		type.addItem("HOST-WINDOWS-PROXY","host-windows-proxy");
 		type.addItem("URL","url");
 		type.addItem("MAIL","email");
 		type.addItem("SIGNED MAIL","semail");
@@ -199,7 +201,7 @@ public class AddFacilityDestinationTabItem implements TabItem {
 					return false;
 				}
 				// check as email
-				if (type.getSelectedIndex() > 3 && type.getSelectedIndex() < 6) {
+				if (type.getSelectedIndex() > 5 && type.getSelectedIndex() < 8) {
 					if (!JsonUtils.isValidEmail(destination.getSuggestBox().getText().trim())) {
 						destination.setError("Not valid email address.");
 						return false;
@@ -225,7 +227,7 @@ public class AddFacilityDestinationTabItem implements TabItem {
 					destination.getSuggestBox().setEnabled(true);
 				}
 
-				if (type.getSelectedIndex() < 3) {
+				if (type.getSelectedIndex() < 5) {
 					destination.getSuggestOracle().clear();
 					for (Host h : hosts) {
 						destination.getSuggestOracle().add(h.getName());
@@ -242,12 +244,16 @@ public class AddFacilityDestinationTabItem implements TabItem {
 				} else if (type.getSelectedIndex() == 2) {
 					destinationLabel.getElement().setInnerHTML("<strong>User@host:port:</strong>");
 				} else if (type.getSelectedIndex() == 3) {
-					destinationLabel.getElement().setInnerHTML("<strong>URL:</strong>");
+					destinationLabel.getElement().setInnerHTML("<strong>User@host-windows:</strong>");
 				} else if (type.getSelectedIndex() == 4) {
-					destinationLabel.getElement().setInnerHTML("<strong>Mail:</strong>");
+					destinationLabel.getElement().setInnerHTML("<strong>Host-Windows-Proxy:</strong>");
 				} else if (type.getSelectedIndex() == 5) {
-					destinationLabel.getElement().setInnerHTML("<strong>Signed mail:</strong>");
+					destinationLabel.getElement().setInnerHTML("<strong>URL:</strong>");
 				} else if (type.getSelectedIndex() == 6) {
+					destinationLabel.getElement().setInnerHTML("<strong>Mail:</strong>");
+				} else if (type.getSelectedIndex() == 7) {
+					destinationLabel.getElement().setInnerHTML("<strong>Signed mail:</strong>");
+				} else if (type.getSelectedIndex() == 8) {
 					destinationLabel.getElement().setInnerHTML("<strong>Service specific:</strong>");
 				}
 


### PR DESCRIPTION
- Added constants and checks for new windows type destinations.
- They are expected to contains hostname or user@hostname values,
  hence we treat them as standard host like destinations when they
  are added.
- Added support for their setting from GUI.
- Added support in CLI (documentation, whitespace/typo fixes).