### PR TITLE
Separation of checkAttributeSyntax from semantics in Member-Resource …

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -1135,6 +1135,39 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		return convertedRanges;
 	}
 
+	/**
+	 * Returns pair of number (BigDecimal) and unit (String) from given string. Returns default value Pair<0, "G"> if parsing fails.
+	 * E.g.: "5T" -> Pair<5, "T">
+	 *
+	 * @param attributeValue string to parse
+	 * @return pair of number and unit
+	 */
+	public static Pair<BigDecimal, String> getNumberAndUnitFromString(String attributeValue) {
+		String numberString = "0";
+		String unit = "G";
+
+		if (attributeValue != null) {
+			Matcher numberMatcher = numberPattern.matcher(attributeValue);
+			Matcher letterMatcher = letterPattern.matcher(attributeValue);
+			numberMatcher.find();
+			letterMatcher.find();
+			try {
+				numberString = attributeValue.substring(numberMatcher.start(), numberMatcher.end());
+			} catch (IllegalStateException ex) {
+				log.debug("No number could be parsed from given string.", ex);
+			}
+			try {
+				unit = attributeValue.substring(letterMatcher.start(), letterMatcher.end());
+			} catch (IllegalStateException ex) {
+				log.debug("No unit could be parsed from given string.", ex);
+			}
+		}
+
+		BigDecimal number = new BigDecimal(numberString.replace(',', '.'));
+
+		return new Pair<>(number, unit);
+	}
+
 	public PerunBl getPerunBl() {
 		return this.perunBl;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimit.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Pair;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
@@ -13,6 +14,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberResourceMismatchException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.MemberResourceAttributesModuleImplApi;
@@ -33,8 +35,8 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Membe
 	private static final String A_R_defaultDataQuota = AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota";
 	private static final String A_MR_dataQuota = AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuota";
 	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
-	private static final Pattern numberPattern = Pattern.compile("[0-9]+([.,])?[0-9]*");
-	private static final Pattern letterPattern = Pattern.compile("[A-Z]");
+	private static final Pattern testingPattern = Pattern.compile("^[0-9]+([.][0-9]+)?[KMGTPE]$");
+
 	final long K = 1024;
 	final long M = K * 1024;
 	final long G = M * 1024;
@@ -43,15 +45,18 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Membe
 	final long E = P * 1024;
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-		Attribute attrDataQuota;
-		String dataQuota;
-		String dataLimit;
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
 
-		String dataQuotaNumber = null;
-		String dataQuotaLetter = null;
-		String dataLimitNumber = null;
-		String dataLimitLetter = null;
+		Matcher testMatcher = testingPattern.matcher(attribute.valueAsString());
+		if (!testMatcher.find())
+			throw new WrongAttributeValueException(attribute, member, resource, "Format of quota must be something like ex.: 1.30M or 2500K, but it is " + attribute.getValue());
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		Attribute attrDataQuota;
+		String dataQuota = null;
 
 		//Get attrDataQuota attribute
 		try {
@@ -70,29 +75,13 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Membe
 				throw new ConsistencyErrorException("Attribute with defaultDataLimit from resource " + resource.getId() + " could not obtained.", ex);
 			}
 		}
-		if (attribute.getValue() != null) {
-			dataLimit = (String) attribute.getValue();
-			Matcher numberMatcher = numberPattern.matcher(dataLimit);
-			Matcher letterMatcher = letterPattern.matcher(dataLimit);
-			numberMatcher.find();
-			letterMatcher.find();
-			try {
-				dataLimitNumber = dataLimit.substring(numberMatcher.start(), numberMatcher.end());
-			} catch (IllegalStateException ex) {
-				dataLimitNumber = null;
-			}
-			try {
-				dataLimitLetter = dataLimit.substring(letterMatcher.start(), letterMatcher.end());
-			} catch (IllegalStateException ex) {
-				dataLimitLetter = "G";
-			}
-		}
-		BigDecimal limitNumber;
-		if(dataLimitNumber != null) limitNumber = new BigDecimal(dataLimitNumber.replace(',', '.'));
-		else limitNumber = new BigDecimal("0");
+
+		Pair<BigDecimal, String> limitNumberAndLetter = ModulesUtilsBlImpl.getNumberAndUnitFromString(attribute.valueAsString());
+		BigDecimal limitNumber = limitNumberAndLetter.getLeft();
+		String dataLimitLetter = limitNumberAndLetter.getRight();
 
 		if (limitNumber.compareTo(BigDecimal.valueOf(0)) < 0) {
-			throw new WrongAttributeValueException(attribute, resource, member, attribute + " cant be less than 0.");
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, member, attribute + " cant be less than 0.");
 		}
 
 		//Get dataQuota value
@@ -103,26 +92,12 @@ public class urn_perun_member_resource_attribute_def_def_dataLimit extends Membe
 				throw new ConsistencyErrorException("Attribute with defaultDataQuota from resource " + resource.getId() + " could not obtained.", ex);
 			}
 		}
-		if (attrDataQuota != null && attrDataQuota.getValue() != null) {
-			dataQuota = (String) attrDataQuota.getValue();
-			Matcher numberMatcher = numberPattern.matcher(dataQuota);
-			Matcher letterMatcher = letterPattern.matcher(dataQuota);
-			numberMatcher.find();
-			letterMatcher.find();
-			try {
-				dataQuotaNumber = dataQuota.substring(numberMatcher.start(), numberMatcher.end());
-			} catch (IllegalStateException ex) {
-				dataQuotaNumber = null;
-			}
-			try {
-				dataQuotaLetter = dataQuota.substring(letterMatcher.start(), letterMatcher.end());
-			} catch (IllegalStateException ex) {
-				dataQuotaLetter = "G";
-			}
-		}
-		BigDecimal quotaNumber;
-		if(dataQuotaNumber != null) quotaNumber = new BigDecimal(dataQuotaNumber.replace(',', '.'));
-		else quotaNumber = new BigDecimal("0");
+
+		if (attrDataQuota != null) dataQuota = attrDataQuota.valueAsString();
+
+		Pair<BigDecimal, String> quotaNumberAndLetter = ModulesUtilsBlImpl.getNumberAndUnitFromString(dataQuota);
+		BigDecimal quotaNumber = quotaNumberAndLetter.getLeft();
+		String dataQuotaLetter = quotaNumberAndLetter.getRight();
 
 		if (quotaNumber.compareTo(BigDecimal.valueOf(0)) < 0) {
 			throw new WrongReferenceAttributeValueException(attribute, attrDataQuota, resource, member, resource, null,  attrDataQuota + " cant be less than 0.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotas.java
@@ -33,7 +33,14 @@ public class urn_perun_member_resource_attribute_def_def_dataQuotas extends Memb
 	public static final String A_R_maxUserDataQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserDataQuotas";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		if(attribute.getValue() == null) return;
+
+		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, member, true);
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//attribute can be null, it means there are no default settings on resource
 		if(attribute.getValue() == null) {
 			return;
@@ -41,7 +48,12 @@ public class urn_perun_member_resource_attribute_def_def_dataQuotas extends Memb
 
 		//Check if every part of this map has the right pattern
 		//And also check if every quota part has right settings (softQuota<=hardQuota)
-		Map<String, Pair<BigDecimal, BigDecimal>> dataQuotasForMemberOnResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, member, true);
+		Map<String, Pair<BigDecimal, BigDecimal>> dataQuotasForMemberOnResource;
+		try {
+			dataQuotasForMemberOnResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, member, true);
+		} catch (WrongAttributeValueException e) {
+			throw new ConsistencyErrorException("Quotas on " + resource + " for member " + member + " are in bad format.", e);
+		}
 
 		//If there are no values after converting quota, we can skip testing against maxUserDataQuota attribute, because there is nothing to check
 		if (dataQuotasForMemberOnResource == null || dataQuotasForMemberOnResource.isEmpty()) return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotasOverride.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotasOverride.java
@@ -22,7 +22,7 @@ import java.util.LinkedHashMap;
 public class urn_perun_member_resource_attribute_def_def_dataQuotasOverride extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//attribute can be null, it means there are no default settings on resource
 		if(attribute.getValue() == null) {
 			return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotasOverride.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_fileQuotasOverride.java
@@ -22,7 +22,7 @@ import java.util.LinkedHashMap;
 public class urn_perun_member_resource_attribute_def_def_fileQuotasOverride extends MemberResourceAttributesModuleAbstract implements MemberResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//attribute can be null, it means there are no default settings on resource
 		if(attribute.getValue() == null) {
 			return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimit.java
@@ -32,7 +32,13 @@ public class urn_perun_member_resource_attribute_def_def_filesLimit extends Memb
 	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		Integer filesLimit = attribute.valueAsInteger();
+		if (filesLimit != null && filesLimit < 0) throw new WrongAttributeValueException(attribute, resource, member, attribute + " cannot be less than 0.");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrFilesQuota;
 		Integer filesQuota = null;
 		Integer filesLimit = null;
@@ -48,7 +54,7 @@ public class urn_perun_member_resource_attribute_def_def_filesLimit extends Memb
 
 		//Get FilesLimit value
 		if(attribute.getValue() != null) {
-			filesLimit = (Integer) attribute.getValue();
+			filesLimit = attribute.valueAsInteger();
 		} else {
 			try {
 				attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, A_R_defaultFilesLimit);
@@ -56,14 +62,14 @@ public class urn_perun_member_resource_attribute_def_def_filesLimit extends Memb
 				throw new ConsistencyErrorException("Attribute with defaultFilesLimit from resource " + resource.getId() + " could not obtained.", ex);
 			}
 			if(attribute != null && attribute.getValue() != null) {
-				filesLimit = (Integer) attribute.getValue();
+				filesLimit = attribute.valueAsInteger();
+				if (filesLimit < 0) throw new WrongReferenceAttributeValueException(attribute, null, resource, member, attribute + " cannot be less than 0.");
 			}
 		}
-		if(filesLimit != null && filesLimit < 0) throw new WrongAttributeValueException(attribute, resource, member, attribute + " cannot be less than 0.");
 
 		//Get FilesQuota value
 		if(attrFilesQuota != null &&  attrFilesQuota.getValue() != null) {
-			filesQuota = (Integer) attrFilesQuota.getValue();
+			filesQuota = attrFilesQuota.valueAsInteger();
 		} else {
 			try {
 				attrFilesQuota = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, A_R_defaultFilesQuota);
@@ -71,7 +77,7 @@ public class urn_perun_member_resource_attribute_def_def_filesLimit extends Memb
 				throw new ConsistencyErrorException("Attribute with defaultFilesQuota from resource " + resource.getId() + " could not obtained.", ex);
 			}
 			if(attrFilesQuota != null && attrFilesQuota.getValue() != null) {
-				filesQuota = (Integer) attrFilesQuota.getValue();
+				filesQuota = attrFilesQuota.valueAsInteger();
 			}
 		}
 		if(filesQuota != null && filesQuota < 0) throw new ConsistencyErrorException(attrFilesQuota + " cannot be less than 0.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuota.java
@@ -32,7 +32,13 @@ public class urn_perun_member_resource_attribute_def_def_filesQuota extends Memb
 	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		Integer filesQuota = attribute.valueAsInteger();
+		if(filesQuota != null && filesQuota < 0) throw new WrongAttributeValueException(attribute, resource, member, attribute + " cannot be less than 0.");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrFilesLimit;
 		Integer filesQuota = null;
 		Integer filesLimit = null;
@@ -48,7 +54,7 @@ public class urn_perun_member_resource_attribute_def_def_filesQuota extends Memb
 
 		//Get FilesQuota value
 		if(attribute.getValue() != null) {
-			filesQuota = (Integer) attribute.getValue();
+			filesQuota = attribute.valueAsInteger();
 		} else {
 			try {
 				attribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, A_R_defaultFilesQuota);
@@ -56,14 +62,14 @@ public class urn_perun_member_resource_attribute_def_def_filesQuota extends Memb
 				throw new ConsistencyErrorException("Attribute with defaultFilesQuota from resource " + resource.getId() + " could not obtained.", ex);
 			}
 			if(attribute != null && attribute.getValue() != null) {
-				filesQuota = (Integer) attribute.getValue();
+				filesQuota = attribute.valueAsInteger();
+				if(filesQuota < 0) throw new WrongReferenceAttributeValueException(attribute, null, resource, member, attribute + " cannot be less than 0.");
 			}
 		}
-		if(filesQuota != null && filesQuota < 0) throw new WrongAttributeValueException(attribute, resource, member, attribute + " cannot be less than 0.");
 
 		//Get FilesLimit value
 		if(attrFilesLimit != null &&  attrFilesLimit.getValue() != null) {
-			filesLimit = (Integer) attrFilesLimit.getValue();
+			filesLimit = attrFilesLimit.valueAsInteger();
 		} else {
 			try {
 				attrFilesLimit = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, resource, A_R_defaultFilesLimit);
@@ -71,7 +77,7 @@ public class urn_perun_member_resource_attribute_def_def_filesQuota extends Memb
 				throw new ConsistencyErrorException("Attribute with defaultFilesLimit from resource " + resource.getId() + " could not obtained.", ex);
 			}
 			if(attrFilesLimit != null && attrFilesLimit.getValue() != null) {
-				filesLimit = (Integer) attrFilesLimit.getValue();
+				filesLimit = attrFilesLimit.valueAsInteger();
 			}
 		}
 		if(filesLimit != null && filesLimit < 0) throw new ConsistencyErrorException(attrFilesLimit + " cannot be less than 0.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_groupStatus.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_groupStatus.java
@@ -30,9 +30,9 @@ public class urn_perun_member_resource_attribute_def_virt_groupStatus extends Me
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_member_resource_attribute_def_virt_groupStatus.class);
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws WrongAttributeValueException {
 
-		String status = (String) attribute.getValue();
+		String status = attribute.valueAsString();
 
 		if (status == null) return; // NULL is ok
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleAbstract.java
@@ -25,7 +25,7 @@ public abstract class MemberResourceAttributesModuleAbstract extends AttributesM
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/MemberResourceAttributesModuleImplApi.java
@@ -42,12 +42,11 @@ public interface MemberResourceAttributesModuleImplApi extends AttributesModuleI
 	 *
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongReferenceAttributeValueException if an referenced attribute against
 	 *         the parameter is to be compared is not available
 	 * @throws WrongAttributeAssignmentException
 	 */
-	void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributeSemantics(PerunSessionImpl perunSession, Member member, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 
 	/**
 	 * This method MAY fill Member's attributes at a specified resource.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimitTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataLimitTest.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_member_resource_attribute_def_def_dataLimitTest {
+
+	private urn_perun_member_resource_attribute_def_def_dataLimit classInstance;
+	private Attribute attributeToCheck;
+	private Member member = new Member();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_member_resource_attribute_def_def_dataLimit();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		reqAttribute = new Attribute();
+
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataQuota")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWrongValue() throws Exception {
+		System.out.println("testSyntaxWrongValue()");
+		attributeToCheck.setValue("-22F");
+
+		classInstance.checkAttributeSyntax(sess, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxWrongValue()");
+		attributeToCheck.setValue("22M");
+
+		classInstance.checkAttributeSyntax(sess, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsQuotaHigherThanLimit() throws Exception {
+		System.out.println("testSemanticsQuotaHigherThanLimit()");
+		attributeToCheck.setValue("22M");
+		reqAttribute.setValue("10T");
+
+		classInstance.checkAttributeSemantics(sess, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsUnlimitedQuotaWithLimit() throws Exception {
+		System.out.println("testSemanticsQuotaHigherThanLimit()");
+		attributeToCheck.setValue("22M");
+		reqAttribute.setValue("0");
+
+		classInstance.checkAttributeSemantics(sess, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("22T");
+		reqAttribute.setValue("10M");
+
+		classInstance.checkAttributeSemantics(sess, member, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotaTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_dataQuotaTest.java
@@ -1,0 +1,78 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_member_resource_attribute_def_def_dataQuotaTest {
+
+	private urn_perun_member_resource_attribute_def_def_dataQuota classInstance;
+	private Attribute attributeToCheck;
+	private Member member = new Member();
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_member_resource_attribute_def_def_dataQuota();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		reqAttribute = new Attribute();
+
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, member, resource, AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":dataLimit")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWrongValue() throws Exception {
+		System.out.println("testSyntaxWrongValue()");
+		attributeToCheck.setValue("-22F");
+
+		classInstance.checkAttributeSyntax(sess, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxWrongValue()");
+		attributeToCheck.setValue("22M");
+
+		classInstance.checkAttributeSyntax(sess, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsQuotaHigherThanLimit() throws Exception {
+		System.out.println("testSemanticsQuotaHigherThanLimit()");
+		attributeToCheck.setValue("22T");
+		reqAttribute.setValue("10M");
+
+		classInstance.checkAttributeSemantics(sess, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsUnlimitedQuotaWithLimit() throws Exception {
+		System.out.println("testSemanticsQuotaHigherThanLimit()");
+		attributeToCheck.setValue("0");
+		reqAttribute.setValue("10M");
+
+		classInstance.checkAttributeSemantics(sess, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("22M");
+		reqAttribute.setValue("10T");
+
+		classInstance.checkAttributeSemantics(sess, member, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimitTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesLimitTest.java
@@ -1,0 +1,90 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.*;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class urn_perun_member_resource_attribute_def_def_filesLimitTest {
+
+	private static urn_perun_member_resource_attribute_def_def_filesLimit classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Member member;
+	private static Resource resource;
+	private static Attribute reqAttribute;
+	private static Attribute reqAttribute2;
+
+	@Before
+	public void SetUp() throws Exception {
+		classInstance = new urn_perun_member_resource_attribute_def_def_filesLimit();
+		attributeToCheck = new Attribute();
+		member = new Member();
+		resource = new Resource();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		reqAttribute = new Attribute();
+		reqAttribute2 = new Attribute();
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, member, resource, AttributesManager.NS_MEMBER_RESOURCE_ATTR_DEF + ":filesQuota")).thenReturn(reqAttribute2);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesLimit")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeNegativeValue() throws Exception {
+		System.out.println("testCheckAttributeNegativeValue()");
+		attributeToCheck.setValue(-1);
+
+		classInstance.checkAttributeSyntax(session, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeValueCorrectSyntax() throws Exception {
+		System.out.println("testCheckAttributeValueCorrectSyntax()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(session, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeNullValueWithNegativeDefaultValue() throws Exception {
+		System.out.println("testCheckAttributeNullValueWithNegativeDefaultValue()");
+		attributeToCheck.setValue(null);
+		reqAttribute.setValue(-1);
+
+		classInstance.checkAttributeSemantics(session, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeValueWithNullQuotaButPositiveLimit() throws Exception {
+		System.out.println("testCheckAttributeValueWithNullQuotaButPositiveLimit()");
+		attributeToCheck.setValue(5);
+		reqAttribute.setValue(1);
+		reqAttribute2.setValue(null);
+
+		classInstance.checkAttributeSemantics(session, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeValueWithQuotaHigherThanLimit() throws Exception {
+		System.out.println("testCheckAttributeValueWithQuotaHigherThanLimit()");
+		attributeToCheck.setValue(1);
+		reqAttribute.setValue(1);
+		reqAttribute2.setValue(3);
+
+		classInstance.checkAttributeSemantics(session, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeValueCorrectSemantics() throws Exception {
+		System.out.println("testCheckAttributeValueCorrectSemantics()");
+		attributeToCheck.setValue(5);
+		reqAttribute.setValue(1);
+		reqAttribute2.setValue(3);
+
+		classInstance.checkAttributeSemantics(session, member, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuotaTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_def_filesQuotaTest.java
@@ -1,0 +1,94 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_member_resource_attribute_def_def_filesQuotaTest {
+
+	private static urn_perun_member_resource_attribute_def_def_filesQuota classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Member member;
+	private static Resource resource;
+	private static Attribute reqAttribute;
+	private static Attribute reqAttribute2;
+
+	@Before
+	public void SetUp() throws Exception {
+		classInstance = new urn_perun_member_resource_attribute_def_def_filesQuota();
+		attributeToCheck = new Attribute();
+		member = new Member();
+		resource = new Resource();
+		session = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		reqAttribute = new Attribute();
+		reqAttribute2 = new Attribute();
+
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesQuota")).thenReturn(reqAttribute);
+		when(session.getPerunBl().getAttributesManagerBl().getAttribute(session, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesLimit")).thenReturn(reqAttribute2);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeNegativeValue() throws Exception {
+		System.out.println("testCheckAttributeNegativeValue()");
+		attributeToCheck.setValue(-1);
+
+		classInstance.checkAttributeSyntax(session, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeValueCorrectSyntax() throws Exception {
+		System.out.println("testCheckAttributeValueCorrectSyntax()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(session, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeNullValueWithNegativeDefaultValue() throws Exception {
+		System.out.println("testCheckAttributeNullValueWithNegativeDefaultValue()");
+		attributeToCheck.setValue(null);
+		reqAttribute.setValue(-1);
+
+		classInstance.checkAttributeSemantics(session, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeValueWithNullQuotaButPositiveLimit() throws Exception {
+		System.out.println("testCheckAttributeValueWithNullQuotaButPositiveLimit()");
+		attributeToCheck.setValue(null);
+		reqAttribute.setValue(5);
+		reqAttribute2.setValue(1);
+
+		classInstance.checkAttributeSemantics(session, member, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeValueWithQuotaHigherThanLimit() throws Exception {
+		System.out.println("testCheckAttributeValueWithQuotaHigherThanLimit()");
+		attributeToCheck.setValue(3);
+		reqAttribute.setValue(3);
+		reqAttribute2.setValue(1);
+
+		classInstance.checkAttributeSemantics(session, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeValueCorrectSemantics() throws Exception {
+		System.out.println("testCheckAttributeValueCorrectSemantics()");
+		attributeToCheck.setValue(3);
+		reqAttribute.setValue(1);
+		reqAttribute2.setValue(5);
+
+		classInstance.checkAttributeSemantics(session, member, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_groupStatusTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_member_resource_attribute_def_virt_groupStatusTest.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class urn_perun_member_resource_attribute_def_virt_groupStatusTest {
+
+	private static urn_perun_member_resource_attribute_def_virt_groupStatus classInstance;
+	private static PerunSessionImpl session;
+	private static Attribute attributeToCheck;
+	private static Member member;
+	private static Resource resource;
+
+	@Before
+	public void SetUp() throws Exception {
+		classInstance = new urn_perun_member_resource_attribute_def_virt_groupStatus();
+		attributeToCheck = new Attribute();
+		member = new Member();
+		resource = new Resource();
+		session = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testCheckAttributeSyntaxWithWrongValue() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValue()");
+		attributeToCheck.setValue("wrong_value");
+
+		classInstance.checkAttributeSyntax(session, member, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeValueCorrectSyntax() throws Exception {
+		System.out.println("testCheckAttributeValueCorrectSyntax()");
+
+		attributeToCheck.setValue("VALID");
+		classInstance.checkAttributeSyntax(session, member, resource, attributeToCheck);
+
+		attributeToCheck.setValue("EXPIRED");
+		classInstance.checkAttributeSyntax(session, member, resource, attributeToCheck);
+	}
+}


### PR DESCRIPTION
…modules

- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in member-resource attribute modules
- also added test for checks