### PR TITLE
ENGINE: Removed unused cron properties

### DIFF
--- a/perun-engine/src/main/resources/perun-engine.xml
+++ b/perun-engine/src/main/resources/perun-engine.xml
@@ -72,8 +72,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 				<prop key="perun.principal.extSourceName">INTERNAL</prop>
 				<prop key="perun.principal.extSourceType">cz.metacentrum.perun.core.impl.ExtSourceInternal</prop>
 				<prop key="engine.cron.propagation">45 0/2 * * * ?</prop>
-				<prop key="engine.cron.processpool">0 0/1 * * * ?</prop>
-				<prop key="engine.cron.taskexecutor">0 0/2 * * * ?</prop>
 				<prop key="engine.thread.gentasks.max">15</prop>
 				<prop key="engine.thread.sendtasks.max">150</prop>
 				<prop key="engine.genscript.path">gen</prop>


### PR DESCRIPTION
- We no longer trigger pool processing and task execution by cron.
  They are event based, hence cron properties are no longer needed
  in Spring context.