### PR TITLE
REGISTRAR: Removed usage of member:virt:loa from module Elixircz

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Elixircz.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/modules/Elixircz.java
@@ -42,7 +42,7 @@ public class Elixircz extends DefaultRegistrarModule {
 		if (app.getGroup() == null && Objects.equals(app.getType(), Application.AppType.INITIAL)) {
 
 			// IF VO INITIAL override VO rules to set unlimited (only to those with LoA = 2).
-			Attribute loaAttr = perun.getAttributesManagerBl().getAttribute(session, member, AttributesManager.NS_MEMBER_ATTR_VIRT + ":loa");
+			Attribute loaAttr = perun.getAttributesManagerBl().getAttribute(session, app.getUser(), AttributesManager.NS_USER_ATTR_VIRT + ":loa");
 			int loa = Integer.valueOf((String) loaAttr.getValue());
 
 			if (loa == 2) {


### PR DESCRIPTION
- We can safely use user:virt:loa instead and member version
  attribute will be removed in the future.