### PR TITLE
New authorization in MembersManagerEntry

### DIFF
--- a/perun-base/src/test/resources/perun-roles.yml
+++ b/perun-base/src/test/resources/perun-roles.yml
@@ -1578,6 +1578,563 @@ perun_policies:
     include_policies:
       - default_policy
 
+  #MembersManagerEntry
+  deleteMember_Member_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  deleteMembers_List<Member>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  deleteAllMembers_Vo_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  createSpecificMember_Vo_Candidate_List<User>_SpecificUserType_List<Group>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  createMember_Vo_Candidate_List<Group>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  createMember_Vo_String_String_String_Candidate_List<Group>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  createMember_Vo_String_String_int_String_Candidate_List<Group>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  createMember_Vo_User_List<Group>_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  createMember_Vo_ExtSource_String_List<Group>_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getMemberByUserExtSource_Vo_UserExtSource_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getMemberById_int_policy:
+    policy_roles:
+      - RPC:
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getMemberByUser_Vo_User_policy:
+    policy_roles:
+      - SELF: User
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getMembersByUser_User_policy:
+    policy_roles:
+      - SELF: User
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getMembers_Vo_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getMembers_Vo_Status_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMemberById_int_policy:
+    policy_roles:
+      - SELF: User
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMemberWithAttributes_Member_policy:
+    policy_roles:
+      - SELF: User
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembersWithAttributes_Vo_List<AttributeDefinition>_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembersWithAttributes_List<String>_Group_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembersWithAttributesByNames_Vo_List<String>_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getCompleteRichMembers_Vo_List<String>_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getCompleteRichMembers_Vo_List<String>_List<String>_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getCompleteRichMembers_Group_List<String>_boolean_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getCompleteRichMembers_Group_Resource_List<String>_List<String>_policy:
+    policy_roles:
+      - ENGINE:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  getCompleteRichMembers_Group_List<String>_List<String>_boolean_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findCompleteRichMembers_Vo_List<String>_String_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findCompleteRichMembers_Vo_List<String>_List<String>_String_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findCompleteRichMembers_List<String>_List<String>_String_policy:
+    policy_roles:
+      - FACILITYADMIN:
+      - GROUPADMIN:
+      - PERUNOBSERVER:
+      - VOOBSERVER:
+      - VOADMIN:
+    include_policies:
+      - default_policy
+
+  filter-findCompleteRichMembers_List<String>_List<String>_String_policy:
+    policy_roles:
+      - FACILITYADMIN: Facility
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+
+  findCompleteRichMembers_Group_List<String>_String_boolean_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findCompleteRichMembers_Group_List<String>_List<String>_String_boolean_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembersWithAttributesByNames_Group_List<String>_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembersWithAttributes_Group_List<AttributeDefinition>_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembers_Group_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembers_Vo_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembers_Vo_Status_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembersWithAttributes_Vo_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getRichMembersWithAttributes_Vo_Status_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getMembersCount_Vo_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getMembersCount_Vo_Status_policy:
+    policy_roles:
+      - GROUPADMIN: Vo
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findMembersByName_String_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  findMembersByNameInVo_Vo_String_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  findMembersInVo_Vo_String_policy:
+    policy_roles:
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+      - PERUNOBSERVER:
+    include_policies:
+      - default_policy
+
+  findMembersInGroup_Group_String_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findRichMembersWithAttributesInGroup_Group_String_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findMembersInParentGroup_Group_String_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findRichMembersWithAttributesInParentGroup_Group_String_policy:
+    policy_roles:
+      - GROUPADMIN: Group
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findRichMembersInVo_Vo_String_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  findRichMembersWithAttributesInVo_Vo_String_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  setStatus_Member_Status_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  setStatus_Member_Status_String_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  suspendMemberTo_Member_Date_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  unsuspendMember_Member_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  validateMemberAsync_Member_policy:
+    policy_roles:
+      - SELF: User
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  extendMembership_Member_policy:
+    policy_roles:
+      - SELF: User
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  canExtendMembership_Member_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - SELF: User
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+    include_policies:
+      - default_policy
+
+  canExtendMembershipWithReason_Member_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - SELF: User
+      - VOADMIN: Vo
+      - VOOBSERVER: Vo
+    include_policies:
+      - default_policy
+
+  canBeMember_Vo_User_String_policy:
+    policy_roles:
+      - SELF: User
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  canBeMemberWithReason_Vo_User_String_policy:
+    policy_roles:
+      - SELF: User
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getMemberByExtSourceNameAndExtLogin_Vo_String_String_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - VOOBSERVER: Vo
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  sendPasswordResetLinkEmail_Member_String_String_String_String_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  createSponsoredMember_Vo_String_Map<String_String>_String_User_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  setSponsorshipForMember_Member_User_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  unsetSponsorshipForMember_Member_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  sponsorMember_Member_User_policy:
+    policy_roles:
+      - VOADMIN:
+    include_policies:
+      - default_policy
+
+  getSponsoredMembers_Vo_User_List<String>_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - REGISTRAR:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getSponsoredMembers_Vo_User_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - REGISTRAR:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  getSponsoredMembers_Vo_policy:
+    policy_roles:
+      - PERUNOBSERVER:
+      - REGISTRAR:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  extendExpirationForSponsoredMember_Member_User_policy:
+    policy_roles:
+      - REGISTRAR:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
+  removeSponsor_Member_User_policy:
+    policy_roles:
+      - VOADMIN: Vo
+    include_policies:
+      - default_policy
+
   #OwnersManagerEntry
   createOwner_Owner_policy:
     policy_roles: []

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -1246,7 +1246,7 @@ public interface MembersManager {
 	 * @throws PrivilegeException if not REGISTRAR or VOADMIN
 	 * @return list of members from given VO who are sponsored by the given user.
 	 */
-	List<RichMember> getSponsoredMembers(PerunSession sess, Vo vo, User user) throws PrivilegeException;
+	List<RichMember> getSponsoredMembers(PerunSession sess, Vo vo, User user) throws PrivilegeException, VoNotExistsException, UserNotExistsException;
 
 	/**
 	 * Gets list of sponsored members of a VO.
@@ -1256,7 +1256,7 @@ public interface MembersManager {
 	 * @throws PrivilegeException if not REGISTRAR or VOADMIN
 	 * @return list of members from given VO who are sponsored
 	 */
-	List<RichMember> getSponsoredMembers(PerunSession sess, Vo vo) throws PrivilegeException;
+	List<RichMember> getSponsoredMembers(PerunSession sess, Vo vo) throws PrivilegeException, VoNotExistsException;
 
 	/**
 	 * Extends expiration date. Sponsored members cannot apply for membership extension, this method allows a sponsor to extend it.
@@ -1267,7 +1267,7 @@ public interface MembersManager {
 	 * @throws PrivilegeException if not REGISTRAR or VOADMIN
 	 * @return new expiration date
 	 */
-	String extendExpirationForSponsoredMember(PerunSession session, Member sponsored, User sponsor) throws PrivilegeException;
+	String extendExpirationForSponsoredMember(PerunSession session, Member sponsored, User sponsor) throws PrivilegeException, MemberNotExistsException, UserNotExistsException;
 
 	/**
 	 * Removes the sponsor.


### PR DESCRIPTION
- In MembersManagerEntry was completely replaced the old authorization.
- For that purpose was updated also perun-roles.yml file with the
  policies used in the MembersManagerEntry.
- All PerunBeans which are passed to the methods and already exist in
  Perun are passed also to the authorization, even when a policy does not
  need them for now. It does not have any effect on the policy evaluation.
  It erase the necessity to change these methods if the policy will change
  in the future.
- removeSponsor is still using method isUserInRoleForVo,
  because it provides authorization against a user not a session.