### PR TITLE
Fixed problem with leap year

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/Utils.java
@@ -1519,28 +1519,35 @@ public class Utils {
 
 	/**
 	 * Returns closest future LocalDate based on values given by matcher.
+	 * If returned value should fall to 29. 2. of non-leap year, the date is extended to 28. 2. instead.
 	 *
 	 * @param matcher matcher with day and month values
 	 * @return Extended date.
 	 */
 	public static LocalDate getClosestExpirationFromStaticDate(Matcher matcher) {
+		int day = Integer.parseInt(matcher.group(1));
+		int month = Integer.parseInt(matcher.group(2));
 
-		int day = Integer.valueOf(matcher.group(1));
-		int month = Integer.valueOf(matcher.group(2));
-
-		// Get current year
-		int year = LocalDate.now().getYear();
-
-		// We must detect if the extension date is in current year or in a next year
-		LocalDate extensionDate = LocalDate.of(year, month, day);
+		// We must detect if the extension date is in current year or in a next year (we use year 2000 in comparison because it is a leap year)
+		LocalDate extensionDate = LocalDate.of(2000, month, day);
 
 		// check if extension is next year
 		// in case of static date being today's date, we want to extend to next year (that's why we use the negation later)
-		boolean extensionThisYear = LocalDate.now().isBefore(extensionDate);
+		boolean extensionInThisYear = LocalDate.of(2000, LocalDate.now().getMonth(), LocalDate.now().getDayOfMonth()).isBefore(extensionDate);
+
+		// Get current year
+		int year = LocalDate.now().getYear();
+		if (!extensionInThisYear) {
+			// Add year to get next year
+			year++;
+		}
 
 		// Set the date to which the membership should be extended, can be changed if there was grace period, see next part of the code
-		if (!extensionThisYear) {
-			extensionDate = extensionDate.plusYears(1);
+		if (day == 29 && month == 2 && !LocalDate.of(year, 1,1).isLeapYear()) {
+			// If extended date is 29. 2. of non-leap year, the date is set to 28. 2.
+			extensionDate = LocalDate.of(year, 2, 28);
+		} else {
+			extensionDate = LocalDate.of(year, month, day);
 		}
 
 		return extensionDate;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AbstractMembershipExpirationRulesModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/attributes/AbstractMembershipExpirationRulesModule.java
@@ -5,10 +5,10 @@ import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -56,16 +56,12 @@ public abstract class AbstractMembershipExpirationRulesModule<T extends PerunBea
 		//For period (only date like 1.1. or 29.4. without year) or (+xy where x is number and y is d/m/y - +35m or +80d)
 		String parameter = membershipPeriodKeyName;
 		if(keys.contains(parameter)) {
-			DateFormat dateFormatter = new SimpleDateFormat("dd.MM.");
-			Date date;
+			DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("d.M.uuuu").withResolverStyle(ResolverStyle.STRICT);
 			try {
-				date = dateFormatter.parse(attrValue.get(parameter));
-				//Test if it is valid date format (need to use standardization: 01.01. = 1.1, 29.03 = 29.3 for both in test)
-				if (!standardFormatDate(dateFormatter.format(date)).equals(standardFormatDate(attrValue.get(parameter)))) {
-					throw new WrongAttributeValueException(attribute, "There is not allowed value (bad date format) for parameter '" + parameter + "': " + attrValue.get(parameter));
-				}
-			} catch (ParseException ex) {
-				//Its not date in format dd.MM. so test for next option exmp: "+18m"
+				//Check if given date is valid date (2000 is a leap year)
+				LocalDate.parse(attrValue.get(parameter) + "2000", dateTimeFormatter);
+			} catch (DateTimeParseException ex) {
+				//It's not date in format d.M. (or dd.MM.) so test for next option, for example: "+18m"
 				Matcher extensionDateMatcher = extensionDatePattern.matcher(attrValue.get(parameter));
 				if(!extensionDateMatcher.find()) throw new WrongAttributeValueException(attribute, "There is not allowed value for parameter '" + parameter + "': " + attrValue.get(parameter));
 			}
@@ -105,15 +101,10 @@ public abstract class AbstractMembershipExpirationRulesModule<T extends PerunBea
 				if(value.contains("..")) {
 					value = value.substring(0, value.length()-1);
 				}
-				DateFormat dateFormatter = new SimpleDateFormat("dd.MM.");
-				Date date;
+				DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("d.M.uuuu").withResolverStyle(ResolverStyle.STRICT);
 				try {
-					date = dateFormatter.parse(value);
-					//Test if it is valid date format (need to use standardization: 01.01. = 1.1, 29.03 = 29.3 for both in test)
-					if (!standardFormatDate(dateFormatter.format(date)).equals(standardFormatDate(value))) {
-						throw new WrongAttributeValueException(attribute, "There is not allowed value (bad date format) for parameter '" + parameter + "': " + attrValue.get(parameter));
-					}
-				} catch (ParseException ex) {
+					LocalDate.parse(value + "2000", dateTimeFormatter);
+				} catch (DateTimeParseException ex) {
 					throw new WrongAttributeValueException(attribute, "There is not allowed value (bad date format) for parameter '" + parameter + "': " + attrValue.get(parameter));
 				}
 			}
@@ -131,28 +122,4 @@ public abstract class AbstractMembershipExpirationRulesModule<T extends PerunBea
 	 * @return true if parameter is allowed, false if is not
 	 */
 	protected abstract boolean isAllowedParameter(String parameter);
-
-
-	/**
-	 * Get String of date and try to create standard format for this module.
-	 * Standard format is : 1.1.
-	 * Standard format is not : 01.01. or 01.1.
-	 * IMPORTANT This is only for equals on string dates in this module!
-	 *
-	 * @param date format of date (1.1. or 01.1. or 01.01. etc)
-	 * @return String standard format of date
-	 */
-	private String standardFormatDate(String date) {
-		int position1 = 0;
-		int position2 = 3;
-		if(date == null || date.length() == 0) return date;
-		if(date.charAt(position1) == '0') {
-			date = date.substring(position1+1);
-			position2--;
-		}
-		if(date.length() == (position2+3) && date.charAt(position2) == '0') {
-			date = date.substring(0,position2) + date.substring(position2+1);
-		}
-		return date;
-	}
 }


### PR DESCRIPTION
- the exception is no longer thrown if expiration date is set to 29. 2. of a leap year
- if extension of membership is set to 29. 2. of a non-leap year, it's set to 28. 2. instead