### PR TITLE
make ldapc read-only w.r.t. the Perun db 

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuditMessagesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuditMessagesManager.java
@@ -58,7 +58,6 @@ public interface AuditMessagesManager {
 	 * @throws InternalErrorException When implementation fails
 	 * @throws PrivilegeException When you are not authorized to poll messages
 	 */
-	@Deprecated
 	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName) throws InternalErrorException, PrivilegeException;
 
 	/**
@@ -82,7 +81,6 @@ public interface AuditMessagesManager {
 	 * @throws InternalErrorException When implementation fails
 	 * @throws PrivilegeException When you are not authorized to poll events
 	 */
-	@Deprecated
 	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException, PrivilegeException;
 
 	/**
@@ -95,7 +93,6 @@ public interface AuditMessagesManager {
 	 * @throws InternalErrorException When implementation fails
 	 * @throws PrivilegeException When you are not authorized to poll events
 	 */
-	@Deprecated
 	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuditMessagesManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuditMessagesManager.java
@@ -58,7 +58,20 @@ public interface AuditMessagesManager {
 	 * @throws InternalErrorException When implementation fails
 	 * @throws PrivilegeException When you are not authorized to poll messages
 	 */
+	@Deprecated
 	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Returns list of <b>AuditMessages</b> from audit log with IDs > lastProcessedId given.
+	 *
+	 * @param perunSession perun session
+	 * @param consumerName consumer to get messages for
+	 * @param lastProcessedId id of the last message 
+	 * @return List of audit messages
+	 * @throws InternalErrorException When implementation fails
+	 * @throws PrivilegeException When you are not authorized to poll messages
+	 */
+	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException;
 
 	/**
 	 * Returns list of <b>AuditEvents</b> from audit log with IDs > lastProcessedId for registered auditer consumer.
@@ -69,7 +82,21 @@ public interface AuditMessagesManager {
 	 * @throws InternalErrorException When implementation fails
 	 * @throws PrivilegeException When you are not authorized to poll events
 	 */
+	@Deprecated
 	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 * Returns list of <b>AuditEvents</b> from audit log with IDs > lastProcessedId for registered auditer consumer.
+	 *
+	 * @param perunSession perun session
+	 * @param consumerName consumer to get messages for
+	 * @param lastProcessedId id of the last event
+	 * @return List of audit messages
+	 * @throws InternalErrorException When implementation fails
+	 * @throws PrivilegeException When you are not authorized to poll events
+	 */
+	@Deprecated
+	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException;
 
 	/**
 	 * Creates new auditer consumer with last processed id which equals current auditer log max id.
@@ -118,6 +145,7 @@ public interface AuditMessagesManager {
 	 * @throws InternalErrorException When implementation fails
 	 * @throws PrivilegeException When you are not authorized to set last processed id
 	 */
+	@Deprecated
 	void setLastProcessedId(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AuditMessagesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AuditMessagesManagerBl.java
@@ -45,7 +45,6 @@ public interface AuditMessagesManagerBl {
 	 * @return List of audit messages
 	 * @throws InternalErrorException When implementation fails
 	 */
-	@Deprecated
 	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName) throws InternalErrorException;
 
 	/**
@@ -67,7 +66,6 @@ public interface AuditMessagesManagerBl {
 	 * @return List of audit messages
 	 * @throws InternalErrorException When implementation fails
 	 */
-	@Deprecated
 	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AuditMessagesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AuditMessagesManagerBl.java
@@ -45,7 +45,19 @@ public interface AuditMessagesManagerBl {
 	 * @return List of audit messages
 	 * @throws InternalErrorException When implementation fails
 	 */
+	@Deprecated
 	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName) throws InternalErrorException;
+
+	/**
+	 * Returns list of <b>AuditMessages</b> from audit log with IDs > lastProcessedId for registered auditer consumer.
+	 *
+	 * @param perunSession perun session
+	 * @param consumerName consumer to get messages for
+	 * @param lastProcessedId id of the last message 
+	 * @return List of audit messages
+	 * @throws InternalErrorException When implementation fails
+	 */
+	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException;
 
 	/**
 	 * Returns list of <b>AuditEvents</b> from audit log with IDs > lastProcessedId for registered auditer consumer.
@@ -55,7 +67,19 @@ public interface AuditMessagesManagerBl {
 	 * @return List of audit messages
 	 * @throws InternalErrorException When implementation fails
 	 */
+	@Deprecated
 	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException;
+
+	/**
+	 * Returns list of <b>AuditEvents</b> from audit log with IDs > lastProcessedId for registered auditer consumer.
+	 *
+	 * @param perunSession perun session
+	 * @param consumerName consumer to get messages for
+	 * @param lastProcessedId id of the last message 
+	 * @return List of audit messages
+	 * @throws InternalErrorException When implementation fails
+	 */
+	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException;
 
 	/**
 	 * Creates new auditer consumer with last processed id which equals current auditer log max id.
@@ -101,6 +125,7 @@ public interface AuditMessagesManagerBl {
 	 * @param lastProcessedId id of last processed message in consumer
 	 * @throws InternalErrorException When implementation fails
 	 */
+	@Deprecated
 	void setLastProcessedId(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuditMessagesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuditMessagesManagerBlImpl.java
@@ -64,8 +64,18 @@ public class AuditMessagesManagerBlImpl implements AuditMessagesManagerBl {
 	}
 
 	@Override
+	public List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException {
+		return getAuditMessagesManagerImpl().pollConsumerMessages(perunSession, consumerName, lastProcessedId);
+	}
+
+	@Override
 	public List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException {
 		return getAuditMessagesManagerImpl().pollConsumerEvents(perunSession, consumerName);
+	}
+
+	@Override
+	public List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException {
+		return getAuditMessagesManagerImpl().pollConsumerEvents(perunSession, consumerName, lastProcessedId);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/AuditMessagesManagerEntry.java
@@ -54,11 +54,27 @@ public class AuditMessagesManagerEntry implements AuditMessagesManager {
 	}
 
 	@Override
+	public List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException {
+		if (!AuthzResolver.isAuthorized(perunSession, Role.PERUNADMIN)) {
+			throw new PrivilegeException(perunSession, "pollConsumerMessages");
+		}
+		return getAuditMessagesManagerBl().pollConsumerMessages(perunSession, consumerName, lastProcessedId);
+	}
+
+	@Override
 	public List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException, PrivilegeException {
 		if (!AuthzResolver.isAuthorized(perunSession, Role.PERUNADMIN)) {
 			throw new PrivilegeException(perunSession, "pollConsumerEvents");
 		}
 		return getAuditMessagesManagerBl().pollConsumerEvents(perunSession, consumerName);
+	}
+
+	@Override
+	public List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException, PrivilegeException {
+		if (!AuthzResolver.isAuthorized(perunSession, Role.PERUNADMIN)) {
+			throw new PrivilegeException(perunSession, "pollConsumerEvents");
+		}
+		return getAuditMessagesManagerBl().pollConsumerEvents(perunSession, consumerName, lastProcessedId);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuditMessagesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuditMessagesManagerImpl.java
@@ -229,6 +229,26 @@ public class AuditMessagesManagerImpl implements AuditMessagesManagerImplApi {
 	}
 
 	@Override
+	public List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException {
+
+		checkAuditerConsumerExists(perunSession, consumerName);
+
+		try {
+
+			List<AuditMessage> messages = new ArrayList<>();
+
+			int maxId = getLastMessageId(perunSession);
+			if(maxId > lastProcessedId) {
+				// get messages
+				messages = jdbc.query("select " + auditMessageMappingSelectQuery + " from auditer_log where id > ? and id <= ? order by id", AUDIT_MESSAGE_MAPPER, lastProcessedId, maxId);
+			}
+			return messages;
+		} catch(Exception ex) {
+			throw new InternalErrorException(ex);
+		}
+	}
+
+	@Override
 	public List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException {
 
 		checkAuditerConsumerExists(perunSession, consumerName);
@@ -244,6 +264,29 @@ public class AuditMessagesManagerImpl implements AuditMessagesManagerImplApi {
 				eventList = jdbc.query("select " + auditMessageMappingSelectQuery + " from auditer_log where id > ? and id <= ? order by id", AUDIT_EVENT_MAPPER, lastProcessedId, maxId);
 				// update counter
 				setLastProcessedId(perunSession, consumerName, maxId);
+			}
+
+			return eventList;
+
+		} catch (Exception ex) {
+			throw new InternalErrorException(ex);
+		}
+
+	}
+
+	@Override
+	public List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException {
+
+		checkAuditerConsumerExists(perunSession, consumerName);
+
+		try {
+
+			List<AuditEvent> eventList = new ArrayList<>();
+
+			int maxId = getLastMessageId(perunSession);
+			if (maxId > lastProcessedId) {
+				// get events
+				eventList = jdbc.query("select " + auditMessageMappingSelectQuery + " from auditer_log where id > ? and id <= ? order by id", AUDIT_EVENT_MAPPER, lastProcessedId, maxId);
 			}
 
 			return eventList;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuditMessagesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuditMessagesManagerImplApi.java
@@ -45,7 +45,19 @@ public interface AuditMessagesManagerImplApi {
 	 * @return List of audit messages
 	 * @throws InternalErrorException When implementation fails
 	 */
+	@Deprecated
 	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName) throws InternalErrorException;
+
+	/**
+	 * Returns list of <b>AuditMessages</b> from audit log with IDs > lastProcessedId for registered auditer consumer.
+	 *
+	 * @param perunSession perun session
+	 * @param consumerName consumer to get messages for
+	 * @param lastProcessedId id of the last message 
+	 * @return List of audit messages
+	 * @throws InternalErrorException When implementation fails
+	 */
+	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException;
 
 	/**
 	 * Returns list of <b>AuditEvents</b> from audit log with IDs > lastProcessedId for registered auditer consumer.
@@ -55,7 +67,19 @@ public interface AuditMessagesManagerImplApi {
 	 * @return List of audit messages
 	 * @throws InternalErrorException When implementation fails
 	 */
+	@Deprecated
 	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException;
+
+	/**
+	 * Returns list of <b>AuditEvents</b> from audit log with IDs > lastProcessedId for registered auditer consumer.
+	 *
+	 * @param perunSession perun session
+	 * @param consumerName consumer to get messages for
+	 * @param lastProcessedId id of the last message 
+	 * @return List of audit messages
+	 * @throws InternalErrorException When implementation fails
+	 */
+	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException;
 
 	/**
 	 * Creates new auditer consumer with last processed id which equals current auditer log max id.
@@ -92,6 +116,7 @@ public interface AuditMessagesManagerImplApi {
 	 * @param lastProcessedId id of last processed message in consumer
 	 * @throws InternalErrorException When implementation fails
 	 */
+	@Deprecated
 	void setLastProcessedId(PerunSession perunSession, String consumerName, int lastProcessedId) throws InternalErrorException;
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuditMessagesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuditMessagesManagerImplApi.java
@@ -45,7 +45,6 @@ public interface AuditMessagesManagerImplApi {
 	 * @return List of audit messages
 	 * @throws InternalErrorException When implementation fails
 	 */
-	@Deprecated
 	List<AuditMessage> pollConsumerMessages(PerunSession perunSession, String consumerName) throws InternalErrorException;
 
 	/**
@@ -67,7 +66,6 @@ public interface AuditMessagesManagerImplApi {
 	 * @return List of audit messages
 	 * @throws InternalErrorException When implementation fails
 	 */
-	@Deprecated
 	List<AuditEvent> pollConsumerEvents(PerunSession perunSession, String consumerName) throws InternalErrorException;
 
 	/**

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/LdapProperties.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/LdapProperties.java
@@ -11,11 +11,13 @@ public class LdapProperties {
 	private String ldapConsumerName;
 	private String ldapBase;
 	private String ldapLoginNamespace;
+	private String ldapStateFile;
 
-	public LdapProperties(String ldapConsumerName, String ldapBase, String ldapLoginNamespace) {
+	public LdapProperties(String ldapConsumerName, String ldapBase, String ldapLoginNamespace, String ldapStateFile) {
 		this.ldapConsumerName = ldapConsumerName;
 		this.ldapBase = ldapBase;
 		this.ldapLoginNamespace = ldapLoginNamespace;
+		this.ldapStateFile = ldapStateFile;
 	}
 
 	public boolean propsLoaded() {
@@ -32,5 +34,9 @@ public class LdapProperties {
 
 	public String getLdapLoginNamespace() {
 		return ldapLoginNamespace;
+	}
+	
+	public String getLdapStateFile() {
+		return ldapStateFile;
 	}
 }

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/main/LdapcStarter.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/main/LdapcStarter.java
@@ -81,9 +81,10 @@ public class LdapcStarter {
 				//Set lastProcessedIdToSet if bigger than 0
 				if(lastProcessedIdToSet > 0) {
 					//Rpc.AuditMessagesManager.setLastProcessedId(rpcCaller, "ldapcConsumer", lastProcessedIdToSet);
-					ldapcStarter.perunBl.getAuditMessagesManager().setLastProcessedId(ldapcStarter.ldapcManager.getPerunSession(),
-							ldapcStarter.ldapProperties.getLdapConsumerName(), lastProcessedIdToSet);
-				}
+					//ldapcStarter.perunBl.getAuditMessagesManager().setLastProcessedId(ldapcStarter.ldapcManager.getPerunSession(),
+					//		ldapcStarter.ldapProperties.getLdapConsumerName(), lastProcessedIdToSet);
+						ldapcStarter.ldapcManager.setLastProcessedId(lastProcessedIdToSet);
+					}
 			}
 
 			// Start processing events (run method in EventProcessorImpl)

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/EventDispatcher.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/processor/EventDispatcher.java
@@ -64,4 +64,6 @@ public interface EventDispatcher extends Runnable {
 	public void registerProcessor(EventProcessor processor, DispatchEventCondition condition);
 
 	public void dispatchEvent(String msg, MessageBeans beans);
+	
+	public void setLastProcessedIdNumber(int lastProcessedId);
 }

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/LdapcManager.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/LdapcManager.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.ldapc.service;
 
+import org.infinispan.objectfilter.impl.ql.parse.IckleParser.in_key_return;
+
 import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;
@@ -28,5 +30,7 @@ public interface LdapcManager {
 	public PerunPrincipal getPerunPrincipal();
 
 	public void setPerunPrincipal(PerunPrincipal perunPrincipal);
+	
+	public void setLastProcessedId(int lastProcessedId);
 
 }

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/LdapcManager.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/LdapcManager.java
@@ -1,7 +1,5 @@
 package cz.metacentrum.perun.ldapc.service;
 
-import org.infinispan.objectfilter.impl.ql.parse.IckleParser.in_key_return;
-
 import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunPrincipal;
 import cz.metacentrum.perun.core.api.PerunSession;

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/impl/LdapcManagerImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/impl/LdapcManagerImpl.java
@@ -66,7 +66,8 @@ public class LdapcManagerImpl implements LdapcManager {
 			groupSynchronizer.synchronizeGroups();
 
 			int lastProcessedMessageId = ((PerunBl)getPerunBl()).getAuditMessagesManagerBl().getLastMessageId(perunSession);
-			((PerunBl)getPerunBl()).getAuditMessagesManagerBl().setLastProcessedId(perunSession, ldapProperties.getLdapConsumerName(), lastProcessedMessageId);
+			// ((PerunBl)getPerunBl()).getAuditMessagesManagerBl().setLastProcessedId(perunSession, ldapProperties.getLdapConsumerName(), lastProcessedMessageId);
+			eventDispatcher.setLastProcessedIdNumber(lastProcessedMessageId);
 		} catch (Exception  e) {
 			log.error("Error synchronizing to LDAP", e);
 			throw new InternalErrorException(e);
@@ -94,5 +95,10 @@ public class LdapcManagerImpl implements LdapcManager {
 
 	public void setPerunPrincipal(PerunPrincipal perunPrincipal) {
 		this.perunPrincipal = perunPrincipal;
+	}
+
+	@Override
+	public void setLastProcessedId(int lastProcessedId) {
+		eventDispatcher.setLastProcessedIdNumber(lastProcessedId);
 	}
 }

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -945,6 +945,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
         <constructor-arg name="ldapConsumerName" index="0" value="${ldap.consumerName}" />
         <constructor-arg name="ldapBase" index="1" value="${ldap.base}" />
         <constructor-arg name="ldapLoginNamespace" index="2" value="${ldap.loginNamespace}" />
+        <constructor-arg name="ldapStateFile" index="3" value="${ldap.stateFile}" />
     </bean>
 
     <!-- These beans are for define ldapTemplate -->


### PR DESCRIPTION
* deprecate methods using lastProcessedId from auditer_consumers table,
* add methods for reading auditer messages with additional parameter - the last processed message id,
* ldapc now stores lastProcessedId locally.

IMPORTANT: requires setting ldapc.stateFile property to filename, where the last processed message id will be stored; if the file can not be created, ldapc will not start