### PR TITLE
CORE, REGISTRAR: Added authz to canBeMember*() methods

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1076,7 +1076,7 @@ public interface MembersManager {
 	 * @throws InternalErrorException
 	 * @throws VoNotExistsException
 	 */
-	boolean canBeMember(PerunSession sess, Vo vo, User user, String loa) throws InternalErrorException, VoNotExistsException;
+	boolean canBeMember(PerunSession sess, Vo vo, User user, String loa) throws InternalErrorException, VoNotExistsException, PrivilegeException;
 
 	/**
 	 * Checks if the user can apply membership to the VO, it decides based on extendMembershipRules on the doNotAllowLoa key
@@ -1089,7 +1089,7 @@ public interface MembersManager {
 	 * @throws VoNotExistsException
 	 * @throws ExtendMembershipException
 	 */
-	boolean canBeMemberWithReason(PerunSession sess, Vo vo, User user, String loa) throws InternalErrorException, VoNotExistsException, ExtendMembershipException;
+	boolean canBeMemberWithReason(PerunSession sess, Vo vo, User user, String loa) throws InternalErrorException, VoNotExistsException, ExtendMembershipException, PrivilegeException;
 
 	/**
 	 * Get member by extSourceName, extSourceLogin and Vo

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -1157,6 +1157,7 @@ public class MembersManagerEntry implements MembersManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, member) &&
+				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, member) &&
 				!AuthzResolver.isAuthorized(sess, Role.SELF, member) &&
 				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
 			throw new PrivilegeException(sess, "extendMembership");
@@ -1173,6 +1174,7 @@ public class MembersManagerEntry implements MembersManager {
 
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, member) &&
+				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, member) &&
 				!AuthzResolver.isAuthorized(sess, Role.SELF, member) &&
 				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
 			throw new PrivilegeException(sess, "canExtendMembershipWithReason");
@@ -1182,18 +1184,34 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
-	public boolean canBeMember(PerunSession sess, Vo vo, User user, String loa) throws InternalErrorException, VoNotExistsException {
+	public boolean canBeMember(PerunSession sess, Vo vo, User user, String loa) throws InternalErrorException, VoNotExistsException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
+				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo) &&
+				!AuthzResolver.isAuthorized(sess, Role.SELF, user) &&
+				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
+			throw new PrivilegeException(sess, "canBeMember");
+		}
 
 		return getMembersManagerBl().canBeMember(sess, vo, user, loa);
 	}
 
 	@Override
 	public boolean canBeMemberWithReason(PerunSession sess, Vo vo, User user, String loa) throws InternalErrorException,
-		VoNotExistsException, ExtendMembershipException {
+			VoNotExistsException, ExtendMembershipException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		getPerunBl().getVosManagerBl().checkVoExists(sess, vo);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, vo) &&
+				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo) &&
+				!AuthzResolver.isAuthorized(sess, Role.SELF, user) &&
+				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
+			throw new PrivilegeException(sess, "canBeMemberWithReason");
+		}
 
 		return getMembersManagerBl().canBeMemberWithReason(sess, vo, user, loa);
 	}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ConsolidatorManagerImpl.java
@@ -79,7 +79,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 
 		// if user known, doesn't actually search and offer joining.
 		try {
-			perun.getUsersManager().getUserByExtSourceNameAndExtLogin(registrarSession, sess.getPerunPrincipal().getExtSourceName(), sess.getPerunPrincipal().getActor());
+			perun.getUsersManagerBl().getUserByExtSourceNameAndExtLogin(sess, sess.getPerunPrincipal().getExtSourceName(), sess.getPerunPrincipal().getActor());
 			return new ArrayList<>();
 		} catch (Exception ex) {
 			// we don't care, that search failed. That is actually OK case.
@@ -101,10 +101,10 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 				String[] mailSearch = mail.split(";");
 				for (String m : mailSearch) {
 					if (m != null && !m.isEmpty())
-						res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, m, attrNames));
+						res.addAll(perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(sess, m, attrNames));
 				}
 			} else {
-				res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, mail, attrNames));
+				res.addAll(perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(sess, mail, attrNames));
 			}
 		}
 
@@ -113,11 +113,11 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 
 			name = sess.getPerunPrincipal().getAdditionalInformations().get("cn");
 
-			if (name != null && !name.isEmpty()) res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames));
+			if (name != null && !name.isEmpty()) res.addAll(perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(sess, name, attrNames));
 
 			name = sess.getPerunPrincipal().getAdditionalInformations().get("displayName");
 
-			if (name != null && !name.isEmpty()) res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames));
+			if (name != null && !name.isEmpty()) res.addAll(perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(sess, name, attrNames));
 
 		}
 
@@ -154,11 +154,11 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 
 			if (item.getFormItem().getType().equals(ApplicationFormItem.Type.VALIDATED_EMAIL)) {
 				// search by email
-				if (value != null && !value.isEmpty()) res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, value, attrNames));
+				if (value != null && !value.isEmpty()) res.addAll(perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(sess, value, attrNames));
 			}
 			if (Objects.equals(item.getFormItem().getPerunDestinationAttribute(), "urn:perun:user:attribute-def:core:displayName")) {
 				// search by name
-				if (value != null && !value.isEmpty()) res.addAll(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, value, attrNames));
+				if (value != null && !value.isEmpty()) res.addAll(perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(sess, value, attrNames));
 			}
 
 		}
@@ -209,7 +209,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 		if (app.getType().equals(Application.AppType.INITIAL) && app.getGroup() == null && app.getUser() == null) {
 
 			try {
-				User u = perun.getUsersManager().getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
+				User u = perun.getUsersManagerBl().getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
 				if (u != null) {
 					// user connected his identity after app creation and before it's approval.
 					// do not show error message in GUI by returning an empty array.
@@ -229,7 +229,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 				if (email != null && !email.isEmpty()) break;
 			}
 
-			List<RichUser> users = (email != null && !email.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, email, attrNames) : new ArrayList<>();
+			List<RichUser> users = (email != null && !email.isEmpty()) ? perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(registrarSession, email, attrNames) : new ArrayList<>();
 
 			if (users != null && !users.isEmpty()) {
 				// found by preferredMail
@@ -246,7 +246,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 				if (email != null && !email.isEmpty()) break;
 			}
 
-			users = (email != null && !email.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, email, attrNames) : new ArrayList<>();
+			users = (email != null && !email.isEmpty()) ? perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(registrarSession, email, attrNames) : new ArrayList<>();
 			if (users != null && !users.isEmpty()) {
 				// found by member mail
 				return convertToIdentities(users);
@@ -283,7 +283,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 				}
 			}
 
-			users = (name != null && !name.isEmpty()) ? perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames) : new ArrayList<>();
+			users = (name != null && !name.isEmpty()) ? perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames) : new ArrayList<>();
 			if (users != null && !users.isEmpty()) {
 				// found by member display name
 				return convertToIdentities(users);
@@ -301,7 +301,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 
 			if (name != null && !name.isEmpty()) {
 				// what was found by name
-				return convertToIdentities(perun.getUsersManager().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames));
+				return convertToIdentities(perun.getUsersManagerBl().findRichUsersWithAttributesByExactMatch(registrarSession, name, attrNames));
 			} else {
 				// not found by name
 				return convertToIdentities(result);
@@ -402,7 +402,7 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 
 		requestCache.remove(token);
 
-		return perun.getUsersManager().getUserExtSources(sess, sess.getPerunPrincipal().getUser());
+		return perun.getUsersManagerBl().getUserExtSources(sess, sess.getPerunPrincipal().getUser());
 
 	}
 
@@ -423,15 +423,16 @@ public class ConsolidatorManagerImpl implements ConsolidatorManager {
 		try {
 			extSource = perun.getExtSourcesManagerBl().getExtSourceByName(registrarSession, extSourceName);
 		} catch (ExtSourceNotExistsException ex) {
-			extSource = perun.getExtSourcesManager().createExtSource(registrarSession, extSource, null);
+			extSource = perun.getExtSourcesManagerBl().createExtSource(registrarSession, extSource, null);
 		}
 
 		UserExtSource ues = new UserExtSource();
 		ues.setLogin(actor);
 		ues.setLoa(loa);
 		ues.setExtSource(extSource);
+		ues.setUserId(user.getId());
 
-		return perun.getUsersManager().addUserExtSource(registrarSession, user, ues);
+		return perun.getUsersManagerBl().addUserExtSource(registrarSession, user, ues);
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -23,6 +23,10 @@ import cz.metacentrum.perun.audit.events.MailManagerEvents.MailSending;
 import cz.metacentrum.perun.audit.events.MailManagerEvents.MailSentForApplication;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.*;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.MembersManagerBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.impl.Compatibility;
 import cz.metacentrum.perun.registrar.exceptions.FormNotExistsException;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
@@ -81,10 +85,10 @@ public class MailManagerImpl implements MailManager {
 	private PerunSession registrarSession;
 	private JdbcPerunTemplate jdbc;
 	private MailSender mailSender;
-	private AttributesManager attrManager;
-	private MembersManager membersManager;
-	private UsersManager usersManager;
-	private GroupsManager groupsManager;
+	private AttributesManagerBl attrManager;
+	private MembersManagerBl membersManager;
+	private UsersManagerBl usersManager;
+	private GroupsManagerBl groupsManager;
 
 	// Spring setters
 
@@ -106,10 +110,10 @@ public class MailManagerImpl implements MailManager {
 				ExtSourcesManager.EXTSOURCE_INTERNAL);
 		registrarSession = perun.getPerunSession(pp, new PerunClient());
 
-		this.attrManager = perun.getAttributesManager();
-		this.membersManager = perun.getMembersManager();
-		this.usersManager = perun.getUsersManager();
-		this.groupsManager = perun.getGroupsManager();
+		this.attrManager = perun.getAttributesManagerBl();
+		this.membersManager = perun.getMembersManagerBl();
+		this.usersManager = perun.getUsersManagerBl();
+		this.groupsManager = perun.getGroupsManagerBl();
 		this.mailSender = BeansUtils.getDefaultMailSender();
 
 	}
@@ -970,10 +974,10 @@ public class MailManagerImpl implements MailManager {
 
 		try {
 
-			Member m = membersManager.getMemberByUser(registrarSession, vo, user);
+			Member m = membersManager.getMemberByUser(sess, vo, user);
 			// is member, is invite to group ?
 			if (group != null) {
-				List<Group> g = groupsManager.getMemberGroups(registrarSession, m);
+				List<Group> g = groupsManager.getMemberGroups(sess, m);
 				if (g.contains(group)) {
 					// user is member of group - can't invite him
 					throw new RegistrarException("User to invite is already member of your group: "+group.getShortName());

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRICollections.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRICollections.java
@@ -16,6 +16,7 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
@@ -71,10 +72,10 @@ public class BBMRICollections implements RegistrarModule {
 	@Override
 	public Application approveApplication(PerunSession session, Application app) throws VoNotExistsException, UserNotExistsException, PrivilegeException, MemberNotExistsException, InternalErrorException, RegistrarException, GroupNotExistsException, AttributeNotExistsException, WrongAttributeAssignmentException, ExternallyManagedException, WrongAttributeValueException, WrongReferenceAttributeValueException, NotGroupMemberException {
 		// get perun and beans from session
-		Perun perun = session.getPerun();
+		PerunBl perun = (PerunBl)session.getPerun();
 		Vo vo = app.getVo();
 		User user = app.getUser();
-		Member member = perun.getMembersManager().getMemberByUser(session, vo, user);
+		Member member = perun.getMembersManagerBl().getMemberByUser(session, vo, user);
 
 		// get the field of application with the collections
 		Set<String> collectionIDsInApplication = getCollectionIDsFromApplication(session, app);
@@ -126,7 +127,7 @@ public class BBMRICollections implements RegistrarModule {
 	 */
 	public void canBeApproved(PerunSession session, Application app) throws PerunException {
 		// get perun and beans from session
-		Perun perun = session.getPerun();
+		PerunBl perun = (PerunBl)session.getPerun();
 		Vo vo = app.getVo();
 
 		// get all collection IDs from Perun
@@ -185,18 +186,18 @@ public class BBMRICollections implements RegistrarModule {
 	 *
 	 * @return Map of collection IDs to group.
 	 */
-	private Map<String, Group> getCollectionIDsToGroupsMap (PerunSession session, Perun perun, Group directoryGroup)
+	private Map<String, Group> getCollectionIDsToGroupsMap (PerunSession session, PerunBl perun, Group directoryGroup)
 			throws GroupNotExistsException, WrongAttributeAssignmentException, InternalErrorException,
 			AttributeNotExistsException, PrivilegeException {
 		Map<String, Group> collectionIDsToGroupMap = new HashMap<>();
 
-		List<Group> collectionGroups = perun.getGroupsManager().getSubGroups(session, directoryGroup);
+		List<Group> collectionGroups = perun.getGroupsManagerBl().getSubGroups(session, directoryGroup);
 
 		for (Group collectionGroup : collectionGroups) {
-			List<Group> representativesGroups = perun.getGroupsManager().getSubGroups(session, collectionGroup);
+			List<Group> representativesGroups = perun.getGroupsManagerBl().getSubGroups(session, collectionGroup);
 			for (Group representativesGroup: representativesGroups) {
 				if (REPRESENTATIVES_GROUP_NAME.equals(representativesGroup.getShortName())) {
-					Attribute collectionIDAttr = perun.getAttributesManager()
+					Attribute collectionIDAttr = perun.getAttributesManagerBl()
 							.getAttribute(session, representativesGroup, COLLECTION_ID_ATTR_NAME);
 
 					if (collectionIDAttr == null || Strings.isNullOrEmpty(collectionIDAttr.valueAsString())) {
@@ -214,7 +215,7 @@ public class BBMRICollections implements RegistrarModule {
 		return collectionIDsToGroupMap;
 	}
 
-	private Set<String> getCollectionIDs(PerunSession session, Perun perun, Group collectionsGroup)
+	private Set<String> getCollectionIDs(PerunSession session, PerunBl perun, Group collectionsGroup)
 			throws InternalErrorException, PrivilegeException, WrongAttributeAssignmentException,
 			AttributeNotExistsException, GroupNotExistsException {
 		return getCollectionIDsToGroupsMap(session, perun, collectionsGroup).keySet();

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRINetworks.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRINetworks.java
@@ -21,6 +21,7 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
@@ -76,16 +77,16 @@ public class BBMRINetworks implements RegistrarModule {
 	 */
 	public Application approveApplication(PerunSession session, Application app) throws VoNotExistsException, UserNotExistsException, PrivilegeException, MemberNotExistsException, InternalErrorException, RegistrarException, GroupNotExistsException, ExternallyManagedException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException, NotGroupMemberException {
 		// get perun and beans from session
-		Perun perun = session.getPerun();
+		PerunBl perun = (PerunBl)session.getPerun();
 		Vo vo = app.getVo();
 		User user = app.getUser();
-		Member member = perun.getMembersManager().getMemberByUser(session, vo, user);
+		Member member = perun.getMembersManagerBl().getMemberByUser(session, vo, user);
 
 		// get the field of application with the collections
 		Set<String> networkIDsInApplication = getNetworkIDsFromApplication(session, app);
 
 		// get map of collection IDs to group from Perun
-		Group networksGroup = perun.getGroupsManager().getGroupByName(session, vo, NETWORKS_GROUP_NAME);
+		Group networksGroup = perun.getGroupsManagerBl().getGroupByName(session, vo, NETWORKS_GROUP_NAME);
 		Map<String, Group> networkIDsToGroupsMap = getNetworkIDsToGroupsMap(session, perun, networksGroup);
 
 		// add user to all groups from the field on application
@@ -130,11 +131,11 @@ public class BBMRINetworks implements RegistrarModule {
 	 */
 	public void canBeApproved(PerunSession session, Application app) throws PerunException {
 		// get perun and beans from session
-		Perun perun = session.getPerun();
+		PerunBl perun = (PerunBl)session.getPerun();
 		Vo vo = app.getVo();
 
 		// get all network IDs from Perun
-		Group networksGroup = perun.getGroupsManager().getGroupByName(session, vo, NETWORKS_GROUP_NAME);
+		Group networksGroup = perun.getGroupsManagerBl().getGroupByName(session, vo, NETWORKS_GROUP_NAME);
 		Set<String> neworksIDsInPerun = getNetworkIDs(session, perun, networksGroup);
 
 		// get the field of application with the collections
@@ -188,12 +189,12 @@ public class BBMRINetworks implements RegistrarModule {
 	 *
 	 * @return Map of collection IDs to group.
 	 */
-	private Map<String, Group> getNetworkIDsToGroupsMap (PerunSession session, Perun perun, Group networksGroup) throws GroupNotExistsException, WrongAttributeAssignmentException, InternalErrorException, AttributeNotExistsException, PrivilegeException {
+	private Map<String, Group> getNetworkIDsToGroupsMap (PerunSession session, PerunBl perun, Group networksGroup) throws GroupNotExistsException, WrongAttributeAssignmentException, InternalErrorException, AttributeNotExistsException, PrivilegeException {
 		Map<String, Group> networkIDsToGroupMap = new HashMap<>();
-		for (Group group : perun.getGroupsManager().getSubGroups(session, networksGroup)) {
-			for (Group subgroup : perun.getGroupsManager().getSubGroups(session, group)) {
+		for (Group group : perun.getGroupsManagerBl().getSubGroups(session, networksGroup)) {
+			for (Group subgroup : perun.getGroupsManagerBl().getSubGroups(session, group)) {
 				if (REPRESENTATIVES_GROUP_NAME.equals(subgroup.getShortName())) {
-					Attribute networkID = perun.getAttributesManager().getAttribute(session, subgroup, NETWORK_ID_ATTR_NAME);
+					Attribute networkID = perun.getAttributesManagerBl().getAttribute(session, subgroup, NETWORK_ID_ATTR_NAME);
 					networkIDsToGroupMap.put(networkID.valueAsString(), subgroup);
 				}
 			}
@@ -202,7 +203,7 @@ public class BBMRINetworks implements RegistrarModule {
 		return networkIDsToGroupMap;
 	}
 
-	private Set<String> getNetworkIDs(PerunSession session, Perun perun, Group collectionsGroup) throws InternalErrorException, PrivilegeException, WrongAttributeAssignmentException, AttributeNotExistsException, GroupNotExistsException {
+	private Set<String> getNetworkIDs(PerunSession session, PerunBl perun, Group collectionsGroup) throws InternalErrorException, PrivilegeException, WrongAttributeAssignmentException, AttributeNotExistsException, GroupNotExistsException {
 		return getNetworkIDsToGroupsMap(session, perun, collectionsGroup).keySet();
 	}
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduTEAMS.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduTEAMS.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
@@ -71,7 +72,7 @@ public class EduTEAMS implements RegistrarModule {
 				Attribute loginAttribute;
 				try {
 					loginAttribute =
-							sess.getPerun().getAttributesManager().getAttribute(sess, user, A_U_D_EDUTEAMS_NICKNAME);
+							((PerunBl)sess.getPerun()).getAttributesManagerBl().getAttribute(sess, user, A_U_D_EDUTEAMS_NICKNAME);
 				} catch (AttributeNotExistsException e) {
 					// do not set the login if the attribute does not exist
 					return application;
@@ -79,7 +80,7 @@ public class EduTEAMS implements RegistrarModule {
 
 				loginAttribute.setValue(nickName);
 
-				sess.getPerun().getAttributesManager().setAttribute(sess, user, loginAttribute);
+				((PerunBl)sess.getPerun()).getAttributesManagerBl().setAttribute(sess, user, loginAttribute);
 			}
 		}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Eduroam.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Eduroam.java
@@ -14,6 +14,7 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
@@ -46,14 +47,14 @@ public class Eduroam implements RegistrarModule {
 		// Add new member to groups eduroam-admin and eduroam-announce just if its initial application form
 		if (Application.AppType.INITIAL.equals(app.getType())) {
 			// Get perun and beans from session
-			Perun perun = session.getPerun();
+			PerunBl perun = (PerunBl)session.getPerun();
 			Vo vo = app.getVo();
 			User user = app.getUser();
-			Member member = perun.getMembersManager().getMemberByUser(session, vo, user);
+			Member member = perun.getMembersManagerBl().getMemberByUser(session, vo, user);
 
 			// Get the groups in which the new member of VO will be automatically added
-			Group eduroamAdmin = perun.getGroupsManager().getGroupByName(session, vo, "eduroam-admin");
-			Group eduroamAnnounce = perun.getGroupsManager().getGroupByName(session, vo, "eduroam-announce");
+			Group eduroamAdmin = perun.getGroupsManagerBl().getGroupByName(session, vo, "eduroam-admin");
+			Group eduroamAnnounce = perun.getGroupsManagerBl().getGroupByName(session, vo, "eduroam-announce");
 
 			// Add member to these groups
 			perun.getGroupsManager().addMember(session, eduroamAdmin, member);

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ElixirBonaFideStatus.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ElixirBonaFideStatus.java
@@ -14,6 +14,8 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
@@ -97,7 +99,7 @@ public class ElixirBonaFideStatus implements RegistrarModule {
 			throw new CantBeApprovedException("This module can be set only for registration to Group.");
 		}
 
-		AttributesManager am = session.getPerun().getAttributesManager();
+		AttributesManagerBl am = ((PerunBl)session.getPerun()).getAttributesManagerBl();
 		Attribute attestation;
 		try {
 			attestation = am.getAttribute(session, group, A_G_D_groupAttestation);
@@ -131,7 +133,7 @@ public class ElixirBonaFideStatus implements RegistrarModule {
 		if (user == null) {
 			throw new CantBeSubmittedException("This module can be set only for registration to Group.");
 		}
-		AttributesManager am = session.getPerun().getAttributesManager();
+		AttributesManagerBl am = ((PerunBl)session.getPerun()).getAttributesManagerBl();
 
 		Attribute affiliations = am.getAttribute(session, user, A_U_D_userEduPersonScopedAffiliations);
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
@@ -14,6 +14,7 @@ import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.registrar.RegistrarManager;
 import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
@@ -61,14 +62,14 @@ public class Metacentrum implements RegistrarModule {
 	public Application approveApplication(PerunSession session, Application app) throws PrivilegeException, InternalErrorException, VoNotExistsException, GroupNotExistsException, UserNotExistsException, MemberNotExistsException, ExternallyManagedException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, WrongAttributeValueException, RegistrarException {
 
 		// get perun from session
-		Perun perun = session.getPerun();
+		PerunBl perun = (PerunBl)session.getPerun();
 
 		if (Application.AppType.INITIAL.equals(app.getType())) {
 
 			Vo vo = app.getVo();
 			User user = app.getUser();
-			Group group = perun.getGroupsManager().getGroupByName(session, vo, "storage");
-			Member mem = perun.getMembersManager().getMemberByUser(session, vo, user);
+			Group group = perun.getGroupsManagerBl().getGroupByName(session, vo, "storage");
+			Member mem = perun.getMembersManagerBl().getMemberByUser(session, vo, user);
 
 			try  {
 				perun.getGroupsManager().addMember(session, group, mem);
@@ -91,22 +92,22 @@ public class Metacentrum implements RegistrarModule {
 		if (statisticGroupName != null && !statisticGroupName.isEmpty()) {
 			Group group;
 			try {
-				group = perun.getGroupsManager().getGroupByName(session, app.getVo(), statisticGroupName);
+				group = perun.getGroupsManagerBl().getGroupByName(session, app.getVo(), statisticGroupName);
 			} catch (GroupNotExistsException | InternalErrorException ex) {
 				// user filled non existing group, just skip adding OR wrong group name
 				return app;
 			}
 
 
-			Attribute isStatisticGroup = perun.getAttributesManager().getAttribute(session, group, "urn:perun:group:attribute-def:def:statisticGroup");
-			Attribute isStatisticGroupAutoFill = perun.getAttributesManager().getAttribute(session, group, "urn:perun:group:attribute-def:def:statisticGroupAutoFill");
+			Attribute isStatisticGroup = perun.getAttributesManagerBl().getAttribute(session, group, "urn:perun:group:attribute-def:def:statisticGroup");
+			Attribute isStatisticGroupAutoFill = perun.getAttributesManagerBl().getAttribute(session, group, "urn:perun:group:attribute-def:def:statisticGroupAutoFill");
 
 			boolean statisticGroup = (isStatisticGroup.getValue() != null) ? (Boolean)isStatisticGroup.getValue() : false;
 			boolean statisticGroupAutoFill = (isStatisticGroupAutoFill.getValue() != null) ? (Boolean)isStatisticGroupAutoFill.getValue() : false;
 
 			if (statisticGroup && statisticGroupAutoFill) {
 				try  {
-					Member mem = perun.getMembersManager().getMemberByUser(session, app.getVo(), app.getUser());
+					Member mem = perun.getMembersManagerBl().getMemberByUser(session, app.getVo(), app.getUser());
 					perun.getGroupsManager().addMember(session, group, mem);
 				} catch (AlreadyMemberException ex) {
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Sitola.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Sitola.java
@@ -54,8 +54,8 @@ public class Sitola implements RegistrarModule {
 
 		if (user != null) {
 
-			Attribute eduroamIdentities = perun.getAttributesManager().getAttribute(session, user, "urn:perun:user:attribute-def:def:eduroamIdentities");
-			Attribute loginMu = perun.getAttributesManager().getAttribute(session, user, "urn:perun:user:attribute-def:def:login-namespace:mu");
+			Attribute eduroamIdentities = perun.getAttributesManagerBl().getAttribute(session, user, "urn:perun:user:attribute-def:def:eduroamIdentities");
+			Attribute loginMu = perun.getAttributesManagerBl().getAttribute(session, user, "urn:perun:user:attribute-def:def:login-namespace:mu");
 
 			if (eduroamIdentities.getValue() == null) {
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Vsup.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Vsup.java
@@ -144,7 +144,7 @@ public class Vsup implements RegistrarModule {
 
 			if (changed) {
 				// update manual expiration attribute
-				perun.getAttributesManager().setAttribute(session, user, manualExpirationAttr);
+				perun.getAttributesManagerBl().setAttribute(session, user, manualExpirationAttr);
 			}
 
 		}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonErrorHandler.java
@@ -252,6 +252,10 @@ public class JsonErrorHandler {
 
 			return ApplicationMessages.INSTANCE.errorWhileCreatingApplication();
 
+		} else if ("AlreadyProcessingException".equalsIgnoreCase(errorName)) {
+
+			return "Operation is already running";
+
 		}
 
 		// default caption
@@ -390,7 +394,11 @@ public class JsonErrorHandler {
 			// TODO - this exception must contain user first !!
 			return "User is already member of VO / Group.";
 
-		} else if ("AlreadyReservedLoginException".equalsIgnoreCase(errorName)) {
+		} else if ("AlreadyProcessingException".equalsIgnoreCase(errorName)) {
+
+			return "<p>" + error.getErrorInfo() + "<p>It was probably started by on of the other administrators. If this problem persist, please contact support.";
+
+		}else if ("AlreadyReservedLoginException".equalsIgnoreCase(errorName)) {
 
 			String text = "";
 			if (error.getLogin() != null) {


### PR DESCRIPTION
- Added authorization for canBeMember() and canBeMemberWithReason().
- Allowed also VOOBSERVER role with some of MembersManager methods.
- Registrar now users Bl layer to skip nested transaction logic. Some input checks are also skipped
  and were introduced right in the registrar logic.
- Application approval/rejection and deletion now prevent concurrent runs.