### PR TITLE
marked most of Maven submodules as skipped during deploy

### DIFF
--- a/perun-auditparser/pom.xml
+++ b/perun-auditparser/pom.xml
@@ -19,45 +19,6 @@
 		<!-- common properties used by this module and all profiles -->
 	</properties>
 
-	<!-- COMMON BUILD SETTINGS USED BY ALL PROFILES -->
-	<build>
-
-		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-		</plugins>
-
-	</build>
-
 	<dependencies>
 
 		<!-- PERUN -->

--- a/perun-base/pom.xml
+++ b/perun-base/pom.xml
@@ -28,36 +28,6 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<executions>
 					<execution>

--- a/perun-cabinet/pom.xml
+++ b/perun-cabinet/pom.xml
@@ -26,31 +26,6 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<includes>

--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -24,37 +24,6 @@
 	<build>
 
 		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
 			<plugin>
 				<groupId>eu.somatik.serviceloader-maven-plugin</groupId>
 				<artifactId>serviceloader-maven-plugin</artifactId>

--- a/perun-dispatcher/pom.xml
+++ b/perun-dispatcher/pom.xml
@@ -23,48 +23,12 @@
 
 	<!-- COMMON BUILD SETTINGS USED BY ALL PROFILES -->
 	<build>
-
-		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-		</plugins>
-
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 			</resource>
 		</resources>
-
 	</build>
 
 

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -21,6 +21,8 @@
 		<start-class>cz.metacentrum.perun.engine.main.EngineStarter</start-class>
 		<!-- module properties used by all profiles -->
 		<perun.test.groups>unit-tests</perun.test.groups>
+		<!-- deploy the resulting jar to a Maven repo -->
+		<maven.deploy.skip>false</maven.deploy.skip>
 	</properties>
 
 	<!-- COMMON BUILD SETTINGS USED BY ALL PROFILES -->

--- a/perun-engine/pom.xml
+++ b/perun-engine/pom.xml
@@ -30,72 +30,12 @@
         <finalName>${project.name}</finalName>
 		<plugins>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-			<!-- Prepare META-INF/MANIFEST.MF entries for JAR file -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<configuration>
-					<archive>
-						<index>true</index>
-						<manifestEntries>
-							<SplashScreen-Image>perun-engine-splash.png</SplashScreen-Image>
-						</manifestEntries>
-					</archive>
-				</configuration>
-			</plugin>
-
 			<!-- Package JAR with Main class and all libraries -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<!-- Main-Class taken from property ${start-class} -->
 			</plugin>
-
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>java</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<mainClass>${start-class}</mainClass>
-				</configuration>
-			</plugin>
-
 		</plugins>
 
 		<resources>

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -19,6 +19,8 @@
 
 	<properties>
 		<start-class>cz.metacentrum.perun.ldapc.main.LdapcStarter</start-class>
+		<!-- deploy the resulting jar to a Maven repo -->
+		<maven.deploy.skip>false</maven.deploy.skip>
 	</properties>
 
 	<!-- common build settings used by all profiles -->

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -28,57 +28,11 @@
 		<finalName>${project.name}</finalName>
 		<plugins>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
 			<!-- Package JAR with Main class and all libraries -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<!-- Main-Class taken from property ${start-class} -->
-			</plugin>
-
-			<!-- Executing plug-in:  mvn exec:java -->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>java</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<mainClass>${start-class}</mainClass>
-				</configuration>
 			</plugin>
 
 		</plugins>

--- a/perun-notification/pom.xml
+++ b/perun-notification/pom.xml
@@ -22,40 +22,6 @@
 
 	<!-- common module build settings used by all profiles -->
 	<build>
-		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-		</plugins>
-
 		<resources>
 			<resource>
 				<!-- exclude DB config files from final jar -->

--- a/perun-openapi/pom.xml
+++ b/perun-openapi/pom.xml
@@ -17,6 +17,11 @@
 	<name>perun-openapi</name>
 	<description>OpenAPI specification of Perun RPC API and its Java client</description>
 
+	<properties>
+		<!-- deploy the resulting jar to a Maven repo-->
+		<maven.deploy.skip>false</maven.deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<!-- generate a Java client from OpenAPI specification of Perun RPC API-->

--- a/perun-registrar-lib/pom.xml
+++ b/perun-registrar-lib/pom.xml
@@ -22,41 +22,6 @@
 
 	<!-- common module build setting used by all profile -->
 	<build>
-
-		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-		</plugins>
-
 		<resources>
 			<resource>
 				<!-- get common resources -->
@@ -64,7 +29,6 @@
 				<filtering>true</filtering>
 			</resource>
 		</resources>
-
 	</build>
 
 

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -24,45 +24,8 @@
 
 	<!-- common module build settings used by all profiles -->
 	<build>
+		<finalName>${project.name}</finalName>
 		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<artifactId>maven-war-plugin</artifactId>
-				<version>${maven-war-plugin.version}</version>
-				<configuration>
-					<warName>perun-rpc</warName>
-				</configuration>
-			</plugin>
 
 			<!-- Allow to run Perun locally in Tomcat container by command "mvn cargo:run"
 				Server is started at ajp://localhost:8009/perun-rpc/

--- a/perun-rpc/pom.xml
+++ b/perun-rpc/pom.xml
@@ -18,6 +18,8 @@
 
 	<properties>
 		<skipTests>true</skipTests>
+		<!-- deploy the resulting jar to a Maven repo -->
+		<maven.deploy.skip>false</maven.deploy.skip>
 	</properties>
 
 	<!-- common module build settings used by all profiles -->

--- a/perun-scim/pom.xml
+++ b/perun-scim/pom.xml
@@ -21,48 +21,12 @@
 
 	<!-- COMMON BUILD SETTINGS USED BY ALL PROFILES -->
 	<build>
-
-		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-		</plugins>
-
 		<resources>
 			<resource>
 				<!-- get common resources -->
 				<directory>src/main/resources</directory>
 			</resource>
 		</resources>
-
 	</build>
 
 	<dependencies>

--- a/perun-voot/pom.xml
+++ b/perun-voot/pom.xml
@@ -21,48 +21,12 @@
 
 	<!-- COMMON BUILD SETTINGS USED BY ALL PROFILES -->
 	<build>
-
-		<plugins>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
-		</plugins>
-
 		<resources>
 			<resource>
 				<!-- get common resources -->
 				<directory>src/main/resources</directory>
 			</resource>
 		</resources>
-
 	</build>
 
 	<dependencies>

--- a/perun-web-gui/pom.xml
+++ b/perun-web-gui/pom.xml
@@ -28,36 +28,6 @@
 		<finalName>${project.name}</finalName>
 		<plugins>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-clean-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-install-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
-
 			<!-- SVN version plugin provides ${buildNumber} property to GUI files -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,6 @@
 
 			<plugins>
 
-				<!-- mvn clean - cleans output folder (target) -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-clean-plugin</artifactId>
-				</plugin>
-
 				<!-- mvn compile - compile as Java 8 app in UTF-8 -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -114,12 +108,6 @@
 						<verbose>false</verbose>
 						<!--<compilerArgument>-Xlint:unchecked,deprecation</compilerArgument>-->
 					</configuration>
-				</plugin>
-
-				<!-- mvn install - build artifact and install it in local repository (.m2 folder) -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-install-plugin</artifactId>
 				</plugin>
 
 				<!-- mvn javadoc - creates javadoc from source (we do append spring javadoc if found) -->
@@ -134,24 +122,6 @@
 							<link>http://docs.spring.io/spring/docs/current/javadoc-api/</link>
 						</links>
 					</configuration>
-				</plugin>
-
-				<!-- mvn source:jar - packages sources -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-source-plugin</artifactId>
-				</plugin>
-
-				<!-- mvn jar:jar - creates final jar -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-jar-plugin</artifactId>
-				</plugin>
-
-				<!-- mvn jar:jar - creates final war -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-war-plugin</artifactId>
 				</plugin>
 
 				<!-- mvn shade - creates shaded jar (1 jar containing everything including dependencies) -->
@@ -175,18 +145,6 @@
 						<skip>false</skip>
 						<runOrder>alphabetical</runOrder>
 					</configuration>
-				</plugin>
-
-				<!-- Copy dependencies plug-in -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-dependency-plugin</artifactId>
-				</plugin>
-
-				<!-- Executing plug-in: mvn exec:java -->
-				<plugin>
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>exec-maven-plugin</artifactId>
 				</plugin>
 
 				<plugin>
@@ -268,41 +226,6 @@
 			</plugins>
 
 		</pluginManagement>
-
-		<plugins>
-			<!--
-			<plugin>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
-				<executions>
-					<execution>
-						<id>checkstyle</id>
-						<phase>compile</phase>
-						<goals>
-							<goal>checkstyle</goal>
-						</goals>
-						<configuration>
-							<failsOnError>false</failsOnError>
-						</configuration>
-					</execution>
-				</executions>
-				<configuration>
-					<configLocation>checkstyle.xml</configLocation>
-					<consoleOutput>true</consoleOutput>
-					<failsOnError>true</failsOnError>
-					<includes>**/*</includes>
-					<resourceIncludes>**/*</resourceIncludes>
-					<sourceDirectories>
-						<sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-						<sourceDirectory>./perun-utils</sourceDirectory>
-						<sourceDirectory>./perun-apps</sourceDirectory>
-						<sourceDirectory>./perun-php</sourceDirectory>
-						<sourceDirectory>./perun-cli</sourceDirectory>
-					</sourceDirectories>
-				</configuration>
-			</plugin>
-			-->
-		</plugins>
 	</build>
 
 	<!-- DEFAULT MAVEN DEPENDENCY SETTINGS

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+		<!-- "mvn deploy" should not deploy subprojects to a Maven repo by default,
+		     exceptions (perun-rpc, perun-openapi) are marked by the value "false" -->
+		<maven.deploy.skip>true</maven.deploy.skip>
+
 		<!-- macros @perun.conf@ @perun.jdbc@ etc replaced in all filtered resources in /src/main/resources during maven build-->
 		<perun.conf>/etc/perun/</perun.conf>
 		<perun.jdbc>file:${perun.conf}jdbc.properties</perun.jdbc>


### PR DESCRIPTION
most of Maven submodules are separate just for organization purposes, only perun-rpc and perun-openapi may need to be deployed