### PR TITLE
Initialization of roles from configuration file

### DIFF
--- a/perun-base/src/test/resources/perun-roles.yml
+++ b/perun-base/src/test/resources/perun-roles.yml
@@ -1,0 +1,23 @@
+---
+# A list of Perun roles that are loaded to the database
+perun_roles:
+  - PERUNADMIN
+  - PERUNOBSERVER
+  - VOADMIN
+  - GROUPADMIN
+  - SELF
+  - FACILITYADMIN
+  - RESOURCEADMIN
+  - RESOURCESELFSERVICE
+  - REGISTRAR
+  - ENGINE
+  - RPC
+  - NOTIFICATIONS
+  - SERVICEUSER
+  - SPONSOR
+  - VOOBSERVER
+  - TOPGROUPCREATOR
+  - SECURITYADMIN
+  - CABINETADMIN
+  - UNKNOWN
+...

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -213,6 +213,11 @@
 			<artifactId>jackson-dataformat-csv</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+		</dependency>
+
 		<!-- PostgreSQL driver -->
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -42,6 +42,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 
 	final static Logger log = LoggerFactory.getLogger(FacilitiesManagerImpl.class);
 
+	private PerunRolesLoader perunRolesLoader;
+
 	//http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/jdbc.html
 	private static JdbcPerunTemplate jdbc;
 
@@ -172,25 +174,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	}
 
 	public void initialize() throws InternalErrorException {
-
-		if(BeansUtils.isPerunReadOnly()) log.debug("Loading authzresolver manager init in readOnly version.");
-
-		// Check if all roles defined in class Role exists in the DB
-		for (Role role: Role.values()) {
-			try {
-				if (0 == jdbc.queryForInt("select count(*) from roles where name=?", role.getRoleName())) {
-					//Skip creating not existing roles for read only Perun
-					if(BeansUtils.isPerunReadOnly()) {
-						throw new InternalErrorException("One of default roles not exists in DB - " + role);
-					} else {
-						int newId = Utils.getNewId(jdbc, "roles_id_seq");
-						jdbc.update("insert into roles (id, name) values (?,?)", newId, role.getRoleName());
-					}
-				}
-			} catch (RuntimeException e) {
-				throw new InternalErrorException(e);
-			}
-		}
+		this.perunRolesLoader.loadPerunRoles(jdbc);
 	}
 
 	public static Map<Role, Set<ActionType>> getRolesWhichCanWorkWithAttribute(ActionType actionType, AttributeDefinition attrDef) throws InternalErrorException {
@@ -746,4 +730,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		}
 	}
 
+	public void setPerunRolesLoader(PerunRolesLoader perunRolesLoader) {
+		this.perunRolesLoader = perunRolesLoader;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
@@ -1,0 +1,67 @@
+package cz.metacentrum.perun.core.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcPerunTemplate;
+import org.springframework.core.io.Resource;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * The purpose of the PerunRolesLoader is to load perun roles and policies from the perun-roles.yml configuration file.
+ *
+ * Production configuration file is located in /etc/perun/perun-roles.yml
+ * Configuration file which is used during the build is located in perun-base/src/test/resources/perun-roles.yml
+ */
+public class PerunRolesLoader {
+
+	private static final Logger log = LoggerFactory.getLogger(PerunBasicDataSource.class);
+
+	private Resource configurationPath;
+
+	public void loadPerunRoles(JdbcPerunTemplate jdbc) {
+		if (BeansUtils.isPerunReadOnly()) log.debug("Loading authzresolver manager init in readOnly version.");
+
+		List<String> roles;
+		ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+		try (InputStream is = configurationPath.getInputStream()) {
+			JsonNode rolesNode = mapper.readTree(is).get("perun_roles");
+			roles = new ObjectMapper().convertValue(rolesNode, new TypeReference<List<String>>() {});
+		} catch (FileNotFoundException e) {
+			throw new InternalErrorException("Configuration file not found for perun roles. It should be in: " + configurationPath, e);
+		} catch (IOException e) {
+			throw new InternalErrorException("IO exception was thrown during the processing of the file: " + configurationPath, e);
+		}
+
+		// Check if all roles defined in class Role exists in the DB
+		for (String role : roles) {
+			try {
+				if (0 == jdbc.queryForInt("select count(*) from roles where name=?", role.toLowerCase())) {
+					//Skip creating not existing roles for read only Perun
+					if (BeansUtils.isPerunReadOnly()) {
+						throw new InternalErrorException("One of default roles not exists in DB - " + role);
+					} else {
+						int newId = Utils.getNewId(jdbc, "roles_id_seq");
+						jdbc.update("insert into roles (id, name) values (?,?)", newId, role.toLowerCase());
+					}
+				}
+			} catch (RuntimeException e) {
+				throw new InternalErrorException(e);
+			}
+		}
+	}
+
+	public void setConfigurationPath(Resource configurationPath) {
+		this.configurationPath = configurationPath;
+	}
+}

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -375,6 +375,7 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 	</bean>
 	<bean id="authzResolverImpl" class="cz.metacentrum.perun.core.impl.AuthzResolverImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
 		<constructor-arg ref="dataSource" />
+		<property name="perunRolesLoader" ref="perunRolesLoader"/>
 	</bean>
 	<bean id="searcherImpl" class="cz.metacentrum.perun.core.impl.SearcherImpl" scope="singleton" depends-on="databaseManagerBl">
 		<constructor-arg ref="dataSource" />
@@ -495,6 +496,11 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 			<property name="auditer" ref="auditer"/>
 			<property name="cacheManager" ref="cacheManager"/>
 		</bean>
+
+		<!-- PerunRolesLoader implementation -->
+		<bean id="perunRolesLoader" class="cz.metacentrum.perun.core.impl.PerunRolesLoader">
+			<property name="configurationPath" value="file:@perun.conf@perun-roles.yml"/>
+		</bean>
 	</beans>
 
 	<beans profile="default">
@@ -503,6 +509,11 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 			<jdbc:script location="classpath:test-schema.sql"/>
 			<jdbc:script location="classpath:test-data.sql"/>
 		</jdbc:embedded-database>
+
+		<!-- PerunRolesLoader implementation -->
+		<bean id="perunRolesLoader" class="cz.metacentrum.perun.core.impl.PerunRolesLoader">
+			<property name="configurationPath" value="classpath:perun-roles.yml"/>
+		</bean>
 	</beans>
 
 </beans>


### PR DESCRIPTION
- roles will be loaded into database from configuration file
  perun-roles.yml instead of the enum class role.
- PerunRolesLoader component was created for this purpose which will be
  called from AuthzResolverImpl initialize() method. PerunRolesLoader
  will be later used also for loading policies.