### PR TITLE
New authorization in AuthzResolver

### DIFF
--- a/perun-base/src/test/resources/perun-roles.yml
+++ b/perun-base/src/test/resources/perun-roles.yml
@@ -168,6 +168,68 @@ perun_policies:
     include_policies:
       - test_resource_admin
 
+  #AuditMessagesManagerEntry
+  pollConsumerMessages_String_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  pollConsumerMessages_String_int_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  pollConsumerEvents_String_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  pollConsumerEvents_String_int_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  createAuditerConsumer_String_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  log_String_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  setLastProcessedId_String_int_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  #AuthzResolver
+  getUserRoleNames_User_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  getUserRoles_int_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  getGroupRoleNames_Group_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  getGroupRoles_int_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
+  loadAuthorizationComponents_policy:
+    policy_roles: []
+    include_policies:
+      - default_policy
+
   #DatabaseManagerEntry
   getCurrentDatabaseVersion_policy:
     policy_roles:

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -466,9 +466,13 @@ public class AuthzResolver {
 	 * @return list of strings, which represents roles.
 	 */
 	public static List<String> getUserRoleNames(PerunSession sess, User user) throws UserNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
 		((PerunBl) sess.getPerun()).getUsersManagerBl().checkUserExists(sess, user);
 
-		if (!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method getUserRoleNames.");
+		//Authorization
+		if (!authorizedInternal(sess, "getUserRoleNames_User_policy"))
+			throw new PrivilegeException("getUserRoleNames.");
+
 		return AuthzResolverBlImpl.getUserRoleNames(sess, user);
 	}
 
@@ -482,9 +486,13 @@ public class AuthzResolver {
 	 * @return AuthzRoles object which contains all roles with perunbeans
 	 */
 	public static AuthzRoles getUserRoles(PerunSession sess, int userId) throws UserNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
 		User user = ((PerunBl) sess.getPerun()).getUsersManagerBl().getUserById(sess, userId);
 
-		if (!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method getUserRoles.");
+		//Authorization
+		if (!authorizedInternal(sess, "getUserRoles_int_policy"))
+			throw new PrivilegeException("getUserRoles.");
+
 		return AuthzResolverBlImpl.getUserRoles(sess, user);
 	}
 
@@ -498,9 +506,13 @@ public class AuthzResolver {
 	 * @return list of strings, which represents roles.
 	 */
 	public static List<String> getGroupRoleNames(PerunSession sess, Group group) throws GroupNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
 		((PerunBl) sess.getPerun()).getGroupsManagerBl().checkGroupExists(sess, group);
 
-		if (!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method getGroupRoleNames.");
+		//Authorization
+		if (!authorizedInternal(sess, "getGroupRoleNames_Group_policy"))
+			throw new PrivilegeException("getGroupRoleNames.");
+
 		return cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl.getGroupRoleNames(sess, group);
 	}
 
@@ -514,9 +526,13 @@ public class AuthzResolver {
 	 * @return AuthzRoles object which contains all roles with perunbeans
 	 */
 	public static AuthzRoles getGroupRoles(PerunSession sess, int groupId) throws GroupNotExistsException, PrivilegeException {
+		Utils.checkPerunSession(sess);
 		Group group = ((PerunBl) sess.getPerun()).getGroupsManagerBl().getGroupById(sess, groupId);
 
-		if (!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException("You are not privileged to use this method getGroupRoles.");
+		//Authorization
+		if (!authorizedInternal(sess, "getGroupRoles_int_policy"))
+			throw new PrivilegeException("getGroupRoles.");
+
 		return AuthzResolverBlImpl.getGroupRoles(sess, group);
 	}
 
@@ -1031,7 +1047,12 @@ public class AuthzResolver {
 	 * @throws PrivilegeException when the principal is not authorized.
 	 */
 	public static void loadAuthorizationComponents(PerunSession sess) throws PrivilegeException {
-		if (!isAuthorized(sess, Role.PERUNADMIN)) throw new PrivilegeException(sess, "loadAuthorizationComponents");
+		Utils.checkPerunSession(sess);
+
+		//Authorization
+		if (!authorizedInternal(sess, "loadAuthorizationComponents_policy"))
+			throw new PrivilegeException(sess, "loadAuthorizationComponents");
+
 		AuthzResolverBlImpl.loadAuthorizationComponents();
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -139,7 +139,7 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		String principalShibIdentityProvider = sess.getPerunPrincipal().getAdditionalInformations().get(UsersManagerBl.ORIGIN_IDENTITY_PROVIDER_KEY);
 
 		//Authorization based on the user
-		if (sess.getPerunPrincipal().getUser() != null && app.getUser() != null && isAuthorized(sess, Role.SELF, app.getUser())) {
+		if (app.getUser() != null && sess.getPerunPrincipal().getUserId() == app.getUser().getId()) {
 			return true;
 		//Authorization based on the extSourceName and extSourceLogin
 		} else if (Objects.equals(app.getCreatedBy(), sess.getPerunPrincipal().getActor()) &&


### PR DESCRIPTION
- In AuthzResolver was completely replaced the old authorization.
- For that purpose was updated also perun-roles.yml file with the
  policies used in the AuthzResolver.
- All PerunBeans which are passed to the methods and already exist in
  Perun are passed also to the authorization, even when a policy does not
  need them for now. It does not have any effect on the policy evaluation.
  It erase the necessity to change these methods if the policy will change
  in the future.