### PR TITLE
LDAPc: Removed "deleted" flag in facility attributes

### DIFF
--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -637,7 +637,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="entityID" />
 					<property name="required" value="false" />
-					<property name="deleted" value="true" />
 					<property name="singleValueExtractor">
 						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
 							<property name="name" value="entityID" />
@@ -648,7 +647,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
 					<property name="name" value="OIDCClientID" />
 					<property name="required" value="false" />
-					<property name="deleted" value="true" />
 					<property name="singleValueExtractor">
 						<bean class="cz.metacentrum.perun.ldapc.model.impl.SingleAttributeValueExtractor">
 							<property name="name" value="OIDCClientID" />


### PR DESCRIPTION
- It was a result of bad merge when resource attributes were marked
  for delete and then removed at all.