### PR TITLE
GUI: Use removeMember(s) which can take list of IDs

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/groupstabs/GroupMembersTabItem.java
@@ -20,6 +20,7 @@ import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.json.JsonUtils;
 import cz.metacentrum.perun.webgui.json.groupsManager.GetGroupMembersCount;
 import cz.metacentrum.perun.webgui.json.groupsManager.RemoveMember;
+import cz.metacentrum.perun.webgui.json.groupsManager.RemoveMembers;
 import cz.metacentrum.perun.webgui.json.membersManager.FindCompleteRichMembers;
 import cz.metacentrum.perun.webgui.json.membersManager.GetCompleteRichMembers;
 import cz.metacentrum.perun.webgui.model.BasicOverlayType;
@@ -211,16 +212,8 @@ public class GroupMembersTabItem implements TabItem, TabItemWithUrl {
 				UiElements.showDeleteConfirm(membersForRemoving, text, new ClickHandler() {
 					@Override
 					public void onClick(ClickEvent clickEvent) {
-						// TODO - SHOULD HAVE ONLY ONE CALLBACK TO CORE !!
-						for (int i = 0; i < membersForRemoving.size(); i++) {
-							RemoveMember request;
-							if (i == membersForRemoving.size() - 1) {
-								request = new RemoveMember(JsonCallbackEvents.disableButtonEvents(removeButton, refreshEvent));
-							} else {
-								request = new RemoveMember(JsonCallbackEvents.disableButtonEvents(removeButton));
-							}
-							request.removeMemberFromGroup(group, membersForRemoving.get(i));
-						}
+						RemoveMembers request = new RemoveMembers(JsonCallbackEvents.disableButtonEvents(removeButton, refreshEvent));
+						request.removeMembersFromGroup(group, membersForRemoving);
 					}
 				});
 			}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberGroupsTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberGroupsTabItem.java
@@ -95,7 +95,8 @@ public class MemberGroupsTabItem implements TabItem {
 		}
 		menu.addWidget(addButton);
 
-		final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, "Remove member from selected group(s)", new ClickHandler() {
+		final CustomButton removeButton = TabMenu.getPredefinedButton(ButtonType.REMOVE, "Remove member from selected group(s)");
+		removeButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent clickEvent) {
 				final ArrayList<Group> list = groupsCall.getTableSelectedList();
@@ -103,16 +104,8 @@ public class MemberGroupsTabItem implements TabItem {
 				UiElements.showDeleteConfirm(list, confirmText, new ClickHandler() {
 					@Override
 					public void onClick(ClickEvent clickEvent) {
-						// TODO - should have only one callback to core
-						for (int i=0; i<list.size(); i++) {
-							if (i == list.size()-1) {
-								RemoveMember request = new RemoveMember(JsonCallbackEvents.refreshTableEvents(groupsCall));
-								request.removeMemberFromGroup(list.get(i), member);
-							} else {
-								RemoveMember request = new RemoveMember();
-								request.removeMemberFromGroup(list.get(i), member);
-							}
-						}
+						RemoveMember request = new RemoveMember(JsonCallbackEvents.disableButtonEvents(removeButton, JsonCallbackEvents.refreshTableEvents(groupsCall)));
+						request.removeMemberFromGroups(member, list);
 					}
 				});
 			}


### PR DESCRIPTION
- We previously removed group members one by one. It could
  possibly cause race conditions or fill up GUI with exceptions,
  when admin tried to remove indirect member from some groups.
- Now we use single callback, performing all changes in a single
  transaction.