### PR TITLE
Make the external configuration file optional, add extension points to configuration

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/AbstractPerunAttributeConfigurer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/AbstractPerunAttributeConfigurer.java
@@ -1,0 +1,20 @@
+package cz.metacentrum.perun.ldapc.beans;
+
+import java.util.List;
+
+import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.ldapc.model.PerunAttribute;
+
+public abstract class AbstractPerunAttributeConfigurer<T extends PerunBean> implements PerunAttributeConfigurer<T> {
+
+	private List<PerunAttribute<T>> attributeDescriptions;
+
+	public List<PerunAttribute<T>> getAttributeDescriptions() {
+		return attributeDescriptions;
+	}
+
+	public void setAttributeDescriptions(List<PerunAttribute<T>> attributeDescriptions) {
+		this.attributeDescriptions = attributeDescriptions;
+	}
+	
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunAttributeConfigurer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunAttributeConfigurer.java
@@ -1,0 +1,12 @@
+package cz.metacentrum.perun.ldapc.beans;
+
+import java.util.List;
+
+import cz.metacentrum.perun.core.api.PerunBean;
+import cz.metacentrum.perun.ldapc.model.PerunAttribute;
+
+public interface PerunAttributeConfigurer<T extends PerunBean> {
+
+	public List<PerunAttribute<T>> getAttributeDescriptions();
+	
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunFacilityAttributeConfigurer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunFacilityAttributeConfigurer.java
@@ -1,0 +1,7 @@
+package cz.metacentrum.perun.ldapc.beans;
+
+import cz.metacentrum.perun.core.api.Facility;
+
+public class PerunFacilityAttributeConfigurer extends AbstractPerunAttributeConfigurer<Facility> {
+
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunGroupAttributeConfigurer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunGroupAttributeConfigurer.java
@@ -1,0 +1,7 @@
+package cz.metacentrum.perun.ldapc.beans;
+
+import cz.metacentrum.perun.core.api.Group;
+
+public class PerunGroupAttributeConfigurer extends AbstractPerunAttributeConfigurer<Group> {
+
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunResourceAttributeConfigurer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunResourceAttributeConfigurer.java
@@ -1,0 +1,7 @@
+package cz.metacentrum.perun.ldapc.beans;
+
+import cz.metacentrum.perun.core.api.Resource;
+
+public class PerunResourceAttributeConfigurer extends AbstractPerunAttributeConfigurer<Resource> {
+
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunUserAttributeConfigurer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunUserAttributeConfigurer.java
@@ -1,0 +1,7 @@
+package cz.metacentrum.perun.ldapc.beans;
+
+import cz.metacentrum.perun.core.api.User;
+
+public class PerunUserAttributeConfigurer extends AbstractPerunAttributeConfigurer<User> {
+
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunVOAttributeConfigurer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/PerunVOAttributeConfigurer.java
@@ -1,0 +1,7 @@
+package cz.metacentrum.perun.ldapc.beans;
+
+import cz.metacentrum.perun.core.api.Vo;
+
+public class PerunVOAttributeConfigurer extends AbstractPerunAttributeConfigurer<Vo> {
+
+}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/AbstractPerunEntry.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/AbstractPerunEntry.java
@@ -8,7 +8,6 @@ import java.util.List;
 import javax.naming.InvalidNameException;
 import javax.naming.Name;
 import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +26,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.ldapc.beans.LdapProperties;
+import cz.metacentrum.perun.ldapc.beans.PerunAttributeConfigurer;
 import cz.metacentrum.perun.ldapc.model.PerunAttribute;
 import cz.metacentrum.perun.ldapc.model.PerunEntry;
 
@@ -60,18 +60,24 @@ public abstract class AbstractPerunEntry<T extends PerunBean> implements Initial
 	protected LdapProperties ldapProperties;
 
 	private List<PerunAttribute<T>> attributeDescriptions;
+	private PerunAttributeConfigurer<T> attributeDescriptionsExt;
 	private List<String> updatableAttributeNames; 
 	
 	public void afterPropertiesSet() {
-		if(attributeDescriptions == null)
-			attributeDescriptions = getDefaultAttributeDescriptions();
-		else
-			attributeDescriptions.addAll(getDefaultAttributeDescriptions());
-		if(updatableAttributeNames == null)
-			updatableAttributeNames = getDefaultUpdatableAttributes();
-		else
-			updatableAttributeNames.addAll(getDefaultUpdatableAttributes());
+		if(attributeDescriptions == null) {
+			attributeDescriptions = new ArrayList<PerunAttribute<T>>();
+		}
+		attributeDescriptions.addAll(getDefaultAttributeDescriptions());
+		if(updatableAttributeNames == null) {
+			updatableAttributeNames = new ArrayList<String>();
+		}
+		updatableAttributeNames.addAll(getDefaultUpdatableAttributes());
 			
+		// add attributes from extension list
+		List<PerunAttribute<T>> attrsExt = attributeDescriptionsExt.getAttributeDescriptions();
+		if(attrsExt != null) {
+			attributeDescriptions.addAll(attrsExt);
+		}
 	}
 
 	abstract protected List<String> getDefaultUpdatableAttributes();
@@ -287,6 +293,14 @@ public abstract class AbstractPerunEntry<T extends PerunBean> implements Initial
 	@Override
 	public void setAttributeDescriptions(List<PerunAttribute<T>> attributeDescriptions) {
 		this.attributeDescriptions = attributeDescriptions;
+	}
+
+	public PerunAttributeConfigurer<T> getAttributeDescriptionsExt() {
+		return attributeDescriptionsExt;
+	}
+
+	public void setAttributeDescriptionsExt(PerunAttributeConfigurer<T> attributeDescriptionsExt) {
+		this.attributeDescriptionsExt = attributeDescriptionsExt;
 	}
 
 	@Override

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -613,6 +613,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				</bean>
 			</list>
 		</property>
+		<property name="attributeDescriptionsExt" ref="perunUserAttributesExt" />
 	</bean>
 
 	<bean id="perunResource" class="cz.metacentrum.perun.ldapc.model.impl.PerunResourceImpl">
@@ -641,6 +642,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				</bean>
 			</list>
 		</property>
+		<property name="attributeDescriptionsExt" ref="perunResourceAttributesExt" />
 	</bean>
 
 	<bean id="perunFacility" class="cz.metacentrum.perun.ldapc.model.impl.PerunFacilityImpl">
@@ -681,12 +683,30 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
  				-->
 			</list>
 		</property>
+		<property name="attributeDescriptionsExt" ref="perunFacilityAttributesExt" />
 	</bean>
 
 	<bean id="perunGroup" class="cz.metacentrum.perun.ldapc.model.impl.PerunGroupImpl">
+		<property name="attributeDescriptionsExt" ref="perunGroupAttributesExt" />
 	</bean>
 
 	<bean id="perunVO" class="cz.metacentrum.perun.ldapc.model.impl.PerunVOImpl">
+		<property name="attributeDescriptionsExt" ref="perunVOAttributesExt" />
+	</bean>
+	
+	<bean id="perunGroupAttributesExt" class="cz.metacentrum.perun.ldapc.beans.PerunGroupAttributeConfigurer">
+	</bean>
+
+	<bean id="perunResourceAttributesExt" class="cz.metacentrum.perun.ldapc.beans.PerunResourceAttributeConfigurer">
+	</bean>
+
+	<bean id="perunFacilityAttributesExt" class="cz.metacentrum.perun.ldapc.beans.PerunFacilityAttributeConfigurer">
+	</bean>
+
+	<bean id="perunUserAttributesExt" class="cz.metacentrum.perun.ldapc.beans.PerunUserAttributeConfigurer">
+	</bean>
+
+	<bean id="perunVOAttributesExt" class="cz.metacentrum.perun.ldapc.beans.PerunVOAttributeConfigurer">
 	</bean>
 
     <bean id="ldapProperties" class="cz.metacentrum.perun.ldapc.beans.LdapProperties">
@@ -706,6 +726,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 
 	<ldap:ldap-template />
 
-	<import resource="file:${perun.conf.custom}/perun-ldapc-attributes.xml" />
+	<import resource="file:${perun.conf.custom}/perun-ldapc-*.xml" />
 
 </beans>


### PR DESCRIPTION
Instead of rewriting beans (`perunGroup`, `perunUser` etc.) to extend them it is now possible to
define just the additional attributes using the `perunGroupConfigurer` etc. beans:
- adds configuration beans infrastructure
- adds wildcard to spring context import (making the imported file optional)
- get extended attribute configuration from configuration beans