### PR TITLE
userCertificates module bug

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertificates.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertificates.java
@@ -10,8 +10,10 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModule
 import cz.metacentrum.perun.core.implApi.modules.attributes.UserAttributesModuleImplApi;
 import org.apache.commons.codec.binary.Base64;
 
-import javax.security.cert.CertificateException;
-import javax.security.cert.X509Certificate;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -33,7 +35,15 @@ public class urn_perun_user_attribute_def_def_userCertificates extends UserAttri
 					String certWithoutBegin = cert.replaceFirst("-----BEGIN CERTIFICATE-----", "");
 					String rawCert = certWithoutBegin.replaceFirst("-----END CERTIFICATE-----", "");
 
-					X509Certificate.getInstance(Base64.decodeBase64(rawCert.getBytes()));
+					CertificateFactory certFact = CertificateFactory.getInstance("X.509");
+					try (ByteArrayInputStream bis = new ByteArrayInputStream(Base64.decodeBase64(rawCert.getBytes()))) {
+						certFact.generateCertificate(bis);
+					} catch (IllegalArgumentException e) {
+						throw new WrongAttributeValueException(attribute, user, "Certificate is not in base64 format!");
+					} catch (IOException e) {
+						throw new InternalError(e);
+					}
+
 
 				}
 			}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertificatesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_userCertificatesTest.java
@@ -4,6 +4,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,10 +51,20 @@ public class urn_perun_user_attribute_def_def_userCertificatesTest {
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
-		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+	public void testCheckAttributeSyntaxWithWrongBase64Value() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongBase64Value()");
 		Map<String, String> value = new LinkedHashMap<>();
 		value.put("bad_example", "bad_example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(session, user, attributeToCheck);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongCertificateValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongCertificateValue()");
+		Map<String, String> value = new LinkedHashMap<>();
+		value.put("bad_example", Base64.encodeBase64String("bad_example".getBytes()));
 		attributeToCheck.setValue(value);
 
 		classInstance.checkAttributeSyntax(session, user, attributeToCheck);


### PR DESCRIPTION
-Problem: The library javax.security.cert.X509Certificate was
 deprecated. Moreover, the decodeBase64() method started to throw
 IllegalArgumentException, which was not catched. Some tests were
 failing because of that.
-Change: The module now works with a library
 java.security.cert.CertificateFactory and the IllegalArgumentException
 is catched and WrongAttributeValue is thrown instead of that.