### PR TITLE
Add new method for testing database performance

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.55 (don't forget to update insert statement at the end of file)
+-- database version 3.1.56 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1382,8 +1382,7 @@ create table tags_resources (
 create table configurations (
 	property varchar(32) not null,  --property (for example database version)
 	value varchar(128) not null,     --value of configuration property
-	constraint config_pk primary key (property),
-	constraint config_prop_chk check (property in ('DATABASE VERSION'))
+	constraint config_pk primary key (property)
 );
 
 -- MAILCHANGE - allow to user to change mail address, temporairly saved mails during change is in progress
@@ -1773,7 +1772,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.55');
+insert into configurations values ('DATABASE VERSION','3.1.56');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/DatabaseManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/DatabaseManager.java
@@ -9,26 +9,36 @@ import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
  * @author Michal Stava email:&lt;stavamichal@gmail.com&gt;
  */
 public interface DatabaseManager {
-	
+
 	/**
 	 * Return current database version in string (ex. 3.0.1)
-	 * 
+	 *
 	 * @return return current database version
 	 */
 	String getCurrentDatabaseVersion(PerunSession perunSession) throws InternalErrorException, PrivilegeException;
-	
+
 	/**
 	 * Get DB driver information from datasource (name-version)
-	 * 
+	 *
 	 * @return string information about database driver
 	 */
 	String getDatabaseDriverInformation(PerunSession sess) throws InternalErrorException, PrivilegeException;
-	
+
 	/**
 	 * Get DB information from datasource (name-version)
-	 * 
+	 *
 	 * @return string information about database
-	 * 
+	 *
 	 */
 	String getDatabaseInformation(PerunSession sess) throws InternalErrorException, PrivilegeException;
+
+	/**
+	 *	Get time in ns "nanoseconds" of calling 1 simple update query to DB.
+	 *  This query will update property for this purpose in configurations table.
+	 *
+	 * @param sess user's session in Perun
+	 * @return time of processing query in nanoseconds
+	 * @throws PrivilegeException wrong privilege to call this method
+	 */
+	long getTimeOfQueryPerformance(PerunSession sess) throws PrivilegeException;
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/DatabaseManagerBl.java
@@ -142,6 +142,30 @@ public interface DatabaseManagerBl {
 	}
 
 	/**
+	 *	Get time in ns "nanoseconds" of calling 1 simple update query to DB.
+	 *  This query will update property for this purpose in configurations table.
+	 *
+	 * @return time of processing query in nanoseconds
+	 */
+	long getTimeOfQueryPerformance();
+
+	/**
+	 * Create new property in configurations. Initial value will be "N/A".
+	 *
+	 * @param property name of property to be created
+	 */
+	void createProperty(String property);
+
+	/**
+	 * Return true if property already exists, false if not.
+	 *
+	 * @param property name of property to check existence
+	 *
+	 * @return true if property exists, false if not
+	 */
+	boolean propertyExists(String property);
+
+	/**
 	 * Return JDBC template for performing custom simple SQLs where jdbc is not normally available
 	 *
 	 * @return Peruns JDBC template

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/DatabaseManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/DatabaseManagerBlImpl.java
@@ -5,6 +5,7 @@ import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.bl.DatabaseManagerBl;
 import cz.metacentrum.perun.core.impl.Compatibility;
+import cz.metacentrum.perun.core.impl.DatabaseManagerImpl;
 import cz.metacentrum.perun.core.implApi.DatabaseManagerImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,21 @@ public class DatabaseManagerBlImpl implements DatabaseManagerBl {
 	}
 
 	@Override
+	public long getTimeOfQueryPerformance() {
+		return this.databaseManagerImpl.getTimeOfQueryPerformance();
+	}
+
+	@Override
+	public void createProperty(String property) {
+		this.databaseManagerImpl.createProperty(property);
+	}
+
+	@Override
+	public boolean propertyExists(String property) {
+		return this.databaseManagerImpl.propertyExists(property);
+	}
+
+	@Override
 	public JdbcPerunTemplate getJdbcPerunTemplate() {
 		return this.databaseManagerImpl.getJdbcPerunTemplate();
 	}
@@ -65,6 +81,15 @@ public class DatabaseManagerBlImpl implements DatabaseManagerBl {
 		//This part of code probably need to be replaced by readOnly setting for every connection in perun
 		//not just the one (this one)
 		boolean readOnly = BeansUtils.isPerunReadOnly();
+
+		//Initialize property for performance testing if not exists
+		if(!this.propertyExists(DatabaseManagerImpl.PERFORMANCE_PROPERTY)) {
+			if(readOnly) {
+				log.error("There is missing property for DB performance testing!");
+			} else {
+				this.createProperty(DatabaseManagerImpl.PERFORMANCE_PROPERTY);
+			}
+		}
 
 		String fileName = POSTGRES_CHANGELOG;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntry.java
@@ -22,43 +22,53 @@ public class DatabaseManagerEntry implements DatabaseManager {
 
 	private DatabaseManagerBl databaseManagerBl;
 	private PerunBl perunBl;
-	
+
 	public DatabaseManagerEntry() {}
 
 	@Override
 	public String getCurrentDatabaseVersion(PerunSession sess) throws InternalErrorException, PrivilegeException {
 		Utils.checkPerunSession(sess);
-		
+
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.SELF)) throw new PrivilegeException(sess, "getCurrentDatabaseVersion");
-		
+
 		return getDatabaseManagerBl().getCurrentDatabaseVersion();
 	}
-	
+
 	@Override
 	public String getDatabaseDriverInformation(PerunSession sess) throws InternalErrorException, PrivilegeException {
 		Utils.checkPerunSession(sess);
-		
+
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.SELF)) throw new PrivilegeException(sess, "getDatabaseDriverInformation");
-		
+
 		return getDatabaseManagerBl().getDatabaseDriverInformation();
 	}
-	
+
 	@Override
 	public String getDatabaseInformation(PerunSession sess) throws InternalErrorException, PrivilegeException {
 		Utils.checkPerunSession(sess);
-		
+
 		// Authorization
 		if (!AuthzResolver.isAuthorized(sess, Role.SELF)) throw new PrivilegeException(sess, "getDatabaseInformation");
-		
+
 		return getDatabaseManagerBl().getDatabaseInformation();
+	}
+
+	@Override
+	public long getTimeOfQueryPerformance(PerunSession sess) throws PrivilegeException {
+		Utils.checkPerunSession(sess);
+
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.SELF)) throw new PrivilegeException(sess, "getTimeOfQueryPerformance");
+
+		return getDatabaseManagerBl().getTimeOfQueryPerformance();
 	}
 
 	public void setDatabaseManagerBl(DatabaseManagerBl databaseManagerBl) {
 		this.databaseManagerBl = databaseManagerBl;
 	}
-	
+
 	public DatabaseManagerBl getDatabaseManagerBl() {
 		return this.databaseManagerBl;
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/DatabaseManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/DatabaseManagerImplApi.java
@@ -2,6 +2,9 @@ package cz.metacentrum.perun.core.implApi;
 
 import cz.metacentrum.perun.core.api.DBVersion;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.impl.Compatibility;
+import cz.metacentrum.perun.core.impl.Utils;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 
 import java.util.List;
@@ -14,28 +17,28 @@ import java.util.List;
 public interface DatabaseManagerImplApi {
 	/**
 	 * Return current database version in string (ex. 3.0.1)
-	 * 
+	 *
 	 * @return return current database version
-	 * 
+	 *
 	 * @throws InternalErrorException
 	 */
 	String getCurrentDatabaseVersion() throws InternalErrorException;
-	
+
 	/**
 	 * Get DB driver information from datasource (name-version)
-	 * 
+	 *
 	 * @return string information about database driver
-	 * 
-	 * @throws InternalErrorException 
+	 *
+	 * @throws InternalErrorException
 	 */
 	String getDatabaseDriverInformation() throws InternalErrorException;
-	
+
 	/**
 	 * Get DB information from datasource (name-version)
-	 * 
+	 *
 	 * @return string information about database
-	 * 
-	 * @throws InternalErrorException 
+	 *
+	 * @throws InternalErrorException
 	 */
 	String getDatabaseInformation() throws InternalErrorException;
 
@@ -71,6 +74,30 @@ public interface DatabaseManagerImplApi {
 	 * @throws InternalErrorException if 1.there is error reading file, 2.currentDBVersion was not found 3.db version does not match pattern 4.db versions are not ordered as they should be
 	 */
 	List<DBVersion> getChangelogVersions(String currentDBVersion, String fileName) throws InternalErrorException;
+
+	/**
+	 *	Get time in ns "nanoseconds" of calling 1 simple update query to DB.
+	 *  This query will update property for this purpose in configurations table.
+	 *
+	 * @return time of processing query in nanoseconds
+	 */
+	long getTimeOfQueryPerformance();
+
+	/**
+	 * Create new property in configurations. Initial value will be "N/A".
+	 *
+	 * @param property name of property to be created
+	 */
+	void createProperty(String property);
+
+	/**
+	 * Return true if property already exists, false if not.
+	 *
+	 * @param property name of property to check existence
+	 *
+	 * @return true if property exists, false if not
+	 */
+	boolean propertyExists(String property);
 
 	/**
 	 * Return JDBC template for performing custom simple SQLs where jdbc is not normally available

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -8,6 +8,10 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.56
+alter table configurations drop constraint config_prop_chk;
+update configurations set value='3.1.56' where property='DATABASE VERSION';
+
 3.1.55
 drop sequence "auditer_log_json_id_seq";
 alter table auditer_log rename to auditer_log_old;

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.56
+alter table configurations drop constraint CONFIG_PROP_CHK;
+update configurations set value='3.1.56' where property='DATABASE VERSION';
+
 3.1.55
 drop sequence auditer_log_json_id_seq;
 alter table auditer_log rename to auditer_log_old;

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.56
+alter table configurations drop constraint config_prop_chk;
+update configurations set value='3.1.56' where property='DATABASE VERSION';
+
 3.1.55
 drop sequence "auditer_log_json_id_seq";
 alter table auditer_log rename to auditer_log_old;

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/DatabaseManagerEntryIntegrationTest.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.entry;
 
 import cz.metacentrum.perun.core.AbstractPerunIntegrationTest;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -8,6 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Integration tests of DatabaseManager.
@@ -18,7 +20,7 @@ public class DatabaseManagerEntryIntegrationTest extends AbstractPerunIntegratio
 
 	private final String DATABASE_MANAGER = "DatabaseManager";
 	final Pattern versionPatter = Pattern.compile("^[1-9][0-9]*[.][1-9][0-9]*[.][1-9][0-9]*");
-	
+
 	@Before
 	public void setUp() {
 	}
@@ -30,14 +32,14 @@ public class DatabaseManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		Matcher versionMatcher = versionPatter.matcher(dbVersion);
 		assertTrue("DBVersion must match to something like '1.0.0'", versionMatcher.matches());
 	}
-	
+
 	@Test
 	public void getDatabaseDriverInformation() throws Exception {
 		System.out.println(DATABASE_MANAGER+".getDatabaseDriverInformation");
 		String driverInfo = perun.getDatabaseManager().getDatabaseDriverInformation(sess);
 		assertTrue("DB driver info can't be empty", !driverInfo.isEmpty());
 	}
-	
+
 	@Test
 	public void getDatabaseInformation() throws Exception {
 		System.out.println(DATABASE_MANAGER+".getDatabaseDriverInformation");
@@ -45,4 +47,32 @@ public class DatabaseManagerEntryIntegrationTest extends AbstractPerunIntegratio
 		assertTrue("DB info can't be empty", !dbInfo.isEmpty());
 	}
 
+	@Test
+	public void propertyExists() throws Exception {
+		System.out.println(DATABASE_MANAGER+".propertyExists");
+		String property = "TEST";
+		assertFalse(perun.getDatabaseManagerBl().propertyExists(property));
+	}
+
+	@Test
+	public void createProperty() throws Exception {
+		System.out.println(DATABASE_MANAGER+".createProperty");
+		String property = "TEST";
+		perun.getDatabaseManagerBl().createProperty(property);
+		assertTrue(perun.getDatabaseManagerBl().propertyExists(property));
+	}
+
+	@Test (expected= InternalErrorException.class)
+	public void createTwiceTheSameProperty() throws Exception {
+		System.out.println(DATABASE_MANAGER+".createTwiceTheSameProperty");
+		String property = "TEST";
+		perun.getDatabaseManagerBl().createProperty(property);
+		perun.getDatabaseManagerBl().createProperty(property);
+	}
+
+	@Test
+	public void getTimeOfQueryPerformance() throws Exception {
+		System.out.println(DATABASE_MANAGER + ".getTimeOfQueryPerformance");
+		assertTrue(perun.getDatabaseManager().getTimeOfQueryPerformance(sess) > 0);
+	}
 }

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.55 (don't forget to update insert statement at the end of file)
+-- database version 3.1.56 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1388,8 +1388,7 @@ create table tags_resources (
 create table configurations (
 	property nvarchar2(32) not null,  --property (for example database version)
 	value nvarchar2(128) not null,     --value of configuration property
-	constraint config_pk primary key (property),
-	constraint config_prop_chk check (property in ('DATABASE VERSION'))
+	constraint config_pk primary key (property)
 );
 
 -- MAILCHANGE - allow to user to change mail address, temporairly saved mails during change is in progress
@@ -1775,7 +1774,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.55');
+insert into configurations values ('DATABASE VERSION','3.1.56');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.55 (don't forget to update insert statement at the end of file)
+-- database version 3.1.56 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1378,8 +1378,7 @@ create table tags_resources (
 create table configurations (
 	property varchar(32) not null,  --property (for example database version)
 	value varchar(128) not null,     --value of configuration property
-	constraint config_pk primary key (property),
-  constraint config_prop_chk check (property in ('DATABASE VERSION'))
+	constraint config_pk primary key (property)
 );
 
 -- MAILCHANGE - allow to user to change mail address, temporairly saved mails during change is in progress
@@ -1873,7 +1872,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.55');
+insert into configurations values ('DATABASE VERSION','3.1.56');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -3365,6 +3365,18 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/databaseManager/getTimeOfQueryPerformance:
+    get:
+      tags:
+        - DatabaseManager
+      operationId: getTimeOfQueryPerformance
+      summary: Get time in ns "nanoseconds" of calling 1 simple update query to DB
+      responses:
+        '200':
+          $ref: '#/components/responses/LongResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   #################################################
   #                                               #
   # ExtSourcesManager                             #
@@ -3372,7 +3384,7 @@ paths:
   #################################################
 
   #TODO createExtSource
-  
+
   #TODO deleteExtSource
 
   /json/extSourcesManager/getExtSourceById:
@@ -3402,11 +3414,11 @@ paths:
           $ref: '#/components/responses/ExtSourceResponse'
         default:
           $ref: '#/components/responses/ExceptionResponse'
-  
+
   #TODO getVoExtSources
-  
+
   #TODO getGroupExtSources
-  
+
   /json/extSourcesManager/getExtSources:
     get:
       tags:
@@ -3420,11 +3432,11 @@ paths:
           $ref: '#/components/responses/ExceptionResponse'
 
   #TODO addExtSource
-  
+
   #TODO removeExtSource
-  
+
   #TODO loadExtSourcesDefinitions
-  
+
   #################################################
   #                                               #
   # UsersManager                                  #

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/DatabaseManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/DatabaseManagerMethod.java
@@ -1,6 +1,8 @@
 package cz.metacentrum.perun.rpc.methods;
 
+import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.rpc.ApiCaller;
 import cz.metacentrum.perun.rpc.ManagerMethod;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
@@ -21,7 +23,7 @@ public enum DatabaseManagerMethod implements ManagerMethod {
 			return ac.getDatabaseManager().getCurrentDatabaseVersion(ac.getSession());
 		}
 	},
-	
+
 	/*#
 	 * Gets current database driver name and version
 	 *
@@ -36,7 +38,7 @@ public enum DatabaseManagerMethod implements ManagerMethod {
 			return ac.getDatabaseManager().getDatabaseDriverInformation(ac.getSession());
 		}
 	},
-	
+
 	/*#
 	 * Gets current database name and version
 	 *
@@ -49,6 +51,22 @@ public enum DatabaseManagerMethod implements ManagerMethod {
 		public Object call(ApiCaller ac, Deserializer parms) throws PerunException {
 
 			return ac.getDatabaseManager().getDatabaseInformation(ac.getSession());
+		}
+	},
+
+	/**
+	 *	Get time in ns "nanoseconds" of calling 1 simple update query to DB.
+	 *  This query will update property for this purpose in configurations table.
+	 *
+	 * @exampleResponse "196920"
+	 * @return time of processing query in nanoseconds
+	 */
+	getTimeOfQueryPerformance {
+
+		@Override
+		public Long call(ApiCaller ac, Deserializer parms) throws PerunException {
+
+			return ac.getDatabaseManager().getTimeOfQueryPerformance(ac.getSession());
 		}
 	};
 }


### PR DESCRIPTION
 - new method getTimeOfQueryPerformance in DatabaseManager on all layers
 (RPC, api, bl, blImpl), can be called by anyone with role SELF and it
 will count processing time (in nanoseconds) of update operation (set
 timestamp to database table configurations to predefined property)
 - for this purpose, other methods was created to support this
 funcionality like createProperty (to create a new property in
 configurations table), propertyExists (to check if specific property
 already exists or need to be created)
 - creating of this new property was added to initialization process of
 DatabaseManager (if property doesn't exist, it will be created on start
 of Perun system)
 - database schemas were modified to remove existing constraint on
 configurations table to allow any property (not just database version)
 - basic tests of new methods were added
 - database version was increased

 IMPORTANT: database need to be changed manually for this commit,
 constraint need to be removed before using properly