### PR TITLE
Overload method authorized

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -20,6 +20,7 @@ import cz.metacentrum.perun.core.impl.AuthzRoles;
 import cz.metacentrum.perun.core.impl.Privileges;
 import cz.metacentrum.perun.core.impl.Utils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -51,6 +52,23 @@ public class AuthzResolver {
 	public static boolean authorizedInternal(PerunSession sess, String policyDefinition, List<PerunBean> objects) {
 		try {
 			return AuthzResolverBlImpl.authorized(sess, policyDefinition, objects);
+		} catch (PolicyNotExistsException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	/**
+	 * Checks if the principal is authorized.
+	 * Used when there are no PerunBeans needed for authorization.
+	 * This method should be used in the internal code.
+	 *
+	 * @param sess PerunSession which contains the principal.
+	 * @param policyDefinition of policy which contains authorization rules.
+	 * @return true if the principal has particular rights, false otherwise.
+	 */
+	public static boolean authorizedInternal(PerunSession sess, String policyDefinition) {
+		try {
+			return AuthzResolverBlImpl.authorized(sess, policyDefinition, Collections.emptyList());
 		} catch (PolicyNotExistsException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/api/AuthzResolverIntegrationTest.java
@@ -47,8 +47,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 			perun,
 			new PerunPrincipal("pepa", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL),
 			new PerunClient()
-		), "default_policy",
-			Collections.emptyList()));
+		), "default_policy"));
 	}
 
 	@Test
@@ -63,7 +62,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 		PerunSession session = getHisSession(createdMember);
 		AuthzResolver.refreshAuthz(session);
 
-		assertTrue(AuthzResolver.authorizedInternal(session, "default_policy", Collections.emptyList()));
+		assertTrue(AuthzResolver.authorizedInternal(session, "default_policy"));
 	}
 
 	@Test
@@ -363,7 +362,7 @@ public class AuthzResolverIntegrationTest extends AbstractPerunIntegrationTest {
 
 		PerunSession session = getHisSession(createdMember);
 		AuthzResolver.refreshAuthz(session);
-		assertFalse(AuthzResolver.authorizedInternal(session, "test_security_admin", Arrays.asList()));
+		assertFalse(AuthzResolver.authorizedInternal(session, "test_security_admin"));
 
 	}
 


### PR DESCRIPTION
- Both methods authorizedInternal and authorizedExternal have overloaded
  version which does not take list of PerunBeans.
- It was created for scenarios, where there is no need to pass beans
  to autrhorization. It erase necessity to call the authorization with
  Collections.emptyList() argument.