### PR TITLE
Change of the CandidateNotExistsException

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/CandidateNotExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/CandidateNotExistsException.java
@@ -9,8 +9,6 @@ package cz.metacentrum.perun.core.api.exceptions;
 public class CandidateNotExistsException extends EntityNotExistsException {
 	static final long serialVersionUID = 0;
 
-	private String candidate;
-
 	public CandidateNotExistsException(String message, Throwable cause) {
 		super(message, cause);
 	}
@@ -19,12 +17,7 @@ public class CandidateNotExistsException extends EntityNotExistsException {
 		super(cause);
 	}
 
-	public CandidateNotExistsException(String candidate) {
-		super(candidate.toString());
-		this.candidate = candidate;
-	}
-
-	public String getCandidate() {
-		return this.candidate;
+	public CandidateNotExistsException(String message) {
+		super(message);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -224,7 +224,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 		try {
 			subject = ((ExtSourceSimpleApi) source).getSubjectByLogin(login);
 		} catch (SubjectNotExistsException e) {
-			throw new CandidateNotExistsException(login);
+			throw new CandidateNotExistsException("Searched candidate with login [" + login + "] does not exist");
 		}
 
 		if (subject == null) {


### PR DESCRIPTION
* This exception no longer has a String variable candidate which was misused - first to store a standard exception message, second to contain a login of the candidate, not the candidate itself

* Edited one throwing of this exception (changed the message)

* changed the name of the message parameter in the constructor