### PR TITLE
Separation of checkAttributeSyntax from semantics in User-Facility mo…

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTime.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTime.java
@@ -13,7 +13,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
@@ -31,20 +31,22 @@ public class urn_perun_user_facility_attribute_def_def_accountExpirationTime ext
 	private static final String A_F_D_accountExpirationTime = AttributesManager.NS_FACILITY_ATTR_DEF + ":accountExpirationTime";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
-		Integer accExpTime = (Integer) attribute.getValue();
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		Integer accExpTime = attribute.valueAsInteger();
 
 		if (accExpTime == null) {
-			throw new WrongAttributeValueException("account expiration time shouldn't be null");
+			throw new WrongReferenceAttributeValueException(attribute, null, user, facility, "account expiration time shouldn't be null");
 		}
 		Integer facilityAccExpTime;
+		Attribute facilityAccExpAttribute;
 		try {
-			facilityAccExpTime = (Integer) perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, facility, A_F_D_accountExpirationTime).getValue();
+			facilityAccExpAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, facility, A_F_D_accountExpirationTime);
+			facilityAccExpTime = facilityAccExpAttribute.valueAsInteger();
 		} catch (AttributeNotExistsException ex) {
 			throw new InternalErrorException(ex);
 		}
 		if(accExpTime > facilityAccExpTime) {
-			throw new WrongAttributeValueException("this user_facility attribute cannot has higher value than same facility attribute");
+			throw new WrongReferenceAttributeValueException(attribute, facilityAccExpAttribute, user, facility, facility, null, "this user_facility attribute cannot has higher value than same facility attribute");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGID.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class urn_perun_user_facility_attribute_def_def_basicDefaultGID extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException, WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException, InternalErrorException, WrongAttributeAssignmentException {
 		Attribute namespaceAttribute;
 			try {
 				namespaceAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGID-namespace");
@@ -36,7 +36,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGID extends U
 		if (namespaceAttribute.getValue() == null) {
 			throw new WrongReferenceAttributeValueException(attribute, namespaceAttribute, "Reference attribute is null");
 		}
-		String namespaceName = (String) namespaceAttribute.getValue();
+		String namespaceName = namespaceAttribute.valueAsString();
 
 		Attribute resourceGidAttribute;
 		try {
@@ -49,14 +49,14 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGID extends U
 		List<Resource> allowedResources = sess.getPerunBl().getUsersManagerBl().getAllowedResources(sess, facility, user);
 		List<Resource> resourcesWithSameGid = sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, resourceGidAttribute);
 		if (resourcesWithSameGid.isEmpty() && allowedResources.isEmpty() && resourceGidAttribute.getValue() == null) return;
-		if (resourcesWithSameGid.isEmpty() && resourceGidAttribute.getValue() != null) throw new WrongAttributeValueException(attribute, user, facility, "Resource with requiered unix GID doesn't exist.");
-		if (allowedResources.isEmpty()) throw new WrongAttributeValueException(attribute, user, "User has not access to required resource");
+		if (resourcesWithSameGid.isEmpty() && resourceGidAttribute.getValue() != null) throw new WrongReferenceAttributeValueException(attribute, null, user, facility, "Resource with requiered unix GID doesn't exist.");
+		if (allowedResources.isEmpty()) throw new WrongReferenceAttributeValueException(attribute, null, user, facility, "User has not access to required resource");
 
 		resourcesWithSameGid.retainAll(allowedResources);
 
 		//We did not find at least one allowed resource with same gid as the user have => attribute is NOK
 		if (resourcesWithSameGid.isEmpty()) {
-			throw new WrongAttributeValueException(attribute, user, "User has not access to resource with required group id");
+			throw new WrongReferenceAttributeValueException(attribute, null, user, facility, "User has not access to resource with required group id");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPoint.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPoint.java
@@ -34,10 +34,9 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends Us
 	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$*");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
-		List<Resource> usersResources;
-		usersResources = session.getPerunBl().getUsersManagerBl().getAllowedResources(session, facility, user);
+		List<Resource> usersResources = session.getPerunBl().getUsersManagerBl().getAllowedResources(session, facility, user);
 
 		List<String> homeMntPointsOnAllResources = new ArrayList<>();
 		for (Resource res : usersResources) {
@@ -47,7 +46,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends Us
 			} catch (AttributeNotExistsException ex) {
 				throw new InternalErrorException("no homemountpoints found on underlying resources", ex);
 			}
-			List<String> homeMntPoint = (List<String>) resAttribute.getValue();
+			List<String> homeMntPoint = resAttribute.valueAsList();
 			if (homeMntPoint != null) {
 				homeMntPointsOnAllResources.addAll(homeMntPoint);
 			}
@@ -56,10 +55,15 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPoint extends Us
 			throw new WrongReferenceAttributeValueException("No homeMountPoints set on associated resources.");
 		}
 		if (!homeMntPointsOnAllResources.contains(attribute.valueAsString())) {
-			throw new WrongAttributeValueException(attribute, user, facility, "User's home mount point is invalid. Valid mount points: " + homeMntPointsOnAllResources);
+			throw new WrongReferenceAttributeValueException(attribute, null, user, facility, "User's home mount point is invalid. Valid mount points: " + homeMntPointsOnAllResources);
 		}
+	}
 
-		Matcher match = pattern.matcher((String) attribute.getValue());
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
+
+		Matcher match = pattern.matcher(attribute.valueAsString());
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, "Attribute has wrong format");
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_o365AccountExtension.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_o365AccountExtension.java
@@ -21,8 +21,8 @@ import java.util.Date;
 public class urn_perun_user_facility_attribute_def_def_o365AccountExtension extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException {
-		String o365AccExtTime = (String) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+		String o365AccExtTime = attribute.valueAsString();
 
 		if(o365AccExtTime == null) return; //null is allowed value
 		Date testDate;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell.java
@@ -26,6 +26,15 @@ import java.util.List;
  */
 public class urn_perun_user_facility_attribute_def_def_shell extends UserFacilityAttributesModuleAbstract implements UserFacilityAttributesModuleImplApi {
 
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		String shell = attribute.valueAsString();
+
+		if (shell == null) return;
+
+		session.getPerunBl().getModulesUtilsBl().checkFormatOfShell(shell, attribute);
+	}
+
 	/**
 	 * Checks an attribute with shell for the user at the specified facility. There
 	 * must be at least some facilities allowed and also the user must have
@@ -33,12 +42,10 @@ public class urn_perun_user_facility_attribute_def_def_shell extends UserFacilit
 	 * in allowed shells and also need to have correct format.
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-		String shell = (String) attribute.getValue();
+	public void checkAttributeSemantics(PerunSessionImpl session, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		String shell = attribute.valueAsString();
 
 		if (shell == null) return;
-
-		session.getPerunBl().getModulesUtilsBl().checkFormatOfShell(shell, attribute);
 
 		List<String> allowedShells = allShellsAtSpecifiedFacility(session, facility, user);
 
@@ -47,7 +54,7 @@ public class urn_perun_user_facility_attribute_def_def_shell extends UserFacilit
 		}
 
 		if (!allowedShells.contains(shell)) {
-			throw new WrongAttributeValueException(attribute, user, facility, "Such shell is not allowed at specified facility for the user.");
+			throw new WrongReferenceAttributeValueException(attribute, null, user, facility, "Such shell is not allowed at specified facility for the user.");
 		}
 	}
 
@@ -67,7 +74,7 @@ public class urn_perun_user_facility_attribute_def_def_shell extends UserFacilit
 				throw new InternalErrorException("Attribute with all shells of facility " + facility.getId() + " could not be obtained", ex);
 			}
 			if (resourceAttr.getValue() != null) {
-				allowedShells.addAll(((List<String>) resourceAttr.getValue()));
+				allowedShells.addAll((resourceAttr.valueAsList()));
 			}
 		}
 		return allowedShells;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scp.java
@@ -10,6 +10,7 @@ import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityAttributesModuleImplApi;
@@ -26,12 +27,17 @@ public class urn_perun_user_facility_attribute_def_def_shell_passwd_scp extends 
 	private static final Pattern pattern = Pattern.compile("^(/[-_.a-zA-Z0-9]+)+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException {
-		String shell = (String) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+		String shell = attribute.valueAsString();
 
-		if(shell == null) throw new WrongAttributeValueException(attribute, "Value can't be null");
+		if(shell == null) return;
 		Matcher matcher = pattern.matcher(shell);
 		if(!matcher.matches()) throw new WrongAttributeValueException(attribute, "Wrong format. ^(/[-_.A-z0-9]+)+$ expected");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, User user, Facility facility, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.valueAsString() == null) throw new WrongReferenceAttributeValueException(attribute, "Value can't be null");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UID.java
@@ -45,7 +45,7 @@ public class urn_perun_user_facility_attribute_def_virt_UID extends UserFacility
 				uidAttribute.setValue(attribute.getValue());
 				sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, user, uidAttribute);
 			} else {
-				throw new WrongReferenceAttributeValueException(attribute, (Attribute) null);
+				throw new WrongReferenceAttributeValueException(attribute, null, user, facility, "Required facility attribute uid-namespace value is null.");
 			}
 		} catch (AttributeNotExistsException e) {
 			throw new ConsistencyErrorException(e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGID.java
@@ -116,7 +116,7 @@ public class urn_perun_user_facility_attribute_def_virt_defaultUnixGID extends U
 
 	@Override
 	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-		if(attribute.getValue() == null) throw new WrongAttributeValueException(attribute, user, facility, "Attribute can't be null.");
+		if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, user, facility, "Attribute can't be null.");
 		try {
 			Attribute defaultUnixGID = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, facility, user, AttributesManager.NS_USER_FACILITY_ATTR_DEF + ":defaultUnixGID");
 			defaultUnixGID.setValue(attribute.getValue());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_groupStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_groupStatus.java
@@ -26,9 +26,9 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserFacilityVirtualA
 public class urn_perun_user_facility_attribute_def_virt_groupStatus extends UserFacilityVirtualAttributesModuleAbstract implements UserFacilityVirtualAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, User user, Facility facility, Attribute attribute) throws WrongAttributeValueException {
 
-		String status = (String) attribute.getValue();
+		String status = attribute.valueAsString();
 
 		if (status == null) return; // NULL is ok
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_login.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_login.java
@@ -38,11 +38,11 @@ public class urn_perun_user_facility_attribute_def_virt_login extends UserFacili
 			if (loginNamespaceAttribute.getValue() != null) {
 				loginAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess,
 						user, AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:" + loginNamespaceAttribute.getValue());
-				if(attribute.getValue() == null) throw new WrongAttributeValueException(loginAttribute, user, facility, "Login can't be null");
+				if(attribute.getValue() == null) throw new WrongReferenceAttributeValueException(loginAttribute, null, user, facility, "Login can't be null");
 				loginAttribute.setValue(attribute.getValue());
 				sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, user, loginAttribute);
 			} else {
-				throw new WrongAttributeValueException(loginNamespaceAttribute, user, facility, "Login-namespace for facility can not be empty.");
+				throw new WrongReferenceAttributeValueException(attribute, loginNamespaceAttribute, user, facility, facility, null, "Login-namespace for facility can not be empty.");
 			}
 		} catch (AttributeNotExistsException e) {
 			throw new ConsistencyErrorException(e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName.java
@@ -38,7 +38,7 @@ public class urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName e
 			if(facilityGroupNameNamespaceAttr.getValue() == null) {
 				throw new WrongReferenceAttributeValueException(attribute, facilityGroupNameNamespaceAttr, user, facility, facility, null, "GroupName-namespace for racility cannot be null.");
 			}
-			String namespace = (String) facilityGroupNameNamespaceAttr.getValue();
+			String namespace = facilityGroupNameNamespaceAttr.valueAsString();
 
 			Attribute preferredUnixGroupNameAttr = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_PREFERRED_UNIX_GROUPNAME_NAMESPACE + namespace);
 			if(attribute.getValue() != null) {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTimeTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_accountExpirationTimeTest.java
@@ -9,7 +9,7 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +53,7 @@ public class urn_perun_user_facility_attribute_def_def_accountExpirationTimeTest
 		classInstance.checkAttributeSemantics(session, new User(), new Facility(), attributeToCheck);
 	}
 
-	@Test(expected = WrongAttributeValueException.class)
+	@Test(expected = WrongReferenceAttributeValueException.class)
 		public void testCheckAttributeSemanticsHigherValueThanFacilityTime() throws Exception {
 			System.out.println("testCheckAttributeSemanticsHigherValueThanFacilityTime()");
 			attributeToCheck.setValue(1000);

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest.java
@@ -6,7 +6,7 @@ import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +61,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest {
 
 		}
 
-		@Test ( expected = WrongAttributeValueException.class)
+		@Test ( expected = WrongReferenceAttributeValueException.class)
 		public void checkValueAttributeIsNotSetTest() throws Exception{
 				System.out.println("urn_perun_user_facility_attribute_def_def_basicDefaultGID.checkValueAttributeIsNotSetTest()");
 				//setup
@@ -95,7 +95,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest {
 				classInstance.checkAttributeSemantics(session, user, facility, basic);
 		}
 
-		@Test(expected = WrongAttributeValueException.class)
+		@Test(expected = WrongReferenceAttributeValueException.class)
 		public void checkValueAttributeIsSetWithoutAllowedResourcesTest() throws Exception{
 				System.out.println("urn_perun_user_facility_attribute_def_def_basicDefaultGID.checkValueAttributeIsSetWithoutAllowedResourcesTest()");
 				//setup
@@ -112,7 +112,7 @@ public class urn_perun_user_facility_attribute_def_def_basicDefaultGIDTest {
 				classInstance.checkAttributeSemantics(session, user, facility, basic);
 		}
 
-		@Test(expected = WrongAttributeValueException.class)
+		@Test(expected = WrongReferenceAttributeValueException.class)
 		public void checkValueAttributeIsSetWithBadValueTest() throws Exception{
 				System.out.println("urn_perun_user_facility_attribute_def_def_basicDefaultGID.checkValueAttributeIsSetWithBadValueTest()");
 				//setup

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_defaultUnixGIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_defaultUnixGIDTest.java
@@ -1,0 +1,111 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.FacilitiesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_facility_attribute_def_def_defaultUnixGIDTest {
+	private urn_perun_user_facility_attribute_def_def_defaultUnixGID classInstance;
+	private Attribute attributeToCheck;
+	private Attribute namespace;
+	private Attribute unixGroupNamespace;
+	private Attribute resourceGidAttribute;
+	private Attribute groupGidAttribute;
+	private Facility facility = new Facility();
+	private User user = new User();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_facility_attribute_def_def_defaultUnixGID();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setValue(5);
+		namespace = new Attribute();
+		namespace.setValue("namespace");
+		unixGroupNamespace = new Attribute();
+		unixGroupNamespace.setValue("unixGroupNamespace");
+		resourceGidAttribute = new Attribute();
+		resourceGidAttribute.setValue("resourceGidAttribute");
+		groupGidAttribute = new Attribute();
+		groupGidAttribute.setValue("groupGidAttribute");
+
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGID-namespace")).thenReturn(namespace);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGroupName-namespace")).thenReturn(unixGroupNamespace);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:" + namespace.valueAsString())).thenReturn(resourceGidAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGID-namespace:" + namespace.valueAsString())).thenReturn(groupGidAttribute);
+
+		ResourcesManagerBl resourcesManagerBl = mock(ResourcesManagerBl.class);
+		when(sess.getPerunBl().getResourcesManagerBl()).thenReturn(resourcesManagerBl);
+
+		UsersManagerBl usersManagerBl = mock(UsersManagerBl.class);
+		when(sess.getPerunBl().getUsersManagerBl()).thenReturn(usersManagerBl);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+		when(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, groupGidAttribute)).thenReturn(new ArrayList<>());
+
+		FacilitiesManagerBl facilitiesManagerBl = mock(FacilitiesManagerBl.class);
+		when(sess.getPerunBl().getFacilitiesManagerBl()).thenReturn(facilitiesManagerBl);
+		when(sess.getPerunBl().getFacilitiesManagerBl().getAllowedGroups(sess, facility, null, null)).thenReturn(new ArrayList<>());
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValueOfNamespaceAttribute() throws Exception {
+		System.out.println("testSemanticsWithNullValueOfNamespaceAttribute()");
+		namespace.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValueOfUnixGroupNameNamespace() throws Exception {
+		System.out.println("testSemanticsWithNullValueOfUnixGroupNameNamespace()");
+		unixGroupNamespace.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNoGroupsForGivenGID() throws Exception {
+		System.out.println("testSemanticsWithNoGroupsForGivenGID()");
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		Resource resource = new Resource();
+		List<Resource> list = new ArrayList<>();
+		list.add(resource);
+		when(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(any(PerunSessionImpl.class), any(Attribute.class))).thenReturn(list);
+		when(sess.getPerunBl().getUsersManagerBl().getAllowedResources(sess, facility, user)).thenReturn(list);
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPointTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_homeMountPointTest.java
@@ -153,7 +153,7 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 	 * Test of checkAttributeSemantics method, of class urn_perun_user_facility_attribute_def_def_homeMountPoint.
 	 * with empty attribute.
 	 */
-	@Test(expected = WrongAttributeValueException.class)
+	@Test(expected = WrongReferenceAttributeValueException.class)
 		public void testCheckAttributeSemanticsWithEmptyAttribute() throws Exception {
 			System.out.println("testCheckAttributeSemanticsWithEmptyAttribute()");
 
@@ -181,8 +181,8 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 	 * with homeMountPoint containing forbiden character.
 	 */
 	@Test(expected = WrongAttributeValueException.class)
-		public void testCheckAttributeSemanticsWronghomeMountPointFormat() throws Exception {
-			System.out.println("testCheckAttributeSemanticsWronghomeMountPointFormat()");
+		public void testCheckAttributeSyntaxWrongHomeMountPointFormat() throws Exception {
+			System.out.println("testCheckAttributeSyntaxWrongHomeMountPointFormat()");
 
 			Attribute attributeToCheck = new Attribute();
 			attributeToCheck.setValue("/bin/\n/bash");
@@ -201,13 +201,13 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 			});
 			when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfMntPts);
 
-			classInstance.checkAttributeSemantics(session, user, facility, attributeToCheck);
+			classInstance.checkAttributeSyntax(session, user, facility, attributeToCheck);
 			fail("Wrong homeMountPoint format should have thrown an exception");
 		}
 
 	@Test(expected = WrongAttributeValueException.class)
-		public void testCheckAttributeSemanticsWronghomeMountPointFormatInvalidCharacter() throws Exception {
-			System.out.println("testCheckAttributeSemanticsWronghomeMountPointFormatInvalidCharacter()");
+		public void testCheckAttributeSyntaxWrongHomeMountPointFormatInvalidCharacter() throws Exception {
+			System.out.println("testCheckAttributeSyntaxWrongHomeMountPointFormatInvalidCharacter()");
 
 			Attribute attributeToCheck = new Attribute();
 			attributeToCheck.setValue("/ok/(&^%");
@@ -226,13 +226,13 @@ public class urn_perun_user_facility_attribute_def_def_homeMountPointTest {
 			});
 			when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Resource.class), anyString())).thenReturn(listOfMntPts);
 
-			classInstance.checkAttributeSemantics(session, user, facility, attributeToCheck) ;
+			classInstance.checkAttributeSyntax(session, user, facility, attributeToCheck) ;
 			fail("Wrong homeMountPoint format should have thrown an exception");
 		}
 
-	@Test(expected = WrongAttributeValueException.class)
-		public void testCheckAttributeSemanticsWronghomeMountPointFormathomeMountPointIsDirectory() throws Exception {
-			System.out.println("testCheckAttributeSemanticsWronghomeMountPointFormathomeMountPointIsDirectory()");
+	@Test(expected = WrongReferenceAttributeValueException.class)
+		public void testCheckAttributeSemanticsWrongHomeMountPointFormatHomeMountPointIsDirectory() throws Exception {
+			System.out.println("testCheckAttributeSemanticsWrongHomeMountPointFormatHomeMountPointIsDirectory()");
 
 			when(session.getPerunBl().getUsersManagerBl().getAllowedResources(any(PerunSession.class), any(Facility.class), any(User.class))).thenReturn(new ArrayList<Resource>() {
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_o365AccountExtensionTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_o365AccountExtensionTest.java
@@ -1,0 +1,44 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_facility_attribute_def_def_o365AccountExtensionTest {
+
+	private urn_perun_user_facility_attribute_def_def_o365AccountExtension classInstance;
+	private Attribute attributeToCheck;
+	private Facility facility = new Facility();
+	private User user = new User();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_facility_attribute_def_def_o365AccountExtension();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongFormat() throws Exception {
+		System.out.println("testSyntaxWithWrongFormat()");
+		attributeToCheck.setValue("2018-31-12");
+
+		classInstance.checkAttributeSyntax(sess, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("2018-12-31");
+
+		classInstance.checkAttributeSyntax(sess, user, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shellTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shellTest.java
@@ -6,7 +6,6 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
@@ -117,7 +116,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 	 * Test of checkAttributeSemantics method, of class urn_perun_user_facility_attribute_def_def_shell.
 	 * with shell containing forbiden character.
 	 */
-	@Test(expected=WrongAttributeValueException.class)
+	@Test(expected=WrongReferenceAttributeValueException.class)
 	public void testCheckAttributeSemanticsWrongShellFormat() throws Exception {
 		System.out.println("testCheckAttributeSemanticsWrongShellFormat()");
 
@@ -132,7 +131,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 		fail("Wrong shell format should have thrown an exception");
 	}
 
-	@Test(expected=WrongAttributeValueException.class)
+	@Test(expected=WrongReferenceAttributeValueException.class)
 	public void testCheckAttributeSemanticsWrongShellFormatInvalidCharacter() throws Exception {
 		System.out.println("testCheckAttributeSemanticsWrongShellFormatInvalidCharacter()");
 
@@ -147,7 +146,7 @@ public class urn_perun_user_facility_attribute_def_def_shellTest {
 		fail("Wrong shell format should have thrown an exception");
 	}
 
-	@Test(expected=WrongAttributeValueException.class)
+	@Test(expected=WrongReferenceAttributeValueException.class)
 	public void testCheckAttributeSemanticsWrongShellFormatShellIsDirectory() throws Exception {
 		System.out.println("testCheckAttributeSemanticsWrongShellFormatShellIsDirectory()");
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scpTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_def_shell_passwd_scpTest.java
@@ -1,0 +1,61 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_facility_attribute_def_def_shell_passwd_scpTest {
+
+	private urn_perun_user_facility_attribute_def_def_shell_passwd_scp classInstance;
+	private Attribute attributeToCheck;
+	private Facility facility = new Facility();
+	private User user = new User();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_facility_attribute_def_def_shell_passwd_scp();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongFormat() throws Exception {
+		System.out.println("testSyntaxWithWrongFormat()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(sess, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSyntax(sess, user, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_UIDTest.java
@@ -1,0 +1,59 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_facility_attribute_def_virt_UIDTest {
+
+	private urn_perun_user_facility_attribute_def_virt_UID classInstance;
+	private Attribute attributeToCheck;
+	private Facility facility = new Facility();
+	private User user = new User();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_facility_attribute_def_virt_UID();
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+		reqAttribute.setValue("namespace");
+		sess = mock(PerunSessionImpl.class);
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(sess.getPerunBl().getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":uid-namespace")).thenReturn(reqAttribute);
+		when(attributesManagerBl.getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":uid-namespace:" + reqAttribute.getValue())).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testSemanticsWithoutReqAttribute()");
+		attributeToCheck.setValue("example");
+		reqAttribute.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -243,4 +244,20 @@ public class urn_perun_user_facility_attribute_def_virt_defaultUnixGIDTest {
 				assertEquals(testAttr, basicDefaultGID);
 		}
 
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithoutReqAttribute() throws Exception {
+		System.out.println("testSemanticsWithoutReqAttribute()");
+		Attribute attributeToCheck = new Attribute();
+
+		classInstance.checkAttributeSemantics(session, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		Attribute attributeToCheck = new Attribute();
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSemantics(session, user, facility, attributeToCheck);
+	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_groupStatusTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_groupStatusTest.java
@@ -1,0 +1,47 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_user_facility_attribute_def_virt_groupStatusTest {
+
+	private urn_perun_user_facility_attribute_def_virt_groupStatus classInstance;
+	private Attribute attributeToCheck;
+	private Facility facility = new Facility();
+	private User user = new User();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_facility_attribute_def_virt_groupStatus();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongStatus() throws Exception {
+		System.out.println("testSyntaxWithWrongStatus()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(sess, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+
+		attributeToCheck.setValue("VALID");
+		classInstance.checkAttributeSyntax(sess, user, facility, attributeToCheck);
+
+		attributeToCheck.setValue("EXPIRED");
+		classInstance.checkAttributeSyntax(sess, user, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_loginTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_loginTest.java
@@ -1,0 +1,70 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_facility_attribute_def_virt_loginTest {
+
+	private urn_perun_user_facility_attribute_def_virt_login classInstance;
+	private Attribute attributeToCheck;
+	private Facility facility = new Facility();
+	private User user = new User();
+	private PerunSessionImpl sess;
+	private Attribute userLoginNamespace;
+	private Attribute facilityLoginNamespace;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_facility_attribute_def_virt_login();
+		attributeToCheck = new Attribute();
+		userLoginNamespace = new Attribute();
+		userLoginNamespace.setValue("user_login_namespace");
+		facilityLoginNamespace = new Attribute();
+		facilityLoginNamespace.setValue("facility_login_namespace");
+		sess = mock(PerunSessionImpl.class);
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(sess.getPerunBl().getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":login-namespace")).thenReturn(facilityLoginNamespace);
+		when(attributesManagerBl.getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":login-namespace:" + facilityLoginNamespace.getValue())).thenReturn(userLoginNamespace);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithoutFacilityLoginNamespaceAttribute() throws Exception {
+		System.out.println("testSemanticsWithoutFacilityLoginNamespaceAttribute()");
+		attributeToCheck.setValue("login");
+		facilityLoginNamespace.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithoutUserLoginNamespaceAttribute() throws Exception {
+		System.out.println("testSemanticsWithoutUserLoginNamespaceAttribute()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("login");
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_facility_attribute_def_virt_preferredUnixGroupNameTest.java
@@ -1,0 +1,62 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_user_facility_attribute_def_virt_preferredUnixGroupNameTest {
+
+	private urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName classInstance;
+	private Attribute attributeToCheck;
+	private Facility facility = new Facility();
+	private User user = new User();
+	private PerunSessionImpl sess;
+	private Attribute facilityGroupNameNamespace;
+	private Attribute preferredUnixGroupName;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_user_facility_attribute_def_virt_preferredUnixGroupName();
+		attributeToCheck = new Attribute();
+		facilityGroupNameNamespace = new Attribute();
+		facilityGroupNameNamespace.setValue("facility_group_namespace");
+		preferredUnixGroupName = new Attribute();
+		preferredUnixGroupName.setValue("preferred_unix_group_name");
+		sess = mock(PerunSessionImpl.class);
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(sess.getPerunBl().getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":unixGroupName-namespace")).thenReturn(facilityGroupNameNamespace);
+		when(attributesManagerBl.getAttribute(sess, user, AttributesManager.NS_USER_ATTR_DEF + ":preferredUnixGroupName-namespace:" + facilityGroupNameNamespace.valueAsString())).thenReturn(preferredUnixGroupName);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithoutFacilityLoginNamespaceAttribute() throws Exception {
+		System.out.println("testSemanticsWithoutFacilityLoginNamespaceAttribute()");
+		attributeToCheck.setValue("name");
+		facilityGroupNameNamespace.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("name");
+
+		classInstance.checkAttributeSemantics(sess, user, facility, attributeToCheck);
+	}
+}


### PR DESCRIPTION
…dules

- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in user-facility attribute modules
- also added test for checks