### PR TITLE
LDAPC: Fill all attribute values in MapEntryValueTransformer

### DIFF
--- a/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/MapEntryValueTransformer.java
+++ b/perun-ldapc/src/main/java/cz/metacentrum/perun/ldapc/beans/MapEntryValueTransformer.java
@@ -25,6 +25,7 @@ public class MapEntryValueTransformer extends ValueTransformerBase implements At
 		int i = 0;
 		for (Map.Entry<String, String> entry : value.entrySet()) {
 			result[i] = entry.getKey() + this.separator + entry.getValue();
+			i++;
 		}
 		return result;
 	}


### PR DESCRIPTION
- We didn't increment iterator used to fill String array for
  multivalued attributes in LDAP. It resulted in pushing only
  single key=value pair to the LDAP.