### PR TITLE
Separation of checkAttributeSyntax from semantics in Entityless modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2870,7 +2870,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongAttributeAssignmentException if the attribute isn't entityless attribute
 	 */
-	void checkAttributeSemantics(PerunSession sess, String key, Attribute attribute) throws InternalErrorException,WrongAttributeValueException,WrongAttributeAssignmentException;
+	void checkAttributeSemantics(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this user ext source attribute has valid semantics.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -3773,7 +3773,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_ENTITYLESS_ATTR);
 
 		getAttributesManagerImpl().checkAttributeSemantics(sess, key, attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3985,7 +3985,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		EntitylessAttributesModuleImplApi attributeModule = getEntitylessAttributeModule(sess, attribute);
 		if (attributeModule == null) return;
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_dnsStateMapping.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_dnsStateMapping.java
@@ -1,10 +1,7 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
-import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleImplApi;
 
@@ -20,18 +17,6 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributes
  * @author Martin Kuba makub@ics.muni.cz
  */
 public class urn_perun_entityless_attribute_def_def_dnsStateMapping extends EntitylessAttributesModuleAbstract implements EntitylessAttributesModuleImplApi {
-
-	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
-		if(key==null) {
-			throw new WrongAttributeValueException(attribute, "null", "key for this entityless attribute must not be null");
-		}
-
-		if(attribute.getValue() == null) return;
-		if(!(attribute.getValue() instanceof String)) {
-			throw new WrongAttributeValueException(attribute, key, "value must be of type String");
-		}
-	}
 
 	@Override
 	public AttributeDefinition getAttributeDefinition() {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_GIDRanges.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_GIDRanges.java
@@ -19,7 +19,7 @@ import java.util.LinkedHashMap;
 public class urn_perun_entityless_attribute_def_def_namespace_GIDRanges extends EntitylessAttributesModuleAbstract implements EntitylessAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//Check if gid ranges are in correct format (we don't need to use the output of the method there, we want to just check it)
 		perunSession.getPerunBl().getModulesUtilsBl().checkAndConvertGIDRanges(attribute);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_uid_policy.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_uid_policy.java
@@ -21,7 +21,7 @@ public class urn_perun_entityless_attribute_def_def_namespace_uid_policy extends
 	public static final String INCREMENT_POLICY = "increment";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
 		if(attribute.getValue() == null) return;
 		if(!(RECYCLE_POLICY.equals(attribute.getValue()) || INCREMENT_POLICY.equals(attribute.getValue()))) throw new WrongAttributeValueException(attribute, key, "Posible values for this attribute are " + RECYCLE_POLICY + " or " + INCREMENT_POLICY);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailSubject_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailSubject_namespace.java
@@ -1,8 +1,5 @@
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import cz.metacentrum.perun.core.api.Attribute;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
-import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributesModuleAbstract;
 
 /**
@@ -11,13 +8,5 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributes
  * @author Daniel Fecko dano9500@gmail.com
  */
 public class urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailSubject_namespace extends EntitylessAttributesModuleAbstract {
-
-	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
-		if (attribute.getValue() == null) return;
-		if (!(attribute.getValue() instanceof String)) {
-			throw new WrongAttributeValueException(attribute, key, "value must be of type String");
-		}
-	}
 
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailTemplate_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailTemplate_namespace.java
@@ -13,13 +13,10 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.EntitylessAttributes
 public class urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailTemplate_namespace extends EntitylessAttributesModuleAbstract {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
 		if (attribute.getValue() == null) return;
-		if (!(attribute.getValue() instanceof String)) {
-			throw new WrongAttributeValueException(attribute, key, "value must be of type String");
-		}
-		String value = attribute.valueAsString();
-		if (!value.contains("{link}")) {
+
+		if (!attribute.valueAsString().contains("{link}")) {
 			throw new WrongAttributeValueException(attribute, key, "value doesn't contain contain tag {link}");
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_orgAups.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_orgAups.java
@@ -26,13 +26,11 @@ import java.util.Set;
 public class urn_perun_entityless_attribute_def_def_orgAups extends EntitylessAttributesModuleAbstract implements EntitylessAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
 
 		if(attribute.getValue() == null) return;
 
-		Map<String, String> map = (Map<String, String>) attribute.getValue();
-
-		if(map.isEmpty()) return;
+		Map<String, String> map = attribute.valueAsMap();
 
 		Set<String> mapKeys = map.keySet();
 		for(String mapKey: mapKeys) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_usedGids.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_usedGids.java
@@ -36,14 +36,12 @@ public class urn_perun_entityless_attribute_def_def_usedGids extends EntitylessA
 	private static final Pattern valuePattern = Pattern.compile("^[1-9][0-9]*$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, String key, Attribute attribute) throws WrongAttributeValueException {
 		//If this attribute value is null, it means there is no GIDS depleted or used.
 		if(attribute.getValue() == null) return;
 		
-		Map<String, String> map = (Map<String, String>) attribute.getValue();
-		//If there are no keys in map, it means the same like null value
-		if(map.isEmpty()) return;
-		
+		Map<String, String> map = attribute.valueAsMap();
+
 		Set<String> mapKeys = map.keySet();
 		for(String mapKey: mapKeys) {
 			//Test key

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1752,7 +1752,7 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 */
-	void checkAttributeSemantics(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException;
+	void checkAttributeSemantics(PerunSession sess, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this user external source attribute has valid semantics.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/EntitylessAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/EntitylessAttributesModuleAbstract.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
 /**
@@ -22,7 +23,7 @@ public abstract class EntitylessAttributesModuleAbstract extends AttributesModul
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/EntitylessAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/EntitylessAttributesModuleImplApi.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
 /**
@@ -34,11 +35,11 @@ public interface EntitylessAttributesModuleImplApi extends AttributesModuleImplA
 	 * @param attribute attribute to check
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
-	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongReferenceAttributeValueException if the attribute value has wrong/illegal semantics
+	 * @throws WrongAttributeAssignmentException if attribute does not belong to appropriate entity
 	 */
 
-	void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributeSemantics(PerunSessionImpl perunSession, String key, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * This method MAY fill an attribute at the specified resource.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_maxUIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_maxUIDTest.java
@@ -1,0 +1,72 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_entityless_attribute_def_def_namespace_maxUIDTest {
+
+	private static urn_perun_entityless_attribute_def_def_namespace_maxUID classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+	private static String key = "key";
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_entityless_attribute_def_def_namespace_maxUID();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		reqAttribute = new Attribute(classInstance.getAttributeDefinition());
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, key, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minUID")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testValueLesserThan1() throws Exception {
+		System.out.println("testValueLesserThan1()");
+		attributeToCheck.setValue(0);
+
+		classInstance.checkAttributeSyntax(session, key, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testValueLesserThan1()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(session, key, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testValueLesserThanMinUID() throws Exception {
+		System.out.println("testValueLesserThanMinUID()");
+		attributeToCheck.setValue(1);
+		reqAttribute.setValue(2);
+
+		classInstance.checkAttributeSemantics(session, key, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue(2);
+		reqAttribute.setValue(1);
+
+		classInstance.checkAttributeSemantics(session, key, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_minUIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_minUIDTest.java
@@ -1,0 +1,72 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_entityless_attribute_def_def_namespace_minUIDTest {
+
+	private static urn_perun_entityless_attribute_def_def_namespace_minUID classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+	private static String key = "key";
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_entityless_attribute_def_def_namespace_minUID();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+		reqAttribute = new Attribute(classInstance.getAttributeDefinition());
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, key, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-maxUID")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testValueLesserThan1() throws Exception {
+		System.out.println("testValueLesserThan1()");
+		attributeToCheck.setValue(0);
+
+		classInstance.checkAttributeSyntax(session, key, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testValueLesserThan1()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(session, key, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testValueLesserThanMinUID() throws Exception {
+		System.out.println("testValueLesserThanMinUID()");
+		attributeToCheck.setValue(2);
+		reqAttribute.setValue(1);
+
+		classInstance.checkAttributeSemantics(session, key, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue(1);
+		reqAttribute.setValue(2);
+
+		classInstance.checkAttributeSemantics(session, key, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_uid_policyTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_namespace_uid_policyTest.java
@@ -1,0 +1,41 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_entityless_attribute_def_def_namespace_uid_policyTest {
+	private static urn_perun_entityless_attribute_def_def_namespace_uid_policy classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_entityless_attribute_def_def_namespace_uid_policy();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute(classInstance.getAttributeDefinition());
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("wrong value");
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testValueLesserThan1()");
+
+		attributeToCheck.setValue("recycle");
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+
+		attributeToCheck.setValue("increment");
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailTemplate_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailTemplate_namespaceTest.java
@@ -1,0 +1,38 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailTemplate_namespaceTest {
+	private static urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailTemplate_namespace classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_entityless_attribute_def_def_nonAuthzPwdResetMailTemplate_namespace();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingTag() throws Exception {
+		System.out.println("testCheckValueWithMissingTag()");
+		attributeToCheck.setValue("value");
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("{link}");
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_orgAupsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_orgAupsTest.java
@@ -1,0 +1,86 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_entityless_attribute_def_def_orgAupsTest {
+
+	private static urn_perun_entityless_attribute_def_def_orgAups classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_entityless_attribute_def_def_orgAups();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithEmptyValue() throws Exception {
+		System.out.println("testCheckValueWithEmptyValue()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("key", "");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingVersion() throws Exception {
+		System.out.println("testCheckValueWithMissingVersion()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("key", "[{date: date, link: link, text: text}]");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingDate() throws Exception {
+		System.out.println("testCheckValueWithMissingDate()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("key", "[{version: version, link: link, text: text}]");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingLink() throws Exception {
+		System.out.println("testCheckValueWithMissingLink()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("key", "[{version: version, date: date, text: text}]");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingText() throws Exception {
+		System.out.println("testCheckValueWithMissingText()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("key", "[{version: version, date: date, link: link}]");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("key", "[{version: version, date: date, link: link, text: text}]");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_usedGidsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_entityless_attribute_def_def_usedGidsTest.java
@@ -1,0 +1,88 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_entityless_attribute_def_def_usedGidsTest {
+
+	private static urn_perun_entityless_attribute_def_def_usedGids classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_entityless_attribute_def_def_usedGids();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithNullKeyInMap() throws Exception {
+		System.out.println("testCheckValueWithNullKeyInMap()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put(null, "");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithWrongKeyInMap() throws Exception {
+		System.out.println("testCheckValueWithWrongKeyInMap()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("bad value", "");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithNullValueInMap() throws Exception {
+		System.out.println("testCheckValueWithNullValueInMap()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("R11", null);
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithWrongValueInMap() throws Exception {
+		System.out.println("testCheckValueWithWrongValueInMap()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("R11", "bad value");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithDepletedAndUsedValue() throws Exception {
+		System.out.println("testCheckValueWithNullKey()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("R11", "11");
+		value.put("D11", "11");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCheckValueWithNullKey()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("R11", "11");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, "key", attributeToCheck);
+	}
+
+}


### PR DESCRIPTION
- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in entityless attribute modules
- also added test for checks