### PR TITLE
Forbid indirect relationship for group unions

### DIFF
--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -245,6 +245,46 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 				foundMember.getGroupStatuses().get(group.getId()), MemberGroupStatus.EXPIRED);
 	}
 
+	@Test (expected=GroupRelationNotAllowed.class)
+	public void createGroupUnionForIndirectRelationship() throws Exception {
+		System.out.println(CLASS_NAME + "createGroupUnionForIndirectRelationship");
+
+		Vo vo = setUpVo();
+		groupsManagerBl.createGroup(sess, vo, group2);
+		groupsManagerBl.createGroup(sess, group2, group3);
+		groupsManagerBl.createGroup(sess, group3, group4);
+
+		groupsManagerBl.createGroupUnion(sess, group2, group4, false);
+	}
+
+	@Test (expected=GroupMoveNotAllowedException.class)
+	public void moveGroupIsForbiddenWhenIndirectRelationshipExists1() throws Exception {
+		System.out.println(CLASS_NAME + "moveGroupIsForbiddenWhenIndirectRelationshipExists");
+
+		Vo vo = setUpVo();
+		groupsManagerBl.createGroup(sess, vo, group2);
+		groupsManagerBl.createGroup(sess, group2, group3);
+		groupsManagerBl.createGroup(sess, vo, group4);
+
+		groupsManagerBl.createGroupUnion(sess, group2, group4, false);
+
+		groupsManagerBl.moveGroup(sess, group3, group4);
+	}
+
+	@Test (expected=GroupMoveNotAllowedException.class)
+	public void moveGroupIsForbiddenWhenIndirectRelationshipExists2() throws Exception {
+		System.out.println(CLASS_NAME + "moveGroupIsForbiddenWhenIndirectRelationshipExists");
+
+		Vo vo = setUpVo();
+		groupsManagerBl.createGroup(sess, vo, group2);
+		groupsManagerBl.createGroup(sess, vo, group3);
+		groupsManagerBl.createGroup(sess, group3, group4);
+
+		groupsManagerBl.createGroupUnion(sess, group2, group4, false);
+
+		groupsManagerBl.moveGroup(sess, group2, group3);
+	}
+
 	@Test
 	public void validateMemberRecursively() throws Exception {
 		System.out.println(CLASS_NAME + "validateMemberRecursively");


### PR DESCRIPTION
 - indirect relationship can exist between groups in the same structure,
 for example if we have 3 groups "A", "A:B", "A:B:C", there is direct
 relationship between "A" and "A:B" and also direct relationship between
 "A:B" and "A:B:C". Because all members of A:B:C are included by this
 relationship to "A:B" and all such members are automatically included
 into "A", there is indirect relationship between groups "A" and "A:B:C"
 not saved in the database, but processed the same way
 - we want to prevent creating of unions between groups with such
 indirect relationship, so if someone want to create union from "A:B:C"
 to "A", it should be prohibited, because there is no benefit in such
 opration (all members of "A:B:C" are already indirect members of "A"
 through "A:B")
 - this situation need to be checked when new union has been created or
 existing group has been moved and there is a possibility that wrong
 union already exists
 - test for both of these use-case were added