### PR TITLE
REGISTRAR: More robust mail validation

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -1699,7 +1699,13 @@ public class MailManagerImpl implements MailManager {
 			ApplicationFormItem item = d.getFormItem();
 			String value = d.getValue();
 			// if mail field and not validated
-			if (ApplicationFormItem.Type.VALIDATED_EMAIL.equals(item.getType()) && !"1".equals(d.getAssuranceLevel())) {
+			int loa = 0;
+			try {
+				loa = Integer.parseInt(d.getAssuranceLevel());
+			} catch (NumberFormatException ex) {
+				// ignore
+			}
+			if (ApplicationFormItem.Type.VALIDATED_EMAIL.equals(item.getType()) && loa < 1) {
 				if (value != null && !value.isEmpty()) {
 					// set TO
 					message.setRecipients(Message.RecipientType.TO, new InternetAddress[] {new InternetAddress(value)});


### PR DESCRIPTION
- User triggered mail validation is now more robust. It fakes
  OK response on already approved or rejected applications
  to prevent their processing.
- We try to verify only new applications.
- We try to auto-approve only verified applications.
- Make sure we do not send mail validation notification for
  mail addresses, which have assurance level >= 1, since it
  means address is verified. It was previously possible to
  notify also loa=2 addresses.