### PR TITLE
Fix wrong exception when updating group with existing name

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/GroupsManager.java
@@ -212,9 +212,10 @@ public interface GroupsManager {
 	 *
 	 * @throws InternalErrorException
 	 * @throws GroupNotExistsException
+	 * @throws GroupExistsException if group with same name already exists in the same VO
 	 * @throws PrivilegeException
 	 */
-	Group updateGroup(PerunSession perunSession, Group group) throws GroupNotExistsException, InternalErrorException, PrivilegeException;
+	Group updateGroup(PerunSession perunSession, Group group) throws GroupNotExistsException, GroupExistsException, InternalErrorException, PrivilegeException;
 
 	/**
 	 * Search for the group with specified id in all VOs.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/GroupsManagerBl.java
@@ -190,8 +190,9 @@ public interface GroupsManagerBl {
 	 * @return updated group with correctly set parameters (including group.name)
 	 *
 	 * @throws InternalErrorException
+	 * @throws GroupExistsException if group with same name already exists in the same VO
 	 */
-	Group updateGroup(PerunSession perunSession, Group group) throws InternalErrorException;
+	Group updateGroup(PerunSession perunSession, Group group) throws InternalErrorException, GroupExistsException;
 
 	/**
 	 * Updates parentGroupId.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -509,7 +509,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	}
 
 	@Override
-	public Group updateGroup(PerunSession sess, Group group) throws InternalErrorException {
+	public Group updateGroup(PerunSession sess, Group group) throws InternalErrorException, GroupExistsException {
 
 		// return group with correct updated name and shortName
 		group = getGroupsManagerImpl().updateGroup(sess, group);
@@ -3951,14 +3951,22 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		if(groupWithOldDescription.getDescription() != null) {
 			if(!groupWithOldDescription.getDescription().equals(groupWithNewDescription.asGroup().getDescription())){
 				groupWithOldDescription.setDescription(groupWithNewDescription.asGroup().getDescription());
-				groupsManagerImpl.updateGroup(sess, groupWithOldDescription);
+				try {
+					groupsManagerImpl.updateGroup(sess, groupWithOldDescription);
+				} catch (GroupExistsException ex) {
+					throw new InternalErrorException("Unexpected exception when trying to modify group description!");
+				}
 				getPerunBl().getAuditer().log(sess, new GroupUpdated(groupWithOldDescription));
 				return true;
 			}
 		// If the new description is not null set the old description to new one
 		} else if(groupWithNewDescription.asGroup().getDescription() != null){
 			groupWithOldDescription.setDescription(groupWithNewDescription.asGroup().getDescription());
-			groupsManagerImpl.updateGroup(sess, groupWithOldDescription);
+			try {
+				groupsManagerImpl.updateGroup(sess, groupWithOldDescription);
+			} catch (GroupExistsException ex) {
+				throw new InternalErrorException("Unexpected exception when trying to modify group description!");
+			}
 			getPerunBl().getAuditer().log(sess, new GroupUpdated(groupWithOldDescription));
 			return true;
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/GroupsManagerEntry.java
@@ -200,7 +200,7 @@ public class GroupsManagerEntry implements GroupsManager {
 	}
 
 	@Override
-	public Group updateGroup(PerunSession sess, Group group) throws GroupNotExistsException, InternalErrorException, PrivilegeException {
+	public Group updateGroup(PerunSession sess, Group group) throws GroupNotExistsException, GroupExistsException, InternalErrorException, PrivilegeException {
 		Utils.checkPerunSession(sess);
 		getGroupsManagerBl().checkGroupExists(sess, group);
 		Utils.notNull(group, "group");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/GroupsManagerImplApi.java
@@ -90,8 +90,9 @@ public interface GroupsManagerImplApi {
 	 * @return updated group with correctly set parameters
 	 *
 	 * @throws InternalErrorException
+	 * @throws GroupExistsException if group with same name already exists in the same VO
 	 */
-	Group updateGroup(PerunSession perunSession, Group group) throws InternalErrorException;
+	Group updateGroup(PerunSession perunSession, Group group) throws InternalErrorException, GroupExistsException;
 
 	/**
 	 * Updates group by ID.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -2515,6 +2515,20 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 
 	}
 
+	@Test (expected=GroupExistsException.class)
+	public void updateGroupNameWhenSuchGroupExists() throws Exception {
+		System.out.println(CLASS_NAME + "updateGroupNameWhenSuchGroupExists");
+
+		vo = setUpVo();
+		setUpGroup(vo);
+
+		String sameName = "GroupsManagerTestGroup1Updated";
+		Group groupWithSameName = new Group(sameName, sameName);
+		groupsManager.createGroup(sess, vo, groupWithSameName);
+		group.setName(sameName);
+		groupsManager.updateGroup(sess, group);
+	}
+
 	@Test (expected=GroupNotExistsException.class)
 	public void updateGroupWhenGroupNotExists() throws Exception {
 		System.out.println(CLASS_NAME + "updateGroupWhenGroupNotExists");

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/GroupsManagerMethod.java
@@ -268,6 +268,7 @@ public enum GroupsManagerMethod implements ManagerMethod {
 	 * Updates a group.
 	 *
 	 * @throw GroupNotExistsException When the group doesn't exist
+	 * @throw GroupExistsException when the group with the same name already exists in the same vo
 	 *
 	 * @param group Group JSON Group class
 	 * @return Group Updated group


### PR DESCRIPTION
 - when we are trying to update a group's name with name which is
 already occupied in the same VO, we need to throw GroupExistsException
 instead of SQL constraint exception