### PR TITLE
Change exception thrown when name was wrongly parsed from raw text

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ParseUserNameException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/ParseUserNameException.java
@@ -1,0 +1,46 @@
+package cz.metacentrum.perun.core.api.exceptions;
+
+/**
+ * This exception is thrown when there is missing important part after parsing user name.
+ * Mandatory parts of user name in perun is "first name" and "last name".
+ *
+ * @author Michal Stava stavamichal@gmail.com
+ */
+public class ParseUserNameException extends IllegalArgumentException {
+
+	private String unparsedName;
+
+	/**
+	 * Simple constructor with a message
+	 * @param message message with details about the cause
+	 */
+	public ParseUserNameException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructor with a message and unparsed user name.
+	 * @param message message with details about the cause
+	 * @param unparsedName name in raw format before parsing
+	 */
+	public ParseUserNameException(String message, String unparsedName) {
+		super(message);
+		this.unparsedName = unparsedName;
+	}
+
+	/**
+	 * Getter for the unparsed name
+	 * @return unparsed name in raw text format
+	 */
+	public String getUnparsedName() {
+		return unparsedName;
+	}
+
+	/**
+	 * Setter for the unparsed name
+	 * @param unparsed name in raw text format
+	 */
+	public void setUnparsedName(String unparsedName) {
+		this.unparsedName = unparsedName;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -107,8 +107,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static cz.metacentrum.perun.core.impl.Utils.parseUserFromCommonName;
-
 public class MembersManagerBlImpl implements MembersManagerBl {
 
 	final static Logger log = LoggerFactory.getLogger(MembersManagerBlImpl.class);
@@ -2366,7 +2364,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		//create new user
 		User user;
 		if (name.containsKey("guestName")) {
-			user = Utils.parseUserFromCommonName(name.get("guestName"));
+			user = Utils.parseUserFromCommonName(name.get("guestName"), true);
 		} else {
 			user = Utils.createUserFromNameMap(name);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -23,6 +23,7 @@ import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.MinSizeExceededException;
 import cz.metacentrum.perun.core.api.exceptions.NumberNotInRangeException;
 import cz.metacentrum.perun.core.api.exceptions.NumbersNotAllowedException;
+import cz.metacentrum.perun.core.api.exceptions.ParseUserNameException;
 import cz.metacentrum.perun.core.api.exceptions.ParserException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.SpaceNotAllowedException;
@@ -502,11 +503,23 @@ public class Utils {
 	 * Imposes limit on leghts of fields.
 	 * @see #parseCommonName(String)
 	 * @param rawName raw name
+	 * @param fullNameRequired if true, throw exception if firstName or lastName is missing, do not throw exception otherwise
 	 * @return user
 	 */
-	public static User parseUserFromCommonName(String rawName) {
-		Map<String, String> m = parseCommonName(rawName);
+	public static User parseUserFromCommonName(String rawName, boolean fullNameRequired) throws ParseUserNameException {
+		Map<String, String> m = parseCommonName(rawName, fullNameRequired);
 		return createUserFromNameMap(m);
+	}
+
+	/**
+	 * @see Utils.parseCommonName(String rawName, boolean fullNameRequired) - where fullNameRequired is false
+	 */
+	public static Map<String, String> parseCommonName(String rawName) {
+		try {
+			return Utils.parseCommonName(rawName, false);
+		} catch (ParseUserNameException ex) {
+			throw new InternalErrorException("Unexpected behavior while parsing user name without full name requirement.");
+		}
 	}
 
 	/**
@@ -535,9 +548,11 @@ public class Utils {
 	 * 9] put these variables to map like key=value, for ex.: Map[titleBefore="Mgr. et Mgr.",firstName="Petr", ... ] and return this map
 	 *
 	 * @param rawName name to parse
+	 * @param fullNameRequired if true, throw exception if firstName or lastName is missing, do not throw exception otherwise
 	 * @return map string to string where are 4 keys (titleBefore,titleAfter,firstName and lastName) with their values (value can be null)
+	 * @throws ParseUserNameException when method was unable to parse both first name and last name from the rawName
 	 */
-	public static Map<String, String> parseCommonName(String rawName) {
+	public static Map<String, String> parseCommonName(String rawName, boolean fullNameRequired) throws ParseUserNameException {
 		// prepare variables and result map
 		Map<String, String> parsedName = new HashMap<>();
 		String titleBefore = "";
@@ -588,6 +603,13 @@ public class Utils {
 		parsedName.put(LAST_NAME, lastName);
 		if (titleAfter.isEmpty()) titleAfter = null;
 		parsedName.put(TITLE_AFTER, titleAfter);
+
+		if(fullNameRequired) {
+			if (parsedName.get(FIRST_NAME) == null)
+				throw new ParseUserNameException("Unable to parse first name from text.", rawName);
+			if (parsedName.get(LAST_NAME) == null)
+				throw new ParseUserNameException("Unable to parse last name from text.", rawName);
+		}
 
 		return parsedName;
 	}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/MembersManagerEntryIntegrationTest.java
@@ -28,6 +28,7 @@ import cz.metacentrum.perun.core.api.exceptions.AlreadySponsorException;
 import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ParseUserNameException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotInRoleException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
@@ -119,6 +120,18 @@ public class MembersManagerEntryIntegrationTest extends AbstractPerunIntegration
 		g1 = perun.getGroupsManagerBl().createGroup(sess, createdVo, new Group("TESTINGGROUP1", "TESTINGGROUP1"));
 		g2 = perun.getGroupsManagerBl().createGroup(sess, createdVo, new Group("TESTINGGROUP2", "TESTINGGROUP2"));
 		g3ing1 = perun.getGroupsManagerBl().createGroup(sess, g1, new Group("TESTINGGROUP3", "TESTINGGROUP3"));
+	}
+
+	@Test (expected=ParseUserNameException.class)
+	public void createSponsoredMembersWithError() throws Exception {
+		System.out.println(CLASS_NAME + "createSponsoredMembersWithError");
+
+		Member sponsorMember = setUpSponsor(createdVo);
+		User sponsorUser = perun.getUsersManagerBl().getUserByMember(sess, sponsorMember);
+		AuthzResolverBlImpl.setRole(sess, sponsorUser, createdVo, Role.SPONSOR);
+		Map<String, String> nameOfUser1 = new HashMap<>();
+		nameOfUser1.put("guestName", "Abraka 123");
+		perun.getMembersManagerBl().createSponsoredMember(sess, createdVo, "dummy", nameOfUser1, "secret", sponsorUser, false);
 	}
 
 	@Test


### PR DESCRIPTION
 - there are situations when we get user name in raw text format and we
 need to parse it from that text. And in specific situations we need to
 get both first name and last name. For these situations we need to get
 better exception than "InternalErrorException". For these reasons new
 exception was created ParseUserNameException to show what was wrong.
 - existing method parseCommonName was modified (parameter
 fullNameRequired was added) to be able to check situation when both
 first name and last name are required. In such situations exception is
 thrown. Otherwise no exception need to be throw at all.
 - method parseUserFromCommonName was modified to work with new
 parameter in parseCommonName method
 - in method createSponsoredMember new exception is used too and can be
 thrown out of the perun (from entry layer) to clients, full name of
 user is required now.
 - javadoc was properly changed
 - test of such situation was added