### PR TITLE
LDAPC: Fixed processing of Integer and Boolean attributes

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/AbstractPerunEntry.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/AbstractPerunEntry.java
@@ -337,7 +337,7 @@ public abstract class AbstractPerunEntry<T extends PerunBean> implements Initial
 	}
 
 	abstract protected Name buildDN(T bean);
-	
+
 	abstract protected void mapToContext(T bean, DirContextOperations context) throws InternalErrorException;
 
 	/**
@@ -404,7 +404,7 @@ public abstract class AbstractPerunEntry<T extends PerunBean> implements Initial
 				values = attrDef.getValues(bean, (Attribute)attr);
 			} else {
 				if(attrDef.hasValue(bean, (Attribute)attr)) {
-				values = Arrays.asList(attrDef.getValue(bean, (Attribute)attr)).toArray();
+					values = Arrays.asList(attrDef.getValue(bean, (Attribute)attr)).toArray();
 				} else {
 					values = null;
 				}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/MultipleAttributeValueExtractor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/MultipleAttributeValueExtractor.java
@@ -19,19 +19,9 @@ public class MultipleAttributeValueExtractor<T extends PerunBean> extends Attrib
 		for (Attribute attribute : attributes) {
 			if(this.appliesToAttribute(attribute)) {
 				if(attribute == null) return null;
-				if (attribute.getType().equals(String.class.getName()) || attribute.getType().equals(BeansUtils.largeStringClassName)) {
-					Object value = attribute.getValue();
-					if(value == null) 
-						return null;
-					else
-						result = new String[] { 
-								(valueTransformer == null) ?
-										(String)value 
-										: valueTransformer.getValue((String)value, attribute) 
-						};
-				} else if (attribute.getType().equals(ArrayList.class.getName()) || attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
+				if (attribute.getType().equals(ArrayList.class.getName()) || attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
 					List<String> values = attribute.valueAsList();
-					if(values == null || values.size() == 0) 
+					if(values == null || values.size() == 0)
 						return null;
 					else {
 						if(valueTransformer == null) {
@@ -41,14 +31,14 @@ public class MultipleAttributeValueExtractor<T extends PerunBean> extends Attrib
 								result = valueTransformer.getAllValues(values, attribute);
 							} else {
 								result = values.stream()
-								.map(value -> valueTransformer.getValue(value, attribute))
-								.toArray(String[]::new);
+										.map(value -> valueTransformer.getValue(value, attribute))
+										.toArray(String[]::new);
 							}
 						}
 					}
 				} else if (attribute.getType().equals(LinkedHashMap.class.getName())) {
 					LinkedHashMap<String, String> values = attribute.valueAsMap();
-					if(values == null || values.isEmpty()) 
+					if(values == null || values.isEmpty())
 						return null;
 					else {
 						if(valueTransformer != null) {
@@ -59,7 +49,16 @@ public class MultipleAttributeValueExtractor<T extends PerunBean> extends Attrib
 						}
 					}
 				} else {
-					return null;
+					// use toString() for String, LargeString, Integer nad Boolean types
+					Object value = attribute.getValue();
+					if(value == null)
+						return null;
+					else
+						result = new String[] {
+								(valueTransformer == null) ?
+										value.toString()
+										: valueTransformer.getValue((String)value, attribute)
+						};
 				}
 				return result;
 			}

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/SingleAttributeValueExtractor.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/model/impl/SingleAttributeValueExtractor.java
@@ -18,32 +18,31 @@ public class SingleAttributeValueExtractor<T extends PerunBean> extends Attribut
 		for (Attribute attribute : attributes) {
 			if(this.appliesToAttribute(attribute)) {
 				if(attribute == null) return null;
-				if (attribute.getType().equals(String.class.getName()) || attribute.getType().equals(BeansUtils.largeStringClassName)) {
+				if (attribute.getType().equals(ArrayList.class.getName()) || attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
+					List<String> values = attribute.valueAsList();
+					if(values == null || values.size() == 0)
+						return null;
+					else
+						result = (valueTransformer == null)
+								? values.toString() : valueTransformer.getValue(values, attribute);
+				} else if (attribute.getType().equals(LinkedHashMap.class.getName())) {
+					LinkedHashMap<String, String> values = attribute.valueAsMap();
+					if(values == null || values.isEmpty())
+						return null;
+					else
+						result = (valueTransformer == null)
+								? values.toString() : valueTransformer.getValue(values, attribute);
+				} else {
+					// use toString() for String, LargeString, Integer nad Boolean types
 					Object value = attribute.getValue();
-					if(value == null) 
+					if(value == null)
 						return null;
 					else {
-						result =  value.toString();
+						result = value.toString();
 						if(valueTransformer != null) {
 							result = valueTransformer.getValue(result, attribute);
 						}
 					}
-				} else if (attribute.getType().equals(ArrayList.class.getName()) || attribute.getType().equals(BeansUtils.largeArrayListClassName)) {
-					List<String> values = attribute.valueAsList();
-					if(values == null || values.size() == 0) 
-						return null;
-					else 
-						result = (valueTransformer == null) 
-							? values.toString() : valueTransformer.getValue(values, attribute);
-				} else if (attribute.getType().equals(LinkedHashMap.class.getName())) {
-					LinkedHashMap<String, String> values = attribute.valueAsMap();
-					if(values == null || values.isEmpty()) 
-						return null;
-					else
-						result = (valueTransformer == null) 
-							? values.toString() : valueTransformer.getValue(values, attribute);
-				} else {
-					return null;
 				}
 				return result;
 			}


### PR DESCRIPTION
- Recent change in AttributeValueExtractors prevented from correct
  value resolving for Integer and Boolean attributes, since it checked
  on String/LargeString attribute type.