### PR TITLE
LDAPC: Use different transaction isolation for LDAP on replica

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/LdapProperties.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/LdapProperties.java
@@ -9,12 +9,14 @@ public class LdapProperties {
 	private String ldapBase;
 	private String ldapLoginNamespace;
 	private String ldapStateFile;
+	private boolean isReplica = false;
 
-	public LdapProperties(String ldapConsumerName, String ldapBase, String ldapLoginNamespace, String ldapStateFile) {
+	public LdapProperties(String ldapConsumerName, String ldapBase, String ldapLoginNamespace, String ldapStateFile, String isReplica) {
 		this.ldapConsumerName = ldapConsumerName;
 		this.ldapBase = ldapBase;
 		this.ldapLoginNamespace = ldapLoginNamespace;
 		this.ldapStateFile = ldapStateFile;
+		this.isReplica = Boolean.parseBoolean(isReplica);
 	}
 
 	public boolean propsLoaded() {
@@ -36,4 +38,9 @@ public class LdapProperties {
 	public String getLdapStateFile() {
 		return ldapStateFile;
 	}
+
+	public boolean isReplica() {
+		return isReplica;
+	}
+
 }

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/main/LdapcStarter.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/main/LdapcStarter.java
@@ -73,7 +73,13 @@ public class LdapcStarter {
 
 			// Synchronize before starting the audit consumer
 			if (doSync)
-				ldapcStarter.ldapcManager.synchronize();
+				if (ldapcStarter.ldapProperties.isReplica()) {
+					// use REPEATABLE_READ sync
+					ldapcStarter.ldapcManager.synchronizeReplica();
+				} else {
+					// use SERIALIZED
+					ldapcStarter.ldapcManager.synchronize();
+				}
 			else {
 
 				//Set lastProcessedIdToSet if bigger than 0

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/LdapcManager.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/LdapcManager.java
@@ -17,7 +17,19 @@ public interface LdapcManager {
 	 */
 	void stopProcessingEvents();
 
+	/**
+	 * Synchronize Perun into LDAP using consistent data (SERIALIZABLE transaction)
+	 *
+	 * @throws InternalErrorException When implementation fails
+	 */
 	void synchronize() throws InternalErrorException;
+
+	/**
+	 * Synchronize Perun in LDAP (replica) using possibly inconsistent data (REPEATABLE_READ transaction).
+	 *
+	 * @throws InternalErrorException When implementation fails
+	 */
+	void synchronizeReplica() throws InternalErrorException;
 
 	public Perun getPerunBl();
 

--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/impl/LdapcManagerImpl.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/service/impl/LdapcManagerImpl.java
@@ -74,6 +74,11 @@ public class LdapcManagerImpl implements LdapcManager {
 		}
 	}
 
+	public void synchronizeReplica() throws InternalErrorException {
+		// let original method to do the work under our transaction settings
+		synchronize();
+	}
+
 	public Perun getPerunBl() {
 		return perunBl;
 	}

--- a/perun-ldapc/src/main/resources/perun-ldapc.xml
+++ b/perun-ldapc/src/main/resources/perun-ldapc.xml
@@ -27,11 +27,19 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 	<aop:config>
 		<aop:advisor advice-ref="txCommonSerialized"
 		             pointcut="execution(* cz.metacentrum.perun.ldapc.service.LdapcManager.synchronize(..))"/>
+		<aop:advisor advice-ref="txCommonRepeatable"
+		             pointcut="execution(* cz.metacentrum.perun.ldapc.service.LdapcManager.synchronizeReplica(..))"/>
 	</aop:config>
 
 	<tx:advice id="txCommonSerialized" transaction-manager="perunTransactionManager">
 		<tx:attributes>
 			<tx:method name="*" rollback-for="Exception" isolation="SERIALIZABLE"/>
+		</tx:attributes>
+	</tx:advice>
+
+	<tx:advice id="txCommonRepeatable" transaction-manager="perunTransactionManager">
+		<tx:attributes>
+			<tx:method name="*" rollback-for="Exception" isolation="REPEATABLE_READ"/>
 		</tx:attributes>
 	</tx:advice>
 
@@ -1082,6 +1090,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		<constructor-arg name="ldapBase" index="1" value="${ldap.base}"/>
 		<constructor-arg name="ldapLoginNamespace" index="2" value="${ldap.loginNamespace}"/>
 		<constructor-arg name="ldapStateFile" index="3" value="${ldap.stateFile}"/>
+		<constructor-arg name="isReplica" index="4" value="${ldap.isReplica}"/>
 	</bean>
 
 	<!-- These beans are for define ldapTemplate -->


### PR DESCRIPTION
- Transaction isolation level is now configurable for full LDAP sync
  (initialization). On hot stand_by replica we can't use SERIALIZED
  level, hence we have different method which uses
  default REPEATABLE_READ level.
  Usage of proper method is determined by new config option
  ldap.isReplica with true/false values. False is the default.