### PR TITLE
Implementation of authorization

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunPolicy.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/PerunPolicy.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * PerunPolicy represents a set of rules which is used to determine principal's access rights.
+ *
+ * policyName is policy's unique identification which is used in the configuration file perun-roles.yml
+ * perunRoles is a list of maps where each map entry consists from a role name as a key and a role object as a value.
+ *            Relation between each map in the list is logical OR and relation between each entry in the map is logical AND.
+ *            Example list - (Map1, Map2...)
+ *            Example map - key: VOADMIN ; value: Vo
+ *                          key: GROUPADMIN ; value: Group
+ * includePolicies is a list of policies names whose rules will be also included in the authorization.
+ *
+ */
+public class PerunPolicy {
+
+	private String policyName;
+	private List<Map<String, String>> perunRoles;
+	private List<String> includePolicies;
+
+	public PerunPolicy(String policyName, List<Map<String, String>> perunRoles, List<String> includePolicies) {
+		this.policyName = policyName;
+		this.perunRoles = perunRoles;
+		this.includePolicies = includePolicies;
+	}
+
+	public List<Map<String, String>> getPerunRoles() {
+		return perunRoles;
+	}
+
+	public void setPerunRoles(List<Map<String, String>> perunRoles) {
+		this.perunRoles = perunRoles;
+	}
+
+	public List<String> getIncludePolicies() {
+		return includePolicies;
+	}
+
+	public void setIncludePolicies(List<String> includePolicies) {
+		this.includePolicies = includePolicies;
+	}
+
+	public String getPolicyName() {
+		return policyName;
+	}
+
+	public void setPolicyName(String policyName) {
+		this.policyName = policyName;
+	}
+
+	@Override
+	public String toString() {
+		return "PerunPolicy{" +
+			"policyName='" + policyName + '\'' +
+			", perunRoles=" + perunRoles +
+			", includePolicies=" + includePolicies +
+			'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		PerunPolicy that = (PerunPolicy) o;
+		return Objects.equals(policyName, that.policyName) &&
+			Objects.equals(perunRoles, that.perunRoles) &&
+			Objects.equals(includePolicies, that.includePolicies);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(policyName, perunRoles, includePolicies);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunBeanNotSupportedException;
+import cz.metacentrum.perun.core.api.exceptions.PolicyNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RoleNotSupportedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
@@ -23,6 +24,19 @@ import java.util.List;
 import java.util.Set;
 
 public class AuthzResolver {
+
+	/**
+	 * Checks if the principal is authorized.
+	 *
+	 * @param sess PerunSession which contains the principal.
+	 * @param policyDefinition of policy which contains authorization rules.
+	 * @param objects as list of PerunBeans on which will be authorization provided. (e.g. groups, Vos, etc...)
+	 * @return true if the principal has particular rights, false otherwise.
+	 * @throws PolicyNotExistsException when the given policyDefinition does not exist in the PerunPoliciesContainer.
+	 */
+	public static boolean authorized(PerunSession sess, String policyDefinition, List<PerunBean> objects) throws PolicyNotExistsException {
+		return AuthzResolverBlImpl.authorized(sess, policyDefinition, objects);
+	}
 
 	/**
 	 * Checks if the principal is authorized.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.core.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import cz.metacentrum.perun.core.api.ActionType;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.BeansUtils;
@@ -8,6 +7,7 @@ import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.PerunPolicy;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Role;
@@ -757,7 +757,11 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		perunPoliciesContainer.setPerunPolicies(this.perunRolesLoader.loadPerunPolicies());
 	}
 
-	public static JsonNode getPerunPolicy(String policyName) throws PolicyNotExistsException {
+	public static PerunPolicy getPerunPolicy(String policyName) throws PolicyNotExistsException {
 		return perunPoliciesContainer.getPerunPolicy(policyName);
+	}
+
+	public static List<PerunPolicy> fetchPolicyWithAllIncludedPolicies(String policyName) throws PolicyNotExistsException {
+		return perunPoliciesContainer.fetchPolicyWithAllIncludedPolicies(policyName);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunPoliciesContainer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunPoliciesContainer.java
@@ -1,25 +1,59 @@
 package cz.metacentrum.perun.core.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import cz.metacentrum.perun.core.api.PerunPolicy;
 import cz.metacentrum.perun.core.api.exceptions.PolicyNotExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 /**
- * PerunPoliciesContainer stores policies in a HashMap.
- * Key is a name of the policy and value is JsonNode which represent the particular policy.
+ * PerunPoliciesContainer stores a list of perun policies.
  */
 public class PerunPoliciesContainer {
 
-	private Map<String, JsonNode> perunPolicies = new HashMap<>();
+	private static final Logger log = LoggerFactory.getLogger(PerunBasicDataSource.class);
+	private List<PerunPolicy> perunPolicies = new ArrayList<>();
 
-	public void setPerunPolicies(Map<String, JsonNode> perunPolicies) {
+	public void setPerunPolicies(List<PerunPolicy> perunPolicies) {
 		this.perunPolicies = perunPolicies;
 	}
 
-	public JsonNode getPerunPolicy(String policyName) throws PolicyNotExistsException {
-		if (!perunPolicies.containsKey(policyName)) throw new PolicyNotExistsException("Policy with name "+ policyName + "does not exists in the PerunPoliciesContainer.");
-		return perunPolicies.get(policyName);
+	public PerunPolicy getPerunPolicy(String policyName) throws PolicyNotExistsException {
+		for (PerunPolicy policy : perunPolicies) {
+			if (policy.getPolicyName().equals(policyName)) return policy;
+		}
+		throw new PolicyNotExistsException("Policy with name "+ policyName + "does not exists in the PerunPoliciesContainer.");
+	}
+
+	/**
+	 * Fetch policy and all its (also nested) included policies.
+	 * Method detects and skips cycles.
+	 *
+	 * @param policyName is a policy definition for which will be policy and its all included policies fetched.
+	 * @return all included policies together with the policy defined by policyName.
+	 * @throws PolicyNotExistsException when the given policyName does not exist in the PerunPoliciesContainer.
+	 */
+	public List<PerunPolicy> fetchPolicyWithAllIncludedPolicies(String policyName) throws PolicyNotExistsException {
+		Map<String, PerunPolicy> allIncludedPolicies = new HashMap<>();
+		Queue<String> policiesToCheck = new LinkedList<>();
+		policiesToCheck.add(policyName);
+
+		while (!policiesToCheck.isEmpty()) {
+			String policy = policiesToCheck.remove();
+			if (allIncludedPolicies.containsKey(policy)) {
+				log.warn("Policy {} creates a cycle in the included policies of the policy {}", policy, policyName);
+				continue;
+			}
+			PerunPolicy policyToCheck = getPerunPolicy(policy);
+			allIncludedPolicies.put(policy, policyToCheck);
+			policiesToCheck.addAll(policyToCheck.getIncludePolicies());
+		}
+		return new ArrayList<>(allIncludedPolicies.values());
 	}
 }


### PR DESCRIPTION
- Created new class PerunPolicy which represents a policy from the
  configuration file. PerunPoliciesContainer now contains a list of
  PerunPolicies instead of Map with JsonNodes.
- PerunPoliciesContainer now also contains method fetchPolicyWithAllIncludedPolicies
  which for given policyName fetch the policy and all policies which
  are included in the policy (and also their included policies and so on).
  Method detects and skips cycles.
- New method authorized() was implemented to resolve principal's access
  rights in the new access control model. Basic tests included.
- Method is not used for now. Extended tests will be added when the
  configuration file will contains all policies.