### PR TITLE
Multiple Identifiers with shibIdentityProvider

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/PerunBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/PerunBl.java
@@ -30,6 +30,7 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 public interface PerunBl extends Perun {
 
 	String INTERNALPRINCIPAL = "INTERNAL";
+	String ORIGIN_IDENTITY_PROVIDER_KEY = "originIdentityProvider";
 
 	/**
 	 * Gets a (possibly cached) Perun session.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AuthzResolverBlImpl.java
@@ -1742,10 +1742,11 @@ public class AuthzResolverBlImpl implements AuthzResolverBl {
 		log.trace("Refreshing session data for session {}.", sess);
 
 		PerunPrincipal principal = sess.getPerunPrincipal();
+		String shibIdentityProvider = principal.getAdditionalInformations().get(PerunBl.ORIGIN_IDENTITY_PROVIDER_KEY);
 
 		try {
 			User user;
-				if(extSourcesWithMultipleIdentifiers.contains(principal.getExtSourceName())) {
+				if(shibIdentityProvider != null && extSourcesWithMultipleIdentifiers.contains(shibIdentityProvider)) {
 					UserExtSource ues = perunBl.getUsersManagerBl().getUserExtSourceFromMultipleIdentifiers(sess, principal);
 					user = perunBl.getUsersManagerBl().getUserByUserExtSource(sess, ues);
 				} else {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -133,10 +133,11 @@ public class PerunBlImpl implements PerunBl {
 		log.debug("creating PerunSession for user {}", principal.getActor());
 		if (principal.getUser() == null && usersManagerBl != null && !dontLookupUsersForLogins.contains(principal.getActor())) {
 			// Get the user if we are completely initialized
+			String shibIdentityProvider = principal.getAdditionalInformations().get(ORIGIN_IDENTITY_PROVIDER_KEY);
 			try {
 				PerunSession internalSession = getPerunSession();
 				User user;
-				if(extSourcesWithMultipleIdentifiers.contains(principal.getExtSourceName())) {
+				if(shibIdentityProvider != null && extSourcesWithMultipleIdentifiers.contains(shibIdentityProvider)) {
 					UserExtSource ues = usersManagerBl.getUserExtSourceFromMultipleIdentifiers(internalSession, principal);
 					user = usersManagerBl.getUserByUserExtSource(internalSession, ues);
 				} else {
@@ -147,7 +148,7 @@ public class PerunBlImpl implements PerunBl {
 				if (client.getType() != PerunClient.Type.OAUTH) {
 					// Try to update LoA for userExtSource
 					UserExtSource ues;
-						if(extSourcesWithMultipleIdentifiers.contains(principal.getExtSourceName())) {
+						if(shibIdentityProvider != null && extSourcesWithMultipleIdentifiers.contains(shibIdentityProvider)) {
 							ues = usersManagerBl.getUserExtSourceFromMultipleIdentifiers(internalSession, principal);
 						} else {
 							ExtSource es = extSourcesManagerBl.getExtSourceByName(internalSession, principal.getExtSourceName());

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -17,6 +17,7 @@ import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
 import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
@@ -233,7 +234,7 @@ public class Api extends HttpServlet {
 
 			// Store IdP used by user to session, since for IdentityConsolidator and Registrar we need to know,
 			// if user logged in through proxy or not - we provide different links etc.
-			additionalInformations.put("originIdentityProvider", shibIdentityProvider);
+			additionalInformations.put(PerunBl.ORIGIN_IDENTITY_PROVIDER_KEY, shibIdentityProvider);
 
 			if (isNotEmpty(remoteUser)) {
 				extLogin = remoteUser;


### PR DESCRIPTION
Problem: Multiple identifiers did not work alongside with original IdPs functionality,
                because configuration for multiple identifiers had set proxy id
		but principals extSource contained original Idp id. Therefore,
		the principal's extSource was never found in multiple identifiers list,
		thus the additional identifiers were not used.
Solution:  Checking, if the principal's extSource is in the list of multiple identifiers configuration,
                was changed. It does not check principal's extSource but principal's originIdentityProvider,
	        which is set to proxy id when a user logs in through some federation.