### PR TITLE
Changed type of vo:def:voLogoURL attribute to large string

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -432,8 +432,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			attrDef.setDisplayName("VO logo's URL");
 			attrDef.setFriendlyName("voLogoURL");
 			attrDef.setNamespace("urn:perun:vo:attribute-def:def");
-			attrDef.setDescription("Full URL of the VO's logo image (including http://).");
-			attrDef.setType(String.class.getName());
+			attrDef.setDescription("Full URL of the VO's logo image (including https://) or base64 encoded data like: 'data:image/png;base64,....'");
+			attrDef.setType(BeansUtils.largeStringClassName);
 			attrDef = attrManager.createAttribute(registrarSession, attrDef);
 			// set attribute rights
 			List<AttributeRights> rights = new ArrayList<>();


### PR DESCRIPTION
- Due to security settings in webserver we don't want to include
  vo logo images in registrar by URL, but rather source base64 encoded
  data. In order to keep them, we must change type of existing attribute
  from string to large string.

On deployment, existing attribute definition must be updated and all
existing values moved from attr_value column to attr_value_text column!!