### PR TITLE
Separation of checkAttributeSyntax from semantics in Resource modules

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -2652,11 +2652,10 @@ public interface AttributesManagerBl {
 	 * @param attribute attribute to check
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongAttributeAssignmentException if attribute isn't resource attribute
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void checkAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void checkAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
 	 *  Batch version of checkAttributeSemantics
@@ -3210,6 +3209,18 @@ public interface AttributesManagerBl {
 	void forceCheckAttributeSemantics(PerunSession sess, Group group, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 	/**
+	 * Check if value of this resource attribute has valid syntax no matter if attribute is required or not.
+	 *
+	 * @param sess perun session
+	 * @param resource resource for which you want to check validity of attribute
+	 * @param attribute attribute to check
+	 *
+	 * @throws WrongAttributeAssignmentException if attribute isn't resource attribute
+	 * @throws WrongAttributeValueException if the attribute value has wrong/illegal syntax
+	 */
+	void forceCheckAttributeSyntax(PerunSession sess, Resource resource, Attribute attribute) throws WrongAttributeAssignmentException, WrongAttributeValueException;
+
+	/**
 	 * Check if value of this resource attribute has valid semantics no matter if attribute is required or not.
 	 *
 	 * @param sess perun session
@@ -3217,11 +3228,10 @@ public interface AttributesManagerBl {
 	 * @param attribute attribute to check
 	 *
 	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongAttributeAssignmentException if attribute isn't resource attribute
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void forceCheckAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
+	void forceCheckAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException;
 
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -3465,7 +3465,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, NS_RESOURCE_ATTR);
 
 		if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, resource, attribute)) return;
@@ -4156,7 +4156,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	}
 
 	@Override
-	public void forceCheckAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void forceCheckAttributeSyntax(PerunSession sess, Resource resource, Attribute attribute) throws WrongAttributeValueException, WrongAttributeAssignmentException {
+		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_RESOURCE_ATTR);
+
+		getAttributesManagerImpl().checkAttributeSyntax(sess, resource, attribute);
+	}
+
+	@Override
+	public void forceCheckAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		getAttributesManagerImpl().checkNamespace(sess, attribute, AttributesManager.NS_RESOURCE_ATTR);
 
 		getAttributesManagerImpl().checkAttributeSemantics(sess, resource, attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -1135,6 +1135,39 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		return convertedRanges;
 	}
 
+	/**
+	 * Returns pair of number (BigDecimal) and unit (String) from given string. Returns default value Pair<0, "G"> if parsing fails.
+	 * E.g.: "5T" -> Pair<5, "T">
+	 *
+	 * @param attributeValue string to parse
+	 * @return pair of number and unit
+	 */
+	public static Pair<BigDecimal, String> getNumberAndUnitFromString(String attributeValue) {
+		String numberString = "0";
+		String unit = "G";
+
+		if (attributeValue != null) {
+			Matcher numberMatcher = numberPattern.matcher(attributeValue);
+			Matcher letterMatcher = letterPattern.matcher(attributeValue);
+			numberMatcher.find();
+			letterMatcher.find();
+			try {
+				numberString = attributeValue.substring(numberMatcher.start(), numberMatcher.end());
+			} catch (IllegalStateException ex) {
+				log.debug("No number could be parsed from given string.", ex);
+			}
+			try {
+				unit = attributeValue.substring(letterMatcher.start(), letterMatcher.end());
+			} catch (IllegalStateException ex) {
+				log.debug("No unit could be parsed from given string.", ex);
+			}
+		}
+
+		BigDecimal number = new BigDecimal(numberString.replace(',', '.'));
+
+		return new Pair<>(number, unit);
+	}
+
 	public PerunBl getPerunBl() {
 		return this.perunBl;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -3888,7 +3888,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException {
 		ResourceAttributesModuleImplApi attributeModule = getResourceAttributeModule(sess, attribute);
 		if (attributeModule == null) return;
 		try {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_accountExpirationTime.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_accountExpirationTime.java
@@ -37,24 +37,28 @@ public class urn_perun_resource_attribute_def_def_accountExpirationTime extends 
 	}
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-		Integer accExpTime = (Integer) attribute.getValue();
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		Integer accExpTime = attribute.valueAsInteger();
 		if(accExpTime == null) {
-			throw new WrongAttributeValueException("Attribute value shouldnt be null");
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute value shouldn't be null");
 		}
 		Facility fac = perunSession.getPerunBl().getResourcesManagerBl().getFacility(perunSession, resource);
-		Integer facilityAccExpTime;
+
+		Attribute facilityAccExpTimeAttribute;
 		try {
 			//FIXME this can't work (different namespace!!)
-			facilityAccExpTime = (Integer) perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, fac, A_F_accountExpirationTime).getValue();
+			facilityAccExpTimeAttribute = perunSession.getPerunBl().getAttributesManagerBl().getAttribute(perunSession, fac, A_F_accountExpirationTime);
+
 		} catch (AttributeNotExistsException ex) {
 			throw new InternalErrorException(ex);
 		}
+
+		Integer facilityAccExpTime = facilityAccExpTimeAttribute.valueAsInteger();
 		if(facilityAccExpTime == null) {
-			throw new WrongReferenceAttributeValueException("cant determine attribute value on underlying facility");
+			throw new WrongReferenceAttributeValueException(attribute, facilityAccExpTimeAttribute, resource, null, fac, null, "cant determine attribute value on underlying facility");
 		}
 		if(facilityAccExpTime < accExpTime) {
-			throw new WrongAttributeValueException("value can be higher than same facility attribute");
+			throw new WrongReferenceAttributeValueException(attribute, facilityAccExpTimeAttribute, resource, null, fac, null, "value can be higher than same facility attribute");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFile.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFile.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -23,17 +24,21 @@ public class urn_perun_resource_attribute_def_def_apacheAuthzFile extends Resour
 	private static final Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9.?*+$%]+)+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		if (attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, resource, null, "Attribute value can not be null.");
-		}
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
 
 		//checks for valid unix file path in attribute based on pattern
-		Matcher match = pattern.matcher((String) attribute.getValue());
+		Matcher match = pattern.matcher(attribute.valueAsString());
 
 		if(!match.matches()) {
 			throw new WrongAttributeValueException(attribute, resource, null, "Wrong file path format in attribute (should be like '/dir1/dir2').");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null)
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute value can not be null.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuotas.java
@@ -32,7 +32,14 @@ public class urn_perun_resource_attribute_def_def_defaultDataQuotas extends Reso
 	public static final String A_R_maxUserDataQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserDataQuotas";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
+
+		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, true);
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//attribute can be null, it means there are no default settings on resource
 		if (attribute.getValue() == null) {
 			return;
@@ -40,7 +47,12 @@ public class urn_perun_resource_attribute_def_def_defaultDataQuotas extends Reso
 
 		//Check if every part of this map has the right pattern
 		//And also check if every quota part has right settings (softQuota<=hardQuota)
-		Map<String, Pair<BigDecimal, BigDecimal>> defaultDataQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, true);
+		Map<String, Pair<BigDecimal, BigDecimal>> defaultDataQuotasForResource;
+		try {
+			defaultDataQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, true);
+		} catch (WrongAttributeValueException e) {
+			throw new ConsistencyErrorException("Final counted quotas on " + resource + " are in bad format.", e);
+		}
 
 		//If there are no values after converting quota, we can skip testing against maxUserDataQuota attribute, because there is nothing to check
 		if (defaultDataQuotasForResource == null || defaultDataQuotasForResource.isEmpty()) return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFileQuotas.java
@@ -32,7 +32,14 @@ public class urn_perun_resource_attribute_def_def_defaultFileQuotas extends Reso
 	public static final String A_R_maxUserFileQuotas = AttributesManager.NS_RESOURCE_ATTR_DEF + ":maxUserFileQuotas";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
+
+		perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, false);
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		//attribute can be null, it means there are no default settings on resource
 		if(attribute.getValue() == null) {
 			return;
@@ -40,7 +47,12 @@ public class urn_perun_resource_attribute_def_def_defaultFileQuotas extends Reso
 
 		//Check if every part of this map has the right pattern
 		//And also check if every quota part has right settings (softQuota<=hardQuota)
-		Map<String, Pair<BigDecimal, BigDecimal>> defaultFileQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, false);
+		Map<String, Pair<BigDecimal, BigDecimal>> defaultFileQuotasForResource;
+		try {
+			defaultFileQuotasForResource = perunSession.getPerunBl().getModulesUtilsBl().checkAndTransferQuotas(attribute, resource, null, false);
+		} catch (WrongAttributeValueException e) {
+			throw new ConsistencyErrorException("Final counted quotas on " + resource + " are in bad format.", e);
+		}
 
 		//If there are no values after converting quota, we can skip testing against maxUserFileQuota attribute, because there is nothing to check
 		if (defaultFileQuotasForResource == null || defaultFileQuotasForResource.isEmpty()) return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesLimit.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesLimit.java
@@ -28,7 +28,17 @@ public class urn_perun_resource_attribute_def_def_defaultFilesLimit extends Reso
 	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		//null value is ok
+		if(attribute.getValue() == null) {
+			return;
+		}
+
+		if (attribute.valueAsInteger() < 0) throw new WrongAttributeValueException(attribute, resource, attribute + " cannot be less than 0.");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrDefaultFilesQuota;
 		Integer defaultFilesQuota = null;
 		Integer defaultFilesLimit = null;
@@ -42,13 +52,12 @@ public class urn_perun_resource_attribute_def_def_defaultFilesLimit extends Reso
 
 		//get defaultFilesLimit value
 		if(attribute.getValue() != null) {
-			defaultFilesLimit = (Integer) attribute.getValue();
+			defaultFilesLimit = attribute.valueAsInteger();
 		}
-		if(defaultFilesLimit != null && defaultFilesLimit < 0) throw new WrongAttributeValueException(attribute, resource, attribute + " cannot be less than 0.");
 
 		//get defaultFilesQuota value
 		if(attrDefaultFilesQuota != null &&  attrDefaultFilesQuota.getValue() != null) {
-			defaultFilesQuota = (Integer) attrDefaultFilesQuota.getValue();
+			defaultFilesQuota = attrDefaultFilesQuota.valueAsInteger();
 		}
 		if(defaultFilesQuota != null && defaultFilesQuota < 0) throw new ConsistencyErrorException(attrDefaultFilesQuota + " cannot be less than 0.");
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesQuota.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesQuota.java
@@ -28,7 +28,17 @@ public class urn_perun_resource_attribute_def_def_defaultFilesQuota extends Reso
 	private static final String A_F_readyForNewQuotas = AttributesManager.NS_FACILITY_ATTR_DEF + ":readyForNewQuotas";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		//null value is ok
+		if(attribute.getValue() == null) {
+			return;
+		}
+
+		if (attribute.valueAsInteger() < 0) throw new WrongAttributeValueException(attribute, resource, attribute + " cannot be less than 0.");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		Attribute attrDefaultFilesLimit;
 		Integer defaultFilesQuota = null;
 		Integer defaultFilesLimit = null;
@@ -42,13 +52,12 @@ public class urn_perun_resource_attribute_def_def_defaultFilesQuota extends Reso
 
 		//Get defaultFilesQuota value
 		if(attribute.getValue() != null) {
-			defaultFilesQuota = (Integer) attribute.getValue();
+			defaultFilesQuota = attribute.valueAsInteger();
 		}
-		if(defaultFilesQuota != null && defaultFilesQuota < 0) throw new WrongAttributeValueException(attribute, resource, attribute + " cannot be less than 0.");
 
 		//Get defaultFilesLimit value
 		if(attrDefaultFilesLimit != null &&  attrDefaultFilesLimit.getValue() != null) {
-			defaultFilesLimit = (Integer) attrDefaultFilesLimit.getValue();
+			defaultFilesLimit = attrDefaultFilesLimit.valueAsInteger();
 		}
 		if(defaultFilesLimit != null && defaultFilesLimit < 0) throw new ConsistencyErrorException(attrDefaultFilesLimit + " cannot be less than 0.");
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultShell.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultShell.java
@@ -59,9 +59,9 @@ public class urn_perun_resource_attribute_def_def_defaultShell extends ResourceA
 	 * new default shell must be included at specified resource.
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 		if (attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, "Attribute value is null.");
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute value is null.");
 		}
 
 		Attribute resourceAttr;
@@ -72,15 +72,12 @@ public class urn_perun_resource_attribute_def_def_defaultShell extends ResourceA
 		}
 
 		if (resourceAttr.getValue() == null) {
-			throw new WrongReferenceAttributeValueException(resourceAttr);
-		} else {
-			List<String> shells = (List<String>) resourceAttr.getValue();
-			if (shells.isEmpty()) {
-				throw new WrongAttributeValueException(resourceAttr);
-			}
-			if (!shells.contains(attribute.valueAsString())) {
-				throw new WrongAttributeValueException("Shell " + attribute.getValue() + " is not at specified resource (" + resource + ")");
-			}
+			throw new WrongReferenceAttributeValueException(resourceAttr, null, resource, null, "Attribute with list of shells from resource has null value.");
+		}
+		List<String> shells = resourceAttr.valueAsList();
+
+		if (!shells.contains(attribute.valueAsString())) {
+			throw new WrongReferenceAttributeValueException(attribute, resourceAttr, resource, null, resource, null, "Shell " + attribute.getValue() + " is not at specified resource (" + resource + ")");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupCode.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupCode.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -17,11 +18,16 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_k4GroupCode extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
 
-		if (attribute.getValue() == null) throw new WrongAttributeValueException("Code of Group in K4 can't be empty.");
-		if (((String)attribute.getValue()).length() > 20) throw new WrongAttributeValueException("Code of Group in K4 musn`t exceed 20 characters.");
+		if (attribute.getValue() == null) return;
+		if ((attribute.valueAsString()).length() > 20) throw new WrongAttributeValueException("Code of Group in K4 mustn't exceed 20 characters.");
 
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Code of Group in K4 can't be empty.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupName.java
@@ -17,10 +17,10 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_k4GroupName extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
 
 		if (attribute.getValue() != null &&
-				((String)attribute.getValue()).length() > 40) throw new WrongAttributeValueException("Name of Group in K4 musn`t exceed 40 characters.");
+				(attribute.valueAsString()).length() > 40) throw new WrongAttributeValueException("Name of Group in K4 mustn't exceed 40 characters.");
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupPriority.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupPriority.java
@@ -4,7 +4,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -17,9 +17,9 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_k4GroupPriority extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
 
-		if (attribute.getValue() == null) throw new WrongAttributeValueException("Priority of Group in K4 can't be empty.");
+		if (attribute.getValue() == null) throw new WrongReferenceAttributeValueException("Priority of Group in K4 can't be empty.");
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k5loginTargetUser.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k5loginTargetUser.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -22,15 +23,20 @@ public class urn_perun_resource_attribute_def_def_k5loginTargetUser extends Reso
 	private static final Pattern userPattern = Pattern.compile("^[-a-zA-Z0-9_]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		if (attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, resource, null, "Attribute value can't be null.");
-		}
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
 
-		String targetUser = (String) attribute.getValue();
+		String targetUser = attribute.valueAsString();
 		Matcher userMatcher = userPattern.matcher(targetUser);
 		if(!userMatcher.matches()) {
 			throw new WrongAttributeValueException(attribute, resource, null, "Matcher must match to ^[-a-zA-Z0-9_]+$ pattern.");
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute value can't be null.");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailaliasesTargetUser.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailaliasesTargetUser.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -22,15 +23,20 @@ public class urn_perun_resource_attribute_def_def_mailaliasesTargetUser extends 
 	private static final Pattern userPattern = Pattern.compile("^[-a-zA-Z0-9_]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		if (attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, resource, null, "Attribute value can't be null.");
-		}
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
 
-		String targetUser = (String) attribute.getValue();
+		String targetUser = attribute.valueAsString();
 		Matcher userMatcher = userPattern.matcher(targetUser);
 		if(!userMatcher.matches()) {
 			throw new WrongAttributeValueException(attribute, resource, null, "Matcher must match to ^[-a-zA-Z0-9_]+$ pattern.");
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute value can't be null.");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailingListManagerEmail.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailingListManagerEmail.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -16,14 +17,17 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_mailingListManagerEmail extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		if (attribute.getValue() == null) return;
+
+		perunSession.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(perunSession, attribute.valueAsString());
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
 		if (attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, resource, "Attribute value is null.");
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute value is null.");
 		}
-
-		perunSession.getPerunBl().getModulesUtilsBl().isNameOfEmailValid(perunSession, (String)attribute.getValue());
-
-
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserDataQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserDataQuotas.java
@@ -22,7 +22,7 @@ import java.util.LinkedHashMap;
 public class urn_perun_resource_attribute_def_def_maxUserDataQuotas extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//attribute can be null, it means there are no max user settings on resource
 		if(attribute.getValue() == null) {
 			return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserFileQuotas.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_maxUserFileQuotas.java
@@ -22,7 +22,7 @@ import java.util.LinkedHashMap;
 public class urn_perun_resource_attribute_def_def_maxUserFileQuotas extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		//attribute can be null, it means there are no max user settings on resource
 		if(attribute.getValue() == null) {
 			return;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_openNebulaGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_openNebulaGroupName.java
@@ -5,7 +5,7 @@ import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -19,11 +19,9 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_openNebulaGroupName extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		String groupName = (String)attribute.getValue();
-
-		if (groupName == null) {
-			throw new WrongAttributeValueException(attribute, resource, "Attribute value is invalid. Group name can't be empty.");
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.valueAsString() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute value is invalid. Group name can't be empty.");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_projectsBasePath.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_projectsBasePath.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -23,17 +24,21 @@ public class urn_perun_resource_attribute_def_def_projectsBasePath extends Resou
 	private static final Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		String path = (String) attribute.getValue();
-		if (path == null) {
-			throw new WrongAttributeValueException(attribute, resource, "Attribute can't be empty.");
-		}
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		String path = attribute.valueAsString();
+		if (path == null) return;
 
 		Matcher match = pattern.matcher(path);
 
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, resource, "Bad format of attribute projectsBasePath (expected something like '/first/second').");
 		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null)
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute can't be empty.");
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_redmineProjectID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_redmineProjectID.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -23,16 +24,21 @@ public class urn_perun_resource_attribute_def_def_redmineProjectID extends Resou
 	private static final Pattern pattern = Pattern.compile("^[a-z][-_a-z0-9]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		String id = (String) attribute.getValue();
-		if (id == null) {
-			throw new WrongAttributeValueException(attribute, resource, "Attribute can't be empty. It can start with a-z and then a-z, 0-9, _ or -");
-		}
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		String id = attribute.valueAsString();
+		if (id == null) return;
 
 		Matcher match = pattern.matcher(id);
 
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, resource, "Bad format of attribute redmineProjectID. It can start with a-z and then a-z, 0-9, _ or -");
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute can't be empty. It can start with a-z and then a-z, 0-9, _ or -");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_redmineRole.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_redmineRole.java
@@ -6,6 +6,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -19,17 +20,21 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_redmineRole extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		String role = (String)attribute.getValue();
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		String role = attribute.valueAsString();
 
-		if (role == null) {
+		if (role == null) return;
+
+		if (!role.equals("Manager") && !role.equals("Reporter") && !role.equals("Developer")) {
 			throw new WrongAttributeValueException(attribute, resource, "Attribute value is invalid. The role can be either Manager, Reporter or Developer");
 		}
-		else if (!role.equals("Manager") && !role.equals("Reporter") && !role.equals("Developer")) {
-			throw new WrongAttributeValueException(attribute, resource, "Attribute value is invalid. The role can be either Manager, Reporter or Developer");
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute value is invalid. The role can be either Manager, Reporter or Developer");
 		}
-
-
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestination.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestination.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -15,15 +16,19 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 public class urn_perun_resource_attribute_def_def_replicaDestination extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		if(attribute.getValue() == null) return;
 
-		if(attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, resource, "Destination for FS replica can't be empty.");
-		}
-
-		if (!perunSession.getPerunBl().getModulesUtilsBl().isFQDNValid(perunSession, (String) attribute.getValue())) {
+		if (!perunSession.getPerunBl().getModulesUtilsBl().isFQDNValid(perunSession, attribute.valueAsString())) {
 			throw new WrongAttributeValueException(attribute, resource, "Bad replicaDestination attribute format " + attribute.getValue() + ". It should be " +
 					"fully qualified domain name.");
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Destination for FS replica can't be empty.");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPath.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPath.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -20,15 +21,19 @@ public class urn_perun_resource_attribute_def_def_replicaDestinationPath extends
 	private static final Pattern pattern = Pattern.compile("^/[-a-zA-Z.0-9_/]*$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		if(attribute.getValue() == null) return;
 
-		if(attribute.getValue() == null) {
-			throw new WrongAttributeValueException(attribute, resource, "Destination path for FS replica can't be empty");
-		}
-
-		Matcher match = pattern.matcher((String) attribute.getValue());
+		Matcher match = pattern.matcher(attribute.valueAsString());
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, resource, "Bad replicaDestinationPath attribute format " + attribute.getValue());
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Destination path for FS replica can't be empty");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_shells.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_shells.java
@@ -47,21 +47,26 @@ public class urn_perun_resource_attribute_def_def_shells extends ResourceAttribu
 		return atr;
 	}
 
+	@Override
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+		List<String> shells = attribute.valueAsList();
+
+		if (shells == null) return;
+
+		for (String st : shells) {
+			perunSession.getPerunBl().getModulesUtilsBl().checkFormatOfShell(st, attribute);
+		}
+	}
+
 	/**
 	 * Checks the attribute with all available shells from resource's facility
 	 */
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
-		List<String> shells = (List<String>) attribute.getValue();
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+		List<String> shells = attribute.valueAsList();
 
 		if (shells == null) {
-			throw new WrongAttributeValueException(attribute, "Attribute was not filled, therefore there is nothing to be checked.");
-		}
-
-		if (!shells.isEmpty()) {
-			for (String st : shells) {
-				perunSession.getPerunBl().getModulesUtilsBl().checkFormatOfShell(st, attribute);
-			}
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Attribute cannot be null.");
 		}
 
 		Facility facility = perunSession.getPerunBl().getResourcesManagerBl().getFacility(perunSession, resource);
@@ -74,11 +79,10 @@ public class urn_perun_resource_attribute_def_def_shells extends ResourceAttribu
 
 
 		if (allShellsPerFacility.getValue() == null) {
-			throw new WrongReferenceAttributeValueException(attribute, allShellsPerFacility);
-		} else {
-			if (!((List<String>) allShellsPerFacility.getValue()).containsAll(shells)) {
-				throw new WrongAttributeValueException(attribute, "Some shells from specified resource are not at home facility " + facility.getId());
-			}
+			throw new WrongReferenceAttributeValueException(attribute, allShellsPerFacility, resource, null, facility, null, "Attribute with list of shells from facility cannot be null.");
+		}
+		if (!(allShellsPerFacility.valueAsList()).containsAll(shells)) {
+			throw new WrongReferenceAttributeValueException(attribute, allShellsPerFacility, resource, null, facility, null, "Some shells from specified resource are not at home facility " + facility.getId());
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUser.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUser.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
 import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
@@ -22,16 +23,21 @@ public class urn_perun_resource_attribute_def_def_sshkeysTargetUser extends Reso
 	private static final Pattern pattern = Pattern.compile("^(?!-)[-_.a-zA-Z0-9]+$");
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
-		String key = (String) attribute.getValue();
-		if (key == null) {
-			throw new WrongAttributeValueException(attribute, resource, "Name of the user can't be empty");
-		}
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+		String key = attribute.valueAsString();
+		if (key == null) return;
 
 		Matcher match = pattern.matcher(key);
 
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, resource, "Bad format of attribute sshkeysTargetUser (only letters, numbers and '.' '_' '-' are allowed. Cannot begin with '-').");
+		}
+	}
+
+	@Override
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongReferenceAttributeValueException {
+		if (attribute.getValue() == null) {
+			throw new WrongReferenceAttributeValueException(attribute, null, resource, null, "Name of the user can't be empty");
 		}
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_vomsRoles.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_vomsRoles.java
@@ -24,17 +24,16 @@ public class urn_perun_resource_attribute_def_def_vomsRoles extends ResourceAttr
 	private static final Pattern pattern = Pattern.compile("^[^<>&]*$");
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws WrongAttributeValueException {
 		if(attribute.getValue() == null) {
 			return;
 		}
 		try {
-			List<String> vomRoles = (List<String>) attribute.getValue();
+			List<String> vomRoles = attribute.valueAsList();
 			for (String vomRole : vomRoles) {
 				Matcher matcher = pattern.matcher(vomRole);
 				if(!matcher.matches()) {
-					throw new WrongAttributeValueException(attribute, "Bad resource vomsRoles value. It should not contain '<>&' characters.");
+					throw new WrongAttributeValueException(attribute, resource, "Bad resource vomsRoles value. It should not contain '<>&' characters.");
 				}
 			}
 		} catch (ClassCastException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_unixGID.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_unixGID.java
@@ -28,7 +28,7 @@ public class urn_perun_resource_attribute_def_virt_unixGID extends ResourceVirtu
 	private static final String A_R_unixGID_namespace = AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute unixGIDNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGIDNamespaceAttributeWithNotNullValue(sess, resource);
 		Attribute gidAttribute;
 		try {
@@ -39,8 +39,6 @@ public class urn_perun_resource_attribute_def_virt_unixGID extends ResourceVirtu
 		gidAttribute.setValue(attribute.getValue());
 		try {
 			sess.getPerunBl().getAttributesManagerBl().forceCheckAttributeSemantics(sess, resource, gidAttribute);
-		} catch(WrongAttributeValueException ex) {
-			throw new WrongAttributeValueException(attribute, ex.getMessage(), ex);
 		} catch(WrongReferenceAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, ex.getReferenceAttribute(), ex);
 		}
@@ -65,6 +63,7 @@ public class urn_perun_resource_attribute_def_virt_unixGID extends ResourceVirtu
 		}
 
 		try {
+			sess.getPerunBl().getAttributesManagerBl().forceCheckAttributeSyntax(sess, resource, gidAttribute);
 			sess.getPerunBl().getAttributesManagerBl().forceCheckAttributeSemantics(sess, resource, gidAttribute);
 			//check passed, we can use value from this physical attribute
 			attribute.setValue(gidAttribute.getValue());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_unixGroupName.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_virt_unixGroupName.java
@@ -28,7 +28,7 @@ public class urn_perun_resource_attribute_def_virt_unixGroupName extends Resourc
 	private static final String A_R_unixGroupName_namespace = AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:";
 
 	@Override
-	public void checkAttributeSemantics(PerunSessionImpl sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
+	public void checkAttributeSemantics(PerunSessionImpl sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException {
 		Attribute unixGroupNameNamespaceAttribute = sess.getPerunBl().getModulesUtilsBl().getUnixGroupNameNamespaceAttributeWithNotNullValue(sess, resource);
 		Attribute groupNameAttribute;
 		try {
@@ -39,8 +39,6 @@ public class urn_perun_resource_attribute_def_virt_unixGroupName extends Resourc
 		groupNameAttribute.setValue(attribute.getValue());
 		try {
 			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, resource, groupNameAttribute);
-		} catch(WrongAttributeValueException ex) {
-			throw new WrongAttributeValueException(attribute, ex.getMessage(), ex);
 		} catch(WrongReferenceAttributeValueException ex) {
 			throw new WrongReferenceAttributeValueException(attribute, ex.getAttribute(), ex);
 		}
@@ -65,6 +63,7 @@ public class urn_perun_resource_attribute_def_virt_unixGroupName extends Resourc
 		}
 
 		try {
+			sess.getPerunBl().getAttributesManagerBl().checkAttributeSyntax(sess, resource, groupNameAttribute);
 			sess.getPerunBl().getAttributesManagerBl().checkAttributeSemantics(sess, resource, groupNameAttribute);
 			//check passed, we can use value from this physical attribute
 			attribute.setValue(groupNameAttribute.getValue());

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AttributesManagerImplApi.java
@@ -1643,7 +1643,7 @@ public interface AttributesManagerImplApi {
 	 * @throws WrongAttributeValueException if the attribute value is wrong/illegal
 	 * @throws WrongReferenceAttributeValueException
 	 */
-	void checkAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException;
+	void checkAttributeSemantics(PerunSession sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException;
 
 	/**
 	 * Check if value of this member-resource attribute has valid semantics.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceAttributesModuleAbstract.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceAttributesModuleAbstract.java
@@ -24,7 +24,7 @@ public abstract class ResourceAttributesModuleAbstract extends AttributesModuleA
 
 	}
 
-	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
+	public void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException {
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceAttributesModuleImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/ResourceAttributesModuleImplApi.java
@@ -53,12 +53,11 @@ public interface ResourceAttributesModuleImplApi extends AttributesModuleImplApi
 	 *
 	 * @throws InternalErrorException if an exception is raised in particular
 	 *         implementation, the exception is wrapped in InternalErrorException
-	 * @throws WrongAttributeValueException if the attribute value is wrong / illegal
 	 * @throws WrongReferenceAttributeValueException if an referenced attribute against
 	 *         the parameter one is to be compared is not available
 	 * @throws WrongAttributeAssignmentException
 	 */
-	void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
+	void checkAttributeSemantics(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongReferenceAttributeValueException, WrongAttributeAssignmentException;
 
 	/**
 	 * If you need to do some further work with other modules, this method do that

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_accountExpirationTimeTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_accountExpirationTimeTest.java
@@ -1,0 +1,72 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_accountExpirationTimeTest {
+
+	private urn_perun_resource_attribute_def_def_accountExpirationTime classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_accountExpirationTime();
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+		sess = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
+		Facility facility = new Facility();
+
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR + ":accountExpirationTime")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getResourcesManagerBl().getFacility(sess, resource)).thenReturn(facility);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsReqAttributeWithNullValue() throws Exception {
+		System.out.println("testSemanticsReqAttributeWithNullValue()");
+		reqAttribute.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsReqAttributeWithLesserValue() throws Exception {
+		System.out.println("testSemanticsReqAttributeWithLesserValue()");
+		attributeToCheck.setValue(6);
+		reqAttribute.setValue(5);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue(4);
+		reqAttribute.setValue(5);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFileTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_apacheAuthzFileTest.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +24,7 @@ public class urn_perun_resource_attribute_def_def_apacheAuthzFileTest {
 		ps = mock(PerunSessionImpl.class, RETURNS_DEEP_STUBS);
 	}
 
-	@Test(expected = WrongAttributeValueException.class)
+	@Test(expected = WrongReferenceAttributeValueException.class)
 	public void checkAttributeWithoutValue() throws Exception {
 		System.out.println("checkAttributeWithoutValue()");
 		authzFileAttr.checkAttributeSemantics(ps, new Resource(), new Attribute());
@@ -34,7 +35,7 @@ public class urn_perun_resource_attribute_def_def_apacheAuthzFileTest {
 		System.out.println("checkAttributeWithWrongValue()");
 		final Attribute attr = new Attribute();
 		attr.setValue("bad/file/path");
-		authzFileAttr.checkAttributeSemantics(ps, new Resource(), attr);
+		authzFileAttr.checkAttributeSyntax(ps, new Resource(), attr);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
@@ -42,7 +43,7 @@ public class urn_perun_resource_attribute_def_def_apacheAuthzFileTest {
 		System.out.println("checkAttributeWithNoSlashInFilePath()");
 		final Attribute attr = new Attribute();
 		attr.setValue("pathToFile");
-		authzFileAttr.checkAttributeSemantics(ps, new Resource(), attr);
+		authzFileAttr.checkAttributeSyntax(ps, new Resource(), attr);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
@@ -50,6 +51,6 @@ public class urn_perun_resource_attribute_def_def_apacheAuthzFileTest {
 		System.out.println("checkAttributeEndingWithSlash()");
 		final Attribute attr = new Attribute();
 		attr.setValue("/ending/with/slash/");
-		authzFileAttr.checkAttributeSemantics(ps, new Resource(), attr);
+		authzFileAttr.checkAttributeSyntax(ps, new Resource(), attr);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataLimitTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataLimitTest.java
@@ -1,0 +1,73 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_defaultDataLimitTest {
+
+	private urn_perun_resource_attribute_def_def_defaultDataLimit classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_defaultDataLimit();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataQuota")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("555");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("555K");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithValueLesserThanDefaultLimit() throws Exception {
+		System.out.println("testSemanticsWithValueLesserThanDefaultLimit()");
+		attributeToCheck.setValue("555.5K");
+		reqAttribute.setValue("20.1M");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("10.1M");
+		reqAttribute.setValue("555.1K");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuotaTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultDataQuotaTest.java
@@ -1,0 +1,73 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_defaultDataQuotaTest {
+
+	private urn_perun_resource_attribute_def_def_defaultDataQuota classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_defaultDataQuota();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultDataLimit")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("555");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("555K");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithValueLesserThanDefaultLimit() throws Exception {
+		System.out.println("testSemanticsWithValueLesserThanDefaultLimit()");
+		attributeToCheck.setValue("555.5K");
+		reqAttribute.setValue("20.1K");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("555,1K");
+		reqAttribute.setValue("20,2M");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesLimitTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesLimitTest.java
@@ -1,0 +1,82 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_defaultFilesLimitTest {
+
+	private urn_perun_resource_attribute_def_def_defaultFilesLimit classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_defaultFilesLimit();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesQuota")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue(-1);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithValueIncompatibleWithDefaultQuota() throws Exception {
+		System.out.println("testSemanticsWithValueIncompatibleWithDefaultQuota()");
+		attributeToCheck.setValue(5);
+		reqAttribute.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithValueLesserThanDefaultQuota() throws Exception {
+		System.out.println("testSemanticsWithValueLesserThanDefaultQuota()");
+		attributeToCheck.setValue(5);
+		reqAttribute.setValue(6);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue(7);
+		reqAttribute.setValue(6);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesQuotaTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultFilesQuotaTest.java
@@ -1,0 +1,82 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_defaultFilesQuotaTest {
+
+	private urn_perun_resource_attribute_def_def_defaultFilesQuota classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_defaultFilesQuota();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+		reqAttribute = new Attribute();
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(attributesManagerBl.getAttribute(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":defaultFilesLimit")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue(-1);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue(1);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithValueIncompatibleWithDefaultQuota() throws Exception {
+		System.out.println("testSemanticsWithValueIncompatibleWithDefaultQuota()");
+		attributeToCheck.setValue(null);
+		reqAttribute.setValue(5);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithValueLesserThanDefaultLimit() throws Exception {
+		System.out.println("testSemanticsWithValueLesserThanDefaultLimit()");
+		attributeToCheck.setValue(6);
+		reqAttribute.setValue(5);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue(4);
+		reqAttribute.setValue(5);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultHomeMountPointTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultHomeMountPointTest.java
@@ -1,0 +1,97 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_defaultHomeMountPointTest {
+
+	private urn_perun_resource_attribute_def_def_defaultHomeMountPoint classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_defaultHomeMountPoint();
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":homeMountPoints")).thenReturn(reqAttribute);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithIncorrectValue() throws Exception {
+		System.out.println("testSyntaxWithIncorrectValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsReqAttributeWithNullValue() throws Exception {
+		System.out.println("testSemanticsReqAttributeWithNullValue()");
+		attributeToCheck.setValue("/example");
+		reqAttribute.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsReqAttributeWithoutNeededValue() throws Exception {
+		System.out.println("testSemanticsReqAttributeWithoutNeededValue()");
+		attributeToCheck.setValue("/example");
+		List<String> value = new ArrayList<>();
+		value.add("something");
+		reqAttribute.setValue(value);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("/example");
+		List<String> value = new ArrayList<>();
+		value.add("/example");
+		reqAttribute.setValue(value);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultShellTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_defaultShellTest.java
@@ -116,7 +116,7 @@ public class urn_perun_resource_attribute_def_def_defaultShellTest {
 
 	}
 
-	@Test(expected=WrongAttributeValueException.class)
+	@Test(expected=WrongReferenceAttributeValueException.class)
 	public void checkAttributeWithoutValue() throws Exception {
 		System.out.println("checkAttributeWithoutValue()");
 		defShellAttr.checkAttributeSemantics(ps, new Resource(), new Attribute());

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_fairshareGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_fairshareGroupNameTest.java
@@ -1,0 +1,91 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.FacilitiesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_fairshareGroupNameTest {
+
+	private urn_perun_resource_attribute_def_def_fairshareGroupName classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_fairshareGroupName();
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+		Facility facility = new Facility();
+		List<Resource> resources = new ArrayList<>();
+		Resource resource2 = new Resource();
+		resources.add(resource2);
+		resources.add(resource);
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource2, attributeToCheck.getName())).thenReturn(reqAttribute);
+
+		ResourcesManagerBl resourcesManagerBl = mock(ResourcesManagerBl.class);
+		when(perunBl.getResourcesManagerBl()).thenReturn(resourcesManagerBl);
+		when(resourcesManagerBl.getFacility(sess, resource)).thenReturn(facility);
+
+		FacilitiesManagerBl facilitiesManagerBl = mock(FacilitiesManagerBl.class);
+		when(perunBl.getFacilitiesManagerBl()).thenReturn(facilitiesManagerBl);
+		when(facilitiesManagerBl.getAssignedResources(sess, facility)).thenReturn(resources);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNameAlreadyTaken() throws Exception {
+		System.out.println("testSemanticsWithNameAlreadyTaken()");
+		attributeToCheck.setValue("example");
+		reqAttribute.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+		reqAttribute.setValue("anotherValue");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_homeMountPointsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_homeMountPointsTest.java
@@ -1,0 +1,104 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_homeMountPointsTest {
+
+	private urn_perun_resource_attribute_def_def_homeMountPoints classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private Attribute reqAttribute;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_homeMountPoints();
+		attributeToCheck = new Attribute();
+		reqAttribute = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+		Facility facility = new Facility();
+
+		List<String> value = new ArrayList<>();
+		value.add("/example");
+		attributeToCheck.setValue(value);
+		reqAttribute.setValue(value);
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, facility, AttributesManager.NS_FACILITY_ATTR_DEF + ":homeMountPoints")).thenReturn(reqAttribute);
+
+		ResourcesManagerBl resourcesManagerBl = mock(ResourcesManagerBl.class);
+		when(perunBl.getResourcesManagerBl()).thenReturn(resourcesManagerBl);
+		when(resourcesManagerBl.getFacility(sess, resource)).thenReturn(facility);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		List<String> badValue = new ArrayList<>();
+		badValue.add("bad_example");
+		attributeToCheck.setValue(badValue);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsReqAttributeWithNullValue() throws Exception {
+		System.out.println("testSemanticsReqAttributeWithNullValue()");
+		reqAttribute.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsReqAttributeWithDifferentValues() throws Exception {
+		System.out.println("testSemanticsReqAttributeWithNullValue()");
+		List<String> badValue = new ArrayList<>();
+		badValue.add("bad_example");
+		reqAttribute.setValue(badValue);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupCodeTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupCodeTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_k4GroupCodeTest {
+
+	private urn_perun_resource_attribute_def_def_k4GroupCode classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_k4GroupCode();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("badValueBecauseItIsTooLong");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupNameTest.java
@@ -1,0 +1,41 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_k4GroupNameTest {
+
+	private urn_perun_resource_attribute_def_def_k4GroupName classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_k4GroupName();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("testWithBadValueBecauseItIsToooooooooLong");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupPriorityTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k4GroupPriorityTest.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_k4GroupPriorityTest {
+
+	private urn_perun_resource_attribute_def_def_k4GroupPriority classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_k4GroupPriority();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k5loginTargetUserTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_k5loginTargetUserTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_k5loginTargetUserTest {
+
+	private urn_perun_resource_attribute_def_def_k5loginTargetUser classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_k5loginTargetUser();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad@exmaple");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailaliasesTargetUserTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailaliasesTargetUserTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_mailaliasesTargetUserTest {
+
+	private urn_perun_resource_attribute_def_def_mailaliasesTargetUser classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_mailaliasesTargetUser();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad@example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailingListManagerEmailTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_mailingListManagerEmailTest.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_mailingListManagerEmailTest {
+
+	private urn_perun_resource_attribute_def_def_mailingListManagerEmail classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_mailingListManagerEmail();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("good@example.mine");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_openNebulaGroupNameTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_openNebulaGroupNameTest.java
@@ -1,0 +1,40 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_openNebulaGroupNameTest {
+
+	private urn_perun_resource_attribute_def_def_openNebulaGroupName classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_openNebulaGroupName();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_projectsBasePathTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_projectsBasePathTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_projectsBasePathTest {
+
+	private urn_perun_resource_attribute_def_def_projectsBasePath classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_projectsBasePath();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_redmineProjectIDTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_redmineProjectIDTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_redmineProjectIDTest {
+
+	private urn_perun_resource_attribute_def_def_redmineProjectID classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_redmineProjectID();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad@example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_redmineRoleTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_redmineRoleTest.java
@@ -1,0 +1,63 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_redmineRoleTest {
+
+	private urn_perun_resource_attribute_def_def_redmineRole classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_redmineRole();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+
+		attributeToCheck.setValue("Manager");
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+
+		attributeToCheck.setValue("Reporter");
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+
+		attributeToCheck.setValue("Developer");
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("Manager");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPathTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationPathTest.java
@@ -1,0 +1,57 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_replicaDestinationPathTest {
+
+	private urn_perun_resource_attribute_def_def_replicaDestinationPath classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_replicaDestinationPath();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad_example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("/example");
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_replicaDestinationTest.java
@@ -1,0 +1,69 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_replicaDestinationTest {
+
+	private urn_perun_resource_attribute_def_def_replicaDestination classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+	private ModulesUtilsBl modulesUtilsBl;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_replicaDestination();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(perunBl.getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		attributeToCheck.setValue("bad_example");
+		when(modulesUtilsBl.isFQDNValid(sess, attributeToCheck.valueAsString())).thenReturn(false);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		attributeToCheck.setValue("example.my");
+		when(modulesUtilsBl.isFQDNValid(sess, attributeToCheck.valueAsString())).thenReturn(true);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSemanticsCorrect() throws Exception {
+		System.out.println("testSemanticsCorrect()");
+		attributeToCheck.setValue("example.my");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_shellsTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_shellsTest.java
@@ -5,7 +5,7 @@ import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
-import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,40 +75,9 @@ public class urn_perun_resource_attribute_def_def_shellsTest {
 
 	/**
 	 * Test of checkAttributeSemantics method, of class urn_perun_resource_attribute_def_def_shells.
-	 * with shell containing forbiden characters.
-	 */
-	@Test(expected=WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsWrongShellFormat() throws Exception {
-		System.out.println("testCheckAttributeSemanticsWrongShellFormat()");
-
-		Attribute attributeToCheck = new Attribute();
-		attributeToCheck.setValue(new ArrayList<String>() {{add("\n");}});
-
-		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Facility.class), anyString())).thenReturn(listOfShells);
-
-		classInstance.checkAttributeSemantics(session, new Resource(), attributeToCheck);
-		fail("Shell attribute with inappropriate format was approved.");
-	}
-
-	@Test(expected=WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsWrongShellFormatShellIsDirectory() throws Exception {
-		System.out.println("testCheckAttributeSemanticsWrongShellFormatShellIsDirectory()");
-
-		Attribute attributeToCheck = new Attribute();
-		attributeToCheck.setValue(new ArrayList<String>() {{add("/bin/bash/");}});
-
-		when(session.getPerunBl().getAttributesManagerBl().getAttribute(any(PerunSession.class), any(Facility.class), anyString())).thenReturn(listOfShells);
-
-		classInstance.checkAttributeSemantics(session, new Resource(), attributeToCheck);
-		fail("Shell attribute with inappropriate format was approved.");
-	}
-
-
-	/**
-	 * Test of checkAttributeSemantics method, of class urn_perun_resource_attribute_def_def_shells.
 	 * with empty attribute.
 	 */
-	@Test(expected=WrongAttributeValueException.class)
+	@Test(expected= WrongReferenceAttributeValueException.class)
 	public void testCheckAttributeSemanticsEmptyAttribute() throws Exception {
 		System.out.println("testCheckAttributeSemanticsEmptyAttribute()");
 
@@ -122,7 +91,7 @@ public class urn_perun_resource_attribute_def_def_shellsTest {
 	 * Test of checkAttributeSemantics method, of class urn_perun_resource_attribute_def_def_shells.
 	 * attempting to set shell which is not available at that particular resource.
 	 */
-	@Test(expected=WrongAttributeValueException.class)
+	@Test(expected=WrongReferenceAttributeValueException.class)
 	public void testCheckAttributeSemanticsUnknownShell() throws Exception {
 		System.out.println("testCheckAttributeSemanticsUnknownShell()");
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUserTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_sshkeysTargetUserTest.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,8 +25,8 @@ public class urn_perun_resource_attribute_def_def_sshkeysTargetUserTest {
 	}
 
 	@Test
-	public void testCheckAttributeSemantics() throws Exception {
-		System.out.println("testCheckAttributeSemantics()");
+	public void testCheckAttributeSyntax() throws Exception {
+		System.out.println("testCheckAttributeSyntax()");
 
 		Attribute attributeToCheck = new Attribute();
 
@@ -40,32 +41,56 @@ public class urn_perun_resource_attribute_def_def_sshkeysTargetUserTest {
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsWithWrongValueHyphen() throws Exception {
-		System.out.println("testCheckAttributeSemanticsWithWrongValueHyphen()");
+	public void testCheckAttributeSyntaxWithWrongValueHyphen() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValueHyphen()");
 
 		Attribute attributeToCheck = new Attribute();
 
 		attributeToCheck.setValue("-Adam");
-		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, resource, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsWithWrongValueWhitespace() throws Exception {
-		System.out.println("testCheckAttributeSemanticsWithWrongValueWhitespace()");
+	public void testCheckAttributeSyntaxWithWrongValueWhitespace() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValueWhitespace()");
 
 		Attribute attributeToCheck = new Attribute();
 
 		attributeToCheck.setValue("Elena Fuente");
-		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+		classInstance.checkAttributeSyntax(session, resource, attributeToCheck);
 	}
 
 	@Test(expected = WrongAttributeValueException.class)
-	public void testCheckAttributeSemanticsWithWrongValueDiacritic() throws Exception {
-		System.out.println("testCheckAttributeSemanticsWithWrongValueDiacritic()");
+	public void testCheckAttributeSyntaxWithWrongValueDiacritic() throws Exception {
+		System.out.println("testCheckAttributeSyntaxWithWrongValueDiacritic()");
 
 		Attribute attributeToCheck = new Attribute();
 
 		attributeToCheck.setValue("Jan_Veselý");
+		classInstance.checkAttributeSyntax(session, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testCheckAttributeSemanticsWithNullValue() throws Exception {
+		System.out.println("testCheckAttributeSemanticsWithNullValue()");
+		Attribute attributeToCheck = new Attribute();
+
+		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCheckAttributeSemantics() throws Exception {
+		System.out.println("testCheckAttributeSemantics()");
+
+		Attribute attributeToCheck = new Attribute();
+
+		attributeToCheck.setValue("Jan_Nepomucky");
+		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+
+		attributeToCheck.setValue(".John_Dale.");
+		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
+
+		attributeToCheck.setValue("_Adele-Frank");
 		classInstance.checkAttributeSemantics(session, resource, attributeToCheck);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGID_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGID_namespaceTest.java
@@ -1,0 +1,117 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class urn_perun_resource_attribute_def_def_unixGID_namespaceTest {
+
+	private urn_perun_resource_attribute_def_def_unixGID_namespace classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private Attribute reqAttribute;
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_unixGID_namespace();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("friendly name");
+		reqAttribute = new Attribute();
+		reqAttribute.setFriendlyName("friendly name");
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, resource, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace" + ":" + attributeToCheck.getNamespace())).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, attributeToCheck.getFriendlyNameParameter(), AttributesManager.NS_ENTITYLESS_ATTR_DEF + ":usedGids")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGID-namespace:")).thenReturn(reqAttribute);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:")).thenReturn(reqAttribute);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(sess.getPerunBl().getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		ResourcesManagerBl resourcesManagerBl = mock(ResourcesManagerBl.class);
+		when(sess.getPerunBl().getResourcesManagerBl()).thenReturn(resourcesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testUnixGroupNameSet() throws Exception {
+		System.out.println("testUnixGroupNameSet()");
+		Set<String> set = new HashSet<>();
+		set.add(attributeToCheck.getNamespace());
+		when(sess.getPerunBl().getModulesUtilsBl().getSetOfGroupNameNamespacesWhereFacilitiesHasTheSameGIDNamespace(sess, new ArrayList<>(), attributeToCheck)).thenReturn(set);
+		reqAttribute.setValue("value");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testDepletedGIDValue() throws Exception {
+		System.out.println("testDepletedGIDValue()");
+		attributeToCheck.setValue(5);
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("D5", "value");
+		reqAttribute.setValue(map);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testResourceWithSameGID() throws Exception {
+		System.out.println("testResourceWithSameGID()");
+		attributeToCheck.setValue(5);
+		Resource resource2 = new Resource();
+		when(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, attributeToCheck)).thenReturn(Arrays.asList(resource, resource2));
+		when(sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:")).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveTheSameAttributeWithTheSameNamespace(sess, resource, attributeToCheck)).thenReturn(2);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testGroupWithSameGID() throws Exception {
+		System.out.println("testGroupWithSameGID()");
+		attributeToCheck.setValue(5);
+		Group group = new Group();
+		when(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, attributeToCheck)).thenReturn(Collections.singletonList(group));
+		when(sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGroupName-namespace:")).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveTheSameAttributeWithTheSameNamespace(sess, group, attributeToCheck)).thenReturn(2);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue(5);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespaceTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespaceTest.java
@@ -4,8 +4,27 @@
  */
 package cz.metacentrum.perun.core.impl.modules.attributes;
 
-import org.junit.Ignore;
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.AttributesManagerBl;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.ModulesUtilsBl;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.ResourcesManagerBl;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -13,9 +32,88 @@ import org.junit.Test;
  */
 public class urn_perun_resource_attribute_def_def_unixGroupName_namespaceTest {
 
-	@Test
-	@Ignore
-	public void testCheckAttributeSemantics() {
+	private urn_perun_resource_attribute_def_def_unixGroupName_namespace classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
 
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_unixGroupName_namespace();
+		attributeToCheck = new Attribute();
+		attributeToCheck.setFriendlyName("unixGID-namespace");
+
+		sess = mock(PerunSessionImpl.class);
+		PerunBl perunBl = mock(PerunBl.class);
+		when(sess.getPerunBl()).thenReturn(perunBl);
+
+		AttributesManagerBl attributesManagerBl = mock(AttributesManagerBl.class);
+		when(perunBl.getAttributesManagerBl()).thenReturn(attributesManagerBl);
+		when(sess.getPerunBl().getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace:")).thenReturn(attributeToCheck);
+
+		GroupsManagerBl groupsManagerBl = mock(GroupsManagerBl.class);
+		when(sess.getPerunBl().getGroupsManagerBl()).thenReturn(groupsManagerBl);
+
+		ModulesUtilsBl modulesUtilsBl = mock(ModulesUtilsBl.class);
+		when(sess.getPerunBl().getModulesUtilsBl()).thenReturn(modulesUtilsBl);
+
+		ResourcesManagerBl resourcesManagerBl = mock(ResourcesManagerBl.class);
+		when(sess.getPerunBl().getResourcesManagerBl()).thenReturn(resourcesManagerBl);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testSemanticsWithNullValue() throws Exception {
+		System.out.println("testSemanticsWithNullValue()");
+		attributeToCheck.setValue(null);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testGroupWithSameGIDAndNoRightsToUseIt() throws Exception {
+		System.out.println("testGroupWithSameGIDAndNoRightsToUseIt()");
+		attributeToCheck.setValue("my name");
+		Group group2 = new Group();
+		List<Group> listOfGroups = new ArrayList<>();
+		listOfGroups.add(group2);
+		when(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, attributeToCheck)).thenReturn(listOfGroups);
+		when(sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:")).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveRightToWriteAttributeInAnyGroupOrResource(sess, listOfGroups, new ArrayList<>(), attributeToCheck, attributeToCheck)).thenReturn(false);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testGroupWithSameGID() throws Exception {
+		System.out.println("testGroupWithSameGID()");
+		attributeToCheck.setValue("my name");
+		Group group2 = new Group();
+		when(sess.getPerunBl().getGroupsManagerBl().getGroupsByAttribute(sess, attributeToCheck)).thenReturn(Collections.singletonList(group2));
+		when(sess.getPerunBl().getModulesUtilsBl().getListOfGroupGIDsFromListOfResourceGIDs(sess, new ArrayList<>())).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveRightToWriteAttributeInAnyGroupOrResource(sess, Collections.singletonList(group2), new ArrayList<>(), attributeToCheck, attributeToCheck)).thenReturn(true);
+		when(sess.getPerunBl().getModulesUtilsBl().haveTheSameAttributeWithTheSameNamespace(sess, group2, attributeToCheck)).thenReturn(2);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test(expected = WrongReferenceAttributeValueException.class)
+	public void testResourceWithSameGID() throws Exception {
+		System.out.println("testResourceWithSameGID()");
+		attributeToCheck.setValue("my name");
+		Resource resource2 = new Resource();
+		when(sess.getPerunBl().getResourcesManagerBl().getResourcesByAttribute(sess, attributeToCheck)).thenReturn(Arrays.asList(resource, resource2));
+		when(sess.getPerunBl().getAttributesManagerBl().getAllAttributesStartWithNameWithoutNullValue(sess, resource, AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace:")).thenReturn(Collections.singletonList(attributeToCheck));
+		when(sess.getPerunBl().getModulesUtilsBl().haveRightToWriteAttributeInAnyGroupOrResource(sess, new ArrayList<>(), Collections.singletonList(resource), attributeToCheck, attributeToCheck)).thenReturn(true);
+		when(sess.getPerunBl().getModulesUtilsBl().haveTheSameAttributeWithTheSameNamespace(sess, resource, attributeToCheck)).thenReturn(2);
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testCorrectSemantics() throws Exception {
+		System.out.println("testCorrectSemantics()");
+		attributeToCheck.setValue("my name");
+
+		classInstance.checkAttributeSemantics(sess, resource, attributeToCheck);
 	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_vomsRolesTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_vomsRolesTest.java
@@ -1,0 +1,48 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class urn_perun_resource_attribute_def_def_vomsRolesTest {
+
+	private urn_perun_resource_attribute_def_def_vomsRoles classInstance;
+	private Attribute attributeToCheck;
+	private Resource resource = new Resource();
+	private PerunSessionImpl sess;
+
+	@Before
+	public void setUp() throws Exception {
+		classInstance = new urn_perun_resource_attribute_def_def_vomsRoles();
+		attributeToCheck = new Attribute();
+		sess = mock(PerunSessionImpl.class);
+	}
+
+	@Test(expected = WrongAttributeValueException.class)
+	public void testSyntaxWithWrongValue() throws Exception {
+		System.out.println("testSyntaxWithWrongValue()");
+		List<String> value = new ArrayList<>();
+		value.add("bad&example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+
+	@Test
+	public void testSyntaxCorrect() throws Exception {
+		System.out.println("testSyntaxCorrect()");
+		List<String> value = new ArrayList<>();
+		value.add("example");
+		attributeToCheck.setValue(value);
+
+		classInstance.checkAttributeSyntax(sess, resource, attributeToCheck);
+	}
+}


### PR DESCRIPTION
- former checkAttributeValue is now separated into checkAttributeSyntax and checkAttributeSemantics in resource attribute modules
- also added test for checks