### PR TITLE
Creating AuditEvents about removing admins of a deleted entity

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -340,6 +340,28 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 			}
 		}
 
+		//remove admins of this facility
+		List<Group> adminGroups = getFacilitiesManagerImpl().getAdminGroups(sess, facility);
+		for (Group adminGroup : adminGroups) {
+			try {
+				AuthzResolverBlImpl.unsetRole(sess, adminGroup, facility, Role.FACILITYADMIN);
+			} catch (GroupNotAdminException e) {
+				log.warn("When trying to unsetRole FacilityAdmin for group {} in the facility {} the exception was thrown {}", adminGroup, facility, e);
+				//skip and log as warning
+			}
+		}
+
+		List<User> adminUsers = getFacilitiesManagerImpl().getAdmins(sess, facility);
+
+		for (User adminUser : adminUsers) {
+			try {
+				AuthzResolverBlImpl.unsetRole(sess, adminUser, facility, Role.FACILITYADMIN);
+			} catch (UserNotAdminException e) {
+				log.warn("When trying to unsetRole FacilityAdmin for user {} in the facility {} the exception was thrown {}", adminUser, facility, e);
+				//skip and log as warning
+			}
+		}
+
 		//remove hosts
 		List<Host> hosts = this.getHosts(sess, facility);
 		for (Host host: hosts) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -362,6 +362,29 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 					}
 				}
 
+				//remove admins of this group
+				List<Group> adminSubGroups = getGroupsManagerImpl().getGroupAdmins(sess, subGroup);
+
+				for (Group adminSubGroup : adminSubGroups) {
+					try {
+						AuthzResolverBlImpl.unsetRole(sess, adminSubGroup, subGroup, Role.GROUPADMIN);
+					} catch (GroupNotAdminException e) {
+						log.warn("When trying to unsetRole GroupAdmin for group {} in the group {} the exception was thrown {}", adminSubGroup, subGroup, e);
+						//skip and log as warning
+					}
+				}
+
+				List<User> adminSubUsers = getGroupsManagerImpl().getAdmins(sess, subGroup);
+
+				for (User adminSubUser : adminSubUsers) {
+					try {
+						AuthzResolverBlImpl.unsetRole(sess, adminSubUser, subGroup, Role.GROUPADMIN);
+					} catch (UserNotAdminException e) {
+						log.warn("When trying to unsetRole GroupAdmin for user {} in the group {} the exception was thrown {}", adminSubUser, subGroup, e);
+						//skip and log as warning
+					}
+				}
+
 				// Deletes also all direct and indirect members of the group
 				getGroupsManagerImpl().deleteGroup(sess, vo, subGroup);
 
@@ -504,6 +527,29 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 				AuthzResolverBlImpl.unsetRole(sess, group, vo1, Role.VOADMIN);
 			} catch (GroupNotAdminException e) {
 				log.warn("Can't unset group {} as admin of facility {} due to group not admin exception {}.", group, vo1, e);
+			}
+		}
+
+		//remove admins of this group
+		List<Group> adminGroups = getGroupsManagerImpl().getGroupAdmins(sess, group);
+
+		for (Group adminGroup : adminGroups) {
+			try {
+				AuthzResolverBlImpl.unsetRole(sess, adminGroup, group, Role.GROUPADMIN);
+			} catch (GroupNotAdminException e) {
+				log.warn("When trying to unsetRole GroupAdmin for group {} in the group {} the exception was thrown {}", adminGroup, group, e);
+				//skip and log as warning
+			}
+		}
+
+		List<User> adminUsers = getGroupsManagerImpl().getAdmins(sess, group);
+
+		for (User adminUser : adminUsers) {
+			try {
+				AuthzResolverBlImpl.unsetRole(sess, adminUser, group, Role.GROUPADMIN);
+			} catch (UserNotAdminException e) {
+				log.warn("When trying to unsetRole GroupAdmin for user {} in the group {} the exception was thrown {}", adminUser, group, e);
+				//skip and log as warning
 			}
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -193,6 +193,28 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		//Get facility for audit messages
 		Facility facility = this.getFacility(sess, resource);
 
+		//remove admins of this resource
+		List<Group> adminGroups = getResourcesManagerImpl().getAdminGroups(sess, resource);
+		for (Group adminGroup : adminGroups) {
+			try {
+				AuthzResolverBlImpl.unsetRole(sess, adminGroup, resource, Role.RESOURCEADMIN);
+			} catch (GroupNotAdminException e) {
+				log.warn("When trying to unsetRole ResourceAdmin for group {} in the resource {} the exception was thrown {}", adminGroup, resource, e);
+				//skip and log as warning
+			}
+		}
+
+		List<User> adminUsers = getResourcesManagerImpl().getAdmins(sess, resource);
+
+		for (User adminUser : adminUsers) {
+			try {
+				AuthzResolverBlImpl.unsetRole(sess, adminUser, resource, Role.RESOURCEADMIN);
+			} catch (UserNotAdminException e) {
+				log.warn("When trying to unsetRole ResourceAdmin for user {} in the resource {} the exception was thrown {}", adminUser, resource, e);
+				//skip and log as warning
+			}
+		}
+
 		// Remove binding between resource and service
 		List<Service> services = getAssignedServices(sess, resource);
 		for (Service service: services) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -90,6 +90,29 @@ public class VosManagerBlImpl implements VosManagerBl {
 		log.debug("Deleting vo {}", vo);
 
 		try {
+			//remove admins of this vo
+			List<Group> adminGroups = getVosManagerImpl().getAdminGroups(sess, vo);
+
+			for (Group adminGroup : adminGroups) {
+				try {
+					AuthzResolverBlImpl.unsetRole(sess, adminGroup, vo, Role.VOADMIN);
+				} catch (GroupNotAdminException e) {
+					log.warn("When trying to unsetRole VoAdmin for group {} in the vo {} the exception was thrown {}", adminGroup, vo, e);
+					//skip and log as warning
+				}
+			}
+
+			List<User> adminUsers = getVosManagerImpl().getAdmins(sess, vo);
+
+			for (User adminUser : adminUsers) {
+				try {
+					AuthzResolverBlImpl.unsetRole(sess, adminUser, vo, Role.VOADMIN);
+				} catch (UserNotAdminException e) {
+					log.warn("When trying to unsetRole VoAdmin for user {} in the vo {} the exception was thrown {}", adminUser, vo, e);
+					//skip and log as warning
+				}
+			}
+
 			List<Member> members = getPerunBl().getMembersManagerBl().getMembers(sess, vo);
 
 			log.debug("Deleting vo {} members", vo);


### PR DESCRIPTION
* added code that removes admin users and admin groups using unsetRole where AuditEvents are logged by default

* entitites where change has been made: Group, Facility, Resource, SecurityTeam, Vo