### PR TITLE
Fix authorization in VosManagerEntry

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/VosManagerEntry.java
@@ -210,7 +210,8 @@ public class VosManagerEntry implements VosManager {
 				!AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, vo) &&
 				!AuthzResolver.isAuthorized(sess, Role.ENGINE) &&
 				!AuthzResolver.isAuthorized(sess, Role.RPC) &&
-				!AuthzResolver.isAuthorized(sess, Role.SELF)) {
+				!AuthzResolver.isAuthorized(sess, Role.SELF) &&
+				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
 			throw new PrivilegeException(sess, "getVoById");
 				}
 
@@ -298,8 +299,8 @@ public class VosManagerEntry implements VosManager {
 		Vo vo = getPerunBl().getGroupsManagerBl().getVo(sess, group);
 
 		// Authorization
-		if (AuthzResolver.isAuthorized(sess, Role.VOADMIN, group) &&
-				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
+		if (AuthzResolver.isAuthorized(sess, Role.VOADMIN, group) ||
+				AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
 			extSources = getPerunBl().getExtSourcesManagerBl().getVoExtSources(sess, vo);
 
 			// null the vo so users are searched in whole perun


### PR DESCRIPTION
- Method getVoById() was missing priviledge for PERUNOBSERVER, so it was
  added.
- getCompleteCandidates() had wrongly composed a conditional statement
  which was satisfied when a user is VOADMIN and is not PERUNOBSERVER.
  This does not make sense so it was changed so the statement is
  satisfied when a user id VOADMIN or PERUNOBSERVER.