### PR TITLE
New method to remove all denials for destinations defined by name

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/controller/service/GeneralServiceManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/controller/service/GeneralServiceManager.java
@@ -119,6 +119,15 @@ public interface GeneralServiceManager {
 	void unblockAllServicesOnFacility(PerunSession perunSession, Facility facility);
 
 	/**
+	 * Erase all the possible denials on destinations defined by the destinationName.
+	 * From this moment on, there are no Services being denied on these destinations.
+	 *
+	 * @param sess
+	 * @param destinationName The name of destinations we want to clear of all the denials.
+	 */
+	void unblockAllServicesOnDestination(PerunSession sess, String destinationName);
+
+	/**
 	 * Erase all the possible denials on this destination.
 	 * From this moment on, there are no Services being denied on this destination.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/controller/service/impl/GeneralServiceManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/controller/service/impl/GeneralServiceManagerImpl.java
@@ -22,6 +22,7 @@ import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyBannedException;
+import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.taskslib.dao.ServiceDenialDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +32,9 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Propagation manager allows to plan/force propagation, block/unblock Services on Facilities and Destinations.
@@ -126,6 +129,14 @@ public class GeneralServiceManagerImpl implements GeneralServiceManager {
 	public void unblockAllServicesOnFacility(PerunSession sess, Facility facility) {
 		serviceDenialDao.unblockAllServicesOnFacility(facility.getId());
 		sess.getPerun().getAuditer().log(sess, new FreeAllDenialsOnFacility(facility));
+	}
+
+	@Override
+	public void unblockAllServicesOnDestination(PerunSession sess, String destinationName) {
+		List<Destination> destinations = ((PerunBlImpl) sess.getPerun()).getServicesManagerBl().getDestinations(sess);
+		for(Destination destination: destinations) {
+			if(destination.getDestination().equals(destinationName)) this.unblockAllServicesOnDestination(sess, destination.getId());
+		}
 	}
 
 	@Override

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GeneralServiceManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GeneralServiceManagerMethod.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.rpc.methods;
 import cz.metacentrum.perun.controller.model.ServiceForGUI;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.rpc.*;
 
 import java.util.List;
@@ -173,8 +174,14 @@ public enum GeneralServiceManagerMethod implements ManagerMethod {
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			if (parms.contains("destination")) {
 				ac.getGeneralServiceManager().unblockAllServicesOnDestination(ac.getSession(), parms.readInt("destination"));
+			} else if (parms.contains("destinationName")) {
+				if(parms.contains("destinationType")) {
+					ac.getGeneralServiceManager().unblockAllServicesOnDestination(ac.getSession(), ac.getServicesManager().getDestinationIdByName(ac.getSession(), parms.readString("destinationName"), parms.readString("destinationType")));
+				} else {
+					ac.getGeneralServiceManager().unblockAllServicesOnDestination(ac.getSession(), parms.readString("destinationName"));
+				}
 			} else {
-				ac.getGeneralServiceManager().unblockAllServicesOnDestination(ac.getSession(), ac.getServicesManager().getDestinationIdByName(ac.getSession(), parms.readString("destinationName"), parms.readString("destinationType")));
+				throw new RpcException(RpcException.Type.MISSING_VALUE, "destination (id) or destinationName (text)");
 			}
 			return null;
 		}


### PR DESCRIPTION
 - we need to remove all denials for destinations found by the
 destination name without defined type (all propagation to this
 destination no matter the type)