### PR TITLE
RPC: Remove requirement on POST for check/get methods

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -1232,8 +1232,6 @@ public enum MembersManagerMethod implements ManagerMethod {
 	canBeMember {
 		@Override
 		public Integer call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
-
 			if (ac.getMembersManager().canBeMember(ac.getSession(), ac.getVoById(parms.readInt("vo")), parms.read("user", User.class) , parms.readString("loa"))) {
 				return 1;
 			} else {
@@ -1256,8 +1254,6 @@ public enum MembersManagerMethod implements ManagerMethod {
 	canBeMemberWithReason {
 		@Override
 		public Integer call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
-
 			if (ac.getMembersManager().canBeMemberWithReason(ac.getSession(), ac.getVoById(parms.readInt("vo")), parms.read("user", User.class) , parms.readString("loa"))) {
 				return 1;
 			} else {
@@ -1276,8 +1272,6 @@ public enum MembersManagerMethod implements ManagerMethod {
 	canExtendMembership {
 		@Override
 		public Integer call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
-
 			if (ac.getMembersManager().canExtendMembership(ac.getSession(), ac.getMemberById(parms.readInt("member")))) {
 				return 1;
 			} else {


### PR DESCRIPTION
- Methods to check whether user can be member or extend membership
  do not change data, hence there is no reason to require POST
  for them.