### PR TITLE
Allow also partial matching for String attribute in Searcher

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/Searcher.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/Searcher.java
@@ -138,11 +138,12 @@ public interface Searcher {
 	 *
 	 * @param sess perun session
 	 * @param attributesWithSearchingValues map of attributes names
-	 *        when attribute is type String, so value is string and we are looking for total match (Partial is not supported now, will be supported later by symbol *)
+	 *        when attribute is type String, so value is string and we are looking for exact or partial match based by parameter 'allowPartialMatchForString'
 	 *        when attribute is type Integer, so value is integer in String and we are looking for total match
 	 *        when attribute is type List<String>, so value is String and we are looking for at least one total or partial matching element
 	 *        when attribute is type Map<String> so value is String in format "key=value" and we are looking total match of both or if is it "key" so we are looking for total match of key
 	 *        IMPORTANT: In map there is not allowed char '=' in key. First char '=' is delimiter in MAP item key=value!!!
+	 * @param allowPartialMatchForString if true, we are looking for partial match, if false, we are looking only for exact match (only for STRING type attributes)
 	 * @return list of resources that have attributes with specific values (behaviour above)
 	 *        if no such resource exists, returns empty list
 	 *
@@ -151,7 +152,7 @@ public interface Searcher {
 	 * @throws AttributeNotExistsException when specified attribute does not exist
 	 * @throws WrongAttributeAssignmentException wrong attribute assignment
 	 */
-	List<Resource> getResources(PerunSession sess, Map<String, String> attributesWithSearchingValues) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
+	List<Resource> getResources(PerunSession sess, Map<String, String> attributesWithSearchingValues, boolean allowPartialMatchForString) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
 
 	/**
 	 * Return members with group expiration date set, which will expire on specified date

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/SearcherBl.java
@@ -149,11 +149,12 @@ public interface SearcherBl {
 	 *
 	 * @param sess perun session
 	 * @param attributesWithSearchingValues map of attributes names
-	 *        when attribute is type String, so value is string and we are looking for total match (Partial is not supported now, will be supported later by symbol *)
+	 *        when attribute is type String, so value is string and we are looking for exact or partial match based by parameter 'allowPartialMatchForString'
 	 *        when attribute is type Integer, so value is integer in String and we are looking for total match
 	 *        when attribute is type List<String>, so value is String and we are looking for at least one total or partial matching element
 	 *        when attribute is type Map<String> so value is String in format "key=value" and we are looking total match of both or if is it "key" so we are looking for total match of key
 	 *        IMPORTANT: In map there is not allowed char '=' in key. First char '=' is delimiter in MAP item key=value!!!
+	 * @param allowPartialMatchForString if true, we are looking for partial match, if false, we are looking only for exact match (only for STRING type attributes)
 	 * @return list of resources that have attributes with specific values (behaviour above)
 	 *        if no such resource exists, returns empty list
 	 *
@@ -161,5 +162,5 @@ public interface SearcherBl {
 	 * @throws AttributeNotExistsException when specified attribute does not exist
 	 * @throws WrongAttributeAssignmentException wrong attribute assignment
 	 */
-	List<Resource> getResources(PerunSession sess, Map<String, String> attributesWithSearchingValues) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
+	List<Resource> getResources(PerunSession sess, Map<String, String> attributesWithSearchingValues, boolean allowPartialMatchForString) throws InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SearcherEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/SearcherEntry.java
@@ -170,7 +170,7 @@ public class SearcherEntry implements Searcher {
 	}
 
 	@Override
-	public List<Resource> getResources(PerunSession sess, Map<String, String> attributesWithSearchingValues) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
+	public List<Resource> getResources(PerunSession sess, Map<String, String> attributesWithSearchingValues, boolean allowPartialMatchForString) throws PrivilegeException, InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN) &&
@@ -178,7 +178,7 @@ public class SearcherEntry implements Searcher {
 			throw new PrivilegeException(sess, "getResources");
 		}
 
-		return searcherBl.getResources(sess, attributesWithSearchingValues);
+		return searcherBl.getResources(sess, attributesWithSearchingValues, allowPartialMatchForString);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SearcherImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/SearcherImplApi.java
@@ -122,16 +122,17 @@ public interface SearcherImplApi {
 	 *
 	 * @param sess perun session
 	 * @param attributesWithSearchingValues map of attributes
-	 *        when attribute is type String, so value is string and we are looking for total match (Partial is not supported now, will be supported later by symbol *)
+	 *        when attribute is type String, so value is string and we are looking for exact or partial match based by parameter 'allowPartialMatchForString'
 	 *        when attribute is type Integer, so value is integer in String and we are looking for total match
 	 *        when attribute is type List<String>, so value is String and we are looking for at least one total or partial matching element
 	 *        when attribute is type Map<String> so value is String in format "key=value" and we are looking total match of both or if is it "key" so we are looking for total match of key
 	 *        IMPORTANT: In map there is not allowed char '=' in key. First char '=' is delimiter in MAP item key=value!!!
+	 * @param allowPartialMatchForString if true, we are looking for partial match, if false, we are looking only for exact match (only for STRING type attributes)
 	 * @return list of resources that have attributes with specific values (behavior above)
 	 *        if no such resource exists, return empty list
 	 *        if attributeWithSearchingValues is empty, return all resources
 	 *
 	 * @throws InternalErrorException internal error
 	 */
-	List<Resource> getResources(PerunSession sess, Map<Attribute, String> attributesWithSearchingValues) throws InternalErrorException;
+	List<Resource> getResources(PerunSession sess, Map<Attribute, String> attributesWithSearchingValues, boolean allowPartialMatchForString) throws InternalErrorException;
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SearcherMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/SearcherMethod.java
@@ -97,11 +97,25 @@ public enum SearcherMethod implements ManagerMethod {
 	 * Better information about format below. When there are more than 1 attribute in Map, it means all must be true "looking for all of them" (AND)
 	 *
 	 * @param attributesWithSearchingValues map of attributes names
-	 *        when attribute is type String, so value is string and we are looking for total match (Partial is not supported now, will be supported later by symbol *)
+	 *        when attribute is type String, so value is string and we are looking for exact match
 	 *        when attribute is type Integer, so value is integer in String and we are looking for total match
 	 *        when attribute is type List<String>, so value is String and we are looking for at least one total or partial matching element
 	 *        when attribute is type Map<String> so value is String in format "key=value" and we are looking total match of both or if is it "key" so we are looking for total match of key
 	 *        IMPORTANT: In map there is not allowed char '=' in key. First char '=' is delimiter in MAP item key=value!!!
+	 * @return list of resources that have attributes with specific values (behaviour above)
+	 *        if no such resource exists, returns empty list
+	 */
+	/*#
+	 * This method get Map of Attributes with searching values and try to find all resources, which have specific attributes in format.
+	 * Better information about format below. When there are more than 1 attribute in Map, it means all must be true "looking for all of them" (AND)
+	 *
+	 * @param attributesWithSearchingValues map of attributes names
+	 *        when attribute is type String, so value is string and we are looking for exact or partial match based by parameter 'allowPartialMatchForString'
+	 *        when attribute is type Integer, so value is integer in String and we are looking for total match
+	 *        when attribute is type List<String>, so value is String and we are looking for at least one total or partial matching element
+	 *        when attribute is type Map<String> so value is String in format "key=value" and we are looking total match of both or if is it "key" so we are looking for total match of key
+	 *        IMPORTANT: In map there is not allowed char '=' in key. First char '=' is delimiter in MAP item key=value!!!
+	 * @param allowPartialMatchForString if true, we are looking for partial match, if false, we are looking only for exact match (only for STRING type attributes)
 	 * @return list of resources that have attributes with specific values (behaviour above)
 	 *        if no such resource exists, returns empty list
 	 */
@@ -110,8 +124,13 @@ public enum SearcherMethod implements ManagerMethod {
 		public List<Resource> call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
 
-			return ac.getSearcher().getResources(ac.getSession(),
-					parms.read("attributesWithSearchingValues", LinkedHashMap.class));
+			if (parms.contains("allowPartialMatchForString")) {
+				return ac.getSearcher().getResources(ac.getSession(),
+					parms.read("attributesWithSearchingValues", LinkedHashMap.class), parms.readBoolean("allowPartialMatchForString"));
+			} else {
+				return ac.getSearcher().getResources(ac.getSession(),
+					parms.read("attributesWithSearchingValues", LinkedHashMap.class), false);
+			}
 		}
 	};
 }


### PR DESCRIPTION
 - now String attributes can be found by partial matching of their
 values, this can be done for both "def" and also "core" attributes
 - implemented only for Resources (others need to be changed separately
 later)
 - default is looking for exact match, this can be changed by parameter
 'allowPartialMatchForString' set to true
 - in RPC, the method getResources in Searcher was extend to support old
 call with default exact match and new call with optional exact or
 partial match by value of parameter 'allowPartialMatchForString'
 - new tests were added to test this functionality