### PR TITLE
Fixed AdminRemovedForFacility audit message

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/AdminRemovedForFacility.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/audit/events/FacilityManagerEvents/AdminRemovedForFacility.java
@@ -18,7 +18,7 @@ public class AdminRemovedForFacility extends AuditEvent implements EngineIgnoreE
 	public AdminRemovedForFacility(User user, Facility facility) {
 		this.user = user;
 		this.facility = facility;
-		this.message = formatMessage("%s was removed from admin of %s.", user, facility);
+		this.message = formatMessage("%s was removed from admins of %s.", user, facility);
 	}
 
 	public User getUser() {


### PR DESCRIPTION
- Unified message to "[User] was removed from admins of [Facility]".
  Fixed "admin" -> "admins" in the message.