### PR TITLE
getUserExtSourceFromMultipleIdentifiers can't return null

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -725,6 +725,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 				throw new InternalErrorException(errorMessage, ex);
 			}
 		}
+		if(ues == null) throw new UserExtSourceNotExistsException("User ext source was not found. Searched value is any from \"" + additionalIdentifiers + "\" in " + additionalIdentifiersPerunAttributeName);
 		return ues;
 	}
 


### PR DESCRIPTION
UserUsersManagerBl.getUserExtSourceFromMultipleIdentifiers should never
return null, according to javadoc. Previous implementation returned null
when the UserExtSource was not found. That caused NullPointerException
later in the code.