### PR TITLE
createSponsoredMember will accept separated name with titles in a map

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1154,7 +1154,7 @@ public interface MembersManager {
 	 * @param session actor
 	 * @param vo virtual organization  for the member
 	 * @param namespace namespace for selecting password module
-	 * @param guestName a designation, usually a full name
+	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
 	 * @param password  password
 	 * @param sponsor sponsoring user or null for the caller
 	 * @return new Member in the Vo
@@ -1169,7 +1169,7 @@ public interface MembersManager {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws UserNotInRoleException
 	 */
-	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, String guestName, String password, User sponsor) throws InternalErrorException, PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException;
+	RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor) throws InternalErrorException, PrivilegeException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException;
 
 	/**
 	 * Transform non-sponsored member to sponsored one with defined sponsor

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -1453,7 +1453,7 @@ public interface MembersManagerBl {
 	 * @param session perun session
 	 * @param vo virtual organization
 	 * @param namespace used for selecting external system in which guest user account will be created
-	 * @param guestName full name or other designation
+	 * @param name a map containing the full name or its parts (mandatory: firstName, lastName; optionally: titleBefore, titleAfter)
 	 * @param password password
 	 * @param sponsor sponsoring user
 	 * @param asyncValidation
@@ -1468,7 +1468,7 @@ public interface MembersManagerBl {
 	 * @throws WrongReferenceAttributeValueException
 	 * @throws UserNotInRoleException if the member is not in required role
 	 */
-	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, String guestName, String password, User sponsor, boolean asyncValidation) throws InternalErrorException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException;
+	Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws InternalErrorException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException;
 
 	/**
 	 * Links sponsored member and sponsoring user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2356,14 +2356,21 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
-	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, String guestName, String password, User sponsor, boolean asyncValidation) throws InternalErrorException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException {
+	public Member createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor, boolean asyncValidation) throws InternalErrorException, AlreadyMemberException, LoginNotExistsException, PasswordCreationFailedException, ExtendMembershipException, WrongAttributeValueException, ExtSourceNotExistsException, WrongReferenceAttributeValueException, UserNotInRoleException {
 		//check that sponsoring user has role SPONSOR for the VO
 		if (!getPerunBl().getVosManagerBl().isUserInRoleForVo(session, sponsor, Role.SPONSOR, vo, true)) {
 			throw new UserNotInRoleException("user " + sponsor.getId() + " is not in role SPONSOR for VO " + vo.getId());
 		}
 		String loginAttributeName = PasswordManagerModule.LOGIN_PREFIX + namespace;
+
 		//create new user
-		User sponsoredUser = getPerunBl().getUsersManagerBl().createUser(session,parseUserFromCommonName(guestName));
+		User user;
+		if (name.containsKey("guestName")) {
+			user = Utils.parseUserFromCommonName(name.get("guestName"));
+		} else {
+			user = Utils.createUserFromNameMap(name);
+		}
+		User sponsoredUser = getPerunBl().getUsersManagerBl().createUser(session, user);
 
 		//create the user account in external system
 		Map<String, String> p = new HashMap<>();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1267,7 +1267,7 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
-	public RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, String guestName, String password, User sponsor)
+	public RichMember createSponsoredMember(PerunSession session, Vo vo, String namespace, Map<String, String> name, String password, User sponsor)
 			throws InternalErrorException, PrivilegeException, AlreadyMemberException,
 			LoginNotExistsException, PasswordCreationFailedException,
 		ExtendMembershipException,
@@ -1275,9 +1275,14 @@ public class MembersManagerEntry implements MembersManager {
 		Utils.checkPerunSession(session);
 		Utils.notNull(vo, "vo");
 		Utils.notNull(namespace, "namespace");
-		Utils.notNull(guestName, "guestName");
+		if (name.get("guestName") == null) {
+			Utils.notNull(name.get("firstName"), "firstName");
+			Utils.notNull(name.get("lastName"), "lastName");
+		}
 		Utils.notNull(password, "password");
-		log.info("createSponsoredMember(vo={},namespace='{}',guestName='{}',sponsor={}", vo.getShortName(), namespace, guestName, sponsor == null ? "null" : sponsor.getId());
+
+		String nameForLog = name.containsKey("guestName") ? name.get("guestName") : name.get("firstName") + " " + name.get("lastName");
+		log.info("createSponsoredMember(vo={},namespace='{}',guestName='{}',sponsor={}", vo.getShortName(), namespace, nameForLog, sponsor == null ? "null" : sponsor.getId());
 
 		if (sponsor == null) {
 			//sponsor is the caller
@@ -1289,7 +1294,7 @@ public class MembersManagerEntry implements MembersManager {
 			}
 		}
 		//create the sponsored member
-		return membersManagerBl.getRichMember(session, membersManagerBl.createSponsoredMember(session, vo, namespace, guestName, password, sponsor, true));
+		return membersManagerBl.getRichMember(session, membersManagerBl.createSponsoredMember(session, vo, namespace, name, password, sponsor, true));
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -485,6 +485,18 @@ public class Utils {
 		return s.length() > limit ? s.substring(0, limit) : s;
 	}
 
+	public static User createUserFromNameMap(Map<String, String> name) throws InternalErrorException {
+		User user = new User();
+		if (name.get(FIRST_NAME) == null || name.get(LAST_NAME) == null || name.get(FIRST_NAME).isEmpty() || name.get(LAST_NAME).isEmpty()) {
+			throw new InternalErrorException("First name/last name is either empty or null when creating user");
+		}
+		user.setTitleBefore(limit(name.get(TITLE_BEFORE),40));
+		user.setFirstName(limit(name.get(FIRST_NAME),64));
+		user.setLastName(limit(name.get(LAST_NAME),64));
+		user.setTitleAfter(limit(name.get(TITLE_AFTER),40));
+		return user;
+	}
+
 	/**
 	 * Creates a new instance of User with names initialized from parsed rawName.
 	 * Imposes limit on leghts of fields.
@@ -494,12 +506,7 @@ public class Utils {
 	 */
 	public static User parseUserFromCommonName(String rawName) {
 		Map<String, String> m = parseCommonName(rawName);
-		User user = new User();
-		user.setTitleBefore(limit(m.get(TITLE_BEFORE),40));
-		user.setFirstName(limit(m.get(FIRST_NAME),64));
-		user.setLastName(limit(m.get(LAST_NAME),64));
-		user.setTitleAfter(limit(m.get(TITLE_AFTER),40));
-		return user;
+		return createUserFromNameMap(m);
 	}
 
 	/**


### PR DESCRIPTION
* original functionality has been preserved, accepting separated name is a new way of creating user to avoid issues with parsing the name as the whole

* changes have been made in RPC as well as in Core

* tests added