### PR TITLE
Separation of checkAttributeSyntax from semantics in Group-Resource m…

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2814,7 +2814,7 @@ public interface AttributesManagerBl {
 	 * @throws GroupResourceMismatchException
 	 */
 
-	void checkAttributeSemantics(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
+	void checkAttributeSemantics(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException;
 
 	/**
 	 * batch version of checkAttributeSemantics
@@ -3196,6 +3196,19 @@ public interface AttributesManagerBl {
 	void checkAttributesSyntax(PerunSession sess, UserExtSource ues, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException;
 
 	/**
+	 * Check if value of this group attribute has valid syntax no matter if attribute is required or not.
+	 *
+	 * @param sess perun session
+	 * @param group group for which you want to check validity of attribute
+	 * @param attribute attribute to check
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException if attribute isn't group attribute
+	 * @throws WrongAttributeValueException if the attribute value has wrong/illegal syntax
+	 */
+	void forceCheckAttributeSyntax(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException;
+
+	/**
 	 * Check if value of this group attribute has valid semantics no matter if attribute is required or not.
 	 *
 	 * @param sess perun session
@@ -3207,7 +3220,7 @@ public interface AttributesManagerBl {
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void forceCheckAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void forceCheckAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this resource attribute has valid semantics no matter if attribute is required or not.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -3687,7 +3687,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
+	public void checkAttributeSemantics(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, GroupResourceMismatchException {
 		this.checkGroupIsFromTheSameVoLikeResource(sess, group, resource);
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_GROUP_RESOURCE_ATTR);
 
@@ -4149,7 +4149,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void forceCheckAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void forceCheckAttributeSyntax(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException {
+		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_GROUP_ATTR);
+
+		getAttributesManagerImpl().checkAttributeSyntax(sess, group, attribute);
+	}
+
+	@Override
+	public void forceCheckAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_GROUP_ATTR);
 
 		getAttributesManagerImpl().checkAttributeSemantics(sess, group, attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -1134,6 +1134,39 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		return convertedRanges;
 	}
 
+	/**
+	 * Returns pair of number (BigDecimal) and unit (String) from given string. Returns default value Pair<0, "G"> if parsing fails.
+	 * E.g.: "5T" -> Pair<5, "T">
+	 *
+	 * @param attributeValue string to parse
+	 * @return pair of number and unit
+	 */
+	public static Pair<BigDecimal, String> getNumberAndUnitFromString(String attributeValue) {
+		String numberString = "0";
+		String unit = "G";
+
+		if (attributeValue != null) {
+			Matcher numberMatcher = numberPattern.matcher(attributeValue);
+			Matcher letterMatcher = letterPattern.matcher(attributeValue);
+			numberMatcher.find();
+			letterMatcher.find();
+			try {
+				numberString = attributeValue.substring(numberMatcher.start(), numberMatcher.end());
+			} catch (IllegalStateException ex) {
+				log.debug("No number could be parsed from given string.", ex);
+			}
+			try {
+				unit = attributeValue.substring(letterMatcher.start(), letterMatcher.end());
+			} catch (IllegalStateException ex) {
+				log.debug("No unit could be parsed from given string.", ex);
+			}
+		}
+
+		BigDecimal number = new BigDecimal(numberString.replace(',', '.'));
+
+		return new Pair<>(number, unit);
+	}
+
 	public PerunBl getPerunBl() {
 		return this.perunBl;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3876,7 +3876,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		//Call attribute module
 		GroupAttributesModuleImplApi groupModule = getGroupAttributeModule(sess, attribute);
 		if (groupModule == null) return; //module doesn't exists
@@ -3973,7 +3973,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		GroupResourceAttributesModuleImplApi attributeModule = getResourceGroupAttributeModule(sess, attribute);
 		if (attributeModule == null) return;
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adName.java
@@ -38,21 +38,20 @@ public class urn_perun_group_resource_attribute_def_def_adName extends GroupReso
 	private static final Pattern pattern = Pattern.compile("(\\w|-|\\.)*");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-		String attributeValue;
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		//Attribute can be null
+		if (attribute.getValue() == null) return;
 
+		if (!pattern.matcher(attribute.valueAsString()).matches()) {
+			throw new WrongAttributeValueException(attribute, "Invalid attribute adName value. It should contain only letters, digits, hyphens, underscores or dots.");
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//Attribute can be null
 		if(attribute.getValue() == null) {
 			return;
-		}
-
-		if(attribute.getValue() instanceof String) {
-			attributeValue = (String) attribute.getValue();
-			if (!pattern.matcher(attributeValue).matches()) {
-				throw new WrongAttributeValueException(attribute, "Invalid attribute adName value. It should contain only letters, digits, hyphens, underscores or dots.");
-			}
-		} else {
-			throw new WrongAttributeValueException(attribute, "Attribute adName value must be a String.");
 		}
 
 		Attribute resourceAdOuName;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isSystemUnixGroup.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isSystemUnixGroup.java
@@ -34,12 +34,18 @@ public class urn_perun_group_resource_attribute_def_def_isSystemUnixGroup extend
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
-
-		Integer isSystemUnixGroup = (Integer) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		Integer isSystemUnixGroup = attribute.valueAsInteger();
 		if(isSystemUnixGroup == null) return; //isSystemUnixGroup can be null. It is equivalent to 0.
 
 		if(isSystemUnixGroup != 0 && isSystemUnixGroup != 1) throw new WrongAttributeValueException(attribute, "Attribute isSystemUnixGroup should not other number than 0 or 1.");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+
+		Integer isSystemUnixGroup = attribute.valueAsInteger();
+		if(isSystemUnixGroup == null) return; //isSystemUnixGroup can be null. It is equivalent to 0.
 
 		Attribute sysUnixGroupName;
 		Attribute sysUnixGID;
@@ -58,16 +64,12 @@ public class urn_perun_group_resource_attribute_def_def_isSystemUnixGroup extend
 
 			try {
 				sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, resource, group, sysUnixGroupName);
-			} catch(WrongAttributeValueException ex) {
-				throw new WrongReferenceAttributeValueException("Bad value in sysUnixGroupName attribute.",ex);
 			} catch (GroupResourceMismatchException ex) {
 				throw new InternalErrorException(ex);
 			}
 
 			try {
 				sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, resource, group, sysUnixGID);
-			} catch(WrongAttributeValueException ex) {
-				throw new WrongReferenceAttributeValueException("Bad value in sysUnixGID.",ex);
 			} catch (GroupResourceMismatchException ex) {
 				throw new InternalErrorException(ex);
 			}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissions.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissions.java
@@ -25,15 +25,13 @@ public class urn_perun_group_resource_attribute_def_def_projectDirPermissions ex
 	private static final Pattern pattern = Pattern.compile("^[01234567]{3}$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		Integer permissions = (Integer) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		Integer permissions = attribute.valueAsInteger();
 		//Permissions can be null (if null, it means DEFAULT 750)
 		if (permissions == null) return;
 
-		String perm = permissions.toString();
-
 		//Only 3 consecutive numbers with value >=0 and <=7 are allowed
-		Matcher match = pattern.matcher(perm);
+		Matcher match = pattern.matcher(permissions.toString());
 
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, group, resource, "Bad format of attribute projectDirPermissions (expected something like '750').");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectName.java
@@ -36,8 +36,8 @@ public class urn_perun_group_resource_attribute_def_def_projectName extends Grou
 	private static final Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-		String name = (String) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		String name = attribute.valueAsString();
 		if (name == null) return;
 
 		Matcher match = pattern.matcher(name);
@@ -45,6 +45,12 @@ public class urn_perun_group_resource_attribute_def_def_projectName extends Grou
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, group, resource, "Bad format of attribute projectName (expected something like 'project_name-24').");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		String name = attribute.valueAsString();
+		if (name == null) return;
 
 		//Prepare this resource projectsBasePath
 		Attribute thisResourceProjectsBasePath;
@@ -57,7 +63,7 @@ public class urn_perun_group_resource_attribute_def_def_projectName extends Grou
 		//Prepare value of this resource projectsBasePath
 		String thisResourceProjectBasePathValue;
 		if(thisResourceProjectsBasePath.getValue() != null) {
-			thisResourceProjectBasePathValue = (String) thisResourceProjectsBasePath.getValue();
+			thisResourceProjectBasePathValue = thisResourceProjectsBasePath.valueAsString();
 		} else {
 			throw new WrongReferenceAttributeValueException(attribute, thisResourceProjectsBasePath, group, resource, resource, null, "Resource must have set projectsBasePath if attribute projectName for it's group need to be set.");
 		}
@@ -79,7 +85,7 @@ public class urn_perun_group_resource_attribute_def_def_projectName extends Grou
 			}
 
 			if(otherResourceProjectsBasePath.getValue() != null) {
-				String otherResourceProjectsBasePathValue = (String) otherResourceProjectsBasePath.getValue();
+				String otherResourceProjectsBasePathValue = otherResourceProjectsBasePath.valueAsString();
 				if(!thisResourceProjectBasePathValue.equals(otherResourceProjectsBasePathValue)) iterator.remove();
 			} else {
 				//If projectsBasePath is null, also remove resource
@@ -90,7 +96,7 @@ public class urn_perun_group_resource_attribute_def_def_projectName extends Grou
 		//For all resources with the same project_base_path look for groups with the same projectName
 		for(Resource r: resources) {
 			List<Group> groups = sess.getPerunBl().getGroupsManagerBl().getAssignedGroupsToResource(sess, r);
-			//Our group may aslo be part of assigned Group, need to be removed
+			//Our group may also be part of assigned Group, so it needs to be removed
 			groups.remove(group);
 			for(Group g: groups) {
 				Attribute groupProjectName;
@@ -104,7 +110,7 @@ public class urn_perun_group_resource_attribute_def_def_projectName extends Grou
 
 				String groupProjectNameValue = null;
 				if(groupProjectName.getValue() != null) {
-					groupProjectNameValue = (String) groupProjectName.getValue();
+					groupProjectNameValue = groupProjectName.valueAsString();
 				}
 
 				//If the name is somewhere same, exception must be thrown

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLogin.java
@@ -12,6 +12,7 @@ import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.GroupResourceAttributesModuleImplApi;
@@ -32,9 +33,8 @@ public class urn_perun_group_resource_attribute_def_def_projectOwnerLogin extend
 	private static final String A_UF_V_login = AttributesManager.NS_USER_FACILITY_ATTR_VIRT + ":login";
 	private static final Pattern pattern = Pattern.compile("^[a-zA-Z0-9][-A-z0-9_.@/]*$");
 
-	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException {
-		String ownerLogin = (String) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		String ownerLogin = attribute.valueAsString();
 		if (ownerLogin == null) return;
 
 		Matcher match = pattern.matcher(ownerLogin);
@@ -42,6 +42,12 @@ public class urn_perun_group_resource_attribute_def_def_projectOwnerLogin extend
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, group, resource, "Bad format of attribute projectOwnerLogin (expected something like 'alois25').");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		String ownerLogin = attribute.valueAsString();
+		if (ownerLogin == null) return;
 
 		//Get Facility from resource
 		Facility facility = sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource);
@@ -60,7 +66,7 @@ public class urn_perun_group_resource_attribute_def_def_projectOwnerLogin extend
 			if (ownerLogin.equals(userLogin.getValue())) return;
 		}
 
-		throw new WrongAttributeValueException(attribute, group, resource, "There is no user with this login:'" + ownerLogin);
+		throw new WrongReferenceAttributeValueException(attribute, null, group, resource, "There is no user with this login:'" + ownerLogin);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGID.java
@@ -36,8 +36,16 @@ public class urn_perun_group_resource_attribute_def_def_systemUnixGID extends Gr
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
-		Integer gid = (Integer) attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		Integer gid = attribute.valueAsInteger();
+		if(gid != null && gid < 1) {
+			throw new WrongAttributeValueException(attribute,"GID number less than 1 is not allowed value.");
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException{
+		Integer gid = attribute.valueAsInteger();
 
 		//Gid should not be null if is system unix group or if less than 1
 		Attribute isSystemGroup;
@@ -51,11 +59,9 @@ public class urn_perun_group_resource_attribute_def_def_systemUnixGID extends Gr
 				throw new InternalErrorException(ex);
 			}
 
-			if(isSystemGroup.getValue() != null && (Integer) isSystemGroup.getValue() == 1) {
-				throw new WrongReferenceAttributeValueException(attribute, "Attribute cant be null if " + group + " on " + resource + " is system unix group.");
+			if (isSystemGroup.getValue() != null && isSystemGroup.valueAsInteger() == 1) {
+				throw new WrongReferenceAttributeValueException(attribute, isSystemGroup, group, resource, "Attribute cant be null if " + group + " on " + resource + " is system unix group.");
 			}
-		} else if(gid < 1) {
-			throw new WrongAttributeValueException(attribute,"GID number less than 1 is not allowed value.");
 		}
 
 
@@ -89,7 +95,8 @@ public class urn_perun_group_resource_attribute_def_def_systemUnixGID extends Gr
 					throw new InternalErrorException(ex);
 				}
 
-				if(facilityForTest.equals(facility) && !(group1GroupName.getValue().equals(group2GroupName.getValue()))) throw new WrongAttributeValueException(attribute, "Gid " + gid + "is allready used by another group-resource.  " + p.getLeft() + " " + p.getRight());
+				if(facilityForTest.equals(facility) && !(group1GroupName.getValue().equals(group2GroupName.getValue())))
+					throw new WrongReferenceAttributeValueException(attribute, attribute, group, resource, "Gid " + gid + "is already used by another group-resource.  " + p.getLeft() + " " + p.getRight());
 			}
 		}
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsGroupName.java
@@ -23,23 +23,15 @@ public class urn_perun_group_resource_attribute_def_def_vomsGroupName extends Gr
     private static final Pattern pattern = Pattern.compile("^[^<>&=]*$");
 
     @Override
-    public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-        String vomsGroupName;
+    public void checkAttributeSyntax(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+        String vomsGroupName = attribute.valueAsString();
 
-        if(attribute.getValue() == null) {
-            return;
-        }
-
-        if(!(attribute.getValue() instanceof String)) {
-            throw new WrongAttributeValueException(attribute, "Wrong type of the attribute. Expected: String");
-        }
-
-        vomsGroupName = (String) attribute.getValue();
+        if(vomsGroupName == null) return;
 
         Matcher matcher = pattern.matcher(vomsGroupName);
 
         if(!matcher.matches()) {
-            throw new WrongAttributeValueException(attribute, "Bad format of attribute vomsGroupName. It should not contain '<>&=' characters.");
+            throw new WrongAttributeValueException(attribute, group, resource, "Bad format of attribute vomsGroupName. It should not contain '<>&=' characters.");
         }
     }
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsRoles.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsRoles.java
@@ -26,20 +26,17 @@ public class urn_perun_group_resource_attribute_def_def_vomsRoles extends GroupR
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws WrongAttributeValueException {
 		if(attribute.getValue() == null) {
 			return;
 		}
-		try {
-			List<String> vomRoles = (List<String>) attribute.getValue();
-			for (String vomRole : vomRoles) {
-				Matcher matcher = pattern.matcher(vomRole);
-				if(!matcher.matches()) {
-					throw new WrongAttributeValueException(attribute, "Bad group vomsRoles value. It should not contain '<>&' characters.");
-				}
+		List<String> vomRoles = attribute.valueAsList();
+
+		for (String vomRole : vomRoles) {
+			Matcher matcher = pattern.matcher(vomRole);
+			if(!matcher.matches()) {
+				throw new WrongAttributeValueException(attribute, "Bad group vomsRoles value. It should not contain '<>&' characters.");
 			}
-		} catch (ClassCastException e) {
-			throw new WrongAttributeValueException(attribute, "Value should be a list of Strings.");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_googleGroupName.java
@@ -27,10 +27,10 @@ import java.util.List;
 public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute googleGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getGoogleGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 		// we don't allow dots in attribute friendlyName, so we convert domain dots to dash.
-		String namespace = ((String) googleGroupNameNamespaceAttribute.getValue()).replaceAll("\\.", "-");
+		String namespace = (googleGroupNameNamespaceAttribute.valueAsString()).replaceAll("\\.", "-");
 		Attribute groupNameAttribute;
 		try {
 			groupNameAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, group, AttributesManager.NS_GROUP_ATTR_DEF + ":googleGroupName-namespace:" + namespace);
@@ -39,13 +39,11 @@ public class urn_perun_group_resource_attribute_def_virt_googleGroupName extends
 		}
 		groupNameAttribute.setValue(attribute.getValue());
 		try {
+			sess.getPerunBl().getAttributesManagerBl().checkAttributeSyntax(sess, group, groupNameAttribute);
 			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, group, groupNameAttribute);
-		} catch(WrongAttributeValueException ex) {
-			throw new WrongAttributeValueException(attribute, ex.getMessage(), ex);
-		} catch(WrongReferenceAttributeValueException ex) {
+		} catch(WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, ex.getAttribute(), ex);
 		}
-
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGID.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute unixGIDNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGIDNamespaceAttributeWithNotNullValue(sess, resource);
 		Attribute gidAttribute;
 		try {
@@ -36,10 +36,9 @@ public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupRe
 		}
 		gidAttribute.setValue(attribute.getValue());
 		try {
+			sess.getPerunBl().getAttributesManagerBl().forceCheckAttributeSyntax(sess, group, gidAttribute);
 			sess.getPerunBl().getAttributesManagerBl().forceCheckAttributeSemantics(sess, group, gidAttribute);
-		} catch(WrongAttributeValueException ex) {
-			throw new WrongAttributeValueException(attribute, ex.getMessage(), ex);
-		} catch(WrongReferenceAttributeValueException ex) {
+		} catch(WrongReferenceAttributeValueException | WrongAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, ex.getAttribute(), ex);
 		}
 	}
@@ -62,6 +61,7 @@ public class urn_perun_group_resource_attribute_def_virt_unixGID extends GroupRe
 		}
 
 		try {
+			sess.getPerunBl().getAttributesManagerBl().forceCheckAttributeSyntax(sess, group, gidAttribute);
 			sess.getPerunBl().getAttributesManagerBl().forceCheckAttributeSemantics(sess, group, gidAttribute);
 			//check passed, we can use value from this physical attribute
 			attribute.setValue(gidAttribute.getValue());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_virt_unixGroupName.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends GroupResourceVirtualAttributesModuleAbstract implements GroupResourceVirtualAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute unixGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 		Attribute groupNameAttribute;
 		try {
@@ -36,10 +36,9 @@ public class urn_perun_group_resource_attribute_def_virt_unixGroupName extends G
 		}
 		groupNameAttribute.setValue(attribute.getValue());
 		try {
+			sess.getPerunBl().getAttributesManagerBl().checkAttributeSyntax(sess, group, groupNameAttribute);
 			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, group, groupNameAttribute);
-		} catch(WrongAttributeValueException ex) {
-			throw new WrongAttributeValueException(attribute, ex.getMessage(), ex);
-		} catch(WrongReferenceAttributeValueException ex) {
+		} catch(WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, ex.getAttribute(), ex);
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1628,10 +1628,9 @@ public interface AttributesManagerImplApi {
 	 * @param attribute attribute to check
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void checkAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void checkAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this resource attribute has valid semantics.
@@ -1739,7 +1738,7 @@ public interface AttributesManagerImplApi {
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void checkAttributeSemantics(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void checkAttributeSemantics(PerunSession sess, Resource resource, Group group, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this entityless attribute has valid semantics.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleAbstract.java
@@ -25,7 +25,7 @@ public abstract class GroupResourceAttributesModuleAbstract extends AttributesMo
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/GroupResourceAttributesModuleImplApi.java
@@ -39,11 +39,10 @@ public interface GroupResourceAttributesModuleImplApi extends AttributesModuleIm
 	 * @param attribute attribute to check
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongAttributeAssignmentException
 	 */
 
-	void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void checkAttributeSemantics(PerunSessionImpl perunSession, Group group, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 * This method MAY fill an attribute at the specified resource.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_adNameTest.java
@@ -1,0 +1,87 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.SearcherBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_resource_attribute_def_def_adNameTest {
+
+	private urn_perun_group_resource_attribute_def_def_adName classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_adName();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":adOuName")).thenReturn(reqAttribute);
+
+		SearcherBl searcherBl = mock(SearcherBl.class);
+		when(perunBl.getSearcherBl()).thenReturn(searcherBl);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("bad@value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("correctValue");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithSameADNameAlreadySetElsewhere() throws Exception {
+		System.out.println("testSemanticsWithSameADNameAlreadySetElsewhere()");
+		attributeToCheck.setValue("correctValue");
+		reqAttribute.setValue("correctValue2");
+		Group group2 = new Group();
+		List<Group> groups = new ArrayList<>();
+		groups.add(group2);
+		groups.add(group);
+		when(sess.getPerunBl().getSearcherBl().getGroupsByGroupResourceSetting(sess, attributeToCheck, reqAttribute)).thenReturn(groups);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("correctValue");
+		reqAttribute.setValue("correctValue2");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_drupalGroupTypeTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_drupalGroupTypeTest.java
@@ -1,0 +1,63 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_resource_attribute_def_def_drupalGroupTypeTest {
+
+	private urn_perun_group_resource_attribute_def_def_drupalGroupType classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_drupalGroupType();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("bad_value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+
+		attributeToCheck.setValue("public");
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+
+		attributeToCheck.setValue("private");
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("public");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_freeipaGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_freeipaGroupNameTest.java
@@ -1,0 +1,91 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_resource_attribute_def_def_freeipaGroupNameTest {
+
+	private urn_perun_group_resource_attribute_def_def_freeipaGroupName classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_freeipaGroupName();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		Facility facility = new Facility();
+		reqAttribute = new Attribute();
+
+		Group group2 = new Group();
+		List<Group> groups = new ArrayList<>();
+		groups.add(group2);
+		groups.add(group);
+
+		when(sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource)).thenReturn(facility);
+		when(sess.getPerunBl().getResourcesManagerBl().getAssignedGroups(sess, resource)).thenReturn(groups);
+		when(sess.getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility)).thenReturn(Collections.singletonList(resource));
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, group2, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":freeipaGroupName")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("bad@value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("correct_value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsMultipleGroupsWithSameName() throws Exception {
+		System.out.println("testSemanticsMultipleGroupsWithSameName()");
+		attributeToCheck.setValue("correct_value");
+		reqAttribute.setValue("correct_value");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("correct_value");
+		reqAttribute.setValue("another_correct_value");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isSystemUnixGroupTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_isSystemUnixGroupTest.java
@@ -1,0 +1,46 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_resource_attribute_def_def_isSystemUnixGroupTest {
+
+	private urn_perun_group_resource_attribute_def_def_isSystemUnixGroup classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_isSystemUnixGroup();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+
+		attributeToCheck.setValue(0);
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+
+		attributeToCheck.setValue(1);
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTest.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.AttributesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
@@ -82,29 +83,21 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 		classInstance.checkAttributeSemantics(session, group, resource, attribute);
 	}
 
-
-	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckType() throws Exception {
-		System.out.println("testCheckType()");
-		attributeToCheck.setValue("AAA");
-		classInstance.checkAttributeSemantics(session, group, resource, attributeToCheck);
-	}
-
 	@Test(expected = WrongAttributeValueException.class)
 	public void testCheckEmailSyntax() throws Exception {
 		System.out.println("testCheckEmailSyntax()");
 		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "a/-+"));
-		classInstance.checkAttributeSemantics(session, group, resource, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, group, resource, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
 	public void testCheckDuplicates() throws Exception {
 		System.out.println("testCheckDuplicates()");
 		attributeToCheck.setValue(Lists.newArrayList("my@example.com", "aaa@bbb.com", "my@example.com"));
-		classInstance.checkAttributeSemantics(session, group, resource, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, group, resource, attributeToCheck);
 	}
 
-	@Test(expected = WrongAttributeValueException.class)
+	@Test(expected = WrongReferenceAttributeValueException.class)
 	public void testCheckValueExistIfAdNameSetWithNull() throws Exception {
 		System.out.println("testCheckValueExistIfAdNameSetWithNull()");
 		attributeToCheck.setValue(null);
@@ -121,7 +114,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 	}
 
 
-	@Test(expected = WrongAttributeValueException.class)
+	@Test(expected = WrongReferenceAttributeValueException.class)
 	public void testCheckValueExistIfAdNameSet() throws Exception {
 		System.out.println("testCheckValueExistIfAdNameSet()");
 		attributeToCheck.setValue(Lists.newArrayList());
@@ -134,8 +127,10 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 		when(adNameAttr.getValue()).thenReturn(null);
 		when(am.getPerunBeanIdsForUniqueAttributeValue(eq(session),any(Attribute.class))).thenReturn(Sets.newHashSet());
 		attributeToCheck.setValue(Lists.newArrayList());
+		classInstance.checkAttributeSyntax(session, group, resource, attributeToCheck);
 		classInstance.checkAttributeSemantics(session, group, resource, attributeToCheck);
 		attributeToCheck.setValue(Lists.newArrayList("my@example.com"));
+		classInstance.checkAttributeSyntax(session, group, resource, attributeToCheck);
 		classInstance.checkAttributeSemantics(session, group, resource, attributeToCheck);
 	}
 
@@ -150,7 +145,7 @@ public class urn_perun_group_resource_attribute_def_def_o365EmailAddresses_muTes
 		classInstance.checkAttributeSemantics(session, group, resource, attributeToCheck);
 	}
 
-	@Test(expected = WrongAttributeValueException.class)
+	@Test(expected = WrongReferenceAttributeValueException.class)
 	public void testUniqClash() throws Exception {
 		System.out.println("testUniqClash");
 		attributeToCheck.setValue(new ArrayList<>(Arrays.asList("my@example.com", "my2@google.com")));

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimitTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataLimitTest.java
@@ -1,0 +1,70 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_resource_attribute_def_def_projectDataLimitTest {
+
+	private urn_perun_group_resource_attribute_def_def_projectDataLimit classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_projectDataLimit();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		reqAttribute = new Attribute();
+
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, group, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectDataQuota")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("0");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("1T");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsQuotaHigherThanLimit() throws Exception {
+		System.out.println("testSemanticsQuotaHigherThanLimit()");
+		attributeToCheck.setValue("22M");
+		reqAttribute.setValue("10T");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("22T");
+		reqAttribute.setValue("10M");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuotaTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDataQuotaTest.java
@@ -1,0 +1,70 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_resource_attribute_def_def_projectDataQuotaTest {
+
+	private urn_perun_group_resource_attribute_def_def_projectDataQuota classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_projectDataQuota();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		reqAttribute = new Attribute();
+
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, group, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectDataLimit")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("0");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("1T");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsQuotaHigherThanLimit() throws Exception {
+		System.out.println("testSemanticsQuotaHigherThanLimit()");
+		attributeToCheck.setValue("22T");
+		reqAttribute.setValue("10M");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("22M");
+		reqAttribute.setValue("10T");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissionsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectDirPermissionsTest.java
@@ -1,0 +1,43 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_resource_attribute_def_def_projectDirPermissionsTest {
+
+	private urn_perun_group_resource_attribute_def_def_projectDirPermissions classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_projectDirPermissions();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue(999);
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue(420);
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectNameTest.java
@@ -1,0 +1,97 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_resource_attribute_def_def_projectNameTest {
+
+	private urn_perun_group_resource_attribute_def_def_projectName classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_projectName();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		Facility facility = new Facility();
+		reqAttribute = new Attribute();
+
+		Resource resource2 = new Resource();
+		List<Resource> resources = new ArrayList<>();
+		resources.add(resource2);
+		resources.add(resource);
+
+		Group group2 = new Group();
+		List<Group> groups = new ArrayList<>();
+		groups.add(group);
+		groups.add(group2);
+
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":projectsBasePath")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource)).thenReturn(facility);
+		when(sess.getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility)).thenReturn(resources);
+		when(sess.getPerunBl().getGroupsManagerBl().getAssignedGroupsToResource(sess, resource2)).thenReturn(groups);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource2, group2, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":projectName")).thenReturn(reqAttribute);
+}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("bad@value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("correct_value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsReqAttributeWithNullValue() throws Exception {
+		System.out.println("testSemanticsReqAttributeWithNullValue()");
+		attributeToCheck.setValue("correct_value");
+		reqAttribute.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsMultipleGroupsWithSameName() throws Exception {
+		System.out.println("testSemanticsMultipleGroupsWithSameName()");
+		attributeToCheck.setValue("correct_value");
+		reqAttribute.setValue("correct_value");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("correct_value");
+		reqAttribute.setValue("another_correct_value");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLoginTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_projectOwnerLoginTest.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_resource_attribute_def_def_projectOwnerLoginTest {
+
+	private urn_perun_group_resource_attribute_def_def_projectOwnerLogin classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_projectOwnerLogin();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		Facility facility = new Facility();
+		reqAttribute = new Attribute();
+
+		User user = new User();
+
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, user, AttributesManager.NS_USER_FACILITY_ATTR_VIRT + ":login")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource)).thenReturn(facility);
+		when(sess.getPerunBl().getUsersManagerBl().getUsers(sess)).thenReturn(Collections.singletonList(user));
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("@value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("correct_value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsNoUserWithGivenName() throws Exception {
+		System.out.println("testSemanticsNoUserWithGivenName()");
+		attributeToCheck.setValue("correct_value");
+		reqAttribute.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("correct_value");
+		reqAttribute.setValue("correct_value");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGIDTest.java
@@ -1,0 +1,95 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.Resource;;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_resource_attribute_def_def_systemUnixGIDTest {
+
+	private urn_perun_group_resource_attribute_def_def_systemUnixGID classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Resource resource = new Resource(1,"resource1","Resource 1",0);
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+	private Attribute reqAttribute2;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_systemUnixGID();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		Facility facility = new Facility();
+		reqAttribute = new Attribute();
+		reqAttribute2 = new Attribute();
+		Resource resource2 = new Resource();
+		Group group2 = new Group();
+		Pair<Group, Resource> pair = new Pair<>(group2, resource2);
+
+		when(sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource2)).thenReturn(facility);
+		when(sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource)).thenReturn(facility);
+		when(sess.getPerunBl().getGroupsManagerBl().getGroupResourcePairsByAttribute(sess, attributeToCheck)).thenReturn(Collections.singletonList(pair));
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, group, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":isSystemUnixGroup")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, group, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGroupName")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource2, group2, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGroupName")).thenReturn(reqAttribute2);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue(0);
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsNullValueWithUnixGroup() throws Exception {
+		System.out.println("testSemanticsNullValueWithUnixGroup()");
+		attributeToCheck.setValue(null);
+		reqAttribute.setValue(1);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsGIDAlreadyUsed() throws Exception {
+		System.out.println("testSemanticsGIDAlreadyUsed()");
+		attributeToCheck.setValue(1);
+		reqAttribute.setValue("name");
+		reqAttribute2.setValue("different_name");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue(1);
+		reqAttribute.setValue("same_name");
+		reqAttribute2.setValue("same_name");
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_systemUnixGroupNameTest.java
@@ -1,0 +1,95 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Pair;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_group_resource_attribute_def_def_systemUnixGroupNameTest {
+
+	private urn_perun_group_resource_attribute_def_def_systemUnixGroupName classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group(1,"group1","Group 1",null,null,null,null,0,0);
+	private Resource resource = new Resource(1,"resource1","Resource 1",0);
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+	private Attribute reqAttribute2;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_systemUnixGroupName();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		Facility facility = new Facility();
+		reqAttribute = new Attribute();
+		reqAttribute2 = new Attribute();
+		Resource resource2 = new Resource();
+		Group group2 = new Group();
+		Pair<Group, Resource> pair = new Pair<>(group2, resource2);
+
+		when(sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource2)).thenReturn(facility);
+		when(sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource)).thenReturn(facility);
+		when(sess.getPerunBl().getGroupsManagerBl().getGroupResourcePairsByAttribute(sess, attributeToCheck)).thenReturn(Collections.singletonList(pair));
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, group, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":isSystemUnixGroup")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, group, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGID")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource2, group2, AttributesManager.NS_GROUP_RESOURCE_ATTR_DEF + ":systemUnixGID")).thenReturn(reqAttribute2);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		attributeToCheck.setValue("bad@value");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("correctName");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsNullValueWithUnixGroup() throws Exception {
+		System.out.println("testSemanticsNullValueWithUnixGroup()");
+		attributeToCheck.setValue(null);
+		reqAttribute.setValue(1);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsGroupNameAlreadyUsed() throws Exception {
+		System.out.println("testSemanticsGroupNameAlreadyUsed()");
+		attributeToCheck.setValue("name");
+		reqAttribute.setValue(1);
+		reqAttribute2.setValue(2);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("name");
+		reqAttribute.setValue(1);
+		reqAttribute2.setValue(1);
+
+		classInstance.checkAttributeSemantics(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsGroupNameTest.java
@@ -1,0 +1,52 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_resource_attribute_def_def_vomsGroupNameTest {
+
+	private urn_perun_group_resource_attribute_def_def_vomsGroupName classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_vomsGroupName();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+
+		attributeToCheck.setValue("<0");
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+
+		attributeToCheck.setValue(">0");
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+
+		attributeToCheck.setValue("&0");
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+
+		attributeToCheck.setValue("=0");
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		attributeToCheck.setValue("5");
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsRolesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_resource_attribute_def_def_vomsRolesTest.java
@@ -1,0 +1,50 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_group_resource_attribute_def_def_vomsRolesTest {
+
+	private urn_perun_group_resource_attribute_def_def_vomsRoles classInstance;
+	private Attribute attributeToCheck;
+	private Group group = new Group();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_group_resource_attribute_def_def_vomsRoles();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testWrongValue() throws Exception {
+		System.out.println("testWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add("<0");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSyntax() throws Exception {
+		System.out.println("testCorrectSyntax()");
+		List<String> value = new ArrayList<>();
+		value.add("0");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, group, resource, attributeToCheck);
+	}
+}


### PR DESCRIPTION
…odules

- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in group-resource attribute modules
- also added test for checks