### PR TITLE
Fix of wrong type of arrayList when setting user ext source attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -202,7 +202,7 @@ public class PerunBlImpl implements PerunBl {
 
 					//for Array list attributes try to parse string value into individual fields
 					if(attributeWithValue.getType().equals(ArrayList.class.getName()) || attributeWithValue.getType().equals(BeansUtils.largeArrayListClassName)) {
-						List<String> value = Arrays.asList(attrValue.split(UsersManagerBlImpl.multivalueAttributeSeparatorRegExp));
+						List<String> value = new ArrayList<>(Arrays.asList(attrValue.split(UsersManagerBlImpl.multivalueAttributeSeparatorRegExp)));
 						attributeWithValue.setValue(value);
 					} else {
 						attributeWithValue.setValue(attrValue);


### PR DESCRIPTION
 - method Arrays.asList returns different type of list than constructor
 of the class "ArrayList". We need to get the right type here because of
 we are checking if value is instance of "ArrayList" which will throw an
 exception if the type is not correct.