### PR TITLE
CLI: Removed forgotten imports of general services manager

### DIFF
--- a/perun-cli/Perun/Agent.pm
+++ b/perun-cli/Perun/Agent.pm
@@ -29,7 +29,6 @@ use Perun::OwnersAgent;
 use Perun::ControlPanel;
 use Perun::AuthzResolverAgent;
 use Perun::HostsAgent;
-use Perun::GeneralServiceAgent;
 use Perun::AuditMessagesAgent;
 use Perun::PropagationStatsReaderAgent;
 use Perun::CabinetAgent;
@@ -44,7 +43,7 @@ use Sys::Hostname;
 my $format = 'json';
 my $contentType = 'application/json; charset=utf-8';
 
-use fields qw(_url _lwpUserAgent _jsonXs _vosAgent _membersAgent _usersAgent _groupsAgent _extSourcesAgent _servicesAgent _searcherAgent _facilitiesAgent _resourcesAgent _controlPanel _attributesAgent _ownersAgent _authzResolverAgent _hostsAgent _clustersAgent _generalServiceAgent _auditMessagesAgent _propagationStatsReaderAgent _cabinetAgent _notificationsAgent _registrarAgent _securityTeamsAgent _banOnResourceAgent _banOnFacilityAgent);
+use fields qw(_url _lwpUserAgent _jsonXs _vosAgent _membersAgent _usersAgent _groupsAgent _extSourcesAgent _servicesAgent _searcherAgent _facilitiesAgent _resourcesAgent _controlPanel _attributesAgent _ownersAgent _authzResolverAgent _hostsAgent _clustersAgent _auditMessagesAgent _propagationStatsReaderAgent _cabinetAgent _notificationsAgent _registrarAgent _securityTeamsAgent _banOnResourceAgent _banOnFacilityAgent);
 
 use constant {
 	AUTHENTICATION_FAILED => "Authentication failed",

--- a/perun-cli/Perun/ServicesAgent.pm
+++ b/perun-cli/Perun/ServicesAgent.pm
@@ -24,11 +24,6 @@ sub listServices {
 }
 
 #service => $serviceId
-sub deleteService {
-	return Perun::Common::callManagerMethod('deleteService', '', @_);
-}
-
-#service => $serviceId
 sub getService {
 	return Perun::Common::callManagerMethod('getService', 'Service', @_);
 }
@@ -236,7 +231,7 @@ sub removeAllRequiredAttributes
 #( id => $destinationId)
 sub getDestinationById
 {
-	return Perun::Common::callManagerMethod('getDestinationById', 'Destination', @_); 
+	return Perun::Common::callManagerMethod('getDestinationById', 'Destination', @_);
 }
 
 #( service => $serviceId, facility => $facilityId)


### PR DESCRIPTION
- Manager was removed, but imports were kept in Agent.pm
  and there was also duplicity in deleteService method in
  ServicesAgent.pm.