### PR TITLE
loadAuthorizationComponents() method

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -959,4 +959,15 @@ public class AuthzResolver {
 	public static boolean roleExists(String role) {
 		return AuthzResolverBlImpl.roleExists(role);
 	}
+
+	/**
+	 * Load perun roles and policies from the configuration file perun-roles.yml.
+	 * Roles are loaded to the database and policies are loaded to the PerunPoliciesContainer.
+	 *
+	 * @throws PrivilegeException when the principal is not authorized.
+	 */
+	public static void loadAuthorizationComponents(PerunSession sess) throws PrivilegeException {
+		if (!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException(sess, "loadAuthorizationComponents");
+		AuthzResolverBlImpl.loadAuthorizationComponents();
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1833,6 +1833,8 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		return authzResolverImpl.roleExists(role);
 	}
 
+	public static void loadAuthorizationComponents() { authzResolverImpl.loadAuthorizationComponents(); }
+
 	/**
 	 * Checks whether the user is in role for Vo.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -177,6 +177,8 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	}
 
 	public void initialize() throws InternalErrorException {
+		if (BeansUtils.isPerunReadOnly()) log.debug("Loading authzresolver manager init in readOnly version.");
+
 		this.perunRolesLoader.loadPerunRoles(jdbc);
 		perunPoliciesContainer.setPerunPolicies(this.perunRolesLoader.loadPerunPolicies());
 	}
@@ -747,6 +749,12 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
+	}
+
+	@Override
+	public void loadAuthorizationComponents() {
+		this.perunRolesLoader.loadPerunRoles(jdbc);
+		perunPoliciesContainer.setPerunPolicies(this.perunRolesLoader.loadPerunPolicies());
 	}
 
 	public static JsonNode getPerunPolicy(String policyName) throws PolicyNotExistsException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunRolesLoader.java
@@ -32,7 +32,6 @@ public class PerunRolesLoader {
 	private Resource configurationPath;
 
 	public void loadPerunRoles(JdbcPerunTemplate jdbc) {
-		if (BeansUtils.isPerunReadOnly()) log.debug("Loading authzresolver manager init in readOnly version.");
 
 		JsonNode rootNode = loadConfigurationFile();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -509,4 +509,10 @@ public interface AuthzResolverImplApi {
 	 * @return true if role exists, false otherwise.
 	 */
 	boolean roleExists(String role);
+
+	/**
+	 * Load perun roles and policies from the configuration file perun-roles.yml.
+	 * Roles are loaded to the database and policies are loaded to the PerunPoliciesContainer.
+	 */
+	void loadAuthorizationComponents();
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/AuthzResolverMethod.java
@@ -611,6 +611,17 @@ public enum AuthzResolverMethod implements ManagerMethod {
 		public String call(ApiCaller ac, Deserializer parms) throws PerunException {
 			return "OK";
 		}
-	};
+	},
 
+	/*#
+	 * Load perun roles and policies from the configuration file perun-roles.yml.
+	 * Roles are loaded to the database and policies are loaded to the PerunPoliciesContainer.
+	 */
+	loadAuthorizationComponents {
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			cz.metacentrum.perun.core.api.AuthzResolver.loadAuthorizationComponents(ac.getSession());
+			return null;
+		}
+	};
 }


### PR DESCRIPTION
- Created method loadAuthorizationComponents() to be able to load perun
  policies and roles without the tomcat restart. method was also added
  to RPC module.
- Moved log information about initializing AuthzResolverImpl in read
  only version from PerunRolesLoader to AuthzResolverImpl.