### PR TITLE
CORE: Allow to customize template for password reset confirmation

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -2221,11 +2221,14 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		if (namespace.isEmpty()) throw new InternalErrorException("Password reset request is not valid anymore or doesn't existed at all for User: "+user);
 
 		List<Attribute> logins = perunBl.getAttributesManagerBl().getLogins(sess, user);
-		boolean found = false;
+		String login = null;
 		for (Attribute a : logins) {
-			if (a.getFriendlyNameParameter().equals(namespace)) found = true;
+			if (a.getFriendlyNameParameter().equals(namespace)) {
+				login = a.valueAsString();
+				break;
+			}
 		}
-		if (!found) throw new InternalErrorException(user.toString()+" doesn't have login in namespace: "+namespace);
+		if (login == null) throw new InternalErrorException(user.toString()+" doesn't have login in namespace: "+namespace);
 
 		// reset password without checking old
 		try {
@@ -2292,7 +2295,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		}
 
 		for (String email : emails) {
-			Utils.sendPasswordResetConfirmationEmail(user, email, namespace, subject, message);
+			Utils.sendPasswordResetConfirmationEmail(user, email, namespace, login, subject, message);
 		}
 
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1061,10 +1061,11 @@ public class Utils {
 	 * @param user user to send notification for
 	 * @param email user's email to send notification to
 	 * @param namespace namespace the password was re-set
+	 * @param login login of user
 	 * @param subject Subject from template or null
 	 * @param content Message from template or null
 	 */
-	public static void sendPasswordResetConfirmationEmail(User user, String email, String namespace, String subject, String content) {
+	public static void sendPasswordResetConfirmationEmail(User user, String email, String namespace, String login, String subject, String content) {
 
 		// create mail sender
 		JavaMailSender mailSender = BeansUtils.getDefaultMailSender();
@@ -1092,10 +1093,13 @@ public class Utils {
 				"\n----------------------------------------------------------------" +
 				"\nPerun - Identity & Access Management System";
 
-
 		if (content == null || content.isEmpty()) {
 			message.setText(text);
 		} else {
+			content = content.replace("{displayName}", user.getDisplayName());
+			content = content.replace("{namespace}", namespace);
+			content = content.replace("{login}", login);
+			content = content.replace("{instanceName}", instanceName);
 			message.setText(content);
 		}
 


### PR DESCRIPTION
- We allowed to set template for password reset confirmation mail,
  but we didn't perform replacement of tags for users name, namespace
  or login. Now we do replacements for all templates.