### PR TITLE
RPC: log authzResolver.keepAlive() in trace, others still in debug

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -780,7 +780,12 @@ public class Api extends HttpServlet {
 
 		out.close();
 
-		log.debug("Method {}.{} called by {} from {}, duration {} ms.", manager, method, caller.getSession().getPerunPrincipal().getActor(), caller.getSession().getPerunPrincipal().getExtSourceName(), (System.currentTimeMillis() - timeStart));
+		if (Objects.equals(manager,"authzResolver") && Objects.equals(method, "keepAlive")) {
+			log.trace("Method {}.{} called by {} from {}, duration {} ms.", manager, method, caller.getSession().getPerunPrincipal().getActor(), caller.getSession().getPerunPrincipal().getExtSourceName(), (System.currentTimeMillis() - timeStart));
+		} else {
+			log.debug("Method {}.{} called by {} from {}, duration {} ms.", manager, method, caller.getSession().getPerunPrincipal().getActor(), caller.getSession().getPerunPrincipal().getExtSourceName(), (System.currentTimeMillis() - timeStart));
+		}
+
 	}
 
 	private Serializer selectSerializer(String format, String manager, String method, OutputStream out,


### PR DESCRIPTION
- Prevent cluttered log files.