### PR TITLE
LDAPC: Fixed name of ORCID attribute from Perun

### DIFF
--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -663,7 +663,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 					<property name="multipleValuesExtractor">
 						<bean class="cz.metacentrum.perun.ldapc.model.impl.MultipleAttributeValueExtractor">
 							<property name="namespace" value="urn:perun:user:attribute-def:virt" />
-							<property name="name" value="eduPersonOrcid" />
+							<property name="name" value="eduPersonORCID" />
 						</bean>
 					</property>
 				</bean>


### PR DESCRIPTION
- Perun attribute (source) name is eduPersonORCID and LDAP attribute
  (destination) is eduPersonOrcid.
  Wrong definition in context of LDAPc prevented from pushing
  data to LDAP.