### PR TITLE
CORE,LDAPC: Added support for AARC resource capabilities on Facility

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_capabilities.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_facility_attribute_def_def_capabilities.java
@@ -3,16 +3,17 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
-import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleAbstract;
-import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesModuleImplApi;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleAbstract;
+import cz.metacentrum.perun.core.implApi.modules.attributes.FacilityAttributesModuleImplApi;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
+
+import static cz.metacentrum.perun.core.impl.modules.attributes.urn_perun_resource_attribute_def_def_capabilities.PATTERN;
 
 /**
  * Module for capabilities according to AARC specification. i.e. specification of resource and optional actions.
@@ -21,27 +22,19 @@ import java.util.regex.Pattern;
  * Example1: value=“res:RESOURCE1:CHILD-RESOURCE1:CHILD-RESOURCE2:act:ACTION1,ACTION2,ACTION3”
  * Example2: value=“res:RESOURCE1:CHILD-RESOURCE1:CHILD-RESOURCE2”
  *
- * @see urn_perun_facility_attribute_def_def_capabilities
+ * @see urn_perun_resource_attribute_def_def_capabilities
  *
  * @author Ondrej Ernst
  */
-public class urn_perun_resource_attribute_def_def_capabilities extends ResourceAttributesModuleAbstract implements ResourceAttributesModuleImplApi {
-
-	private static final String RESOURCE_ALLOWED_CHARACTERS = "[\\-a-zA-Z0-9()+,.=@;$_!*']";
-	private static final String ACTION_ALLOWED_CHARACTERS = "[\\-a-zA-Z0-9()+.:=@;$_!*']";
-	private static final String NOT_ALLOWED_PARTS = "?!(:act$|:act:|.*:,|.*,:|.*::|.*:$)";
-	protected static final Pattern PATTERN = Pattern.compile("res((" + NOT_ALLOWED_PARTS + ")(:" +
-			RESOURCE_ALLOWED_CHARACTERS + "+))+(:act:((" + ACTION_ALLOWED_CHARACTERS +
-			"+,)*(" + ACTION_ALLOWED_CHARACTERS + "+)))?");
-
+public class urn_perun_facility_attribute_def_def_capabilities extends FacilityAttributesModuleAbstract implements FacilityAttributesModuleImplApi {
 
 	@Override
-	public void checkAttributeSyntax(PerunSessionImpl perunSession, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeSyntax(PerunSessionImpl perunSession, Facility facility, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		if (attribute.getValue() == null) return;
 		List<String> values = attribute.valueAsList();
 		for (String value : values) {
 			if (!PATTERN.matcher(value).matches()) {
-				throw new WrongAttributeValueException(attribute, resource.getName() + " has attribute whose value is not valid. Example of valid value: res:RESOURCE[:CHILD-RESOURCE1][:CHILD-RESOURCE2]...[:act:ACTION[,ACTION]...]");
+				throw new WrongAttributeValueException(attribute, facility.getName() + " has attribute whose value is not valid. Example of valid value: res:RESOURCE[:CHILD-RESOURCE1][:CHILD-RESOURCE2]...[:act:ACTION[,ACTION]...]");
 			}
 		}
 	}
@@ -49,7 +42,7 @@ public class urn_perun_resource_attribute_def_def_capabilities extends ResourceA
 	@Override
 	public AttributeDefinition getAttributeDefinition() {
 		AttributeDefinition attr = new AttributeDefinition();
-		attr.setNamespace(AttributesManager.NS_RESOURCE_ATTR_DEF);
+		attr.setNamespace(AttributesManager.NS_FACILITY_ATTR_DEF);
 		attr.setFriendlyName("capabilities");
 		attr.setDisplayName("Capabilities");
 		attr.setType(ArrayList.class.getName());

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -920,6 +920,16 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 						</bean>
 					</property>
 				</bean>
+				<bean class="cz.metacentrum.perun.ldapc.model.impl.PerunAttributeDesc">
+					<property name="name" value="capabilities" />
+					<property name="required" value="false" />
+					<property name="multipleValuesExtractor">
+						<bean class="cz.metacentrum.perun.ldapc.model.impl.MultipleAttributeValueExtractor">
+							<property name="name" value="capabilities" />
+							<property name="namespace" value="urn:perun:facility:attribute-def:def" />
+						</bean>
+					</property>
+				</bean>
 			</list>
 		</property>
 		<property name="attributeDescriptionsExt" ref="perunFacilityAttributesExt" />

--- a/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
+++ b/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
@@ -50,6 +50,6 @@ olcObjectClasses: {0}( 1.3.6.1.4.1.8057.2.80.4 NAME 'perunUser' DESC 'User manag
 olcObjectClasses: {1}( 1.3.6.1.4.1.8057.2.80.5 NAME 'perunGroup' DESC 'Group managed by Perun' SUP top  STRUCTURAL MUST ( cn $ perunGroupId $ perunVoId $ perunUniqueGroupName ) MAY ( uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ perunParentGroup $ perunParentGroupId $ assignedToResourceId $ adminOfVo $ adminOfGroup $ adminOfFacility) )
 olcObjectClasses: {2}( 1.3.6.1.4.1.8057.2.80.15 NAME 'perunResource' DESC 'Resource managed by Perun' SUP top STRUCTURAL MUST ( cn $  perunResourceId $ perunVoId $ perunFacilityId ) MAY (uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $ description $ assignedGroupId $ perunFacilityDn $ capabilities ))
 olcObjectClasses: {3}( 1.3.6.1.4.1.8057.2.80.6 NAME 'perunVO' DESC 'VO managed by Perun' SUP organization STRUCTURAL MUST perunVoId MAY uniqueMember )
-olcObjectClasses: {4}( 1.3.6.1.4.1.8057.2.80.34 NAME 'perunFacility' DESC 'Facility managed by Perun' SUP top STRUCTURAL MUST ( cn $ perunFacilityId ) MAY ( description $ entityID $ OIDCClientID $ checkGroupMembership $ voShortNames $ wayfFilter $ wayfEFilter $ isTestSp $ proxyIdentifiers $ showOnServiceList ) )
+olcObjectClasses: {4}( 1.3.6.1.4.1.8057.2.80.34 NAME 'perunFacility' DESC 'Facility managed by Perun' SUP top STRUCTURAL MUST ( cn $ perunFacilityId ) MAY ( description $ entityID $ OIDCClientID $ checkGroupMembership $ voShortNames $ wayfFilter $ wayfEFilter $ isTestSp $ proxyIdentifiers $ showOnServiceList $ capabilities ) )
 -
 


### PR DESCRIPTION
- As extension to existing resource capabilities logic in Perun
  we want to allow settings its value on Facility (as a whole
  representation of end-service), so that admin doesn't have to
  set same values on all existing resources in perun.
- Added module to check syntax for facility:def:capabilities.
- Enabled pushing this attribute in LDAPc.
- Updated LDAP schema to allow "capabilities" attribute for facility
  object class.