### PR TITLE
Store also created/modified_by(_uid) in blocked facilities/destination

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ServicesManagerBlImpl.java
@@ -98,13 +98,13 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 
 	@Override
 	public void blockServiceOnFacility(PerunSession sess, Service service, Facility facility) throws InternalErrorException, ServiceAlreadyBannedException {
-		getServicesManagerImpl().blockServiceOnFacility(service.getId(), facility.getId());
+		getServicesManagerImpl().blockServiceOnFacility(sess, service.getId(), facility.getId());
 		sess.getPerun().getAuditer().log(sess, new BanServiceOnFacility(service, facility));
 	}
 
 	@Override
 	public void blockServiceOnDestination(PerunSession sess, Service service, int destinationId) throws InternalErrorException, ServiceAlreadyBannedException {
-		getServicesManagerImpl().blockServiceOnDestination(service.getId(), destinationId);
+		getServicesManagerImpl().blockServiceOnDestination(sess, service.getId(), destinationId);
 		sess.getPerun().getAuditer().log(sess, new BanServiceOnDestination(service, destinationId));
 	}
 
@@ -113,7 +113,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		List<Service> services = getAssignedServices(sess, facility);
 		for (Service service : services) {
 			try {
-				getServicesManagerImpl().blockServiceOnFacility(service.getId(), facility.getId());
+				getServicesManagerImpl().blockServiceOnFacility(sess, service.getId(), facility.getId());
 				sess.getPerun().getAuditer().log(sess, new BanServiceOnFacility(service, facility));
 			} catch (ServiceAlreadyBannedException e) {
 				// we ignore, that service was already blocked
@@ -126,7 +126,7 @@ public class ServicesManagerBlImpl implements ServicesManagerBl {
 		List<Service> services = getServicesManagerImpl().getServicesFromDestination(destinationId);
 		for (Service service : services) {
 			try {
-				getServicesManagerImpl().blockServiceOnDestination(service.getId(), destinationId);
+				getServicesManagerImpl().blockServiceOnDestination(sess, service.getId(), destinationId);
 				sess.getPerun().getAuditer().log(sess, new BanServiceOnDestination(service, destinationId));
 			} catch (ServiceAlreadyBannedException e) {
 				// we ignore, that service was already blocked

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ServicesManagerImpl.java
@@ -195,10 +195,12 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 
 	@SuppressWarnings("ConstantConditions")
 	@Override
-	public void blockServiceOnFacility(int serviceId, int facilityId) throws InternalErrorException, ServiceAlreadyBannedException {
+	public void blockServiceOnFacility(PerunSession sess, int serviceId, int facilityId) throws InternalErrorException, ServiceAlreadyBannedException {
 		int newBanId = Utils.getNewId(jdbc, "service_denials_id_seq");
 		try {
-			jdbc.update("insert into service_denials(id, facility_id, service_id) values (?,?,?)", newBanId, facilityId, serviceId);
+			jdbc.update("insert into service_denials(id, facility_id, service_id, created_by, modified_by, created_by_uid, modified_by_uid) values (?,?,?,?,?,?,?)",
+					newBanId, facilityId, serviceId, sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(),
+					sess.getPerunPrincipal().getUserId());
 		} catch (DuplicateKeyException ex) {
 			throw new ServiceAlreadyBannedException(String.format("Service with id %d is already banned on the facility with id %d", serviceId, facilityId));
 		} catch (RuntimeException ex) {
@@ -208,10 +210,12 @@ public class ServicesManagerImpl implements ServicesManagerImplApi {
 
 	@SuppressWarnings("ConstantConditions")
 	@Override
-	public void blockServiceOnDestination(int serviceId, int destinationId) throws InternalErrorException, ServiceAlreadyBannedException {
+	public void blockServiceOnDestination(PerunSession sess, int serviceId, int destinationId) throws InternalErrorException, ServiceAlreadyBannedException {
 		try {
 			int newBanId = Utils.getNewId(jdbc, "service_denials_id_seq");
-			jdbc.update("insert into service_denials(id, destination_id, service_id) values (?,?,?)", newBanId, destinationId, serviceId);
+			jdbc.update("insert into service_denials(id, destination_id, service_id, created_by, modified_by, created_by_uid, modified_by_uid) values (?,?,?,?,?,?,?)",
+					newBanId, destinationId, serviceId, sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(),
+					sess.getPerunPrincipal().getUserId());
 		} catch (DuplicateKeyException ex) {
 			throw new ServiceAlreadyBannedException(String.format("Service with id %d is already banned on the destination with id %d", serviceId, destinationId));
 		} catch (RuntimeException ex) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ServicesManagerImplApi.java
@@ -39,20 +39,22 @@ public interface ServicesManagerImplApi {
 	 * Block Service on Facility. It won't be possible to propagate service on whole facility
 	 * or any of its destinations.
 	 *
+	 * @param session
 	 * @param serviceId The Service to be blocked on the Facility
 	 * @param facilityId The Facility on which we want to block the Service
 	 * @throws InternalErrorException
 	 */
-	void blockServiceOnFacility(int serviceId, int facilityId) throws InternalErrorException, ServiceAlreadyBannedException;
+	void blockServiceOnFacility(PerunSession session, int serviceId, int facilityId) throws InternalErrorException, ServiceAlreadyBannedException;
 
 	/**
 	 * Block Service on specific Destination. Service still can be propagated to other facility Destinations.
 	 *
+	 * @param session
 	 * @param serviceId The Service to be blocked on this particular destination
 	 * @param destinationId The destination on which we want to block the Service
 	 * @throws InternalErrorException
 	 */
-	void blockServiceOnDestination(int serviceId, int destinationId) throws InternalErrorException, ServiceAlreadyBannedException;
+	void blockServiceOnDestination(PerunSession session, int serviceId, int destinationId) throws InternalErrorException, ServiceAlreadyBannedException;
 
 	/**
 	 * Unblock Service on whole Facility. If was not blocked, nothing happens.


### PR DESCRIPTION
- While we had proper columns in service_denials table, we didn't fill them
  with metadata about action actor. Now we store it in the table.