### PR TITLE
Fix problem with removing member from group while synchronization

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -830,4 +830,38 @@ public class BeansUtils {
 
 	}
 
+	/**
+	 * Convert object richMember to object candidate.
+	 * PrimaryUserExtSource is used as the main userExtSource for candidate object
+	 *
+	 * @param richMember
+	 * @param primaryUserExtSource main userExtSource for candidate object
+	 *
+	 * @return converted object candidate from richMember
+	 */
+	public static Candidate convertRichMemberToCandidate(RichMember richMember, UserExtSource primaryUserExtSource) {
+		if(richMember == null) throw new InternalErrorException("RichMember can't be null when converting to Candidate.");
+		if(primaryUserExtSource == null) throw new InternalErrorException("PrimaryUserExtSource can't be null when converting to Candidate.");
+
+		//Prepare additional userExtSources
+		List<UserExtSource> additionalUserExtSources = new ArrayList<>();
+		if(richMember.getUserExtSources() != null) additionalUserExtSources.addAll(richMember.getUserExtSources());
+		//remove primaryUserExtSource from additional userExtSources
+		additionalUserExtSources.remove(primaryUserExtSource);
+
+		//Prepare attributes
+		List<Attribute> allAttributes = new ArrayList<>();
+		if(richMember.getMemberAttributes() != null) allAttributes.addAll(richMember.getMemberAttributes());
+		if(richMember.getUserAttributes() != null) allAttributes.addAll(richMember.getUserAttributes());
+		Map<String, String> candidateAttributes = new HashMap<>();
+		for(Attribute attribute: allAttributes) {
+			candidateAttributes.put(attribute.getName(), attributeValueToString(attribute));
+		}
+
+		Candidate candidate = new Candidate(richMember.getUser(), primaryUserExtSource);
+		candidate.setAdditionalUserExtSources(additionalUserExtSources);
+		candidate.setAttributes(candidateAttributes);
+
+		return candidate;
+	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -207,17 +207,6 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 
 	@Override
 	public Candidate getCandidate(PerunSession sess, ExtSource source, String login) throws InternalErrorException, CandidateNotExistsException, ExtSourceUnsupportedOperationException {
-		// New Candidate
-		Candidate candidate = new Candidate();
-
-		// Prepare userExtSource object
-		UserExtSource userExtSource = new UserExtSource();
-		userExtSource.setExtSource(source);
-		userExtSource.setLogin(login);
-
-		// Set the userExtSource
-		candidate.setUserExtSource(userExtSource);
-
 		// Get the subject from the extSource
 		Map<String, String> subject;
 		try {
@@ -230,60 +219,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 			throw new CandidateNotExistsException("Candidate with login [" + login + "] not exists");
 		}
 
-		//If first name of candidate is not in format of name, set null instead
-		candidate.setFirstName(subject.get("firstName"));
-		if(candidate.getFirstName() != null) {
-			Matcher name = namePattern.matcher(candidate.getFirstName());
-			if(!name.matches()) candidate.setFirstName(null);
-		}
-		// If last name of candidate is not in format of name, set null instead
-		candidate.setLastName(subject.get("lastName"));
-		if(candidate.getLastName()!= null) {
-			Matcher name = namePattern.matcher(candidate.getLastName());
-			if(!name.matches()) candidate.setLastName(null);
-		}
-		candidate.setMiddleName(subject.get("middleName"));
-		candidate.setTitleAfter(subject.get("titleAfter"));
-		candidate.setTitleBefore(subject.get("titleBefore"));
-
-		//Set service user
-		if(subject.get("isServiceUser") == null) {
-			candidate.setServiceUser(false);
-		} else {
-			String isServiceUser = subject.get("isServiceUser");
-			if(isServiceUser.equals("true")) {
-				candidate.setServiceUser(true);
-			} else {
-				candidate.setServiceUser(false);
-			}
-		}
-
-		// Set sponsored user
-		if(subject.get("isSponsoredUser") == null) {
-			candidate.setSponsoredUser(false);
-		} else {
-			String isSponsoredUser = subject.get("isSponsoredUser");
-			if(isSponsoredUser.equals("true")) {
-				candidate.setSponsoredUser(true);
-			} else {
-				candidate.setSponsoredUser(false);
-			}
-		}
-
-		// Filter attributes
-		Map<String, String> attributes = new HashMap<>();
-		for (String attrName: subject.keySet()) {
-			// Allow only users and members attributes
-			// FIXME volat metody z attributesManagera nez kontrolovat na zacatek jmena
-			if (attrName.startsWith(AttributesManager.NS_MEMBER_ATTR) || attrName.startsWith(AttributesManager.NS_USER_ATTR)) {
-				attributes.put(attrName, subject.get(attrName));
-			}
-		}
-		List<UserExtSource> additionalUserExtSources = Utils.extractAdditionalUserExtSources(sess, subject);
-		candidate.setAdditionalUserExtSources(additionalUserExtSources);
-		candidate.setAttributes(attributes);
-
-		return candidate;
+		return this.getCandidate(sess, subject, source, login);
 	}
 
 	@Override


### PR DESCRIPTION
 - in synchronization when we are using one extSource to get logins
 and other one to get attributes for these logins, there is a situation
 when a member is already in the Group (synced from the last time), he
 was aquired from login extSource but was not found in second extSource
 to get his attributes. When this happend, we don't want to remove this
 member from the group, just skip him and inform about this situation
 to the synchronization result. For such member we don't want to update
 attributes differently then already stored in Perun.
 - in GroupsManagerBlImpl method convertSubjectsToCandidates was changed
 to resolve this situation by finding member with his basic attributes
 in Perun instaed of the second ExtSource, so we will preserve him in
 the last state as he was before. The message in the synchronization
 result is then different from the situation when member wasn't find
 at all.
 - for methods "getCandidate" in ExtSourcemanagerBlImpl the duplicity of
 code were removed
 - new method convertRichMemberToCandidate was added to BeansUtils and
 it will convert existing RichMember from Perun to object Candidate for
 easier working in synchronizations
 - some typo in the name of variable were fixed