### PR TITLE
initial perun-synchronizer

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1,6 +1,8 @@
 set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
+-- set row locking
+set database transaction control mvcc;
 
 -- database version 3.1.58 (don't forget to update insert statement at the end of file)
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunLocksUtils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/PerunLocksUtils.java
@@ -1,21 +1,22 @@
 package cz.metacentrum.perun.core.impl;
 
+import static java.util.stream.Collectors.joining;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcPerunTemplate;
+import org.springframework.jdbc.core.RowCountCallbackHandler;
+
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Methods and structures for working with locks on objects and actions.
@@ -26,6 +27,8 @@ public class PerunLocksUtils {
 
 	private final static Logger log = LoggerFactory.getLogger(PerunLocksUtils.class);
 
+	private static JdbcPerunTemplate jdbc = null;
+
 	//This empty object is used just for purpose of saving and identifying all locks for separate transaction
 	public static final ThreadLocal<Object> uniqueKey = ThreadLocal.withInitial(Object::new);
 
@@ -33,6 +36,11 @@ public class PerunLocksUtils {
 	private static final ConcurrentHashMap<Group, ReadWriteLock> groupsLocks = new ConcurrentHashMap<>();
 	private static final ConcurrentHashMap<Group, ConcurrentHashMap<Member, Lock>> groupsMembersLocks = new ConcurrentHashMap<>();
 
+	private static PerunLocksUtils setDataSource(DataSource perunPool) {
+		PerunLocksUtils.jdbc = new  JdbcPerunTemplate(perunPool);
+		return new PerunLocksUtils();
+	}
+	
 	/**
 	 * Create transaction locks for combination of group and member (from list of members)
 	 * and also bind them to the transaction (as resource by Object uniqueKey)
@@ -47,53 +55,17 @@ public class PerunLocksUtils {
 		if(group == null) throw new InternalErrorException("Group can't be null when creating lock for group and list of members.");
 		if(members == null) throw new InternalErrorException("Members can't be null or empty when creating lock for group and list of members.");
 
-		//Sort list of members strictly by ids (there is compareTo method in perunBean using ids for comparing)
-		Collections.sort(members);
-
-		List<Lock> returnedLocks = new ArrayList<>();
-
-		try {
-			try {
-				//try to lock all needed locks there
-				ReadWriteLock groupReadWriteLock = groupsLocks.computeIfAbsent(group, f -> new ReentrantReadWriteLock(true));
-
-				if (!groupReadWriteLock.readLock().tryLock(4, TimeUnit.HOURS)) {
-					throw new InternalErrorException("Can't acquire a lock in expected time.");
-				}
-
-				returnedLocks.add(groupReadWriteLock.readLock());
-				for (Member member : members) {
-					//Get members lock map by group if exists or create a new one
-					ConcurrentHashMap<Member, Lock> membersLocks = groupsMembersLocks.get(group);
-					if (membersLocks == null) {
-						groupsMembersLocks.putIfAbsent(group, new ConcurrentHashMap<>());
-						membersLocks = groupsMembersLocks.get(group);
-					}
-
-					//Get concrete member lock from members lock map or create a new one if not exists
-					Lock memberLock = membersLocks.computeIfAbsent(member, f -> new ReentrantLock(true));
-
-					//Lock the lock and return it
-					if (!memberLock.tryLock(4, TimeUnit.HOURS)) {
-						throw new InternalErrorException("Can't acquire a lock in expected time.");
-					}
-					returnedLocks.add(memberLock);
-				}
-
-				//bind these locks like transaction resource
-				if (TransactionSynchronizationManager.getResource(uniqueKey.get()) == null) {
-					TransactionSynchronizationManager.bindResource(uniqueKey.get(), returnedLocks);
-				} else {
-					// the returned resource can never be null because of the previous check
-					((List<Lock>) TransactionSynchronizationManager.getResource(uniqueKey.get())).addAll(returnedLocks);
-				}
-			} catch (InterruptedException ex) {
-				throw new InternalErrorException("Interrupted exception has been thrown while locking group " + group + " and list of members " + members, ex);
-			}
-		} catch (Exception ex) {
-			//if some exception has been thrown, unlock all already locked locks
-			unlockAll(returnedLocks);
-			throw ex;
+		lockGroupMembership(group);
+		
+		RowCountCallbackHandler countCallback = new RowCountCallbackHandler();  //
+		log.debug("Trying to get lock on " + members.size() + " members" );
+		jdbc.query("select * from  members where members.id in (" + 
+				members.stream()
+					.map(m -> String.valueOf(m.getId()))
+					.collect(joining(",")) + ") for update", countCallback);
+		if(countCallback.getRowCount() != members.size()) {
+			throw new InternalErrorException("Error locking members - some members not found (expected " 
+					+ members.size() + ", got " + countCallback.getRowCount() + ")");
 		}
 	}
 
@@ -108,32 +80,14 @@ public class PerunLocksUtils {
 	public static void lockGroupMembership(Group group) throws InternalErrorException {
 		if(group == null) throw new InternalErrorException("Group can't be null when creating lock for group.");
 
-		List<Lock> returnedLocks = new ArrayList<>();
-		try {
-			try {
-				//Need to investigate if we have all needed locks already in the structure or we need to create them
-				ReadWriteLock groupReadWriteLock = groupsLocks.computeIfAbsent(group, f -> new ReentrantReadWriteLock(true));
-
-				if (!groupReadWriteLock.writeLock().tryLock(4, TimeUnit.HOURS)) {
-					throw new InternalErrorException("Can't acquire a lock in expected time.");
-				}
-				returnedLocks.add(groupReadWriteLock.writeLock());
-
-				//bind these locks like transaction resource
-				if (TransactionSynchronizationManager.getResource(uniqueKey.get()) == null) {
-					TransactionSynchronizationManager.bindResource(uniqueKey.get(), returnedLocks);
-				} else {
-					// the returned resource can never be null because of the previous check
-					((List<Lock>) TransactionSynchronizationManager.getResource(uniqueKey.get())).addAll(returnedLocks);
-				}
-			} catch (InterruptedException ex) {
-				throw new InternalErrorException("Interrupted exception has been thrown while locking group " + group, ex);
-			}
-		} catch (Exception ex) {
-			//if some exception has been thrown, unlock all already locked locks
-			unlockAll(returnedLocks);
-			throw ex;
+		//jdbc.execute("select * from groups where id =  " + String.valueOf(group.getId()) + " for update");
+		RowCountCallbackHandler countCallback = new RowCountCallbackHandler();  //
+		log.debug("Trying to get lock on group " + group.getId());
+		jdbc.query("select * from  groups where groups.id = " + String.valueOf(group.getId()) + " for update", countCallback);
+		if(countCallback.getRowCount() == 0) {
+			throw new InternalErrorException("Error locking group - no such group " + group.getId());
 		}
+		
 	}
 
 	/**

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -170,6 +170,10 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<constructor-arg ref="perun" />
 	</bean>
 
+    <bean class="cz.metacentrum.perun.core.impl.PerunLocksUtils" factory-method="setDataSource" scope="singleton">
+		<constructor-arg ref="dataSource" />
+    </bean>
+    
 	<!-- Perun implementation -->
 	<bean id="perun" class="cz.metacentrum.perun.core.blImpl.PerunBlImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
 		<constructor-arg name="auditer" ref="auditer"/>
@@ -409,10 +413,6 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<constructor-arg ref="localCacheManager" />
 	</bean>
 
-	<bean id="synchronizer" class="cz.metacentrum.perun.core.impl.Synchronizer" scope="singleton" depends-on="databaseManagerBl">
-		<constructor-arg ref="perun" />
-	</bean>
-
 	<bean class="cz.metacentrum.perun.core.impl.ExtSourceGoogle" factory-method="setPerunBlImpl">
 		<constructor-arg ref="perun" />
 	</bean>
@@ -512,7 +512,7 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<!--DataSource implementation-->
 		<jdbc:embedded-database id="dataSource" type="HSQL">
 			<jdbc:script location="classpath:test-schema.sql"/>
-			<jdbc:script location="classpath:test-data.sql"/>
+			<jdbc:script location="classpath:test-data.sql" />
 		</jdbc:embedded-database>
 
 		<!-- PerunRolesLoader implementation -->

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -26,7 +26,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Auditer;
-import cz.metacentrum.perun.core.impl.Synchronizer;
 import cz.metacentrum.perun.registrar.model.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +51,7 @@ import java.util.stream.Collectors;
  */
 public class ExpirationNotifScheduler {
 
-	private final static Logger log = LoggerFactory.getLogger(Synchronizer.class);
+	private final static Logger log = LoggerFactory.getLogger(ExpirationNotifScheduler.class);
 	private PerunSession sess;
 
 	private PerunBl perun;

--- a/perun-rpc/src/main/resources/perun-rpc.xml
+++ b/perun-rpc/src/main/resources/perun-rpc.xml
@@ -11,7 +11,7 @@
 	<import resource="classpath:perun-core.xml"/>
 
 	<!--  <import resource="classpath:perun-controller.xml"/>  -->
-	<import resource="classpath:perun-core-synchronizers.xml"/>
+	<!--  <import resource="classpath:perun-core-synchronizers.xml"/> -->
 	<import resource="classpath:perun-cabinet.xml"/>
 	<import resource="classpath:perun-registrar-lib.xml"/>
 	<import resource="classpath:perun-registrar-lib-scheduler.xml"/>

--- a/perun-synchronizer/pom.xml
+++ b/perun-synchronizer/pom.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  	<modelVersion>4.0.0</modelVersion>
+
+  	<parent>
+    	<groupId>cz.metacentrum</groupId>
+    	<artifactId>perun</artifactId>
+    	<version>3.10.0-SNAPSHOT</version>
+  	</parent>
+
+  	<groupId>cz.metacentrum.perun</groupId>
+  	<artifactId>perun-synchronizer</artifactId>
+	<packaging>jar</packaging>
+
+
+  	<name>perun-synchronizer</name>
+
+  	<url>http://maven.apache.org</url>
+
+  	<properties>
+ 		<start-class>cz.metacentrum.perun.synchronizer.main.SynchronizerStarter</start-class>
+  	</properties>
+
+	<!-- common build settings used by all profiles -->
+	<build>
+        <finalName>${project.name}</finalName>
+		<plugins>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-install-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+
+			<!-- Package JAR with Main class and all libraries -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<!-- Main-Class taken from property ${start-class} -->
+			</plugin>
+
+			<!-- Executing plug-in:  mvn exec:java -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<mainClass>${start-class}</mainClass>
+				</configuration>
+			</plugin>
+
+		</plugins>
+
+		<resources>
+			<resource>
+				<!-- to set jdbc.properties path and logging folder -->
+				<directory>src/main/resources/</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
+
+	</build>
+
+	<dependencies>
+		<!-- PERUN -->
+
+		<dependency>
+			<groupId>cz.metacentrum.perun</groupId>
+			<artifactId>perun-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- SPRING -->
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-pool</groupId>
+			<artifactId>commons-pool</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- TESTS -->
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- imports logback-test.xml for test from perun-base -->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>perun-base</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- imports logback-test.xml for test from perun-base -->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>perun-base</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+  	</dependencies>
+  	
+	<profiles>
+
+		<profile>
+			<!-- adds Oracle JDBC drivers if run with "mvn -Doracle=True"-->
+			<id>oracle</id>
+			<activation>
+				<property>
+					<name>oracle</name>
+					<value>True</value>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- Oracle jdbc driver -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>ojdbc8</artifactId>
+				</dependency>
+				<!-- Oracle internationalization -->
+				<dependency>
+					<groupId>com.oracle</groupId>
+					<artifactId>orai18n</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+
+	</profiles>
+
+</project>

--- a/perun-synchronizer/src/main/java/cz/metacentrum/perun/synchronizer/beans/Synchronizer.java
+++ b/perun-synchronizer/src/main/java/cz/metacentrum/perun/synchronizer/beans/Synchronizer.java
@@ -1,4 +1,4 @@
-package cz.metacentrum.perun.core.impl;
+package cz.metacentrum.perun.synchronizer.beans;
 
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.PerunClient;

--- a/perun-synchronizer/src/main/java/cz/metacentrum/perun/synchronizer/main/SynchronizerStarter.java
+++ b/perun-synchronizer/src/main/java/cz/metacentrum/perun/synchronizer/main/SynchronizerStarter.java
@@ -1,0 +1,33 @@
+package cz.metacentrum.perun.synchronizer.main;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class SynchronizerStarter {
+	private final static Logger log = LoggerFactory.getLogger(SynchronizerStarter.class);
+
+	private AbstractApplicationContext springCtx;
+
+	public SynchronizerStarter () {
+		springCtx = new ClassPathXmlApplicationContext("/perun-synchronizer.xml");
+	}
+	
+	public static void main(String[] args) {
+		System.out.println("Starting Perun-Synchronizer...");
+
+		SynchronizerStarter startMe = new SynchronizerStarter();
+		
+		DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+		Date date = new Date();
+		log.info(dateFormat.format(date) + ": Done. Perun-Synchronizer has started.");
+		System.out.println(dateFormat.format(date) + ": Done. Perun-Synchronizer has started.");
+
+	}
+
+}

--- a/perun-synchronizer/src/main/resources/perun-core-synchronizers.xml
+++ b/perun-synchronizer/src/main/resources/perun-core-synchronizers.xml
@@ -9,7 +9,7 @@ http://www.springframework.org/schema/task http://www.springframework.org/schema
 
 	<task:scheduler id="scheduler" pool-size="1"/>
 
-	<beans profile="production">
+	<beans profile="aproduction">
 		<task:scheduled-tasks scheduler="scheduler">
 			<task:scheduled ref="synchronizer" method="synchronizeGroups" cron="0 0/5 * * * ?"/> <!-- every 5 minutes -->
 			<task:scheduled ref="synchronizer" method="synchronizeGroupsStructures" cron="0 0/5 * * * ?"/> <!-- every 5 minutes -->

--- a/perun-synchronizer/src/main/resources/perun-synchronizer.xml
+++ b/perun-synchronizer/src/main/resources/perun-synchronizer.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:aop="http://www.springframework.org/schema/aop"
+    xmlns:context="http://www.springframework.org/schema/context"
+           xmlns:tx="http://www.springframework.org/schema/tx"
+	xsi:schemaLocation="
+http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<import resource="classpath:perun-core.xml"/>
+	<import resource="classpath:perun-core-synchronizers.xml"/>
+
+	<aop:config>
+		<aop:advisor advice-ref="txAdviceSerialized" pointcut="execution(* cz.metacentrum.perun.synchronizer.test.GroupAccessor.accessGroup*(..))"/>
+		<!-- 
+		<aop:advisor advice-ref="txAdviceSerialized" pointcut="execution(* cz.metacentrum.perun.synchronizer.test.GroupAccessor.setUp(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.synchronizer.test.GroupAccessor.accessGroup*(..))"/>
+		<aop:advisor advice-ref="txAdviceReadOnlySerialized" pointcut="execution(* cz.metacentrum.perun.synchronizer.test.GroupAccessor.accessGroup*(..))"/>
+		-->
+	</aop:config>
+
+        <tx:advice id="txAdviceSerialized" transaction-manager="springTransactionManager">
+		<tx:attributes>
+	        	<tx:method name="*" read-only="false" rollback-for="Exception" isolation="READ_COMMITTED"/>
+	        </tx:attributes>
+	</tx:advice>
+
+	
+    <!-- Scans for @Repository, @Service and @Component -->
+    <context:component-scan base-package="cz.metacentrum.perun.synchronizer.test"/>
+    <context:annotation-config/>
+
+	<bean id="synchronizer" class="cz.metacentrum.perun.synchronizer.beans.Synchronizer" scope="singleton" depends-on="databaseManagerBl">
+		<constructor-arg ref="perun" />
+	</bean>
+
+</beans>

--- a/perun-synchronizer/src/test/java/cz/metacentrum/perun/synchronizer/test/AbstractSynchronizerTest.java
+++ b/perun-synchronizer/src/test/java/cz/metacentrum/perun/synchronizer/test/AbstractSynchronizerTest.java
@@ -1,0 +1,60 @@
+package cz.metacentrum.perun.synchronizer.test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.Host;
+import cz.metacentrum.perun.core.api.PerunClient;
+import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.impl.CacheManager;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+		@ContextConfiguration(locations = {
+					"classpath:perun-base.xml", 
+					"classpath:perun-core.xml", 
+					"classpath:perun-synchronizer.xml"})
+})
+@Transactional(transactionManager = "perunTestTransactionManager")
+public abstract class AbstractSynchronizerTest {
+	
+	@Autowired
+	protected PerunBl perun;
+
+	protected static PerunSession sess;
+
+	protected final SortedSet<User> usersForDeletion = new TreeSet<>();
+	protected final Set<Host> hostsForDeletion = new HashSet<>();
+
+	public void setPerun(PerunBl p) {
+		this.perun = p;
+	}
+
+	@Before
+	public void setUpSessAndCache() throws Exception {
+		final PerunPrincipal pp = new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
+		sess = perun.getPerunSession(pp, new PerunClient());
+		CacheManager.setCacheDisabled(true);
+	}
+
+	@After
+	public void tearDownCache() {
+		CacheManager.setCacheDisabled(false);
+	}
+
+}

--- a/perun-synchronizer/src/test/java/cz/metacentrum/perun/synchronizer/test/GroupAccessor.java
+++ b/perun-synchronizer/src/test/java/cz/metacentrum/perun/synchronizer/test/GroupAccessor.java
@@ -1,0 +1,67 @@
+package cz.metacentrum.perun.synchronizer.test;
+
+import static cz.metacentrum.perun.core.impl.PerunLocksUtils.lockGroupMembership;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.Semaphore;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.stereotype.Component;
+
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+
+@Component
+public class GroupAccessor {
+
+	/**
+	 * 
+	 */
+	private Group group;
+
+
+	public GroupAccessor() {
+	}
+	
+	public void accessGroupThread1(Semaphore starter) throws GroupNotExistsException, InternalErrorException, PrivilegeException, InterruptedException {
+		lockGroupMembership(group);
+		group.setDescription("failure");
+		starter.release();
+		// groupsManagerBl.getGroupsManagerImpl().updateGroup(sess, group);
+		// allow the other thread time for mischief
+		Thread.sleep(500);
+		group.setDescription("success");
+		// groupsManagerBl.updateGroup(sess, group);
+	}
+
+	public String accessGroupThread2(Semaphore starter) throws GroupNotExistsException, InternalErrorException, PrivilegeException, InterruptedException {
+		starter.acquire();
+		lockGroupMembership(group);
+		// Group resultGroup = groupsManagerBl.getGroupsManagerImpl().getGroupById(sess, group.getId());
+		String result = group.getDescription();
+		return result;
+	}
+
+	public void accessGroupThread3(Semaphore starter) throws GroupNotExistsException, InternalErrorException, PrivilegeException, InterruptedException {
+		group.setDescription("success2");
+		starter.release();
+		Thread.sleep(500);
+		// groupsManagerBl.getGroupsManagerImpl().updateGroup(sess, group);
+		// allow the other thread time for mischief
+		group.setDescription("failure2");
+		// groupsManagerBl.updateGroup(sess, group);
+	}
+	
+	public Group getGroup() {
+		return group;
+	}
+
+	public void setGroup(Group group) {
+		this.group = group;
+	}
+
+}

--- a/perun-synchronizer/src/test/java/cz/metacentrum/perun/synchronizer/test/PerunLocksUtilsTest.java
+++ b/perun-synchronizer/src/test/java/cz/metacentrum/perun/synchronizer/test/PerunLocksUtilsTest.java
@@ -1,0 +1,288 @@
+package cz.metacentrum.perun.synchronizer.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.sql.DataSource;
+
+import org.hsqldb.jdbcDriver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.Candidate;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.GroupsManager;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.Vo;
+import cz.metacentrum.perun.core.bl.GroupsManagerBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
+
+public class PerunLocksUtilsTest extends AbstractSynchronizerTest {
+
+	// these must be setUp"type" before every method to be in DB
+	final ExtSource extSource = new ExtSource(0, "testExtSource", "cz.metacentrum.perun.core.impl.ExtSourceInternal");
+	final Group group = new Group("GroupsManagerTestGroup1","testovaci1");
+	final Group group2 = new Group("GroupsManagerTestGroup2","testovaci2");
+	final Group group21 = new Group("GroupsManagerTestGroup21","testovaci21");
+	final Group group3 = new Group("GroupsManagerTestGroup3","testovaci3");
+	final Group group4 = new Group("GroupsManagerTestGroup4","testovaci4");
+	final Group group5 = new Group("GroupsManagerTestGroup5","testovaci5");
+	final Group group6 = new Group("GroupsManagerTestGroup6","testovaci6");
+	final Group group7 = new Group("GroupsManagerTestGroup7","testovaci7");
+	final Group group8 = new Group("GroupsManagerTestGroup8","testovaci8");
+
+	private Vo vo;
+	private List<Attribute> attributesList = new ArrayList<>();
+
+	// exists before every method
+	private GroupsManager groupsManager;
+	private GroupsManagerBl groupsManagerBl;
+	private AttributesManager attributesManager;
+	private UsersManagerBl usersManagerBl;
+
+	private String result;
+	
+	@Autowired
+	private DataSource dataSource; 
+	
+	@Autowired 
+	public GroupAccessor testAccess;
+	
+	@Before
+	public void setUp() throws Exception {
+
+		groupsManager = perun.getGroupsManager();
+		groupsManagerBl = perun.getGroupsManagerBl();
+		attributesManager = perun.getAttributesManager();
+		usersManagerBl = perun.getUsersManagerBl();
+		//vo = setUpVo();
+		//setUpGroup(vo);
+		// moved to every method to save testing time
+
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		cleanUp();
+	}
+
+	@Test
+	public void testLockGroupMembershipGroupListOfMember() {
+		fail("Not yet implemented");
+	}
+
+
+	@Test
+	public void testLockGroupMembershipGroup() throws Exception {
+
+		JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+
+		Connection conn = DataSourceUtils.getConnection(dataSource);
+		conn.setAutoCommit(false);
+		vo = setUpVo();
+		setUpGroup(vo);
+		testAccess.setGroup(group);
+		conn.commit();
+
+		final Semaphore starter = new Semaphore(0); 
+
+		Thread thread1 = new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+
+				try {
+					testAccess.accessGroupThread1(starter);
+				} catch (Exception e) {
+					result = e.getMessage();
+				}
+			}
+			
+		});
+		Thread thread2 = new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+
+				try {
+					result = testAccess.accessGroupThread2(starter);
+				} catch (Exception e) {
+					result = e.getMessage();
+				}
+			}
+			
+		});
+
+		result = "undetermined";
+		
+		thread1.start();
+		thread2.start();
+		
+		// wait for both threads exit
+		thread1.join(1000);
+		thread2.join(1000);
+
+		assertEquals("success", result);
+
+		thread1 = new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+
+				try {
+					testAccess.accessGroupThread3(starter);
+				} catch (Exception e) {
+					result = e.getMessage();
+				}
+			}
+			
+		});
+
+		thread2 = new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+
+				try {
+					result = testAccess.accessGroupThread2(starter);
+				} catch (Exception e) {
+					result = e.getMessage();
+				}
+			}
+			
+		});
+		
+		result = "undetermined";
+
+		thread1.start();
+		thread2.start();
+
+		// wait for both threads exit
+		thread1.join(1000);
+		thread2.join(1000);
+
+		assertEquals("success2", result);
+	}
+
+	@Test
+	public void testLockGroupMembershipListOfGroup() {
+		fail("Not yet implemented");
+	}
+
+	// PRIVATE METHODS -------------------------------------------------------------
+
+	private Vo setUpVo() throws Exception {
+
+		Vo newVo = new Vo(0, "SynchronizerTestVo", "SyncTestVo");
+		Vo returnedVo = perun.getVosManager().createVo(sess, newVo);
+		// create test VO in database
+		assertNotNull("unable to create testing Vo",returnedVo);
+
+		//ExtSource es = perun.getExtSourcesManager().getExtSourceByName(sess, "LDAPMETA");
+		// get real external source from DB
+		//perun.getExtSourcesManager().addExtSource(sess, returnedVo, es);
+		// add real ext source to our VO
+
+		return returnedVo;
+
+	}
+
+	private Member setUpMember(Vo vo) throws Exception {
+
+		// List<Candidate> candidates = perun.getVosManager().findCandidates(sess, vo, extLogin);
+		// find candidates from ext source based on extLogin
+		// assertTrue(candidates.size() > 0);
+
+		Candidate candidate = setUpCandidate(0);
+		Member member = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate); // candidates.get(0)
+		// set first candidate as member of test VO
+		assertNotNull("No member created", member);
+		usersForDeletion.add(perun.getUsersManager().getUserByMember(sess, member));
+		// save user for deletion after test
+		return member;
+
+	}
+
+	private Candidate setUpCandidate(int i) {
+
+		String userFirstName = Long.toHexString(Double.doubleToLongBits(Math.random()));
+		String userLastName = Long.toHexString(Double.doubleToLongBits(Math.random()));
+		String extLogin = Long.toHexString(Double.doubleToLongBits(Math.random()));              // his login in external source
+
+		Candidate candidate = new Candidate();  //Mockito.mock(Candidate.class);
+		candidate.setFirstName(userFirstName);
+		candidate.setId(0+i);
+		candidate.setMiddleName("");
+		candidate.setLastName(userLastName);
+		candidate.setTitleBefore("");
+		candidate.setTitleAfter("");
+		final UserExtSource userExtSource = new UserExtSource(extSource, extLogin);
+		candidate.setUserExtSource(userExtSource);
+		candidate.setAttributes(new HashMap<>());
+		return candidate;
+
+	}
+
+	private void setUpGroup(Vo vo) throws Exception {
+
+		Group returnedGroup = groupsManager.createGroup(sess, vo, group);
+		assertNotNull("unable to create a group",returnedGroup);
+		returnedGroup = groupsManager.getGroupById(sess, group.getId()); 
+		assertEquals("created group should be same as returned group",group,returnedGroup);
+
+	}
+
+	private List<Group> setUpGroups(Vo vo) throws Exception {
+		List<Group> groups = new ArrayList<>();
+		groups.add(groupsManager.createGroup(sess, vo, group3));
+		groups.add(groupsManager.createGroup(sess, vo, group4));
+		return groups;
+	}
+
+	private Resource setUpResource(Vo vo, Facility facility) throws Exception {
+
+		Resource resource = new Resource();
+		resource.setName("GroupsManagerTestResource");
+		resource.setDescription("testing resource");
+		assertNotNull("unable to create resource",perun.getResourcesManager().createResource(sess, resource, vo, facility));
+
+		return resource;
+
+	}
+
+	private void cleanUp() throws Exception 
+	{
+		JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+		
+		Connection conn = DataSourceUtils.getConnection(dataSource);
+                conn.setAutoCommit(false);
+		jdbc.execute("delete from groups where vo_id = (select id from vos where short_name = 'SyncTestVo')");
+		jdbc.execute("delete from vos where short_name = 'SyncTestVo'");
+		conn.commit();
+	}
+	
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -37,7 +36,8 @@
 		<module>perun-scim</module>
 		<module>perun-openapi</module>
 		<module>perun-cli-java</module>
-	</modules>
+    	<module>perun-synchronizer</module>
+  </modules>
 
 	<!-- common environmental and version properties-->
 	<properties>


### PR DESCRIPTION
- move scheduling and top level synchronizer class away from Perun core (and RPC) into new module
perun-synchronizer,
- add starter class to start-up independent process

This is not yet complete, the infrastructure for actually starting the system process (OS startup file & conf) is still missing.