### PR TITLE
Fix problem with creating a group union

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -4161,7 +4161,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 
 		// check indirect relationships (for example "A" with "A:B:C" are in indirect relationship using "A:B")
 		// looking for situation where result group is predecessor of operand group (by name) but not a parent of it (which is ok)
-		if(!parentFlag && operandGroup.getName().startsWith(resultGroup.getName())) {
+		if(!parentFlag && operandGroup.getName().startsWith(resultGroup.getName() + ":")) {
 			throw new GroupRelationNotAllowed("There is an indirect relationship between result group " + resultGroup +
 					" and operand group " + operandGroup);
 		}


### PR DESCRIPTION
- there was a problem when two groups (for example 'A' and 'AB' was incorrectly checked as predecessors. Only prefix of groups should be test there
- for this reason, we need to set result group as the full prefix using ':' character on it's name end
