### PR TITLE
Fixed audit messages resolving in user:virt:userCertDNs

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_userCertDNs.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_userCertDNs.java
@@ -69,9 +69,9 @@ public class urn_perun_user_attribute_def_virt_userCertDNs extends UserVirtualAt
 		List<AuditEvent> resolvingMessages = new ArrayList<>();
 		if (message == null) return resolvingMessages;
 
-		if (message instanceof UserExtSourceAddedToUser && ((UserExtSourceAddedToUser) message).getUserExtSource().getExtSource() instanceof ExtSourceX509) {
+		if (message instanceof UserExtSourceAddedToUser && ExtSourcesManager.EXTSOURCE_X509.equals(((UserExtSourceAddedToUser) message).getUserExtSource().getExtSource().getType())) {
 			resolvingMessages.add(resolveEvent(perunSession, ((UserExtSourceAddedToUser) message).getUser()));
-		} else if (message instanceof UserExtSourceRemovedFromUser && ((UserExtSourceRemovedFromUser) message).getUserExtSource().getExtSource() instanceof ExtSourceX509) {
+		} else if (message instanceof UserExtSourceRemovedFromUser && ExtSourcesManager.EXTSOURCE_X509.equals(((UserExtSourceRemovedFromUser) message).getUserExtSource().getExtSource().getType())) {
 			resolvingMessages.add(resolveEvent(perunSession, ((UserExtSourceRemovedFromUser) message).getUser()));
 		}
 


### PR DESCRIPTION
- ExtSource contained in AuditerMessage about UES adding/removal
  is of base class ExtSource and not specific X509/IdP etc.
  We must explicitly compare type of ExtSource object in order
  to produce resolved auditer messages about virt attr value change.