### PR TITLE
GUI: Support setting expiration together with member status change

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonCallbackEvents.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonCallbackEvents.java
@@ -168,7 +168,7 @@ public class JsonCallbackEvents {
 			public void onFinished(JavaScriptObject jso)
 			{
 				button.setProcessing(false);
-				session.getTabManager().closeTab(tab);
+				session.getTabManager().closeTab(tab, tab.isRefreshParentOnClose());
 				if(events != null){
 					events.onFinished(jso);
 				}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonUtils.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/JsonUtils.java
@@ -683,6 +683,9 @@ public class JsonUtils {
 
 	}-*/;
 
+	public static final native String stringify(JavaScriptObject jso)  /*-{
+		return JSON.stringify(jso);
+	}-*/;
 
 	/**
 	 * Returns list of attribute URNs (strings)

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/columnProviders/MemberColumnProvider.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/columnProviders/MemberColumnProvider.java
@@ -258,6 +258,11 @@ public class MemberColumnProvider {
 				PerunWebSession.getInstance().getTabManager().addTabToCurrentTab(new ChangeStatusTabItem(object.cast(), new JsonCallbackEvents(){
 					@Override
 					public void onFinished(JavaScriptObject jso) {
+
+						// fixme - since we pass this event to more tabs and update expiration (set attributes)
+						//  passed object might not be relevant for this action
+						if (jso == null) return;
+
 						Member m = jso.cast();
 						// set status to object in cell to change rendered value
 						object.setStatus(m.getStatus());

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberOverviewTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MemberOverviewTabItem.java
@@ -41,6 +41,7 @@ public class MemberOverviewTabItem implements TabItem {
 	private SimplePanel contentWidget = new SimplePanel();
 	private Label titleWidget = new Label("Loading member details");
 	private int groupId = 0;
+	private TabItem tabItem = this;
 
 	/**
 	 * Constructor
@@ -140,13 +141,17 @@ public class MemberOverviewTabItem implements TabItem {
 				@Override
 				public void onFinished(JavaScriptObject jso) {
 					// UPDATE OBJECT
-					Member m = jso.cast();
-					member.setStatus(m.getStatus());
+					if (jso != null) {
+						// fixme - since we pass this event to more tabs and update expiration (set attributes)
+						//  passed object might not be relevant for this action
+						Member m = jso.cast();
+						member.setStatus(m.getStatus());
+					}
 				}
 			};
-			statusWidget = new PerunStatusWidget<RichMember>(member, member.getUser().getFullName(), event);
+			statusWidget = new PerunStatusWidget<RichMember>(member, member.getUser().getFullName(), event, tabItem);
 		} else {
-			statusWidget = new PerunStatusWidget<RichMember>(member, member.getUser().getFullName(), null);
+			statusWidget = new PerunStatusWidget<RichMember>(member, member.getUser().getFullName(), null, tabItem);
 		}
 		memberLayout.setWidget(0, 1, statusWidget);
 		memberLayout.getFlexCellFormatter().setRowSpan(0, 0, 2);
@@ -303,7 +308,7 @@ public class MemberOverviewTabItem implements TabItem {
 						} else if (a.getName().equalsIgnoreCase("urn:perun:member:attribute-def:def:membershipExpiration")) {
 							// set attribute inside member
 							member.setAttribute(a);
-							memberLayout.setWidget(2, 1, new MembershipExpirationWidget(member));
+							memberLayout.setWidget(2, 1, new MembershipExpirationWidget(member, tabItem));
 						} else if (a.getName().equalsIgnoreCase("urn:perun:member:attribute-def:def:sponzoredMember")) {
 							if (!"null".equals(value)) {
 								memberLayout.setHTML(4, 1, value + " (ID of RT ticket with explanation)");

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MembershipExpirationTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/memberstabs/MembershipExpirationTabItem.java
@@ -83,10 +83,11 @@ public class MembershipExpirationTabItem implements TabItem {
 		layout.setSize("100%","100%");
 		layout.setStyleName("inputFormFlexTable");
 
-		layout.setHTML(0, 0, "Current expiration:");
+		layout.setHTML(0, 0, "Current&nbsp;expiration:");
 		layout.getFlexCellFormatter().setStyleName(0, 0, "itemName");
 
 		layout.setHTML(0, 1, SafeHtmlUtils.fromString(member.getStatus()).asString());
+		layout.getFlexCellFormatter().getElement(0, 1).setAttribute("style", "width: 100%; font-size: 130%;");
 
 		final Attribute expire = member.getAttribute("urn:perun:member:attribute-def:def:membershipExpiration");
 		String expirationValue = null;
@@ -97,7 +98,7 @@ public class MembershipExpirationTabItem implements TabItem {
 			layout.setHTML(0, 1, "<i>never</i>");
 		}
 
-		layout.setHTML(1, 0, "New expiration:");
+		layout.setHTML(1, 0, "New&nbsp;expiration:");
 		layout.getFlexCellFormatter().setStyleName(1, 0, "itemName");
 
 		final CustomButton changeButton = new CustomButton("Save", "Save changes in membership expiration date", SmallIcons.INSTANCE.diskIcon());
@@ -111,6 +112,7 @@ public class MembershipExpirationTabItem implements TabItem {
 			@Override
 			public void onValueChange(ValueChangeEvent<Date> dateValueChangeEvent) {
 				layout.setHTML(1, 1, DateTimeFormat.getFormat("yyyy-MM-dd").format(picker.getValue()));
+				layout.getFlexCellFormatter().getElement(1, 1).setAttribute("style", "width: 100%; font-size: 130%;");
 				changeButton.setEnabled(true);
 				changeOrNever = true;
 			}
@@ -131,6 +133,7 @@ public class MembershipExpirationTabItem implements TabItem {
 			@Override
 			public void onClick(ClickEvent event) {
 				layout.setHTML(1, 1, "<i>never</i>");
+				layout.getFlexCellFormatter().getElement(1, 1).setAttribute("style", "width: 100%; font-size: 130%;");
 				changeOrNever = false;
 				changeButton.setEnabled(true);
 			}
@@ -152,14 +155,14 @@ public class MembershipExpirationTabItem implements TabItem {
 					expire.setValueAsString(DateTimeFormat.getFormat("yyyy-MM-dd").format(picker.getValue()));
 					Map<String, Integer> ids = new HashMap<String, Integer>();
 					ids.put("member", member.getId());
-					SetAttributes request = new SetAttributes(JsonCallbackEvents.closeTabDisableButtonEvents(changeButton, tab));
+					SetAttributes request = new SetAttributes(JsonCallbackEvents.closeTabDisableButtonEvents(changeButton, tab, events));
 					ArrayList<Attribute> list = new ArrayList<Attribute>();
 					list.add(expire);
 					request.setAttributes(ids, list);
 				} else {
 					Map<String, Integer> ids = new HashMap<String, Integer>();
 					ids.put("member", member.getId());
-					RemoveAttributes request = new RemoveAttributes(JsonCallbackEvents.closeTabDisableButtonEvents(changeButton, tab));
+					RemoveAttributes request = new RemoveAttributes(JsonCallbackEvents.closeTabDisableButtonEvents(changeButton, tab, events));
 					ArrayList<Attribute> list = new ArrayList<Attribute>();
 					list.add(expire);
 					request.removeAttributes(ids, list);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/MembershipExpirationWidget.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/widgets/MembershipExpirationWidget.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.webgui.widgets;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.Anchor;
@@ -9,6 +10,7 @@ import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
 import cz.metacentrum.perun.webgui.model.Attribute;
 import cz.metacentrum.perun.webgui.model.RichMember;
+import cz.metacentrum.perun.webgui.tabs.TabItem;
 import cz.metacentrum.perun.webgui.tabs.memberstabs.MembershipExpirationTabItem;
 
 /**
@@ -21,6 +23,18 @@ public class MembershipExpirationWidget extends Composite {
 	// the widget itself
 	private FlexTable statusWidget = new FlexTable();
 	private RichMember member;
+	private TabItem containingTabItem = null;
+
+	/**
+	 * Creates the new status widget
+	 * @param m member to show expiration for
+	 */
+	public MembershipExpirationWidget(RichMember m, TabItem tabItem) {
+		this.member = m;
+		this.containingTabItem = tabItem;
+		this.initWidget(statusWidget);
+		this.build();
+	}
 
 	/**
 	 * Creates the new status widget
@@ -55,7 +69,15 @@ public class MembershipExpirationWidget extends Composite {
 				change.addClickHandler(new ClickHandler() {
 					@Override
 					public void onClick(ClickEvent clickEvent) {
-						PerunWebSession.getInstance().getTabManager().addTabToCurrentTab(new MembershipExpirationTabItem(member, null));
+						PerunWebSession.getInstance().getTabManager().addTabToCurrentTab(new MembershipExpirationTabItem(member, new JsonCallbackEvents() {
+							@Override
+							public void onFinished(JavaScriptObject jso) {
+								if (containingTabItem != null) {
+									// forcefully refresh tab !!
+									containingTabItem.draw();
+								}
+							}
+						}));
 					}
 				});
 				statusWidget.setWidget(0, 1, change);


### PR DESCRIPTION
- Changing member status in GUI continues to expiration settings
  if destination status is either VALID or EXPIRED.
- Updated refresh events once status and expiration are set.
- JsonCallbackEvents for tab closing respect isRefreshParentOnClose() flag.
- Added JsonUtils.stringify() method for usage in debugging.