### PR TITLE
enabled RPC pathinfo to have more than 3 parts

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -544,8 +544,8 @@ public class Api extends HttpServlet {
 					throw new RpcException(RpcException.Type.NO_PATHINFO);
 				}
 
-				fcm = req.getPathInfo().substring(1).split("/", 3);
-				if (fcm.length != 3 || fcm[2].isEmpty()) {
+				fcm = req.getPathInfo().substring(1).split("/");
+				if (fcm.length < 3 || fcm[0].isEmpty() || fcm[1].isEmpty() || fcm[2].isEmpty()) {
 					throw new RpcException(RpcException.Type.INVALID_URL, req.getPathInfo());
 				}
 				manager = fcm[1];


### PR DESCRIPTION
Some RPC methods are overloaded. For example, the path  /json/attributesManager/getAttribute is in fact 26 different methods depending on combination of parameters. This is impossible to describe in OpenAPI format, because OpenAPI identifies a method by tuple of path and HTTP method. 

This pull request enables to create more URL paths from a single one by enabling more than 3 parts. I.e. the same java method would be callable by multiple URL paths like /json/attributesManager/getAttribute/facility-aname?facility=1&attributeName="urn:perun:facility:attribute-def:def:OIDCClientID" and /json/attributesManager/getAttribute/user-group-att_id?group=1&user=2&attributeId=3 where the 4th part will be ignored, but it will allow to describe the 26 different methods in OpenAPI by using different paths for different parameter combinations.