### PR TITLE
Separation of checkAttributeSyntax from semantics in User modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_IPAddresses.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_IPAddresses.java
@@ -28,7 +28,7 @@ public class urn_perun_user_attribute_def_def_IPAddresses extends UserAttributes
 	private static final Pattern IPv6_PATTERN_SHORT = Pattern.compile("^((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
 		List<String> value = attribute.valueAsList();
 		if (value != null) {
 			for (String address : value) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_cnCeitecAD.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_cnCeitecAD.java
@@ -6,7 +6,7 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
@@ -27,10 +27,10 @@ import java.util.Set;
 public class urn_perun_user_attribute_def_def_cnCeitecAD extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 
 		if (attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, user, "Value can't be null");
+			throw new WrongReferenceAttributeValueException(attribute, null, user, null, "Value can't be null");
 		}
 
 		// check existing DN
@@ -45,7 +45,7 @@ public class urn_perun_user_attribute_def_def_cnCeitecAD extends UserAttributesM
 		usersWithSameCN.remove(user); //remove self
 		if (!usersWithSameCN.isEmpty()) {
 			if(usersWithSameCN.size() > 1) throw new ConsistencyErrorException("FATAL ERROR: Duplicated CN detected." +  attribute + " " + usersWithSameCN);
-			throw new WrongAttributeValueException(attribute, user, "This CN " + attribute.getValue() + " is already occupied for CEITEC AD");
+			throw new WrongReferenceAttributeValueException(attribute, attribute, user, null, usersWithSameCN.iterator().next(), null, "This CN " + attribute.getValue() + " is already occupied for CEITEC AD");
 		}
 
 	}
@@ -75,7 +75,7 @@ public class urn_perun_user_attribute_def_def_cnCeitecAD extends UserAttributesM
 			try {
 				checkAttributeSemantics(session, user, filledAttribute);
 				return filledAttribute;
-			} catch (WrongAttributeValueException ex) {
+			} catch (WrongReferenceAttributeValueException ex) {
 				// continue in a WHILE cycle
 				iterator++;
 			}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_eduroamIdentities.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_eduroamIdentities.java
@@ -26,9 +26,9 @@ public class urn_perun_user_attribute_def_def_eduroamIdentities extends UserAttr
 	private static final Pattern pattern = Pattern.compile("^[-/_.a-zA-Z0-9]+@[-_.A-z0-9]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
 		if(attribute == null) return; //null is OK
-		List<String> value = (List<String>) attribute.getValue();
+		List<String> value = attribute.valueAsList();
 		for(String login : value) {
 			Matcher matcher = pattern.matcher(login);
 			if(!matcher.matches()) throw new WrongAttributeValueException(attribute, "Value is not in correct format. format: login@organization");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirScopedAffiliation.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirScopedAffiliation.java
@@ -24,9 +24,9 @@ public class urn_perun_user_attribute_def_def_elixirScopedAffiliation extends Us
 	private static final Pattern pattern = Pattern.compile("^(member|affiliate|faculty)@[-A-Za-z0-9]+(\\.[-A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
 
-		List<String> values = ((List<String>)attribute.getValue());
+		List<String> values = attribute.valueAsList();
 		if (values != null && !values.isEmpty()) {
 			for (String value : values) {
 				// check each value

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_k4Nav.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_k4Nav.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 public class urn_perun_user_attribute_def_def_k4Nav extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
 
 		if (attribute.getValue() != null) {
 			if (!Objects.equals(attribute.getValue(), "0") && !Objects.equals(attribute.getValue(), "1")) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_k4Staleakt.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_k4Staleakt.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 public class urn_perun_user_attribute_def_def_k4Staleakt extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
 
 		if (attribute.getValue() != null) {
 			if (!Objects.equals(attribute.getValue(), "0") && !Objects.equals(attribute.getValue(), "1")) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosAdminPrincipal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosAdminPrincipal.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
@@ -22,11 +23,16 @@ public class urn_perun_user_attribute_def_def_kerberosAdminPrincipal extends Use
 	private static final Pattern pattern = Pattern.compile("^[-/_.a-zA-Z0-9]+@[-_.A-z0-9]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "Attribute's value can't be null");
-		String value = (String) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+		if(attribute.getValue() == null) return;
+		String value = attribute.valueAsString();
 		Matcher matcher = pattern.matcher(value);
 		if(!matcher.matches()) throw new WrongAttributeValueException(attribute, user, "Attribute's value is not in correct format. format: login@realm");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, user, null, "Attribute's value can't be null");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosLogins.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosLogins.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
@@ -22,14 +23,18 @@ public class urn_perun_user_attribute_def_def_kerberosLogins extends UserAttribu
 	private static final Pattern pattern = Pattern.compile("^[-/_.a-zA-Z0-9@]+@[-_.A-z0-9]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "Attribute's value can't be null.");
-		List<String> value = (List<String>) attribute.getValue();
-		if(value.isEmpty()) throw new WrongAttributeValueException(attribute, user, "Attribute's value can't be empty list");
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+		if(attribute.getValue() == null) return;
+		List<String> value = attribute.valueAsList();
 		for(String login : value) {
 			Matcher matcher = pattern.matcher(login);
 			if(!matcher.matches()) throw new WrongAttributeValueException(attribute, user, "Attribute's value is not in correct format. format: login@realm");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, user, null, "Attribute's value can't be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_ceitec.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_ceitec.java
@@ -36,7 +36,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_ceitec extends urn
 	private final String CEITEC_PROXY_SCOPE_AD = "ceitec.local";
 
 	/**
-	 * Checks if the user's login is unique in the namespace organization.
+	 * Check if the user's login is in the correct format and if it is permitted to use.
 	 * Check if maximum length is 20 chars, because of MSAD limitations.
 	 *
 	 * @param sess PerunSession
@@ -44,17 +44,16 @@ public class urn_perun_user_attribute_def_def_login_namespace_ceitec extends urn
 	 * @param attribute Attribute to check value to
 	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException
-	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 
-		// check uniqueness
-		super.checkAttributeSemantics(sess, user, attribute);
+		// check syntax of attribute
+		super.checkAttributeSyntax(sess, user, attribute);
 
 		// plus check, that login is max 20 chars.
 		if (attribute.getValue() != null) {
-			if (((String)attribute.getValue()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
+			if ((attribute.valueAsString()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
 		}
 
 	}
@@ -120,7 +119,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_ceitec extends urn
 				try {
 					checkAttributeSemantics(perunSession, user, filledAttribute);
 					return filledAttribute;
-				} catch (WrongAttributeValueException ex) {
+				} catch (WrongReferenceAttributeValueException ex) {
 					// continue in a WHILE cycle
 					iterator++;
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickname.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickname.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.slf4j.Logger;
@@ -21,7 +22,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickn
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickname.class);
 
 	/**
-	 * Checks if the user's login is unique in the namespace organization.
+	 * Check if the user's login is in the correct format and if it is permitted to use.
 	 * Check if maximum length is 20 chars
 	 *
 	 * @param sess PerunSession
@@ -29,17 +30,16 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickn
 	 * @param attribute Attribute to check value to
 	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException
-	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 
-		// check uniqueness
-		super.checkAttributeSemantics(sess, user, attribute);
+		// check syntax of attribute
+		super.checkAttributeSyntax(sess, user, attribute);
 
 		// plus check, that login is max 20 chars.
 		if (attribute.getValue() != null) {
-			if (((String)attribute.getValue()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
+			if ((attribute.valueAsString()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
 		}
 
 	}
@@ -104,7 +104,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickn
 				try {
 					checkAttributeSemantics(perunSession, user, filledAttribute);
 					return filledAttribute;
-				} catch (WrongAttributeValueException ex) {
+				} catch (WrongReferenceAttributeValueException ex) {
 					// continue in a WHILE cycle
 					iterator++;
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_nickname.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_nickname.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.slf4j.Logger;
@@ -21,7 +22,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduteams_nickname 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace_eduteams_nickname.class);
 
 	/**
-	 * Checks if the user's login is unique in the namespace organization.
+	 * Check if the user's login is in the correct format and if it is permitted to use.
 	 * Check if maximum length is 20 chars
 	 *
 	 * @param sess PerunSession
@@ -29,17 +30,15 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduteams_nickname 
 	 * @param attribute Attribute to check value to
 	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException
-	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 
-		// check uniqueness
-		super.checkAttributeSemantics(sess, user, attribute);
+		super.checkAttributeSyntax(sess, user, attribute);
 
 		// plus check, that login is max 20 chars.
 		if (attribute.getValue() != null) {
-			if (((String)attribute.getValue()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
+			if ((attribute.valueAsString()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
 		}
 
 	}
@@ -104,7 +103,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_eduteams_nickname 
 				try {
 					checkAttributeSemantics(perunSession, user, filledAttribute);
 					return filledAttribute;
-				} catch (WrongAttributeValueException ex) {
+				} catch (WrongReferenceAttributeValueException ex) {
 					// continue in a WHILE cycle
 					iterator++;
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_nickname.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_nickname.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.slf4j.Logger;
@@ -21,7 +22,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_nickname ext
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace_fenix_nickname.class);
 
 	/**
-	 * Checks if the user's login is unique in the namespace organization.
+	 * Check if the user's login is in the correct format and if it is permitted to use.
 	 * Check if maximum length is 20 chars
 	 *
 	 * @param sess PerunSession
@@ -29,17 +30,16 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_nickname ext
 	 * @param attribute Attribute to check value to
 	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException
-	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 
-		// check uniqueness
-		super.checkAttributeSemantics(sess, user, attribute);
+		// check attribute syntax
+		super.checkAttributeSyntax(sess, user, attribute);
 
 		// plus check, that login is max 20 chars.
 		if (attribute.getValue() != null) {
-			if (((String)attribute.getValue()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
+			if ((attribute.valueAsString()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
 		}
 
 	}
@@ -104,7 +104,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_nickname ext
 				try {
 					checkAttributeSemantics(perunSession, user, filledAttribute);
 					return filledAttribute;
-				} catch (WrongAttributeValueException ex) {
+				} catch (WrongReferenceAttributeValueException ex) {
 					// continue in a WHILE cycle
 					iterator++;
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_vsup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_vsup.java
@@ -39,7 +39,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_vsup extends urn_p
 	private final static String VSUP_MAIL_NAMESPACE = AttributesManager.NS_USER_ATTR_DEF + ":vsupMail";
 
 	/**
-	 * Checks if the user's login is unique in the namespace organization.
+	 * Check if the user's login is in the correct format and if it is permitted to use.
 	 * Check if maximum length is 20 chars, because of MSAD limitations.
 	 *
 	 * @param sess PerunSession
@@ -47,20 +47,19 @@ public class urn_perun_user_attribute_def_def_login_namespace_vsup extends urn_p
 	 * @param attribute Attribute to check value to
 	 * @throws cz.metacentrum.perun.core.api.exceptions.InternalErrorException
 	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException
-	 * @throws cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 
 		Utils.notNull(attribute, "attribute");
 		if (unpermittedLogins.contains(attribute.valueAsString())) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' is not permitted.");
 
-		// check uniqueness
-		super.checkAttributeSemantics(sess, user, attribute);
+		// check attribute syntax
+		super.checkAttributeSyntax(sess, user, attribute);
 
 		// plus check, that login is max 20 chars.
 		if (attribute.getValue() != null) {
-			if (((String)attribute.getValue()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
+			if ((attribute.valueAsString()).length() > 20) throw new WrongAttributeValueException(attribute, user, "Login '" + attribute.getValue() + "' exceeds 20 chars limit.");
 		}
 
 	}
@@ -125,7 +124,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_vsup extends urn_p
 				try {
 					checkAttributeSemantics(perunSession, user, filledAttribute);
 					return filledAttribute;
-				} catch (WrongAttributeValueException ex) {
+				} catch (WrongReferenceAttributeValueException ex) {
 					// continue in a WHILE cycle
 					iterator++;
 				}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mailaliasesGenericMail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mailaliasesGenericMail.java
@@ -20,11 +20,9 @@ import java.util.regex.Matcher;
 public class urn_perun_user_attribute_def_def_mailaliasesGenericMail extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
-		String attributeValue;
-
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
 		if(attribute.getValue() == null) return;
-		else attributeValue = (String) attribute.getValue();
+		String attributeValue = attribute.valueAsString();
 
 		Matcher emailMatcher = Utils.emailPattern.matcher(attributeValue);
 		if(!emailMatcher.find()) throw new WrongAttributeValueException(attribute, user, "Email is not in correct form.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_osbIddc2.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_osbIddc2.java
@@ -4,7 +4,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
@@ -17,9 +17,9 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
 public class urn_perun_user_attribute_def_def_osbIddc2 extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
 
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "ID from DC2 can't be null.");
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, user, null, "ID from DC2 can't be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_phone.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_phone.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
@@ -23,12 +24,9 @@ public class urn_perun_user_attribute_def_def_phone extends UserAttributesModule
 	private static final Pattern pattern = Pattern.compile("^[+][0-9]{4,16}$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
 		// null attribute
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "User attribute phone cannot be null.");
-
-		// wrong type of the attribute
-		if (!(attribute.getValue() instanceof String)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: String");
+		if (attribute.getValue() == null) return;
 
 		String phone = attribute.valueAsString();
 
@@ -36,6 +34,13 @@ public class urn_perun_user_attribute_def_def_phone extends UserAttributesModule
 		if (!matcher.matches()) {
 			throw new WrongAttributeValueException(attribute, "Phone is not in correct format!");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
+		// null attribute
+		if (attribute.getValue() == null)
+			throw new WrongReferenceAttributeValueException(attribute, "User attribute phone cannot be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredEduPersonPrincipalName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredEduPersonPrincipalName.java
@@ -50,11 +50,11 @@ public class urn_perun_user_attribute_def_def_preferredEduPersonPrincipalName ex
 	@Override
 	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
-		String value = (String)attribute.getValue();
+		String value = attribute.valueAsString();
 		try {
 			Attribute eppns = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, user, A_U_eduPersonPrincipalNames);
 			if (eppns.getValue() != null) {
-				List<String> values = (List<String>)eppns.getValue();
+				List<String> values = eppns.valueAsList();
 				if (!values.contains(value)) {
 					// value is not allowed
 					throw new WrongReferenceAttributeValueException(attribute, eppns, user, null, user, null, "Value '"+value+"' is not allowed. Please use one of allowed.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredMail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredMail.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
@@ -20,11 +21,9 @@ public class urn_perun_user_attribute_def_def_preferredMail extends UserAttribut
 	private static final String A_M_mail = AttributesManager.NS_MEMBER_ATTR_DEF + ":mail";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
-		String attributeValue;
-
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "User preferred mail can't be set to null.");
-		else attributeValue = (String) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+		if(attribute.getValue() == null) return;
+		String attributeValue = attribute.valueAsString();
 
 		Matcher emailMatcher = Utils.emailPattern.matcher(attributeValue);
 		if(!emailMatcher.find()) throw new WrongAttributeValueException(attribute, user, "Email is not in correct form.");
@@ -51,6 +50,12 @@ public class urn_perun_user_attribute_def_def_preferredMail extends UserAttribut
 		}
 		throw new WrongAttributeValueException("Attribute user preffered mail can be null (if no members mail exists) or one of the existing member's mails [" + possiblePrefferedMailValues.toString() + "]. " + attribute);
 		*/
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null)
+			throw new WrongReferenceAttributeValueException(attribute, null, user, null, "User preferred mail can't be set to null.");
 	}
 
 	/* Not needed now this funcionality

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredShells.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredShells.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
@@ -17,21 +18,13 @@ import java.util.List;
 public class urn_perun_user_attribute_def_def_preferredShells extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
-		List<String> pshell = (List<String>) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
 
-		if (pshell != null){
-			for(String shell : pshell){
-				if(shell != null){
-					if(shell.isEmpty()){
-						throw new WrongAttributeValueException(attribute, user, "shell cannot be empty string");
-					}else{
-						sess.getPerunBl().getModulesUtilsBl().checkFormatOfShell(shell, attribute);
-					}
-				}else{
-					throw new WrongAttributeValueException(attribute, user, "shell cannot be null");
-				}
-			}
+		List<String> pshell = attribute.valueAsList();
+		for (String shell : pshell) {
+			if (shell == null) throw new WrongAttributeValueException(attribute, user, "shell cannot be empty string");
+			sess.getPerunBl().getModulesUtilsBl().checkFormatOfShell(shell, attribute);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace.java
@@ -20,9 +20,9 @@ public class urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace e
 	private static final Pattern pattern = Pattern.compile("^[-_.a-zA-Z0-9]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
 		if(attribute.getValue()!= null) {
-			for(String groupName: (List<String>)attribute.getValue()) {
+			for(String groupName: attribute.valueAsList()) {
 				Matcher matcher = pattern.matcher(groupName);
 				if (!matcher.matches()) throw new WrongAttributeValueException(attribute, user, "GroupName: " + groupName + " content invalid characters. Allowed are only letters, numbers and characters _ and - and .");
 			}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_rootMailAliasesMail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_rootMailAliasesMail.java
@@ -19,8 +19,8 @@ import java.util.regex.Matcher;
 public class urn_perun_user_attribute_def_def_rootMailAliasesMail extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
     @Override
-    public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
-        String attributeValue = (String) attribute.getValue();
+    public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+        String attributeValue = attribute.valueAsString();
 
         Matcher emailMatcher = Utils.emailPattern.matcher(attributeValue);
         if (!emailMatcher.find()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicAdminKey.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicAdminKey.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
@@ -18,16 +19,21 @@ import java.util.List;
 public class urn_perun_user_attribute_def_def_sshPublicAdminKey extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user,"Cant be null.");
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+		if(attribute.getValue() == null) return;
 		
 		//Testing if some ssh key contains new line character
-		List<String> sshKeys = (ArrayList<String>) attribute.getValue();
+		List<String> sshKeys = attribute.valueAsList();
 		for(String sshKey: sshKeys) {
 			if(sshKey != null) {
 				if(sshKey.contains("\n")) throw new WrongAttributeValueException(attribute, user, "One of keys in attribute contains new line character. New line character is not allowed here.");
 			}
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, user, null, "Cant be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKey.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKey.java
@@ -18,12 +18,12 @@ import java.util.List;
 public class urn_perun_user_attribute_def_def_sshPublicKey extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
 		//Null in value is ok here
 		if(attribute.getValue() == null) return;
 		
 		//Testing if some ssh key contains new line character
-		List<String> sshKeys = (ArrayList<String>) attribute.getValue();
+		List<String> sshKeys = attribute.valueAsList();
 		for(String sshKey: sshKeys) {
 			if(sshKey != null) {
 				if(sshKey.contains("\n")) throw new WrongAttributeValueException(attribute, user, "One of keys in attribute contains new line character. New line character is not allowed here.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_timezone.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_timezone.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
@@ -576,13 +577,17 @@ public class urn_perun_user_attribute_def_def_timezone extends UserAttributesMod
 	));
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "Timezone must be set");
-		if (!(attribute.getValue() instanceof String)) throw new WrongAttributeValueException(attribute, user, "Attribute value (timezone) is not String type.");
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
 
-		String attributeValue = (String) attribute.getValue();
+		String attributeValue = attribute.valueAsString();
 
 		if (!(timezones.contains(attributeValue))) throw new WrongAttributeValueException(attribute, user, "Timezone is not in the correct form.");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, user, null, "Timezone must be set");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_ucoVsup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_ucoVsup.java
@@ -11,7 +11,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleAbstract;
@@ -26,9 +26,9 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
 public class urn_perun_user_attribute_def_def_ucoVsup extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
 
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "UČO can't be null.");
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, user, null, "UČO can't be null.");
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertDNs.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertDNs.java
@@ -28,10 +28,9 @@ public class urn_perun_user_attribute_def_def_userCertDNs extends UserAttributes
 	private static final Pattern certPattern = Pattern.compile("^/");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "This attribute value can't be null");
-		Map<String, String> value = (Map) attribute.getValue();
-		if(value.isEmpty()) throw new WrongAttributeValueException(attribute, "This attribute value can't be empty");
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+		if(attribute.getValue() == null) return;
+		Map<String, String> value = attribute.valueAsMap();
 
 		Set<String> valueKeys = value.keySet();
 		for(String k: valueKeys) {
@@ -41,6 +40,12 @@ public class urn_perun_user_attribute_def_def_userCertDNs extends UserAttributes
 			Matcher certValueOfKeyMatcher = certPattern.matcher(valueOfKey);
 			if(!certValueOfKeyMatcher.find()) throw new WrongAttributeValueException(attribute, "There is wrong value for key's value " + valueOfKey + " in hashMap of UserCertDns for key " + k);
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null)
+			throw new WrongReferenceAttributeValueException(attribute, null, user, null, "This attribute value can't be null");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertificates.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertificates.java
@@ -12,8 +12,8 @@ import org.apache.commons.codec.binary.Base64;
 
 import javax.security.cert.CertificateException;
 import javax.security.cert.X509Certificate;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * @author Michal Stava <stavamichal@gmail.com>
@@ -21,9 +21,9 @@ import java.util.LinkedHashMap;
 public class urn_perun_user_attribute_def_def_userCertificates extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
 		try {
-			HashMap<String,String> certs = (HashMap<String,String>) attribute.getValue();
+			Map<String,String> certs = attribute.valueAsMap();
 
 			if (certs != null) {
 				for (String certDN : certs.keySet()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userPreferredCertDN.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userPreferredCertDN.java
@@ -25,7 +25,7 @@ import java.util.Set;
 public class urn_perun_user_attribute_def_def_userPreferredCertDN extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute userCertDNs;
 		try {
 			userCertDNs = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":userCertDNs");
@@ -34,16 +34,16 @@ public class urn_perun_user_attribute_def_def_userPreferredCertDN extends UserAt
 		}
 		Map<String, String> certDNsValue;
 		if(userCertDNs.getValue() != null) {
-			certDNsValue = (Map<String, String>) userCertDNs.getValue();
+			certDNsValue = userCertDNs.valueAsMap();
 		} else {
-			if(attribute.getValue() != null) throw new WrongReferenceAttributeValueException(attribute, userCertDNs, "There is no certificates for this user so preferred certificate can't be choose.");
+			if(attribute.getValue() != null) throw new WrongReferenceAttributeValueException(attribute, userCertDNs, user, null, user, null, "There is no certificates for this user so preferred certificate can't be choose.");
 			else return;
 		}
 		if(attribute.getValue() == null) {
-			if(certDNsValue != null && !certDNsValue.isEmpty()) throw new WrongAttributeValueException(attribute, user, "This attribute value can't be null because of notNull attribute userCertDNs");
+			if(certDNsValue != null && !certDNsValue.isEmpty()) throw new WrongReferenceAttributeValueException(attribute, userCertDNs, user, null, user, null, "This attribute value can't be null because of notNull attribute userCertDNs");
 		} else {
-			String preferredCertDNValue = (String) attribute.getValue();
-			if(!certDNsValue.containsKey(preferredCertDNValue)) throw new WrongAttributeValueException(attribute, "This attribute value must be one of exsiting keys in userCertDNs.");
+			String preferredCertDNValue = attribute.valueAsString();
+			if(!certDNsValue.containsKey(preferredCertDNValue)) throw new WrongReferenceAttributeValueException(attribute, userCertDNs, user, null, user, null, "This attribute value must be one of exsiting keys in userCertDNs.");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMail.java
@@ -55,7 +55,16 @@ public class urn_perun_user_attribute_def_def_vsupMail extends UserAttributesMod
 	private static final String A_U_D_loginNamespace_vsup = AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:vsup";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() != null) {
+			Matcher emailMatcher = emailPattern.matcher(attribute.valueAsString());
+			if (!emailMatcher.find())
+				throw new WrongAttributeValueException(attribute, user, "School mail is not in a correct form: \"login@vsup.cz\".");
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 
 		// check only if not null
 		if (attribute.getValue() != null) {
@@ -77,9 +86,6 @@ public class urn_perun_user_attribute_def_def_vsupMail extends UserAttributesMod
 			}
 
 			//if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "School mail can't be null.");
-
-			Matcher emailMatcher = emailPattern.matcher((String)attribute.getValue());
-			if(!emailMatcher.find()) throw new WrongAttributeValueException(attribute, user, "School mail is not in a correct form: \"login@vsup.cz\".");
 
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailAliases.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailAliases.java
@@ -39,9 +39,9 @@ import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_user_a
 public class urn_perun_user_attribute_def_def_vsupMailAliases extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
 
-		List<String> mails = (attribute.getValue() != null) ? ((List<String>)attribute.getValue()) : (new ArrayList<>());
+		List<String> mails = (attribute.getValue() != null) ? (attribute.valueAsList()) : (new ArrayList<>());
 
 		for (String mail : mails) {
 			Matcher emailMatcher = emailPattern.matcher(mail);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupPreferredMail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupPreferredMail.java
@@ -47,7 +47,7 @@ import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_user_a
 public class urn_perun_user_attribute_def_def_vsupPreferredMail extends UserAttributesModuleAbstract implements UserAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
 
 		// we must allow null, since when setting required attributes all at once, value might not be filled yet
 		// if vsupMail or vsupMailAlias is empty, but it's checked by method impl.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loa.java
@@ -14,7 +14,7 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserVirtualAttributesModuleImplApi;
@@ -37,8 +37,8 @@ public class urn_perun_user_attribute_def_virt_loa extends UserVirtualAttributes
 	private static final Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_virt_loa.class);
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongAttributeValueException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, "Attribute value is null.");
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, user, null, "Attribute value is null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleAbstract.java
@@ -24,7 +24,7 @@ public abstract class UserAttributesModuleAbstract extends AttributesModuleAbstr
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/UserAttributesModuleImplApi.java
@@ -38,13 +38,11 @@ public interface UserAttributesModuleImplApi extends AttributesModuleImplApi {
 	 *
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongReferenceAttributeValueException if an referenced attribute against
 	 *         the parameter is to be compared is not available
-	 * @throws WrongReferenceAttributeValueException
-	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongAttributeAssignmentException if attribute does not belong to appropriate entity
 	 */
-	void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Tries to fill an attribute to the specified user.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_IPAddressesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_IPAddressesTest.java
@@ -32,11 +32,11 @@ public class urn_perun_user_attribute_def_def_IPAddressesTest {
 	}
 
 	@Test
-	public void testCheckAttributeSemantics() throws Exception {
-		System.out.println("testCheckAttributeSemantics()");
+	public void testCheckAttributeSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
 
 		Attribute attributeToCheck = new Attribute();
-		List ipAddresses = new ArrayList<>();
+		List<String> ipAddresses = new ArrayList<>();
 		ipAddresses.add("255.255.255.255");
 		ipAddresses.add("192.168.1.0");
 		ipAddresses.add("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
@@ -44,18 +44,18 @@ public class urn_perun_user_attribute_def_def_IPAddressesTest {
 		ipAddresses.add("2001:db8::2:1");
 
 		attributeToCheck.setValue(ipAddresses);
-		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsWithWrongValue() throws Exception {
-		System.out.println("testCheckAttributeSemanticsWithWrongValue()");
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
 
 		Attribute attributeToCheck = new Attribute();
-		List ipAddresses = new ArrayList<>();
+		List<String> ipAddresses = new ArrayList<>();
 		ipAddresses.add("123");
 		attributeToCheck.setValue(ipAddresses);
 
-		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_cnCeitecADTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_cnCeitecADTest.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_cnCeitecADTest {
+
+	private static urn_perun_user_attribute_def_def_cnCeitecAD classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static User secondUser;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_cnCeitecAD();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		secondUser = new User(1, "Jane", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+		attributeToCheck.setValue("něco");
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(session.getPerunBl().getUsersManagerBl()).thenReturn(usersManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testNullValue() throws Exception {
+		System.out.println("testNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAlreadyOccupiedValue() throws Exception {
+		System.out.println("testCheckAlreadyOccupiedValue()");
+		when(session.getPerunBl().getUsersManagerBl().getUsersByAttribute(session, attributeToCheck)).thenReturn(Arrays.asList(user, secondUser));
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		when(session.getPerunBl().getUsersManagerBl().getUsersByAttribute(session, attributeToCheck)).thenReturn(Collections.singletonList(user));
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_eduroamIdentitiesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_eduroamIdentitiesTest.java
@@ -1,0 +1,49 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_eduroamIdentitiesTest {
+
+	private static urn_perun_user_attribute_def_def_eduroamIdentities classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_eduroamIdentities();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("my@example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add("bad.example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirScopedAffiliationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_elixirScopedAffiliationTest.java
@@ -1,0 +1,49 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_elixirScopedAffiliationTest {
+
+	private static urn_perun_user_attribute_def_def_elixirScopedAffiliation classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_elixirScopedAffiliation();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("member@my.example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add("bad@example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_k4NavTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_k4NavTest.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_k4NavTest {
+
+	private static urn_perun_user_attribute_def_def_k4Nav classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_k4Nav();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+
+		attributeToCheck.setValue("0");
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+
+		attributeToCheck.setValue("1");
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		attributeToCheck.setValue("5");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_k4StaleaktTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_k4StaleaktTest.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_k4StaleaktTest {
+
+	private static urn_perun_user_attribute_def_def_k4Staleakt classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_k4Staleakt();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+
+		attributeToCheck.setValue("0");
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+
+		attributeToCheck.setValue("1");
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		attributeToCheck.setValue("5");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosAdminPrincipalTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosAdminPrincipalTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_kerberosAdminPrincipalTest {
+
+	private static urn_perun_user_attribute_def_def_kerberosAdminPrincipal classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_kerberosAdminPrincipal();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("my@example");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad.example");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testNullValue() throws Exception {
+		System.out.println("testNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("my@example");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosLoginsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_kerberosLoginsTest.java
@@ -1,0 +1,68 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_kerberosLoginsTest {
+
+	private static urn_perun_user_attribute_def_def_kerberosLogins classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_kerberosLogins();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("my@example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add("bad.example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testNullValue() throws Exception {
+		System.out.println("testNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		List<String> value = new ArrayList<>();
+		value.add("my@example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_ceitecTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_ceitecTest.java
@@ -1,0 +1,53 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_login_namespace_ceitecTest {
+
+	private static urn_perun_user_attribute_def_def_login_namespace_ceitec classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_login_namespace_ceitec();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		String value = "my_example";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		String value = "too_long_to_be_namespace";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduroam_vsupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduroam_vsupTest.java
@@ -1,0 +1,86 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_login_namespace_eduroam_vsupTest {
+
+	private static urn_perun_user_attribute_def_def_login_namespace_eduroam_vsup classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+	private static Attribute attribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_login_namespace_eduroam_vsup();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly_name");
+		attribute = new Attribute();
+		attribute.setValue("same_value");
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(perunBl.getUsersManagerBl()).thenReturn(usersManagerBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:vsup")).thenReturn(attribute);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
+		String value = "my_example";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		String value = "admin";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
+		String value = "same_value";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		String value = "not_same_value";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nicknameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nicknameTest.java
@@ -1,0 +1,52 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nicknameTest {
+	private static urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickname classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_login_namespace_eduteams_acc_nickname();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
+		String value = "my_example";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		String value = "too_long_to_be_namespace";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_nicknameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_eduteams_nicknameTest.java
@@ -1,0 +1,52 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_login_namespace_eduteams_nicknameTest {
+	private static urn_perun_user_attribute_def_def_login_namespace_eduteams_nickname classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_login_namespace_eduteams_nickname();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
+		String value = "my_example";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		String value = "too_long_to_be_namespace";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_nicknameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_nicknameTest.java
@@ -1,0 +1,52 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_login_namespace_fenix_nicknameTest {
+	private static urn_perun_user_attribute_def_def_login_namespace_fenix_nickname classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_login_namespace_fenix_nickname();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		String value = "my_example";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		String value = "too_long_to_be_namespace";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_vsupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_vsupTest.java
@@ -1,0 +1,62 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_login_namespace_vsupTest {
+
+	private static urn_perun_user_attribute_def_def_login_namespace_vsup classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_login_namespace_vsup();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		String value = "my_example";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		String value = "too_long_to_be_namespace";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue2() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue2()");
+		String value = "admin";
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mailaliasesGenericMailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_mailaliasesGenericMailTest.java
@@ -1,0 +1,43 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_mailaliasesGenericMailTest {
+
+	private static urn_perun_user_attribute_def_def_mailaliasesGenericMail classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_mailaliasesGenericMail();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		attributeToCheck.setValue("my@example.com");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad@example");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_osbIddc2Test.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_osbIddc2Test.java
@@ -1,0 +1,43 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_osbIddc2Test {
+
+	private static urn_perun_user_attribute_def_def_osbIddc2 classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_osbIddc2();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckCorrectSemantics() throws Exception {
+		System.out.println("testCheckCorrectSemantics()");
+		attributeToCheck.setValue("my_example");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_phoneTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_phoneTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_phoneTest {
+
+	private static urn_perun_user_attribute_def_def_phone classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_phone();
+		session = mock(PerunSessionImpl.class);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("+420123456789");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		attributeToCheck.setValue("123456789");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testNullValue() throws Exception {
+		System.out.println("testNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("+420123456789");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredEduPersonPrincipalNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredEduPersonPrincipalNameTest.java
@@ -1,0 +1,75 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_preferredEduPersonPrincipalNameTest {
+
+	private static urn_perun_user_attribute_def_def_preferredEduPersonPrincipalName classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_preferredEduPersonPrincipalName();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(session.getPerunBl().getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_VIRT + ":eduPersonPrincipalNames")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNullValue() throws Exception {
+		System.out.println("testCheckNullValue()");
+		List<String> list = new ArrayList<>();
+		list.add("not name");
+		reqAttribute.setValue(list);
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNotAllowedValue() throws Exception {
+		System.out.println("testCheckNotAllowedValue()");
+		List<String> list = new ArrayList<>();
+		list.add("not name");
+		reqAttribute.setValue(list);
+		attributeToCheck.setValue("name");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		List<String> list = new ArrayList<>();
+		list.add("name");
+		reqAttribute.setValue(list);
+		attributeToCheck.setValue("name");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredMailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredMailTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_preferredMailTest {
+
+	private static urn_perun_user_attribute_def_def_preferredMail classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_preferredMail();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCheckCorrectAttributeSyntax() throws Exception {
+		System.out.println("testCheckCorrectAttributeSyntax()");
+		attributeToCheck.setValue("my@example.com");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad@example");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckSemanticsWithNullAttributeValue() throws Exception {
+		System.out.println("testCheckSemanticsWithNullAttributeValue()");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemantics() throws Exception {
+		System.out.println("testCheckAttributeSemantics()");
+		attributeToCheck.setValue("my@example.com");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredShellsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredShellsTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_preferredShellsTest {
+
+	private static urn_perun_user_attribute_def_def_preferredShells classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_preferredShells();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+	}
+
+	@Test
+	public void testCheckAttributeSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add(null);
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredUnixGroupName_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_preferredUnixGroupName_namespaceTest.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_preferredUnixGroupName_namespaceTest {
+
+	private static urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_preferredUnixGroupName_namespace();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCheckCorrectAttributeSyntax() throws Exception {
+		System.out.println("testCheckCorrectAttributeSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("_example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add("bad@example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_rootMailAliasesMailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_rootMailAliasesMailTest.java
@@ -1,0 +1,43 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_rootMailAliasesMailTest {
+
+	private static urn_perun_user_attribute_def_def_rootMailAliasesMail classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_rootMailAliasesMail();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCheckCorrectAttributeSyntax() throws Exception {
+		System.out.println("testCheckCorrectAttributeSyntax()");
+		attributeToCheck.setValue("my@example.com");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad@example");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicAdminKeyTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicAdminKeyTest.java
@@ -1,0 +1,68 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_sshPublicAdminKeyTest {
+
+	private static urn_perun_user_attribute_def_def_sshPublicAdminKey classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_sshPublicAdminKey();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		List<String> value = new ArrayList<>();
+		value.add("my_example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add("bad_example\n");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		List<String> value = new ArrayList<>();
+		value.add("my_example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKeyTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_sshPublicKeyTest.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_sshPublicKeyTest {
+
+	private static urn_perun_user_attribute_def_def_sshPublicKey classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_sshPublicKey();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCheckCorrectAttributeSyntax() throws Exception {
+		System.out.println("testCheckCorrectAttributeSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("my_example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add("bad_example\n");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_timezoneTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_timezoneTest.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,28 +30,54 @@ public class urn_perun_user_attribute_def_def_timezoneTest {
 	}
 
 	@Test
+	public void testCheckAttributeSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
+
+		Attribute attributeToCheck = new Attribute();
+
+		attributeToCheck.setValue("Europe/Prague");
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+
+		attributeToCheck.setValue("Africa/Johannesburg");
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+
+		attributeToCheck.setValue("Jamaica");
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+		public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+			System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+
+			Attribute attributeToCheck = new Attribute();
+			attributeToCheck.setValue("123");
+
+			classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+		}
+
+	@Test
 	public void testCheckAttributeSemantics() throws Exception {
 		System.out.println("testCheckAttributeSemantics()");
 
 		Attribute attributeToCheck = new Attribute();
 
 		attributeToCheck.setValue("Europe/Prague");
-		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
 
 		attributeToCheck.setValue("Africa/Johannesburg");
-		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
 
 		attributeToCheck.setValue("Jamaica");
 		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
 	}
 
-	@Test(expected = WrongAttributeValueException.class)
-		public void testCheckAttributeSemanticsWithWrongValue() throws Exception {
-			System.out.println("testCheckAttributeSemanticsWithWrongValue()");
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
 
-			Attribute attributeToCheck = new Attribute();
-			attributeToCheck.setValue("123");
+		Attribute attributeToCheck = new Attribute();
 
-			classInstance.checkAttributeSemantics(session, user, attributeToCheck);
-		}
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_ucoVsupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_ucoVsupTest.java
@@ -1,0 +1,45 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_ucoVsupTest {
+
+	private static PerunSessionImpl session;
+	private static urn_perun_user_attribute_def_def_ucoVsup classInstance;
+	private static User user;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_ucoVsup();
+		user = new User();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+	}
+
+	@Test
+	public void testCheckCorrectAttributeSemantics() throws Exception {
+		System.out.println("testCheckCorrectAttributeSemantics()");
+
+		Attribute attributeToCheck = new Attribute();
+
+		attributeToCheck.setValue("not_null");
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+
+		Attribute attributeToCheck = new Attribute();
+
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_uid_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_uid_namespaceTest.java
@@ -1,0 +1,122 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_uid_namespaceTest {
+	private static urn_perun_user_attribute_def_def_uid_namespace classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+	private static Attribute minUid;
+	private static Attribute maxUid;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_uid_namespace();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("name:param");
+		minUid = new Attribute();
+		maxUid = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(session.getPerunBl().getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, "param", AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-minUID")).thenReturn(minUid);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, "param", AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":namespace-maxUID")).thenReturn(maxUid);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(session.getPerunBl().getUsersManagerBl()).thenReturn(usersManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithNullValue() throws Exception {
+		System.out.println("testCheckWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithNullWithNullMinUid() throws Exception {
+		System.out.println("testCheckWithNullWithNullMinUid()");
+		minUid.setValue(null);
+		maxUid.setValue(6);
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithNullWithNullMaxUid() throws Exception {
+		System.out.println("testCheckWithNullWithNullMaxUid()");
+		minUid.setValue(1);
+		maxUid.setValue(null);
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithUidLesserThanMin() throws Exception {
+		System.out.println("testCheckWithUidLesserThanMin()");
+		minUid.setValue(2);
+		maxUid.setValue(6);
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithUidHigherThanMax() throws Exception {
+		System.out.println("testCheckWithUidHigherThanMax()");
+		minUid.setValue(2);
+		maxUid.setValue(6);
+		attributeToCheck.setValue(7);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithDuplicate() throws Exception {
+		System.out.println("testCheckWithDuplicate()");
+		minUid.setValue(2);
+		maxUid.setValue(6);
+		attributeToCheck.setValue(5);
+
+		List<User> list = new ArrayList<>();
+		list.add(user);
+		list.add(new User());
+		when(session.getPerunBl().getUsersManagerBl().getUsersByAttribute(session, attributeToCheck)).thenReturn(list);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		minUid.setValue(2);
+		maxUid.setValue(6);
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertDNsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertDNsTest.java
@@ -1,0 +1,79 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_userCertDNsTest {
+
+	private static urn_perun_user_attribute_def_def_userCertDNs classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_userCertDNs();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithIncorrectKeyValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectKeyValue()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("bad_example", "/example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithIncorrectValueValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValueValue()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("/example", "");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("/example", "/example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("/example", "/example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertificatesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertificatesTest.java
@@ -1,0 +1,61 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_attribute_def_def_userCertificatesTest {
+
+	private static urn_perun_user_attribute_def_def_userCertificates classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_user_attribute_def_def_userCertificates();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		user = new User();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("example", "-----BEGIN CERTIFICATE-----\n" +
+			"MIIBwzCCAWqgAwIBAgIRAIi5QRl9kz1wb+SUP20gB1kwCgYIKoZIzj0EAwIwGzEZ\n" +
+			"MBcGA1UEAxMQTDVkIFRlc3QgUm9vdCBDQTAeFw0xODExMDYyMjA0MDNaFw0yODEx\n" +
+			"MDMyMjA0MDNaMCMxITAfBgNVBAMTGEw1ZCBUZXN0IEludGVybWVkaWF0ZSBDQTBZ\n" +
+			"MBMGByqGSM49AgEGCCqGSM49AwEHA0IABAST8h+JftPkPocZyuZ5CVuPUk3vUtgo\n" +
+			"cgRbkYk7Ong7ey/fM5fJdRNdeW6SouV5h3nF9JvYKEXuoymSNjGbKomjgYYwgYMw\n" +
+			"DgYDVR0PAQH/BAQDAgGmMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAS\n" +
+			"BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBRc+LHppFk8sflIpm/XKpbNMwx3\n" +
+			"SDAfBgNVHSMEGDAWgBTirEpzC7/gexnnz7ozjWKd71lz5DAKBggqhkjOPQQDAgNH\n" +
+			"ADBEAiAejDEfua7dud78lxWe9eYxYcM93mlUMFIzbWlOJzg+rgIgcdtU9wIKmn5q\n" +
+			"FU3iOiRP5VyLNmrsQD3/ItjUN1f1ouY=\n" +
+			"-----END CERTIFICATE-----");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("bad_example", "bad_example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userPreferredCertDNTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userPreferredCertDNTest.java
@@ -1,0 +1,84 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_userPreferredCertDNTest {
+
+	private static urn_perun_user_attribute_def_def_userPreferredCertDN classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_userPreferredCertDN();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(session.getPerunBl().getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF + ":userCertDNs")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithPreferredValueButNoCertificates() throws Exception {
+		System.out.println("testCheckWithPreferredValueButNoCertificates()");
+		reqAttribute.setValue(null);
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithNullPreferredValue() throws Exception {
+		System.out.println("testCheckWithNullPreferredValue()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("example", "example");
+		reqAttribute.setValue(value);
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckWithInvalidPreferredValue() throws Exception {
+		System.out.println("testCheckWithInvalidPreferredValue()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("example", "example");
+		reqAttribute.setValue(value);
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("example", "example");
+		reqAttribute.setValue(value);
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailAliasTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailAliasTest.java
@@ -1,0 +1,89 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_user_attribute_def_def_vsupMail.usedMailsKeyVsup;
+import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_user_attribute_def_def_vsupMail.usedMailsUrn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_vsupMailAliasTest {
+
+	private static urn_perun_user_attribute_def_def_vsupMailAlias classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_vsupMailAlias();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+		User user2 = new User(5, "John", "Doe", "", "", "");
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(session.getPerunBl().getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(session.getPerunBl().getAttributesManagerBl().getEntitylessAttributeForUpdate(session, usedMailsKeyVsup, usedMailsUrn)).thenReturn(reqAttribute);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(session.getPerunBl().getUsersManagerBl()).thenReturn(usersManagerBl);
+		when(session.getPerunBl().getUsersManagerBl().getUserById(session, 5)).thenReturn(user2);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckSemanticsWithInvalidLogin() throws Exception {
+		System.out.println("testCheckSemanticsWithInvalidLogin()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("john.doe@vsup.cz", "5");
+		reqAttribute.setValue(value);
+		attributeToCheck.setValue("john.doe@vsup.cz");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCheckSemanticsWithInvalidLogin()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("john.doe@vsup.cz", "5");
+		reqAttribute.setValue(value);
+		attributeToCheck.setValue("john.doe1@vsup.cz");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithIncorrectEmail() throws Exception {
+		System.out.println("testSyntaxWithIncorrectEmail()");
+		attributeToCheck.setValue("bad@example");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("john.doe@vsup.cz");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailAliasesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailAliasesTest.java
@@ -1,0 +1,54 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_vsupMailAliasesTest {
+
+	private static urn_perun_user_attribute_def_def_vsupMailAliases classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_vsupMailAliases();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithIncorrectEmail() throws Exception {
+		System.out.println("testSyntaxWithIncorrectEmail()");
+		List<String> value = new ArrayList<>();
+		value.add("bad@example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("example@vsup.cz");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupMailTest.java
@@ -1,0 +1,74 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_vsupMailTest {
+
+	private static urn_perun_user_attribute_def_def_vsupMail classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_vsupMail();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(session.getPerunBl().getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:vsup")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckSemanticsWithInvalidLogin() throws Exception {
+		System.out.println("testCheckSemanticsWithInvalidLogin()");
+		reqAttribute.setValue("bad_example");
+		attributeToCheck.setValue("example@vsup.cz");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		reqAttribute.setValue("example");
+		attributeToCheck.setValue("example@vsup.cz");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithIncorrectEmail() throws Exception {
+		System.out.println("testSyntaxWithIncorrectEmail()");
+		attributeToCheck.setValue("bad@example");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("example@vsup.cz");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupPreferredMailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_vsupPreferredMailTest.java
@@ -1,0 +1,47 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_def_vsupPreferredMailTest {
+
+	private static urn_perun_user_attribute_def_def_vsupPreferredMail classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_def_vsupPreferredMail();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithIncorrectEmail() throws Exception {
+		System.out.println("testSyntaxWithIncorrectEmail()");
+		attributeToCheck.setValue("bad@example");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("example@vsup.cz");
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loaTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_loaTest.java
@@ -1,0 +1,47 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_attribute_def_virt_loaTest {
+
+	private static urn_perun_user_attribute_def_virt_loa classInstance;
+	private static PerunSessionImpl session;
+	private static User user;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_attribute_def_virt_loa();
+		session = mock(PerunSessionImpl.class);
+		user = new User(0, "John", "Doe", "", "", "");
+		attributeToCheck = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("5");
+
+		classInstance.checkAttributeSemantics(session, user, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in user attribute modules
- also added test for checks