### PR TITLE
Creating entities with the invalid name should throw IllegalArgumentException

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -295,7 +295,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 
 		//check facility name, it can contain only a-zA-Z.0-9_-
 		if (!facility.getName().matches("^[ a-zA-Z.0-9_-]+$")) {
-			throw new InternalErrorException(new IllegalArgumentException("Wrong facility name, facility name can contain only a-Z0-9.-_ and space characters"));
+			throw new IllegalArgumentException("Wrong facility name, facility name can contain only a-Z0-9.-_ and space characters");
 		}
 
 		//check if facility have uniq name
@@ -391,7 +391,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	public Facility updateFacility(PerunSession sess, Facility facility) throws InternalErrorException, FacilityExistsException {
 		//check facility name, it can contain only a-zA-Z.0-9_-
 		if (!facility.getName().matches("^[ a-zA-Z.0-9_-]+$")) {
-			throw new InternalErrorException(new IllegalArgumentException("Wrong facility name, facility name can contain only a-Z0-9.-_ and space characters"));
+			throw new IllegalArgumentException("Wrong facility name, facility name can contain only a-Z0-9.-_ and space characters");
 		}
 
 		getPerunBl().getAuditer().log(sess, new FacilityUpdated(facility));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -1528,7 +1528,7 @@ public class AttributesManagerEntry implements AttributesManager {
 		Utils.notNull(attribute, "attributeDefinition");
 		if(!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("Only perunAdmin can create new Attribute.");
 		if (!attribute.getFriendlyName().matches(AttributesManager.ATTRIBUTES_REGEXP)) {
-			throw new InternalErrorException(new IllegalArgumentException("Wrong attribute name " + attribute.getFriendlyName() + ", attribute name must match " + AttributesManager.ATTRIBUTES_REGEXP));
+			throw new IllegalArgumentException("Wrong attribute name " + attribute.getFriendlyName() + ", attribute name must match " + AttributesManager.ATTRIBUTES_REGEXP);
 		}
 		return getAttributesManagerBl().createAttribute(sess, attribute);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -92,7 +92,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 
 		if (!group.getName().matches(GroupsManager.GROUP_SHORT_NAME_REGEXP)) {
-			throw new InternalErrorException(new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP));
+			throw new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP);
 		}
 
 		if (group.getParentGroupId() != null) throw new InternalErrorException("Top-level groups can't have parentGroupId set!");
@@ -121,7 +121,7 @@ public class GroupsManagerEntry implements GroupsManager {
 
 
 		if (!group.getName().matches(GroupsManager.GROUP_SHORT_NAME_REGEXP)) {
-			throw new InternalErrorException(new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP));
+			throw new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP);
 		}
 
 		// Authorization
@@ -207,7 +207,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		Utils.notNull(group.getName(), "group.name");
 
 		if (!group.getShortName().matches(GroupsManager.GROUP_SHORT_NAME_REGEXP)) {
-			throw new InternalErrorException(new IllegalArgumentException("Wrong group shortName, group shortName must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP));
+			throw new IllegalArgumentException("Wrong group shortName, group shortName must matches " + GroupsManager.GROUP_SHORT_NAME_REGEXP);
 		}
 
 		// Authorization
@@ -276,7 +276,7 @@ public class GroupsManagerEntry implements GroupsManager {
 		Utils.notNull(name, "name");
 
 		if (!name.matches(GroupsManager.GROUP_FULL_NAME_REGEXP)) {
-			throw new InternalErrorException(new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_FULL_NAME_REGEXP));
+			throw new IllegalArgumentException("Wrong group name, group name must matches " + GroupsManager.GROUP_FULL_NAME_REGEXP);
 		}
 
 		Group group = getGroupsManagerBl().getGroupByName(sess, vo, name);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
@@ -13,6 +13,7 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
@@ -102,11 +103,11 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		}
 
 		if (securityTeam.getName().length() > 128) {
-			throw new InternalErrorException("Security Team name is too long, >128 characters");
+			throw new IllegalArgumentException("Security Team name is too long, >128 characters");
 		}
 
 		if (!securityTeam.getName().matches("^[-_a-zA-z0-9.]{1,128}$")) {
-			throw new InternalErrorException("Wrong Security name - must matches [-_a-zA-z0-9.]+ and not be longer than 128 characters.");
+			throw new IllegalArgumentException("Wrong Security name - must matches [-_a-zA-z0-9.]+ and not be longer than 128 characters.");
 		}
 
 		getSecurityTeamsManagerBl().checkSecurityTeamNotExists(sess, securityTeam);
@@ -130,11 +131,11 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		}
 
 		if (securityTeam.getName().length() > 128) {
-			throw new InternalErrorException("Security Team name is too long, >128 characters");
+			throw new IllegalArgumentException("Security Team name is too long, >128 characters");
 		}
 
 		if (!securityTeam.getName().matches("^[-_a-zA-z0-9.]{1,128}$")) {
-			throw new InternalErrorException("Wrong Security name - must matches [-_a-zA-z0-9.]+ and not be longer than 128 characters.");
+			throw new IllegalArgumentException("Wrong Security name - must matches [-_a-zA-z0-9.]+ and not be longer than 128 characters.");
 		}
 
 		getSecurityTeamsManagerBl().checkSecurityTeamExists(sess, securityTeam);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ServicesManagerEntry.java
@@ -67,7 +67,7 @@ public class ServicesManagerEntry implements ServicesManager {
 		Utils.notNull(service.getName(), "service.name");
 
 		if (!service.getName().matches(ServicesManager.SERVICE_NAME_REGEXP)) {
-			throw new InternalErrorException(new IllegalArgumentException("Wrong service name, service name must matches " + ServicesManager.SERVICE_NAME_REGEXP + ", but was: " + service.getName()));
+			throw new IllegalArgumentException("Wrong service name, service name must matches " + ServicesManager.SERVICE_NAME_REGEXP + ", but was: " + service.getName());
 		}
 
 		// Authorization

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -149,11 +149,11 @@ public class VosManagerEntry implements VosManager {
 
 
 		if (vo.getName().length() > 128) {
-			throw new InternalErrorException("VO name is too long, >128 characters");
+			throw new IllegalArgumentException("VO name is too long, >128 characters");
 		}
 
 		if (!vo.getShortName().matches("^[-_a-zA-z0-9.]{1,32}$")) {
-			throw new InternalErrorException("Wrong VO short name - must matches [-_a-zA-z0-9.]+ and not be longer than 32 characters.");
+			throw new IllegalArgumentException("Wrong VO short name - must matches [-_a-zA-z0-9.]+ and not be longer than 32 characters.");
 		}
 
 		return vosManagerBl.createVo(sess, vo);
@@ -170,11 +170,11 @@ public class VosManagerEntry implements VosManager {
 		}
 
 		if (vo.getName().length() > 128) {
-			throw new InternalErrorException("VO name is too long, >128 characters");
+			throw new IllegalArgumentException("VO name is too long, >128 characters");
 		}
 
 		if (!vo.getShortName().matches("^[-_a-zA-z0-9.]{1,32}$")) {
-			throw new InternalErrorException("Wrong VO short name - must matches [-_a-zA-z0-9.]+ and not be longer than 32 characters.");
+			throw new IllegalArgumentException("Wrong VO short name - must matches [-_a-zA-z0-9.]+ and not be longer than 32 characters.");
 		}
 
 		return vosManagerBl.updateVo(sess, vo);


### PR DESCRIPTION
* replaced all cases where InternalErrorException was thrown because of the invalid name of an entity to IllegalArgumentException since InternalErrorException should only be used for errors which the user can't solve himself