### PR TITLE
made engine and dispatcher names independent on IP address

### DIFF
--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1789,11 +1789,11 @@ insert into action_types (id, action_type, description) values (action_types_seq
 insert into action_types (id, action_type, description) values (action_types_seq.nextval, 'write_public', 'Anyone can write, rewrite and remove value.');
 
 -- insert default engine on default port
-insert into engines (id, ip_address, port, last_check_in) VALUES (1, '127.0.0.1', 6061, sysdate);
+insert into engines (id, ip_address, port, last_check_in) VALUES (1, 'engine1', 6061, sysdate);
 
 -- init default auditer consumers
-insert into perun.auditer_consumers (id, name, last_processed_id) values (auditer_consumers_id_seq.nextval, '127.0.0.1:6071', 0); -- engine
-insert into perun.auditer_consumers (id, name, last_processed_id) values (auditer_consumers_id_seq.nextval, 'notifications', 0);  -- notification
+insert into perun.auditer_consumers (id, name, last_processed_id) values (auditer_consumers_id_seq.nextval, 'dispatcher', 0);
+insert into perun.auditer_consumers (id, name, last_processed_id) values (auditer_consumers_id_seq.nextval, 'notifications', 0);
 
 -- initial user, user_ext_source and internal ext_source
 insert into perun.ext_sources (id,name,type) values (ext_sources_id_seq.nextval,'INTERNAL','cz.metacentrum.perun.core.impl.ExtSourceInternal');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1887,11 +1887,11 @@ insert into action_types (id, action_type, description) values (nextval('action_
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'write_public', 'Anyone can write, rewrite and remove value.');
 
 -- insert default engine on default port
-insert into engines (id, ip_address, port, last_check_in) VALUES (1, '127.0.0.1', 6061, statement_timestamp());
+insert into engines (id, ip_address, port, last_check_in) VALUES (1, 'engine1', 6061, statement_timestamp());
 
 -- init default auditer consumers
-insert into perun.auditer_consumers (id, name, last_processed_id) values (nextval('auditer_consumers_id_seq'), '127.0.0.1:6071', 0); -- engine
-insert into perun.auditer_consumers (id, name, last_processed_id) values (nextval('auditer_consumers_id_seq'), 'notifications', 0);  -- notification
+insert into perun.auditer_consumers (id, name, last_processed_id) values (nextval('auditer_consumers_id_seq'), 'dispatcher', 0);
+insert into perun.auditer_consumers (id, name, last_processed_id) values (nextval('auditer_consumers_id_seq'), 'notifications', 0);
 
 -- initial user, user_ext_source and internal ext_source
 insert into perun.ext_sources (id,name,type) values (nextval('ext_sources_id_seq'),'INTERNAL','cz.metacentrum.perun.core.impl.ExtSourceInternal');

--- a/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/AuditerListener.java
+++ b/perun-dispatcher/src/main/java/cz/metacentrum/perun/dispatcher/processing/AuditerListener.java
@@ -84,8 +84,6 @@ public class AuditerListener extends AbstractRunner {
 
 		boolean whichOfTwoRules = false;
 
-		String dispatcherName = dispatcherProperties.getProperty("dispatcher.ip.address") + ":" + dispatcherProperties.getProperty("dispatcher.port");
-
 		try {
 
 			try {
@@ -105,7 +103,7 @@ public class AuditerListener extends AbstractRunner {
 
 			while (!shouldStop()) {
 				try {
-					for (AuditEvent message : perun.getAuditMessagesManager().pollConsumerEvents(sess, dispatcherName)) {
+					for (AuditEvent message : perun.getAuditMessagesManager().pollConsumerEvents(sess, "dispatcher")) {
 						// create event for each message
 						Event event = new Event();
 						event.setTimeStamp(System.currentTimeMillis());

--- a/perun-engine/src/main/resources/perun-engine.xml
+++ b/perun-engine/src/main/resources/perun-engine.xml
@@ -62,8 +62,6 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 			<props>
 				<!-- set where perun-engine JSM runs -->
 				<prop key="engine.unique.id">1</prop>
-				<prop key="engine.ip.address">127.0.0.1</prop>
-				<prop key="engine.port">6061</prop>
 				<!-- set where perun-dispatcher JMS runs -->
 				<prop key="dispatcher.ip.address">127.0.0.1</prop>
 				<prop key="dispatcher.port">6071</prop>


### PR DESCRIPTION
In containerized Perun, the Dispatcher and Engine will no longer be located on IP 127.0.0.1, thus their names were changed to "dispatcher" and "engine1" respectively.