### PR TITLE
OpenApi - attribute entity

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -184,6 +184,9 @@ components:
             displayName: { type: string }
             writable: { type: boolean }
             unique: { type: boolean }
+            entity:
+              type: string
+              readOnly: true
       discriminator:
         propertyName: beanName
 


### PR DESCRIPTION
* Added property 'entity' to attribute.

* This values is not present in the Attribute class itself, but it is
encoded from the getter method.