### PR TITLE
ExtSource implements ExtSourceSimpleApi

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/ExtSource.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/ExtSource.java
@@ -1,6 +1,11 @@
 package cz.metacentrum.perun.core.api;
 
-import java.util.HashMap;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
+import cz.metacentrum.perun.core.interfaces.ExtSourceSimpleApi;
+
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -8,7 +13,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSource extends Auditable implements Comparable<PerunBean>{
+public class ExtSource extends Auditable implements ExtSourceSimpleApi, Comparable<PerunBean>{
 
 	private String name;
 	private String type;
@@ -126,5 +131,40 @@ public class ExtSource extends Auditable implements Comparable<PerunBean>{
 		} else {
 			return (this.getId() - perunBean.getId());
 		}
+	}
+
+	@Override
+	public List<Map<String, String>> findSubjectsLogins(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
+	public List<Map<String, String>> findSubjectsLogins(String searchString, int maxResults) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
+	public Map<String, String> getSubjectByLogin(String login) throws InternalErrorException, SubjectNotExistsException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
+	public void close() throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
+	}
+
+	@Override
+	public List<Map<String, String>> getUsersSubjects() throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		throw new ExtSourceUnsupportedOperationException();
 	}
 }

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/interfaces/ExtSourceApi.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/interfaces/ExtSourceApi.java
@@ -1,7 +1,8 @@
-package cz.metacentrum.perun.core.implApi;
+package cz.metacentrum.perun.core.interfaces;
 
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.interfaces.ExtSourceSimpleApi;
 
 import java.util.List;
 import java.util.Map;

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/interfaces/ExtSourceSimpleApi.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/interfaces/ExtSourceSimpleApi.java
@@ -1,4 +1,4 @@
-package cz.metacentrum.perun.core.implApi;
+package cz.metacentrum.perun.core.interfaces;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -32,7 +32,6 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.bl.ExtSourcesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import cz.metacentrum.perun.core.implApi.ExtSourcesManagerImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -173,7 +172,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 
 			// Check if the login is still present in the extSource
 			try {
-				((ExtSourceSimpleApi) source).getSubjectByLogin(userLogin);
+				source.getSubjectByLogin(userLogin);
 			} catch (SubjectNotExistsException e) {
 				invalidUsers.add(user);
 			} catch (ExtSourceUnsupportedOperationException e) {
@@ -222,7 +221,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 		// Get the subject from the extSource
 		Map<String, String> subject;
 		try {
-			subject = ((ExtSourceSimpleApi) source).getSubjectByLogin(login);
+			subject = source.getSubjectByLogin(login);
 		} catch (SubjectNotExistsException e) {
 			throw new CandidateNotExistsException(login);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -41,7 +41,6 @@ import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberGroupStatus;
 import cz.metacentrum.perun.core.api.MembershipType;
 import cz.metacentrum.perun.core.api.Pair;
-import cz.metacentrum.perun.core.api.PerunBeanProcessingPool;
 import cz.metacentrum.perun.core.api.PerunClient;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -107,8 +106,8 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.SynchronizationPool;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceSimpleApi;
 import cz.metacentrum.perun.core.implApi.GroupsManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule;
 import org.slf4j.Logger;
@@ -2945,7 +2944,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		//-- Get Subjects in form of map where left string is name of attribute and right string is value of attribute, every subject is one map
 		List<Map<String, String>> subjects;
 		try {
-			subjects = ((ExtSourceSimpleApi) source).getGroupSubjects(groupAttributesMap);
+			subjects = source.getGroupSubjects(groupAttributesMap);
 			log.debug("Group synchronization {}: external group contains {} members.", group, subjects.size());
 		} catch (ExtSourceUnsupportedOperationException e2) {
 			throw new InternalErrorException("ExtSource " + source.getName() + " doesn't support getGroupSubjects", e2);
@@ -3468,7 +3467,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		//Close open extSources (not empty ones) if they support this operation
 		if(membersSource != null) {
 			try {
-				((ExtSourceSimpleApi) membersSource).close();
+				membersSource.close();
 			} catch (ExtSourceUnsupportedOperationException e) {
 				// ExtSource doesn't support that functionality, so silently skip it.
 			} catch (InternalErrorException e) {
@@ -3477,7 +3476,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		}
 		if(source != null) {
 			try {
-				((ExtSourceSimpleApi) source).close();
+				source.close();
 			} catch (ExtSourceUnsupportedOperationException e) {
 				// ExtSource doesn't support that functionality, so silently skip it.
 			} catch (InternalErrorException e) {
@@ -3823,7 +3822,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		List<Map<String, String>> subjects;
 		try {
-			subjects = ((ExtSourceSimpleApi) source).getSubjectGroups(groupAttributesMap);
+			subjects = source.getSubjectGroups(groupAttributesMap);
 			log.debug("Group synchronization {}: external source contains {} group.", group, subjects.size());
 		} catch (ExtSourceUnsupportedOperationException e2) {
 			throw new InternalErrorException("ExtSource " + source.getName() + " doesn't support getSubjectGroups", e2);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -80,8 +80,8 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Auditer;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceSimpleApi;
 import cz.metacentrum.perun.core.implApi.MembersManagerImplApi;
 import cz.metacentrum.perun.core.implApi.modules.attributes.AbstractMembershipExpirationRulesModule;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
@@ -641,7 +641,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		try {
 			if (extSource instanceof ExtSourceApi) {
 				//get first subject, then create candidate
-				Map<String, String> subject = ((ExtSourceSimpleApi) extSource).getSubjectByLogin(login);
+				Map<String, String> subject = extSource.getSubjectByLogin(login);
 				candidate = (getPerunBl().getExtSourcesManagerBl().getCandidate(sess, subject, extSource, login));
 			} else if (extSource instanceof ExtSourceSimpleApi) {
 				// get candidates from external source by login

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -15,7 +15,6 @@ import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberCandidate;
 import cz.metacentrum.perun.core.api.Pair;
-import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichUser;
@@ -44,8 +43,7 @@ import cz.metacentrum.perun.core.bl.MembersManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.bl.VosManagerBl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import cz.metacentrum.perun.core.implApi.VosManagerImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -256,7 +254,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 							simpleExtSource = false;
 						} else {
 							// find subjects only with logins - they then must be retrieved by login
-							subjects = ((ExtSourceSimpleApi) source).findSubjectsLogins(searchString, maxNumOfResults);
+							subjects = source.findSubjectsLogins(searchString, maxNumOfResults);
 						}
 					} catch (ExtSourceUnsupportedOperationException e1) {
 						log.warn("ExtSource {} doesn't support findSubjects", source.getName());
@@ -266,7 +264,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 						continue;
 					} finally {
 						try {
-							((ExtSourceSimpleApi) source).close();
+							source.close();
 						} catch (ExtSourceUnsupportedOperationException e) {
 							// ExtSource doesn't support that functionality, so silently skip it.
 						} catch (InternalErrorException e) {
@@ -375,7 +373,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 							simpleExtSource = false;
 						} else {
 							// find subjects only with logins - they then must be retrieved by login
-							subjects = ((ExtSourceSimpleApi) source).findSubjectsLogins(searchString);
+							subjects = source.findSubjectsLogins(searchString);
 						}
 					} catch (ExtSourceUnsupportedOperationException e1) {
 						log.warn("ExtSource {} doesn't support findSubjects", source.getName());
@@ -385,7 +383,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 						continue;
 					} finally {
 						try {
-							((ExtSourceSimpleApi) source).close();
+							source.close();
 						} catch (ExtSourceUnsupportedOperationException e) {
 							// ExtSource doesn't support that functionality, so silently skip it.
 						} catch (InternalErrorException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -9,7 +9,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationExc
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceEGISSO.java
@@ -4,7 +4,7 @@ import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
@@ -16,7 +16,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationExc
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -8,7 +8,6 @@ import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +26,7 @@ import java.util.Map;
 /**
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceISMU extends ExtSource {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceISMU.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
@@ -5,7 +5,6 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +16,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceIdp extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceIdp extends ExtSource {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceIdp.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
@@ -5,7 +5,6 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +16,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceInternal extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceInternal extends ExtSource {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceInternal.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
@@ -5,7 +5,6 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +16,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceKerberos extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceKerberos extends ExtSource {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceKerberos.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -6,7 +6,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationExc
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -13,7 +13,7 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import cz.metacentrum.perun.rpc.deserializer.JsonDeserializer;
 import org.apache.http.HttpResponse;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
@@ -12,7 +12,7 @@ import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -8,7 +8,6 @@ import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.rt.InternalErrorRuntimeException;
 import cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +31,7 @@ import java.util.Properties;
 /**
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceSql extends ExtSource {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceSql.class);
 	private static final Map<String, String> attributeNameMapping = new HashMap<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSqlComplex.java
@@ -2,7 +2,7 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 
 import java.util.List;
 import java.util.Map;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceTCS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceTCS.java
@@ -15,7 +15,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidCertificateException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.util.io.pem.PemObject;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
@@ -7,7 +7,7 @@ import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
@@ -6,7 +6,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationExc
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
@@ -5,7 +5,6 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +16,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceX509 extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceX509 extends ExtSource {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceX509.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -6,7 +6,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationExc
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
-import cz.metacentrum.perun.core.implApi.ExtSourceApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceApi;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
@@ -15,7 +15,7 @@ import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.impl.ExtSourceLdap;
-import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
+import cz.metacentrum.perun.core.interfaces.ExtSourceSimpleApi;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
* making ExtSource implement ExtSourceSimpleApi so that classes inheriting from ExtSource don't have to implement it themselves

* this required moving ExtSourceSimpleApi to perun-base, I have also moved ExtSourceApi (so that they wouldn't be separated but ExtSourceApi doesn't have to be in perun-base so it's up to you, ExtSource might implement that as well.