### PR TITLE
Add member-group attributes for object RichGroup

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -1074,9 +1074,13 @@ public interface GroupsManager {
 	 * Return all RichGroups for specified member, containing selected attributes.
 	 * "members" group is not included.
 	 *
+	 * Supported are attributes from these namespaces:
+	 *  - group
+	 *  - member-group
+	 *
 	 * @param sess internal session
 	 * @param member the member to get the rich groups for
-	 * @param attrNames list of selected attributes
+	 * @param attrNames list of selected attributes from supported namespaces
 	 * @return list of rich groups with selected attributes
 	 * @throws InternalErrorException
 	 * @throws MemberNotExistsException

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -1359,6 +1359,10 @@ public interface GroupsManagerBl {
 	 * Return all RichGroups for specified member, containing selected attributes.
 	 * "members" group is not included.
 	 *
+	 * Supported are attributes from these namespaces:
+	 *  - group
+	 *  - member-group
+	 *
 	 * @param sess internal session
 	 * @param member the member to get the rich groups for
 	 * @param attrNames list of selected attributes
@@ -1767,7 +1771,7 @@ public interface GroupsManagerBl {
 
 	/**
 	 *  Get list of groups where the given group is given the admin role.
-	 *  
+	 *
 	 * @param perunSession
 	 * @param Group with the admin role.
 	 * @return List of administered groups.
@@ -1777,7 +1781,7 @@ public interface GroupsManagerBl {
 
 	/**
 	 *  Get list of VOs where the given group is given the admin role.
-	 *  
+	 *
 	 * @param perunSession
 	 * @param Group with the admin role.
 	 * @return List of administered VOs.
@@ -1787,7 +1791,7 @@ public interface GroupsManagerBl {
 
 	/**
 	 *  Get list of facilities where the given group is given the admin role.
-	 *  
+	 *
 	 * @param perunSession
 	 * @param Group with the admin role.
 	 * @return List of administered facilities.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -2442,7 +2442,28 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 	@Override
 	public List<RichGroup> getMemberRichGroupsWithAttributesByNames(PerunSession sess, Member member, List<String> attrNames) throws InternalErrorException {
-		return convertGroupsToRichGroupsWithAttributes(sess, this.getMemberGroups(sess, member), attrNames);
+		List<Group> memberGroups = this.getMemberGroups(sess, member);
+		List<RichGroup> richGroups = new ArrayList<>();
+
+		if(attrNames == null) {
+			//if attrNames is null, it means all possible group and member-group attributes
+			for(Group group: memberGroups) {
+				List<Attribute> allGroupAndMemberGroupAttributes = new ArrayList<>();
+				allGroupAndMemberGroupAttributes.addAll(this.getPerunBl().getAttributesManagerBl().getAttributes(sess, group));
+				allGroupAndMemberGroupAttributes.addAll(this.getPerunBl().getAttributesManagerBl().getAttributes(sess, member, group));
+				richGroups.add(new RichGroup(group, allGroupAndMemberGroupAttributes));
+			}
+		} else {
+			//if attrNames is not null, it means only selected group and member-group attributes
+			for (Group group : memberGroups) {
+				List<Attribute> selectedGroupAndMemberGroupAttributes = new ArrayList<>();
+				selectedGroupAndMemberGroupAttributes.addAll(this.getPerunBl().getAttributesManagerBl().getAttributes(sess, group, attrNames));
+				selectedGroupAndMemberGroupAttributes.addAll(this.getPerunBl().getAttributesManagerBl().getAttributes(sess, member, group, attrNames));
+				richGroups.add(new RichGroup(group, selectedGroupAndMemberGroupAttributes));
+			}
+		}
+
+		return richGroups;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -1412,7 +1412,7 @@ public class GroupsManagerEntry implements GroupsManager {
 			}
 		}
 
-		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, null, true);
+		return getGroupsManagerBl().filterOnlyAllowedAttributes(sess, richGroups, member, null, true);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1228,14 +1228,13 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public List<Attribute> getAttributes(PerunSession sess, Member member, Group group, List<String> attrNames) throws InternalErrorException {
+		List<String> controlledAttrNames = new ArrayList<>();
+		for(String attributeName: attrNames) {
+			//check namespace
+			if(attributeName.startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) controlledAttrNames.add(attributeName);
+		}
+
 		if(!CacheManager.isCacheDisabled()) {
-			List<String> controlledAttrNames = new ArrayList<>();
-
-			for(String attributeName: attrNames) {
-				//check namespace
-				if(attributeName.startsWith(AttributesManager.NS_MEMBER_GROUP_ATTR)) controlledAttrNames.add(attributeName);
-			}
-
 			List<Attribute> attrs = perun.getCacheManager().getAttributesByNames(controlledAttrNames, new Holder(member.getId(), Holder.HolderType.MEMBER), new Holder(group.getId(), Holder.HolderType.GROUP));
 			return this.setValuesOfAttributes(sess, attrs, member, group);
 		}
@@ -1246,7 +1245,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		parameters.addValue("nSO", AttributesManager.NS_MEMBER_GROUP_ATTR_OPT);
 		parameters.addValue("nSD", AttributesManager.NS_MEMBER_GROUP_ATTR_DEF);
 		parameters.addValue("nSV", AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
-		parameters.addValue("attrNames", attrNames);
+		parameters.addValue("attrNames", controlledAttrNames);
 
 		try {
 			return namedParameterJdbcTemplate.query("select " + getAttributeMappingSelectQuery("mem_gr") + " from attr_names " +
@@ -1403,14 +1402,14 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 
 	@Override
 	public List<Attribute> getAttributes(PerunSession sess, Group group, List<String> attrNames) throws InternalErrorException {
+		//filter only group attribute names
+		List<String> controlledAttrNames = new ArrayList<>();
+		for(String attributeName: attrNames) {
+			//check namespace
+			if(attributeName.startsWith(AttributesManager.NS_GROUP_ATTR)) controlledAttrNames.add(attributeName);
+		}
+
 		if(!CacheManager.isCacheDisabled()) {
-			List<String> controlledAttrNames = new ArrayList<>();
-
-			for(String attributeName: attrNames) {
-				//check namespace
-				if(attributeName.startsWith(AttributesManager.NS_GROUP_ATTR)) controlledAttrNames.add(attributeName);
-			}
-
 			List<Attribute> attrs = perun.getCacheManager().getAttributesByNames(controlledAttrNames, new Holder(group.getId(), Holder.HolderType.GROUP), null);
 			return this.setValuesOfAttributes(sess, attrs, group, null);
 		}
@@ -1421,7 +1420,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		parameters.addValue("nSO", AttributesManager.NS_GROUP_ATTR_OPT);
 		parameters.addValue("nSD", AttributesManager.NS_GROUP_ATTR_DEF);
 		parameters.addValue("nSV", AttributesManager.NS_GROUP_ATTR_VIRT);
-		parameters.addValue("attrNames", attrNames);
+		parameters.addValue("attrNames", controlledAttrNames);
 
 		try {
 			return namedParameterJdbcTemplate.query("select " + getAttributeMappingSelectQuery("groupattr") + " from attr_names " +

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -1405,6 +1405,10 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 *
 	 * "members" group is not included!
 	 *
+	 * Supported are attributes from these namespaces:
+	 *  - group
+	 *  - member-group
+	 *
 	 * @throw MemberNotExistsException When the member doesn't exist
 	 *
 	 * @param member int <code>id</code> of member
@@ -1419,6 +1423,10 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * Example: [1,2,3,4], toIndex=2 => [1,2,3]
 	 *
 	 * "members" group is not included!
+	 *
+	 * Supported are attributes from these namespaces:
+	 *  - group
+	 *  - member-group
 	 *
 	 * @throw MemberNotExistsException When the member doesn't exist
 	 *
@@ -1435,6 +1443,10 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 *
 	 * "members" group is not included!
 	 *
+	 * Supported are attributes from these namespaces:
+	 *  - group
+	 *  - member-group
+	 *
 	 * @throw MemberNotExistsException When the member doesn't exist
 	 *
 	 * @param member int <code>id</code> of member
@@ -1447,6 +1459,10 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * Returns full list of member's RichGroups containing selected attributes.
 	 *
 	 * "members" group is not included!
+	 *
+	 * Supported are attributes from these namespaces:
+	 *  - group
+	 *  - member-group
 	 *
 	 * @throw MemberNotExistsException When the member doesn't exist
 	 *


### PR DESCRIPTION
 - in method getMemberRichGroupsWithAttributesByNames we can return not
 only RichGroup with group attributes, but also with member-group
 attributes using object Member in parameters.
 - javadoc was updated
 - simple test were added