### PR TITLE
Force multiple identifiers

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -78,6 +78,7 @@ public class CoreConfig {
 	private String smtpUser;
 	private String smtpPass;
 	private List<String> autocreatedNamespaces;
+	private boolean extSourcesForceMultipleIdentifiers;
 
 	public int getGroupMaxConcurentGroupsToSynchronize() {
 		return groupMaxConcurentGroupsToSynchronize;
@@ -638,5 +639,13 @@ public class CoreConfig {
 
 	public void setQueryTimeout(int queryTimeout) {
 		this.queryTimeout = queryTimeout;
+	}
+
+	public void setExtSourcesForceMultipleIdentifiers(boolean extSourcesForceMultipleIdentifiers) {
+		this.extSourcesForceMultipleIdentifiers = extSourcesForceMultipleIdentifiers;
+	}
+
+	public boolean isForceMultipleIdentifiersEnabled() {
+		return extSourcesForceMultipleIdentifiers;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -15,6 +15,7 @@
 		<property name="dbType" value="${perun.db.type}"/>
 		<property name="dontLookupUsers" value="#{'${perun.dont.lookup.users}'.split('\s*,\s*')}"/>
 		<property name="extSourcesMultipleIdentifiers" value="#{'${perun.extsources.multiple.identifiers}'.split('\s*,\s*')}"/>
+		<property name="extSourcesForceMultipleIdentifiers" value="${perun.extsources.force.multiple.identifiers}"/>
 		<property name="enginePrincipals" value="#{'${perun.engine.principals}'.split('\s*,\s*')}"/>
 		<property name="generatedLoginNamespaces" value="#{'${perun.loginNamespace.generated}'.split('\s*,\s*')}"/>
 		<property name="groupSynchronizationInterval" value="${perun.group.synchronization.interval}"/>
@@ -123,6 +124,7 @@
 				<prop key="perun.allowedCorsDomains"></prop>
 				<prop key="perun.cacheEnabled">false</prop>
 				<prop key="perun.queryTimeout">-1</prop>
+				<prop key="perun.extsources.force.multiple.identifiers">false</prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -118,6 +118,7 @@ public class PerunBlImpl implements PerunBl {
 
 	private final static Set<String> dontLookupUsersForLogins = BeansUtils.getCoreConfig().getDontLookupUsers();
 	private final static Set<String> extSourcesWithMultipleIdentifiers = BeansUtils.getCoreConfig().getExtSourcesMultipleIdentifiers();
+	private final static boolean isForceMultipleIdentifiersEnabled = BeansUtils.getCoreConfig().isForceMultipleIdentifiersEnabled();
 
 	public PerunBlImpl() {
 
@@ -136,7 +137,8 @@ public class PerunBlImpl implements PerunBl {
 			try {
 				PerunSession internalSession = getPerunSession();
 				User user;
-				if(extSourcesWithMultipleIdentifiers.contains(principal.getExtSourceName())) {
+				if(extSourcesWithMultipleIdentifiers.contains(principal.getExtSourceName()) ||
+					(principal.getExtSourceType().equals(ExtSourcesManager.EXTSOURCE_IDP) && isForceMultipleIdentifiersEnabled)) {
 					UserExtSource ues = usersManagerBl.getUserExtSourceFromMultipleIdentifiers(internalSession, principal);
 					user = usersManagerBl.getUserByUserExtSource(internalSession, ues);
 				} else {
@@ -147,7 +149,8 @@ public class PerunBlImpl implements PerunBl {
 				if (client.getType() != PerunClient.Type.OAUTH) {
 					// Try to update LoA for userExtSource
 					UserExtSource ues;
-						if(extSourcesWithMultipleIdentifiers.contains(principal.getExtSourceName())) {
+						if(extSourcesWithMultipleIdentifiers.contains(principal.getExtSourceName()) ||
+							(principal.getExtSourceType().equals(ExtSourcesManager.EXTSOURCE_IDP) && isForceMultipleIdentifiersEnabled)) {
 							ues = usersManagerBl.getUserExtSourceFromMultipleIdentifiers(internalSession, principal);
 						} else {
 							ExtSource es = extSourcesManagerBl.getExtSourceByName(internalSession, principal.getExtSourceName());


### PR DESCRIPTION
Added force option for multiple identifiers which permits to use
multiple identifiers even when theprincipal's extSource is not in the
multipleIdentifiers extSources.