### PR TITLE
hasRole NullPointerException bug

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/impl/AuthzRoles.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/impl/AuthzRoles.java
@@ -79,14 +79,14 @@ public class AuthzRoles extends HashMap<String, Map<String, Set<Integer>>> {
 	public boolean hasRole(String role, PerunBean perunBean) {
 		//Use converted beanName instead of classic bean name, because for ex.: RichGroup is the same like Group for this purpose
 		String convertedBeanName = BeansUtils.convertRichBeanNameToBeanName(perunBean.getBeanName());
-		return this.get(role).containsKey(convertedBeanName)
+		return this.containsKey(role) && this.get(role).containsKey(convertedBeanName)
 			&& this.get(role).get(convertedBeanName).contains(perunBean.getId());
 	}
 
 	public boolean hasRole(String role, String perunBeanName, int id) {
 		//Use converted beanName instead of classic bean name, because for ex.: RichGroup is the same like Group for this purpose
 		String convertedBeanName = BeansUtils.convertRichBeanNameToBeanName(perunBeanName);
-		return this.get(role).containsKey(convertedBeanName)
+		return this.containsKey(role) && this.get(role).containsKey(convertedBeanName)
 			&& this.get(role).get(convertedBeanName).contains(id);
 	}
 


### PR DESCRIPTION
-Problem: Methods hasRole(..) in AuthzRoles which were checking the role
 against some complementary object, were throwing NullPointerException when
 a given role did not exist in the AuthzRoles map.
-Change: Added check the methods if AuthzRoles contains the role. If not it will
 return false, if true it will proceed to other checks.