### PR TITLE
isAuthorized method Deprecated

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -83,6 +83,7 @@ public class AuthzResolver {
 	 * @return true if the principal authorized, false otherwise
 	 * @throws InternalErrorException if something goes wrong
 	 */
+	@Deprecated
 	public static boolean isAuthorized(PerunSession sess, String role, PerunBean complementaryObject) {
 		if (!roleExists(role)) {
 			throw new InternalErrorException("Role: "+ role +" does not exists.");
@@ -347,6 +348,7 @@ public class AuthzResolver {
 	 * @return true if the principal authorized, false otherwise
 	 * @throws InternalErrorException if something goes wrong
 	 */
+	@Deprecated
 	public static boolean isAuthorized(PerunSession sess, String role) {
 		if (!roleExists(role)) {
 			throw new InternalErrorException("Role: "+ role +" does not exists.");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -139,6 +139,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * @return true if the principal authorized, false otherwise
 	 * @throws InternalErrorException if something goes wrong
 	 */
+	@Deprecated
 	public static boolean isAuthorized(PerunSession sess, String role, PerunBean complementaryObject) {
 		log.trace("Entering isAuthorized: sess='" + sess + "', role='" + role + "', complementaryObject='" + complementaryObject + "'");
 		Utils.notNull(sess, "sess");
@@ -931,6 +932,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	 * @return true if the principal authorized, false otherwise
 	 * @throws InternalErrorException if something goes wrong
 	 */
+	@Deprecated
 	public static boolean isAuthorized(PerunSession sess, String role) {
 		return isAuthorized(sess, role, null);
 	}


### PR DESCRIPTION
- Method isAuthorized() was deprecated because of the new authorization logic,
  which is evaluated through the method authorizedInternal().