### PR TITLE
Bug fix for synchro group extSources switching

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -3602,19 +3602,15 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		//for each group set attributes for members synchronization, synchronize them and save the result
 		for (Group group: groupsForMemberSynchronization) {
-
-			if (!getPerunBl().getExtSourcesManagerBl().getGroupExtSources(sess, group).contains(source)) {
-				try {
-					getPerunBl().getExtSourcesManagerBl().addExtSource(sess, group, source);
-				} catch (ExtSourceAlreadyAssignedException e) {
-					log.info("ExtSource already assigned to group: {}", group);
-				}
-				getPerunBl().getAttributesManagerBl().setAttribute(sess, group, extSourceNameAttr);
+			try {
+				getPerunBl().getExtSourcesManagerBl().addExtSource(sess, group, source);
+			} catch (ExtSourceAlreadyAssignedException e) {
+				log.info("ExtSource already assigned to group: {}", group);
 			}
 
 			membersQueryAttribute.setValue(baseMembersQuery.getValue().toString().replace("?", group.getShortName()));
 
-			getPerunBl().getAttributesManagerBl().setAttributes(sess, group, Arrays.asList(baseMemberExtsource, lightWeightSynchronization, synchronizationInterval, synchroEnabled, membersQueryAttribute, synchronizationTimes));
+			getPerunBl().getAttributesManagerBl().setAttributes(sess, group, Arrays.asList(baseMemberExtsource, lightWeightSynchronization, synchronizationInterval, synchroEnabled, membersQueryAttribute, synchronizationTimes, extSourceNameAttr));
 		}
 
 	}


### PR DESCRIPTION
**Problem**: While setting subGroups attributes during the group structure
	synchronization, the groupExtSource attribute is set only if the
	extSource is not already in the assigned group extSources. It is
	because the setAttribute method is in conditional statement together
	with group extSource assignemnt. The conditional statement is
	checking if the extSource is not already in group's assigned extSources.
**Change**: The condition statement was removed from the code.
**Result**: When a duplicate extSource is assigned to a group, exception is
	thrown which is catched and logged. Attribute groupExtSource is
	always set to a new value, even when the new value is same as
	the old one.