### PR TITLE
Separation of checkAttributeSyntax from semantics in Facility modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_accountExpirationTime.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_accountExpirationTime.java
@@ -9,7 +9,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -22,10 +22,9 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
 public class urn_perun_facility_attribute_def_def_accountExpirationTime extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
-		Integer accountExpTime = (Integer) attribute.getValue();
-		if(accountExpTime == null) {
-			throw new WrongAttributeValueException("account expiration time shouldn't be null");
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if(attribute.getValue() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, facility, null, "account expiration time shouldn't be null");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_googleGroupsDomain.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_googleGroupsDomain.java
@@ -6,7 +6,7 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -20,16 +20,16 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
 public class urn_perun_facility_attribute_def_def_googleGroupsDomain extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Attribute value can't be null");
+	public void checkAttributeSemantics(PerunSessionImpl sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, facility, null, "Attribute value can't be null");
 
 		// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
-		String namespace = ((String) attribute.getValue()).replaceAll("\\.", "-");
+		String namespace = (attribute.valueAsString()).replaceAll("\\.", "-");
 
 		try {
 			sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
 		} catch (AttributeNotExistsException e) {
-			throw new WrongAttributeValueException(attribute, e);
+			throw new WrongReferenceAttributeValueException(attribute, null, e);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeDirUmask.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeDirUmask.java
@@ -25,9 +25,9 @@ public class urn_perun_facility_attribute_def_def_homeDirUmask extends FacilityA
 	 * Method for checking permission mask of home directory.
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
 
-		String mask = (String) attribute.getValue();
+		String mask = attribute.valueAsString();
 
 		if (mask != null) {
 			Matcher matcher = pattern.matcher(mask);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scp.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -21,12 +22,17 @@ public class urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scp exte
 	private static final Pattern pattern = Pattern.compile("^(/[-_.a-zA-Z0-9]+)+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
-		String value = (String) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+		String value = attribute.valueAsString();
 
-		if(value == null) throw new WrongAttributeValueException(attribute, "Value can't be null");
+		if (value == null) return;
 		Matcher matcher = pattern.matcher(value);
 		if (!matcher.matches()) throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected.");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, facility, null, "Value can't be null");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoints.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoints.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -24,27 +25,34 @@ public class urn_perun_facility_attribute_def_def_homeMountPoints extends Facili
 	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
 
 	/**
-	 * Checks attribute facility_homeMountPoints, this attribute must not be null and must be valid *nix path
+	 * Checks attribute facility_homeMountPoints, this attribute must be valid *nix path
 	 * @param perunSession current session
 	 * @param facility facility to which this attribute belongs
 	 * @param attribute checked attribute
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
+	 * @throws WrongAttributeValueException if the attribute value has wrong/illegal syntax
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
 
-		if(attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute);
+		if(attribute.getValue() == null) return;
+
+		List<String> homeMountPoints = attribute.valueAsList();
+		for (String st : homeMountPoints) {
+			Matcher match = pattern.matcher(st);
+			if (!match.matches()) throw new WrongAttributeValueException(attribute, "Bad homeMountPoints attribute format " + st);
 		}
-		List<String> homeMountPoints = (List<String>) attribute.getValue();
-		if (!homeMountPoints.isEmpty()) {
-			for (String st : homeMountPoints) {
-				Matcher match = pattern.matcher(st);
-				if (!match.matches()) throw new WrongAttributeValueException(attribute, "Bad homeMountPoints attribute format " + st);
-			}
-		} else {
-			throw new WrongAttributeValueException(attribute,"Attribute can't be empty");
-		}
+	}
+
+	/**
+	 * Checks attribute facility_homeMountPoints, this attribute must not be null
+	 * @param perunSession current session
+	 * @param facility facility to which this attribute belongs
+	 * @param attribute checked attribute
+	 * @throws WrongReferenceAttributeValueException if the attribute value is null
+	 */
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Attribute cannot be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_ldapBaseDN.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_ldapBaseDN.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -17,13 +18,11 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
 public class urn_perun_facility_attribute_def_def_ldapBaseDN extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
 
-		if (attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, facility, "attribute is null");
-		}
+		if (attribute.getValue() == null) return;
 
-		String value = (String) attribute.getValue();
+		String value = attribute.valueAsString();
 		if (value.length() < 3) {
 			throw new WrongAttributeValueException(attribute, facility, "attribute has to start with \"ou=\" or \"dc=\"");
 		}
@@ -33,6 +32,11 @@ public class urn_perun_facility_attribute_def_def_ldapBaseDN extends FacilityAtt
 		if ( !(sub.equalsIgnoreCase("ou=") || sub.equalsIgnoreCase("dc=")) ) {
 			throw new WrongAttributeValueException(attribute, facility, "attribute has to start with \"ou=\" or \"dc=\"");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, facility, null, "attribute is null");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_login_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_login_namespace.java
@@ -5,8 +5,8 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -23,14 +23,14 @@ public class urn_perun_facility_attribute_def_def_login_namespace extends Facili
 	 * Checks if the corresponding attribute uf:login-namespace:[namespace] exists.
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl session, Facility facility, Attribute attribute) throws InternalErrorException {
+	public void checkAttributeSemantics(PerunSessionImpl session, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		String userFacilityLoginNamespaceAttributeName =
 			AttributesManager.NS_USER_ATTR_DEF + ":" + attribute.getFriendlyName() + ":" + attribute.getValue();
 
 		try {
 			session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, userFacilityLoginNamespaceAttributeName);
 		} catch (AttributeNotExistsException e) {
-			throw new ConsistencyErrorException("Attribute " + userFacilityLoginNamespaceAttributeName + " doesn't exists");
+			throw new WrongReferenceAttributeValueException(attribute, null, facility, null, "Attribute " + userFacilityLoginNamespaceAttributeName + " doesn't exists");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_passwdScpDestinationFile.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_passwdScpDestinationFile.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -27,14 +28,18 @@ public class urn_perun_facility_attribute_def_def_passwdScpDestinationFile exten
 	 * Try to check if the path is equal to pattern ^(/[-_a-zA-Z0-9]+)+$
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+		String path = attribute.valueAsString();
+		if (path == null) return;
 
-		String path = (String) attribute.getValue();
-		if (path == null) {
-			throw new WrongAttributeValueException(attribute, "Attribute was not filled, therefore there is nothing to be checked.");
-		}
 		Matcher matcher = pattern.matcher(path);
 		if (!matcher.matches()) throw new WrongAttributeValueException(attribute, "Bad path to destination of file in attribute format " + path);
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null)
+			throw new WrongReferenceAttributeValueException(attribute, "Attribute was not filled, therefore there is nothing to be checked.");
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_quotaEnabled.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_quotaEnabled.java
@@ -17,12 +17,12 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesMo
 public class urn_perun_facility_attribute_def_def_quotaEnabled extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi  {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
 		//Null means the same like 0 (not enabled)
 		if(attribute.getValue() == null) return;
 		
-		Integer quotaEnabled = (Integer) attribute.getValue();
-		if(quotaEnabled > 1 || quotaEnabled < 0) throw new WrongAttributeValueException(attribute, facility, null, "Attribute has only two possible options for quota: 0 - means not enabled, 1 - means enabled.");
+		Integer quotaEnabled = attribute.valueAsInteger();
+		if(quotaEnabled > 1 || quotaEnabled < 0) throw new WrongAttributeValueException(attribute, facility, "Attribute has only two possible options for quota: 0 - means not enabled, 1 - means enabled.");
 		 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_reqAups.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_reqAups.java
@@ -5,7 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -26,9 +26,9 @@ public class urn_perun_facility_attribute_def_def_reqAups extends FacilityAttrib
 	private final static String availableAups = AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":orgAups";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 
-		List<String> aups = (List<String>) attribute.getValue();
+		List<String> aups = attribute.valueAsList();
 
 		if (aups == null || aups.isEmpty()) return;
 
@@ -40,13 +40,13 @@ public class urn_perun_facility_attribute_def_def_reqAups extends FacilityAttrib
 		// fill available keys
 		for (Attribute a : allAUPS) {
 			if (a != null && a.getValue() != null && a.getValue() instanceof LinkedHashMap) {
-				LinkedHashMap<String,String> map = (LinkedHashMap<String,String>)a.getValue();
+				LinkedHashMap<String,String> map = a.valueAsMap();
 				keys.addAll(map.keySet());
 			}
 		}
 
 		for (String aup : aups) {
-			if (!keys.contains(aup)) throw new WrongAttributeValueException(attribute, aup+" AUP doesn't exist in available organization AUPs.");
+			if (!keys.contains(aup)) throw new WrongReferenceAttributeValueException(attribute, null, facility, null, aup+" AUP doesn't exist in available organization AUPs.");
 		}
 
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_rtOutputFileName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_rtOutputFileName.java
@@ -24,14 +24,14 @@ public class urn_perun_facility_attribute_def_def_rtOutputFileName extends Facil
 	Pattern fileNamePattern = Pattern.compile("^[-_a-zA-Z0-9]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
 
 		//attribute can be empty
 		if (attribute.getValue() == null) {
 			return;
 		}
 
-		String value = (String) attribute.getValue();
+		String value = attribute.valueAsString();
 
 		Matcher matcher = fileNamePattern.matcher(value);
 		if (!matcher.matches()) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_scratchDirPermissions.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_scratchDirPermissions.java
@@ -22,12 +22,11 @@ public class urn_perun_facility_attribute_def_def_scratchDirPermissions  extends
 	private static final Pattern pattern = Pattern.compile("^[01234567]?[01234567]{3}$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
 		//Null is ok, it means use default permissions in script (probably 0700)
 		if(attribute.getValue() == null) return;
-		String attrValue = (String) attribute.getValue();
 		
-		Matcher match = pattern.matcher(attrValue);
+		Matcher match = pattern.matcher(attribute.valueAsString());
 
 		if(!match.matches()) throw new WrongAttributeValueException(attribute, facility, "Bad format of attribute, (expected something like '750' or '0700').");
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_scratchLocalDirPermissions.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_scratchLocalDirPermissions.java
@@ -22,10 +22,10 @@ public class urn_perun_facility_attribute_def_def_scratchLocalDirPermissions ext
 	private static final Pattern pattern = Pattern.compile("^[01234567]?[01234567]{3}$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
 		//Null is ok, it means use default permissions in script (probably 0700)
 		if(attribute.getValue() == null) return;
-		String attrValue = (String) attribute.getValue();
+		String attrValue = attribute.valueAsString();
 		
 		Matcher match = pattern.matcher(attrValue);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shell_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shell_passwd_scp.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -21,12 +22,17 @@ public class urn_perun_facility_attribute_def_def_shell_passwd_scp extends Facil
 	private static final Pattern pattern = Pattern.compile("^(/[-_.a-zA-Z0-9]+)+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
-		String shell = (String) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+		String shell = attribute.valueAsString();
 
-		if(shell == null) throw new WrongAttributeValueException(attribute, "Value can't be null");
+		if(shell == null) return;
 		Matcher matcher = pattern.matcher(shell);
 		if(!matcher.matches())  throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Value can't be null");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shells.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shells.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -26,20 +27,19 @@ public class urn_perun_facility_attribute_def_def_shells extends FacilityAttribu
 	 * e.g. corretct unix path.
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
-		List<String> shells = (List<String>) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+		List<String> shells = attribute.valueAsList();
 
-		if (shells == null) {
-			throw new WrongAttributeValueException(attribute, "This attribute cannot be null.");
-		}
+		if (shells == null) return;
 
-		if (!shells.isEmpty()) {
-			for (String st : shells) {
-				perunSession.getPerunBl().getModulesUtilsBl().checkFormatOfShell(st, attribute);
-			}
-		} else {
-			throw new WrongAttributeValueException(attribute);
+		for (String st : shells) {
+			perunSession.getPerunBl().getModulesUtilsBl().checkFormatOfShell(st, attribute);
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "This attribute cannot be null.");
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_uid_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_uid_namespace.java
@@ -5,9 +5,8 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -24,8 +23,8 @@ public class urn_perun_facility_attribute_def_def_uid_namespace extends Facility
 	 * Checks if the corresponding attribute u:uid-namespace:[namespace] exists.
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl session, Facility facility, Attribute attribute) throws WrongAttributeValueException, InternalErrorException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, facility, "Missing uid namespace for facility.");
+	public void checkAttributeSemantics(PerunSessionImpl session, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException, InternalErrorException {
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, facility, null, "Missing uid namespace for facility.");
 
 		String userFacilityUidNamespaceAttributeName =
 			AttributesManager.NS_USER_ATTR_DEF + ":" + attribute.getFriendlyName() + ":" + attribute.getValue();
@@ -33,7 +32,7 @@ public class urn_perun_facility_attribute_def_def_uid_namespace extends Facility
 		try {
 			session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, userFacilityUidNamespaceAttributeName);
 		} catch (AttributeNotExistsException e) {
-			throw new ConsistencyErrorException("Attribute " + userFacilityUidNamespaceAttributeName + " doesn't exists");
+			throw new WrongReferenceAttributeValueException("Attribute " + userFacilityUidNamespaceAttributeName + " doesn't exists");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_unixGID_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_unixGID_namespace.java
@@ -6,7 +6,7 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -23,14 +23,14 @@ public class urn_perun_facility_attribute_def_def_unixGID_namespace extends Faci
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_facility_attribute_def_def_unixGID_namespace.class);
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Attribute value can't be null");
+	public void checkAttributeSemantics(PerunSessionImpl sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Attribute value can't be null");
 
 		try {
 			sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:" + attribute.getValue());
 			sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGID-namespace:" + attribute.getValue());
 		} catch (AttributeNotExistsException e) {
-			throw new WrongAttributeValueException(attribute, e);
+			throw new WrongReferenceAttributeValueException(attribute, null, e);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_unixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_unixGroupName_namespace.java
@@ -6,7 +6,7 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
@@ -23,14 +23,14 @@ public class urn_perun_facility_attribute_def_def_unixGroupName_namespace extend
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_facility_attribute_def_def_unixGID_namespace.class);
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Attribute value can't be null");
+	public void checkAttributeSemantics(PerunSessionImpl sess, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Attribute value can't be null");
 
 		try {
 			sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:" + attribute.getValue());
 			sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:" + attribute.getValue());
 		} catch (AttributeNotExistsException e) {
-			throw new WrongAttributeValueException(attribute, e);
+			throw new WrongReferenceAttributeValueException(attribute, null, e);
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_GIDRanges.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_GIDRanges.java
@@ -33,8 +33,8 @@ public class urn_perun_facility_attribute_def_virt_GIDRanges extends FacilityVir
 		try {
 			Attribute gidNamespaceAttribute = getUnixGIDNamespaceAttribute(sess, facility);
 			if(gidNamespaceAttribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, gidNamespaceAttribute, "There is missing GID namespace on the facility.");
-			Attribute namespaceGIDRangesAttribute = getNamespaceGIDRangesAttribute(sess, (String) gidNamespaceAttribute.getValue());
-			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, (String) gidNamespaceAttribute.getValue(), namespaceGIDRangesAttribute);
+			Attribute namespaceGIDRangesAttribute = getNamespaceGIDRangesAttribute(sess, gidNamespaceAttribute.valueAsString());
+			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, gidNamespaceAttribute.valueAsString(), namespaceGIDRangesAttribute);
 		} catch(WrongReferenceAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, ex.getReferenceAttribute());
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_maxUID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_maxUID.java
@@ -32,8 +32,8 @@ public class urn_perun_facility_attribute_def_virt_maxUID extends FacilityVirtua
 		try {
 			Attribute uidNamespaceAttribute = getUidNamespaceAttribute(sess, facility);
 			if(uidNamespaceAttribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, uidNamespaceAttribute);
-			Attribute namespaceMaxUidAttribute = getNamespaceMaxUidAttribute(sess, (String) uidNamespaceAttribute.getValue());
-			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, (String) uidNamespaceAttribute.getValue(), namespaceMaxUidAttribute);
+			Attribute namespaceMaxUidAttribute = getNamespaceMaxUidAttribute(sess, uidNamespaceAttribute.valueAsString());
+			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, uidNamespaceAttribute.valueAsString(), namespaceMaxUidAttribute);
 		} catch(WrongReferenceAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, ex.getReferenceAttribute());
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_minUID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_minUID.java
@@ -32,8 +32,8 @@ public class urn_perun_facility_attribute_def_virt_minUID extends FacilityVirtua
 		try {
 			Attribute uidNamespaceAttribute = getUidNamespaceAttribute(sess, facility);
 			if(uidNamespaceAttribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, uidNamespaceAttribute);
-			Attribute namespaceMinUidAttribute = getNamespaceMinUidAttribute(sess, (String) uidNamespaceAttribute.getValue());
-			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, (String) uidNamespaceAttribute.getValue(), namespaceMinUidAttribute);
+			Attribute namespaceMinUidAttribute = getNamespaceMinUidAttribute(sess, uidNamespaceAttribute.valueAsString());
+			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, uidNamespaceAttribute.valueAsString(), namespaceMinUidAttribute);
 		} catch(WrongReferenceAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, ex.getReferenceAttribute());
 		}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_accountExpirationTimeTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_accountExpirationTimeTest.java
@@ -1,0 +1,42 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_facility_attribute_def_def_accountExpirationTimeTest {
+
+	private static urn_perun_facility_attribute_def_def_accountExpirationTime classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_facility_attribute_def_def_accountExpirationTime();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_googleGroupsDomainTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_googleGroupsDomainTest.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_def_googleGroupsDomainTest {
+
+	private static urn_perun_facility_attribute_def_def_googleGroupsDomain classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_googleGroupsDomain();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue("domain");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + "domain")).thenThrow(new AttributeNotExistsException(""));
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("domain");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + "domain")).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeDirUmaskTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeDirUmaskTest.java
@@ -29,41 +29,41 @@ public class urn_perun_facility_attribute_def_def_homeDirUmaskTest {
 	}
 
 	@Test
-	public void testCheckAttributeSemantics() throws Exception {
-		System.out.println("testCheckAttributeSemantics()");
+	public void testCheckAttributeSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
 
 		Attribute attributeToCheck = new Attribute();
 
 		attributeToCheck.setValue(null);
-		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
 
 		attributeToCheck.setValue("0542");
-		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
 
 		attributeToCheck.setValue("215");
-		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
 
 		attributeToCheck.setValue("0521");
-		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsWithWrongValue() throws Exception {
-		System.out.println("testCheckAttributeSemanticsWithWrongValue()");
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
 
 		Attribute attributeToCheck = new Attribute();
 
 		attributeToCheck.setValue("5891");
-		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsWithWrongValueLength() throws Exception {
-		System.out.println("testCheckAttributeSemanticsWithWrongValue()");
+	public void testCheckAttributeSyntaxWithWrongValueLength() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValueLength()");
 
 		Attribute attributeToCheck = new Attribute();
 
 		attributeToCheck.setValue("12");
-		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scpTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scpTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scpTest {
+
+	private static urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scp classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_homeMountPoint_passwd_scp();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithIncorrectValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPointsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_homeMountPointsTest.java
@@ -8,6 +8,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,41 +39,44 @@ public class urn_perun_facility_attribute_def_def_homeMountPointsTest {
 	 * with all properly set
 	 */
 	@Test
-	public void testCheckAttributeSemantics() throws Exception {
-		System.out.println("testCheckAttributeSemantics()");
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
 
 		ArrayList<String> homeMountPts= new ArrayList<>();
 		homeMountPts.add("/mnt/mymountpoint1");
 		homeMountPts.add("/mnt/mymountpoint2");
 		attribute.setValue(homeMountPts);
 
-		classInstance.checkAttributeSemantics(session, new Facility(), attribute);
+		classInstance.checkAttributeSyntax(session, new Facility(), attribute);
 
 	}
 
 	@Test(expected=WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxBadFormat() throws Exception {
+		System.out.println("testCheckAttributeSyntaxBadFormat");
+		ArrayList<String> homeMountPts= new ArrayList<>();
+		homeMountPts.add("/mnt/mymountpoint/");
+		homeMountPts.add("/mnt/mymountpoin@@t2\n");
+		attribute.setValue(homeMountPts);
+
+		classInstance.checkAttributeSyntax(session, new Facility(), attribute);
+	}
+
+	@Test(expected= WrongReferenceAttributeValueException.class)
 	public void testCheckAttributeSemanticsEmptyAttribute() throws Exception {
 		System.out.println("testCheckAttributeSemanticsEmptyAttribute()");
 
 		classInstance.checkAttributeSemantics(session, new Facility(), attribute);
 	}
 
-	@Test(expected=WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsBadFormat() throws Exception {
-		System.out.println("testCheckAttributeSemanticsBadFormat");
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+
 		ArrayList<String> homeMountPts= new ArrayList<>();
-		homeMountPts.add("/mnt/mymountpoint/");
-		homeMountPts.add("/mnt/mymountpoin@@t2\n");
+		homeMountPts.add("/mnt/mymountpoint1");
 		attribute.setValue(homeMountPts);
 
-		classInstance.checkAttributeSemantics(session, new Facility(), attribute);
-	}
-
-	@Test(expected=WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsNoHomeMountPointsSet() throws Exception {
-		System.out.println("testCheckAttributeSemanticsNoHomeMountPointsSet()");
-
-		attribute.setValue(new ArrayList<String>());
 		classInstance.checkAttributeSemantics(session, new Facility(), attribute);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_ldapBaseDNTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_ldapBaseDNTest.java
@@ -3,8 +3,12 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
-import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Created by Oliver Mrázik on 3. 7. 2014.
@@ -13,41 +17,65 @@ import org.junit.Test;
  */
 public class urn_perun_facility_attribute_def_def_ldapBaseDNTest {
 
-	final FacilityAttributesModuleImplApi module = new urn_perun_facility_attribute_def_def_ldapBaseDN();
+	private static urn_perun_facility_attribute_def_def_ldapBaseDN classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_ldapBaseDN();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+	}
 
 	@Test
-	public void testCheckAttributeSemantics() throws Exception {
-		Attribute attribute = new Attribute(module.getAttributeDefinition());
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		Attribute attribute = new Attribute(classInstance.getAttributeDefinition());
 		attribute.setValue("dc=example,dc=domain");
 
-		module.checkAttributeSemantics(null, null, attribute);
+		classInstance.checkAttributeSyntax(session, facility, attribute);
 
 		attribute.setValue("ou=example,dc=domain");
 
-		module.checkAttributeSemantics(null, new Facility(), attribute);
+		classInstance.checkAttributeSyntax(session, facility, attribute);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsEmptyString() throws Exception {
-		Attribute attribute = new Attribute(module.getAttributeDefinition());
+	public void testCheckAttributeSyntaxEmptyString() throws Exception {
+		Attribute attribute = new Attribute(classInstance.getAttributeDefinition());
 		attribute.setValue("");
 
-		module.checkAttributeSemantics(null, new Facility(), attribute);
+		classInstance.checkAttributeSyntax(session, facility, attribute);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsFailsLessChars() throws Exception {
-		Attribute attribute = new Attribute(module.getAttributeDefinition());
+	public void testCheckAttributeSyntaxFailsLessChars() throws Exception {
+		Attribute attribute = new Attribute(classInstance.getAttributeDefinition());
 		attribute.setValue("ou");
 
-		module.checkAttributeSemantics(null, new Facility(), attribute);
+		classInstance.checkAttributeSyntax(session, facility, attribute);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
 	public void testCheckAttributeSemanticsWrongChars() throws Exception {
-		Attribute attribute = new Attribute(module.getAttributeDefinition());
+		Attribute attribute = new Attribute(classInstance.getAttributeDefinition());
 		attribute.setValue("cn=example,dc=domain");
 
-		module.checkAttributeSemantics(null, new Facility(), attribute);
+		classInstance.checkAttributeSyntax(session, facility, attribute);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		Attribute attribute = new Attribute(classInstance.getAttributeDefinition());
+
+		classInstance.checkAttributeSemantics(session, facility, attribute);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		Attribute attribute = new Attribute(classInstance.getAttributeDefinition());
+		attribute.setValue("dc=example,dc=domain");
+
+		classInstance.checkAttributeSemantics(session, facility, attribute);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_login_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_login_namespaceTest.java
@@ -1,0 +1,58 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_def_login_namespaceTest {
+
+	private static urn_perun_facility_attribute_def_def_login_namespace classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_login_namespace();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly_name");
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_USER_ATTR_DEF + ":" + attributeToCheck.getFriendlyName() + ":" + attributeToCheck.getValue())).thenThrow(new AttributeNotExistsException(""));
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_USER_ATTR_DEF + ":" + attributeToCheck.getFriendlyName() + ":" + attributeToCheck.getValue())).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_passwdScpDestinationFileTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_passwdScpDestinationFileTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_facility_attribute_def_def_passwdScpDestinationFileTest {
+
+	private static urn_perun_facility_attribute_def_def_passwdScpDestinationFile classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_passwdScpDestinationFile();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithIncorrectValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_pbsServerTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_pbsServerTest.java
@@ -1,0 +1,73 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.FacilitiesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_def_pbsServerTest {
+
+	private static urn_perun_facility_attribute_def_def_pbsServer classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_pbsServer();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		Attribute name = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		FacilitiesManagerBl facilitiesManagerBl = mock(FacilitiesManagerBl.class);
+		when(perunBl.getFacilitiesManagerBl()).thenReturn(facilitiesManagerBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttributeDefinition(session, AttributesManager.NS_FACILITY_ATTR_CORE + ":name")).thenReturn(name);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutSameNameFacility() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutSameNameFacility()");
+		attributeToCheck.setValue("domain");
+		when(session.getPerunBl().getFacilitiesManagerBl().getFacilities(session)).thenReturn(new ArrayList<>());
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+		Facility facilityToReturn = new Facility();
+		facilityToReturn.setName("example");
+		when(session.getPerunBl().getFacilitiesManagerBl().getFacilities(session)).thenReturn(Collections.singletonList(facilityToReturn));
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_quotaEnabledTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_quotaEnabledTest.java
@@ -1,0 +1,56 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_facility_attribute_def_def_quotaEnabledTest {
+
+	private static urn_perun_facility_attribute_def_def_quotaEnabled classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_quotaEnabled();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithTooLargeValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithTooSmallValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue(-1);
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+
+		attributeToCheck.setValue(null);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+
+		attributeToCheck.setValue(0);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+
+		attributeToCheck.setValue(1);
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_reqAupsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_reqAupsTest.java
@@ -1,0 +1,72 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_def_reqAupsTest {
+
+	private static urn_perun_facility_attribute_def_def_reqAups classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_reqAups();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(session.getPerunBl().getAttributesManagerBl().getEntitylessAttributes(session, AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":orgAups")).thenReturn(Collections.singletonList(reqAttribute));
+
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutAUPInOrganization() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithoutAUPInOrganization()");
+		List<String> value = new ArrayList<>();
+		value.add("bad_example");
+		attributeToCheck.setValue(value);
+		Map<String, String> value2 = new LinkedHashMap<>();
+		value2.put("example", "example");
+		reqAttribute.setValue(value2);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		List<String> value = new ArrayList<>();
+		value.add("example");
+		attributeToCheck.setValue(value);
+		Map<String, String> value2 = new LinkedHashMap<>();
+		value2.put("example", "example");
+		reqAttribute.setValue(value2);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_rtOutputFileNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_rtOutputFileNameTest.java
@@ -1,0 +1,42 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_facility_attribute_def_def_rtOutputFileNameTest {
+
+	private static urn_perun_facility_attribute_def_def_rtOutputFileName classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_rtOutputFileName();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithIncorrectValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue("/bad_example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_scratchDirPermissionsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_scratchDirPermissionsTest.java
@@ -1,0 +1,42 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_facility_attribute_def_def_scratchDirPermissionsTest {
+
+	private static urn_perun_facility_attribute_def_def_scratchDirPermissions classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_scratchDirPermissions();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithIncorrectValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		attributeToCheck.setValue("750");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_scratchLocalDirPermissionsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_scratchLocalDirPermissionsTest.java
@@ -1,0 +1,42 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_facility_attribute_def_def_scratchLocalDirPermissionsTest {
+
+	private static urn_perun_facility_attribute_def_def_scratchLocalDirPermissions classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_scratchLocalDirPermissions();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithIncorrectValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		attributeToCheck.setValue("750");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shell_passwd_scpTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shell_passwd_scpTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_facility_attribute_def_def_shell_passwd_scpTest {
+
+	private static urn_perun_facility_attribute_def_def_shell_passwd_scp classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_shell_passwd_scp();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithIncorrectValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSyntaxCorrect() throws Exception {
+		System.out.println("testCheckAttributeSyntaxCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSyntax(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shellsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_shellsTest.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
@@ -37,8 +38,8 @@ public class urn_perun_facility_attribute_def_def_shellsTest {
 	 * with all properly set
 	 */
 	@Test
-	public void testCheckAttributeSemantics() throws Exception {
-		System.out.println("testCheckAttributeSemantics()");
+	public void testCheckAttributeSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
 
 		ArrayList<String> shells = new ArrayList<>();
 		shells.add("/bin/bash");
@@ -49,18 +50,10 @@ public class urn_perun_facility_attribute_def_def_shellsTest {
 
 	}
 
-	@Test(expected=WrongAttributeValueException.class)
+	@Test(expected= WrongReferenceAttributeValueException.class)
 	public void testCheckAttributeSemanticsEmptyAttribute() throws Exception {
 		System.out.println("testCheckAttributeSemanticsEmptyAttribute()");
 
-		classInstance.checkAttributeSemantics(session, new Facility(), attribute);
-	}
-
-	@Test(expected=WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsNoShellsSet() throws Exception {
-		System.out.println("testCheckAttributeSemanticsNoShellsSet()");
-
-		attribute.setValue(new ArrayList<String>());
 		classInstance.checkAttributeSemantics(session, new Facility(), attribute);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_uid_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_uid_namespaceTest.java
@@ -1,0 +1,65 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_def_uid_namespaceTest {
+
+	private static urn_perun_facility_attribute_def_def_uid_namespace classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_uid_namespace();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly_name");
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_USER_ATTR_DEF + ":" + attributeToCheck.getFriendlyName() + ":" + attributeToCheck.getValue())).thenThrow(new AttributeNotExistsException(""));
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_USER_ATTR_DEF + ":" + attributeToCheck.getFriendlyName() + ":" + attributeToCheck.getValue())).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_unixGID_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_unixGID_namespaceTest.java
@@ -1,0 +1,66 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_def_unixGID_namespaceTest {
+
+	private static urn_perun_facility_attribute_def_def_unixGID_namespace classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_unixGID_namespace();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly_name");
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:" + attributeToCheck.getValue())).thenThrow(new AttributeNotExistsException(""));
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:" + attributeToCheck.getValue())).thenReturn(reqAttribute);
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGID-namespace:" + attributeToCheck.getValue())).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_unixGroupName_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_unixGroupName_namespaceTest.java
@@ -1,0 +1,66 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_def_unixGroupName_namespaceTest {
+
+	private static urn_perun_facility_attribute_def_def_unixGroupName_namespace classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_def_unixGroupName_namespace();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly_name");
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:" + attributeToCheck.getValue())).thenThrow(new AttributeNotExistsException(""));
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:" + attributeToCheck.getValue())).thenReturn(reqAttribute);
+		when(session.getPerunBl().getAttributesManagerBl().getAttributeDefinition(session, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:" + attributeToCheck.getValue())).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_GIDRangesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_GIDRangesTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_virt_GIDRangesTest {
+
+	private static urn_perun_facility_attribute_def_virt_GIDRanges classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_virt_GIDRanges();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly_name");
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithReqAttributeWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithReqAttributeWithNullValue()");
+		reqAttribute.setValue(null);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGID-namespace")).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		reqAttribute.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGID-namespace")).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_maxUIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_maxUIDTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_virt_maxUIDTest {
+
+	private static urn_perun_facility_attribute_def_virt_maxUID classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_virt_maxUID();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly_name");
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithReqAttributeWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithReqAttributeWithNullValue()");
+		reqAttribute.setValue(null);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":uid-namespace")).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		reqAttribute.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":uid-namespace")).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_minUIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_virt_minUIDTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_facility_attribute_def_virt_minUIDTest {
+
+	private static urn_perun_facility_attribute_def_virt_minUID classInstance;
+	private static PerunSessionImpl session;
+	private static Facility facility;
+	private static Attribute attributeToCheck;
+	private static Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_facility_attribute_def_virt_minUID();
+		session = mock(PerunSessionImpl.class);
+		facility = new Facility();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly_name");
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithReqAttributeWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithReqAttributeWithNullValue()");
+		reqAttribute.setValue(null);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":uid-namespace")).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemanticsCorrect() throws Exception {
+		System.out.println("testCheckAttributeSemanticsCorrect()");
+		reqAttribute.setValue("example");
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":uid-namespace")).thenReturn(reqAttribute);
+
+		classInstance.checkAttributeSemantics(session, facility, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in facility attribute modules
- also added test for checks