### PR TITLE
Removed unused service_principal table

### DIFF
--- a/perun-base/src/test/resources/test-data.sql
+++ b/perun-base/src/test/resources/test-data.sql
@@ -1900,8 +1900,6 @@ insert into routing_rules (created_by_uid,modified_by_uid,id,routing_rule,create
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,1,timestamp '2011-11-15 14:42:35.3','PERUNV3',timestamp '2011-11-15 14:42:35.3','PERUNV3','0');
 insert into engine_routing_rule (created_by_uid,modified_by_uid,engine_id,routing_rule_id,created_at,created_by,modified_at,modified_by,status) values (null,null,1,2,timestamp '2011-11-15 14:43:13.3','PERUNV3',timestamp '2011-11-15 14:43:13.3','PERUNV3','0');
 
-drop sequence service_principals_id_seq;
-create sequence service_principals_id_seq start with 1;
 drop sequence pn_template_message_id_seq;
 create sequence pn_template_message_id_seq start with 162;
 drop sequence users_id_seq;

--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -1203,21 +1203,6 @@ create table auditer_log (
 	constraint audlog_pk primary key (id)
 );
 
--- SERVICE_PRINCIPALS - principals for executing of services by engine, actually is not used
-create table service_principals (
-	id integer not null,
-	description varchar(1024),    --description
-	name varchar(128) not null,   --name of principal
-	created_at timestamp default current_date not null,
-	created_by varchar(1300) default user not null,
-	modified_at timestamp default current_date not null,
-	modified_by varchar(1300) default user not null,
-	status char(1) default '0' not null,
-	created_by_uid integer,
-	modified_by_uid integer,
-	constraint ser_princ_pk primary key (id)
-);
-
 -- RESERVED_LOGINS - reserved lognames, actually is not used. Prepared for reservation by core.
 create table reserved_logins (
 	login varchar(256),        --logname
@@ -1537,7 +1522,6 @@ create table authz (
 	group_id integer,         --identifier of group
 	service_id integer,       --identifier of service
 	resource_id integer,      --identifier of resource
-	service_principal_id integer,  --identifier service principal
 	sponsored_user_id integer, --identifier of sponsored user
 	created_by_uid integer,
 	modified_by_uid integer,
@@ -1552,13 +1536,10 @@ create table authz (
 	constraint authz_group_fk foreign key (group_id) references groups(id),
 	constraint authz_service_fk foreign key (service_id) references services(id),
 	constraint authz_res_fk foreign key (resource_id) references resources(id),
-	constraint authz_ser_princ_fk foreign key (service_principal_id) references service_principals(id),
 	constraint authz_sponsu_fk foreign key (sponsored_user_id) references users(id),
 	constraint authz_sec_team_fk foreign key (security_team_id) references security_teams(id),
-	constraint authz_user_serprinc_autgrp_chk check
-	((user_id is not null and service_principal_id is null and authorized_group_id is null)
-	 or (user_id is null and service_principal_id is not null and authorized_group_id is null)
-	 or (user_id is null and service_principal_id is null and authorized_group_id is not null))
+	constraint authz_user_autgrp_chk check
+	     ((user_id is not null and authorized_group_id is null) or (user_id is null and authorized_group_id is not null))
 );
 
 create sequence attr_names_id_seq;
@@ -1588,7 +1569,6 @@ create sequence cabinet_authorships_id_seq;
 create sequence cabinet_thanks_id_seq;
 create sequence cabinet_categories_id_seq;
 create sequence roles_id_seq;
-create sequence service_principals_id_seq;
 create sequence application_form_id_seq;
 create sequence application_form_items_id_seq;
 create sequence application_id_seq;
@@ -1694,10 +1674,9 @@ create index idx_fk_authz_mem on authz(member_id);
 create index idx_fk_authz_group on authz(group_id);
 create index idx_fk_authz_service on authz(service_id);
 create index idx_fk_authz_res on authz(resource_id);
-create index idx_fk_authz_ser_princ on authz(service_principal_id);
 create index idx_fk_authz_sec_team on authz(security_team_id);
 create index idx_fk_authz_sponsu on authz(sponsored_user_id);
-create unique index idx_authz_u on authz (user_id, authorized_group_id, service_principal_id, role_id, group_id, vo_id, facility_id, member_id, resource_id, service_id, security_team_id, sponsored_user_id);
+create unique index idx_authz_u on authz (user_id, authorized_group_id, role_id, group_id, vo_id, facility_id, member_id, resource_id, service_id, security_team_id, sponsored_user_id);
 create index idx_fk_faccont_fac on facility_contacts(facility_id);
 create index idx_fk_faccont_usr on facility_contacts(user_id);
 create index idx_fk_faccont_own on facility_contacts(owner_id);
@@ -1772,7 +1751,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.56');
+insert into configurations values ('DATABASE VERSION','3.1.57');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -55,7 +55,7 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	private final static String authzRoleMappingSelectQuery = " authz.user_id as authz_user_id, authz.role_id as authz_role_id," +
 		"authz.authorized_group_id as authz_authorized_group_id, authz.vo_id as pb_vo_id, authz.group_id as pb_group_id, " +
 		"authz.facility_id as pb_facility_id, authz.member_id as pb_member_id, authz.resource_id as pb_resource_id, " +
-		"authz.service_id as pb_service_id, authz.service_principal_id as pb_user_id, authz.security_team_id as pb_security_team_id, " +
+		"authz.service_id as pb_service_id, authz.security_team_id as pb_security_team_id, " +
 		"authz.sponsored_user_id as pb_sponsored_user_id";
 
 

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -8,6 +8,18 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.57
+drop index idx_authz_u;
+create unique index idx_authz_u ON authz (COALESCE(user_id, '0'), COALESCE(authorized_group_id, '0'), role_id, COALESCE(group_id, '0'), COALESCE(vo_id, '0'), COALESCE(facility_id, '0'), COALESCE(member_id, '0'), COALESCE(resource_id, '0'), COALESCE(service_id, '0'), COALESCE(security_team_id, '0'), COALESCE(sponsored_user_id, '0'));
+alter table authz drop constraint authz_user_serprinc_autgrp_chk;
+alter table authz add constraint authz_user_autgrp_chk check ((user_id is not null and authorized_group_id is null) or (user_id is null and authorized_group_id is not null))
+drop index idx_fk_authz_ser_princ;
+alter table authz drop constraint authz_ser_princ_fk;
+alter table authz drop column service_principal_id;
+drop table service_principals;
+drop sequence "service_principals_id_seq";
+update configurations set value='3.1.57' where property='DATABASE VERSION';
+
 3.1.56
 alter table configurations drop constraint config_prop_chk;
 update configurations set value='3.1.56' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -6,6 +6,22 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.57
+-- recreate unique index on authz without service_principal_id !!
+drop index IDX_AUTHZ_U;
+create unique index IDX_AUTHZ_U on authz(user_id, authorized_group_id, role_id, group_id, vo_id, facility_id, member_id, resource_id, service_id, security_team_id, sponsored_user_id);
+-- recreate constraint for non-null user_id or authorized_group_id
+alter table authz drop constraint authz_user_serprinc_autgrp_chk;
+alter table authz add constraint authz_user_autgrp_chk check ((user_id is not null and authorized_group_id is null) or (user_id is null and authorized_group_id is not null));
+-- drop index/constraint/column
+drop index IDX_FK_AUTHZ_SER_PRINC;
+alter table authz drop constraint authz_ser_princ_fk;
+alter table authz drop column service_principal_id;
+-- drop service_principals
+drop table service_principals;
+drop sequence SERVICE_PRINCIPALS_ID_SEQ;
+update configurations set value='3.1.57' where property='DATABASE VERSION';
+
 3.1.56
 alter table configurations drop constraint CONFIG_PROP_CHK;
 update configurations set value='3.1.56' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,18 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.57
+drop index idx_authz_u;
+create unique index idx_authz_u ON authz (COALESCE(user_id, '0'), COALESCE(authorized_group_id, '0'), role_id, COALESCE(group_id, '0'), COALESCE(vo_id, '0'), COALESCE(facility_id, '0'), COALESCE(member_id, '0'), COALESCE(resource_id, '0'), COALESCE(service_id, '0'), COALESCE(security_team_id, '0'), COALESCE(sponsored_user_id, '0'));
+alter table authz drop constraint authz_user_serprinc_autgrp_chk;
+alter table authz add constraint authz_user_autgrp_chk check ((user_id is not null and authorized_group_id is null) or (user_id is null and authorized_group_id is not null));
+drop index idx_fk_authz_ser_princ;
+alter table authz drop constraint authz_ser_princ_fk;
+alter table authz drop column service_principal_id;
+drop table service_principals;
+drop sequence "service_principals_id_seq";
+update configurations set value='3.1.57' where property='DATABASE VERSION';
+
 3.1.56
 alter table configurations drop constraint config_prop_chk;
 update configurations set value='3.1.56' where property='DATABASE VERSION';

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.56 (don't forget to update insert statement at the end of file)
+-- database version 3.1.57 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1209,21 +1209,6 @@ create table auditer_log (
 	constraint audlog_pk primary key (id)
 );
 
--- SERVICE_PRINCIPALS - principals for executing of services by engine, actually is not used
-create table service_principals (
-	id integer not null,
-	description nvarchar2(1024),    --description
-	name nvarchar2(128) not null,   --name of principal
-	created_at date default sysdate not null,
-	created_by nvarchar2(1300) default user not null,
-	modified_at date default sysdate not null,
-	modified_by nvarchar2(1300) default user not null,
-	status char(1) default '0' not null,
-	created_by_uid integer,
-	modified_by_uid integer,
-	constraint ser_princ_pk primary key (id)
-);
-
 -- RESERVED_LOGINS - reserved lognames, actually is not used. Prepared for reservation by core.
 create table reserved_logins (
 	login nvarchar2(256),        --logname
@@ -1543,7 +1528,6 @@ create table authz (
 	group_id integer,         --identifier of group
 	service_id integer,       --identifier of service
 	resource_id integer,      --identifier of resource
-	service_principal_id integer,  --identifier service principal
 	sponsored_user_id integer, --identifier of sponsored user
 	created_by_uid integer,
 	modified_by_uid integer,
@@ -1558,13 +1542,10 @@ create table authz (
 	constraint authz_group_fk foreign key (group_id) references groups(id),
 	constraint authz_service_fk foreign key (service_id) references services(id),
 	constraint authz_res_fk foreign key (resource_id) references resources(id),
-	constraint authz_ser_princ_fk foreign key (service_principal_id) references service_principals(id),
 	constraint authz_sponsu_fk foreign key (sponsored_user_id) references users(id),
 	constraint authz_sec_team_fk foreign key (security_team_id) references security_teams(id),
-	constraint authz_user_serprinc_autgrp_chk check
-	((user_id is not null and service_principal_id is null and authorized_group_id is null)
-	 or (user_id is null and service_principal_id is not null and authorized_group_id is null)
-	 or (user_id is null and service_principal_id is null and authorized_group_id is not null))
+	constraint authz_user_autgrp_chk check
+	     ((user_id is not null and authorized_group_id is null) or (user_id is null and authorized_group_id is not null))
 );
 
 
@@ -1595,7 +1576,6 @@ create sequence CABINET_AUTHORSHIPS_ID_SEQ nocache;
 create sequence CABINET_THANKS_ID_SEQ nocache;
 create sequence CABINET_CATEGORIES_ID_SEQ nocache;
 create sequence ROLES_ID_SEQ nocache;
-create sequence SERVICE_PRINCIPALS_ID_SEQ nocache;
 create sequence APPLICATION_FORM_ID_SEQ nocache;
 create sequence APPLICATION_FORM_ITEMS_ID_SEQ nocache;
 create sequence APPLICATION_ID_SEQ nocache;
@@ -1705,10 +1685,9 @@ create index IDX_FK_AUTHZ_MEM on authz(member_id);
 create index IDX_FK_AUTHZ_GROUP on authz(group_id);
 create index IDX_FK_AUTHZ_SERVICE on authz(service_id);
 create index IDX_FK_AUTHZ_RES on authz(resource_id);
-create index IDX_FK_AUTHZ_SER_PRINC on authz(service_principal_id);
 create index IDX_FK_AUTHZ_SPONSU on authz(sponsored_user_id);
 create index IDX_FK_AUTHZ_SEC_TEAM on authz(security_team_id);
-create unique index IDX_AUTHZ_U on authz(user_id, authorized_group_id, service_principal_id, role_id, group_id, vo_id, facility_id, member_id, resource_id, service_id, security_team_id, sponsored_user_id);
+create unique index IDX_AUTHZ_U on authz(user_id, authorized_group_id, role_id, group_id, vo_id, facility_id, member_id, resource_id, service_id, security_team_id, sponsored_user_id);
 create index IDX_FK_GRRES_GR on groups_resources(group_id);
 create index IDX_FK_GRRES_RES on groups_resources(resource_id);
 create index IDX_FK_GRPMEM_GR on groups_members(group_id);
@@ -1774,7 +1753,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.56');
+insert into configurations values ('DATABASE VERSION','3.1.57');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.56 (don't forget to update insert statement at the end of file)
+-- database version 3.1.57 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1199,21 +1199,6 @@ create table auditer_log (
 	constraint audlog_pk primary key (id)
 );
 
--- SERVICE_PRINCIPALS - principals for executing of services by engine, actually is not used
-create table service_principals (
-	id integer not null,
-	description varchar(1024),    --description
-	name varchar(128) not null,   --name of principal
-	created_at timestamp default statement_timestamp() not null,
-	created_by varchar(1300) default user not null,
-	modified_at timestamp default statement_timestamp() not null,
-	modified_by varchar(1300) default user not null,
-	status char(1) default '0' not null,
-	created_by_uid integer,
-	modified_by_uid integer,
-	constraint ser_princ_pk primary key (id)
-);
-
 -- RESERVED_LOGINS - reserved lognames, actually is not used. Prepared for reservation by core.
 create table reserved_logins (
 	login varchar(256),        --logname
@@ -1533,7 +1518,6 @@ create table authz (
 	group_id integer,         --identifier of group
 	service_id integer,       --identifier of service
 	resource_id integer,      --identifier of resource
-	service_principal_id integer,  --identifier service principal
 	sponsored_user_id integer, --identifier of sponsored user
 	created_by_uid integer,
 	modified_by_uid integer,
@@ -1548,13 +1532,10 @@ create table authz (
 	constraint authz_group_fk foreign key (group_id) references groups(id),
 	constraint authz_service_fk foreign key (service_id) references services(id),
 	constraint authz_res_fk foreign key (resource_id) references resources(id),
-	constraint authz_ser_princ_fk foreign key (service_principal_id) references service_principals(id),
 	constraint authz_sponsu_fk foreign key (sponsored_user_id) references users(id),
 	constraint authz_sec_team_fk foreign key (security_team_id) references security_teams(id),
-	constraint authz_user_serprinc_autgrp_chk check
-	((user_id is not null and service_principal_id is null and authorized_group_id is null)
-	 or (user_id is null and service_principal_id is not null and authorized_group_id is null)
-	 or (user_id is null and service_principal_id is null and authorized_group_id is not null))
+	constraint authz_user_autgrp_chk check
+	     ((user_id is not null and authorized_group_id is null) or (user_id is null and authorized_group_id is not null))
 );
 
 
@@ -1585,7 +1566,6 @@ create sequence "cabinet_authorships_id_seq";
 create sequence "cabinet_thanks_id_seq";
 create sequence "cabinet_categories_id_seq";
 create sequence "roles_id_seq";
-create sequence "service_principals_id_seq";
 create sequence "application_form_id_seq";
 create sequence "application_form_items_id_seq";
 create sequence "application_id_seq";
@@ -1686,7 +1666,7 @@ create index idx_fk_entlatval_attr on entityless_attr_values(attr_id);
 create index idx_fk_catpub_sys on cabinet_publications(publicationsystemid);
 create index idx_fk_cabpub_cat on cabinet_publications(categoryid);
 create unique index idx_faccont_u2 ON facility_contacts (COALESCE(user_id, '0'), COALESCE(owner_id, '0'), COALESCE(group_id, '0'), facility_id, name);
-create unique index idx_authz_u ON authz (COALESCE(user_id, '0'), COALESCE(authorized_group_id, '0'), COALESCE(service_principal_id, '0'), role_id, COALESCE(group_id, '0'), COALESCE(vo_id, '0'), COALESCE(facility_id, '0'), COALESCE(member_id, '0'), COALESCE(resource_id, '0'), COALESCE(service_id, '0'), COALESCE(security_team_id, '0'), COALESCE(sponsored_user_id, '0'));
+create unique index idx_authz_u ON authz (COALESCE(user_id, '0'), COALESCE(authorized_group_id, '0'), role_id, COALESCE(group_id, '0'), COALESCE(vo_id, '0'), COALESCE(facility_id, '0'), COALESCE(member_id, '0'), COALESCE(resource_id, '0'), COALESCE(service_id, '0'), COALESCE(security_team_id, '0'), COALESCE(sponsored_user_id, '0'));
 create index idx_fk_authz_role on authz(role_id);
 create index idx_fk_authz_user on authz(user_id);
 create index idx_fk_authz_authz_group on authz(authorized_group_id);
@@ -1696,7 +1676,6 @@ create index idx_fk_authz_mem on authz(member_id);
 create index idx_fk_authz_group on authz(group_id);
 create index idx_fk_authz_service on authz(service_id);
 create index idx_fk_authz_res on authz(resource_id);
-create index idx_fk_authz_ser_princ on authz(service_principal_id);
 create index idx_fk_authz_sec_team on authz(security_team_id);
 create index idx_fk_authz_sponsu on authz(sponsored_user_id);
 create index idx_fk_grres_gr on groups_resources(group_id);
@@ -1839,7 +1818,6 @@ grant all on roles to perun;
 grant all on authz to perun;
 grant all on groups_resources to perun;
 grant all on groups_members to perun;
-grant all on service_principals to perun;
 grant all on application_mails to perun;
 grant all on application_mail_texts to perun;
 grant all on reserved_logins to perun;
@@ -1872,7 +1850,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.56');
+insert into configurations values ('DATABASE VERSION','3.1.57');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/table_order
+++ b/perun-db/table_order
@@ -22,7 +22,6 @@ roles
 action_types
 membership_types
 services
-service_principals
 security_teams
 attr_names
 attributes_authz


### PR DESCRIPTION
- There is no logic in perun to manage content of service_principal table.
  If comment in DB definition sql file was true, then there are no plans
  to specify different authz for different engine principals (we have one).
- service_principal table (its id column) was only referenced from authz table.
  All references, indexes and constraints to this table were removed
  or updated.
- Single column usage in authz table was removed from authz mapper. It was mapped
  to pb_user_id (like user/group could be authorized to another user). Weird.
- Bumped db version to 3.1.57, upgrade changelog included.