### PR TITLE
CORE: Store mail used in pwd reset notifications

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.57 (don't forget to update insert statement at the end of file)
+-- database version 3.1.58 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1386,6 +1386,7 @@ create table mailchange (
 create table pwdreset (
 	id integer not null,
 	namespace text not null,
+	mail text,
 	user_id integer not null,
 	created_at timestamp default current_date not null,
 	created_by varchar(1300) default user not null,
@@ -1751,7 +1752,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.57');
+insert into configurations values ('DATABASE VERSION','3.1.58');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -2306,7 +2306,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			throw new InternalErrorException(ex);
 		}
 
-		int id = getMembersManagerImpl().storePasswordResetRequest(sess, user, namespace);
+		int id = getMembersManagerImpl().storePasswordResetRequest(sess, user, namespace, mailAddress);
 		Utils.sendPasswordResetEmail(user, mailAddress, namespace, url, id, message, subject);
 
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -315,14 +315,14 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 	}
 
 	@Override
-	public int storePasswordResetRequest(PerunSession sess, User user, String namespace) throws InternalErrorException {
+	public int storePasswordResetRequest(PerunSession sess, User user, String namespace, String mail) throws InternalErrorException {
 
 		int newId = Utils.getNewId(jdbc, "pwdreset_id_seq");
 
 		try {
-			jdbc.update("insert into pwdreset (id, namespace, user_id, created_by, created_by_uid, created_at) "
-							+ "values (?,?,?,?,?," + Compatibility.getSysdate() + ")",
-					newId, namespace, user.getId(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
+			jdbc.update("insert into pwdreset (id, namespace, user_id, mail, created_by, created_by_uid, created_at) "
+							+ "values (?,?,?,?,?,?," + Compatibility.getSysdate() + ")",
+					newId, namespace, user.getId(), mail, sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1264,21 +1264,21 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	@Override
-	public String loadPasswordResetRequest(User user, int requestId) {
+	public Pair<String,String> loadPasswordResetRequest(User user, int requestId) {
 
 		int validWindow = BeansUtils.getCoreConfig().getPwdresetValidationWindow();
 
-		String result = "";
+		Pair<String,String> result = new Pair<>();
 		try {
 			if (Compatibility.isPostgreSql()) {
 
-				result = jdbc.queryForObject("select namespace from pwdreset where user_id=? and id=? and (created_at > (now() - interval '" + validWindow + " hours'))",
-					(resultSet, i) -> resultSet.getString("namespace"), user.getId(), requestId);
+				result = jdbc.queryForObject("select namespace, mail from pwdreset where user_id=? and id=? and (created_at > (now() - interval '" + validWindow + " hours'))",
+					(resultSet, i) -> new Pair<>(resultSet.getString("namespace"), resultSet.getString("mail")), user.getId(), requestId);
 
 			} else {
 
-				result =  jdbc.queryForObject("select namespace from pwdreset where user_id=? and id=? and (created_at > (SYSTIMESTAMP - INTERVAL '"+validWindow+"' HOUR))",
-					(resultSet, i) -> resultSet.getString("namespace"), user.getId(), requestId);
+				result =  jdbc.queryForObject("select namespace, mail from pwdreset where user_id=? and id=? and (created_at > (SYSTIMESTAMP - INTERVAL '"+validWindow+"' HOUR))",
+					(resultSet, i) -> new Pair<>(resultSet.getString("namespace"), resultSet.getString("mail")), user.getId(), requestId);
 			}
 
 			jdbc.update("delete from pwdreset where user_id=? and id=?", user.getId(), requestId);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -214,10 +214,11 @@ public interface MembersManagerImplApi {
 	 * @param sess PerunSession
 	 * @param user User to reset password for
 	 * @param namespace namespace to reset password in
+	 * @param mail mail address used to send request to
 	 * @return ID of request to be used for validation
 	 * @throws InternalErrorException
 	 */
-	int storePasswordResetRequest(PerunSession sess, User user, String namespace) throws InternalErrorException;
+	int storePasswordResetRequest(PerunSession sess, User user, String namespace, String mail) throws InternalErrorException;
 
 	/**
 	 * Creates a new member in given Vo with flag "sponsored", and linked to its sponsoring user.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -691,13 +691,13 @@ public interface UsersManagerImplApi {
 	 * Return only valid password reset requests for selected user and request ID.
 	 * Validity is determined by time since request creation and actual usage (only once).
 	 *
-	 * If no valid entry is found, then empty string is returned. Entry is invalidated once loaded.
+	 * If no valid entry is found, then NULL is returned. Entry is invalidated once loaded.
 	 *
 	 * @param user user to get requests for
 	 * @param request request ID to get
-	 * @return namespace where user wants to reset password in or empty string
+	 * @return Pair with "left" = namespace user wants to reset password, "right" = mail used for notification
 	 */
-	String loadPasswordResetRequest(User user, int request);
+	Pair<String,String> loadPasswordResetRequest(User user, int request);
 
 	/**
 	 * Removes all password reset requests associated with user.

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -8,6 +8,10 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.58
+alter table pwdreset add column mail text;
+update configurations set value='3.1.58' where property='DATABASE VERSION';
+
 3.1.57
 drop index idx_authz_u;
 create unique index idx_authz_u ON authz (COALESCE(user_id, '0'), COALESCE(authorized_group_id, '0'), role_id, COALESCE(group_id, '0'), COALESCE(vo_id, '0'), COALESCE(facility_id, '0'), COALESCE(member_id, '0'), COALESCE(resource_id, '0'), COALESCE(service_id, '0'), COALESCE(security_team_id, '0'), COALESCE(sponsored_user_id, '0'));

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.58
+alter table pwdreset add column mail nvarchar2(4000);
+update configurations set value='3.1.58' where property='DATABASE VERSION';
+
 3.1.57
 drop index IDX_AUTHZ_U;
 create unique index IDX_AUTHZ_U on authz(user_id, authorized_group_id, role_id, group_id, vo_id, facility_id, member_id, resource_id, service_id, security_team_id, sponsored_user_id);

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.58
+alter table pwdreset add column mail text;
+update configurations set value='3.1.58' where property='DATABASE VERSION';
+
 3.1.57
 drop index idx_authz_u;
 create unique index idx_authz_u ON authz (COALESCE(user_id, '0'), COALESCE(authorized_group_id, '0'), role_id, COALESCE(group_id, '0'), COALESCE(vo_id, '0'), COALESCE(facility_id, '0'), COALESCE(member_id, '0'), COALESCE(resource_id, '0'), COALESCE(service_id, '0'), COALESCE(security_team_id, '0'), COALESCE(sponsored_user_id, '0'));

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.57 (don't forget to update insert statement at the end of file)
+-- database version 3.1.58 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1392,6 +1392,7 @@ create table mailchange (
 create table pwdreset (
 	id integer not null,
 	namespace nvarchar2(512) not null,
+	mail nvarchar2(4000),
 	user_id integer not null,
 	created_at date default sysdate not null,
 	created_by nvarchar2(1300) default user not null,
@@ -1753,7 +1754,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.57');
+insert into configurations values ('DATABASE VERSION','3.1.58');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.57 (don't forget to update insert statement at the end of file)
+-- database version 3.1.58 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1382,6 +1382,7 @@ create table mailchange (
 create table pwdreset (
 	id integer not null,
 	namespace text not null,
+	mail text,
 	user_id integer not null,
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar(1300) default user not null,
@@ -1850,7 +1851,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.57');
+insert into configurations values ('DATABASE VERSION','3.1.58');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
- We allow sending password reset to non-standard mail addresses by
  choosing source mail attribute. When password is actually re-set,
  we should notify user on the same address as was used first time.
- This change contains DB version update.