### PR TITLE
Fixed loading initial data in the Cache and saving the Attribute

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -2348,12 +2348,6 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public boolean setAttribute(final PerunSession sess, final PerunBean bean1, final PerunBean bean2, final Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, WrongAttributeValueException {
-		String tableName;
-		String namespace;
-		Integer identificator1;
-		Integer identificator2;
-		Holder holder1;
-		Holder holder2;
 
 		// get bean names
 		String name1 = bean1.getBeanName().toLowerCase();
@@ -2366,14 +2360,11 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			name2 = name2.replaceFirst("rich", "");
 		}
 		// get namespace of the perun bean
-		namespace = BEANS_TO_NAMESPACES_MAP.get(name1 + "_" + name2);
-		identificator1 = bean1.getId();
-		identificator2 = bean2.getId();
-		holder1 = createHolderTypeByStringAndId(identificator1, name1);
-		holder2 = createHolderTypeByStringAndId(identificator2, name2);
-
+		String namespace = BEANS_TO_NAMESPACES_MAP.get(name1 + "_" + name2);
+		int identificator1 = bean1.getId();
+		int identificator2 = bean2.getId();
 		if (namespace == null) {
-			// swap the names and beans and try again
+			// swap the names and beans/ids and try again
 			String nameTmp = name1;
 			name1 = name2;
 			name2 = nameTmp;
@@ -2385,7 +2376,9 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 			// the combination of perun beans is not in the namespace map
 			throw new InternalErrorException(new IllegalArgumentException("Setting attribute for perun bean " + bean1 + " and " + bean2 + " is not allowed."));
 		}
-		tableName = name1 + "_" + name2 + "_attr_values";
+		Holder holder1 = createHolderTypeByStringAndId(identificator1, name1);
+		Holder holder2 = createHolderTypeByStringAndId(identificator2, name2);
+		String tableName = name1 + "_" + name2 + "_attr_values";
 
 		// check that given object is consistent with the attribute
 		checkNamespace(sess, attribute, namespace);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/CacheManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/CacheManager.java
@@ -1747,7 +1747,7 @@ public class CacheManager implements CacheManagerApi {
 
 		List<AttributeHolders> attrs = jdbc.query("select " + AttributesManagerImpl.getAttributeMappingSelectQuery(tableName) +
 						", "+ primHolder +"_id as primary_holder_id , " + secHolder + "_id as secondary_holder_id from attr_names " +
-						"join " + tableName + " on id=attr_id where (attr_id < 10 and attr_value is not null or attr_value_text is not null)",
+						"join " + tableName + " on id=attr_id where (attr_value is not null or attr_value_text is not null)",
 				new AttributesManagerImpl.AttributeHoldersRowMapper(sess, attrManagerImpl, primHolderType, secHolderType));
 
 		this.setAttributes(attrs);


### PR DESCRIPTION
- There was forgotten condition on id<10 while loading non empty attributes
  in the cache. It resulted in empty values for attributes with two holders.
- When storing attributes in DB/Cache we must build Holder objects based on
  expected order/namespace. In case of wrong order, we previously didn't
  rebuild Holder objects, hence probably saved values in cache with wrong ID.
  We should really use strict order in the api in future and remove those
  repetitive fixes for switching the order.