### PR TITLE
Load and get perun policies

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PolicyNotExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/PolicyNotExistsException.java
@@ -1,0 +1,35 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when trying to get a policy which does not exist in the PerunPoliciesContainer
+ *
+ * @author Peter Balčirák
+ */
+public class PolicyNotExistsException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public PolicyNotExistsException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public PolicyNotExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public PolicyNotExistsException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/test/resources/perun-roles.yml
+++ b/perun-base/src/test/resources/perun-roles.yml
@@ -20,4 +20,12 @@ perun_roles:
   - SECURITYADMIN
   - CABINETADMIN
   - UNKNOWN
+
+#A list of Perun policies that are loaded to the PerunPoliciesContainer.
+perun_policies:
+
+  default_policy:
+    policy_roles:
+      - PERUNADMIN:
+    include_policies: []
 ...

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.BeansUtils;
@@ -18,6 +19,7 @@ import cz.metacentrum.perun.core.api.Vo;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PolicyNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.implApi.AuthzResolverImplApi;
 import org.slf4j.Logger;
@@ -43,6 +45,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	final static Logger log = LoggerFactory.getLogger(FacilitiesManagerImpl.class);
 
 	private PerunRolesLoader perunRolesLoader;
+	private static PerunPoliciesContainer perunPoliciesContainer = new PerunPoliciesContainer();
 
 	//http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/jdbc.html
 	private static JdbcPerunTemplate jdbc;
@@ -175,6 +178,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 
 	public void initialize() throws InternalErrorException {
 		this.perunRolesLoader.loadPerunRoles(jdbc);
+		perunPoliciesContainer.setPerunPolicies(this.perunRolesLoader.loadPerunPolicies());
 	}
 
 	public static Map<String, Set<ActionType>> getRolesWhichCanWorkWithAttribute(ActionType actionType, AttributeDefinition attrDef) throws InternalErrorException {
@@ -743,5 +747,9 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
+	}
+
+	public static JsonNode getPerunPolicy(String policyName) throws PolicyNotExistsException {
+		return perunPoliciesContainer.getPerunPolicy(policyName);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunPoliciesContainer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunPoliciesContainer.java
@@ -1,0 +1,25 @@
+package cz.metacentrum.perun.core.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import cz.metacentrum.perun.core.api.exceptions.PolicyNotExistsException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * PerunPoliciesContainer stores policies in a HashMap.
+ * Key is a name of the policy and value is JsonNode which represent the particular policy.
+ */
+public class PerunPoliciesContainer {
+
+	private Map<String, JsonNode> perunPolicies = new HashMap<>();
+
+	public void setPerunPolicies(Map<String, JsonNode> perunPolicies) {
+		this.perunPolicies = perunPolicies;
+	}
+
+	public JsonNode getPerunPolicy(String policyName) throws PolicyNotExistsException {
+		if (!perunPolicies.containsKey(policyName)) throw new PolicyNotExistsException("Policy with name "+ policyName + "does not exists in the PerunPoliciesContainer.");
+		return perunPolicies.get(policyName);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
@@ -14,7 +14,10 @@ import org.springframework.core.io.Resource;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The purpose of the PerunRolesLoader is to load perun roles and policies from the perun-roles.yml configuration file.
@@ -31,17 +34,10 @@ public class PerunRolesLoader {
 	public void loadPerunRoles(JdbcPerunTemplate jdbc) {
 		if (BeansUtils.isPerunReadOnly()) log.debug("Loading authzresolver manager init in readOnly version.");
 
-		List<String> roles;
-		ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+		JsonNode rootNode = loadConfigurationFile();
 
-		try (InputStream is = configurationPath.getInputStream()) {
-			JsonNode rolesNode = mapper.readTree(is).get("perun_roles");
-			roles = new ObjectMapper().convertValue(rolesNode, new TypeReference<List<String>>() {});
-		} catch (FileNotFoundException e) {
-			throw new InternalErrorException("Configuration file not found for perun roles. It should be in: " + configurationPath, e);
-		} catch (IOException e) {
-			throw new InternalErrorException("IO exception was thrown during the processing of the file: " + configurationPath, e);
-		}
+		JsonNode rolesNode = rootNode.get("perun_roles");
+		List<String> roles = new ObjectMapper().convertValue(rolesNode, new TypeReference<List<String>>() {});
 
 		// Check if all roles defined in class Role exists in the DB
 		for (String role : roles) {
@@ -59,6 +55,35 @@ public class PerunRolesLoader {
 				throw new InternalErrorException(e);
 			}
 		}
+	}
+
+	public Map<String, JsonNode> loadPerunPolicies() {
+		Map<String, JsonNode> policies = new HashMap<>();
+		JsonNode rootNode = loadConfigurationFile();
+		JsonNode policiesNode = rootNode.get("perun_policies");
+
+		Iterator<String> policyNames = policiesNode.fieldNames();
+		while(policyNames.hasNext()) {
+			String policyname = policyNames.next();
+			policies.put(policyname, policiesNode.get(policyname));
+		}
+
+		return policies;
+	}
+
+	private JsonNode loadConfigurationFile() {
+		ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+		JsonNode rootNode;
+		try (InputStream is = configurationPath.getInputStream()) {
+			rootNode = mapper.readTree(is);
+		} catch (FileNotFoundException e) {
+			throw new InternalErrorException("Configuration file not found for perun roles. It should be in: " + configurationPath, e);
+		} catch (IOException e) {
+			throw new InternalErrorException("IO exception was thrown during the processing of the file: " + configurationPath, e);
+		}
+
+		return rootNode;
 	}
 
 	public void setConfigurationPath(Resource configurationPath) {


### PR DESCRIPTION
- PerunRolesLoader was extended to also support loading perun policies
  from the configuration file.
- New class PerunPoliciesContainer was created which will store the
  policies.
- AuthzResolverImpl will load the policies to the PerunPoliciesContainer
  during the initialize() method. It has now also method
  getPolicy(String policyName) which will fetch the given policy from the
  container.