### PR TITLE
CORE: Throw AlreadyAdminException in makeUserPerunAdmin()

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AlreadyAdminException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/AlreadyAdminException.java
@@ -55,6 +55,19 @@ public class AlreadyAdminException extends PerunException {
 	}
 
 	/**
+	 * Constructor with a message, Throwable object, user and role
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 * @param user user who is already in the role
+	 * @param role the role in which the user already is
+	 */
+	public AlreadyAdminException(String message, Throwable cause, User user, String role) {
+		super(message, cause);
+		this.user = user;
+		this.role = role;
+	}
+
+	/**
 	 * Constructor with a message, Throwable object, user, vo and role
 	 * @param message message with details about the cause
 	 * @param cause Throwable that caused throwing of this exception
@@ -153,6 +166,19 @@ public class AlreadyAdminException extends PerunException {
 		super(user.toString());
 		this.user = user;
 		this.vo = vo;
+	}
+
+	/**
+	 * Constructor with a message, Throwable object, authorized group and role
+	 * @param message message with details about the cause
+	 * @param cause Throwable that caused throwing of this exception
+	 * @param authorizedGroup group which is already in the specific role
+	 * @param role the role in which the group already is
+	 */
+	public AlreadyAdminException(String message, Throwable cause, Group authorizedGroup, String role) {
+		super(message, cause);
+		this.authorizedGroup = authorizedGroup;
+		this.role = role;
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1123,11 +1123,12 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 	/**
 	 * Make user to be PERUNADMIN!
 	 *
-	 * @param sess
+	 * @param sess PerunSession with authorization
 	 * @param user which will get role "PERUNADMIN" in the system
-	 * @throws InternalErrorException
+	 * @throws InternalErrorException When implementation fails
+	 * @throws AlreadyAdminException When user is already perun admin
 	 */
-	public static void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException {
+	public static void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException, AlreadyAdminException {
 		getPerunBl().getAuditer().log(sess, new UserPromotedToPerunAdmin(user));
 		authzResolverImpl.makeUserPerunAdmin(sess, user);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AuthzResolverImpl.java
@@ -512,27 +512,33 @@ public class AuthzResolverImpl implements AuthzResolverImplApi {
 	}
 
 	@Override
-	public void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException {
+	public void makeUserPerunAdmin(PerunSession sess, User user) throws AlreadyAdminException, InternalErrorException {
 		try {
 			jdbc.update("insert into authz (user_id, role_id) values (?, (select id from roles where name=?))", user.getId(), Role.PERUNADMIN.toLowerCase());
+		} catch (DataIntegrityViolationException e) {
+			throw new AlreadyAdminException("User id=" + user.getId() + " is already perun admin", e, user, Role.PERUNADMIN);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public void makeUserPerunObserver(PerunSession sess, User user) throws InternalErrorException {
+	public void makeUserPerunObserver(PerunSession sess, User user) throws AlreadyAdminException, InternalErrorException {
 		try {
 			jdbc.update("insert into authz (user_id, role_id) values (?, (select id from roles where name=?))", user.getId(), Role.PERUNOBSERVER.toLowerCase());
+		} catch (DataIntegrityViolationException e) {
+			throw new AlreadyAdminException("User id=" + user.getId() + " is already perun observer", e, user, Role.PERUNOBSERVER);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public void makeAuthorizedGroupPerunObserver(PerunSession sess, Group authorizedGroup) throws InternalErrorException {
+	public void makeAuthorizedGroupPerunObserver(PerunSession sess, Group authorizedGroup) throws AlreadyAdminException, InternalErrorException {
 		try {
 			jdbc.update("insert into authz (authorized_group_id, role_id) values (?, (select id from roles where name=?))", authorizedGroup.getId(), Role.PERUNOBSERVER.toLowerCase());
+		} catch (DataIntegrityViolationException e) {
+			throw new AlreadyAdminException("Group id=" + authorizedGroup.getId() + " is already perun observer", e, authorizedGroup, Role.PERUNOBSERVER);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/AuthzResolverImplApi.java
@@ -303,7 +303,7 @@ public interface AuthzResolverImplApi {
 	 * @param user
 	 * @throws InternalErrorException
 	 */
-	void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException;
+	void makeUserPerunAdmin(PerunSession sess, User user) throws InternalErrorException, AlreadyAdminException;
 
 	/**
 	 * Make user Perun observer
@@ -312,7 +312,7 @@ public interface AuthzResolverImplApi {
 	 * @param user user to be promoted to perunObserver
 	 * @throws InternalErrorException
 	 */
-	void makeUserPerunObserver(PerunSession sess, User user) throws InternalErrorException;
+	void makeUserPerunObserver(PerunSession sess, User user) throws InternalErrorException, AlreadyAdminException;
 
 	/**
 	 * Make group Perun observer
@@ -321,7 +321,7 @@ public interface AuthzResolverImplApi {
 	 * @param authorizedGroup authorizedGroup to be promoted to perunObserver
 	 * @throws InternalErrorException
 	 */
-	void makeAuthorizedGroupPerunObserver(PerunSession sess, Group authorizedGroup) throws InternalErrorException;
+	void makeAuthorizedGroupPerunObserver(PerunSession sess, Group authorizedGroup) throws InternalErrorException, AlreadyAdminException;
 
 	/**
 	 * Remove role perunAdmin for user.


### PR DESCRIPTION
- When we assign role to the user/group, we throw AlreadyAdminException
  if user is already in the role. This logic was missing from
  makeUserPerunAdmin() method and also makeUserPerunObserver()
  and makeGroupPerunObserver().
- Now implementation of all methods is aligned.
- Added new constructors to AlreadyAdminException object.