### PR TITLE
LDAPC: Allow switching ldap attributes to deleted state

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunAttribute.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/PerunAttribute.java
@@ -103,6 +103,8 @@ public interface PerunAttribute<T extends PerunBean> {
 
 	public boolean isMultiValued();
 
+	public boolean isDeleted();
+
 	public String getName();
 
 	public String getName(AttributeDefinition attr);

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunAttributeDesc.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/PerunAttributeDesc.java
@@ -14,13 +14,14 @@ public class PerunAttributeDesc<T extends PerunBean> implements PerunAttribute<T
 	private String name;
 	private Boolean required;
 	private Boolean multivalued;
+	private Boolean deleted = false;
 	private PerunAttribute.SingleValueExtractor<T> singleValueExtractor;
 	private PerunAttribute.MultipleValuesExtractor<T> multipleValuesExtractor;
 
 	public PerunAttributeDesc() {
 		super();
 	}
-	
+
 	public PerunAttributeDesc(String name, Boolean required, PerunAttribute.SingleValueExtractor<T> extractor) {
 		super();
 		this.name = name;
@@ -36,7 +37,7 @@ public class PerunAttributeDesc<T extends PerunBean> implements PerunAttribute<T
 		this.multivalued = true;
 		this.multipleValuesExtractor = extractor;
 	}
-	
+
 	@Override
 	public boolean isRequired() {
 		return getRequired();
@@ -45,6 +46,11 @@ public class PerunAttributeDesc<T extends PerunBean> implements PerunAttribute<T
 	@Override
 	public boolean isMultiValued() {
 		return getMultivalued();
+	}
+
+	@Override
+	public boolean isDeleted() {
+		return getDeleted();
 	}
 
 	@Override
@@ -107,6 +113,14 @@ public class PerunAttributeDesc<T extends PerunBean> implements PerunAttribute<T
 		return multivalued;
 	}
 
+	public Boolean getDeleted() {
+		return deleted;
+	}
+
+	public void setDeleted(Boolean deleted) {
+		this.deleted = deleted;
+	}
+
 	@Override
 	public PerunAttribute.SingleValueExtractor<T> getSingleValueExtractor() {
 		return singleValueExtractor;
@@ -132,10 +146,10 @@ public class PerunAttributeDesc<T extends PerunBean> implements PerunAttribute<T
 	@Override
 	public boolean requiresAttributeBean() {
 		if(isMultiValued()) {
-			return getMultipleValuesExtractor() instanceof AttributeValueExtractor; 
+			return getMultipleValuesExtractor() instanceof AttributeValueExtractor;
 		} else {
 			return getSingleValueExtractor() instanceof AttributeValueExtractor;
 		}
 	}
-	
+
 }

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -633,6 +633,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="entityID" />
 					<property name="required" value="false" />
+					<property name="deleted" value="true" />
 					<property name="singleValueExtractor">
 						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
 							<property name="name" value="entityID" />
@@ -643,6 +644,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="OIDCClientID" />
 					<property name="required" value="false" />
+					<property name="deleted" value="true" />
 					<property name="singleValueExtractor">
 						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
 							<property name="name" value="OIDCClientID" />


### PR DESCRIPTION
- LDAPC will clear all values of attributes marked as deleted
  in the context.
- Marked all current Resource attributes as deleted.
  We will migrate them to Facility in next release.