### PR TITLE
ENGINE: Store TaskResults for failed GEN Tasks

### DIFF
--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/GenPlanner.java
@@ -80,7 +80,7 @@ public class GenPlanner extends AbstractRunner {
 				throw new RuntimeException(errorStr, e);
 
 			} catch (Throwable ex) {
-				log.error("Unexpected exception in GenPlanner thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later {}.", ex);
+				log.error("Unexpected exception in GenPlanner thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later.", ex);
 			}
 		}
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendCollector.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendCollector.java
@@ -120,7 +120,7 @@ public class SendCollector extends AbstractRunner {
 				log.error("[{}] Error occurred while sending Task to destination {}", task.getId(), e.getDestination());
 
 			} catch (Throwable ex) {
-				log.error("Unexpected exception in SendCollector thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later. {}", ex);
+				log.error("Unexpected exception in SendCollector thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later.", ex);
 				continue;
 			}
 

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendPlanner.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/runners/SendPlanner.java
@@ -115,7 +115,7 @@ public class SendPlanner extends AbstractRunner {
 				throw new RuntimeException(errorStr, e);
 
 			} catch (Throwable ex) {
-				log.error("Unexpected exception in SendPlanner thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later. {}", ex);
+				log.error("Unexpected exception in SendPlanner thread. Stuck Tasks will be cleaned by PropagationMaintainer#endStuckTasks() later.", ex);
 			}
 		}
 	}


### PR DESCRIPTION
- We now store TaskResults for all destinations present in a Task
  after data generation fails. When it succeed, we continue with
  sending and handle TaskResults as usual.