### PR TITLE
OpenApi - removed beanName from models

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -83,7 +83,6 @@ components:
             modifiedBy: { type: string }
             createdByUid: { type: integer }
             modifiedByUid: { type: integer }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -100,7 +99,6 @@ components:
             sponsoredUser: { type: boolean }
             specificUser: { type: boolean }
             majorSpecificType:  { type: string }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -110,7 +108,6 @@ components:
         - properties:
             userExtSources: { type: array, items: { $ref: '#/components/schemas/UserExtSource' } }
             userAttributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
-            beanName: { type: string }
           required:
             - userExtSources
             - userAttributes
@@ -134,7 +131,6 @@ components:
               type: object
               additionalProperties:
                 type: string
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -146,7 +142,6 @@ components:
             userExtSources: { type: array, items: { $ref: '#/components/schemas/UserExtSource' } }
             userAttributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
             memberAttributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
-            beanName: { type: string }
           required:
             - user
             - userExtSources
@@ -163,7 +158,6 @@ components:
             persistent: { type: boolean }
             lastAccess: { type: string, format: timestamp, description: 'SQL timestamp', example: '2012-01-01 00:00:00.100000' }
             extSource: { $ref: '#/components/schemas/ExtSource' }
-            beanName: { type: string }
           required:
             - login
             - extSource
@@ -176,7 +170,6 @@ components:
         - properties:
             name: { type: string }
             type: { type: string }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -191,7 +184,6 @@ components:
             displayName: { type: string }
             writable: { type: boolean }
             unique: { type: boolean }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -204,7 +196,6 @@ components:
             valueModifiedAt: { type: string }
             valueModifiedBy: { type: string }
             value: { type: object }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -214,7 +205,6 @@ components:
         - properties:
             name: { type: string }
             description: { type: string }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -223,7 +213,6 @@ components:
         - $ref: '#/components/schemas/Facility'
         - properties:
             facilityOwners: { type: array, items: { $ref: '#/components/schemas/Owner' } }
-            beanName: { type: string }
           required:
             - facilityOwners
       discriminator:
@@ -234,7 +223,6 @@ components:
         - $ref: '#/components/schemas/Auditable'
         - properties:
             hostname: { type: string }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -247,7 +235,6 @@ components:
             type:
               type: string
               enum: [ technical, administrative ]
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -260,7 +247,6 @@ components:
             description: { type: string }
             voId: { type: integer }
             parentGroupId: { type: integer }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -269,7 +255,6 @@ components:
         - $ref: '#/components/schemas/Group'
         - properties:
             attributes: { type: array, items: { $ref: '#/components/schemas/Attribute' } }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -281,7 +266,6 @@ components:
             description: { type: string }
             voId: { type: integer }
             facilityId: { type: integer }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -292,7 +276,6 @@ components:
             vo: { $ref: '#/components/schemas/Vo' }
             facility: { $ref: '#/components/schemas/Facility' }
             resourceTags: { type: array, items: { $ref: '#/components/schemas/ResourceTag' } }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -302,7 +285,6 @@ components:
         - properties:
             tagName: { type: string }
             voId: { type: integer }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -312,7 +294,6 @@ components:
         - properties:
             name: { type: string }
             shortName: { type: string }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -334,7 +315,6 @@ components:
             recurrence: { type: integer }
             enabled: { type: boolean }
             script: { type: string }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -364,7 +344,6 @@ components:
             destination: { type: string }
             type: { $ref: '#/components/schemas/DestinationType' }
             propagationType: { $ref: '#/components/schemas/DestinationPropagationType' }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 
@@ -374,7 +353,6 @@ components:
         - properties:
             service: { $ref: '#/components/schemas/Service' }
             facility: { $ref: '#/components/schemas/Facility' }
-            beanName: { type: string }
       discriminator:
         propertyName: beanName
 


### PR DESCRIPTION
* The property beanName is defined for model Auditable. All other models
inherit this property and it is not needed to be redeclared. Actually,
it causes a problem for angular generator.
* Removed beanName property from all models except PerunBean.