### PR TITLE
DISPATCHER: Store TaskResult for blocked destinations

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/SchedulingPool.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/SchedulingPool.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.dispatcher.jms.EngineMessageProducer;
 import cz.metacentrum.perun.taskslib.exceptions.TaskStoreException;
 import cz.metacentrum.perun.taskslib.model.Task;
+import cz.metacentrum.perun.taskslib.model.TaskResult;
 import cz.metacentrum.perun.taskslib.service.TaskStore;
 
 import java.util.List;
@@ -126,5 +127,13 @@ public interface SchedulingPool extends TaskStore {
 	 * @param string Serialized TaskResult object
 	 */
 	void onTaskDestinationComplete(int clientID, String string);
-	
+
+	/**
+	 * Store TaskResult sent from Engine.
+	 *
+	 * @param clientID ID of Engine
+	 * @param taskResult TaskResult object
+	 */
+	void onTaskDestinationComplete(int clientID, TaskResult taskResult);
+
 }

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/impl/SchedulingPoolImpl.java
@@ -604,7 +604,7 @@ public class SchedulingPoolImpl implements SchedulingPool {
 			if (!listOfBeans.isEmpty()) {
 				TaskResult taskResult = (TaskResult) listOfBeans.get(0);
 				log.debug("[{}] Received TaskResult for Task from Engine {}.", taskResult.getTaskId(), clientID);
-				resultManager.insertNewTaskResult(taskResult, clientID);
+				onTaskDestinationComplete(clientID, taskResult);
 			} else {
 				log.error("No TaskResult found in message from Engine {}: {}.", clientID, string);
 			}
@@ -612,6 +612,15 @@ public class SchedulingPoolImpl implements SchedulingPool {
 			log.error("Could not save TaskResult from Engine {}, {}, {}", clientID, string, e.getMessage());
 		}
 
+	}
+
+	@Override
+	public void onTaskDestinationComplete(int clientID, TaskResult taskResult) {
+		try {
+			resultManager.insertNewTaskResult(taskResult, clientID);
+		} catch (Exception e) {
+			log.error("Could not save TaskResult from Engine {}, {}, {}", clientID, taskResult, e.getMessage());
+		}
 	}
 
 }


### PR DESCRIPTION
- Let admin know about blocked destinations by storing TaskResult
  for each destination, which was removed from the set.