### PR TITLE
UTILS: Do not chown PID files for ldapc/engine services

### DIFF
--- a/perun-utils/init.d-scripts/perun-engine.debian
+++ b/perun-utils/init.d-scripts/perun-engine.debian
@@ -18,6 +18,7 @@
 # 04.05.2015 Create, chown and delete pidfile in order to allow user "perun" to start/stop the service
 # 14.04.2015 Modified path to perun.conf.custom and log4j to /etc/perun
 # 04.04.2015 Log stdout/stderr to perun-engine-out.log
+# 14.10.2019 Do not chown PID file to "perun" since it won't start on Deb 10
 #
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Perun Engine"
@@ -69,12 +70,10 @@ do_start () {
 	PID_DIR="/var/run/perun";
 	if [ ! -d $PID_DIR ]; then
 		mkdir $PID_DIR;
-		chown $DAEMON_USER $PID_DIR;
 	fi
 
 	# Create empty pidfile
 	touch $PIDFILE;
-	chown $DAEMON_USER $PIDFILE;
 
 	# Start with output logging, but we need to create log-file first for perun:perun
 	start-stop-daemon --make-pidfile --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \

--- a/perun-utils/init.d-scripts/perun-ldapc.debian
+++ b/perun-utils/init.d-scripts/perun-ldapc.debian
@@ -15,6 +15,7 @@
 # 23.03.2018 Reworked perun-engine init.d script for LDAPc
 # 17.04.2018 Respect $LAST_PROCESSED_ID is set in /etc/perun/perun-ldapc
 #            (specify where ldapc should start reading auditer log)
+# 14.10.2019 Do not chown PID file to "perun" since it won't start on Deb 10
 #
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Perun LDAPc"
@@ -71,12 +72,10 @@ do_start () {
 	PID_DIR="/var/run/perun";
 	if [ ! -d $PID_DIR ]; then
 		mkdir $PID_DIR;
-		chown $DAEMON_USER $PID_DIR;
 	fi
 
 	# Create empty pidfile
 	touch $PIDFILE;
-	chown $DAEMON_USER $PIDFILE;
 
 	# Start with output logging, but we need to create log-file first for perun:perun
 	start-stop-daemon --make-pidfile --start --quiet ${DAEMON_USER:+--chuid $DAEMON_USER} \


### PR DESCRIPTION
- start-stop-daemon on Debian 10 won't start the process, if PID file
  is writable by others or not owned by the root. Hence we must not
  chown our pid files to perun.
  This change prevents us from restarting the service on deployment,
  we must always restart it manually.