### PR TITLE
Default loa for IdP

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -20,6 +20,7 @@ public class CoreConfig {
 	private final static Logger log = LoggerFactory.getLogger(CoreConfig.class);
 
 	private Properties properties;
+	private String defaultLoaIdP;
 
 	/**
 	 * Stores this bean into static BeansUtils for backward compatibility. Called by init-method in perun-base.xml.
@@ -638,5 +639,13 @@ public class CoreConfig {
 
 	public void setQueryTimeout(int queryTimeout) {
 		this.queryTimeout = queryTimeout;
+	}
+
+	public void setDefaultLoaIdP(String defaultLoaIdP) {
+		this.defaultLoaIdP = defaultLoaIdP;
+	}
+
+	public String getDefaultLoaIdP() {
+		return defaultLoaIdP;
 	}
 }

--- a/perun-base/src/main/resources/perun-base.xml
+++ b/perun-base/src/main/resources/perun-base.xml
@@ -62,6 +62,7 @@
 		<property name="autocreatedNamespaces" value="#{'${perun.autocreatedNamespaces}'.split('\s*,\s*')}" />
 		<property name="rtSendToMail" value="${perun.rt.sendToMail}" />
 		<property name="queryTimeout" value="${perun.queryTimeout}" />
+		<property name="defaultLoaIdP" value="${perun.defaultLoa.idp}"/>
 	</bean>
 
 
@@ -123,6 +124,7 @@
 				<prop key="perun.allowedCorsDomains"></prop>
 				<prop key="perun.cacheEnabled">false</prop>
 				<prop key="perun.queryTimeout">-1</prop>
+				<prop key="perun.defaultLoa.idp">2</prop>
 				<!--
 				   this creates a map from OIDC issuer to user extsources that are used for looking up a user identified by "sub" claim
 				-->

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -222,7 +222,7 @@ public class Api extends HttpServlet {
 			extSourceName = getOriginalIdP(shibIdentityProvider, sourceIdpEntityId);
 			extSourceType = ExtSourcesManager.EXTSOURCE_IDP;
 			extSourceLoaString = getStringAttribute(req, LOA);
-			if(isEmpty(extSourceLoaString)) extSourceLoaString = "2";
+			if(isEmpty(extSourceLoaString)) extSourceLoaString = BeansUtils.getCoreConfig().getDefaultLoaIdP();
 
 			// FIXME: find better place where do the operation with attributes from federation
 			String eppn = getStringAttribute(req, "eppn");


### PR DESCRIPTION
Problem: When proxy did not send loa attribute, perun set it to 2. In eduTeams we need to configure this default value.
Solution: New configuration property was created for this purpose. when it is not set, the default value remains 2.