### PR TITLE
LDAPC: Fixed Resource handling

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunResource.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunResource.java
@@ -1,7 +1,6 @@
 package cz.metacentrum.perun.ldapc.model;
 
 import java.util.List;
-import java.util.Map;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Group;
@@ -19,13 +18,12 @@ public interface PerunResource extends PerunEntry<Resource> {
 	public void deleteResource(Resource resource) throws InternalErrorException;
 
 	/**
-	 * Add resource to LDAP.
+	 * Add resource to LDAP
 	 *
 	 * @param resource resource from Perun
-	 * @param facilityAttributes map of facility attributes to be stored within resource
 	 * @throws InternalErrorException if NameNotFoundException is thrown
 	 */
-	public void addResource(Resource resource, Map<String,String> facilityAttributes) throws InternalErrorException;
+	public void addResource(Resource resource) throws InternalErrorException;
 
 	public void updateResource(Resource resource) throws InternalErrorException;
 

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunResource.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunResource.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.ldapc.model;
 
 import java.util.List;
+import java.util.Map;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Group;
@@ -21,18 +22,18 @@ public interface PerunResource extends PerunEntry<Resource> {
 	 * Add resource to LDAP.
 	 *
 	 * @param resource resource from Perun
-	 * @param entityID entityID if exists, or null if not
+	 * @param facilityAttributes map of facility attributes to be stored within resource
 	 * @throws InternalErrorException if NameNotFoundException is thrown
 	 */
-	public void addResource(Resource resource, String entityID) throws InternalErrorException;
+	public void addResource(Resource resource, Map<String,String> facilityAttributes) throws InternalErrorException;
 
 	public void updateResource(Resource resource) throws InternalErrorException;
-	
+
 	public void assignGroup(Resource resource, Group group) throws InternalErrorException;
-	
+
 	public void removeGroup(Resource resource, Group group) throws InternalErrorException;
 
 	public void synchronizeResource(Resource resource, Iterable<Attribute> attrs, List<Group> assignedGroups) throws InternalErrorException;
-	
+
 	public void synchronizeGroups(Resource resource, List<Group> assignedGroups) throws InternalErrorException;
 }

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunResourceImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunResourceImpl.java
@@ -5,6 +5,7 @@ import static org.springframework.ldap.query.LdapQueryBuilder.query;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.naming.Name;
 
@@ -76,13 +77,15 @@ public class PerunResourceImpl extends AbstractPerunEntry<Resource> implements P
 				);
 	}
 
-	public void addResource(Resource resource, String entityID) throws InternalErrorException {
+	public void addResource(Resource resource, Map<String,String> facilityAttributes) throws InternalErrorException {
 		addEntry(resource);
 		// get info about entityID attribute if exists
-		if(entityID != null) {
+		if (!facilityAttributes.isEmpty()) {
 			try {
 				DirContextOperations context = findByDN(buildDN(resource));
-				context.setAttributeValue(PerunAttribute.PerunAttributeNames.ldapAttrEntityID, entityID);
+				for (String ldapAttrName : facilityAttributes.keySet()) {
+					context.setAttributeValue(ldapAttrName, facilityAttributes.get(ldapAttrName));
+				}
 				ldapTemplate.modifyAttributes(context);
 			} catch (Exception e) {
 				throw new InternalErrorException(e);

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunResourceImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunResourceImpl.java
@@ -47,50 +47,38 @@ public class PerunResourceImpl extends AbstractPerunEntry<Resource> implements P
 						PerunAttribute.PerunAttributeNames.ldapAttrCommonName,
 						PerunAttribute.REQUIRED,
 						(PerunAttribute.SingleValueExtractor<Resource>)(resource, attrs) -> resource.getName()
-						),
+				),
 				new PerunAttributeDesc<>(
 						PerunAttribute.PerunAttributeNames.ldapAttrPerunResourceId,
 						PerunAttribute.REQUIRED,
 						(PerunAttribute.SingleValueExtractor<Resource>)(resource, attrs) -> String.valueOf(resource.getId())
-						),
+				),
 				new PerunAttributeDesc<>(
 						PerunAttribute.PerunAttributeNames.ldapAttrPerunFacilityId,
 						PerunAttribute.REQUIRED,
 						(PerunAttribute.SingleValueExtractor<Resource>)(resource, attrs) -> String.valueOf(resource.getFacilityId())
-						),
+				),
 				new PerunAttributeDesc<>(
 						PerunAttribute.PerunAttributeNames.ldapAttrPerunVoId,
 						PerunAttribute.REQUIRED,
 						(PerunAttribute.SingleValueExtractor<Resource>)(resource, attrs) -> String.valueOf(resource.getVoId())
-						),
+				),
 				new PerunAttributeDesc<>(
 						PerunAttribute.PerunAttributeNames.ldapAttrDescription,
 						PerunAttribute.OPTIONAL,
 						(PerunAttribute.SingleValueExtractor<Resource>)(resource, attrs) -> resource.getDescription()
-						),
+				),
 				new PerunAttributeDesc<>(
 						PerunAttribute.PerunAttributeNames.ldapAttrPerunFacilityDn,
 						PerunAttribute.OPTIONAL,
 						(PerunAttribute.SingleValueExtractor<Resource>)(resource, attrs) -> perunFacility.getEntryDN(String.valueOf(resource.getFacilityId())).toString()
-															+ "," + ldapProperties.getLdapBase()
-						)
-				);
+								+ "," + ldapProperties.getLdapBase()
+				)
+		);
 	}
 
-	public void addResource(Resource resource, Map<String,String> facilityAttributes) throws InternalErrorException {
+	public void addResource(Resource resource) throws InternalErrorException {
 		addEntry(resource);
-		// get info about entityID attribute if exists
-		if (!facilityAttributes.isEmpty()) {
-			try {
-				DirContextOperations context = findByDN(buildDN(resource));
-				for (String ldapAttrName : facilityAttributes.keySet()) {
-					context.setAttributeValue(ldapAttrName, facilityAttributes.get(ldapAttrName));
-				}
-				ldapTemplate.modifyAttributes(context);
-			} catch (Exception e) {
-				throw new InternalErrorException(e);
-			}
-		}
 	}
 
 	public void deleteResource(Resource resource) throws InternalErrorException {
@@ -101,7 +89,6 @@ public class PerunResourceImpl extends AbstractPerunEntry<Resource> implements P
 	@Override
 	public void updateResource(Resource resource) throws InternalErrorException {
 		modifyEntry(resource);
-
 	}
 
 	@Override
@@ -168,7 +155,7 @@ public class PerunResourceImpl extends AbstractPerunEntry<Resource> implements P
 	@Override
 	public List<Name> listEntries() throws InternalErrorException {
 		return ldapTemplate.search(query().
-				where("objectclass").is(PerunAttribute.PerunAttributeNames.objectClassPerunResource),
+						where("objectclass").is(PerunAttribute.PerunAttributeNames.objectClassPerunResource),
 				getNameMapper());
 	}
 

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/CreationEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/CreationEventProcessor.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.ldapc.processor.impl;
 
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ldap.NamingException;
@@ -16,10 +18,18 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.ldapc.model.PerunAttribute;
 import cz.metacentrum.perun.ldapc.processor.EventDispatcher.MessageBeans;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static cz.metacentrum.perun.ldapc.model.PerunAttribute.PerunAttributeNames.perunAttrClientID;
+import static cz.metacentrum.perun.ldapc.model.PerunAttribute.PerunAttributeNames.perunAttrEntityID;
+
 public class CreationEventProcessor extends AbstractEventProcessor {
 
 	private final static Logger log = LoggerFactory.getLogger(CreationEventProcessor.class);
-	
+
 	@Override
 	public void processEvent(String msg, MessageBeans beans) {
 		for(int beanFlag: beans.getPresentBeansFlags()) {
@@ -34,22 +44,22 @@ public class CreationEventProcessor extends AbstractEventProcessor {
 					log.debug("Adding new group: {}", beans.getGroup());
 					perunGroup.addGroup(beans.getGroup());
 					break;
-					
+
 				case MessageBeans.RESOURCE_F:
 					log.debug("Adding new resource: {}", beans.getResource());
-					perunResource.addResource(beans.getResource(), getFacilityEntityIdValue(beans.getResource().getFacilityId()));
+					perunResource.addResource(beans.getResource(), getFacilityAttributes(beans.getResource().getFacilityId()));
 					break;
-					
+
 				case MessageBeans.FACILITY_F:
 					log.debug("Adding new facility: {}", beans.getFacility());
 					perunFacility.addFacility(beans.getFacility());
 					break;
-					
+
 				case MessageBeans.USER_F:
 					log.debug("Adding new user: {}", beans.getUser());
 					perunUser.addUser(beans.getUser());
 					break;
-					
+
 				case MessageBeans.VO_F:
 					if (beans.getGroup() != null) {
 						break;
@@ -57,9 +67,9 @@ public class CreationEventProcessor extends AbstractEventProcessor {
 					log.debug("Adding new VO: {}", beans.getVo());
 					perunVO.addVo(beans.getVo());
 					break;
-					
+
 				default:
-					break;	
+					break;
 				}
 			} catch(NamingException | InternalErrorException e) {
 				log.error("Error creating new entry: {}", e.getMessage());
@@ -69,42 +79,39 @@ public class CreationEventProcessor extends AbstractEventProcessor {
 	}
 
 	/**
-	 * Get entityID value from perun by facilityId.
+	 * Get facility attributes as map of LDAP attr names to their values. Key in a map is omitted if value is empty
 	 *
 	 * @param facilityId the facilityId
-	 * @return value of entityID or null, if value is null or user not exists yet
+	 * @return value of facility attributes stored in resource or null, if value is null or facility not exists yet
 	 * @throws InternalErrorException if some exception is thrown from RPC
 	 */
-	private String getFacilityEntityIdValue(int facilityId) throws InternalErrorException {
-		Perun perun = ldapcManager.getPerunBl();
+	private Map<String,String> getFacilityAttributes(int facilityId) throws InternalErrorException {
+
+		Map<String,String> result = new HashMap<>();
+		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		PerunSession perunSession = ldapcManager.getPerunSession();
 		Facility facility = null;
 		try {
-			// facility = Rpc.FacilitiesManager.getFacilityById(ldapcManager.getRpcCaller(), facilityId);
-			facility = perun.getFacilitiesManager().getFacilityById(perunSession, facilityId);
-		} catch (PrivilegeException ex) {
-			throw new InternalErrorException("There are no privilegies for getting facility by id.", ex);
+			facility = perun.getFacilitiesManagerBl().getFacilityById(perunSession, facilityId);
 		} catch (FacilityNotExistsException ex) {
 			//If facility not exist in perun now, probably will be deleted in next step so its ok. The value is null anyway.
-			return null;
+			return result;
 		}
 
-		cz.metacentrum.perun.core.api.Attribute entityID = null;
-		try {
-			// entityID = Rpc.AttributesManager.getAttribute(ldapcManager.getRpcCaller(), facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":" + PerunAttribute.PerunAttributeNames.perunAttrEntityID);
-			entityID = perun.getAttributesManager().getAttribute(perunSession, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":" + PerunAttribute.PerunAttributeNames.perunAttrEntityID);
-		} catch(PrivilegeException ex) {
-			throw new InternalErrorException("There are no privilegies for getting facility attribute.", ex);
-		} catch(AttributeNotExistsException ex) {
-			throw new InternalErrorException("There is no such attribute.", ex);
-		} catch(FacilityNotExistsException ex) {
-			//If facility not exist in perun now, probably will be deleted in next step so its ok. The value is null anyway.
-			return null;
-		} catch(WrongAttributeAssignmentException ex) {
-			throw new InternalErrorException("There is problem with wrong attribute assignment exception.", ex);
+		// FIXME - at least for those two attributes perun and ldap attr name is the same
+		// we might include static mapping if new attrs are added
+
+		List<Attribute> attributes = perun.getAttributesManagerBl().getAttributes(perunSession, facility, Arrays.asList(
+				AttributesManager.NS_FACILITY_ATTR_DEF + ":" + perunAttrEntityID,
+				AttributesManager.NS_FACILITY_ATTR_DEF + ":" + perunAttrClientID));
+
+		for (Attribute a : attributes) {
+			if (a.getValue() != null) {
+				result.put(a.getFriendlyName(), a.valueAsString());
+			}
 		}
-		if(entityID.getValue() == null) return null;
-		else return (String) entityID.getValue();
+		return result;
+
 	}
 
 

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/CreationEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/CreationEventProcessor.java
@@ -1,30 +1,22 @@
 package cz.metacentrum.perun.ldapc.processor.impl;
 
 import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.ldapc.model.PerunEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ldap.NamingException;
 
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
-import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.ldapc.model.PerunAttribute;
 import cz.metacentrum.perun.ldapc.processor.EventDispatcher.MessageBeans;
 
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-
-import static cz.metacentrum.perun.ldapc.model.PerunAttribute.PerunAttributeNames.perunAttrClientID;
-import static cz.metacentrum.perun.ldapc.model.PerunAttribute.PerunAttributeNames.perunAttrEntityID;
 
 public class CreationEventProcessor extends AbstractEventProcessor {
 
@@ -47,7 +39,10 @@ public class CreationEventProcessor extends AbstractEventProcessor {
 
 				case MessageBeans.RESOURCE_F:
 					log.debug("Adding new resource: {}", beans.getResource());
-					perunResource.addResource(beans.getResource(), getFacilityAttributes(beans.getResource().getFacilityId()));
+					perunResource.addResource(beans.getResource());
+					// push also facility attributes with it using sync
+					PerunEntry.SyncOperation op = perunResource.beginSynchronizeEntry(beans.getResource(), getFacilityAttributes(beans.getResource()));
+					perunResource.commitSyncOperation(op);
 					break;
 
 				case MessageBeans.FACILITY_F:
@@ -79,38 +74,27 @@ public class CreationEventProcessor extends AbstractEventProcessor {
 	}
 
 	/**
-	 * Get facility attributes as map of LDAP attr names to their values. Key in a map is omitted if value is empty
+	 * Get facility attributes requested by the resource
 	 *
-	 * @param facilityId the facilityId
-	 * @return value of facility attributes stored in resource or null, if value is null or facility not exists yet
+	 * @param resource to get facility from
+	 * @return List of facility attributes requested by resource
 	 * @throws InternalErrorException if some exception is thrown from RPC
 	 */
-	private Map<String,String> getFacilityAttributes(int facilityId) throws InternalErrorException {
+	private List<Attribute> getFacilityAttributes(Resource resource) throws InternalErrorException {
 
-		Map<String,String> result = new HashMap<>();
 		PerunBl perun = (PerunBl)ldapcManager.getPerunBl();
 		PerunSession perunSession = ldapcManager.getPerunSession();
 		Facility facility = null;
 		try {
-			facility = perun.getFacilitiesManagerBl().getFacilityById(perunSession, facilityId);
+			facility = perun.getFacilitiesManagerBl().getFacilityById(perunSession, resource.getFacilityId());
 		} catch (FacilityNotExistsException ex) {
 			//If facility not exist in perun now, probably will be deleted in next step so its ok. The value is null anyway.
-			return result;
+			return new ArrayList<>();
 		}
-
-		// FIXME - at least for those two attributes perun and ldap attr name is the same
-		// we might include static mapping if new attrs are added
-
-		List<Attribute> attributes = perun.getAttributesManagerBl().getAttributes(perunSession, facility, Arrays.asList(
-				AttributesManager.NS_FACILITY_ATTR_DEF + ":" + perunAttrEntityID,
-				AttributesManager.NS_FACILITY_ATTR_DEF + ":" + perunAttrClientID));
-
-		for (Attribute a : attributes) {
-			if (a.getValue() != null) {
-				result.put(a.getFriendlyName(), a.valueAsString());
-			}
-		}
-		return result;
+		// get only facility attributes
+		List<String> filteredNames = perunResource.getPerunAttributeNames();
+		filteredNames.removeIf(attrName-> !attrName.startsWith(AttributesManager.NS_FACILITY_ATTR));
+		return perun.getAttributesManagerBl().getAttributes(perunSession, facility, filteredNames);
 
 	}
 

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/DeletionEventProcessor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/impl/DeletionEventProcessor.java
@@ -10,7 +10,7 @@ import cz.metacentrum.perun.ldapc.processor.EventDispatcher.MessageBeans;
 public class DeletionEventProcessor extends AbstractEventProcessor {
 
 	private final static Logger log = LoggerFactory.getLogger(DeletionEventProcessor.class);
-	
+
 	@Override
 	public void processEvent(String msg, MessageBeans beans) {
 		for(int beanFlag: beans.getPresentBeansFlags()) {
@@ -20,29 +20,32 @@ public class DeletionEventProcessor extends AbstractEventProcessor {
 					log.debug("Removing group {}", beans.getGroup());
 					perunGroup.removeGroup(beans.getGroup());
 					break;
-					
+
 				case MessageBeans.RESOURCE_F:
 					log.debug("Removing resource {}", beans.getResource());
 					perunResource.deleteResource(beans.getResource());
 					break;
-					
+
 				case MessageBeans.FACILITY_F:
+					// skip if it is actually resource deletion
+					if (beans.getResource() != null) break;
+					// was facility deletion - proceed
 					log.debug("Removing facility {}", beans.getFacility());
 					perunFacility.deleteFacility(beans.getFacility());
 					break;
-					
+
 				case MessageBeans.USER_F:
 					log.debug("Removing user {}", beans.getUser());
 					perunUser.deleteUser(beans.getUser());
 					break;
-					
+
 				case MessageBeans.VO_F:
 					log.debug("Removing VO {}", beans.getVo());
 					perunVO.deleteVo(beans.getVo());
 					break;
-					
+
 				default:
-					break;	
+					break;
 				}
 			} catch(NamingException | InternalErrorException e) {
 				log.error("Error removing entry: {}", e.getMessage());

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -647,6 +647,16 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 			<!--  this list will be added to built-in defaultAttributeDescriptions -->
 			<list>
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
+					<property name="name" value="entityID" />
+					<property name="required" value="false" />
+					<property name="singleValueExtractor">
+						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
+							<property name="name" value="entityID" />
+							<property name="namespace" value="urn:perun:facility:attribute-def:def" />
+						</bean>
+					</property>
+				</bean>
+				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="OIDCClientID" />
 					<property name="required" value="false" />
 					<property name="singleValueExtractor">
@@ -656,7 +666,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 						</bean>
 					</property>
 				</bean>
-				<!-- not used (yet) 
+				<!-- not used (yet)
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="OIDCCheckGroupMembership" />
 					<property name="required" value="false" />
@@ -671,7 +681,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 			</list>
 		</property>
 	</bean>
-	
+
 	<bean id="perunGroup" class="cz.metacentrum.perun.ldapc.model.impl.PerunGroupImpl">
 	</bean>
 

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -65,6 +65,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<property name="beansCondition">
 						<list>
 							<value>cz.metacentrum.perun.core.api.Resource</value>
+							<value>cz.metacentrum.perun.core.api.Facility</value>
 						</list>
 					</property>
 					<property name="pattern" value=" deleted.#Facility" />

--- a/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
+++ b/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
@@ -34,8 +34,8 @@ olcAttributeTypes: {28}( 1.3.6.1.4.1.8057.2.80.32 NAME 'perunFacilityDn' DESC 'D
 replace: olcObjectClasses
 olcObjectClasses: {0}( 1.3.6.1.4.1.8057.2.80.4 NAME 'perunUser' DESC 'User managed by Perun' SUP inetOrgPerson STRUCTURAL MUST ( perunUserId $ isServiceUser  $ isSponsoredUser ) MAY ( preferredMail $ userCertificateSubject $ uidNumber $ login $ eduPersonPrincipalNames $ userPassword $ memberOfPerunVo $ libraryIDs $ schacHomeOrganizations $ eduPersonScopedAffiliations $ bonaFideStatus $ groupNames $ institutionsCountries $ isCesnetEligible $ loa $ internalUserIdentifiers ) )
 olcObjectClasses: {1}( 1.3.6.1.4.1.8057.2.80.5 NAME 'perunGroup' DESC 'Group managed by Perun' SUP top  STRUCTURAL MUST ( cn $ perunGroupId $ perunVoId $ perunUniqueGroupName ) MAY ( uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ perunParentGroup $ perunParentGroupId $ assignedToResourceId ) )
-olcObjectClasses: {2}( 1.3.6.1.4.1.8057.2.80.15 NAME 'perunResource' DESC 'Resource managed by Perun' SUP top STRUCTURAL MUST ( cn $  perunResourceId $ perunVoId $ perunFacilityId ) MAY (uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ assignedGroupId  $ entityID $ OIDCClientID $ perunFacilityDn ))
+olcObjectClasses: {2}( 1.3.6.1.4.1.8057.2.80.15 NAME 'perunResource' DESC 'Resource managed by Perun' SUP top STRUCTURAL MUST ( cn $  perunResourceId $ perunVoId $ perunFacilityId ) MAY (uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ assignedGroupId $ entityID $ OIDCClientID $ perunFacilityDn ))
 olcObjectClasses: {3}( 1.3.6.1.4.1.8057.2.80.6 NAME 'perunVO' DESC 'VO managed by Perun' SUP organization STRUCTURAL MUST perunVoId MAY uniqueMember )
-olcObjectClasses: {4}( 1.3.6.1.4.1.8057.2.80.34 NAME 'perunFacility' DESC 'Facility managed by Perun' SUP top STRUCTURAL MUST ( cn $ perunFacilityId ) MAY ( description $ OIDCClientID ) )
+olcObjectClasses: {4}( 1.3.6.1.4.1.8057.2.80.34 NAME 'perunFacility' DESC 'Facility managed by Perun' SUP top STRUCTURAL MUST ( cn $ perunFacilityId ) MAY ( description $ entityID $ OIDCClientID ) )
 -
 


### PR DESCRIPTION
- Fixed Resource creation, we now include all expected facility attributes with it.
- Fixed Resource deletion, which didn't reacted on the auditer message (more beans were in the
  message than in the condition).
- Fixed schema to include entityID attribute with Facility too.