### PR TITLE
CORE: Fixed getBeanName() for ExtSource

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/ExtSource.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/ExtSource.java
@@ -85,6 +85,15 @@ public class ExtSource extends Auditable implements Comparable<PerunBean>{
 		return result;
 	}
 
+	/*
+	 * Overriding this, since implementation of each ExtSource returned their class name
+	 * instead of required unified "ExtSource" value.
+	 */
+	@Override
+	public String getBeanName() {
+		return ExtSource.class.getSimpleName();
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) return true;


### PR DESCRIPTION
- Implementations of ExtSource returned specific value of
  "beanName" param, while they should have return unified
  value "ExtSource."
- This change forces using class name of the base class.