### PR TITLE
Separation of checkAttributeSyntax from semantics in MemberGroup modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpiration.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpiration.java
@@ -21,7 +21,7 @@ import java.util.Date;
  */
 public class urn_perun_member_group_attribute_def_def_groupMembershipExpiration extends MemberGroupAttributesModuleAbstract implements MemberGroupAttributesModuleImplApi {
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws WrongAttributeValueException {
 		String membershipExpTime = (String) attribute.getValue();
 
 		if(membershipExpTime == null) return; // NULL is ok

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpiration.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpiration.java
@@ -22,7 +22,7 @@ import java.util.Date;
 public class urn_perun_member_group_attribute_def_def_groupMembershipExpiration extends MemberGroupAttributesModuleAbstract implements MemberGroupAttributesModuleImplApi {
 	@Override
 	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws WrongAttributeValueException {
-		String membershipExpTime = (String) attribute.getValue();
+		String membershipExpTime = attribute.valueAsString();
 
 		if(membershipExpTime == null) return; // NULL is ok
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_groupStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_groupStatus.java
@@ -27,7 +27,7 @@ public class urn_perun_member_group_attribute_def_virt_groupStatus extends Membe
 	@Override
 	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws WrongAttributeValueException {
 
-		String status = (String) attribute.getValue();
+		String status = attribute.valueAsString();
 
 		if (status == null) return; // NULL is ok
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_groupStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_groupStatus.java
@@ -25,7 +25,7 @@ public class urn_perun_member_group_attribute_def_virt_groupStatus extends Membe
 	final static Logger log = LoggerFactory.getLogger(urn_perun_member_group_attribute_def_virt_groupStatus.class);
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws WrongAttributeValueException {
 
 		String status = (String) attribute.getValue();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupAttributesModuleAbstract.java
@@ -23,7 +23,7 @@ public abstract class MemberGroupAttributesModuleAbstract extends AttributesModu
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberGroupAttributesModuleImplApi.java
@@ -39,10 +39,8 @@ public interface MemberGroupAttributesModuleImplApi extends AttributesModuleImpl
 	 * @param member Member
 	 * @param group Group
 	 * @param attribute Attribute to be checked.
-	 *
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 */
-	void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute) throws WrongAttributeValueException;
+	void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Group group, Attribute attribute);
 
 	/**
 	 * This method MAY fill Member's attributes in a specified group.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpirationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpirationTest.java
@@ -27,7 +27,7 @@ public class urn_perun_member_group_attribute_def_def_groupMembershipExpirationT
 
 	@Test
 	public void testCheckAttributeReturnNull() throws Exception {
-		System.out.println("testCheckAttriubuteReturnNull()");
+		System.out.println("testCheckAttributeReturnNull()");
 		attributeToCheck.setValue(null);
 
 		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpirationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_def_groupMembershipExpirationTest.java
@@ -1,0 +1,107 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_member_group_attribute_def_def_groupMembershipExpirationTest {
+
+
+	private static urn_perun_member_group_attribute_def_def_groupMembershipExpiration classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void SetUp() {
+		classInstance = new urn_perun_member_group_attribute_def_def_groupMembershipExpiration();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+	}
+
+	@Test
+	public void testCheckAttributeReturnNull() throws Exception {
+		System.out.println("testCheckAttriubuteReturnNull()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeCommonValue() throws Exception {
+		System.out.println("testCheckAttributeCommonValue()");
+		attributeToCheck.setValue("2001-12-25");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeLowBorderValue() throws Exception {
+		System.out.println("testCheckAttributeLowBorderValue()");
+		attributeToCheck.setValue("1000-01-01");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeHighBorderValue() throws Exception {
+		System.out.println("testCheckAttributeHighBorderValue()");
+		attributeToCheck.setValue("9999-12-31");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongMonths() throws Exception {
+		System.out.println("testCheckAttributeWrongMonth()");
+		attributeToCheck.setValue("1500-15-25");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongYears() throws Exception {
+		System.out.println("testCheckAttributeWrongYear()");
+		attributeToCheck.setValue("500-10-25");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongDays() throws Exception {
+		System.out.println("testCheckAttributeWrongDay()");
+		attributeToCheck.setValue("1500-10-32");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongMonthWithBadDaysValueTime() throws Exception {
+		System.out.println("testCheckAttributeWrongMonthWithBadDaysValueTime()");
+		attributeToCheck.setValue("3595-11-31");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongCharInDate() throws Exception {
+		System.out.println("testCheckAttributeWrongCharsInDate()");
+		attributeToCheck.setValue("3595-11-31s");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongCharsBetweenDate() throws Exception {
+		System.out.println("testCheckAttributeWrongCharsBetweenDate()");
+		attributeToCheck.setValue("3595.11.31");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_groupStatusTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_group_attribute_def_virt_groupStatusTest.java
@@ -1,0 +1,52 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_member_group_attribute_def_virt_groupStatusTest {
+
+	private static urn_perun_member_group_attribute_def_virt_groupStatus classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void SetUp() {
+		classInstance = new urn_perun_member_group_attribute_def_virt_groupStatus();
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		session = mock(PerunSessionImpl.class);
+	}
+
+	@Test
+	public void testCheckAttributeValueNull() throws Exception {
+		System.out.println("testCheckAttributeValueNull()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeValueCorrect() throws Exception {
+		System.out.println("testCheckAttributeValueCorrect()");
+
+		attributeToCheck.setValue("VALID");
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+
+		attributeToCheck.setValue("EXPIRED");
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeWrongValue() throws Exception {
+		System.out.println("testCheckAttributeWrongValue()");
+		attributeToCheck.setValue("SUSPENDED");
+
+		classInstance.checkAttributeSyntax(session, new Member(), new Group(), attributeToCheck);
+	}
+}


### PR DESCRIPTION
- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in member-group attribute modules
- also added test for checks