### PR TITLE
CORE/ENGINE/LDAPC: Optimized default logging configuration

### DIFF
--- a/perun-base/src/main/resources/logback-default.xml
+++ b/perun-base/src/main/resources/logback-default.xml
@@ -46,8 +46,8 @@
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="main">
 		<file>${LOGDIR}perun.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun.log.%d.%i</fileNamePattern>
-			<maxFileSize>10MB</maxFileSize>
+			<fileNamePattern>${LOGDIR}perun.log.%d.%i.gz</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
 			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
@@ -73,25 +73,13 @@
 	-->
 
 	<!--
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="notification">
-		<file>${LOGDIR}perun-notif.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-notif.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.notif" level="info" additivity="false">
-		<appender-ref ref="notification"/>
-	</logger>
-
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-auditer">
 		<file>${LOGDIR}perun-auditer.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-auditer.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-auditer.log.%d.%i.gz</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -104,9 +92,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-cabinet">
 		<file>${LOGDIR}perun-cabinet.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-cabinet.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-cabinet.log.%d.%i.gz</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -119,15 +109,20 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-core">
 		<file>${LOGDIR}perun-core.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-core.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-core.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
 	<logger name="cz.metacentrum.perun.core" level="info" additivity="false">
+		<appender-ref ref="perun-core"/>
+	</logger>
+	<logger name="cz.metacentrum.perun.rpclib" level="info" additivity="false">
 		<appender-ref ref="perun-core"/>
 	</logger>
 	<logger name="cz.metacentrum.perun.core.impl.JdbcPerunTemplate" level="error"/>
@@ -137,7 +132,7 @@
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-ultimate">
         <file>${LOGDIR}perun-ultimate.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-ultimate.log.%d.%i</fileNamePattern>
+			<fileNamePattern>${LOGDIR}perun-ultimate.log.%d.%i.gz</fileNamePattern>
 			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
 			<totalSizeCap>1GB</totalSizeCap>
@@ -150,39 +145,29 @@
 		<appender-ref ref="perun-ultimate"/>
     </logger>
 
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-eventProcessor">
-		<file>${LOGDIR}perun-dispatcher-eventProcessor.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-eventProcessor.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher.processing.EventProcessor" level="info" additivity="false">
-		<appender-ref ref="perun-dispatcher-eventProcessor"/>
-	</logger>
-
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-events">
 		<file>${LOGDIR}perun-dispatcher-events.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-events.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-dispatcher-events.log.%d.%i.gz</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
 		</encoder>
 	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher.processing.EventLogger" level="info" additivity="false">
+	<logger name="cz.metacentrum.perun.dispatcher.processing" level="info" additivity="false">
 		<appender-ref ref="perun-dispatcher-events"/>
 	</logger>
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-jms">
 		<file>${LOGDIR}perun-dispatcher-jms.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-jms.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-dispatcher-jms.log.%d.%i.gz</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -194,9 +179,11 @@
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher">
 		<file>${LOGDIR}perun-dispatcher.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-dispatcher.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -205,54 +192,17 @@
 	<logger name="cz.metacentrum.perun.dispatcher" level="info" additivity="false">
 		<appender-ref ref="perun-dispatcher"/>
 	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-matcher">
-		<file>${LOGDIR}perun-dispatcher-matcher.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-matcher.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher.processing.impl.SmartMatcherImpl" level="info" additivity="false">
-		<appender-ref ref="perun-dispatcher-matcher"/>
-	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-dispatcher-queue">
-		<file>${LOGDIR}perun-dispatcher-queue.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-dispatcher-queue.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.dispatcher.jms.DispatcherQueue" level="info" additivity="false">
-		<appender-ref ref="perun-dispatcher-queue"/>
-	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-engine">
-		<file>${LOGDIR}perun-engine.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-engine.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.engine" level="info" additivity="false">
-		<appender-ref ref="perun-engine"/>
+	<logger name="cz.metacentrum.perun.taskslib" level="info" additivity="false">
+		<appender-ref ref="perun-dispatcher"/>
 	</logger>
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-registrar">
 		<file>${LOGDIR}perun-registrar.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-registrar.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-registrar.log.%d.%i</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -262,25 +212,13 @@
 		<appender-ref ref="perun-registrar"/>
 	</logger>
 
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-rpc-lib">
-		<file>${LOGDIR}perun-rpc-lib.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-rpc-lib.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.rpclib" level="info" additivity="false">
-		<appender-ref ref="perun-rpc-lib"/>
-	</logger>
-
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-rpc">
 		<file>${LOGDIR}perun-rpc.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-rpc.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-rpc.log.%d.%i.gz</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -290,11 +228,29 @@
 		<appender-ref ref="perun-rpc"/>
 	</logger>
 
+	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="notification">
+		<file>${LOGDIR}perun-notif.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-notif.log.%d.%i.gz</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
+			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
+		</rollingPolicy>
+		<encoder>
+			<pattern>${ENCODER_PATTERN}</pattern>
+		</encoder>
+	</appender>
+	<logger name="cz.metacentrum.perun.notif" level="info" additivity="false">
+		<appender-ref ref="notification"/>
+	</logger>
+
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-notif-sended">
 		<file>${LOGDIR}perun-notif-sended.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-notif-sended.log.%d</fileNamePattern>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<fileNamePattern>${LOGDIR}perun-notif-sended.log.%d.%i.gz</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>${MAXHISTORY}</maxHistory>
+			<totalSizeCap>1GB</totalSizeCap>
 		</rollingPolicy>
 		<encoder>
 			<pattern>${ENCODER_PATTERN}</pattern>
@@ -303,36 +259,6 @@
 	<logger name="sendMessages" level="info" additivity="false">
 		<appender-ref ref="perun-notif-sended"/>
 	</logger>
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-controller">
-		<file>${LOGDIR}perun-controller.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-controller.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.controller" level="info" additivity="false">
-		<appender-ref ref="perun-controller"/>
-	</logger>
-
-
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-tasklib">
-		<file>${LOGDIR}perun-tasklib.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-tasklib.log.%d</fileNamePattern>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
-	</appender>
-	<logger name="cz.metacentrum.perun.taskslib" level="info" additivity="false">
-		<appender-ref ref="perun-tasklib"/>
-	</logger>
-
-   -->
+	-->
 
 </configuration>

--- a/perun-engine/src/main/resources/logback.xml
+++ b/perun-engine/src/main/resources/logback.xml
@@ -13,7 +13,7 @@
 		<file>${LOGDIR}perun-engine.log</file>
 		<!-- see https://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy -->
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-engine.log.%d.%i</fileNamePattern>
+			<fileNamePattern>${LOGDIR}perun-engine.log.%d.%i.gz</fileNamePattern>
 			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>30</maxHistory>
 			<totalSizeCap>1GB</totalSizeCap>

--- a/perun-ldapc/src/main/resources/logback.xml
+++ b/perun-ldapc/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
 		<file>${LOGDIR}perun-ldapc.log</file>
 		<!-- see https://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy -->
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-ldapc.log.%d.%i</fileNamePattern>
+			<fileNamePattern>${LOGDIR}perun-ldapc.log.%d.%i.gz</fileNamePattern>
 			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>30</maxHistory>
 			<totalSizeCap>1GB</totalSizeCap>


### PR DESCRIPTION
This is non-conflicting portion of ongoing logging rework.

- Removed perun-rpc-lib.log, we will log few existing messages to perun-core.log.
- Removed perun-controller.log, there shouldn't be any messages left.
- Optimized logging of perun-dispatcher.log. We will have only 3 log files.
  One for Audit events processing, one for JMS processing and one for the rest.
- Gzip logs of all usually large log files, which are not that much interesting.
- Shared log rolling policy on max file number / file size / date.