### PR TITLE
eduTEAMS fenix extSourceName and domainName

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -78,6 +78,8 @@ public class CoreConfig {
 	private String smtpUser;
 	private String smtpPass;
 	private List<String> autocreatedNamespaces;
+	private String extSourceNameFenix;
+	private String domainNameFenix;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -638,5 +640,21 @@ public class CoreConfig {
 
 	public void setQueryTimeout(int queryTimeout) {
 		this.queryTimeout = queryTimeout;
+	}
+
+	public void setExtSourceNameFenix(String extSourceNameFenix) {
+		this.extSourceNameFenix = extSourceNameFenix;
+	}
+
+	public String getExtSourceNameFenix() {
+		return extSourceNameFenix;
+	}
+
+	public void setDomainNameFenix(String domainNameFenix) {
+		this.domainNameFenix = domainNameFenix;
+	}
+
+	public String getDomainNameFenix() {
+		return domainNameFenix;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -62,6 +62,8 @@
 		<property name="autocreatedNamespaces" value="#{'${perun.autocreatedNamespaces}'.split('\s*,\s*')}" />
 		<property name="rtSendToMail" value="${perun.rt.sendToMail}" />
 		<property name="queryTimeout" value="${perun.queryTimeout}" />
+		<property name="extSourceNameFenix" value="${perun.extSourceNameFenix}" />
+		<property name="domainNameFenix" value="${perun.domainNameFenix}" />
 	</bean>
 
 
@@ -123,6 +125,8 @@
 				<prop key="perun.allowedCorsDomains"></prop>
 				<prop key="perun.cacheEnabled">false</prop>
 				<prop key="perun.queryTimeout">-1</prop>
+				<prop key="perun.extSourceNameFenix"/>
+				<prop key="perun.domainNameFenix"/>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.attributes;
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
@@ -21,8 +22,8 @@ import org.slf4j.LoggerFactory;
 public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow extends urn_perun_user_attribute_def_def_login_namespace {
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow.class);
-	private final static String extSourceNameFenix = "https://proxy-fenix.pilot.eduteams.org/proxy";
-	private final static String domainNameFenix = "@fenix.pilot.eduteams.org";
+	private final static String extSourceNameFenix = BeansUtils.getCoreConfig().getExtSourceNameFenix();
+	private final static String domainNameFenix = BeansUtils.getCoreConfig().getDomainNameFenix();
 	private final static String attrNameFenix = "login-namespace:fenix-persistent-shadow";
 
 	/**
@@ -38,10 +39,15 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_s
 	@Override
 	public Attribute fillAttribute(PerunSessionImpl perunSession, User user, AttributeDefinition attribute) throws InternalErrorException {
 
+		if (domainNameFenix == null || domainNameFenix.isEmpty()) {
+			throw new InternalErrorException("The value of variable domainNameFenix is null or empty due to the wrong mapping configuration.");
+		}
+		String domain = "@" + domainNameFenix;
+
 		Attribute filledAttribute = new Attribute(attribute);
 
 		if (attribute.getFriendlyName().equals(attrNameFenix)) {
-			filledAttribute.setValue(sha1HashCount(user, domainNameFenix).toString() + domainNameFenix);
+			filledAttribute.setValue(sha1HashCount(user, domain).toString() + domain);
 			return filledAttribute;
 		} else {
 			// without value
@@ -66,6 +72,10 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_s
 			String userNamespace = attribute.getFriendlyNameParameter();
 
 			if(userNamespace.equals("fenix-persistent-shadow") && attribute.getValue() != null){
+				if (extSourceNameFenix == null || extSourceNameFenix.isEmpty()) {
+					throw new InternalErrorException("The value of variable extSourceNameFenix is null or empty due to the wrong mapping configuration.");
+				}
+
 				ExtSource extSource = session.getPerunBl().getExtSourcesManagerBl().getExtSourceByName(session, extSourceNameFenix);
 				UserExtSource userExtSource = new UserExtSource(extSource, 0, attribute.getValue().toString());
 
@@ -85,7 +95,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_s
 		attr.setDisplayName("FENIX login");
 		attr.setType(String.class.getName());
 		attr.setDescription("Login for FENIX. Do not use it directly! " +
-				"Use \"user:virt:login-namespace:fenix-persistent\" attribute instead.");
+			"Use \"user:virt:login-namespace:fenix-persistent\" attribute instead.");
 		return attr;
 	}
 


### PR DESCRIPTION
- Added support to configure extSourceName and domainName properties,
  which are used in the module urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow
  because they are different for fenix and fenix-pilot instances.