### PR TITLE
Remove slash on the end of normalized path

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -370,6 +370,8 @@ public interface ModulesUtilsBl {
 	 *
 	 * Example of suitable format: key=/path/to/volume, softQuota=50000000000000, hradQuota=0
 	 *
+	 * The key is always a path tested as checked valid URI without '/' on the end (except the path "/", which is also valid)
+	 *
 	 * Left part of value is softQuota, right part after delimeter ':' is hardQuota.
 	 * SoftQuota must be less or equals to hardQuota. '0' means unlimited.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -736,7 +736,8 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 			String canonicalPath;
 			try {
 				canonicalPath = new URI(path).normalize().getPath();
-				if(!canonicalPath.endsWith("/")) canonicalPath = canonicalPath.concat("/");
+				//path should not end on '/' (problem with some systems as GPFS)
+				if(!canonicalPath.equals("/") && canonicalPath.endsWith("/")) canonicalPath = canonicalPath.substring(0, canonicalPath.length() - 1);
 			} catch (URISyntaxException ex) {
 				throw new WrongAttributeValueException(quotasAttribute, firstPlaceholder, secondPlaceholder, "Path '" + path + "' is not correct form.");
 			}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ModulesUtilsEntryIntegrationTest.java
@@ -669,7 +669,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		Resource resource = new Resource(10, "test", "test", 10, 10);
 		Attribute fileQuotasAttribute = getFileQuotasAttribute();
 		Attribute maxFileQuotasAttribute = getMaxFileQuotasAttribute();
-		((LinkedHashMap<String,String>) maxFileQuotasAttribute.getValue()).put("/var/log/test/", "1000:2000");
+		((LinkedHashMap<String,String>) maxFileQuotasAttribute.getValue()).put("/var/log/test", "1000:2000");
 		modulesUtilsBl.checkIfQuotasIsInLimit(
 				modulesUtilsBl.checkAndTransferQuotas(fileQuotasAttribute, resource, null, false),
 				modulesUtilsBl.checkAndTransferQuotas(maxFileQuotasAttribute, resource, null, false));
@@ -680,7 +680,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		System.out.println(CLASS_NAME + "QuotaNotInAllowedLimitException");
 		Resource resource = new Resource(10, "test", "test", 10, 10);
 		Attribute dataQuotasAttribute = getDataQuotasAttribute();
-		((LinkedHashMap<String,String>) dataQuotasAttribute.getValue()).put("/var/log/test/", "1G:0");
+		((LinkedHashMap<String,String>) dataQuotasAttribute.getValue()).put("/var/log/test", "1G:0");
 		Attribute maxDataQuotasAttribute = getMaxDataQuotasAttribute();
 		modulesUtilsBl.checkIfQuotasIsInLimit(
 				modulesUtilsBl.checkAndTransferQuotas(dataQuotasAttribute, resource, null, true),
@@ -702,7 +702,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		System.out.println(CLASS_NAME + "checkQuotasErrorInMetric");
 		Resource resource = new Resource(10, "test", "test", 10, 10);
 		Attribute dataQuotasAttribute = getDataQuotasAttribute();
-		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/new/path/", "1Z:1");
+		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/new/path", "1Z:1");
 		modulesUtilsBl.checkAndTransferQuotas(dataQuotasAttribute, resource, null, true);
 	}
 
@@ -711,7 +711,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		System.out.println(CLASS_NAME + "WrongAttributeValueException");
 		Resource resource = new Resource(10, "test", "test", 10, 10);
 		Attribute dataQuotasAttribute = getDataQuotasAttribute();
-		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/new/path/", "b20:1");
+		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/new/path", "b20:1");
 		modulesUtilsBl.checkAndTransferQuotas(dataQuotasAttribute, resource, null, true);
 	}
 
@@ -720,7 +720,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		System.out.println(CLASS_NAME + "checkIfQuotasContainsDifferentPathThanMaxQuotas");
 		Resource resource = new Resource(10, "test", "test", 10, 10);
 		Attribute dataQuotasAttribute = getDataQuotasAttribute();
-		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/new/path/", "1:1");
+		((LinkedHashMap) dataQuotasAttribute.getValue()).put("/new/path", "1:1");
 		Attribute maxDataQuotasAttribute = getMaxDataQuotasAttribute();
 		modulesUtilsBl.checkIfQuotasIsInLimit(
 				modulesUtilsBl.checkAndTransferQuotas(dataQuotasAttribute, resource, null, true),
@@ -756,7 +756,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 						modulesUtilsBl.checkAndTransferQuotas(fileQuotasOverrideAttribute, resource, null, false)),
 				false );
 		Map<String, String> expectedResult = new HashMap<>((HashMap<String,String>) memberResourceFileQuotasAttribute.getValue());
-		expectedResult.put("/var/log/test/","1:0");
+		expectedResult.put("/var/log/test","1:0");
 		assertEquals(expectedResult, mergedMapOfQuotas);
 	}
 
@@ -774,12 +774,12 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 		countOfQuotas.add(modulesUtilsBl.checkAndTransferQuotas(fileQuotasOverrideAttribute, resource, null, false));
 		Map<String, String> result = modulesUtilsBl.transferQuotasBackToAttributeValue(modulesUtilsBl.countUserFacilityQuotas(countOfQuotas), false);
 		Map<String, String> expectedResult = new HashMap<>();
-		expectedResult.put("/var/log/test/", "3001:0");
-		expectedResult.put("/etc/test/", "11000:110000");
-		expectedResult.put("/usr/test/", "300:0");
-		expectedResult.put("/home/test/", "0:0");
-		expectedResult.put("/tmp/test/", "2:3");
-		expectedResult.put("/dev/zero/", "0:0");
+		expectedResult.put("/var/log/test", "3001:0");
+		expectedResult.put("/etc/test", "11000:110000");
+		expectedResult.put("/usr/test", "300:0");
+		expectedResult.put("/home/test", "0:0");
+		expectedResult.put("/tmp/test", "2:3");
+		expectedResult.put("/dev/zero", "0:0");
 		assertEquals(expectedResult, result);
 	}
 
@@ -788,7 +788,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 	private Attribute getOverrideFileQuotasAttribute() {
 		Attribute attribute = new Attribute((new urn_perun_member_resource_attribute_def_def_fileQuotasOverride()).getAttributeDefinition());
 		Map<String, String> value = new LinkedHashMap<>();
-		String path1 = "/var/log/test/";
+		String path1 = "/var/log/test";
 		String value1 = "1:0";
 		String path2 = "/dev/zero";
 		String value2 = "0:0";
@@ -801,7 +801,7 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 	private Attribute getOverrideDataQuotasAttribute() {
 		Attribute attribute = new Attribute((new urn_perun_member_resource_attribute_def_def_dataQuotasOverride()).getAttributeDefinition());
 		Map<String, String> value = new LinkedHashMap<>();
-		String path1 = "/var/log/test/";
+		String path1 = "/var/log/test";
 		String value1 = "1:0";
 		String path2 = "/dev/zero";
 		String value2 = "0:0";
@@ -814,10 +814,10 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 	private Attribute getFileQuotasAttribute() {
 		Attribute attribute = new Attribute((new urn_perun_resource_attribute_def_def_defaultFileQuotas()).getAttributeDefinition());
 		Map<String, String> value = new LinkedHashMap<>();
-		String path1 = "/var/log/test/";
-		String path2 = "/etc/test/";
-		String path3 = "/usr/test/";
-		String path4 = "/home/test/";
+		String path1 = "/var/log/test";
+		String path2 = "/etc/test";
+		String path3 = "/usr/test";
+		String path4 = "/home/test";
 		String value1 = "1000:10000";
 		String value2 = "5000:50000";
 		String value3 = "100:0";
@@ -833,11 +833,11 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 	private Attribute getMaxFileQuotasAttribute() {
 		Attribute attribute = new Attribute((new urn_perun_resource_attribute_def_def_maxUserFileQuotas()).getAttributeDefinition());
 		Map<String, String> value = new LinkedHashMap<>();
-		String path1 = "/var/log/test/";
-		String path2 = "/etc/test/";
-		String path3 = "/usr/test/";
-		String path4 = "/home/test/";
-		String path5 = "/tmp/test/";
+		String path1 = "/var/log/test";
+		String path2 = "/etc/test";
+		String path3 = "/usr/test";
+		String path4 = "/home/test";
+		String path5 = "/tmp/test";
 		String value1 = "2000:11000";
 		String value2 = "6000:60000";
 		String value3 = "200:0";
@@ -855,10 +855,10 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 	private Attribute getDataQuotasAttribute() {
 		Attribute attribute = new Attribute((new urn_perun_resource_attribute_def_def_defaultDataQuotas()).getAttributeDefinition());
 		Map<String, String> value = new LinkedHashMap<>();
-		String path1 = "/var/log/test/";
-		String path2 = "/etc/test/";
-		String path3 = "/usr/test/";
-		String path4 = "/home/test/";
+		String path1 = "/var/log/test";
+		String path2 = "/etc/test";
+		String path3 = "/usr/test";
+		String path4 = "/home/test";
 		String value1 = "1G:10G";
 		String value2 = "5G:50G";
 		String value3 = "100K:0";
@@ -874,11 +874,11 @@ public class ModulesUtilsEntryIntegrationTest extends AbstractPerunIntegrationTe
 	private Attribute getMaxDataQuotasAttribute() {
 		Attribute attribute = new Attribute((new urn_perun_resource_attribute_def_def_maxUserDataQuotas()).getAttributeDefinition());
 		Map<String, String> value = new LinkedHashMap<>();
-		String path1 = "/var/log/test/";
-		String path2 = "/etc/test/";
-		String path3 = "/usr/test/";
-		String path4 = "/home/test/";
-		String path5 = "/tmp/test/";
+		String path1 = "/var/log/test";
+		String path2 = "/etc/test";
+		String path3 = "/usr/test";
+		String path4 = "/home/test";
+		String path5 = "/tmp/test";
 		String value1 = "2G:11G";
 		String value2 = "6G:51G";
 		String value3 = "101K:0";


### PR DESCRIPTION
 - for method checkAndTransferQuotas in ModulesUtils, we are transfering
 input quotas to normalized output. As part of the output is a path
 which is defined as normalized URI path. For such a path the character
 '/' on the end of the path is removed unless it is the only character
 in the path (root directory is valid input).
 - we are changing this behavior because of some file systems (as GPFS)
 which can't work with directories which end on character '/'