### PR TITLE
Fix text in AuditMessages about promoting group to be admin

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/AdminGroupAddedForFacility.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/AdminGroupAddedForFacility.java
@@ -18,7 +18,7 @@ public class AdminGroupAddedForFacility extends AuditEvent implements EngineIgno
 	public AdminGroupAddedForFacility(Group group, Facility facility) {
 		this.group = group;
 		this.facility = facility;
-		this.message = formatMessage("Group %s was added as admin of %s.", group, facility);
+		this.message = formatMessage("%s was added as admin of %s.", group, facility);
 	}
 
 	public Group getGroup() {

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/AdminGroupRemovedForFacility.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/AdminGroupRemovedForFacility.java
@@ -18,7 +18,7 @@ public class AdminGroupRemovedForFacility extends AuditEvent implements EngineIg
 	public AdminGroupRemovedForFacility(Group group, Facility facility) {
 		this.group = group;
 		this.facility = facility;
-		this.message = formatMessage("Group %s was removed from admins of %s.", group, facility);
+		this.message = formatMessage("%s was removed from admins of %s.", group, facility);
 	}
 
 	public Group getGroup() {

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/AdminGroupAddedForGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/AdminGroupAddedForGroup.java
@@ -17,7 +17,7 @@ public class AdminGroupAddedForGroup extends AuditEvent implements EngineIgnoreE
 	public AdminGroupAddedForGroup(Group authorizedGroup, Group group) {
 		this.authorizedGroup = authorizedGroup;
 		this.group = group;
-		this.message = formatMessage("Group %s was added as admin of %s.", authorizedGroup, group);
+		this.message = formatMessage("%s was added as admin of %s.", authorizedGroup, group);
 	}
 
 	@Override

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/AdminGroupRemovedFromGroup.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/GroupManagerEvents/AdminGroupRemovedFromGroup.java
@@ -17,7 +17,7 @@ public class AdminGroupRemovedFromGroup extends AuditEvent implements EngineIgno
 	public AdminGroupRemovedFromGroup(Group authorizedGroup, Group group) {
 		this.group = group;
 		this.authorizedGroup = authorizedGroup;
-		this.message = formatMessage("Group %s was removed from admins of %s.", authorizedGroup, group);
+		this.message = formatMessage("%s was removed from admins of %s.", authorizedGroup, group);
 	}
 
 	@Override

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/VoManagerEvents/AdminGroupAddedForVo.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/VoManagerEvents/AdminGroupAddedForVo.java
@@ -18,7 +18,7 @@ public class AdminGroupAddedForVo extends AuditEvent implements EngineIgnoreEven
 	public AdminGroupAddedForVo(Group group, Vo vo) {
 		this.group = group;
 		this.vo = vo;
-		this.message = formatMessage("Group %s was added as admin of %s.", group, vo);
+		this.message = formatMessage("%s was added as admin of %s.", group, vo);
 	}
 
 	@Override

--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/VoManagerEvents/AdminGroupRemovedForVo.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/VoManagerEvents/AdminGroupRemovedForVo.java
@@ -18,7 +18,7 @@ public class AdminGroupRemovedForVo extends AuditEvent implements EngineIgnoreEv
 	public AdminGroupRemovedForVo(Group group, Vo vo) {
 		this.vo = vo;
 		this.group = group;
-		this.message = formatMessage("Group %s was removed from admins of %s.", group, vo);
+		this.message = formatMessage("%s was removed from admins of %s.", group, vo);
 	}
 
 	@Override


### PR DESCRIPTION
 - There is no need to specify object Group twice as "Group Group:[]..."