### PR TITLE
New authorization in TasksManagerEntry

### DIFF
--- a/perun-base/src/test/resources/perun-roles.yml
+++ b/perun-base/src/test/resources/perun-roles.yml
@@ -466,4 +466,103 @@ perun_policies:
       - PERUNOBSERVER:
     include_policies:
       - default_policy
+
+  #TasksManagerEntry
+  getTask_Service_Facility_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getTaskById_int_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  listAllTasksForFacility_int_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  isThereSuchTask_Service_Facility_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getTask_int_int_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getTaskResultsByTask_int_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getTaskResultsForGUIByTaskOnlyNewest_int_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getTaskResultsForGUIByTaskAndDestination_int_int_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getTaskResultsForGUIByTask_int_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getFacilityState_Facility_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+      - ENGINE:
+    include_policies:
+      - default_policy
+
+  getAllFacilitiesStatesForVo_Vo_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getResourcesState_Vo_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getFacilityServicesState_Facility_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  deleteTask_Task_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+    include_policies:
+      - default_policy
 ...

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/TasksManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/TasksManager.java
@@ -7,6 +7,7 @@ import cz.metacentrum.perun.core.api.exceptions.DestinationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.taskslib.model.Task;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
@@ -18,7 +19,7 @@ import java.util.List;
  */
 public interface TasksManager {
 
-	Task getTask(PerunSession perunSession, Service service, Facility facility) throws PrivilegeException;
+	Task getTask(PerunSession perunSession, Service service, Facility facility) throws PrivilegeException, FacilityNotExistsException, ServiceNotExistsException;
 
 	Task getTaskById(PerunSession perunSession, int id) throws PrivilegeException;
 
@@ -37,7 +38,7 @@ public interface TasksManager {
 
 	List<Task> listAllTasksInState(PerunSession perunSession, Task.TaskStatus state) throws PrivilegeException;
 
-	boolean isThereSuchTask(PerunSession session, Service service, Facility facility) throws PrivilegeException;
+	boolean isThereSuchTask(PerunSession session, Service service, Facility facility) throws PrivilegeException, FacilityNotExistsException, ServiceNotExistsException;
 
 	int countTasks();
 
@@ -126,7 +127,7 @@ public interface TasksManager {
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 */
-	List<ServiceState> getFacilityServicesState(PerunSession sess, Facility facility) throws PrivilegeException;
+	List<ServiceState> getFacilityServicesState(PerunSession sess, Facility facility) throws PrivilegeException, FacilityNotExistsException;
 
 	/**
 	 * Delete Task and it's TaskResults. Use this method only before deleting whole Facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/TasksManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/TasksManagerEntry.java
@@ -15,14 +15,18 @@ import cz.metacentrum.perun.core.api.exceptions.DestinationNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
+import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.TasksManagerBl;
 import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
+import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.taskslib.model.Task;
 import cz.metacentrum.perun.taskslib.model.TaskResult;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -37,22 +41,30 @@ public class TasksManagerEntry implements TasksManager {
 	private TasksManagerBl tasksManagerBl;
 
 	@Override
-	public Task getTask(PerunSession perunSession, Service service, Facility facility) throws PrivilegeException {
-		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(perunSession, Role.PERUNOBSERVER)) {
+	public Task getTask(PerunSession perunSession, Service service, Facility facility) throws PrivilegeException, FacilityNotExistsException, ServiceNotExistsException {
+		Utils.notNull(perunSession, "perunSession");
+		perun.getFacilitiesManagerBl().checkFacilityExists(perunSession, facility);
+		perun.getServicesManagerBl().checkServiceExists(perunSession, service);
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(perunSession, "getTask_Service_Facility_policy", Arrays.asList(service, facility))) {
 			throw new PrivilegeException(perunSession, "getTask");
 		}
+
 		return tasksManagerBl.getTask(perunSession, service, facility);
 	}
 
 	@Override
 	public Task getTaskById(PerunSession perunSession, int id) throws PrivilegeException {
+		Utils.notNull(perunSession, "perunSession");
 		Task task = tasksManagerBl.getTaskById(id);
 		Facility facility = task.getFacility();
-		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(perunSession, Role.PERUNOBSERVER)) {
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(perunSession, "getTaskById_int_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(perunSession, "getTaskResultsByTask");
 		}
+
 		return tasksManagerBl.getTaskById(perunSession, id);
 	}
 
@@ -63,26 +75,35 @@ public class TasksManagerEntry implements TasksManager {
 
 	@Override
 	public List<Task> listAllTasksForFacility(PerunSession session, int facilityId) throws PrivilegeException {
+		Utils.notNull(session, "session");
 		Facility facility = new Facility();
 		facility.setId(facilityId);
-		if (!AuthzResolver.isAuthorized(session, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(session, Role.PERUNOBSERVER)) {
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(session, "listAllTasksForFacility_int_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(session, "listAllTasksForFacility");
 		}
+
 		return tasksManagerBl.listAllTasksForFacility(session, facilityId);
 	}
 
 	@Override
 	public List<Task> listAllTasksInState(PerunSession perunSession, Task.TaskStatus state) throws PrivilegeException {
+		Utils.notNull(perunSession, "perunSession");
 		return tasksManagerBl.listAllTasksInState(perunSession, state);
 	}
 
 	@Override
-	public boolean isThereSuchTask(PerunSession session, Service service, Facility facility) throws PrivilegeException {
-		if (!AuthzResolver.isAuthorized(session, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(session, Role.PERUNOBSERVER)) {
+	public boolean isThereSuchTask(PerunSession session, Service service, Facility facility) throws PrivilegeException, FacilityNotExistsException, ServiceNotExistsException {
+		Utils.notNull(session, "session");
+		perun.getFacilitiesManagerBl().checkFacilityExists(session, facility);
+		perun.getServicesManagerBl().checkServiceExists(session, service);
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(session, "isThereSuchTask_Service_Facility_policy", Arrays.asList(service, facility))) {
 			throw new PrivilegeException(session, "isThereSuchTask");
 		}
+
 		return tasksManagerBl.isThereSuchTask(service, facility);
 	}
 
@@ -93,12 +114,15 @@ public class TasksManagerEntry implements TasksManager {
 
 	@Override
 	public Task getTask(PerunSession perunSession,int serviceId, int facilityId) throws PrivilegeException {
+		Utils.notNull(perunSession, "perunSession");
 		Facility facility = new Facility();
 		facility.setId(facilityId);
-		if (!AuthzResolver.isAuthorized(perunSession, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(perunSession, Role.PERUNOBSERVER)) {
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(perunSession, "getTask_int_int_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(perunSession, "getTask");
 		}
+
 		return tasksManagerBl.getTask(perunSession, serviceId, facilityId);
 	}
 
@@ -109,69 +133,90 @@ public class TasksManagerEntry implements TasksManager {
 
 	@Override
 	public List<TaskResult> getTaskResultsByTask(PerunSession sess, int taskId) throws PrivilegeException {
+		Utils.notNull(sess, "sess");
 		Task task = tasksManagerBl.getTaskById(taskId);
 		Facility facility = task.getFacility();
-		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getTaskResultsByTask_int_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(sess, "getTaskResultsByTask");
 		}
+
 		return tasksManagerBl.getTaskResultsByTask(taskId);
 	}
 
 	@Override
 	public List<TaskResult> getTaskResultsForGUIByTaskOnlyNewest(PerunSession session, int taskId) throws PrivilegeException {
+		Utils.notNull(session, "session");
 		Task task = tasksManagerBl.getTaskById(taskId);
 		Facility facility = task.getFacility();
-		if (!AuthzResolver.isAuthorized(session, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(session, Role.PERUNOBSERVER)) {
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTaskOnlyNewest_int_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(session, "getTaskResultsByTask");
 		}
+
 		return tasksManagerBl.getTaskResultsForGUIByTaskOnlyNewest(session, taskId);
 	}
 
 	@Override
 	public List<TaskResult> getTaskResultsForGUIByTaskAndDestination(PerunSession session, int taskId, int destinationId) throws DestinationNotExistsException, FacilityNotExistsException, PrivilegeException {
+		Utils.notNull(session, "session");
 		Task task = tasksManagerBl.getTaskById(taskId);
 		Facility facility = task.getFacility();
-		if (!AuthzResolver.isAuthorized(session, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(session, Role.PERUNOBSERVER)) {
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTaskAndDestination_int_int_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(session, "getTaskResultsByTask");
 		}
+
 		return tasksManagerBl.getTaskResultsForGUIByTaskAndDestination(session, taskId, destinationId);
 	}
 
 	@Override
 	public List<TaskResult> getTaskResultsForGUIByTask(PerunSession session, int taskId) throws PrivilegeException {
+		Utils.notNull(session, "session");
 		Task task = tasksManagerBl.getTaskById(taskId);
 		Facility facility = task.getFacility();
-		if (!AuthzResolver.isAuthorized(session, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(session, Role.PERUNOBSERVER)) {
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(session, "getTaskResultsForGUIByTask_int_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(session, "getTaskResultsByTask");
 		}
+
 		return tasksManagerBl.getTaskResultsForGUIByTask(session, taskId);
 	}
 
 	@Override
 	public FacilityState getFacilityState(PerunSession session, Facility facility) throws PrivilegeException, FacilityNotExistsException {
-		if (!AuthzResolver.isAuthorized(session, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(session, Role.ENGINE) &&
-				!AuthzResolver.isAuthorized(session, Role.PERUNOBSERVER)) {
+		Utils.notNull(session, "session");
+		perun.getFacilitiesManagerBl().checkFacilityExists(session, facility);
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(session, "getFacilityState_Facility_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(session, "getFacilityState");
 		}
+
 		return tasksManagerBl.getFacilityState(session, facility);
 	}
 
 	@Override
 	public List<FacilityState> getAllFacilitiesStates(PerunSession session) throws FacilityNotExistsException {
+		Utils.notNull(session, "session");
+
 		return tasksManagerBl.getAllFacilitiesStates(session);
 	}
 
 	@Override
 	public List<FacilityState> getAllFacilitiesStatesForVo(PerunSession session, Vo vo) throws PrivilegeException, VoNotExistsException, FacilityNotExistsException {
-		if (!AuthzResolver.isAuthorized(session, Role.VOADMIN, vo) &&
-				!AuthzResolver.isAuthorized(session, Role.PERUNOBSERVER)) {
+		Utils.notNull(session, "session");
+		perun.getVosManagerBl().checkVoExists(session, vo);
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(session, "getAllFacilitiesStatesForVo_Vo_policy", Collections.singletonList(vo))) {
 			throw new PrivilegeException(session, "getAllFacilitiesStatesForVo");
 		}
+
 		return tasksManagerBl.getAllFacilitiesStatesForVo(session, vo);
 	}
 
@@ -181,35 +226,49 @@ public class TasksManagerEntry implements TasksManager {
 	}
 
 	public List<TaskResult> getTaskResultsForDestinations(PerunSession session, List<String> destinationsNames) {
+		Utils.notNull(session, "session");
+
 		//FIXME check privileges, probably only some monitoring system can request these data
 		return tasksManagerBl.getTaskResultsForDestinations(session, destinationsNames);
 	}
 
 	@Override
 	public List<ResourceState> getResourcesState(PerunSession session, Vo vo) throws PrivilegeException, VoNotExistsException {
-		if (!AuthzResolver.isAuthorized(session, Role.VOADMIN, vo) &&
-				!AuthzResolver.isAuthorized(session, Role.PERUNOBSERVER)) {
+		Utils.notNull(session, "session");
+		perun.getVosManagerBl().checkVoExists(session, vo);
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(session, "getResourcesState_Vo_policy", Collections.singletonList(vo))) {
 			throw new PrivilegeException(session, "getResourcesState");
 		}
+
 		return tasksManagerBl.getResourcesState(session, vo);
 	}
 
 	@Override
-	public List<ServiceState> getFacilityServicesState(PerunSession sess, Facility facility) throws PrivilegeException{
-		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility) &&
-				!AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
+	public List<ServiceState> getFacilityServicesState(PerunSession sess, Facility facility) throws PrivilegeException, FacilityNotExistsException {
+		Utils.notNull(sess, "sess");
+		perun.getFacilitiesManagerBl().checkFacilityExists(sess, facility);
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "getFacilityServicesState_Facility_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(sess, "getFacilityServicesState");
 		}
+
 		return tasksManagerBl.getFacilityServicesState(sess, facility);
 
 	}
 
 	@Override
 	public void deleteTask(PerunSession sess, Task task) throws PrivilegeException {
+		Utils.notNull(sess, "sess");
 		Facility facility = task.getFacility();
-		if (!AuthzResolver.isAuthorized(sess, Role.FACILITYADMIN, facility)) {
+
+		//Authorization
+		if (!AuthzResolver.authorizedInternal(sess, "deleteTask_Task_policy", Collections.singletonList(facility))) {
 			throw new PrivilegeException(sess, "deleteTask");
 		}
+
 		tasksManagerBl.deleteTask(sess, task);
 	}
 


### PR DESCRIPTION
- In TasksManagerEntry was completely replaced the old authorization.
- For that purpose was updated also perun-roles.yml file with the
  policies used in the TasksManagerEntry.
- All PerunBeans which are passed to the methods and already exist in
  Perun are passed also to the authorization, even when a policy does not
  need them for now. It does not have any effect on the policy evaluation.
  It erase the necessity to change these methods if the policy will change
  in the future.