### PR TITLE
Use voPersonExternalAffiliation instead of forwardedScopedAffiliation

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -483,6 +483,7 @@ public class CoreConfig {
 					attr.setDisplayName("affiliation");
 					attr.setDescription("person's relation to organization");
 					break;
+				// voPersonExternalAffiliation
 				case "schacHomeOrganization":
 					attr.setDisplayName("schacHomeOrganization");
 					attr.setDescription("domain name of person's organization (SChema for Academia)");
@@ -491,8 +492,6 @@ public class CoreConfig {
 					attr.setDisplayName("alternativeLoginName");
 					attr.setDescription("person's alternative login name in organization (not related to IdP identity).");
 					break;
-				// forwardedScopedAffiliation - is not standardized and published by the proxy itself, we do not
-				// set it back to the Perun (UES attribute), but we can read it (for registrar purpose).
 				case "entitlement":
 					attr.setDisplayName("eduPersonEntitlement");
 					attr.setDescription("Entitlements of user (aka group memberships).");

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -116,7 +116,7 @@
 				<prop key="perun.DBInitializatorEnabled">false</prop>
 				<prop key="perun.userExtSources.persistent">PERUN,[\w\d]*</prop>
 				<prop key="perun.proxyIdPs"/>
-				<prop key="perun.attributesForUpdate.idp">mail,cn,sn,givenName,o,ou,eppn,affiliation,displayName,uid,epuid,schacHomeOrganization,forwardedScopedAffiliation,alternativeLoginName,isCesnetEligibleLastSeen,IdPOrganizationName,sourceIdPName,entitlement,assurance,eduPersonOrcid,organizationURL</prop>
+				<prop key="perun.attributesForUpdate.idp">mail,cn,sn,givenName,o,ou,eppn,affiliation,displayName,uid,epuid,schacHomeOrganization,voPersonExternalAffiliation,alternativeLoginName,isCesnetEligibleLastSeen,IdPOrganizationName,sourceIdPName,entitlement,assurance,eduPersonOrcid,organizationURL</prop>
 				<prop key="perun.attributesForUpdate.x509">mail,cn,o,dn,cadn,certificate</prop>
 				<prop key="perun.instanceId">AOJ26J3D9DCK3OA7</prop>
 				<prop key="perun.instanceName">LOCAL</prop>

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/EditFormItemTabItem.java
@@ -459,7 +459,7 @@ public class EditFormItemTabItem implements TabItem {
 		federationAttributes.addItem("IdP Category", "md_entityCategory");
 		federationAttributes.addItem("IdP Affiliation", "affiliation");
 		federationAttributes.addItem("EduPersonScopedAffiliation", "eduPersonScopedAffiliation");
-		federationAttributes.addItem("Forwarded Affiliation from Proxy", "forwardedScopedAffiliation");
+		federationAttributes.addItem("Forwarded Affiliation from Proxy", "voPersonExternalAffiliation");
 		federationAttributes.addItem("schacHomeOrganization", "schacHomeOrganization");
 		federationAttributes.addItem("Login", "uid");
 		federationAttributes.addItem("Alternative login name", "alternativeLoginName");


### PR DESCRIPTION
- We will use standard "voPersonExternalAffiliation" to gather
  affiliations from original IdP user used to sign-in.
  At most instances we have own proxy and it will map external/original
  affiliation to "affiliation". Hence this attribute is filled only
  when original IdP is also a proxy and it forwards external user
  affiliations.
- forwardedScopedAffiliations is now unused and values MUST be copied to
  the new attribute on deployment!