### PR TITLE
Added createApplicationForm method

### DIFF
--- a/perun-cli/Perun/RegistrarAgent.pm
+++ b/perun-cli/Perun/RegistrarAgent.pm
@@ -28,6 +28,11 @@ sub copyMails
 	return Perun::Common::callManagerMethod('copyMails', 'null', @_);
 }
 
+sub createApplicationForm
+{
+	return Perun::Common::callManagerMethod('createApplicationForm', 'null', @_);
+}
+
 sub updateForm
 {
 	return Perun::Common::callManagerMethod('updateForm', 'null', @_);


### PR DESCRIPTION
- Added createApplicationForm method to the RegistrarAgent.
  - This method is needed when we want to i.e. copy form for the created group from another group (which already has the form configured). This method creates an empty form. After that, we can copy the desired form. Without using this method we get FormDoesNotExistException.