### PR TITLE
getFacilitiesByDestination authorization bug

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/FacilitiesManagerEntry.java
@@ -158,23 +158,22 @@ public class FacilitiesManagerEntry implements FacilitiesManager {
 		Utils.notNull(destination, "destination");
 
 		// Authorization
-		if (!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
-				!AuthzResolver.isAuthorized(sess, Role.RPC) &&
-				!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN) &&
-				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
+		if (AuthzResolver.isAuthorized(sess, Role.ENGINE) ||
+				AuthzResolver.isAuthorized(sess, Role.RPC) ||
+				AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
+			return getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination);
+		} else if (AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN)) {
+			List<Facility> facilities = getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination);
+			if (!facilities.isEmpty()) {
+				Iterator<Facility> facilityByDestination = facilities.iterator();
+				while(facilityByDestination.hasNext()) {
+					if(!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facilityByDestination.next())) facilityByDestination.remove();
+				}
+			}
+			return facilities;
+		} else {
 			throw new PrivilegeException(sess, "getFacilitiesByDestination");
 		}
-
-		List<Facility> facilities = getFacilitiesManagerBl().getFacilitiesByDestination(sess, destination);
-
-		if (!facilities.isEmpty()) {
-			Iterator<Facility> facilityByDestination = facilities.iterator();
-			while(facilityByDestination.hasNext()) {
-				if(!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facilityByDestination.next())) facilityByDestination.remove();
-			}
-		}
-
-		return facilities;
 	}
 
 	@Override


### PR DESCRIPTION
-Problem: ENGINE, RPC and PERUNOBSERVER always get empty list of
 facilities, because of the filter which remove all facilities from the
 list when the principal is not FACILITYADMIN on the facility.
-Change: Method returns all facilities when the principal is ENGINE or RPC or PERUNOBSERVER.
 Method filter facilities when the principal is FACILITYADMIN.
 Method throw an Exception otherwise.