### PR TITLE
Yaml indendation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,8 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
+
+# YAML Files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
-Yaml supports only 2 spaces indendation, so the .editorconfig file was
 extended by the yaml file indendation.