### PR TITLE
CORE: Fixed dao layer of getAttributes(sess, group, attrNames)

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -1420,7 +1420,7 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 		parameters.addValue("nSO", AttributesManager.NS_GROUP_ATTR_OPT);
 		parameters.addValue("nSD", AttributesManager.NS_GROUP_ATTR_DEF);
 		parameters.addValue("nSV", AttributesManager.NS_GROUP_ATTR_VIRT);
-		parameters.addValue("attrNames", controlledAttrNames);
+		parameters.addValue("attrNames", attrNames);
 
 		try {
 			return namedParameterJdbcTemplate.query("select " + getAttributeMappingSelectQuery("groupattr") + " from attr_names " +


### PR DESCRIPTION
- We must use original list of attribute names, since its by BL check
  non-empty. Cleared up list is useful only for the cache method.