### PR TITLE
CORE: Allow cookies when synchronizing with other Perun instances

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -18,9 +18,11 @@ import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import cz.metacentrum.perun.rpc.deserializer.JsonDeserializer;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +55,8 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 	private String perunUrl;
 	private String username;
 	private String password;
+	// this will allow us to keep session to other Perun instances on all subsequent synchronization calls
+	private static CookieStore cookieStore = new BasicCookieStore();
 
 	private String extSourceNameForLogin = null;
 	public static final Pattern attributePattern = Pattern.compile("[{](.+)[}]");
@@ -294,8 +298,7 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 		//Prepare sending message
 		HttpResponse response;
 		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-		// just like cookie-policy: ignore cookies
-		httpClientBuilder.disableCookieManagement();
+		httpClientBuilder.setDefaultCookieStore(cookieStore);
 		HttpClient httpClient = httpClientBuilder.build();
 
 		String commandUrl = perunUrl + format + "/" + managerName + "/" + methodName;


### PR DESCRIPTION
- To prevent unnecessary session initialization on remote side we
  should keep session by using cookies.
  We perform many subsequent calls to remote Perun API and it generates
  a lot of auditer messages there.
- BasicCookieStore is a thread safe and shared between all instances of
  ExtSourcePerun, since for each group synchronization, new instance
  is created and performs own callback.
  Only if we call same perun instance with different authorizations,
  then it performs session init on remote side, since the "actor"
  has changed (and cookie is overwritten back and forth).