### PR TITLE
Changing adding of admins to the entities

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -605,54 +605,6 @@ public interface FacilitiesManagerBl {
 	 */
 
 	/**
-	 * Adds user administrator to the Facility.
-	 *
-	 * @param sess
-	 * @param facility
-	 * @param user
-	 * @throws InternalErrorException
-	 * @throws PrivilegeException
-	 * @throws AlreadyAdminException
-	 */
-	void addAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Adds group administrator to the Facility.
-	 *
-	 * @param sess
-	 * @param facility
-	 * @param group that will become a Facility administrator
-	 * @throws InternalErrorException
-	 * @throws PrivilegeException
-	 * @throws AlreadyAdminException
-	 */
-	void addAdmin(PerunSession sess, Facility facility, Group group) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Removes a user administrator from the Facility.
-	 *
-	 * @param sess
-	 * @param facility
-	 * @param user
-	 * @throws InternalErrorException
-	 * @throws PrivilegeException
-	 * @throws UserNotAdminException
-	 */
-	void removeAdmin(PerunSession sess, Facility facility, User user) throws InternalErrorException, UserNotAdminException;
-
-	/**
-	 * Removes a group administrator from the Facility.
-	 *
-	 * @param sess
-	 * @param facility
-	 * @param group group that will lose a Facility administrator role
-	 * @throws InternalErrorException
-	 * @throws PrivilegeException
-	 * @throws GroupNotAdminException
-	 */
-	void removeAdmin(PerunSession sess, Facility facility, Group group) throws InternalErrorException, GroupNotAdminException;
-
-	/**
 	 * Get list of all user administrators for supported role and given facility.
 	 *
 	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -714,54 +714,6 @@ public interface GroupsManagerBl {
 	List<Group> getAllSubGroups(PerunSession sess, Group parentGroup) throws InternalErrorException;
 
 	/**
-	 * Adds an administrator of the group.
-	 *
-	 * @param perunSession
-	 * @param group
-	 * @param user
-	 *
-	 * @throws InternalErrorException
-	 * @throws AlreadyAdminException
-	 */
-	void addAdmin(PerunSession perunSession, Group group,  User user) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Adds a group administrator to the group.
-	 *
-	 * @param perunSession
-	 * @param group - group that will be assigned admins (users) from authorizedGroup
-	 * @param authorizedGroup - group that will be given the privilege
-	 *
-	 * @throws InternalErrorException
-	 * @throws AlreadyAdminException
-	 */
-	void addAdmin(PerunSession perunSession, Group group, Group authorizedGroup) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Removes an administrator form the group.
-	 *
-	 * @param perunSession
-	 * @param group
-	 * @param user
-	 *
-	 * @throws InternalErrorException
-	 * @throws UserNotAdminException
-	 */
-	void removeAdmin(PerunSession perunSession, Group group, User user) throws InternalErrorException, UserNotAdminException;
-
-	/**
-	 * Removes a group administrator of the group.
-	 *
-	 * @param perunSession
-	 * @param group
-	 * @param authorizedGroup group that will be removed the privilege
-	 *
-	 * @throws InternalErrorException
-	 * @throws GroupNotAdminException
-	 */
-	void removeAdmin(PerunSession perunSession, Group group, Group authorizedGroup) throws InternalErrorException, GroupNotAdminException;
-
-	/**
 	 * Get list of all user administrators for supported role and specific group.
 	 *
 	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ResourcesManagerBl.java
@@ -823,62 +823,6 @@ public interface ResourcesManagerBl {
 	List<Group> getAdminGroups(PerunSession sess, Resource resource) throws InternalErrorException;
 
 	/**
-	 * Add role resource admin to user for the selected resource.
-	 *
-	 * @param sess
-	 * @param resource
-	 * @param user
-	 * @throws InternalErrorException
-	 * @throws UserNotExistsException
-	 * @throws PrivilegeException
-	 * @throws AlreadyAdminException
-	 * @throws ResourceNotExistsException
-	 */
-	void addAdmin(PerunSession sess, Resource resource, User user) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Add role resource admin to group for the selected resource.
-	 *
-	 * @param sess
-	 * @param resource
-	 * @param group
-	 * @throws InternalErrorException
-	 * @throws UserNotExistsException
-	 * @throws PrivilegeException
-	 * @throws AlreadyAdminException
-	 * @throws ResourceNotExistsException
-	 */
-	void addAdmin(PerunSession sess, Resource resource, Group group) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Remove role resource admin from user for the selected resource.
-	 *
-	 * @param sess
-	 * @param resource
-	 * @param user
-	 * @throws InternalErrorException
-	 * @throws UserNotExistsException
-	 * @throws PrivilegeException
-	 * @throws AlreadyAdminException
-	 * @throws ResourceNotExistsException
-	 */
-	void removeAdmin(PerunSession sess, Resource resource, User user) throws InternalErrorException, UserNotAdminException;
-
-	/**
-	 * Remove role resource admin from group for the selected resource.
-	 *
-	 * @param sess
-	 * @param resource
-	 * @param group
-	 * @throws InternalErrorException
-	 * @throws GroupNotExistsException
-	 * @throws PrivilegeException
-	 * @throws GroupNotAdminException
-	 * @throws ResourceNotExistsException
-	 */
-	void removeAdmin(PerunSession sess, Resource resource, Group group) throws InternalErrorException, GroupNotAdminException;
-
-	/**
 	 * Set ban for member on resource
 	 *
 	 * @param sess

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SecurityTeamsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SecurityTeamsManagerBl.java
@@ -120,50 +120,6 @@ public interface SecurityTeamsManagerBl {
 	List<Group> getAdminGroups(PerunSession sess, SecurityTeam securityTeam) throws InternalErrorException;
 
 	/**
-	 * create security admin from given user and add him as security admin of given security team
-	 *
-	 * @param sess
-	 * @param securityTeam
-	 * @param user
-	 * @throws InternalErrorException
-	 * @throws AlreadyAdminException
-	 */
-	void addAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Create group as security admins group of given security team (all users in group will have security admin rights)
-	 *
-	 * @param sess
-	 * @param securityTeam
-	 * @param group
-	 * @throws InternalErrorException
-	 * @throws AlreadyAdminException
-	 */
-	void addAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Remove security admin role for given security team from user
-	 *
-	 * @param sess
-	 * @param securityTeam
-	 * @param user
-	 * @throws InternalErrorException
-	 * @throws UserNotAdminException
-	 */
-	void removeAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws InternalErrorException, UserNotAdminException;
-
-	/**
-	 * Remove security admin role for given security team from group
-	 *
-	 * @param sess
-	 * @param securityTeam
-	 * @param group
-	 * @throws InternalErrorException
-	 * @throws GroupNotAdminException
-	 */
-	void removeAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException;
-
-	/**
 	 * Blacklist user by given security team with description.
 	 *
 	 * Description can be null.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/VosManagerBl.java
@@ -171,51 +171,6 @@ public interface VosManagerBl {
 	List<MemberCandidate> getCompleteCandidates(PerunSession sess, Vo vo, Group group, List<String> attrNames, String searchString, List<ExtSource> extSources) throws InternalErrorException;
 
 	/**
-	 * Add a user administrator to the VO.
-	 *
-	 * @param perunSession
-	 * @param vo
-	 * @param user user who will became an VO administrator
-	 * @throws InternalErrorException
-	 * @throws AlreadyAdminException
-	 */
-	void addAdmin(PerunSession perunSession, Vo vo, User user) throws InternalErrorException, AlreadyAdminException;
-
-
-	/**
-	 * Add a group administrator to the VO.
-	 *
-	 * @param perunSession
-	 * @param vo
-	 * @param group group who will become a VO administrator
-	 * @throws InternalErrorException
-	 * @throws AlreadyAdminException
-	 */
-	void addAdmin(PerunSession perunSession, Vo vo, Group group) throws InternalErrorException, AlreadyAdminException;
-
-	/**
-	 * Removes a user administrator from the VO.
-	 *
-	 * @param perunSession
-	 * @param vo
-	 * @param user user who will lose an VO administrator role
-	 * @throws InternalErrorException
-	 * @throws UserNotAdminException
-	 */
-	void removeAdmin(PerunSession perunSession, Vo vo, User user) throws InternalErrorException, UserNotAdminException;
-
-	/**
-	 * Removes a group administrator from the VO.
-	 *
-	 * @param perunSession
-	 * @param vo
-	 * @param group group who will lose a VO administrator role
-	 * @throws InternalErrorException
-	 * @throws GroupNotAdminException
-	 */
-	void removeAdmin(PerunSession perunSession, Vo vo, Group group) throws InternalErrorException, GroupNotAdminException;
-
-	/**
 	 * Get list of all user administrators for supported role and specific vo.
 	 *
 	 * If onlyDirectAdmins is true, return only direct users of the group for supported role.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1,6 +1,26 @@
 package cz.metacentrum.perun.core.blImpl;
 
+import cz.metacentrum.perun.audit.events.FacilityManagerEvents.AdminAddedForFacility;
+import cz.metacentrum.perun.audit.events.FacilityManagerEvents.AdminGroupAddedForFacility;
+import cz.metacentrum.perun.audit.events.FacilityManagerEvents.AdminGroupRemovedForFacility;
+import cz.metacentrum.perun.audit.events.FacilityManagerEvents.AdminRemovedForFacility;
+import cz.metacentrum.perun.audit.events.GroupManagerEvents.AdminAddedForGroup;
+import cz.metacentrum.perun.audit.events.GroupManagerEvents.AdminGroupAddedForGroup;
+import cz.metacentrum.perun.audit.events.GroupManagerEvents.AdminGroupRemovedFromGroup;
+import cz.metacentrum.perun.audit.events.GroupManagerEvents.AdminRemovedForGroup;
+import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminGroupAddedForResource;
+import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminGroupRemovedForResource;
+import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminUserAddedForResource;
+import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminUserRemovedForResource;
+import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.AdminAddedForSecurityTeam;
+import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.AdminGroupAddedForSecurityTeam;
+import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.AdminGroupRemovedFromSecurityTeam;
+import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.AdminRemovedFromSecurityTeam;
 import cz.metacentrum.perun.audit.events.UserManagerEvents.UserPromotedToPerunAdmin;
+import cz.metacentrum.perun.audit.events.VoManagerEvents.AdminAddedForVo;
+import cz.metacentrum.perun.audit.events.VoManagerEvents.AdminGroupAddedForVo;
+import cz.metacentrum.perun.audit.events.VoManagerEvents.AdminGroupRemovedForVo;
+import cz.metacentrum.perun.audit.events.VoManagerEvents.AdminRemovedForVo;
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
@@ -1116,8 +1136,13 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 					}
 				} else if (role.equals(Role.VOADMIN)) {
 					if (complementaryObject instanceof Vo) {
-						if (user != null) authzResolverImpl.addVoRole(sess, Role.VOADMIN,(Vo) complementaryObject, user);
-						else authzResolverImpl.addVoRole(sess, Role.VOADMIN, (Vo) complementaryObject, authorizedGroup);
+						if (user != null) {
+							authzResolverImpl.addVoRole(sess, Role.VOADMIN,(Vo) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminAddedForVo(user, (Vo) complementaryObject));
+						} else {
+							authzResolverImpl.addVoRole(sess, Role.VOADMIN, (Vo) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupAddedForVo(authorizedGroup, (Vo) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for VoAdmin: " + complementaryObject);
 					}
@@ -1130,29 +1155,49 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 					}
 				} else if (role.equals(Role.GROUPADMIN)) {
 					if (complementaryObject instanceof Group) {
-						if (user != null) authzResolverImpl.addAdmin(sess, (Group) complementaryObject, user);
-						else authzResolverImpl.addAdmin(sess, (Group) complementaryObject, authorizedGroup);
+						if (user != null) {
+							authzResolverImpl.addAdmin(sess, (Group) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminAddedForGroup(user, (Group) complementaryObject));
+						} else {
+							authzResolverImpl.addAdmin(sess, (Group) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupAddedForGroup(authorizedGroup, (Group) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for GroupAdmin: " + complementaryObject);
 					}
 				} else if (role.equals(Role.FACILITYADMIN)) {
 					if (complementaryObject instanceof Facility) {
-						if (user != null) authzResolverImpl.addAdmin(sess, (Facility) complementaryObject, user);
-						else authzResolverImpl.addAdmin(sess, (Facility) complementaryObject, authorizedGroup);
+						if (user != null) {
+							authzResolverImpl.addAdmin(sess, (Facility) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminAddedForFacility(user, (Facility) complementaryObject));
+						} else {
+							authzResolverImpl.addAdmin(sess, (Facility) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupAddedForFacility(authorizedGroup, (Facility) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for FacilityAdmin: " + complementaryObject);
 					}
 				} else if (role.equals(Role.RESOURCEADMIN)) {
 					if (complementaryObject instanceof Resource) {
-						if (user != null) authzResolverImpl.addAdmin(sess, (Resource) complementaryObject, user);
-						else authzResolverImpl.addAdmin(sess, (Resource) complementaryObject, authorizedGroup);
+						if (user != null) {
+							authzResolverImpl.addAdmin(sess, (Resource) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminUserAddedForResource(user, (Resource) complementaryObject));
+						} else {
+							authzResolverImpl.addAdmin(sess, (Resource) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupAddedForResource(authorizedGroup, (Resource) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for ResourceAdmin: " + complementaryObject);
 					}
 				} else if (role.equals(Role.SECURITYADMIN)) {
 					if (complementaryObject instanceof SecurityTeam) {
-						if (user != null) addAdmin(sess, (SecurityTeam) complementaryObject, user);
-						else addAdmin(sess, (SecurityTeam) complementaryObject, authorizedGroup);
+						if (user != null) {
+							addAdmin(sess, (SecurityTeam) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminAddedForSecurityTeam(user, (SecurityTeam) complementaryObject));
+						} else {
+							addAdmin(sess, (SecurityTeam) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupAddedForSecurityTeam(authorizedGroup, (SecurityTeam) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for FacilityAdmin: " + complementaryObject);
 					}
@@ -1197,8 +1242,13 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 					}
 				} else if (role.equals(Role.VOADMIN)) {
 					if (complementaryObject instanceof Vo) {
-						if (user != null) authzResolverImpl.removeVoRole(sess, Role.VOADMIN,(Vo) complementaryObject, user);
-						else authzResolverImpl.removeVoRole(sess, Role.VOADMIN,(Vo) complementaryObject, authorizedGroup);
+						if (user != null) {
+							authzResolverImpl.removeVoRole(sess, Role.VOADMIN,(Vo) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminRemovedForVo(user, (Vo) complementaryObject));
+						} else {
+							authzResolverImpl.removeVoRole(sess, Role.VOADMIN,(Vo) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupRemovedForVo(authorizedGroup, (Vo) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for VoAdmin: " + complementaryObject);
 					}
@@ -1211,29 +1261,49 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 					}
 				} else if (role.equals(Role.GROUPADMIN)) {
 					if (complementaryObject instanceof Group) {
-						if (user != null) authzResolverImpl.removeAdmin(sess, (Group) complementaryObject, user);
-						else authzResolverImpl.removeAdmin(sess, (Group) complementaryObject, authorizedGroup);
+						if (user != null) {
+							authzResolverImpl.removeAdmin(sess, (Group) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminRemovedForGroup(user, (Group) complementaryObject));
+						} else {
+							authzResolverImpl.removeAdmin(sess, (Group) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupRemovedFromGroup(authorizedGroup, (Group) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for GroupAdmin: " + complementaryObject);
 					}
 				} else if (role.equals(Role.FACILITYADMIN)) {
 					if (complementaryObject instanceof Facility) {
-						if (user != null) authzResolverImpl.removeAdmin(sess, (Facility) complementaryObject, user);
-						else authzResolverImpl.removeAdmin(sess, (Facility) complementaryObject, authorizedGroup);
+						if (user != null) {
+							authzResolverImpl.removeAdmin(sess, (Facility) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminRemovedForFacility(user, (Facility) complementaryObject));
+						} else {
+							authzResolverImpl.removeAdmin(sess, (Facility) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupRemovedForFacility(authorizedGroup, (Facility) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for FacilityAdmin: " + complementaryObject);
 					}
 				} else if (role.equals(Role.RESOURCEADMIN)) {
 					if (complementaryObject instanceof Resource) {
-						if (user != null) authzResolverImpl.removeAdmin(sess, (Resource) complementaryObject, user);
-						else authzResolverImpl.removeAdmin(sess, (Resource) complementaryObject, authorizedGroup);
+						if (user != null) {
+							authzResolverImpl.removeAdmin(sess, (Resource) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminUserRemovedForResource(user, (Resource) complementaryObject));
+						} else {
+							authzResolverImpl.removeAdmin(sess, (Resource) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupRemovedForResource(authorizedGroup, (Resource) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for ResourceAdmin: " + complementaryObject);
 					}
 				} else if (role.equals(Role.SECURITYADMIN)) {
 					if (complementaryObject instanceof SecurityTeam) {
-						if (user != null) removeAdmin(sess, (SecurityTeam) complementaryObject, user);
-						else removeAdmin(sess, (SecurityTeam) complementaryObject, authorizedGroup);
+						if (user != null) {
+							removeAdmin(sess, (SecurityTeam) complementaryObject, user);
+							getPerunBl().getAuditer().log(sess, new AdminRemovedFromSecurityTeam(user, (SecurityTeam) complementaryObject));
+						} else {
+							removeAdmin(sess, (SecurityTeam) complementaryObject, authorizedGroup);
+							getPerunBl().getAuditer().log(sess, new AdminGroupRemovedFromSecurityTeam(authorizedGroup, (SecurityTeam) complementaryObject));
+						}
 					} else {
 						throw new InternalErrorException("Not supported complementary object for VoObserver: " + complementaryObject);
 					}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -456,7 +456,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<Facility> facilitiesWhereGroupIsAdmin = getGroupsManagerImpl().getFacilitiesWhereGroupIsAdmin(sess, group);
 		for (Facility facility : facilitiesWhereGroupIsAdmin) {
 			try {
-				perunBl.getFacilitiesManagerBl().removeAdmin(sess, facility, group);
+				AuthzResolverBlImpl.unsetRole(sess, group, facility, Role.FACILITYADMIN);
 			} catch (GroupNotAdminException e) {
 				log.warn("Can't unset group {} as admin of facility {} due to group not admin exception {}.", group, facility, e);
 			}
@@ -465,7 +465,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<Group> groupsWhereGroupIsAdmin = getGroupsManagerImpl().getGroupsWhereGroupIsAdmin(sess, group);
 		for (Group group1 : groupsWhereGroupIsAdmin) {
 			try {
-				removeAdmin(sess, group1, group);
+				AuthzResolverBlImpl.unsetRole(sess, group, group1, Role.GROUPADMIN);
 			} catch (GroupNotAdminException e) {
 				log.warn("Can't unset group {} as admin of group {} due to group not admin exception {}.", group, group1, e);
 			}
@@ -474,7 +474,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<Resource> resourcesWhereGroupIsAdmin = getGroupsManagerImpl().getResourcesWhereGroupIsAdmin(sess, group);
 		for (Resource resource : resourcesWhereGroupIsAdmin) {
 			try {
-				perunBl.getResourcesManagerBl().removeAdmin(sess, resource, group);
+				AuthzResolverBlImpl.unsetRole(sess, group, resource, Role.RESOURCEADMIN);
 			} catch (GroupNotAdminException e) {
 				log.warn("Can't unset group {} as admin of resource {} due to group not admin exception {}.", group, resource, e);
 			}
@@ -492,7 +492,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<SecurityTeam> securityTeamsWhereGroupIsAdmin = getGroupsManagerImpl().getSecurityTeamsWhereGroupIsAdmin(sess, group);
 		for (SecurityTeam securityTeam : securityTeamsWhereGroupIsAdmin) {
 			try {
-				perunBl.getSecurityTeamsManagerBl().removeAdmin(sess, securityTeam, group);
+				AuthzResolverBlImpl.unsetRole(sess, group, securityTeam, Role.SECURITYADMIN);
 			} catch (GroupNotAdminException e) {
 				log.warn("Can't unset group {} as admin of security team {} due to group not admin exception {}.", group, securityTeam, e);
 			}
@@ -501,7 +501,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<Vo> vosWhereGroupIsAdmin = getGroupsManagerImpl().getVosWhereGroupIsAdmin(sess, group);
 		for (Vo vo1 : vosWhereGroupIsAdmin) {
 			try {
-				perunBl.getVosManagerBl().removeAdmin(sess, vo1, group);
+				AuthzResolverBlImpl.unsetRole(sess, group, vo1, Role.VOADMIN);
 			} catch (GroupNotAdminException e) {
 				log.warn("Can't unset group {} as admin of facility {} due to group not admin exception {}.", group, vo1, e);
 			}
@@ -1270,36 +1270,6 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	public int getGroupMembersCount(PerunSession sess, Group group) throws InternalErrorException {
 		List<Member> members = this.getGroupMembers(sess, group);
 		return members.size();
-	}
-
-	@Override
-	public void addAdmin(PerunSession sess, Group group, User user) throws InternalErrorException, AlreadyAdminException {
-		AuthzResolverBlImpl.setRole(sess, user, group, Role.GROUPADMIN);
-		getPerunBl().getAuditer().log(sess, new AdminAddedForGroup(user, group));
-	}
-
-	@Override
-	public void addAdmin(PerunSession sess, Group group, Group authorizedGroup) throws InternalErrorException, AlreadyAdminException {
-		List<Group> listOfAdmins = getAdminGroups(sess, group);
-		if (listOfAdmins.contains(authorizedGroup)) throw new AlreadyAdminException(authorizedGroup);
-
-		AuthzResolverBlImpl.setRole(sess, authorizedGroup, group, Role.GROUPADMIN);
-		getPerunBl().getAuditer().log(sess, new AdminGroupAddedForGroup(authorizedGroup, group));
-	}
-
-	@Override
-	public void removeAdmin(PerunSession sess, Group group, User user) throws InternalErrorException, UserNotAdminException {
-		AuthzResolverBlImpl.unsetRole(sess, user, group, Role.GROUPADMIN);
-		getPerunBl().getAuditer().log(sess, new AdminRemovedForGroup(user, group));
-	}
-
-	@Override
-	public void removeAdmin(PerunSession sess, Group group, Group authorizedGroup) throws InternalErrorException, GroupNotAdminException {
-		List<Group> listOfAdmins = getAdminGroups(sess, group);
-		if (!listOfAdmins.contains(authorizedGroup)) throw new GroupNotAdminException(authorizedGroup);
-
-		AuthzResolverBlImpl.unsetRole(sess, authorizedGroup, group, Role.GROUPADMIN);
-		getPerunBl().getAuditer().log(sess, new AdminGroupRemovedFromGroup(authorizedGroup, group));
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -838,36 +838,6 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
     }
 
 	@Override
-	public void addAdmin(PerunSession sess, Resource resource, User user) throws InternalErrorException, AlreadyAdminException {
-		AuthzResolverBlImpl.setRole(sess, user, resource, Role.RESOURCEADMIN);
-		getPerunBl().getAuditer().log(sess, new AdminUserAddedForResource(user, resource));
-	}
-
-	@Override
-	public void addAdmin(PerunSession sess, Resource resource, Group group) throws InternalErrorException, AlreadyAdminException {
-		List<Group> listOfAdmins = getAdminGroups(sess, resource);
-		if (listOfAdmins.contains(group)) throw new AlreadyAdminException(group);
-
-		AuthzResolverBlImpl.setRole(sess, group, resource, Role.RESOURCEADMIN);
-		getPerunBl().getAuditer().log(sess, new AdminGroupAddedForResource(group, resource));
-	}
-
-	@Override
-	public void removeAdmin(PerunSession sess, Resource resource, User user) throws InternalErrorException, UserNotAdminException {
-		AuthzResolverBlImpl.unsetRole(sess, user, resource, Role.RESOURCEADMIN);
-		getPerunBl().getAuditer().log(sess, new AdminUserRemovedForResource(user, resource));
-	}
-
-	@Override
-	public void removeAdmin(PerunSession sess, Resource resource, Group group) throws InternalErrorException, GroupNotAdminException {
-		List<Group> listOfAdmins = getAdminGroups(sess, resource);
-		if (!listOfAdmins.contains(group)) throw new GroupNotAdminException(group);
-
-		AuthzResolverBlImpl.unsetRole(sess, group, resource, Role.RESOURCEADMIN);
-		getPerunBl().getAuditer().log(sess, new AdminGroupRemovedForResource(group, resource));
-	}
-
-	@Override
 	public BanOnResource setBan(PerunSession sess, BanOnResource banOnResource) throws InternalErrorException, BanAlreadyExistsException {
 		if(this.banExists(sess, banOnResource.getMemberId(), banOnResource.getResourceId())) throw new BanAlreadyExistsException(banOnResource);
 		banOnResource = getResourcesManagerImpl().setBan(sess, banOnResource);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
@@ -154,30 +154,6 @@ public class SecurityTeamsManagerBlImpl implements SecurityTeamsManagerBl {
 	}
 
 	@Override
-	public void addAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws AlreadyAdminException, InternalErrorException {
-		AuthzResolverBlImpl.addAdmin(sess, securityTeam, user);
-		getPerunBl().getAuditer().log(sess, new AdminAddedForSecurityTeam(user, securityTeam));
-	}
-
-	@Override
-	public void addAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, AlreadyAdminException {
-		AuthzResolverBlImpl.addAdmin(sess, securityTeam, group);
-		getPerunBl().getAuditer().log(sess, new AdminGroupAddedForSecurityTeam(group, securityTeam));
-	}
-
-	@Override
-	public void removeAdmin(PerunSession sess, SecurityTeam securityTeam, User user) throws UserNotAdminException, InternalErrorException {
-		AuthzResolverBlImpl.removeAdmin(sess, securityTeam, user);
-		getPerunBl().getAuditer().log(sess, new AdminRemovedFromSecurityTeam(user, securityTeam));
-	}
-
-	@Override
-	public void removeAdmin(PerunSession sess, SecurityTeam securityTeam, Group group) throws InternalErrorException, GroupNotAdminException {
-		AuthzResolverBlImpl.removeAdmin(sess, securityTeam, group);
-		getPerunBl().getAuditer().log(sess, new AdminGroupRemovedFromSecurityTeam(group, securityTeam));
-	}
-
-	@Override
 	public void addUserToBlacklist(PerunSession sess, SecurityTeam securityTeam, User user, String description) throws InternalErrorException {
 		getSecurityTeamsManagerImpl().addUserToBlacklist(sess, securityTeam, user, description);
 		getPerunBl().getAuditer().log(sess, new UserAddedToBlackListOfSecurityTeam(user, securityTeam, description));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -58,6 +58,7 @@ import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.FacilitiesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.FacilitiesManagerImplApi;
 import org.slf4j.Logger;
@@ -800,7 +801,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
-		getFacilitiesManagerBl().addAdmin(sess, facility, user);
+		AuthzResolverBlImpl.setRole(sess, user, facility, Role.FACILITYADMIN);
 	}
 
 	@Override
@@ -815,7 +816,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
-		getFacilitiesManagerBl().addAdmin(sess, facility, group);
+		AuthzResolverBlImpl.setRole(sess, group, facility, Role.FACILITYADMIN);
 	}
 
 	@Override
@@ -829,7 +830,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			throw new PrivilegeException(sess, "deleteAdmin");
 		}
 
-		getFacilitiesManagerBl().removeAdmin(sess, facility, user);
+		AuthzResolverBlImpl.unsetRole(sess, user, facility, Role.FACILITYADMIN);
 
 	}
 
@@ -844,7 +845,7 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 			throw new PrivilegeException(sess, "deleteAdmin");
 		}
 
-		getFacilitiesManagerBl().removeAdmin(sess, facility, group);
+		AuthzResolverBlImpl.unsetRole(sess, group, facility, Role.FACILITYADMIN);
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -53,6 +53,7 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.GroupsManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.GroupsManagerImplApi;
 
@@ -660,7 +661,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "addAdmin");
 				}
 
-		getGroupsManagerBl().addAdmin(sess, group, user);
+		AuthzResolverBlImpl.setRole(sess, user, group, Role.GROUPADMIN);
 	}
 
 	@Override
@@ -676,7 +677,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "addAdmin");
 				}
 
-		getGroupsManagerBl().addAdmin(sess, group, authorizedGroup);
+		AuthzResolverBlImpl.setRole(sess, authorizedGroup, group, Role.GROUPADMIN);
 	}
 
 	@Override
@@ -691,7 +692,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "removeAdmin");
 				}
 
-		getGroupsManagerBl().removeAdmin(sess, group, user);
+		AuthzResolverBlImpl.unsetRole(sess, user, group, Role.GROUPADMIN);
 	}
 
 	@Override
@@ -706,7 +707,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			throw new PrivilegeException(sess, "removeAdmin");
 				}
 
-		getGroupsManagerBl().removeAdmin(sess, group, authorizedGroup);
+		AuthzResolverBlImpl.unsetRole(sess, authorizedGroup, group, Role.GROUPADMIN);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ResourcesManagerEntry.java
@@ -47,6 +47,7 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1085,7 +1086,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
-		getResourcesManagerBl().addAdmin(sess, resource, user);
+		AuthzResolverBlImpl.setRole(sess, user, resource, Role.RESOURCEADMIN);
 	}
 
 	@Override
@@ -1099,7 +1100,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
-		getResourcesManagerBl().addAdmin(sess, resource, group);
+		AuthzResolverBlImpl.setRole(sess, group, resource, Role.RESOURCEADMIN);
 	}
 
 	@Override
@@ -1113,7 +1114,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			throw new PrivilegeException(sess, "removeAdmin");
 		}
 
-		getResourcesManagerBl().removeAdmin(sess, resource, user);
+		AuthzResolverBlImpl.unsetRole(sess, user, resource, Role.RESOURCEADMIN);
 	}
 
 	@Override
@@ -1127,8 +1128,7 @@ public class ResourcesManagerEntry implements ResourcesManager {
 			throw new PrivilegeException(sess, "removeAdmin");
 		}
 
-		getResourcesManagerBl().removeAdmin(sess, resource, group);
-
+		AuthzResolverBlImpl.unsetRole(sess, group, resource, Role.RESOURCEADMIN);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SecurityTeamsManagerEntry.java
@@ -242,7 +242,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
-		getSecurityTeamsManagerBl().addAdmin(sess, securityTeam, user);
+		AuthzResolverBlImpl.setRole(sess, user, securityTeam, Role.SECURITYADMIN);
 	}
 
 	@Override
@@ -257,7 +257,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
-		getSecurityTeamsManagerBl().addAdmin(sess, securityTeam, group);
+		AuthzResolverBlImpl.setRole(sess, group, securityTeam, Role.SECURITYADMIN);
 
 	}
 
@@ -274,7 +274,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 		}
 
 
-		getSecurityTeamsManagerBl().removeAdmin(sess, securityTeam, user);
+		AuthzResolverBlImpl.unsetRole(sess, user, securityTeam, Role.SECURITYADMIN);
 	}
 
 	@Override
@@ -289,7 +289,7 @@ public class SecurityTeamsManagerEntry implements cz.metacentrum.perun.core.api.
 			throw new PrivilegeException(sess, "removeAdmin");
 		}
 
-		getSecurityTeamsManagerBl().removeAdmin(sess, securityTeam, group);
+		AuthzResolverBlImpl.unsetRole(sess, group, securityTeam, Role.SECURITYADMIN);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -324,7 +324,7 @@ public class VosManagerEntry implements VosManager {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
-		vosManagerBl.addAdmin(sess, vo, user);
+		AuthzResolverBlImpl.setRole(sess, user, vo, Role.VOADMIN);
 	}
 
 
@@ -339,7 +339,7 @@ public class VosManagerEntry implements VosManager {
 			throw new PrivilegeException(sess, "addAdmin");
 		}
 
-		vosManagerBl.addAdmin(sess, vo, group);
+		AuthzResolverBlImpl.setRole(sess, group, vo, Role.VOADMIN);
 	}
 
 	@Override
@@ -353,7 +353,7 @@ public class VosManagerEntry implements VosManager {
 			throw new PrivilegeException(sess, "deleteAdmin");
 		}
 
-		vosManagerBl.removeAdmin(sess, vo, user);
+		AuthzResolverBlImpl.unsetRole(sess, user, vo, Role.VOADMIN);
 	}
 
 	@Override
@@ -367,7 +367,7 @@ public class VosManagerEntry implements VosManager {
 			throw new PrivilegeException(sess, "deleteAdmin");
 		}
 
-		vosManagerBl.removeAdmin(sess, vo, group);
+		AuthzResolverBlImpl.unsetRole(sess, group, vo, Role.VOADMIN);
 	}
 
 	@Override

--- a/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTMainAndFilterIntegrationTest.java
+++ b/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTMainAndFilterIntegrationTest.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.voot;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -209,9 +210,9 @@ public class VOOTMainAndFilterIntegrationTest extends AbstractVOOTTest {
 		member2OfUser1 = perun.getMembersManagerBl().createMember(session, vo2, user1);
 
 		perun.getGroupsManagerBl().addMember(session, group1OfVo1, member1OfUser1);
-		perun.getGroupsManagerBl().addAdmin(session, group1OfVo1, user1);
+		AuthzResolverBlImpl.setRole(session, user1, group1OfVo1, Role.GROUPADMIN);
 		perun.getGroupsManagerBl().addMember(session, group2OfVo1, member1OfUser1);
-		perun.getGroupsManagerBl().addAdmin(session, group2OfVo1, user1);
+		AuthzResolverBlImpl.setRole(session, user1, group2OfVo1, Role.GROUPADMIN);
 		perun.getGroupsManagerBl().addMember(session, group1OfVo2, member2OfUser1);
 
 		user2 = new User(2, "user2-firstName", "user2-lastName", null, null, null);

--- a/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTSortIntegrationTest.java
+++ b/perun-voot/src/test/java/cz/metacentrum/perun/voot/VOOTSortIntegrationTest.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.voot;
 
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -194,13 +195,13 @@ public class VOOTSortIntegrationTest extends AbstractVOOTTest {
 
 		perun.getGroupsManagerBl().addMember(session, group1, member1);
 		perun.getGroupsManagerBl().addMember(session, group2, member1);
-		perun.getGroupsManagerBl().addAdmin(session, group2, user1);
+		AuthzResolverBlImpl.setRole(session, user1, group2, Role.GROUPADMIN);
 		perun.getGroupsManagerBl().addMember(session, group3, member1);
-		perun.getGroupsManagerBl().addAdmin(session, group3, user1);
+		AuthzResolverBlImpl.setRole(session, user1, group3, Role.GROUPADMIN);
 
 		perun.getGroupsManagerBl().addMember(session, group1, member2);
 		perun.getGroupsManagerBl().addMember(session, group1, member3);
-		perun.getGroupsManagerBl().addAdmin(session, group1, user3);
+		AuthzResolverBlImpl.setRole(session, user3, group1, Role.GROUPADMIN);
 
 	}
 


### PR DESCRIPTION
* Audit events are now logged in setRole in AuthzResolverBlImpl for every entity

* started using setRole/unsetRole in AuthzResolverBlImpl directly from the entry layer for setting admin instead of addAdmin/removeAdmin in Bl layer of the managers

* Removed addAdmin and removeAdmin methods from Bl layer of the managers
