### PR TITLE
added missing checkAttributeDependencies

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -4725,6 +4725,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
 			checkAttributesSemantics(sess, member, resource, attributes);
+			checkAttributesDependencies(sess, member, resource, attributes);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new ConsistencyErrorException(ex);
 		}
@@ -4809,6 +4810,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		for (Attribute attribute : attributes) attribute.setValue(null);
 		try {
 			checkAttributesSemantics(sess, member, group, attributes);
+			checkAttributesDependencies(sess, member, group, attributes);
 		} catch (WrongAttributeAssignmentException ex) {
 			throw new ConsistencyErrorException(ex);
 		}


### PR DESCRIPTION
- checkAttributeDependencies method was missing in removeallAttributes
  for member-resource and member-group attributes. So the checks were
  added to this methods.