### PR TITLE
GUI/REGISTRAR: Allow updating form item data by perun admin

### DIFF
--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -9222,6 +9222,30 @@ paths:
         default:
           $ref: '#/components/responses/ExceptionResponse'
 
+  /json/registrarManager/updateFormItemData:
+    post:
+      tags:
+        - RegistrarManager
+      operationId: updateFormItemData
+      summary: Update application form item data value, which was originally submitted by the User.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: InputFormItemData
+              description: "input to updateFormItemData"
+              type: object
+              required:
+                - data
+              properties:
+                data: { $ref: '#/components/schemas/ApplicationFormItemData' }
+      responses:
+        '200':
+          $ref: '#/components/responses/VoidResponse'
+        default:
+          $ref: '#/components/responses/ExceptionResponse'
+
   #################################################
   #                                               #
   # ServicesManager                               #

--- a/perun-openapi/openapi.yml
+++ b/perun-openapi/openapi.yml
@@ -9237,8 +9237,10 @@ paths:
               description: "input to updateFormItemData"
               type: object
               required:
+                - appId
                 - data
               properties:
+                appId: { type: integer, description: "application id" }
                 data: { $ref: '#/components/schemas/ApplicationFormItemData' }
       responses:
         '200':

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -461,6 +461,16 @@ public interface RegistrarManager {
 	void updateApplicationUser(PerunSession sess, Application app) throws InternalErrorException;
 
 	/**
+	 * Updated data stored for specific application and form item.
+	 *
+	 * @param session
+	 * @param app
+	 * @throws InternalErrorException
+	 * @throws PrivilegeException
+	 */
+	void updateFormItemData(PerunSession session, ApplicationFormItemData app) throws InternalErrorException, PrivilegeException;
+
+	/**
 	 * Getter for Mail manager used for notifications
 	 *
 	 * @return mail manager

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -464,11 +464,13 @@ public interface RegistrarManager {
 	 * Updated data stored for specific application and form item.
 	 *
 	 * @param session
-	 * @param app
+	 * @param applicationId ID of submitted application
+	 * @param data Form item data to update
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
+	 * @throws RegistrarException
 	 */
-	void updateFormItemData(PerunSession session, ApplicationFormItemData app) throws InternalErrorException, PrivilegeException;
+	void updateFormItemData(PerunSession session, int applicationId, ApplicationFormItemData data) throws InternalErrorException, PrivilegeException, RegistrarException;
 
 	/**
 	 * Getter for Mail manager used for notifications

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -2765,6 +2765,24 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 	}
 
+	public void updateFormItemData(PerunSession sess, ApplicationFormItemData app) throws InternalErrorException, PrivilegeException {
+
+		if (!AuthzResolver.isAuthorized(sess, Role.PERUNADMIN)) {
+			throw new PrivilegeException(sess, "updateApplicationData");
+		}
+
+		try {
+			int result = jdbc.update("update application_data set value=? where id=?", app.getValue(), app.getId());
+			log.info("{} manually updated form item data {}", sess.getPerunPrincipal(), app);
+			if (result != 1) {
+				throw new InternalErrorException("Unable to update form item data");
+			}
+		} catch (RuntimeException ex) {
+			throw new InternalErrorException(ex);
+		}
+
+	}
+
 	@Override
 	public MailManager getMailManager() {
 		return this.mailManager;

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -1249,9 +1249,12 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 	},
 
 	/*#
-	 * Update data of specific application form item, which was originally submitted by user.
-	 * Only PerunAdmin can use this.
+	 * Update data of specific application form item, which was originally submitted by the user.
+	 * Only PerunAdmin can use this. Only applications in NEW or VERIFIED state can have form items updated.
+	 * Form items of types: FROM_FEDERATION_HIDDEN, FROM_FEDERATION_SHOW, USERNAME, PASSWORD, HEADING, HTML_COMMENT,
+	 * SUBMIT_BUTTON and AUTO_SUBMIT_BUTTON are not updatable by this method.
 	 *
+	 * @param appId int ID of Application this data belongs to.
 	 * @param data ApplicationFormItemData Form item data to be updated by its ID.
 	 */
 	updateFormItemData {
@@ -1259,7 +1262,7 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 		@Override
 		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
 			ac.stateChangingCheck();
-			ac.getRegistrarManager().updateFormItemData(ac.getSession(), parms.read("data", ApplicationFormItemData.class));
+			ac.getRegistrarManager().updateFormItemData(ac.getSession(), parms.readInt("appId"), parms.read("data", ApplicationFormItemData.class));
 			return null;
 		}
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/RegistrarManagerMethod.java
@@ -1246,6 +1246,23 @@ public enum RegistrarManagerMethod implements ManagerMethod {
 
 		}
 
+	},
+
+	/*#
+	 * Update data of specific application form item, which was originally submitted by user.
+	 * Only PerunAdmin can use this.
+	 *
+	 * @param data ApplicationFormItemData Form item data to be updated by its ID.
+	 */
+	updateFormItemData {
+
+		@Override
+		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
+			ac.stateChangingCheck();
+			ac.getRegistrarManager().updateFormItemData(ac.getSession(), parms.read("data", ApplicationFormItemData.class));
+			return null;
+		}
+
 	};
 
 }

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/client/applicationresources/RegistrarFormItemGenerator.java
@@ -481,6 +481,17 @@ public class RegistrarFormItemGenerator {
 
 	}
 
+	public boolean isUpdatable() {
+		return !"FROM_FEDERATION_HIDDEN".equalsIgnoreCase(item.getType()) &&
+				!"FROM_FEDERATION_SHOW".equalsIgnoreCase(item.getType()) &&
+				!"USERNAME".equalsIgnoreCase(item.getType()) &&
+				!"PASSWORD".equalsIgnoreCase(item.getType()) &&
+				!"HEADING".equalsIgnoreCase(item.getType()) &&
+				!"HTML_COMMENT".equalsIgnoreCase(item.getType()) &&
+				!"SUBMIT_BUTTON".equalsIgnoreCase(item.getType()) &&
+				!"AUTO_SUBMIT_BUTTON".equalsIgnoreCase(item.getType());
+	}
+
 	/**
 	 * Generates the readonly textbox
 	 * @return

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
@@ -59,6 +59,8 @@ public class GetApplicationDataById implements JsonCallback{
 	// whether to show hidden information
 	private boolean showAdminItems = true;
 
+	private boolean editable = false;
+
 	/**
 	 * Creates a new method instance
 	 *
@@ -78,6 +80,10 @@ public class GetApplicationDataById implements JsonCallback{
 	public GetApplicationDataById(int id, JsonCallbackEvents events) {
 		this(id);
 		this.events = events;
+	}
+
+	public void setEditable(boolean editable) {
+		this.editable = editable;
 	}
 
 	/**
@@ -201,7 +207,7 @@ public class GetApplicationDataById implements JsonCallback{
 						ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong>");
 					}
 
-					if (PerunWebSession.getInstance().isPerunAdmin()) {
+					if (PerunWebSession.getInstance().isPerunAdmin() && gen.isUpdatable() && editable) {
 						final int finalI = i;
 						CustomButton editButton = new CustomButton("", "Editor form item data.", SmallIcons.INSTANCE.applicationFormEditIcon(), new ClickHandler() {
 							@Override
@@ -213,7 +219,7 @@ public class GetApplicationDataById implements JsonCallback{
 								}
 								content.setSize("350px", "100px");
 
-								Confirm confirm = new Confirm("Edit item: " + item.getShortname(), content, new ClickHandler() {
+								Confirm confirm = new Confirm("Edit item: " + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString(), content, new ClickHandler() {
 									@Override
 									public void onClick(ClickEvent event) {
 										// save old value and push new value
@@ -231,7 +237,7 @@ public class GetApplicationDataById implements JsonCallback{
 												item.setValue(previousValue);
 											}
 										});
-										update.updateFormItemData(item);
+										update.updateFormItemData(appId, item);
 									}
 								}, "Update form item",true);
 								confirm.setNonScrollable(true);

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/GetApplicationDataById.java
@@ -1,12 +1,15 @@
 package cz.metacentrum.perun.webgui.json.registrarManager;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.FlexTable.FlexCellFormatter;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.client.applicationresources.RegistrarFormItemGenerator;
+import cz.metacentrum.perun.webgui.client.resources.SmallIcons;
 import cz.metacentrum.perun.webgui.client.resources.Utils;
 import cz.metacentrum.perun.webgui.json.JsonCallback;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
@@ -15,6 +18,8 @@ import cz.metacentrum.perun.webgui.json.JsonUtils;
 import cz.metacentrum.perun.webgui.model.ApplicationFormItemData;
 import cz.metacentrum.perun.webgui.model.PerunError;
 import cz.metacentrum.perun.webgui.widgets.AjaxLoaderImage;
+import cz.metacentrum.perun.webgui.widgets.Confirm;
+import cz.metacentrum.perun.webgui.widgets.CustomButton;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -148,7 +153,9 @@ public class GetApplicationDataById implements JsonCallback{
 
 		FlexTable ft = new FlexTable();
 		ft.setWidth("100%");
-		ft.setCellPadding(10);
+		ft.setCellPadding(5);
+		ft.setCellSpacing(0);
+		ft.setStyleName("stripped");
 		FlexCellFormatter fcf = ft.getFlexCellFormatter();
 		String locale = "en";
 		if (!Utils.getNativeLanguage().isEmpty() &&
@@ -194,16 +201,57 @@ public class GetApplicationDataById implements JsonCallback{
 						ft.setHTML(i, 0, "<strong>" + SafeHtmlUtils.fromString(gen.getLabelOrShortname()).asString() + "</strong>");
 					}
 
+					if (PerunWebSession.getInstance().isPerunAdmin()) {
+						final int finalI = i;
+						CustomButton editButton = new CustomButton("", "Editor form item data.", SmallIcons.INSTANCE.applicationFormEditIcon(), new ClickHandler() {
+							@Override
+							public void onClick(ClickEvent event) {
+
+								TextArea content = new TextArea();
+								if (item.getValue() != null) {
+									content.setText(item.getValue());
+								}
+								content.setSize("350px", "100px");
+
+								Confirm confirm = new Confirm("Edit item: " + item.getShortname(), content, new ClickHandler() {
+									@Override
+									public void onClick(ClickEvent event) {
+										// save old value and push new value
+										String previousValue = item.getValue();
+										item.setValue(content.getText());
+										UpdateFormItemData update = new UpdateFormItemData(new JsonCallbackEvents(){
+											@Override
+											public void onFinished(JavaScriptObject jso) {
+												// update local UI
+												ft.setWidget(finalI, 2, new HTML((item.getValue() != null) ? (SafeHtmlUtils.fromString(item.getValue()).asString()) : null));
+											}
+											@Override
+											public void onError(PerunError error) {
+												// put back old value
+												item.setValue(previousValue);
+											}
+										});
+										update.updateFormItemData(item);
+									}
+								}, "Update form item",true);
+								confirm.setNonScrollable(true);
+								confirm.show();
+
+							}
+						});
+						ft.setWidget(i, 1, editButton);
+					}
+
 					// 1 = value
-					ft.setWidget(i, 1, new HTML((item.getValue() != null) ? (SafeHtmlUtils.fromString(item.getValue()).asString()) : null));
+					ft.setWidget(i, 2, new HTML((item.getValue() != null) ? (SafeHtmlUtils.fromString(item.getValue()).asString()) : null));
 
 					// format
 					fcf.setVerticalAlignment(i, 0, HasVerticalAlignment.ALIGN_TOP);
-					fcf.setVerticalAlignment(i, 1, HasVerticalAlignment.ALIGN_TOP);
+					fcf.setVerticalAlignment(i, 2, HasVerticalAlignment.ALIGN_TOP);
 					fcf.setHorizontalAlignment(i, 0, HasHorizontalAlignment.ALIGN_RIGHT);
-					fcf.setHorizontalAlignment(i, 1, HasHorizontalAlignment.ALIGN_LEFT);
+					fcf.setHorizontalAlignment(i, 2, HasHorizontalAlignment.ALIGN_LEFT);
 					fcf.setWidth(i, 0, "25%");
-					fcf.setWidth(i, 1, "75%");
+					fcf.setWidth(i, 2, "75%");
 
 				}
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItemData.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItemData.java
@@ -1,0 +1,112 @@
+package cz.metacentrum.perun.webgui.json.registrarManager;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONObject;
+import cz.metacentrum.perun.webgui.client.PerunWebSession;
+import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
+import cz.metacentrum.perun.webgui.json.JsonPostClient;
+import cz.metacentrum.perun.webgui.model.ApplicationFormItemData;
+import cz.metacentrum.perun.webgui.model.PerunError;
+
+/**
+ * Request, which updates form item data
+ *
+ * @author Pavel Zlamal <256627@mail.muni.cz>
+ */
+public class UpdateFormItemData {
+
+	// web session
+	private PerunWebSession session = PerunWebSession.getInstance();
+
+	// URL to call
+	final String JSON_URL = "registrarManager/updateFormItemData";
+
+	// custom events
+	private JsonCallbackEvents events = new JsonCallbackEvents();
+
+	/**
+	 * Creates a new request
+	 *
+	 */
+	public UpdateFormItemData() {
+	}
+
+	/**
+	 * Creates a new request with custom events
+	 *
+	 * @param events Custom events
+	 */
+	public UpdateFormItemData(JsonCallbackEvents events) {
+		this.events = events;
+	}
+
+	/**
+	 * Updates form item value in DB
+	 *
+	 * @param data
+	 */
+	public void updateFormItemData(ApplicationFormItemData data) {
+
+		// new events
+		JsonCallbackEvents newEvents = new JsonCallbackEvents(){
+			public void onError(PerunError error) {
+				session.getUiElements().setLogErrorText("Updating form item failed.");
+				events.onError(error);
+			};
+
+			public void onFinished(JavaScriptObject jso) {
+				session.getUiElements().setLogSuccessText("Form item updated.");
+				events.onFinished(jso);
+			};
+
+			public void onLoadingStart() {
+				events.onLoadingStart();
+			};
+		};
+
+		// sending data
+		JsonPostClient jspc = new JsonPostClient(newEvents);
+		jspc.sendData(JSON_URL, prepareJSONObject(data));
+
+	}
+
+	/**
+	 * Prepares a JSON object.
+	 * @return JSONObject - the whole query
+	 */
+	private JSONObject prepareJSONObject(ApplicationFormItemData data) {
+
+		JSONObject query = new JSONObject();
+
+		JSONObject obj = new JSONObject(data.getFormItem());
+		JSONObject newItem = new JSONObject();
+		newItem.put("id", obj.get("id"));
+		newItem.put("shortname", obj.get("shortname"));
+		newItem.put("required", obj.get("required"));
+		newItem.put("type", obj.get("type"));
+		newItem.put("federationAttribute", obj.get("federationAttribute"));
+		newItem.put("perunSourceAttribute", obj.get("perunSourceAttribute"));
+		newItem.put("perunDestinationAttribute", obj.get("perunDestinationAttribute"));
+		newItem.put("regex", obj.get("regex"));
+		newItem.put("appTypes", obj.get("appTypes"));
+		newItem.put("ordnum", obj.get("ordnum"));
+		newItem.put("forDelete", obj.get("forDelete"));
+		newItem.put("applicationTypes", obj.get("applicationTypes"));
+
+		JSONObject obj2 = new JSONObject(data);
+		JSONObject newItem2 = new JSONObject();
+		newItem2.put("id", obj2.get("id"));
+		newItem2.put("shortName", obj2.get("shortName"));
+		newItem2.put("value", obj2.get("value"));
+		newItem2.put("prefilledValue", obj2.get("prefilledValue"));
+		newItem2.put("assuranceLevel", obj2.get("assuranceLevel"));
+		newItem2.put("formItem", newItem);
+
+		query.put("data", newItem2);
+
+		return query;
+
+	}
+
+}

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItemData.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/registrarManager/UpdateFormItemData.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.webgui.json.registrarManager;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.json.client.JSONObject;
 import cz.metacentrum.perun.webgui.client.PerunWebSession;
 import cz.metacentrum.perun.webgui.json.JsonCallbackEvents;
@@ -25,6 +26,8 @@ public class UpdateFormItemData {
 	// custom events
 	private JsonCallbackEvents events = new JsonCallbackEvents();
 
+	private int appId = 0;
+
 	/**
 	 * Creates a new request
 	 *
@@ -46,7 +49,9 @@ public class UpdateFormItemData {
 	 *
 	 * @param data
 	 */
-	public void updateFormItemData(ApplicationFormItemData data) {
+	public void updateFormItemData(int appId, ApplicationFormItemData data) {
+
+		this.appId = appId;
 
 		// new events
 		JsonCallbackEvents newEvents = new JsonCallbackEvents(){
@@ -103,6 +108,7 @@ public class UpdateFormItemData {
 		newItem2.put("assuranceLevel", obj2.get("assuranceLevel"));
 		newItem2.put("formItem", newItem);
 
+		query.put("appId", new JSONNumber(appId));
 		query.put("data", newItem2);
 
 		return query;

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/ApplicationDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/registrartabs/ApplicationDetailTabItem.java
@@ -404,6 +404,7 @@ public class ApplicationDetailTabItem implements TabItem, TabItemWithUrl {
 		menu.addWidget(new HTML("<strong>STATE: </strong>"+Application.getTranslatedState(app.getState())));
 
 		GetApplicationDataById data = new GetApplicationDataById(appId);
+		data.setEditable(app.getState().equals("VERIFIED") || app.getState().equals("NEW"));
 		data.retrieveData();
 		ScrollPanel sp = new ScrollPanel(data.getContents());
 		sp.setSize("100%", "100%");

--- a/perun-web-gui/src/main/webapp/PerunWeb.css
+++ b/perun-web-gui/src/main/webapp/PerunWeb.css
@@ -1333,3 +1333,8 @@ h3 {
     visibility:hidden !important;
     background:blue !important;
 }
+
+/* stripped table */
+.stripped tr:nth-child(even) {
+    background-color: #f3f7fb;
+}


### PR DESCRIPTION
- Perun admin can edit submitted application form item data
  on application detail.
- Added registrar logic and RPC API method.
- Added OpenAPI method definition.
- Added UI and client callback to GUI.
- Display application form with stripped lines.