### PR TITLE
CORE: Fixed null pointer when storing UserExtSource attributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -202,7 +202,10 @@ public class PerunBlImpl implements PerunBl {
 
 					//for Array list attributes try to parse string value into individual fields
 					if(attributeWithValue.getType().equals(ArrayList.class.getName()) || attributeWithValue.getType().equals(BeansUtils.largeArrayListClassName)) {
-						List<String> value = new ArrayList<>(Arrays.asList(attrValue.split(UsersManagerBlImpl.multivalueAttributeSeparatorRegExp)));
+						List<String> value = new ArrayList<>();
+						if (attrValue != null) {
+							value = new ArrayList<>(Arrays.asList(attrValue.split(UsersManagerBlImpl.multivalueAttributeSeparatorRegExp)));
+						}
 						attributeWithValue.setValue(value);
 					} else {
 						attributeWithValue.setValue(attrValue);


### PR DESCRIPTION
- When splitting list of incoming attribute values from federation
  we must check on null.