### PR TITLE
getUserExtSourceFromMultipleIdentifiers null

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -512,15 +512,14 @@ public interface UsersManagerBl {
 
 	/**
 	 * Iteratively searches through additional identifiers trying to find userExtSource with the same identifier.
-	 * Returns first found userExtSource or null when no matching userExtSource found.
+	 * Returns first found userExtSource or throw an exception when no matching userExtSource is found.
 	 *
 	 * @param sess PerunSession to retrieve UserExtSource
 	 * @param principal PerunPrincipal which contains additionalIdentifiers
 	 *
-	 * @return UserExtSource found using additionalIdentifiers or null
+	 * @return UserExtSource found using additionalIdentifiers
 	 *
-	 * @throws InternalErrorException When attribute is not defined in Perun
-	 * @throws UserExtSourceNotExistsException When the multiple identifiers received are actually empty
+	 * @throws UserExtSourceNotExistsException When no matching userExtSource is found
 	 */
 	UserExtSource getUserExtSourceFromMultipleIdentifiers(PerunSession sess, PerunPrincipal principal) throws InternalErrorException, UserExtSourceNotExistsException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -706,10 +706,10 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	}
 
 	@Override
-	public UserExtSource getUserExtSourceFromMultipleIdentifiers(PerunSession sess, PerunPrincipal principal) throws InternalErrorException, UserExtSourceNotExistsException {
+	public UserExtSource getUserExtSourceFromMultipleIdentifiers(PerunSession sess, PerunPrincipal principal) throws UserExtSourceNotExistsException {
 		String additionalIdentifiers = principal.getAdditionalInformations().get(additionalIdentifiersAttributeName);
 		if (additionalIdentifiers == null) {
-			throw new UserExtSourceNotExistsException("Mandatory attribute is not defined: ".concat(additionalIdentifiersAttributeName));
+			throw new InternalErrorException("Entry " + additionalIdentifiersAttributeName + " is not defined in the principal's additional information. Either it was not provided by external source used for sign-in or the mapping configuration is wrong.");
 		}
 		UserExtSource ues = null;
 		for(String identifier : additionalIdentifiers.split(multivalueAttributeSeparatorRegExp)) {
@@ -719,12 +719,13 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 				break;
 			} catch (UserExtSourceNotExistsException ex) {
 				//try to find user ext source using different identifier in the next iteration of for cycle
-			} catch (InternalErrorException | AttributeNotExistsException ex) {
+			} catch (AttributeNotExistsException ex) {
 				String errorMessage = "Mandatory attribute is not defined: ".concat(additionalIdentifiersPerunAttributeName);
 				log.error(errorMessage);
 				throw new InternalErrorException(errorMessage, ex);
 			}
 		}
+		if (ues == null) throw new UserExtSourceNotExistsException("User ext source was not found. Searched value is any from \"" + additionalIdentifiers + "\" in " + additionalIdentifiersPerunAttributeName);
 		return ues;
 	}
 


### PR DESCRIPTION
- Previous implementation of the method returned null
  when the UserExtSource was not found. That caused NullPointerException
  later in the method getUserByUserExtSource which was called by the method
  getPerunSession.
- Therefore, the method getUserExtSourceFromMultipleIdentifiers was changed
  to throw the UserExtSourceNotExistException when the UserExtSource was not found.
- In this method was also check for null additionalIdentifiers, which was throwing
  the UserExtSourceNotExistsException. This exception was replaced by the
  WrongReferenceAttributeValueException, which is usually used when an attribute
  is null and it cannot be null. The exception is catched in getPerunSession same as
  the USerExtSourceNotExistsException so the behaviour will not change.