### PR TITLE
WIP: Reorganized logging

### DIFF
--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -142,6 +142,11 @@
 			<version>${json.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.codehaus.janino</groupId>
+			<artifactId>janino</artifactId>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/perun-base/src/main/resources/logback-default.xml
+++ b/perun-base/src/main/resources/logback-default.xml
@@ -68,7 +68,7 @@
 	<logger name="cz.metacentrum.perun.rpc.Main" level="info"/>
 
 	<!--
-		logging to separate files - set by the atribute additivity="false" and
+		logging to separate files - set by the attribute additivity="false" and
 		the element	appender-ref on loggers
 	-->
 
@@ -146,21 +146,6 @@
 		<appender-ref ref="perun-cabinet"/>
 	</logger>
 
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-eventProcessor">
-		<file>${LOGDIR}perun-dispatcher-eventProcessor.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-eventProcessor.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher.processing.EventProcessor" level="info" additivity="false">
-		<appender-ref ref="perun-dispatcher-eventProcessor"/>
-	</logger>
-
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-events">
 		<file>${LOGDIR}perun-dispatcher-events.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -171,7 +156,7 @@
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher.processing.EventLogger" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.dispatcher.processing" level="info" additivity="false">
 		<appender-ref ref="perun-dispatcher-events"/>
 	</logger>
 
@@ -201,34 +186,6 @@
 	</appender>
 	<logger name="cz.metacentrum.perun.dispatcher" level="info" additivity="false">
 		<appender-ref ref="perun-dispatcher"/>
-	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-matcher">
-		<file>${LOGDIR}perun-dispatcher-matcher.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-matcher.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher.processing.impl.SmartMatcherImpl" level="info" additivity="false">
-		<appender-ref ref="perun-dispatcher-matcher"/>
-	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-queue">
-		<file>${LOGDIR}perun-dispatcher-queue.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-queue.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher.jms.DispatcherQueue" level="info" additivity="false">
-		<appender-ref ref="perun-dispatcher-queue"/>
 	</logger>
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-engine">

--- a/perun-base/src/main/resources/logback-default.xml
+++ b/perun-base/src/main/resources/logback-default.xml
@@ -73,49 +73,20 @@
 	-->
 
 	<!--
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="notification">
-		<file>${LOGDIR}perun-notif.log</file>
+
+	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-rpc">
+		<file>${LOGDIR}perun-rpc.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-notif.log.%d</fileNamePattern>
+			<fileNamePattern>${LOGDIR}perun-rpc.log.%d</fileNamePattern>
 			<maxHistory>${MAXHISTORY}</maxHistory>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
-	<logger name="cz.metacentrum.perun.notif" level="info" additivity="false">
-		<appender-ref ref="notification"/>
+	<logger name="cz.metacentrum.perun" level="error" additivity="false">
+		<appender-ref ref="perun-rpc"/>
 	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-auditer">
-		<file>${LOGDIR}perun-auditer.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-auditer.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-
-	<logger name="cz.metacentrum.perun.core.impl.Auditer" level="error" additivity="false">
-		<appender-ref ref="perun-auditer"/>
-	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-cabinet">
-		<file>${LOGDIR}perun-cabinet.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-cabinet.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.cabinet" level="info" additivity="false">
-		<appender-ref ref="perun-cabinet"/>
-	</logger>
-
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-core">
 		<file>${LOGDIR}perun-core.log</file>
@@ -134,21 +105,47 @@
 	<logger name="cz.metacentrum.perun.core.impl.PerunTransactionManager" level="error"/>
 	<logger name="cz.metacentrum.perun.core.impl.PerunBasicDataSource" level="error"/>
 
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-ultimate">
-        <file>${LOGDIR}perun-ultimate.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-ultimate.log.%d.%i</fileNamePattern>
-			<maxFileSize>100MB</maxFileSize>
+	<logger name="cz.metacentrum.perun.rpc" level="info" additivity="false">
+		<appender-ref ref="perun-core"/>
+	</logger>
+	<logger name="cz.metacentrum.perun.taskslib" level="info" additivity="false">
+		<appender-ref ref="perun-core"/>
+	</logger>
+	<logger name="cz.metacentrum.perun.scim" level="info" additivity="false">
+		<appender-ref ref="perun-core"/>
+	</logger>
+	<logger name="cz.metacentrum.perun.voot" level="info" additivity="false">
+		<appender-ref ref="perun-core"/>
+	</logger>
+
+	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-auditer">
+		<file>${LOGDIR}perun-auditer.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-auditer.log.%d</fileNamePattern>
 			<maxHistory>${MAXHISTORY}</maxHistory>
-			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
-    	<encoder>
+		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
-    </appender>
-	<logger name="ultimate_logger" level="debug" additivity="false">
-		<appender-ref ref="perun-ultimate"/>
-    </logger>
+	</appender>
+	<logger name="cz.metacentrum.perun.core.impl.Auditer" level="error" additivity="false">
+		<appender-ref ref="perun-auditer"/>
+	</logger>
+
+	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-cabinet">
+		<file>${LOGDIR}perun-cabinet.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-cabinet.log.%d</fileNamePattern>
+			<maxHistory>${MAXHISTORY}</maxHistory>
+		</rollingPolicy>
+		<encoder>
+			<pattern>${ENCODER_PATTERN}</pattern>
+		</encoder>
+	</appender>
+	<logger name="cz.metacentrum.perun.cabinet" level="info" additivity="false">
+		<appender-ref ref="perun-cabinet"/>
+	</logger>
+
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-eventProcessor">
 		<file>${LOGDIR}perun-dispatcher-eventProcessor.log</file>
@@ -262,32 +259,18 @@
 		<appender-ref ref="perun-registrar"/>
 	</logger>
 
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-rpc-lib">
-		<file>${LOGDIR}perun-rpc-lib.log</file>
+	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="notification">
+		<file>${LOGDIR}perun-notif.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-rpc-lib.log.%d</fileNamePattern>
+			<fileNamePattern>${LOGDIR}perun-notif.log.%d</fileNamePattern>
 			<maxHistory>${MAXHISTORY}</maxHistory>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
-	<logger name="cz.metacentrum.perun.rpclib" level="info" additivity="false">
-		<appender-ref ref="perun-rpc-lib"/>
-	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-rpc">
-		<file>${LOGDIR}perun-rpc.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-rpc.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.rpc" level="info" additivity="false">
-		<appender-ref ref="perun-rpc"/>
+	<logger name="cz.metacentrum.perun.notif" level="info" additivity="false">
+		<appender-ref ref="notification"/>
 	</logger>
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-notif-sended">
@@ -302,35 +285,6 @@
 	</appender>
 	<logger name="sendMessages" level="info" additivity="false">
 		<appender-ref ref="perun-notif-sended"/>
-	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-controller">
-		<file>${LOGDIR}perun-controller.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-controller.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.controller" level="info" additivity="false">
-		<appender-ref ref="perun-controller"/>
-	</logger>
-
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-tasklib">
-		<file>${LOGDIR}perun-tasklib.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-tasklib.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.taskslib" level="info" additivity="false">
-		<appender-ref ref="perun-tasklib"/>
 	</logger>
 
    -->

--- a/perun-base/src/main/resources/logback-default.xml
+++ b/perun-base/src/main/resources/logback-default.xml
@@ -86,6 +86,13 @@
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
+		<filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+			<evaluator>
+				<expression>return !Level.ERROR.equals(Level.toLevel(level)) &amp;&amp; logger.startsWith("cz.metacentrum.perun");</expression>
+			</evaluator>
+			<OnMismatch>NEUTRAL</OnMismatch>
+			<OnMatch>DENY</OnMatch>
+		</filter>
 	</appender>
 	<logger name="cz.metacentrum.perun" level="error" additivity="false">
 		<appender-ref ref="perun-rpc"/>
@@ -103,23 +110,23 @@
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
-	<logger name="cz.metacentrum.perun.core" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.core" level="info">
 		<appender-ref ref="perun-core"/>
 	</logger>
 	<logger name="cz.metacentrum.perun.core.impl.JdbcPerunTemplate" level="error"/>
 	<logger name="cz.metacentrum.perun.core.impl.PerunTransactionManager" level="error"/>
 	<logger name="cz.metacentrum.perun.core.impl.PerunBasicDataSource" level="error"/>
 
-	<logger name="cz.metacentrum.perun.rpc" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.rpc" level="info">
 		<appender-ref ref="perun-core"/>
 	</logger>
-	<logger name="cz.metacentrum.perun.taskslib" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.taskslib" level="info">
 		<appender-ref ref="perun-core"/>
 	</logger>
-	<logger name="cz.metacentrum.perun.scim" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.scim" level="info">
 		<appender-ref ref="perun-core"/>
 	</logger>
-	<logger name="cz.metacentrum.perun.voot" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.voot" level="info">
 		<appender-ref ref="perun-core"/>
 	</logger>
 
@@ -199,7 +206,7 @@
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.dispatcher" level="info">
 		<appender-ref ref="perun-dispatcher"/>
 	</logger>
 
@@ -231,7 +238,7 @@
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
-	<logger name="cz.metacentrum.perun.registrar" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.registrar" level="info">
 		<appender-ref ref="perun-registrar"/>
 	</logger>
 
@@ -247,7 +254,7 @@
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
-	<logger name="cz.metacentrum.perun.notif" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.notif" level="info">
 		<appender-ref ref="notification"/>
 	</logger>
 
@@ -267,6 +274,6 @@
 		<appender-ref ref="perun-notif-sended"/>
 	</logger>
 
-   -->
+	-->
 
 </configuration>

--- a/perun-base/src/main/resources/logback-default.xml
+++ b/perun-base/src/main/resources/logback-default.xml
@@ -47,7 +47,7 @@
 		<file>${LOGDIR}perun.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
 			<fileNamePattern>${LOGDIR}perun.log.%d.%i</fileNamePattern>
-			<maxFileSize>10MB</maxFileSize>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
 			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
@@ -66,6 +66,7 @@
 	<logger name="org.springframework" level="warn"/>
 	<logger name="org.springframework.web.context.ContextLoader" level="warn"/>
 	<logger name="cz.metacentrum.perun.rpc.Main" level="info"/>
+	<logger name="com.zaxxer.hikari" level="debug" />
 
 	<!--
 		logging to separate files - set by the attribute additivity="false" and
@@ -76,9 +77,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-rpc">
 		<file>${LOGDIR}perun-rpc.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-rpc.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-rpc.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -90,9 +93,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-core">
 		<file>${LOGDIR}perun-core.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-core.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-core.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -120,9 +125,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-auditer">
 		<file>${LOGDIR}perun-auditer.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-auditer.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-auditer.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -134,9 +141,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-cabinet">
 		<file>${LOGDIR}perun-cabinet.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-cabinet.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-cabinet.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -148,9 +157,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-events">
 		<file>${LOGDIR}perun-dispatcher-events.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-events.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-dispatcher-events.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -162,9 +173,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-jms">
 		<file>${LOGDIR}perun-dispatcher-jms.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-jms.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-dispatcher-jms.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -176,9 +189,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher">
 		<file>${LOGDIR}perun-dispatcher.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-dispatcher.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -190,9 +205,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-engine">
 		<file>${LOGDIR}perun-engine.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-engine.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-engine.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -204,9 +221,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-registrar">
 		<file>${LOGDIR}perun-registrar.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-registrar.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-registrar.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -218,9 +237,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="notification">
 		<file>${LOGDIR}perun-notif.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-notif.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-notif.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -232,9 +253,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-notif-sended">
 		<file>${LOGDIR}perun-notif-sended.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-notif-sended.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-notif-sended.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>


### PR DESCRIPTION
Do not merge. This is WIP and will be manually tested first.

- Reorganized logging withi perun-rpc.log and perun-core.log
  perun-rpc.log should log only errors in whole perun.
  perun-core.log will handle everyting in "cz.metacentrum.perun" package.
- Removed unused perun-controller.log
- Removed unused perun-rpc-lib.log
- Reordered entries in default config.
- Simplified logging of perun-dispatcher. We will have only 3 log files.
  One for Audit events processing, one for JMS processing and one for the rest.
- Max 1GB together for each log appender.
- Max 100MB per file.
- Max 7 files history.