### PR TITLE
CORE: Fixed oracle changelog for 3.1.57

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.56 (don't forget to update insert statement at the end of file)
+-- database version 3.1.57 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -7,17 +7,13 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 3.1.57
--- recreate unique index on authz without service_principal_id !!
 drop index IDX_AUTHZ_U;
 create unique index IDX_AUTHZ_U on authz(user_id, authorized_group_id, role_id, group_id, vo_id, facility_id, member_id, resource_id, service_id, security_team_id, sponsored_user_id);
--- recreate constraint for non-null user_id or authorized_group_id
 alter table authz drop constraint authz_user_serprinc_autgrp_chk;
 alter table authz add constraint authz_user_autgrp_chk check ((user_id is not null and authorized_group_id is null) or (user_id is null and authorized_group_id is not null));
--- drop index/constraint/column
 drop index IDX_FK_AUTHZ_SER_PRINC;
 alter table authz drop constraint authz_ser_princ_fk;
 alter table authz drop column service_principal_id;
--- drop service_principals
 drop table service_principals;
 drop sequence SERVICE_PRINCIPALS_ID_SEQ;
 update configurations set value='3.1.57' where property='DATABASE VERSION';


### PR DESCRIPTION
- We do not allow SQL comments in the changelog body.
- Fixed version in comment of test-schema.sql.