### PR TITLE
CORE: Fixed audit message resolving for eduPersonScopedAffiliations

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -498,14 +498,25 @@ public interface MembersManagerBl {
 	Member getMemberByUser(PerunSession sess, Vo vo, User user) throws InternalErrorException, MemberNotExistsException;
 
 	/**
-	 * Returns members by his user.
+	 * Return all VO Members of the User.
 	 *
 	 * @param sess
 	 * @param user
-	 * @return member
+	 * @return List of Members
 	 * @throws InternalErrorException
 	 */
 	List<Member> getMembersByUser(PerunSession sess, User user) throws InternalErrorException;
+
+	/**
+	 * Return all VO Members of the User, which have specified Status in their VO.
+	 *
+	 * @param sess
+	 * @param user
+	 * @param status
+	 * @return List of Members
+	 * @throws InternalErrorException
+	 */
+	List<Member> getMembersByUserWithStatus(PerunSession sess, User user, Status status) throws InternalErrorException;
 
 	/**
 	 * Returns member by his userId.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -730,6 +730,11 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	}
 
 	@Override
+	public List<Member> getMembersByUserWithStatus(PerunSession sess, User user, Status status) throws InternalErrorException {
+		return getMembersManagerImpl().getMembersByUserWithStatus(sess, user, status);
+	}
+
+	@Override
 	public List<Member> getMembers(PerunSession sess, Vo vo) throws InternalErrorException {
 		try {
 			Group g = getPerunBl().getGroupsManagerBl().getGroupByName(sess, vo, VosManager.MEMBERS_GROUP);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -151,7 +151,7 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 	public List<Member> getMembersByUserWithStatus(PerunSession sess, User user, Status status) throws InternalErrorException {
 		try {
 			return jdbc.query("SELECT " + memberMappingSelectQuery + " FROM" +
-							" members WHERE members.user_id=? and members.status "+Compatibility.castToInteger()+"=?",
+							" members WHERE members.user_id=? and members.status"+Compatibility.castToInteger()+"=?",
 					MEMBER_MAPPER, user.getId(), status.getCode());
 		} catch (EmptyResultDataAccessException ex) {
 			throw new InternalErrorException(new MemberNotExistsException("user=" + user));

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/MembersManagerImpl.java
@@ -148,6 +148,19 @@ public class MembersManagerImpl implements MembersManagerImplApi {
 	}
 
 	@Override
+	public List<Member> getMembersByUserWithStatus(PerunSession sess, User user, Status status) throws InternalErrorException {
+		try {
+			return jdbc.query("SELECT " + memberMappingSelectQuery + " FROM" +
+							" members WHERE members.user_id=? and members.status "+Compatibility.castToInteger()+"=?",
+					MEMBER_MAPPER, user.getId(), status.getCode());
+		} catch (EmptyResultDataAccessException ex) {
+			throw new InternalErrorException(new MemberNotExistsException("user=" + user));
+		} catch (RuntimeException err) {
+			throw new InternalErrorException(err);
+		}
+	}
+
+	@Override
 	public Member getMemberById(PerunSession sess, int id) throws InternalErrorException, MemberNotExistsException {
 		try {
 			return jdbc.queryForObject("SELECT " + memberMappingSelectQuery + " FROM members "

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations.java
@@ -143,7 +143,7 @@ public class urn_perun_user_attribute_def_virt_eduPersonScopedAffiliations exten
 		Attribute manualEPSAAttr = null;
 		try {
 			manualEPSAAttr = sess.getPerunBl().getAttributesManagerBl()
-				.getAttribute(sess, user, getSecondarySourceAttributeName());
+					.getAttribute(sess, user, getSecondarySourceAttributeName());
 		} catch (WrongAttributeAssignmentException e) {
 			throw new InternalErrorException("Wrong assignment of " + getSecondarySourceAttributeFriendlyName() + " for user " + user.getId(), e);
 		} catch (AttributeNotExistsException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -97,17 +97,25 @@ public interface MembersManagerImplApi {
 	Member getMemberByUserId(PerunSession perunSession, Vo vo, int userId) throws InternalErrorException, MemberNotExistsException;
 
 	/**
-	 * Returns members by his user.
+	 * Return all VO Members of the User.
 	 *
-	 * @param perunSession
+	 * @param sess
 	 * @param user
-	 * @return list of members
+	 * @return List of Members
 	 * @throws InternalErrorException
-	 * @throws MemberNotExistsException
-	 * @throws VoNotExistsException
-	 * @throws UserNotExistsException
 	 */
-	List<Member> getMembersByUser(PerunSession perunSession, User user) throws InternalErrorException;
+	List<Member> getMembersByUser(PerunSession sess, User user) throws InternalErrorException;
+
+	/**
+	 * Return all VO Members of the User, which have specified Status in their VO.
+	 *
+	 * @param sess
+	 * @param user
+	 * @param status
+	 * @return List of Members
+	 * @throws InternalErrorException
+	 */
+	List<Member> getMembersByUserWithStatus(PerunSession sess, User user, Status status) throws InternalErrorException;
 
 	/**
 	 * Check if member exists in underlaying data source.


### PR DESCRIPTION
- Shorter code when resolving affiliations from users groups.
- Added getMembersByUserWithStatus() into MembersManagerBl, it
  returns only those members of users, which have specified status,
  eg. VALID.
- Module for user:virt:eduPersonScopedAffiliations now reacts also
  on necessary group membership and member status events.
  Implemented new message resolving within module for case of source
  group attribute changes, since we must iterate over current group
  users.