### PR TITLE
fixed beanName in OpenAPI

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -83,6 +83,7 @@ components:
             modifiedBy: { type: string }
             createdByUid: { type: integer }
             modifiedByUid: { type: integer }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -99,6 +100,7 @@ components:
             sponsoredUser: { type: boolean }
             specificUser: { type: boolean }
             majorSpecificType:  { type: string }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -108,6 +110,7 @@ components:
         - properties:
             userExtSources: { type: array, items: { $ref: '#/components/schemas/UserExtSource' } }
             userAttributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
+            beanName: { type: string }
           required:
             - userExtSources
             - userAttributes
@@ -131,6 +134,7 @@ components:
               type: object
               additionalProperties:
                 type: string
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -142,6 +146,7 @@ components:
             userExtSources: { type: array, items: { $ref: '#/components/schemas/UserExtSource' } }
             userAttributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
             memberAttributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
+            beanName: { type: string }
           required:
             - user
             - userExtSources
@@ -158,6 +163,7 @@ components:
             persistent: { type: boolean }
             lastAccess: { type: string }
             extSource: { $ref: '#/components/schemas/ExtSource' }
+            beanName: { type: string }
           required:
             - login
             - extSource
@@ -170,6 +176,7 @@ components:
         - properties:
             name: { type: string }
             type: { type: string }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
         mapping:
@@ -201,6 +208,7 @@ components:
             displayName: { type: string }
             writable: { type: boolean }
             unique: { type: boolean }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -213,6 +221,7 @@ components:
             valueModifiedAt: { type: string }
             valueModifiedBy: { type: string }
             value: { type: object }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -222,6 +231,7 @@ components:
         - properties:
             name: { type: string }
             description: { type: string }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -230,6 +240,7 @@ components:
         - $ref: '#/components/schemas/Facility'
         - properties:
             facilityOwners: { type: array, items: { $ref: '#/components/schemas/Owner' } }
+            beanName: { type: string }
           required:
             - facilityOwners
       discriminator:
@@ -240,6 +251,7 @@ components:
         - $ref: '#/components/schemas/Auditable'
         - properties:
             hostname: { type: string }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -252,6 +264,7 @@ components:
             type:
               type: string
               enum: [ technical, administrative ]
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -264,6 +277,7 @@ components:
             description: { type: string }
             voId: { type: integer }
             parentGroupId: { type: integer }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -272,6 +286,7 @@ components:
         - $ref: '#/components/schemas/Group'
         - properties:
             attributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -283,6 +298,7 @@ components:
             description: { type: string }
             voId: { type: integer }
             facilityId: { type: integer }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -293,6 +309,7 @@ components:
             vo: { $ref: '#/components/schemas/Vo' }
             facility: { $ref: '#/components/schemas/Facility' }
             resourceTags: { type: array, items: { $ref: '#/components/schemas/ResourceTag' } }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -302,6 +319,7 @@ components:
         - properties:
             tagName: { type: string }
             voId: { type: integer }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -311,6 +329,7 @@ components:
         - properties:
             name: { type: string }
             shortName: { type: string }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -324,6 +343,7 @@ components:
             recurrence: { type: integer }
             enabled: { type: boolean }
             script: { type: string }
+            beanName: { type: string }
       discriminator:
         propertyName: beanName
 

--- a/perun-openapi/pom.xml
+++ b/perun-openapi/pom.xml
@@ -23,7 +23,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>4.2.0</version>
+				<version>4.2.1</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Added property beanName to every descendant from PerunBean. Without it, the Python OpenAPI-generator does not generate correct deserializers. 