### PR TITLE
ENGINE, DISPATCHER: Make constant for stuck tasks configurable

### DIFF
--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/scheduling/PropagationMaintainer.java
@@ -33,7 +33,12 @@ import javax.annotation.Resource;
 public class PropagationMaintainer extends AbstractRunner {
 
 	private final static Logger log = LoggerFactory.getLogger(PropagationMaintainer.class);
-	private final static int rescheduleTime = 190;
+
+	/**
+	 * After how many minutes is processing Task considered as stuck and re-scheduled.
+	 * Should be above same property for "Engine", which is by default 180.
+	 */
+	private int rescheduleTime = 190;
 
 	private PerunSession perunSession;
 
@@ -79,6 +84,13 @@ public class PropagationMaintainer extends AbstractRunner {
 	@Resource(name="dispatcherPropertiesBean")
 	public void setDispatcherProperties(Properties dispatcherProperties) {
 		this.dispatcherProperties = dispatcherProperties;
+		if (dispatcherProperties != null) {
+			try {
+				rescheduleTime = Integer.parseInt(dispatcherProperties.getProperty("dispatcher.propagation.timeout", "190"));
+			} catch (NumberFormatException ex) {
+				rescheduleTime = 190;
+			}
+		}
 	}
 
 	public TaskManager getTaskManager() {

--- a/perun-dispatcher/src/main/resources/perun-dispatcher.xml
+++ b/perun-dispatcher/src/main/resources/perun-dispatcher.xml
@@ -77,6 +77,7 @@ http://www.springframework.org/schema/tx http://www.springframework.org/schema/t
 				<prop key="dispatcher.task.delay.time">30000</prop>
 				<prop key="dispatcher.task.delay.count">4</prop>
 				<prop key="dispatcher.datadir">/tmp/perun-dispatcher-data</prop>
+				<prop key="dispatcher.propagation.timeout">190</prop>
 			</props>
 		</property>
 	</bean>

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/GenWorkerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/GenWorkerImpl.java
@@ -75,10 +75,10 @@ public class GenWorkerImpl extends AbstractWorker<Task> implements GenWorker {
 
 		} catch (IOException e) {
 			log.error("[{}] GEN worker failed for Task. IOException: {}.",  task.getId(), e);
-			throw new TaskExecutionException(task, e);
+			throw new TaskExecutionException(task, 2, "", e.getMessage());
 		} catch (InterruptedException e) {
 			log.warn("[{}] GEN worker failed for Task. Execution was interrupted {}.", task.getId(), e);
-			throw new TaskExecutionException(task, e);
+			throw new TaskExecutionException(task, 1, "", e.getMessage());
 		}
 
 	}

--- a/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/PropagationMaintainerImpl.java
+++ b/perun-engine/src/main/java/cz/metacentrum/perun/engine/scheduling/impl/PropagationMaintainerImpl.java
@@ -21,6 +21,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.Future;
 
@@ -32,12 +33,13 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 	/**
 	 * After how many minutes is processing Task considered as stuck and re-scheduled.
 	 */
-	private final static int rescheduleTime = 180;
+	private int rescheduleTime = 180;
 
 	private BlockingGenExecutorCompletionService generatingTasks;
 	private BlockingSendExecutorCompletionService sendingSendTasks;
 	private SchedulingPool schedulingPool;
 	private JMSQueueManager jmsQueueManager;
+	private Properties propertiesBean;
 
 	// ----- setters ------------------------------
 
@@ -75,6 +77,22 @@ public class PropagationMaintainerImpl implements PropagationMaintainer {
 	@Autowired
 	public void setSendingSendTasks(BlockingSendExecutorCompletionService sendingSendTasks) {
 		this.sendingSendTasks = sendingSendTasks;
+	}
+
+	public Properties getPropertiesBean() {
+		return propertiesBean;
+	}
+
+	@Autowired
+	public void setPropertiesBean(Properties propertiesBean) {
+		this.propertiesBean = propertiesBean;
+		if (propertiesBean != null) {
+			try {
+				rescheduleTime = Integer.parseInt(propertiesBean.getProperty("engine.propagation.timeout", "180"));
+			} catch (NumberFormatException ex) {
+				rescheduleTime = 180;
+			}
+		}
 	}
 
 	// ----- methods ------------------------------

--- a/perun-engine/src/main/resources/perun-engine.xml
+++ b/perun-engine/src/main/resources/perun-engine.xml
@@ -78,6 +78,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<prop key="engine.thread.sendtasks.max">150</prop>
 				<prop key="engine.genscript.path">gen</prop>
 				<prop key="engine.sendscript.path">send</prop>
+				<prop key="engine.propagation.timeout">180</prop>
 			</props>
 		</property>
 	</bean>


### PR DESCRIPTION
- Current timeout for stuck tasks in PropagationMaintainer classes
  of both Engine and Dispatcher was not configurable and caused
  long tasks to be re-scheduled, while they were running on the
  backend. Now we can configure timeouts on both side for each Perun
  instance.
- Make sure we set return code to non-zero when GEN Task is cancelled
  (considered as stuck by engine).
  It previously made TaskResults for GEN Tasks to appear OK, while they
  were cancelled and re-scheduled.