### PR TITLE
Separation of checkAttributeSyntax from semantics in Group modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -145,15 +145,16 @@ public interface ModulesUtilsBl {
 	/**
 	 * Check if gid in arguments is free in the namespace
 	 *
-	 * @param sess
+	 * @param sess perun session
 	 * @param attribute group or resource unixGID-namespace attribute with value
 	 *
-	 * @throws InternalErrorException
-	 * @throws WrongAttributeAssignmentException
-	 * @throws AttributeNotExistsException
-	 * @throws WrongAttributeValueException
+	 * @throws InternalErrorException if something is not correct or attribute is null
+	 * @throws WrongAttributeAssignmentException if attribute does not belong to appropriate entity
+	 * @throws AttributeNotExistsException if attribute does not exist
+	 * @throws WrongAttributeValueException if the attribute value has wrong/illegal syntax
+	 * @throws WrongReferenceAttributeValueException if the attribute value has wrong/illegal semantics
 	 */
-	void checkIfGIDIsWithinRange(PerunSessionImpl sess, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongAttributeValueException;
+	void checkIfGIDIsWithinRange(PerunSessionImpl sess, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Return true if i have right on any of groups or resources to WRITE the attribute

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -229,7 +229,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	}
 
 	@Override
-	public void checkIfGIDIsWithinRange(PerunSessionImpl sess, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongAttributeValueException {
+	public void checkIfGIDIsWithinRange(PerunSessionImpl sess, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		Utils.notNull(attribute, "attribute");
 		Integer gid = null;
 		if(attribute.getValue() != null) gid = (Integer) attribute.getValue();
@@ -243,7 +243,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 
 		//Gid is not in range, throw exception
 		if(!isGIDWithinRanges(gidRanges, gid)) {
-			throw new WrongAttributeValueException(attribute, "GID number is not in allowed ranges " + gidRanges + " for namespace " + gidNamespace);
+			throw new WrongReferenceAttributeValueException(attribute, gidRangesAttribute, null, null, gidNamespace, null, "GID number is not in allowed ranges " + gidRanges + " for namespace " + gidNamespace);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_authoritativeGroup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_authoritativeGroup.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.VosManager;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
@@ -25,15 +26,20 @@ public class urn_perun_group_attribute_def_def_authoritativeGroup extends GroupA
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_group_attribute_def_def_authoritativeGroup.class);
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
 
-		//Member group can't have set this attribute
-		if(group.getName().equals(VosManager.MEMBERS_GROUP)) throw new WrongAttributeValueException(attribute, group, "Members group is authoritative automatic, there is not allowed to set this attribute for members group.");
-	
-		Integer value = (Integer) attribute.getValue();
+		Integer value = attribute.valueAsInteger();
 		if(value < 0 || value > 1) throw new WrongAttributeValueException(attribute, group, "Attribute can have only value 1 or 0 (true or false).");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongReferenceAttributeValueException {
+		//Null value is ok, means no settings for group
+		if (attribute.getValue() == null) return;
+		//Member group can't have set this attribute
+		if(group.getName().equals(VosManager.MEMBERS_GROUP)) throw new WrongReferenceAttributeValueException(attribute, null, group, null, "Members group is authoritative automatic, there is not allowed to set this attribute for members group.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_collectionID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_collectionID.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
@@ -17,18 +18,9 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModul
 public class urn_perun_group_attribute_def_def_collectionID extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongReferenceAttributeValueException {
 		// null attribute
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Attribute collectionID cannot be null.");
-
-		// wrong type of the attribute
-		if (!(attribute.getValue() instanceof String)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: String");
-
-		String collectionID = attribute.valueAsString();
-
-		if (collectionID.isEmpty()) {
-			throw new WrongAttributeValueException(attribute, "Attribute collectionID cannot be empty.");
-		}
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Attribute collectionID cannot be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabled.java
@@ -9,6 +9,7 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.AttributesManagerBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
@@ -30,7 +31,7 @@ public class urn_perun_group_attribute_def_def_flatGroupStructureEnabled extends
 	private static final String MANDATORY_ATTRIBUTE_NAME = GroupsManager.GROUPS_STRUCTURE_SYNCHRO_ENABLED_ATTRNAME;
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
 
@@ -38,7 +39,7 @@ public class urn_perun_group_attribute_def_def_flatGroupStructureEnabled extends
 		try {
 			Attribute foundAttribute = attributeManager.getAttribute(perunSession, group, MANDATORY_ATTRIBUTE_NAME);
 			if(foundAttribute == null || foundAttribute.getValue() == null) {
-				throw new WrongAttributeAssignmentException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " must be defined first.");
+				throw new WrongReferenceAttributeValueException(attribute, foundAttribute, group, null, group, null, "Attribute " + MANDATORY_ATTRIBUTE_NAME + " must be defined first.");
 			}
 		} catch (AttributeNotExistsException exc) {
 			throw new ConsistencyErrorException("Attribute " + MANDATORY_ATTRIBUTE_NAME + " is supposed to exist", exc);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_fromEmail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_fromEmail.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
@@ -21,9 +22,9 @@ public class urn_perun_group_attribute_def_def_fromEmail  extends GroupAttribute
 	private static final Pattern pattern = Pattern.compile("^\".+\" <.+>$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
 		// null attribute
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Group fromEmail cannot be null.");
+		if (attribute.getValue() == null) return;
 
 		// wrong type of the attribute
 		if (!(attribute.getValue() instanceof String)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: String");
@@ -45,6 +46,12 @@ public class urn_perun_group_attribute_def_def_fromEmail  extends GroupAttribute
 				}
 			}
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null)
+			throw new WrongReferenceAttributeValueException(attribute, "Group fromEmail cannot be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_googleGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_googleGroupName_namespace.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
@@ -26,10 +27,10 @@ public class urn_perun_group_attribute_def_def_googleGroupName_namespace extends
 	private static final Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9']+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//prepare groupName value variable
 		String groupName = null;
-		if(attribute.getValue() != null) groupName = (String) attribute.getValue();
+		if(attribute.getValue() != null) groupName = attribute.valueAsString();
 
 		if(groupName == null) {
 			// if this is group attribute, its ok
@@ -40,6 +41,12 @@ public class urn_perun_group_attribute_def_def_googleGroupName_namespace extends
 
 		//TODO Check reserved google group names
 		//sess.getPerunBl().getModulesUtilsBl().checkReservedGoogleGroupNames(attribute);
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		// null value is ok
+		if (attribute.getValue() == null) return;
 
 		//prepare lists of groups with the same groupName value in the same namespace
 
@@ -58,7 +65,7 @@ public class urn_perun_group_attribute_def_def_googleGroupName_namespace extends
 				}
 			}
 			//if not, than can't use already used groupName
-			if(!haveRights) throw new WrongAttributeValueException(attribute, group, "GroupName is already used in this namespace: " + attribute.getFriendlyNameParameter() + " and you haven't right to use it.");
+			if(!haveRights) throw new WrongReferenceAttributeValueException(attribute, null, group, null, "GroupName is already used in this namespace: " + attribute.getFriendlyNameParameter() + " and you haven't right to use it.");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupExtSource.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupExtSource.java
@@ -9,7 +9,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleImplApi;
@@ -24,10 +24,10 @@ import java.util.List;
 public class urn_perun_group_attribute_def_def_groupExtSource extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		//prepare groupName value variable
 		String extSourceName = null;
-		if(attribute.getValue() != null) extSourceName = (String) attribute.getValue();
+		if(attribute.getValue() != null) extSourceName = attribute.valueAsString();
 
 		//if extSourceName is null, attribute can be removed
 		if (extSourceName != null) {
@@ -37,7 +37,7 @@ public class urn_perun_group_attribute_def_def_groupExtSource extends GroupAttri
 				for(ExtSource es: allowedExtSources) {
 					if(extSourceName.equals(es.getName())) return;
 				}
-				throw new WrongAttributeValueException(attribute, group, "ExtSourceName " + extSourceName + " is not valid, because VO " + groupVo + " of this group has no such extSource assigned.");
+				throw new WrongReferenceAttributeValueException(attribute, null, group, null, "ExtSourceName " + extSourceName + " is not valid, because VO " + groupVo + " of this group has no such extSource assigned.");
 			} catch (VoNotExistsException ex) {
 				throw new ConsistencyErrorException("Vo of this group " + group + " not exists!");
 			}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationInterval.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationInterval.java
@@ -9,7 +9,6 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
@@ -21,14 +20,14 @@ import java.util.List;
 public class urn_perun_group_attribute_def_def_groupStructureSynchronizationInterval extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
 
 		try {
 			Attribute foundAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUP_STRUCTURE_SYNCHRO_TIMES_ATTRNAME);
 			if(foundAttribute.getValue() != null) {
-				throw new WrongAttributeAssignmentException("Attribute " + attribute.getName() + " cannot be set because attribute " + GroupsManager.GROUP_STRUCTURE_SYNCHRO_TIMES_ATTRNAME + " is already set.");
+				throw new WrongReferenceAttributeValueException(attribute, foundAttribute, group, null, group, null, "Attribute " + attribute.getName() + " cannot be set because attribute " + GroupsManager.GROUP_STRUCTURE_SYNCHRO_TIMES_ATTRNAME + " is already set.");
 			}
 		} catch (AttributeNotExistsException exc) {
 			throw new ConsistencyErrorException("Attribute " + GroupsManager.GROUP_STRUCTURE_SYNCHRO_TIMES_ATTRNAME + " is supposed to exist", exc);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationTimes.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationTimes.java
@@ -19,18 +19,9 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationTime
 	private static final Pattern pattern = Pattern.compile("^(([0-1][0-9])|(2[0-3])):[0-5][0,5]$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
-
-		try {
-			Attribute foundAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME);
-			if(foundAttribute.getValue() != null) {
-				throw new WrongAttributeAssignmentException("Attribute " + attribute.getName() + " cannot be set because attribute " + GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME + " is already set.");
-			}
-		} catch (AttributeNotExistsException exc) {
-			throw new ConsistencyErrorException("Attribute " + GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME + " is supposed to exist", exc);
-		}
 
 		ArrayList<String> attrValues = attribute.valueAsList();
 
@@ -42,8 +33,18 @@ public class urn_perun_group_attribute_def_def_groupStructureSynchronizationTime
 		}
 	}
 
-
-
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		if (attribute.getValue() == null) return;
+		try {
+			Attribute foundAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME);
+			if(foundAttribute.getValue() != null) {
+				throw new WrongReferenceAttributeValueException(attribute, foundAttribute, group, null, group, null, "Attribute " + attribute.getName() + " cannot be set because attribute " + GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME + " is already set.");
+			}
+		} catch (AttributeNotExistsException exc) {
+			throw new ConsistencyErrorException("Attribute " + GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME + " is supposed to exist", exc);
+		}
+	}
 
 	@Override
 	public List<String> getDependencies() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupSynchronizationInterval.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupSynchronizationInterval.java
@@ -9,7 +9,6 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModuleAbstract;
@@ -21,14 +20,14 @@ import java.util.List;
 public class urn_perun_group_attribute_def_def_groupSynchronizationInterval extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
 
 		try {
 			Attribute foundAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUP_SYNCHRO_TIMES_ATTRNAME);
 			if(foundAttribute.getValue() != null) {
-				throw new WrongAttributeAssignmentException("Attribute " + attribute.getName() + " cannot be set because attribute " + GroupsManager.GROUP_SYNCHRO_TIMES_ATTRNAME + " is already set.");
+				throw new WrongReferenceAttributeValueException(attribute, foundAttribute, group, null, group, null, "Attribute " + attribute.getName() + " cannot be set because attribute " + GroupsManager.GROUP_SYNCHRO_TIMES_ATTRNAME + " is already set.");
 			}
 		} catch (AttributeNotExistsException exc) {
 			throw new ConsistencyErrorException("Attribute " + GroupsManager.GROUP_SYNCHRO_TIMES_ATTRNAME + " is supposed to exist", exc);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupSynchronizationTimes.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupSynchronizationTimes.java
@@ -20,18 +20,9 @@ public class urn_perun_group_attribute_def_def_groupSynchronizationTimes extends
 	private static final Pattern pattern = Pattern.compile("^(([0-1][0-9])|(2[0-3])):[0-5][0,5]$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
-
-		try {
-			Attribute foundAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
-			if(foundAttribute.getValue() != null) {
-				throw new WrongAttributeAssignmentException("Attribute " + attribute.getName() + " cannot be set because attribute " + GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME + " is already set.");
-			}
-		} catch (AttributeNotExistsException exc) {
-			throw new ConsistencyErrorException("Attribute " + GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME + " is supposed to exist", exc);
-		}
 
 		ArrayList<String> attrValues = attribute.valueAsList();
 
@@ -43,7 +34,18 @@ public class urn_perun_group_attribute_def_def_groupSynchronizationTimes extends
 		}
 	}
 
-
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeAssignmentException, InternalErrorException, WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) return;
+		try {
+			Attribute foundAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME);
+			if(foundAttribute.getValue() != null) {
+				throw new WrongReferenceAttributeValueException(attribute, foundAttribute, group, null, group, null, "Attribute " + attribute.getName() + " cannot be set because attribute " + GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME + " is already set.");
+			}
+		} catch (AttributeNotExistsException exc) {
+			throw new ConsistencyErrorException("Attribute " + GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME + " is supposed to exist", exc);
+		}
+	}
 
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationTimestamp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationTimestamp.java
@@ -25,16 +25,16 @@ import java.util.Date;
 public class urn_perun_group_attribute_def_def_lastSynchronizationTimestamp extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
 
 		//test of timestamp format
-		String attrValue = (String) attribute.getValue();
+		String attrValue = attribute.valueAsString();
 		try {
 			Date date = BeansUtils.getDateFormatter().parse(attrValue);
 		} catch (ParseException ex) {
-			throw new WrongAttributeValueException(attribute, group, "Format of timestamp is not correct and can't be parsed correctly. Ex. 'dd-MM-yyyy HH:mm:ss'", ex);
+			throw new WrongAttributeValueException(attribute, group, "Format of timestamp is not correct and can't be parsed correctly. Ex. 'yyyy-MM-dd HH:mm:ss.S'", ex);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabled.java
@@ -27,30 +27,35 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.GroupAttributesModul
 public class urn_perun_group_attribute_def_def_synchronizationEnabled extends GroupAttributesModuleAbstract implements GroupAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//Null value is ok, means no settings for group
 		if(attribute.getValue() == null) return;
 
-		String attrValue = (String) attribute.getValue();
+		String attrValue = attribute.valueAsString();
 
 		if(!attrValue.equals("true") && !attrValue.equals("false")) {
 			throw new WrongAttributeValueException(attribute, group, "If attribute is not null, only string 'true' or 'false' is correct format.");
 		}
-			try {
-				if (attrValue.equals("true")) {
-					Attribute requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
-					if (requiredAttribute.getValue() == null) {
-						throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
-					}
+	}
 
-					requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPEXTSOURCE_ATTRNAME);
-					if (requiredAttribute.getValue() == null) {
-						throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, requiredAttribute.toString() + " must be set in order to enable synchronization.");
-					}
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeAssignmentException, InternalErrorException, WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) return;
+		try {
+			if (attribute.valueAsString().equals("true")) {
+				Attribute requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
+				if (requiredAttribute.getValue() == null) {
+					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, group, null, group, null, requiredAttribute.toString() + " must be set in order to enable synchronization.");
 				}
-			} catch (AttributeNotExistsException e) {
-				throw new ConsistencyErrorException(e);
+
+				requiredAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPEXTSOURCE_ATTRNAME);
+				if (requiredAttribute.getValue() == null) {
+					throw new WrongReferenceAttributeValueException(attribute, requiredAttribute, group, null, group, null, requiredAttribute.toString() + " must be set in order to enable synchronization.");
+				}
 			}
+		} catch (AttributeNotExistsException e) {
+			throw new ConsistencyErrorException(e);
+		}
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AbstractMembershipExpirationRulesModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AbstractMembershipExpirationRulesModule.java
@@ -2,7 +2,6 @@ package cz.metacentrum.perun.core.implApi.modules.attributes;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.PerunBean;
-import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
@@ -31,11 +30,7 @@ public abstract class AbstractMembershipExpirationRulesModule<T extends PerunBea
 	public static final String membershipPeriodLoaKeyName = "periodLoa";
 	public static final String membershipDoNotAllowLoaKeyName = "doNotAllowLoa";
 
-	public void checkAttributeSyntax(PerunSessionImpl perunSession, T entity, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
-
-	}
-
-	public void checkAttributeSemantics(PerunSessionImpl sess, T entity, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, T entity, Attribute attribute) throws WrongAttributeValueException {
 		Map<String, String> attrValue;
 
 		//For no value is correct (it means no rules)
@@ -123,6 +118,10 @@ public abstract class AbstractMembershipExpirationRulesModule<T extends PerunBea
 				}
 			}
 		}
+	}
+
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, T entity, Attribute attribute) {
+
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupAttributesModuleAbstract.java
@@ -24,7 +24,7 @@ public abstract class GroupAttributesModuleAbstract extends AttributesModuleAbst
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupAttributesModuleImplApi.java
@@ -36,11 +36,11 @@ public interface GroupAttributesModuleImplApi extends AttributesModuleImplApi{
 	 * @param attribute attribute to check
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
-	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongReferenceAttributeValueException if the attribute value has wrong/illegal semantics
+	 * @throws WrongAttributeAssignmentException if attribute does not belong to appropriate entity
 	 */
 
-	void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * This method MAY fill an attribute at the specified resource.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.QuotaNotInAllowedLimitException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_entityless_attribute_def_def_namespace_GIDRanges;
@@ -280,7 +281,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 				else a.setValue(100005);
 				try {
 					modulesUtilsBl.checkIfGIDIsWithinRange((PerunSessionImpl) sess, a);
-				} catch (WrongAttributeValueException ex) {
+				} catch (WrongReferenceAttributeValueException ex) {
 					i++;
 				}
 			}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_authoritativeGroupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_authoritativeGroupTest.java
@@ -1,0 +1,71 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.VosManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_attribute_def_def_authoritativeGroupTest {
+
+	private urn_perun_group_attribute_def_def_authoritativeGroup classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_authoritativeGroup();
+		sess = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckSmallValue() throws Exception {
+		System.out.println("testCheckSmallValue()");
+		attributeToCheck.setValue(-1);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckHighValue() throws Exception {
+		System.out.println("testCheckHighValue()");
+		attributeToCheck.setValue(2);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckMemberGroup() throws Exception {
+		System.out.println("testCheckHighValue()");
+		attributeToCheck.setValue(1);
+		group.setName(VosManager.MEMBERS_GROUP);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+
+		attributeToCheck.setValue(0);
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+
+		attributeToCheck.setValue(1);
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_collectionIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_collectionIDTest.java
@@ -1,0 +1,42 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_attribute_def_def_collectionIDTest {
+
+	private urn_perun_group_attribute_def_def_collectionID classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_collectionID();
+		sess = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNullValue() throws Exception {
+		System.out.println("testCheckNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("0");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabledTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_flatGroupStructureEnabledTest.java
@@ -1,0 +1,53 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_flatGroupStructureEnabledTest {
+
+	private urn_perun_group_attribute_def_def_flatGroupStructureEnabled classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private AttributesManagerBl attributesManagerBl;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_flatGroupStructureEnabled();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+
+		attributesManagerBl = mock(AttributesManagerBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithoutMandatoryAttributeSemantics() throws Exception {
+		System.out.println("testCheckWithoutMandatoryAttributeSemantics()");
+		when(attributesManagerBl.getAttribute(sess, group, GroupsManager.GROUPS_STRUCTURE_SYNCHRO_ENABLED_ATTRNAME)).thenReturn(null);
+		attributeToCheck.setValue(true);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		when(attributesManagerBl.getAttribute(sess, group, GroupsManager.GROUPS_STRUCTURE_SYNCHRO_ENABLED_ATTRNAME)).thenReturn(attributeToCheck);
+		attributeToCheck.setValue(true);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_fromEmailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_fromEmailTest.java
@@ -1,0 +1,73 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_fromEmailTest {
+
+	private urn_perun_group_attribute_def_def_fromEmail classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private ModulesUtilsBl modulesUtilsBl;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_fromEmail();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+		modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongTypeOfValue() throws Exception {
+		System.out.println("testWrongTypeOfValue()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		String correctValue = "my@example.com";
+		when(modulesUtilsBl.isNameOfEmailValid(sess, correctValue)).thenReturn(true);
+		String correctValue2 = "\"my example\" <my@example.com>";
+		when(modulesUtilsBl.isNameOfEmailValid(sess, correctValue2)).thenReturn(true);
+
+		attributeToCheck.setValue(correctValue);
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+
+		attributeToCheck.setValue(correctValue2);
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testNullValue() throws Exception {
+		System.out.println("testNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("\"my example\" <my@example.com>");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_googleGroupName_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_googleGroupName_namespaceTest.java
@@ -1,0 +1,45 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_googleGroupName_namespaceTest {
+
+	private urn_perun_group_attribute_def_def_googleGroupName_namespace classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_googleGroupName_namespace();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongSyntax() throws Exception {
+		System.out.println("testWrongSyntax()");
+		attributeToCheck.setValue("???");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("my_example");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupExtSourceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupExtSourceTest.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.ExtSourcesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.VosManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_groupExtSourceTest {
+
+	private urn_perun_group_attribute_def_def_groupExtSource classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_groupExtSource();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(perunBl.getGroupsManagerBl()).thenReturn(groupsManagerBl);
+
+		Vo groupVo = mock(Vo.class);
+		VosManagerBl vosManagerBl = mock(VosManagerBl.class);
+		when(perunBl.getVosManagerBl()).thenReturn(vosManagerBl);
+		when(sess.getPerunBl().getVosManagerBl().getVoById(sess, group.getVoId())).thenReturn(groupVo);
+
+		ExtSource extSource = new ExtSource(1, "my_example", "type");
+		ExtSourcesManagerBl extSourcesManagerBl = mock(ExtSourcesManagerBl.class);
+		when(sess.getPerunBl().getExtSourcesManagerBl()).thenReturn(extSourcesManagerBl);
+		when(sess.getPerunBl().getExtSourcesManagerBl().getVoExtSources(sess, groupVo)).thenReturn(Collections.singletonList(extSource));
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testWrongSemantics() throws Exception {
+		System.out.println("testWrongSemantics()");
+		attributeToCheck.setValue("my_bad_example");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("my_example");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabledTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabledTest.java
@@ -1,0 +1,76 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabledTest {
+
+	private urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Attribute reqAttribute;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_groupStructureSynchronizationEnabled();
+		reqAttribute = new Attribute(classInstance.getAttributeDefinition());
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+		when(sess.getPerunBl().getGroupsManagerBl().isGroupSynchronizedFromExternallSource(sess, group)).thenReturn(false);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROENABLED_ATTRNAME)).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSQUERY_ATTRNAME)).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME)).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPEXTSOURCE_ATTRNAME)).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testGroupSyncEnabled() throws Exception {
+		System.out.println("testGroupSyncEnabled()");
+		attributeToCheck.setValue(true);
+		reqAttribute.setValue("true");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testMissingReqAttribute() throws Exception {
+		System.out.println("testMissingReqAttribute()");
+		attributeToCheck.setValue(true);
+		reqAttribute.setValue("false");
+		Attribute attribute = new Attribute();
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSQUERY_ATTRNAME)).thenReturn(attribute);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue(true);
+		reqAttribute.setValue("false");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationIntervalTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationIntervalTest.java
@@ -1,0 +1,55 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_groupStructureSynchronizationIntervalTest {
+	private urn_perun_group_attribute_def_def_groupStructureSynchronizationInterval classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Attribute reqAttribute;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_groupStructureSynchronizationInterval();
+		reqAttribute = new Attribute(classInstance.getAttributeDefinition());
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUP_STRUCTURE_SYNCHRO_TIMES_ATTRNAME)).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testMissingReqAttribute() throws Exception {
+		System.out.println("testMissingReqAttribute()");
+		attributeToCheck.setValue("value");
+		reqAttribute.setValue("value");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("value");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationTimesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupStructureSynchronizationTimesTest.java
@@ -1,0 +1,84 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_groupStructureSynchronizationTimesTest {
+
+	private urn_perun_group_attribute_def_def_groupStructureSynchronizationTimes classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Attribute syncInterval;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_groupStructureSynchronizationTimes();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		syncInterval = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+		when(sess.getPerunBl().getGroupsManagerBl().isGroupSynchronizedFromExternallSource(sess, group)).thenReturn(false);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUP_STRUCTURE_SYNCHRO_INTERVAL_ATTRNAME)).thenReturn(syncInterval);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testMissingReqAttribute() throws Exception {
+		System.out.println("testMissingReqAttribute()");
+		attributeToCheck.setValue(Collections.singleton("08:50"));
+		syncInterval.setValue("true");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongSyntax() throws Exception {
+		System.out.println("testWrongSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("08:51");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("08:50");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupSynchronizationIntervalTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupSynchronizationIntervalTest.java
@@ -1,0 +1,53 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_groupSynchronizationIntervalTest {
+	private urn_perun_group_attribute_def_def_groupSynchronizationInterval classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Attribute syncTimes;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_groupSynchronizationInterval();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		syncTimes = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUP_SYNCHRO_TIMES_ATTRNAME)).thenReturn(syncTimes);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testMissingReqAttribute() throws Exception {
+		System.out.println("testMissingReqAttribute()");
+		syncTimes.setValue("true");
+		attributeToCheck.setValue("value");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("value");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupSynchronizationTimesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_groupSynchronizationTimesTest.java
@@ -1,0 +1,85 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_groupSynchronizationTimesTest {
+
+	private urn_perun_group_attribute_def_def_groupSynchronizationTimes classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Attribute syncInterval;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_groupSynchronizationTimes();
+		syncInterval = new Attribute(classInstance.getAttributeDefinition());
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+		when(sess.getPerunBl().getGroupsManagerBl().isGroupSynchronizedFromExternallSource(sess, group)).thenReturn(false);
+
+		AttributesManagerBl attributesManagerBl;
+		attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME)).thenReturn(syncInterval);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testMissingReqAttribute() throws Exception {
+		System.out.println("testMissingReqAttribute()");
+		attributeToCheck.setValue(Collections.singletonList("08:50"));
+		syncInterval.setValue("true");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongSyntax() throws Exception {
+		System.out.println("testWrongSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("08:51");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("08:50");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationTimestampTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_lastSynchronizationTimestampTest.java
@@ -1,0 +1,89 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_attribute_def_def_lastSynchronizationTimestampTest {
+
+	private urn_perun_group_attribute_def_def_lastSynchronizationTimestamp classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_lastSynchronizationTimestamp();
+		sess = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+	}
+
+	@Test
+	public void testCheckAttributeReturnNull() throws Exception {
+		System.out.println("testCheckAttriubuteReturnNull()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckCorrectSyntax() throws Exception {
+		System.out.println("testCheckCorrectSyntax()");
+		attributeToCheck.setValue("2001-12-25 22:22:22.0");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongMonths() throws Exception {
+		System.out.println("testCheckAttributeWrongMonth()");
+		attributeToCheck.setValue("1500-15-25 22:22:22.0");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongTime() throws Exception {
+		System.out.println("testCheckAttributeWrongYear()");
+		attributeToCheck.setValue("500-10-25 25:22:22.0");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongDays() throws Exception {
+		System.out.println("testCheckAttributeWrongDay()");
+		attributeToCheck.setValue("1500-10-32 22:22:22.0");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongMonthWithBadDaysValueTime() throws Exception {
+		System.out.println("testCheckAttributeWrongMonthWithBadDaysValueTime()");
+		attributeToCheck.setValue("3595-11-31 22:22:22.0");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongCharInDate() throws Exception {
+		System.out.println("testCheckAttributeWrongCharsInDate()");
+		attributeToCheck.setValue("3595-11-31s 22:22:22.0");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongCharsBetweenDate() throws Exception {
+		System.out.println("testCheckAttributeWrongCharsBetweenDate()");
+		attributeToCheck.setValue("3595.11.31 22:22:22.0");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabledTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_synchronizationEnabledTest.java
@@ -1,0 +1,83 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_synchronizationEnabledTest {
+
+	private urn_perun_group_attribute_def_def_synchronizationEnabled classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Attribute reqAttribute;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_synchronizationEnabled();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		reqAttribute = new Attribute(classInstance.getAttributeDefinition());
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+		when(sess.getPerunBl().getGroupsManagerBl().isGroupSynchronizedFromExternallSource(sess, group)).thenReturn(false);
+
+		AttributesManagerBl attributesManagerBl;
+		attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME)).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, GroupsManager.GROUPEXTSOURCE_ATTRNAME)).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testMissingReqAttribute() throws Exception {
+		System.out.println("testMissingReqAttribute()");
+		attributeToCheck.setValue("true");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("true");
+		reqAttribute.setValue("value");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongSyntax() throws Exception {
+		System.out.println("testWrongSyntax()");
+		attributeToCheck.setValue("value");
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+
+		attributeToCheck.setValue("true");
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+
+		attributeToCheck.setValue("false");
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
+	}
+
+
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGID_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGID_namespaceTest.java
@@ -4,18 +4,126 @@
  */
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import org.junit.Ignore;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
 import org.junit.Test;
 
-/**
- *
- * @author Norexan
- */
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class urn_perun_group_attribute_def_def_unixGID_namespaceTest {
+	private urn_perun_group_attribute_def_def_unixGID_namespace classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Attribute reqAttribute;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_unixGID_namespace();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly name");
+		reqAttribute = new Attribute();
+		reqAttribute.setFriendlyName("friendly name");
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+		when(sess.getPerunBl().getGroupsManagerBl().isGroupSynchronizedFromExternallSource(sess, group)).thenReturn(false);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace" + ":" + attributeToCheck.getNamespace())).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, "", AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":usedGids")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:")).thenReturn(reqAttribute);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(sess.getPerunBl().getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		ResourcesManagerBl resourcesManagerBl = mock(ResourcesManagerBl.class);
+		when(sess.getPerunBl().getResourcesManagerBl()).thenReturn(resourcesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testUnixGroupNameSet() throws Exception {
+		System.out.println("testUnixGroupNameSet()");
+		Set<String> set = new HashSet<>();
+		set.add(attributeToCheck.getNamespace());
+		when(sess.getPerunBl().getModulesUtilsBl().getSetOfGroupNameNamespacesWhereFacilitiesHasTheSameGIDNamespace(sess, new ArrayList<>(), attributeToCheck)).thenReturn(set);
+		reqAttribute.setValue("value");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testDepletedGIDValue() throws Exception {
+		System.out.println("testDepletedGIDValue()");
+		attributeToCheck.setValue(5);
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("D5", "value");
+		reqAttribute.setValue(map);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testGroupWithSameGID() throws Exception {
+		System.out.println("testGroupWithSameGID()");
+		attributeToCheck.setValue(5);
+		Group group2 = new Group(2,"group2","Group 2",null,null,null,null,0,0);
+		when(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, attributeToCheck)).thenReturn(Arrays.asList(group, group2));
+		when(sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:")).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveTheSameAttributeWithTheSameNamespace(sess, group2, attributeToCheck)).thenReturn(2);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testResourceWithSameGID() throws Exception {
+		System.out.println("testResourceWithSameGID()");
+		attributeToCheck.setValue(5);
+		Resource resource = mock(Resource.class);
+		when(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, attributeToCheck)).thenReturn(Collections.singletonList(resource));
+		when(sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:")).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveTheSameAttributeWithTheSameNamespace(sess, resource, attributeToCheck)).thenReturn(2);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
 
 	@Test
-	@Ignore
-	public void testCheckAttributeSemantics() {
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue(5);
 
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSyntax(sess, group, attributeToCheck);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGroupName_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGroupName_namespaceTest.java
@@ -1,0 +1,90 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_attribute_def_def_unixGroupName_namespaceTest {
+	private urn_perun_group_attribute_def_def_unixGroupName_namespace classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_attribute_def_def_unixGroupName_namespace();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("unixGID-namespace");
+
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:")).thenReturn(attributeToCheck);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+		when(sess.getPerunBl().getGroupsManagerBl().isGroupSynchronizedFromExternallSource(sess, group)).thenReturn(false);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(sess.getPerunBl().getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		ResourcesManagerBl resourcesManagerBl = mock(ResourcesManagerBl.class);
+		when(sess.getPerunBl().getResourcesManagerBl()).thenReturn(resourcesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testGroupWithSameGID() throws Exception {
+		System.out.println("testGroupWithSameGID()");
+		attributeToCheck.setValue("my name");
+		Group group2 = new Group(2,"group2","Group 2",null,null,null,null,0,0);
+		List<Group> listOfGroups = new ArrayList<>();
+		listOfGroups.add(group2);
+		when(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, attributeToCheck)).thenReturn(listOfGroups);
+		when(sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGID-namespace:")).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveRightToWriteAttributeInAnyGroupOrResource(sess, listOfGroups, new ArrayList<>(), attributeToCheck, attributeToCheck)).thenReturn(true);
+		when(sess.getPerunBl().getModulesUtilsBl().haveTheSameAttributeWithTheSameNamespace(sess, group2, attributeToCheck)).thenReturn(2);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testResourceWithSameGID() throws Exception {
+		System.out.println("testResourceWithSameGID()");
+		attributeToCheck.setValue("my name");
+		Resource resource = mock(Resource.class);
+		when(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, attributeToCheck)).thenReturn(Collections.singletonList(resource));
+		when(sess.getPerunBl().getModulesUtilsBl().getListOfResourceGIDsFromListOfGroupGIDs(sess, new ArrayList<>())).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveRightToWriteAttributeInAnyGroupOrResource(sess, new ArrayList<>(), Collections.singletonList(resource), attributeToCheck, attributeToCheck)).thenReturn(true);
+		when(sess.getPerunBl().getModulesUtilsBl().haveTheSameAttributeWithTheSameNamespace(sess, resource, attributeToCheck)).thenReturn(2);
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("my name");
+
+		classInstance.checkAttributeSemantics(sess, group, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in group attribute modules
- also added test for checks