### PR TITLE
Added RoleManagementRules

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/RoleManagementRules.java
@@ -1,0 +1,96 @@
+package cz.metacentrum.perun.core.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * RoleManagementRules represents a set of rules which is used to determine principal's access rights for managing a role.
+ * Moreover, it contains a allowed combinations of object and entity to/from which will be the role un/assigned.
+ * Each object and entity also contains a mapping to the specific column in the authz table,
+ * so the database query can be created and executed more generally.
+ *
+ * roleName is role's unique identification which is used in the configuration file perun-roles.yml
+ * privilegedRoles is a list of maps where each map entry consists from a role name as a key and a role object as a value.
+ *            Relation between each map in the list is logical OR and relation between each entry in the map is logical AND.
+ *            Example list - (Map1, Map2...)
+ *            Example map - key: VOADMIN ; value: Vo
+ *                          key: GROUPADMIN ; value: Group
+ * entitiesToManage is a map of entities which can be set to the role. Key is a entity name and value is mapping to the database.
+ *            Example entry: key: User; value: user_id
+ * assignedObjects is a map of objects which can be assigned with the role. Key is a object name and value is mapping to the database.
+ *            Example entry: key: Resource; value: resource_id
+ *
+ */
+public class RoleManagementRules {
+
+	private String roleName;
+	private List<Map<String, String>> privilegedRoles;
+	private Map<String, String> entitiesToManage;
+	private Map<String, String> assignedObjects;
+
+	public RoleManagementRules(String roleName, List<Map<String, String>> privilegedRoles, Map<String, String> entitiesToManage, Map<String, String> assignedObjects) {
+		this.roleName = roleName;
+		this.privilegedRoles = privilegedRoles;
+		this.entitiesToManage = entitiesToManage;
+		this.assignedObjects = assignedObjects;
+	}
+
+	public String getRoleName() {
+		return roleName;
+	}
+
+	public void setRoleName(String roleName) {
+		this.roleName = roleName;
+	}
+
+	public List<Map<String, String>> getPrivilegedRoles() {
+		return privilegedRoles;
+	}
+
+	public void setPrivilegedRoles( List<Map<String, String>> privilegedRoles) {
+		this.privilegedRoles = privilegedRoles;
+	}
+
+	public Map<String, String> getEntitiesToManage() {
+		return entitiesToManage;
+	}
+
+	public void setEntitiesToManage(Map<String, String> entitiesToManage) {
+		this.entitiesToManage = entitiesToManage;
+	}
+
+	public Map<String, String> getAssignedObjects() {
+		return assignedObjects;
+	}
+
+	public void setAssignedObjects(Map<String, String> assignedObjects) {
+		this.assignedObjects = assignedObjects;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		RoleManagementRules that = (RoleManagementRules) o;
+		return Objects.equals(roleName, that.roleName) &&
+			Objects.equals(privilegedRoles, that.privilegedRoles) &&
+			Objects.equals(entitiesToManage, that.entitiesToManage) &&
+			Objects.equals(assignedObjects, that.assignedObjects);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(roleName, privilegedRoles, entitiesToManage, assignedObjects);
+	}
+
+	@Override
+	public String toString() {
+		return "RoleManagementRules{" +
+			"roleName='" + roleName + '\'' +
+			", privilegedRoles=" + privilegedRoles +
+			", entitiesToManage=" + entitiesToManage +
+			", assignedObjects=" + assignedObjects +
+			'}';
+	}
+}

--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/RoleManagementRulesNotExistsException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/RoleManagementRulesNotExistsException.java
@@ -1,0 +1,35 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when trying to get a role management rules which does not exist in the PerunPoliciesContainer
+ *
+ * @author Peter Balčirák
+ */
+public class RoleManagementRulesNotExistsException extends PerunException {
+	static final long serialVersionUID = 0;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public RoleManagementRulesNotExistsException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and Throwable object
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public RoleManagementRulesNotExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructor with a Throwable object
+	 * @param cause Throwable that caused throwing of this exception
+	 */
+	public RoleManagementRulesNotExistsException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/perun-base/src/test/resources/perun-roles.yml
+++ b/perun-base/src/test/resources/perun-roles.yml
@@ -3664,4 +3664,160 @@ perun_policies:
       - VOADMIN: Vo
     include_policies:
       - default_policy
+
+# A list of Perun management rules that are loaded to the PerunPoliciesContainer.
+perun_roles_management:
+
+  PERUNADMIN:
+    assign_to_objects: {}
+    entities_to_manage:
+      User: user_id
+    privileged_roles:
+      - PERUNADMIN:
+
+  PERUNOBSERVER:
+    assign_to_objects: {}
+    entities_to_manage:
+      User: user_id
+    privileged_roles:
+      - PERUNADMIN:
+
+  VOADMIN:
+    assign_to_objects:
+      Vo: vo_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - VOADMIN: Vo
+
+  GROUPADMIN:
+    assign_to_objects:
+      Group: group_id
+      Vo: vo_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - VOADMIN: Vo
+      - GROUPADMIN: Group
+
+  SELF:
+    assign_to_objects: {}
+    entities_to_manage: {}
+    privileged_roles: []
+
+  FACILITYADMIN:
+    assign_to_objects:
+      Facility: facility_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - FACILITYADMIN: Facility
+
+  RESOURCEADMIN:
+    assign_to_objects:
+      Resource: resource_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - VOADMIN: Vo
+      - RESOURCEADMIN: Resource
+
+  RESOURCESELFSERVICE:
+    assign_to_objects:
+      Resource: resource_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - VOADMIN: Vo
+      - RESOURCEADMIN: Resource
+
+  REGISTRAR:
+    assign_to_objects: {}
+    entities_to_manage: {}
+    privileged_roles: []
+
+  ENGINE:
+    assign_to_objects: {}
+    entities_to_manage: {}
+    privileged_roles: []
+
+  RPC:
+    assign_to_objects: {}
+    entities_to_manage: {}
+    privileged_roles: []
+
+  NOTIFICATIONS:
+    assign_to_objects: {}
+    entities_to_manage: {}
+    privileged_roles: []
+
+  SERVICEUSER:
+    assign_to_objects: {}
+    entities_to_manage: {}
+    privileged_roles: []
+
+  SPONSOR:
+    assign_to_objects:
+      Vo: vo_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - VOADMIN: Vo
+
+  VOOBSERVER:
+    assign_to_objects:
+      Vo: vo_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+
+  TOPGROUPCREATOR:
+    assign_to_objects:
+      Vo: vo_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - VOADMIN: Vo
+
+  SECURITYADMIN:
+    assign_to_objects:
+      SecurityTeam: security_team_id
+    entities_to_manage:
+      User: user_id
+      Group: authorized_group_id
+    privileged_roles:
+      - PERUNADMIN:
+      - SECURITYADMIN: SecurityTeam
+
+  CABINETADMIN:
+    assign_to_objects: {}
+    entities_to_manage:
+      User: user_id
+    privileged_roles:
+      - PERUNADMIN:
+      - CABINETADMIN:
+
+  UNKNOWN:
+    assign_to_objects: {}
+    entities_to_manage: {}
+    privileged_roles: []
+
 ...

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -11,6 +11,7 @@ import cz.metacentrum.perun.core.api.PerunPolicy;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.Role;
+import cz.metacentrum.perun.core.api.RoleManagementRules;
 import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.SpecificUserType;
@@ -20,6 +21,7 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PolicyNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RoleManagementRulesNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.implApi.AuthzResolverImplApi;
 import org.slf4j.Logger;
@@ -181,6 +183,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 
 		this.perunRolesLoader.loadPerunRoles(jdbc);
 		perunPoliciesContainer.setPerunPolicies(this.perunRolesLoader.loadPerunPolicies());
+		perunPoliciesContainer.setRolesManagementRules(this.perunRolesLoader.loadPerunRolesManagement());
 	}
 
 	public static Map<String, Set<ActionType>> getRolesWhichCanWorkWithAttribute(ActionType actionType, AttributeDefinition attrDef) {
@@ -761,6 +764,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	public void loadAuthorizationComponents() {
 		this.perunRolesLoader.loadPerunRoles(jdbc);
 		perunPoliciesContainer.setPerunPolicies(this.perunRolesLoader.loadPerunPolicies());
+		perunPoliciesContainer.setRolesManagementRules(this.perunRolesLoader.loadPerunRolesManagement());
 	}
 
 	public static PerunPolicy getPerunPolicy(String policyName) throws PolicyNotExistsException {
@@ -778,5 +782,9 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	 */
 	public static List<PerunPolicy> getAllPolicies() {
 		return perunPoliciesContainer.getAllPolicies();
+	}
+
+	public static RoleManagementRules getRoleManagementRules(String roleName) throws RoleManagementRulesNotExistsException {
+		return perunPoliciesContainer.getRoleManagementRules(roleName);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunPoliciesContainer.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunPoliciesContainer.java
@@ -1,7 +1,9 @@
 package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.PerunPolicy;
+import cz.metacentrum.perun.core.api.RoleManagementRules;
 import cz.metacentrum.perun.core.api.exceptions.PolicyNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.RoleManagementRulesNotExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,9 +22,15 @@ public class PerunPoliciesContainer {
 
 	private static final Logger log = LoggerFactory.getLogger(PerunBasicDataSource.class);
 	private List<PerunPolicy> perunPolicies = new ArrayList<>();
+	private Map<String, RoleManagementRules> rolesManagementRules = new HashMap<>();
 
 	public void setPerunPolicies(List<PerunPolicy> perunPolicies) {
 		this.perunPolicies = perunPolicies;
+	}
+
+
+	public void setRolesManagementRules(Map<String, RoleManagementRules> rolesManagementRules) {
+		this.rolesManagementRules = rolesManagementRules;
 	}
 
 	public PerunPolicy getPerunPolicy(String policyName) throws PolicyNotExistsException {
@@ -30,6 +38,12 @@ public class PerunPoliciesContainer {
 			if (policy.getPolicyName().equals(policyName)) return policy;
 		}
 		throw new PolicyNotExistsException("Policy with name "+ policyName + "does not exists in the PerunPoliciesContainer.");
+	}
+
+	public RoleManagementRules getRoleManagementRules(String roleName) throws RoleManagementRulesNotExistsException {
+		if (rolesManagementRules.containsKey(roleName))
+			return rolesManagementRules.get(roleName);
+		else throw new RoleManagementRulesNotExistsException("Management rules for role name "+ roleName + "does not exists in the PerunPoliciesContainer.");
 	}
 
 	/**


### PR DESCRIPTION
- RoleManagementRules represents a set of rules which is used to determine principal's access rights for managing a role.
  Moreover, it contains a allowed combinations of object and entity to/from which will be the role un/assigned.
  Each object and entity also contains a mapping to the specific column in the authz table,
  so the database query can be created and executed more generally.
- These rules were created in the perun-roles.yml file
- Perun roles loader load them to the PerunPoliciesContainer
- RoleManagementRules class was created to represents the rules for one
  role.
- Exception RoleManagementRulesNotExistsException was created
- method getRoleManagementRules() was created which return the object
  or the Exception if the object does not exists in the
  PerunPoliciesContainer.