### PR TITLE
CORE: Fixed getMemberRichGroupsWithAttributesByNames()

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1245,7 +1245,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		parameters.addValue("nSO", AttributesManager.NS_MEMBER_GROUP_ATTR_OPT);
 		parameters.addValue("nSD", AttributesManager.NS_MEMBER_GROUP_ATTR_DEF);
 		parameters.addValue("nSV", AttributesManager.NS_MEMBER_GROUP_ATTR_VIRT);
-		parameters.addValue("attrNames", controlledAttrNames);
+		parameters.addValue("attrNames", attrNames);
 
 		try {
 			return namedParameterJdbcTemplate.query("select " + getAttributeMappingSelectQuery("mem_gr") + " from attr_names " +


### PR DESCRIPTION
- We must pass original (non empty) list of attr names
  to method retrieving member-group attributes, even if
  they are not of correct namespace, since SQL expect
  non empty input.
- Only correct member-group attributes are retrieved by the
  nature of SQL conditions.