### PR TITLE
Creation of additional identifiers attribute

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/CoreConfig.java
@@ -523,6 +523,12 @@ public class CoreConfig {
 					attr.setDescription("PEM encoded X509 certificate");
 					attr.setType(BeansUtils.largeStringClassName);
 					break;
+				case "additionalIdentifiers":
+					attr.setDisplayName("Additional Identifiers");
+					attr.setDescription("Additional unique user identifiers");
+					attr.setType(ArrayList.class.getName());
+					attr.setUnique(true);
+					break;
 				default:
 					attr.setDisplayName(attrName);
 					attr.setDescription(attrName);


### PR DESCRIPTION
- UserExtSource attribute additionalIdentifiers was added to the method
  createAttributeDefinitions in CoreConfig, so it is created with correct parameters.
  However, this method does not support creation of attribute rights, so these were not set.
  It should not be a problem, because this attribute should have only Read pribilege for SELF role
  according to the created attribute in eduTeams instances.