### PR TITLE
LDAP: login attribute must be case sensitive

### DIFF
--- a/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
+++ b/perun-utils/ldapc-scripts/schemas/perun-schema.ldif
@@ -10,7 +10,7 @@ olcAttributeTypes: {5}( 1.3.6.1.4.1.8057.2.80.12 NAME 'isServiceUser' DESC 'If u
 olcAttributeTypes: {6}( 1.3.6.1.4.1.8057.2.80.11 NAME 'assignedToResourceId' DESC 'Identifier of resource which is group assigned to.' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcAttributeTypes: {7}( 1.3.6.1.4.1.8057.2.80.18 NAME 'assignedGroupId' DESC 'Identifier of group which is assigned to this resource' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcAttributeTypes: {8}( 1.3.6.1.4.1.8057.2.84.7 NAME 'preferredMail' DESC 'RFC1274: RFC822 Mailbox' EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
-olcAttributeTypes: {9}( 1.3.6.1.4.1.8057.2.80.9 NAME 'login' DESC 'User login for namespace' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+olcAttributeTypes: {9}( 1.3.6.1.4.1.8057.2.80.9 NAME 'login' DESC 'User login for namespace' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
 olcAttributeTypes: {10}( 1.3.6.1.4.1.8057.2.80.14 NAME 'perunUniqueGroupName' DESC 'uniqueName of group like "VoName:ParentGroupName:GroupName"' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: {11}( 1.3.6.1.4.1.8057.2.80.10 NAME 'eduPersonPrincipalNames' DESC 'User ExtLogin for UserExtSource with Type IDP' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcAttributeTypes: {12}( 1.3.6.1.4.1.11433.2.2.1.9 NAME 'userCertificateSubject' DESC 'User certificate subject' EQUALITY caseExactMatch SUBSTR caseExactSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)


### PR DESCRIPTION
- We have case sensitive login attribute in Perun, hence we must
  use case exact matching rule in LDAP.