### PR TITLE
Separation of checkAttributeSyntax from semantics in Vo modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AttributesManager.java
@@ -2598,7 +2598,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeAssignmentException if attribute isn't vo attribute
 	 * @throws WrongAttributeValueException      if the attribute value is wrong/illegal
 	 */
-	void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws PrivilegeException, InternalErrorException, VoNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException;
+	void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws PrivilegeException, InternalErrorException, VoNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException;
 
 	/**
 	 * PRIVILEGE: Check attributes only when principal has access to write on them.
@@ -2608,7 +2608,7 @@ public interface AttributesManager {
 	 * @throws WrongAttributeValueException if any of attributes values is wrong/illegal
 	 * @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeSemantics(PerunSession, Vo, Attribute)
 	 */
-	void checkAttributesSemantics(PerunSession sess, Vo vo, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, VoNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException;
+	void checkAttributesSemantics(PerunSession sess, Vo vo, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, VoNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this resource attribute has valid semantics.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2613,14 +2613,14 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeAssignmentException if attribute isn't vo attribute
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 */
-	void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 *  Batch version of checkAttributeSemantics
 	 *  @throws WrongAttributeValueException if any of attributes values is wrong/illegal
 	 *  @see cz.metacentrum.perun.core.api.AttributesManager#checkAttributeSemantics(PerunSession,Vo,Attribute)
 	 */
-	void checkAttributesSemantics(PerunSession sess, Vo vo, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributesSemantics(PerunSession sess, Vo vo, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this group attribute has valid semantics.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -3428,7 +3428,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_VO_ATTR);
 
 		if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, vo, attribute)) return;
@@ -3436,7 +3436,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributesSemantics(PerunSession sess, Vo vo, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributesSemantics(PerunSession sess, Vo vo, List<Attribute> attributes) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attributes, NS_VO_ATTR);
 
 		for (Attribute attribute : attributes) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AttributesManagerEntry.java
@@ -2977,7 +2977,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws PrivilegeException, InternalErrorException, VoNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException {
+	public void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws PrivilegeException, InternalErrorException, VoNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributeExists(sess, attribute);
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
@@ -2988,7 +2988,7 @@ public class AttributesManagerEntry implements AttributesManager {
 	}
 
 	@Override
-	public void checkAttributesSemantics(PerunSession sess, Vo vo, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, VoNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException {
+	public void checkAttributesSemantics(PerunSession sess, Vo vo, List<Attribute> attributes) throws PrivilegeException, InternalErrorException, VoNotExistsException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException {
 		Utils.checkPerunSession(sess);
 		getAttributesManagerBl().checkAttributesExists(sess, attributes);
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3869,7 +3869,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
 		//Call attribute module
 		VoAttributesModuleImplApi voModule = getVoAttributeModule(sess, attribute);
 		if (voModule == null) return; //module doesn't exists

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_RTVoQueue.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_RTVoQueue.java
@@ -13,18 +13,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleIm
  */
 public class urn_perun_vo_attribute_def_def_RTVoQueue extends VoAttributesModuleAbstract implements VoAttributesModuleImplApi {
 
-	//Pattern extensionDatePattern = Pattern.compile("^$");
-
-	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Vo vo, Attribute attribute) {
-		//There is no special queue in RT for this VO (in specific method use default queue)
-		if(attribute.getValue() == null) return;
-
-		//Get value from attribute
-		String attrValue = attribute.valueAsString();
-
-		//TODO: Create some regexp Pattern for RTVoQueue and test it there
-	}
+	//TODO: Create some regexp Pattern for RTVoQueue and test it there
 
 	@Override
 	public Attribute fillAttribute(PerunSessionImpl sess, Vo vo, AttributeDefinition attribute) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_aup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_aup.java
@@ -23,11 +23,11 @@ import org.json.JSONObject;
 public class urn_perun_vo_attribute_def_def_aup extends VoAttributesModuleAbstract implements VoAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws WrongAttributeValueException {
 
-		String value = (String)attribute.getValue();
+		String value = attribute.valueAsString();
 
-		if (value == null || value.isEmpty()) return;
+		if (value == null) return;
 
 		// we expect array or AUPs
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_contactEmail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_contactEmail.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
@@ -19,22 +20,21 @@ import java.util.List;
 public class urn_perun_vo_attribute_def_def_contactEmail extends VoAttributesModuleAbstract implements VoAttributesModuleImplApi{
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongAttributeValueException {
-		// null attribute
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Vo contact email list cannot be null.");
-
-		// wrong type of the attribute
-		if (!(attribute.getValue() instanceof List)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: List");
+	public void checkAttributeSyntax(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongAttributeValueException {
+		// null value is ok for syntax check
+		if (attribute.getValue() == null) return;
 
 		List<String> contactEmails = attribute.valueAsList();
 
-		// the List is empty
-		if (contactEmails.isEmpty()) throw new WrongAttributeValueException(attribute, "Attribute List of contact emails is empty.");
-
 		for (String email : contactEmails) {
-			if (email == null) throw new WrongAttributeValueException(attribute, "Email is null.");
 			if (!(sess.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(sess, email))) throw new WrongAttributeValueException(attribute, "Vo : " + vo.getName() +" has contact email " + email +" which is not valid.");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongReferenceAttributeValueException {
+		// null attribute
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Vo contact email list cannot be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_fromEmail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_fromEmail.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
@@ -21,12 +22,9 @@ public class urn_perun_vo_attribute_def_def_fromEmail extends VoAttributesModule
 	private static final Pattern pattern = Pattern.compile("^\".+\" <.+>$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongAttributeValueException {
-		// null attribute
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Vo fromEmail cannot be null.");
-
-		// wrong type of the attribute
-		if (!(attribute.getValue() instanceof String)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: String");
+	public void checkAttributeSyntax(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongAttributeValueException {
+		// null attribute is ok for syntax check
+		if (attribute.getValue() == null) return;
 
 		String fromEmail = attribute.valueAsString();
 
@@ -45,6 +43,12 @@ public class urn_perun_vo_attribute_def_def_fromEmail extends VoAttributesModule
 				}
 			}
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongReferenceAttributeValueException {
+		// null attribute
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Vo fromEmail cannot be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_toEmail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_toEmail.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.VoAttributesModuleImplApi;
@@ -18,22 +19,21 @@ import java.util.List;
 public class urn_perun_vo_attribute_def_def_toEmail extends VoAttributesModuleAbstract implements VoAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongAttributeValueException {
-		// null attribute
-		if (attribute.getValue() == null) throw new WrongAttributeValueException(attribute, "Vo toEmail list cannot be null.");
-
-		// wrong type of the attribute
-		if (!(attribute.getValue() instanceof List)) throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: List");
+	public void checkAttributeSyntax(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongAttributeValueException {
+		// null attribute is ok for syntax check
+		if (attribute.getValue() == null) return;
 
 		List<String> toEmails = attribute.valueAsList();
 
-		// the List is empty
-		if (toEmails.isEmpty()) throw new WrongAttributeValueException(attribute, "Attribute List of toEmails is empty.");
-
 		for (String email : toEmails) {
-			if (email == null) throw new WrongAttributeValueException(attribute, "Email is null.");
 			if (!(sess.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(sess, email))) throw new WrongAttributeValueException(attribute, "Vo : " + vo.getName() +" has toEmail " + email +" which is not valid.");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Vo vo, Attribute attribute) throws WrongReferenceAttributeValueException {
+		// null attribute
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, "Vo toEmail list cannot be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1618,7 +1618,7 @@ public interface AttributesManagerImplApi {
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 */
-	void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException;
+	void checkAttributeSemantics(PerunSession sess, Vo vo, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this group attribute has valid semantics.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/VoAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/VoAttributesModuleAbstract.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
 /**
@@ -22,7 +23,7 @@ public abstract class VoAttributesModuleAbstract extends AttributesModuleAbstrac
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws WrongReferenceAttributeValueException {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/VoAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/VoAttributesModuleImplApi.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
 /**
@@ -46,9 +47,10 @@ public interface VoAttributesModuleImplApi extends AttributesModuleImplApi {
 	 * @param vo Virtual Organization
 	 * @param attribute attribute to be checked
 	 *
+	 * @throws WrongReferenceAttributeValueException if the attribute value has wrong/illegal semantics
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 */
-	void checkAttributeSemantics(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws WrongAttributeValueException;
+	void checkAttributeSemantics(PerunSessionImpl perunSession, Vo vo, Attribute attribute) throws WrongReferenceAttributeValueException, WrongAttributeValueException;
 
 	/**
 	 * If you need to do some further work with other modules, this method do that

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_aupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_aupTest.java
@@ -1,0 +1,66 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_vo_attribute_def_def_aupTest {
+
+	private static urn_perun_vo_attribute_def_def_aup classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Vo vo;
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_vo_attribute_def_def_aup();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+		vo = new Vo();
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingVersion() throws Exception {
+		System.out.println("testCheckValueWithMissingVersion()");
+		attributeToCheck.setValue("[{date: date, link: link, text: text}]");
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingDate() throws Exception {
+		System.out.println("testCheckValueWithMissingDate()");
+		attributeToCheck.setValue("[{version: version, link: link, text: text}]");
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingLink() throws Exception {
+		System.out.println("testCheckValueWithMissingLink()");
+		attributeToCheck.setValue("[{version: version, date: date, text: text}]");
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithMissingText() throws Exception {
+		System.out.println("testCheckValueWithMissingText()");
+		attributeToCheck.setValue("[{version: version, date: date, link: link}]");
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("[{version: version, date: date, link: link, text: text}]");
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_contactEmailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_contactEmailTest.java
@@ -1,0 +1,81 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_vo_attribute_def_def_contactEmailTest {
+
+	private static urn_perun_vo_attribute_def_def_contactEmail classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Vo vo;
+	private static String correctEmail = "my@example.com";
+	private static String incorrectEmail = "myBadExample.com";
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_vo_attribute_def_def_contactEmail();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+		vo = new Vo();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+		when(session.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(session, correctEmail)).thenReturn(true);
+		when(session.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(session, incorrectEmail)).thenReturn(false);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNullValue() throws Exception {
+		System.out.println("testCheckNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, vo, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithIncorrectEmail() throws Exception {
+		System.out.println("testCheckValueWithIncorrectEmail()");
+		List<String> value = new ArrayList<>();
+		value.add(incorrectEmail);
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add(correctEmail);
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		List<String> value = new ArrayList<>();
+		value.add(correctEmail);
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSemantics(session, vo, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_fromEmailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_fromEmailTest.java
@@ -1,0 +1,86 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_vo_attribute_def_def_fromEmailTest {
+
+	private static urn_perun_vo_attribute_def_def_fromEmail classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Vo vo;
+	private static String correctEmail = "my@example.com";
+	private static String correctEmailWithHeader = "\"header\" <my@example.com>";
+	private static String incorrectEmail = "myBadExample.com";
+	private static String correctEmailWithIncorrectHeader = "header <myBadExample.com>";
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_vo_attribute_def_def_fromEmail();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+		vo = new Vo();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+		when(session.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(session, correctEmail)).thenReturn(true);
+		when(session.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(session, correctEmailWithHeader)).thenReturn(false);
+		when(session.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(session, incorrectEmail)).thenReturn(false);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNullValue() throws Exception {
+		System.out.println("testCheckNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, vo, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithIncorrectEmail() throws Exception {
+		System.out.println("testCheckValueWithIncorrectEmail()");
+		attributeToCheck.setValue(incorrectEmail);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithIncorrectHeader() throws Exception {
+		System.out.println("testCheckValueWithIncorrectHeader()");
+		attributeToCheck.setValue(correctEmailWithIncorrectHeader);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+
+		attributeToCheck.setValue(correctEmail);
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+
+		attributeToCheck.setValue(correctEmailWithHeader);
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue(correctEmail);
+
+		classInstance.checkAttributeSemantics(session, vo, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_toEmailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_vo_attribute_def_def_toEmailTest.java
@@ -1,0 +1,81 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_vo_attribute_def_def_toEmailTest {
+
+	private static urn_perun_vo_attribute_def_def_toEmail classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Vo vo;
+	private static String correctEmail = "my@example.com";
+	private static String incorrectEmail = "myBadExample.com";
+
+	@Before
+	public void setUp() {
+		classInstance = new urn_perun_vo_attribute_def_def_toEmail();
+		session = mock(PerunSessionImpl.class);
+		attributeToCheck = new Attribute();
+		vo = new Vo();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(session.getPerunBl()).thenReturn(perunBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+		when(session.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(session, correctEmail)).thenReturn(true);
+		when(session.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(session, incorrectEmail)).thenReturn(false);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckNullValue() throws Exception {
+		System.out.println("testCheckNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, vo, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckValueWithIncorrectEmail() throws Exception {
+		System.out.println("testCheckValueWithIncorrectEmail()");
+		List<String> value = new ArrayList<>();
+		value.add(incorrectEmail);
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add(correctEmail);
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, vo, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		List<String> value = new ArrayList<>();
+		value.add(correctEmail);
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSemantics(session, vo, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in vo attribute modules
- also added test for checks