### PR TITLE
UrlDeserializer - readArrayOfInts

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/rpc/deserializer/UrlDeserializer.java
@@ -68,6 +68,11 @@ public class UrlDeserializer extends Deserializer {
 	}
 
 	@Override
+	public int[] readArrayOfInts(String name) throws RpcException {
+		return readList(name, Integer.class).stream().mapToInt(i->i).toArray();
+	}
+
+	@Override
 	public int readInt(String name) throws RpcException {
 		if (!contains(name)) throw new RpcException(RpcException.Type.MISSING_VALUE, name);
 


### PR DESCRIPTION
* Implemented readArrayOfInts in the UrlDeserializer. It has not been
implemented yet and we need to be able to use this method with this
deserializer (e.g. because of the methods defined in the OpenAPI which
uses this deserializer).