### PR TITLE
REGISTRAR: Support login generating workflow

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItemWithPrefilledValue.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/registrar/model/ApplicationFormItemWithPrefilledValue.java
@@ -10,6 +10,7 @@ public class ApplicationFormItemWithPrefilledValue {
 	private ApplicationFormItem formItem;
 	private String prefilledValue;
 	private String assuranceLevel;
+	private boolean generated = false;
 
 	public ApplicationFormItemWithPrefilledValue(ApplicationFormItem formItem, String prefilledValue) {
 		this.formItem = formItem;
@@ -40,6 +41,14 @@ public class ApplicationFormItemWithPrefilledValue {
 		this.assuranceLevel = assuranceLevel;
 	}
 
+	public boolean isGenerated() {
+		return generated;
+	}
+
+	public void setGenerated(boolean generated) {
+		this.generated = generated;
+	}
+
 	/**
 	 * Return bean name as PerunBean does.
 	 *
@@ -55,6 +64,7 @@ public class ApplicationFormItemWithPrefilledValue {
 			"formItem='" + getFormItem().toString() + '\'' +
 			", prefilledValue='" + getPrefilledValue() + '\'' +
 			", assuranceLevel='" + getAssuranceLevel() + '\'' +
+			", generated='" + isGenerated() + '\'' +
 			']';
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarModule.java
@@ -24,7 +24,9 @@ import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueExce
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
 import cz.metacentrum.perun.registrar.model.Application;
+import cz.metacentrum.perun.registrar.model.ApplicationForm;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItemWithPrefilledValue;
 
 /**
  * Interface for all registrar modules. They extend core registrar functionality and are
@@ -98,5 +100,17 @@ public interface RegistrarModule {
 	 * @param params custom params
 	 */
 	void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException;
+
+	/**
+	 * Custom logic for processing pre-filled form item data before they are returned from Perun to GUI
+	 * in order to display form. It can be used to modify pre-filled data retrieved from perun or federation attributes.
+	 *
+	 * @param session who approves the application
+	 * @param appType initial/extension application type
+	 * @param form form this form items belongs to
+	 * @param formItems form items with pre-filled data if any
+	 */
+	void processFormItemsWithData(PerunSession session, Application.AppType appType, ApplicationForm form,
+	                              List<ApplicationFormItemWithPrefilledValue> formItems) throws PerunException;
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -106,7 +106,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	private static final String FRIENDLY_NAME_GROUP_FROM_EMAIL = "fromEmail";
 	private static final String NAMESPACE_GROUP_FROM_EMAIL = AttributesManager.NS_GROUP_ATTR_DEF;
 	static final String URN_GROUP_FROM_EMAIL = NAMESPACE_GROUP_FROM_EMAIL + ":" +  FRIENDLY_NAME_GROUP_FROM_EMAIL;
-	
+
 	private static final String DISPLAY_NAME_GROUP_FROM_NAME_EMAIL = "\"From\" name";
 	private static final String FRIENDLY_NAME_GROUP_FROM__NAME_EMAIL = "fromNameEmail";
 	private static final String NAMESPACE_GROUP_FROM_NAME_EMAIL = AttributesManager.NS_GROUP_ATTR_DEF;
@@ -1225,7 +1225,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 					// skip logins with empty/null value
 					if (itemData.getValue() == null || itemData.getValue().isEmpty() || itemData.getValue().equals("null")) continue;
 					// skip unchanged pre-filled logins, since they must have been handled last time
-					if (itemData.getValue().equals(itemData.getPrefilledValue()) && itemType != PASSWORD) continue;
+					if (itemType == USERNAME && Objects.equals(itemData.getValue(), itemData.getPrefilledValue())) continue;
 					logins.add(itemData);
 				}
 			}
@@ -2447,6 +2447,10 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				}
 
 			}
+		}
+
+		if (module != null) {
+			module.processFormItemsWithData(sess, appType, form, itemsWithValues);
 		}
 
 		if (!itemsWithMissingData.isEmpty() && extSourceType.equals(ExtSourcesManager.EXTSOURCE_IDP)) {

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRICollections.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRICollections.java
@@ -17,8 +17,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
 import cz.metacentrum.perun.registrar.model.Application;
@@ -40,25 +38,13 @@ import java.util.*;
  * @author Jiri Mauritz <jirmaurtiz@gmail.com> (original)
  * @author Dominik Frantisek Bucik <bucik@ics.muni.cz> (modifications)
  */
-public class BBMRICollections implements RegistrarModule {
+public class BBMRICollections extends DefaultRegistrarModule {
 
 	private final static Logger log = LoggerFactory.getLogger(BBMRICollections.class);
 
 	private static final String COLLECTION_IDS_FIELD = "Comma or new-line separated list of IDs of collections you are representing:";
 	private static final String COLLECTION_ID_ATTR_NAME = "urn:perun:group:attribute-def:def:collectionID";
 	private static final String REPRESENTATIVES_GROUP_NAME = "representatives";
-
-	private RegistrarManager registrar;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-		this.registrar = registrar;
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) {
-		return data;
-	}
 
 	/**
 	 * Find groups representing collections by input. Groups are looked for in subgroups
@@ -106,17 +92,6 @@ public class BBMRICollections implements RegistrarModule {
 		return app;
 	}
 
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) {
-		return app;
-	}
-
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
 	/**
 	 * Checks whether all collection IDs found in user input really exists in Perun.
 	 * If not, CantBeApproved exception is thrown.
@@ -146,11 +121,6 @@ public class BBMRICollections implements RegistrarModule {
 			throw new CantBeApprovedException("Collections " + collectionIDsInApplication + " do not exist." +
 					"If you approve the application, these collections will be skipped.", "", "", "", true);
 		}
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) {
-
 	}
 
 	/**

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRINetworks.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/BBMRINetworks.java
@@ -3,7 +3,6 @@ package cz.metacentrum.perun.registrar.modules;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.Group;
 import cz.metacentrum.perun.core.api.Member;
-import cz.metacentrum.perun.core.api.Perun;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
@@ -22,8 +21,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
 import cz.metacentrum.perun.registrar.model.Application;
@@ -46,7 +43,7 @@ import java.util.Set;
  * @author Jiri Mauritz <jirmaurtiz@gmail.com> (original)
  * @author Dominik Frantisek Bucik <bucik@ics.muni.cz> (modifications)
  */
-public class BBMRINetworks implements RegistrarModule {
+public class BBMRINetworks extends DefaultRegistrarModule {
 
 	private final static Logger log = LoggerFactory.getLogger(BBMRINetworks.class);
 	private static final String NETWORK_IDS_FIELD = "Comma or new-line separated list of IDs of networks you are representing:";
@@ -54,18 +51,6 @@ public class BBMRINetworks implements RegistrarModule {
 	private static final String NETWORK_ID_ATTR_NAME = "urn:perun:group:attribute-def:def:networkID";
 	private static final String REPRESENTATIVES_GROUP_NAME = "representatives";
 	private static final String ADD_NEW_NETWORKS_GROUP_NAME = "addNewNetworks";
-
-	private RegistrarManager registrar;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-		this.registrar = registrar;
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) {
-		return data;
-	}
 
 	/**
 	 * Add users to the listed groups.
@@ -110,17 +95,6 @@ public class BBMRINetworks implements RegistrarModule {
 		return app;
 	}
 
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) {
-		return app;
-	}
-
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
 	/**
 	 * Checks whether all network IDs found in user input really exists in Perun.
 	 * If not, CantBeApproved exception is thrown.
@@ -149,11 +123,6 @@ public class BBMRINetworks implements RegistrarModule {
 			throw new CantBeApprovedException("Networks with IDs: " + networkIDsInApplication + " do not exist." +
 					"If you approve the application, these networks will be skipped.", "", "", "", true);
 		}
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) {
-		// automatically overridden method
 	}
 
 	/**

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Ceitec.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Ceitec.java
@@ -2,8 +2,6 @@ package cz.metacentrum.perun.registrar.modules;
 
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
@@ -11,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -22,36 +19,9 @@ import java.util.Objects;
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class Ceitec implements RegistrarModule {
+public class Ceitec extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(Ceitec.class);
-
-	private RegistrarManager registrar;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-		this.registrar = registrar;
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
-
-	@Override
-	public Application approveApplication(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
 
 	@Override
 	public void canBeApproved(PerunSession session, Application app) throws PerunException {
@@ -74,10 +44,6 @@ public class Ceitec implements RegistrarModule {
 			throw new CantBeApprovedException("Users name provided by IdP and User differ. Please check for correct name before approval.","","","",true);
 		}
 
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 	}
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/CeitecNcbr.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/CeitecNcbr.java
@@ -2,16 +2,10 @@ package cz.metacentrum.perun.registrar.modules;
 
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Module for CEITEC@MUNI and NCBR@MUNI VOs at CESNET instance of Perun.
@@ -22,44 +16,15 @@ import java.util.Map;
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class CeitecNcbr implements RegistrarModule {
+public class CeitecNcbr extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(CeitecNcbr.class);
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
-
-	@Override
-	public Application approveApplication(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
 
 	@Override
 	public void canBeApproved(PerunSession session, Application app) throws PerunException {
 
 		if (app.getExtSourceLoa() == 2) return;
 		throw new CantBeApprovedException("Application can't be approved automatically. LoA is: "+app.getExtSourceLoa()+". Please double check users identity before manual/force approval.", "", "", "", true);
-
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/DefaultRegistrarModule.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/DefaultRegistrarModule.java
@@ -1,0 +1,86 @@
+package cz.metacentrum.perun.registrar.modules;
+
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
+import cz.metacentrum.perun.core.api.exceptions.AlreadyMemberException;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
+import cz.metacentrum.perun.core.api.exceptions.ExternallyManagedException;
+import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.NotGroupMemberException;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.registrar.RegistrarManager;
+import cz.metacentrum.perun.registrar.RegistrarModule;
+import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
+import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
+import cz.metacentrum.perun.registrar.model.Application;
+import cz.metacentrum.perun.registrar.model.ApplicationForm;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItemWithPrefilledValue;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default implementation of registrar module, which does nothing, just sets RegistrarManager.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz>
+ */
+public class DefaultRegistrarModule implements RegistrarModule {
+
+	protected RegistrarManager registrar;
+
+	@Override
+	public void setRegistrar(RegistrarManager registrar) {
+		this.registrar = registrar;
+	}
+
+	@Override
+	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
+		// return unmodified data
+		return data;
+	}
+
+	@Override
+	public Application approveApplication(PerunSession session, Application app) throws UserNotExistsException, PrivilegeException, AlreadyAdminException, InternalErrorException, GroupNotExistsException, VoNotExistsException, MemberNotExistsException, AlreadyMemberException, ExternallyManagedException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException, RegistrarException, ExtendMembershipException, ExtSourceNotExistsException, NotGroupMemberException {
+		// return unmodified data
+		return app;
+	}
+
+	@Override
+	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
+		// return unmodified data
+		return app;
+	}
+
+	@Override
+	public Application beforeApprove(PerunSession session, Application app) throws CantBeApprovedException, InternalErrorException, RegistrarException, PrivilegeException {
+		// return unmodified data
+		return app;
+	}
+
+	@Override
+	public void canBeApproved(PerunSession session, Application app) throws PerunException {
+
+	}
+
+	@Override
+	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
+
+	}
+
+	@Override
+	public void processFormItemsWithData(PerunSession session, Application.AppType appType, ApplicationForm form, List<ApplicationFormItemWithPrefilledValue> formItems) throws PerunException {
+
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Du.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Du.java
@@ -4,8 +4,6 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.exceptions.CantBeSubmittedException;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
@@ -29,31 +27,9 @@ import java.util.Objects;
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class Du implements RegistrarModule {
+public class Du extends DefaultRegistrarModule {
 
 	private final static Logger log = LoggerFactory.getLogger(Du.class);
-
-	private RegistrarManager registrar;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-		this.registrar = registrar;
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
-
-	@Override
-	public Application approveApplication(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
 
 	@Override
 	public Application beforeApprove(PerunSession session, Application app) throws CantBeApprovedException, RegistrarException, PrivilegeException, InternalErrorException {

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/DuSoft.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/DuSoft.java
@@ -2,10 +2,7 @@ package cz.metacentrum.perun.registrar.modules;
 
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
 import cz.metacentrum.perun.registrar.model.Application;
@@ -20,7 +17,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -28,37 +24,9 @@ import java.util.Objects;
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class DuSoft implements RegistrarModule {
+public class DuSoft extends DefaultRegistrarModule {
 
 	private final static Logger log = LoggerFactory.getLogger(DuSoft.class);
-
-	private RegistrarManager registrar;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-		this.registrar = registrar;
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
-
-	@Override
-	public Application approveApplication(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		// allow approval of any application based on VO rules
-		return app;
-	}
 
 	@Override
 	public void canBeApproved(PerunSession session, Application app) throws RegistrarException, PrivilegeException, InternalErrorException, CantBeApprovedException {
@@ -97,11 +65,6 @@ public class DuSoft implements RegistrarModule {
 		}
 
 		throw new CantBeApprovedException("User is not eligible for CESNET services. User must log-in using verified academic identity (at least once a year) in order to access CESNET services.", "NOT_ELIGIBLE", null, null, true);
-
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ELIXIRCILogonDNGenerator.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ELIXIRCILogonDNGenerator.java
@@ -3,15 +3,11 @@ package cz.metacentrum.perun.registrar.modules;
 import cz.metacentrum.perun.core.api.*;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.impl.Utils;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,8 +20,6 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Application module for ELIXIR purpose
@@ -40,7 +34,7 @@ import java.util.Map;
  *
  * Implementation must be kept in sync with: https://github.com/ttomttom/aarc-delegation-server/blob/master/src/main/java/org/delegserver/oauth2/generator/DNGenerator.java#L483
  */
-public class ELIXIRCILogonDNGenerator implements RegistrarModule {
+public class ELIXIRCILogonDNGenerator extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(ELIXIRCILogonDNGenerator.class);
 
@@ -50,15 +44,6 @@ public class ELIXIRCILogonDNGenerator implements RegistrarModule {
 
 	private static final String RDN_TRUNCATE_SIGN = "...";
 	private static final int RDN_MAX_SIZE = 64;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
 
 	/**
 	 * All new members will get new userExtSource with generated DN according to the CILogon rules:
@@ -117,26 +102,6 @@ public class ELIXIRCILogonDNGenerator implements RegistrarModule {
 		return app;
 
 	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
-
-	}
-
 
 	/**
 	 * Implementation of the general truncating rule outlined in the RCauth Policy Document

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduGain.java
@@ -8,31 +8,18 @@ import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Map;
 
 /**
  * Application module for EduGain purpose
  */
-public class EduGain implements RegistrarModule {
+public class EduGain extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(Metacentrum.class);
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
 
 	/**
 	 * All new members will be given role VOOBSERVER and TOPGROUPCREATOR

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduTEAMS.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/EduTEAMS.java
@@ -5,21 +5,17 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Module for eduTEAMS instance.
@@ -32,24 +28,11 @@ import java.util.Map;
  *
  * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
  */
-public class EduTEAMS implements RegistrarModule {
+public class EduTEAMS extends DefaultRegistrarModule {
 
 	private static final String A_U_D_EDUTEAMS_NICKNAME =
 			"urn:perun:user:attribute-def:def:login-namespace:eduteams-nickname";
 	private static final String APPLICATION_NICKNAME_ITEM = "nickname";
-
-	private RegistrarManager registrar;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-		this.registrar = registrar;
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession session, Application application,
-	                                                       List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
 
 	@Override
 	public Application approveApplication(PerunSession sess, Application application) throws RegistrarException, PrivilegeException, InternalErrorException, UserNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, AttributeNotExistsException {
@@ -87,23 +70,4 @@ public class EduTEAMS implements RegistrarModule {
 		return application;
 	}
 
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-		// do nothing
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
-		// do nothing
-	}
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Eduroam.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Eduroam.java
@@ -7,7 +7,6 @@ import cz.metacentrum.perun.core.api.exceptions.ExternallyManagedException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
@@ -15,32 +14,14 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.*;
 
 /**
  * Custom logic for VO eduroam.
  *
  * @author Jan Zverina <zverina@cesnet.cz>
  */
-public class Eduroam implements RegistrarModule {
-
-	final static Logger log = LoggerFactory.getLogger(DuSoft.class);
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
+public class Eduroam extends DefaultRegistrarModule {
 
 	@Override
 	public Application approveApplication(PerunSession session, Application app) throws VoNotExistsException, UserNotExistsException, PrivilegeException, MemberNotExistsException, InternalErrorException, GroupNotExistsException, AlreadyMemberException, ExternallyManagedException, WrongAttributeValueException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongReferenceAttributeValueException {
@@ -62,26 +43,6 @@ public class Eduroam implements RegistrarModule {
 		}
 
 		return app;
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
-
 	}
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Elixir.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Elixir.java
@@ -1,0 +1,180 @@
+package cz.metacentrum.perun.registrar.modules;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.PerunException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.blImpl.ModulesUtilsBlImpl;
+import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.registrar.model.Application;
+import cz.metacentrum.perun.registrar.model.ApplicationForm;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItem;
+import cz.metacentrum.perun.registrar.model.ApplicationFormItemWithPrefilledValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Registration module used in "Elixir" VO on Elixir Perun instance.
+ * It is used to pre-generate available user login on application form for new users.
+ *
+ * @author Pavel Zlámal <zlamal@cesnet.cz/>
+ */
+public class Elixir extends DefaultRegistrarModule {
+
+	final static Logger log = LoggerFactory.getLogger(Elixir.class);
+
+	private static String URN_USER_DISPLAY_NAME = AttributesManager.NS_USER_ATTR_CORE + ":" + "displayName";
+	private static String URN_USER_PREFERRED_MAIL = AttributesManager.NS_USER_ATTR_DEF + ":" + "preferredMail";
+
+	@Override
+	public void processFormItemsWithData(PerunSession session, Application.AppType appType, ApplicationForm form, List<ApplicationFormItemWithPrefilledValue> formItems) throws PerunException {
+
+		// generate login only on initial application
+		if (!Application.AppType.INITIAL.equals(appType)) return;
+
+		for (ApplicationFormItemWithPrefilledValue item : formItems) {
+			if (Objects.equals(ApplicationFormItem.Type.USERNAME, item.getFormItem().getType())) {
+
+				// skip if user already has login pre-filled from perun or federation
+				if (!StringUtils.isEmpty(item.getPrefilledValue())) continue;
+
+				// do not generate login if destination attribute is not set (won't be stored)
+				if (StringUtils.isEmpty(item.getFormItem().getPerunDestinationAttribute())) continue;
+
+				// set new generated value
+				item.setPrefilledValue(generateLogin(session, item, formItems));
+				// mark value as generated so the GUI allows editing and on submit server process new login
+				item.setGenerated(true);
+
+			}
+		}
+
+	}
+
+	/**
+	 * Generates new login for input data
+	 *
+	 *
+	 * @param session PerunSession
+	 * @param formItems Whole form data
+	 * @return
+	 */
+	private String generateLogin(PerunSession session, ApplicationFormItemWithPrefilledValue loginItem, List<ApplicationFormItemWithPrefilledValue> formItems) {
+
+		String displayName = fetchFormValue(formItems, URN_USER_DISPLAY_NAME);
+		PerunBl perun = (PerunBl)session.getPerun();
+
+		User user = null;
+		try {
+			user = Utils.parseUserFromCommonName(displayName);
+		} catch (Exception ex) {
+
+			log.warn("We couldn't parse commonName/displayName into User object");
+
+			String mail = fetchFormValue(formItems, URN_USER_PREFERRED_MAIL);
+			if (mail != null) {
+				mail = mail.split("@")[0];
+				user = new User(0, null, mail, null, null, null);
+			}
+
+		}
+
+		if (user != null) {
+
+			ModulesUtilsBlImpl.LoginGenerator generator = new ModulesUtilsBlImpl.LoginGenerator();
+
+			String login = generator.generateLogin(user, new ModulesUtilsBlImpl.LoginGenerator.LoginGeneratorFunction() {
+				@Override
+				public String generateLogin(String firstName, String lastName) {
+
+					String wholeLogin = "";
+					if (firstName != null && !firstName.isEmpty()) {
+						wholeLogin = firstName;
+					}
+					if (lastName != null && !lastName.isEmpty()) {
+						wholeLogin = wholeLogin + lastName;
+					}
+					return wholeLogin;
+
+				}
+			});
+
+			if (StringUtils.isEmpty(login)) return null;
+
+			String checkedLogin = login;
+
+			// fill value (with incremental number on conflict)
+			int iterator = 0;
+			while (iterator >= 0) {
+
+				if (iterator > 0) {
+					int iteratorLength = String.valueOf(iterator).length();
+					if (login.length() + iteratorLength > 20) {
+						// if login+iterator > 20 => crop login & reset iterator
+						checkedLogin = login.substring(0, login.length()-1);
+						iterator = 0;
+					} else {
+						checkedLogin = login + iterator;
+					}
+				} else {
+					// checked login is used
+				}
+
+				try {
+
+					AttributeDefinition def = perun.getAttributesManagerBl().getAttributeDefinition(session, loginItem.getFormItem().getPerunDestinationAttribute());
+					Attribute checkAttribute = new Attribute(def, checkedLogin);
+					perun.getAttributesManagerBl().checkAttributeSemantics(session, user, checkAttribute);
+					return checkedLogin;
+
+				} catch (WrongReferenceAttributeValueException ex) {
+					// continue in a WHILE cycle - generated login was used
+					iterator++;
+				} catch (AttributeNotExistsException ex) {
+					// we couldn't pre-fill login, its mapped to non-existing attribute
+					log.warn("We couldn't generate new login, since its mapped to non-exisitng attribute {}., {}", loginItem.getFormItem().getPerunDestinationAttribute(), ex);
+					return null;
+				} catch (WrongAttributeAssignmentException | InternalErrorException e) {
+					log.warn("We couldn't generate new login, because of exception.", e);
+					return null;
+				}
+			}
+
+		} else {
+			log.error("We couldn't create arbitrary User object with name from form items in order to generate login.");
+		}
+
+		return null;
+
+	}
+
+	/**
+	 * Retrieves specific attribute value from form items (first occurrence)
+	 *
+	 * @param formItems form items to search in
+	 * @param perunDestinationAttribute destination attribute
+	 * @return value of first found form item mapped to perunDestinationAttribute
+	 */
+	private String fetchFormValue(List<ApplicationFormItemWithPrefilledValue> formItems, String perunDestinationAttribute) {
+
+		for (ApplicationFormItemWithPrefilledValue item : formItems) {
+			if (perunDestinationAttribute.equals(item.getFormItem().getPerunDestinationAttribute())) {
+				return item.getPrefilledValue();
+			}
+		}
+		return null;
+
+	}
+
+}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ElixirBonaFideStatus.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/ElixirBonaFideStatus.java
@@ -16,12 +16,9 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.AttributesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.exceptions.CantBeSubmittedException;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +32,7 @@ import java.util.Map;
  *
  * @author Dominik Frantisek Bucik <bucik@ics.muni.cz>
  */
-public class ElixirBonaFideStatus implements RegistrarModule {
+public class ElixirBonaFideStatus extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(ElixirBonaFideStatus.class);
 
@@ -48,16 +45,6 @@ public class ElixirBonaFideStatus implements RegistrarModule {
 	private static final String A_U_D_userBonaFideStatusRems = AttributesManager.NS_USER_ATTR_DEF + ':' + USER_BONA_FIDE_STATUS_REMS_ATTR_NAME;
 	private static final String A_U_D_userEduPersonScopedAffiliations = AttributesManager.NS_USER_ATTR_VIRT + ':' + USER_AFFILIATIONS_ATTR_NAME;
 	private static final String A_G_D_groupAttestation = AttributesManager.NS_GROUP_ATTR_DEF + ':' + GROUP_ATESTATION_ATTR_NAME;
-
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
 
 	/**
 	 * Add new bonaFideStatus to the user attribute.
@@ -88,11 +75,6 @@ public class ElixirBonaFideStatus implements RegistrarModule {
 	}
 
 	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
 	public Application beforeApprove(PerunSession session, Application app) throws CantBeApprovedException, InternalErrorException {
 		Group group = app.getGroup();
 		if (group == null) {
@@ -117,11 +99,6 @@ public class ElixirBonaFideStatus implements RegistrarModule {
 		}
 
 		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-
 	}
 
 	/**

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Elixircz.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Elixircz.java
@@ -8,20 +8,14 @@ import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtendMembershipException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.MemberNotExistsException;
-import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -35,18 +29,9 @@ import java.util.Objects;
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class Elixircz implements RegistrarModule {
+public class Elixircz extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(Elixircz.class);
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
 
 	@Override
 	public Application approveApplication(PerunSession session, Application app) throws MemberNotExistsException, InternalErrorException, AttributeNotExistsException, WrongAttributeAssignmentException, WrongAttributeValueException, WrongReferenceAttributeValueException, ExtendMembershipException {
@@ -80,24 +65,6 @@ public class Elixircz implements RegistrarModule {
 
 		return app;
 
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 	}
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/LifescienceHostel.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/LifescienceHostel.java
@@ -9,19 +9,12 @@ import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Module for VOs managing LifeScience Hostel
@@ -29,22 +22,13 @@ import java.util.Map;
  * @author Pavel Zlamal <256627@mail.muni.cz>
  * @author Dominik Frantisek Bucik <bucik@ics.muni.cz>
  */
-public class LifescienceHostel implements RegistrarModule {
+public class LifescienceHostel extends DefaultRegistrarModule {
 
 	private final static Logger log = LoggerFactory.getLogger(LifescienceHostel.class);
 
 	private final static String LIFESCIENCE_HOSTEL_NS = "login-namespace:lifescience-hostel";
 	private final static String LS_HOSTEL_SCOPE = "@lifescience-hostel.org";
 	private final static String LS_HOSTEL_EXT_SOURCE_NAME = "https://login.bbmri-eric.eu/lshostel/";
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession session, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
 
 	/**
 	 * Create proper UserExtSource
@@ -84,24 +68,6 @@ public class LifescienceHostel implements RegistrarModule {
 
 		return app;
 
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 	}
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Metacentrum.java
@@ -15,8 +15,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.exceptions.RegistrarException;
 import cz.metacentrum.perun.registrar.model.Application;
@@ -31,7 +29,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -39,21 +36,9 @@ import java.util.Objects;
  *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-public class Metacentrum implements RegistrarModule {
+public class Metacentrum extends DefaultRegistrarModule {
 
 	private final static Logger log = LoggerFactory.getLogger(Metacentrum.class);
-
-	private RegistrarManager registrar;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-		this.registrar = registrar;
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
 
 	/**
 	 * Add all new Metacentrum members to "storage" group.
@@ -74,7 +59,7 @@ public class Metacentrum implements RegistrarModule {
 			try  {
 				perun.getGroupsManager().addMember(session, group, mem);
 			} catch (AlreadyMemberException ex) {
-
+				// IGNORE
 			}
 		}
 
@@ -119,16 +104,6 @@ public class Metacentrum implements RegistrarModule {
 	}
 
 	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
 	public void canBeApproved(PerunSession session, Application app) throws PerunException {
 
 		// allow only Education & Research community members
@@ -165,11 +140,6 @@ public class Metacentrum implements RegistrarModule {
 		}
 
 		throw new CantBeApprovedException("User is not eligible for CESNET services.", "NOT_ELIGIBLE", null, null, true);
-
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Sitola.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Sitola.java
@@ -5,23 +5,18 @@ import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -29,18 +24,9 @@ import java.util.Objects;
  *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-public class Sitola implements RegistrarModule {
+public class Sitola extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(Sitola.class);
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
 
 	/**
 	 * All new Sitola members will have MU eduroam identity added if they posses MU login.
@@ -100,26 +86,6 @@ public class Sitola implements RegistrarModule {
 		}
 
 		return app;
-
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 
 	}
 

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Vsup.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Vsup.java
@@ -16,8 +16,6 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.model.Application;
 import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
@@ -27,7 +25,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -35,16 +32,9 @@ import java.util.Objects;
  *
  * @author Pavel Zlamal <256627@mail.muni.cz>
  */
-public class Vsup implements RegistrarModule {
+public class Vsup extends DefaultRegistrarModule {
 
 	private final static Logger log = LoggerFactory.getLogger(Vsup.class);
-
-	private RegistrarManager registrar;
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-		this.registrar = registrar;
-	}
 
 	@Override
 	public List<ApplicationFormItemData> createApplication(PerunSession session, Application application, List<ApplicationFormItemData> data) throws PerunException {
@@ -151,24 +141,6 @@ public class Vsup implements RegistrarModule {
 
 		return app;
 
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public void canBeApproved(PerunSession session, Application app) throws PerunException {
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 	}
 
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/WeNMR.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/WeNMR.java
@@ -5,16 +5,12 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.registrar.RegistrarManager;
-import cz.metacentrum.perun.registrar.RegistrarModule;
 import cz.metacentrum.perun.registrar.exceptions.CantBeApprovedException;
 import cz.metacentrum.perun.registrar.model.Application;
-import cz.metacentrum.perun.registrar.model.ApplicationFormItemData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -26,33 +22,9 @@ import java.util.Objects;
  *
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class WeNMR implements RegistrarModule {
+public class WeNMR extends DefaultRegistrarModule {
 
 	final static Logger log = LoggerFactory.getLogger(WeNMR.class);
-
-	@Override
-	public void setRegistrar(RegistrarManager registrar) {
-	}
-
-	@Override
-	public List<ApplicationFormItemData> createApplication(PerunSession user, Application application, List<ApplicationFormItemData> data) throws PerunException {
-		return data;
-	}
-
-	@Override
-	public Application approveApplication(PerunSession session, Application app) {
-		return app;
-	}
-
-	@Override
-	public Application rejectApplication(PerunSession session, Application app, String reason) throws PerunException {
-		return app;
-	}
-
-	@Override
-	public Application beforeApprove(PerunSession session, Application app) {
-		return app;
-	}
 
 	@Override
 	public void canBeApproved(PerunSession session, Application app) throws PerunException {
@@ -88,11 +60,6 @@ public class WeNMR implements RegistrarModule {
 		}
 
 		// submitted from trusted IdP
-
-	}
-
-	@Override
-	public void canBeSubmitted(PerunSession session, Map<String, String> params) throws PerunException {
 
 	}
 


### PR DESCRIPTION
- Added new "generated" property in ApplicationFormItemWithPrefilledValue.
  Its false by default, but can be set to TRUE if we want to notify GUI, that value
  was generated by perun and not retrieved from stored data.
- Added new RegistrarModule method processFormItemsWithData(), which is called right
  before form item data are returned from the server to GUI. It can be used
  to modify form data (eg. pre-filled values).
- Its up to GUI to clear pre-filled value from ApplicationFormItemData (if value was
  generated) on form submission to make sure, that new login is registered and
  not considered as already existing.
- Added DefaultRegistrarModule class with empty implementation of RegistrarModule,
  all other modules extend it to prevent code duplicity.
- New module for VO Elixir will allow generating of new login for
  users on registration form. New login is generated from name or
  mail prefix, if name is not parseable.