### PR TITLE
Fixed documentation in servicesmanager

### DIFF
--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/ServicesManagerMethod.java
@@ -434,7 +434,7 @@ public enum ServicesManagerMethod implements ManagerMethod {
 	/*#
 	 * Get all services with given attribute.
 	 *
-	 * @param attributeDefinition AttributeDefinition attributeDefinition
+	 * @param attributeDefinition int attributeDefinition <code>id</code>
 	 * @return all services with given attribute
 	 */
 	getServicesByAttributeDefinition {


### PR DESCRIPTION
* The method getServicesByAttributeDefinition contained an invalid
parameter type. The actual type of the `attributeDefinition` parameter
is int.