### PR TITLE
additional identifiers support in RegistrarModule

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/BeansUtils.java
@@ -1,5 +1,7 @@
 package cz.metacentrum.perun.core.api;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import java.io.BufferedInputStream;
@@ -9,6 +11,7 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -37,6 +40,7 @@ public class BeansUtils {
 	private static final char LIST_DELIMITER = ',';
 	private static final char KEY_VALUE_DELIMITER = ':';
 	private final static int MAX_SIZE_OF_ITEMS_IN_SQL_IN_CLAUSE = 1000;
+	private final static String MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX = ";";
 	private final static String configurationsLocations = "/etc/perun/";
 	public final static String largeStringClassName = "java.lang.LargeString";
 	public final static String largeArrayListClassName = "java.util.LargeArrayList";
@@ -45,6 +49,7 @@ public class BeansUtils {
 
 	private final static JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
 	private static boolean mailSenderInitialized = false;
+	private static ObjectMapper objectMapper = new ObjectMapper();
 
 	/**
 	 * Method create formatter with default settings for perun timestamps and set lenient on false
@@ -477,6 +482,17 @@ public class BeansUtils {
 	}
 
 	/**
+	 * Converts string representation of an attribute value to the LinkedHashMap
+	 *
+	 * @param attributesAsString Map attribute in String representation.
+	 * @return LinkedHashMap with key values pairs extracted from the input
+	 */
+	public static LinkedHashMap<String, String> stringToMapOfAttributes(String attributesAsString) {
+		Object mapAsObject = BeansUtils.stringToAttributeValue(attributesAsString, LinkedHashMap.class.getName());
+		return objectMapper.convertValue(mapAsObject, new TypeReference<LinkedHashMap<String, String>>() {});
+	}
+
+	/**
 	 * Take perunBean name and if it is RichObject, convert it to simple name.
 	 *
 	 * RichObject mean: starts with "Rich" and continue with Upper Letter [A-Z]
@@ -883,5 +899,26 @@ public class BeansUtils {
 		candidate.setAttributes(candidateAttributes);
 
 		return candidate;
+	}
+
+	/**
+	 * creates an intersection of two additionalIdentifiers arrays given as string.
+	 *
+	 * @param firstAdditionalIdentifiers first parameter which contains additional identifiers
+	 * @param secondAdditionalIdentifiers second parameter which contains additional identifiers
+	 * @return Intersection of the given String parameters
+	 */
+	public static List<String> additionalIdentifiersIntersection(String firstAdditionalIdentifiers, String secondAdditionalIdentifiers) {
+		String[] firstIdentifiersArray = {};
+		if (firstAdditionalIdentifiers != null) {
+			firstIdentifiersArray = firstAdditionalIdentifiers.split(MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX);
+		}
+		String[] secondIdentifiersArray = {};
+		if (secondAdditionalIdentifiers != null) {
+			secondIdentifiersArray = secondAdditionalIdentifiers.split(MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX);
+		}
+		HashSet<String> firstIdentifiersSet = new HashSet<>(Arrays.asList(firstIdentifiersArray));
+		firstIdentifiersSet.retainAll(Arrays.asList(secondIdentifiersArray));
+		return new ArrayList<>(firstIdentifiersSet);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/AuthzResolver.java
@@ -19,6 +19,7 @@ import cz.metacentrum.perun.core.blImpl.AuthzResolverBlImpl;
 import cz.metacentrum.perun.core.impl.AuthzRoles;
 import cz.metacentrum.perun.core.impl.Privileges;
 import cz.metacentrum.perun.core.impl.Utils;
+import cz.metacentrum.perun.registrar.model.Application;
 
 import java.util.Collections;
 import java.util.List;
@@ -72,6 +73,17 @@ public class AuthzResolver {
 		} catch (PolicyNotExistsException e) {
 			throw new InternalErrorException(e);
 		}
+	}
+
+	/**
+	 * Check if the principal is the owner of the application.
+	 *
+	 * @param sess PerunSession which contains the principal.
+	 * @param app application which principal wants to access
+	 * @return true if the principal has particular rights, false otherwise.
+	 */
+	public static boolean selfAuthorizedForApplication(PerunSession sess, Application app) {
+		return AuthzResolverBlImpl.selfAuthorizedForApplication(sess, app);
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/PerunBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/PerunBl.java
@@ -30,7 +30,6 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 public interface PerunBl extends Perun {
 
 	String INTERNALPRINCIPAL = "INTERNAL";
-	String ORIGIN_IDENTITY_PROVIDER_KEY = "originIdentityProvider";
 
 	/**
 	 * Gets a (possibly cached) Perun session.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.bl;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.AttributeDefinition;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
@@ -58,6 +59,11 @@ import java.util.Map;
  * @author Sona Mastrakova
  */
 public interface UsersManagerBl {
+
+	String ORIGIN_IDENTITY_PROVIDER_KEY = "originIdentityProvider";
+	String MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX = ";";
+	String ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME = "additionalIdentifiers";
+	String ADDITIONAL_IDENTIFIERS_PERUN_ATTRIBUTE_NAME = AttributesManager.NS_UES_ATTR_DEF + ":" + ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME;
 
 	/**
 	 * Returns user by his login in external source and external source.
@@ -411,6 +417,20 @@ public interface UsersManagerBl {
 	 * @throws InternalErrorException
 	 */
 	void updateUserExtSourceLastAccess(PerunSession perunSession, UserExtSource userExtSource);
+
+	/**
+	 * Get user by principal's additional identifiers or extSourceName and extSourceLogin.
+	 * Additional identifiers are used in case principal's extSource was send through proxy which has enabled multiple identifiers.
+	 * extSourceName and extSourceLogin are used otherwise.
+	 *
+	 * @param sess
+	 * @param principal
+	 * @return
+	 * @throws UserExtSourceNotExistsException
+	 * @throws UserNotExistsException
+	 * @throws ExtSourceNotExistsException
+	 */
+	User getUserByExtSourceInformation(PerunSession sess, PerunPrincipal principal) throws UserExtSourceNotExistsException, UserNotExistsException, ExtSourceNotExistsException;
 
 	/**
 	 * Gets list of all users external sources by specific type and extLogin.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -133,27 +133,21 @@ public class PerunBlImpl implements PerunBl {
 		log.debug("creating PerunSession for user {}", principal.getActor());
 		if (principal.getUser() == null && usersManagerBl != null && !dontLookupUsersForLogins.contains(principal.getActor())) {
 			// Get the user if we are completely initialized
-			String shibIdentityProvider = principal.getAdditionalInformations().get(ORIGIN_IDENTITY_PROVIDER_KEY);
 			try {
 				PerunSession internalSession = getPerunSession();
-				User user;
-				if(shibIdentityProvider != null && extSourcesWithMultipleIdentifiers.contains(shibIdentityProvider)) {
-					UserExtSource ues = usersManagerBl.getUserExtSourceFromMultipleIdentifiers(internalSession, principal);
-					user = usersManagerBl.getUserByUserExtSource(internalSession, ues);
-				} else {
-					user = usersManagerBl.getUserByExtSourceNameAndExtLogin(internalSession, principal.getExtSourceName(), principal.getActor());
-				}
+				User user = usersManagerBl.getUserByExtSourceInformation(internalSession, principal);
 				principal.setUser(user);
 
 				if (client.getType() != PerunClient.Type.OAUTH) {
 					// Try to update LoA for userExtSource
 					UserExtSource ues;
-						if(shibIdentityProvider != null && extSourcesWithMultipleIdentifiers.contains(shibIdentityProvider)) {
-							ues = usersManagerBl.getUserExtSourceFromMultipleIdentifiers(internalSession, principal);
-						} else {
-							ExtSource es = extSourcesManagerBl.getExtSourceByName(internalSession, principal.getExtSourceName());
-							ues = usersManagerBl.getUserExtSourceByExtLogin(internalSession, es, principal.getActor());
-						}
+					String shibIdentityProvider = principal.getAdditionalInformations().get(UsersManagerBl.ORIGIN_IDENTITY_PROVIDER_KEY);
+					if(shibIdentityProvider != null && extSourcesWithMultipleIdentifiers.contains(shibIdentityProvider)) {
+						ues = usersManagerBl.getUserExtSourceFromMultipleIdentifiers(internalSession, principal);
+					} else {
+						ExtSource es = extSourcesManagerBl.getExtSourceByName(internalSession, principal.getExtSourceName());
+						ues = usersManagerBl.getUserExtSourceByExtLogin(internalSession, es, principal.getActor());
+					}
 					if (ues != null && ues.getLoa() != principal.getExtSourceLoa()) {
 						ues.setLoa(principal.getExtSourceLoa());
 						usersManagerBl.updateUserExtSource(internalSession, ues);
@@ -209,7 +203,7 @@ public class PerunBlImpl implements PerunBl {
 					if(attributeWithValue.getType().equals(ArrayList.class.getName()) || attributeWithValue.getType().equals(BeansUtils.largeArrayListClassName)) {
 						List<String> value = new ArrayList<>();
 						if (attrValue != null) {
-							value = new ArrayList<>(Arrays.asList(attrValue.split(UsersManagerBlImpl.multivalueAttributeSeparatorRegExp)));
+							value = new ArrayList<>(Arrays.asList(attrValue.split(UsersManagerBl.MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX)));
 						}
 						attributeWithValue.setValue(value);
 					} else {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -118,9 +118,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	private static final String A_USER_DEF_ALT_PASSWORD_NAMESPACE = AttributesManager.NS_USER_ATTR_DEF + ":altPasswords:";
 
-	public final static String multivalueAttributeSeparatorRegExp = ";";
-	private final static String additionalIdentifiersAttributeName = "additionalIdentifiers";
-	private final static String additionalIdentifiersPerunAttributeName = AttributesManager.NS_UES_ATTR_DEF + ":" + additionalIdentifiersAttributeName;
+	private final static Set<String> extSourcesWithMultipleIdentifiers = BeansUtils.getCoreConfig().getExtSourcesMultipleIdentifiers();
 
 
 	/**
@@ -692,26 +690,37 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	@Override
 	public UserExtSource getUserExtSourceFromMultipleIdentifiers(PerunSession sess, PerunPrincipal principal) throws UserExtSourceNotExistsException {
-		String additionalIdentifiers = principal.getAdditionalInformations().get(additionalIdentifiersAttributeName);
+		String additionalIdentifiers = principal.getAdditionalInformations().get(ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME);
 		if (additionalIdentifiers == null) {
-			throw new InternalErrorException("Entry " + additionalIdentifiersAttributeName + " is not defined in the principal's additional information. Either it was not provided by external source used for sign-in or the mapping configuration is wrong.");
+			throw new InternalErrorException("Entry " + ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME + " is not defined in the principal's additional information. Either it was not provided by external source used for sign-in or the mapping configuration is wrong.");
 		}
 		UserExtSource ues = null;
-		for(String identifier : additionalIdentifiers.split(multivalueAttributeSeparatorRegExp)) {
+		for(String identifier : additionalIdentifiers.split(MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX)) {
 			try {
-				ues = perunBl.getUsersManagerBl().getUserExtSourceByUniqueAttributeValue(sess, additionalIdentifiersPerunAttributeName, identifier);
+				ues = perunBl.getUsersManagerBl().getUserExtSourceByUniqueAttributeValue(sess, ADDITIONAL_IDENTIFIERS_PERUN_ATTRIBUTE_NAME, identifier);
 				log.debug("UserExtSource found using additional identifiers: " + ues);
 				break;
 			} catch (UserExtSourceNotExistsException ex) {
 				//try to find user ext source using different identifier in the next iteration of for cycle
 			} catch (AttributeNotExistsException ex) {
-				String errorMessage = "Mandatory attribute is not defined: ".concat(additionalIdentifiersPerunAttributeName);
+				String errorMessage = "Mandatory attribute is not defined: ".concat(ADDITIONAL_IDENTIFIERS_PERUN_ATTRIBUTE_NAME);
 				log.error(errorMessage);
 				throw new InternalErrorException(errorMessage, ex);
 			}
 		}
-		if (ues == null) throw new UserExtSourceNotExistsException("User ext source was not found. Searched value is any from \"" + additionalIdentifiers + "\" in " + additionalIdentifiersPerunAttributeName);
+		if (ues == null) throw new UserExtSourceNotExistsException("User ext source was not found. Searched value is any from \"" + additionalIdentifiers + "\" in " + ADDITIONAL_IDENTIFIERS_PERUN_ATTRIBUTE_NAME);
 		return ues;
+	}
+
+	@Override
+	public User getUserByExtSourceInformation(PerunSession sess, PerunPrincipal principal) throws UserExtSourceNotExistsException, UserNotExistsException, ExtSourceNotExistsException {
+		String shibIdentityProvider = principal.getAdditionalInformations().get(ORIGIN_IDENTITY_PROVIDER_KEY);
+		if(shibIdentityProvider != null && extSourcesWithMultipleIdentifiers.contains(shibIdentityProvider)) {
+			UserExtSource ues = getUserExtSourceFromMultipleIdentifiers(sess, principal);
+			return getUserByUserExtSource(sess, ues);
+		} else {
+			return getUserByExtSourceNameAndExtLogin(sess, principal.getExtSourceName(), principal.getActor());
+		}
 	}
 
 	@Override

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/RegistrarManager.java
@@ -486,4 +486,22 @@ public interface RegistrarManager {
 	 */
 	ConsolidatorManager getConsolidatorManager();
 
+	/**
+	 * Return all applications from the given list which belong to the principal's identity in perun session.
+	 * Check is performed based on additional identifiers (if the user is logged through proxy for which they are enabled),
+	 * user_id (if principal's user is not null) and extSource name and extSource login.
+	 *
+	 * @param sess principal's session
+	 * @return list of applications which belongs to the principal in the perun session
+	 */
+	List<Application> filterPrincipalApplications(PerunSession sess, List<Application> applications);
+
+	/**
+	 * Return all applications from the given list which belong to the given user.
+	 * Check is performed based on additional identifiers, user_id, and extSource name and extSource login.
+	 *
+	 * @param sess principal's session
+	 * @return list of applications which belongs to the user
+	 */
+	List<Application> filterUserApplications(PerunSession sess, User user, List<Application> applications);
 }

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/MailManagerImpl.java
@@ -439,33 +439,12 @@ public class MailManagerImpl implements MailManager {
 			throw new RegistrarException("USER_INVITE notification can't be sent this way. Use sendInvitation() instead.");
 		}
 
-		// authz
-		boolean pass = false;
-		// managers can
-		if (app.getGroup() == null) {
-			if (AuthzResolver.isAuthorized(sess, Role.VOADMIN, app.getVo())) {
-				pass = true;
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, app.getVo()) &&
+			!AuthzResolver.selfAuthorizedForApplication(sess, app)) {
+			if (app.getGroup() == null ||  !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, app.getGroup())) {
+				throw new PrivilegeException(sess, "sendMessage");
 			}
-		} else {
-			if (AuthzResolver.isAuthorized(sess, Role.VOADMIN, app.getVo()) || AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, app.getGroup())) {
-				pass = true;
-			}
-		}
-
-		// self can
-		if (Objects.equals(sess.getPerunPrincipal().getUser(), app.getUser())) {
-			pass = true;
-		} else {
-			if (Objects.equals(app.getCreatedBy(), sess.getPerunPrincipal().getActor()) &&
-					Objects.equals(app.getExtSourceName(), sess.getPerunPrincipal().getExtSourceName()) &&
-					Objects.equals(app.getExtSourceType(), sess.getPerunPrincipal().getExtSourceType())
-					) {
-				pass = true;
-			}
-		}
-
-		if (!pass) {
-			throw new PrivilegeException(sess, "sendMessage");
 		}
 
 		ApplicationForm form = getForm(app);
@@ -1069,6 +1048,9 @@ public class MailManagerImpl implements MailManager {
 	 * @return modified text
 	 */
 	private String substituteCommonStrings(Application app, List<ApplicationFormItemData> data, String mailText, String reason, List<Exception> exceptions) {
+		LinkedHashMap<String, String> additionalAttributes = BeansUtils.stringToMapOfAttributes(app.getFedInfo());
+		PerunPrincipal applicationPrincipal = new PerunPrincipal(app.getCreatedBy(), app.getExtSourceName(), app.getExtSourceType(), app.getExtSourceLoa(), additionalAttributes);
+
 		// replace app ID
 		if (mailText.contains(FIELD_APP_ID)) {
 			mailText = mailText.replace(FIELD_APP_ID, app.getId()+EMPTY_STRING);
@@ -1133,7 +1115,7 @@ public class MailManagerImpl implements MailManager {
 					user = app.getUser();
 				} else {
 					try {
-						user = usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
+						user = usersManager.getUserByExtSourceInformation(registrarSession, applicationPrincipal);
 					} catch (Exception ex) {
 						// user not found is ok
 					}
@@ -1162,7 +1144,7 @@ public class MailManagerImpl implements MailManager {
 					user = app.getUser();
 				} else {
 					try {
-						user = usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
+						user = usersManager.getUserByExtSourceInformation(registrarSession, applicationPrincipal);
 					} catch (Exception ex) {
 						// user not found is ok
 					}
@@ -1191,7 +1173,7 @@ public class MailManagerImpl implements MailManager {
 					user = app.getUser();
 				} else {
 					try {
-						user = usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
+						user = usersManager.getUserByExtSourceInformation(registrarSession, applicationPrincipal);
 					} catch (Exception ex) {
 						// user not found is ok
 					}

--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/RegistrarManagerImpl.java
@@ -78,6 +78,7 @@ import static cz.metacentrum.perun.registrar.model.ApplicationFormItem.Type.*;
 public class RegistrarManagerImpl implements RegistrarManager {
 
 	private final static Logger log = LoggerFactory.getLogger(RegistrarManagerImpl.class);
+	private final static Set<String> extSourcesWithMultipleIdentifiers = BeansUtils.getCoreConfig().getExtSourcesMultipleIdentifiers();
 
 	// identifiers for selected attributes
 	private static final String URN_USER_TITLE_BEFORE = "urn:perun:user:attribute-def:core:titleBefore";
@@ -1601,6 +1602,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			throw new RegistrarException("User didn't verify his email address yet. Please wait until application will be in a 'Submitted' state. You can send mail verification notification to user again if you wish.");
 		}
 
+		LinkedHashMap<String, String> additionalAttributes = BeansUtils.stringToMapOfAttributes(app.getFedInfo());
+		PerunPrincipal applicationPrincipal = new PerunPrincipal(app.getCreatedBy(), app.getExtSourceName(), app.getExtSourceType(), app.getExtSourceLoa(), additionalAttributes);
+
 		// get registrar module
 		RegistrarModule module;
 		if (app.getGroup() != null) {
@@ -1645,7 +1649,7 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				if (app.getUser() == null) {
 
 					// application for group doesn't have user set, but it can exists in perun (joined identities after submission)
-					User u = usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, app.getExtSourceName(), app.getCreatedBy());
+					User u = perun.getUsersManagerBl().getUserByExtSourceInformation(registrarSession, applicationPrincipal);
 
 					// put user back to application
 					app.setUser(u);
@@ -1701,96 +1705,48 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 			} else {
 
-				// put application data into Candidate
-				final Map<String, String> attributes = new HashMap<>();
-				jdbc.query("select dst_attr,value from application_data d, application_form_items i where d.item_id=i.id "
-								+ "and i.dst_attr is not null and d.value is not null and app_id=?",
-						(resultSet, i) -> {
-							attributes.put(resultSet.getString("dst_attr"), resultSet.getString("value"));
-							return null;
-						}, appId);
-
-				// DO NOT STORE LOGINS THROUGH CANDIDATE
-				// we do not set logins by candidate object to prevent accidental overwrite while joining identities in process
-				attributes.entrySet().removeIf(entry -> entry.getKey().contains("urn:perun:user:attribute-def:def:login-namespace:"));
-
-				Candidate candidate = new Candidate();
-				candidate.setAttributes(attributes);
-
-				log.debug("[REGISTRAR] Retrieved candidate from DB {}", candidate);
-
-				// first try to parse display_name if not null and not empty
-				if (attributes.containsKey(URN_USER_DISPLAY_NAME) && attributes.get(URN_USER_DISPLAY_NAME) != null &&
-						!attributes.get(URN_USER_DISPLAY_NAME).isEmpty()) {
-					// parse
-					Map<String, String> commonName = Utils.parseCommonName(attributes.get(URN_USER_DISPLAY_NAME));
-					if (commonName.get("titleBefore") != null
-							&& !commonName.get("titleBefore").isEmpty()) {
-						candidate.setTitleBefore(commonName.get("titleBefore"));
-					}
-					if (commonName.get("firstName") != null
-							&& !commonName.get("firstName").isEmpty()) {
-						candidate.setFirstName(commonName.get("firstName"));
-					}
-					// FIXME - ? there is no middleName in Utils.parseCommonName() implementation
-					if (commonName.get("middleName") != null
-							&& !commonName.get("middleName").isEmpty()) {
-						candidate.setMiddleName(commonName.get("middleName"));
-					}
-					if (commonName.get("lastName") != null
-							&& !commonName.get("lastName").isEmpty()) {
-						candidate.setLastName(commonName.get("lastName"));
-					}
-					if (commonName.get("titleAfter") != null
-							&& !commonName.get("titleAfter").isEmpty()) {
-						candidate.setTitleAfter(commonName.get("titleAfter"));
-					}
-				}
-
-				// if names are separated, used them after
-				for (String attrName : attributes.keySet()) {
-					// if value not null or empty - set to candidate
-					if (attributes.get(attrName) != null
-							&& !attributes.get(attrName).isEmpty()) {
-						if (URN_USER_TITLE_BEFORE.equals(attrName)) {
-							candidate.setTitleBefore(attributes.get(attrName));
-						} else if (URN_USER_TITLE_AFTER.equals(attrName)) {
-							candidate.setTitleAfter(attributes.get(attrName));
-						} else if (URN_USER_FIRST_NAME.equals(attrName)) {
-							candidate.setFirstName(attributes.get(attrName));
-						} else if (URN_USER_LAST_NAME.equals(attrName)) {
-							candidate.setLastName(attributes.get(attrName));
-						} else if (URN_USER_MIDDLE_NAME.equals(attrName)) {
-							candidate.setMiddleName(attributes.get(attrName));
-						}
-					}
-				}
-
 				// free reserved logins so they can be set as attributes
 				jdbc.update("delete from application_reserved_logins where app_id=?", appId);
 
-				// create member and user
-				log.debug("[REGISTRAR] Trying to make member from candidate {}", candidate);
-
-				// added duplicit check, since we switched from entry to bl call of createMember()
-				Utils.checkMaxLength("TitleBefore", candidate.getTitleBefore(), 40);
-				Utils.checkMaxLength("TitleAfter", candidate.getTitleAfter(), 40);
-
-				member = membersManager.createMember(sess, app.getVo(), app.getExtSourceName(), app.getExtSourceType(), app.getExtSourceLoa(), app.getCreatedBy(), candidate);
-				User u = usersManager.getUserById(registrarSession, member.getUserId());
-
+				User u;
 				if (app.getUser() != null) {
+					u = app.getUser();
+					log.debug("[REGISTRAR] Trying to make member from user {}", u);
+					member = membersManager.createMember(sess, app.getVo(), u);
+					// store all attributes (but not logins)
+					storeApplicationAttributes(app);
 					// if user was already known to perun, createMember() will set attributes
 					// via setAttributes() method so core attributes are skipped
 					// ==> updateNameTitles() in case of change in appForm.
 					updateUserNameTitles(app);
 				} else {
+					try {
+						u = perun.getUsersManagerBl().getUserByExtSourceInformation(registrarSession, applicationPrincipal);
+						log.debug("[REGISTRAR] Trying to make member from user {}", u);
+						member = membersManager.createMember(sess, app.getVo(), u);
+						// store all attributes (but not logins)
+						storeApplicationAttributes(app);
+						// if user was already known to perun, createMember() will set attributes
+						// via setAttributes() method so core attributes are skipped
+						// ==> updateNameTitles() in case of change in appForm.
+						updateUserNameTitles(app);
+					} catch (UserExtSourceNotExistsException | UserNotExistsException | ExtSourceNotExistsException  ex) {
+						Candidate candidate = createCandidateFromApplicationData(appId);
+						// create member and user
+						log.debug("[REGISTRAR] Trying to make member from candidate {}", candidate);
+
+						// added duplicit check, since we switched from entry to bl call of createMember()
+						Utils.checkMaxLength("TitleBefore", candidate.getTitleBefore(), 40);
+						Utils.checkMaxLength("TitleAfter", candidate.getTitleAfter(), 40);
+
+						member = membersManager.createMember(sess, app.getVo(), app.getExtSourceName(), app.getExtSourceType(), app.getExtSourceLoa(), app.getCreatedBy(), candidate);
+						u = usersManager.getUserById(registrarSession, member.getUserId());
+					}
 					// user originally not known -> set UserExtSource attributes from source identity for new User and UES
 					ExtSource es = perun.getExtSourcesManagerBl().getExtSourceByName(sess, app.getExtSourceName());
 					UserExtSource ues = usersManager.getUserExtSourceByExtLogin(sess, es, app.getCreatedBy());
 					// we have historical data in "fedInfo" item, hence we must safely ignore any parsing errors.
 					try {
-						LinkedHashMap<String, String> additionalAttributes = (LinkedHashMap<String, String>)BeansUtils.stringToAttributeValue(app.getFedInfo(), LinkedHashMap.class.getName());
 						((PerunBlImpl)perun).setUserExtSourceAttributes(sess, ues, additionalAttributes);
 					} catch (Exception ex) {
 						log.error("Unable to store UES attributes from application ID: {}, attributes: {}, with exception: {}", appId, app.getFedInfo(), ex);
@@ -1927,7 +1883,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			try {
 				User u = application.getUser();
 				if (u == null) {
-					u = usersManager.getUserByExtSourceNameAndExtLogin(registrarSession, application.getExtSourceName(), application.getCreatedBy());
+					LinkedHashMap<String, String> additionalAttributes = BeansUtils.stringToMapOfAttributes(application.getFedInfo());
+					PerunPrincipal applicationPrincipal = new PerunPrincipal(application.getCreatedBy(), application.getExtSourceName(), application.getExtSourceType(), application.getExtSourceLoa(), additionalAttributes);
+					u = perun.getUsersManagerBl().getUserByExtSourceInformation(registrarSession, applicationPrincipal);
 				}
 				Member member = membersManager.getMemberByUser(registrarSession, application.getVo(), u);
 				if (!Arrays.asList(Status.VALID, Status.INVALID).contains(member.getStatus())) {
@@ -1948,63 +1906,15 @@ public class RegistrarManagerImpl implements RegistrarManager {
 		Application app = getApplicationById(appId);
 		if (app == null) throw new RegistrarException("Application with ID="+appId+" doesn't exists.");
 
-		// authz ex post
-		if (app.getGroup() == null) {
-
-			if (app.getUser() != null) {
-
-				// is admin of application or self
-				if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, app.getVo())
-						&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, app.getVo())
-						&& !AuthzResolver.hasRole(sess.getPerunPrincipal(), Role.RPC)
-						&& !AuthzResolver.isAuthorized(sess, Role.SELF, app.getUser())
-						&& !AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
-					throw new PrivilegeException(sess, "getApplicationById");
-				}
-
-			} else {
-
-				// is admin of application or self based on current actor/extSource
-				if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, app.getVo())
-						&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, app.getVo())
-						&& !AuthzResolver.hasRole(sess.getPerunPrincipal(), Role.RPC)
-						&& !AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)
-						&& !(app.getCreatedBy().equals(sess.getPerunPrincipal().getActor()) &&
-						app.getExtSourceName().equals(sess.getPerunPrincipal().getExtSourceName()))) {
-					throw new PrivilegeException(sess, "getApplicationById");
-				}
-
+		// Authorization
+		if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, app.getVo())
+			&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, app.getVo())
+			&& !AuthzResolver.hasRole(sess.getPerunPrincipal(), Role.RPC)
+			&& !AuthzResolver.selfAuthorizedForApplication(sess, app)
+			&& !AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
+			if (app.getGroup() == null ||  !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, app.getGroup())) {
+				throw new PrivilegeException(sess, "getApplicationById");
 			}
-
-		} else {
-
-			if (app.getUser() != null) {
-
-				// is admin of application or self
-				if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, app.getVo())
-						&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, app.getVo())
-						&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, app.getGroup())
-						&& !AuthzResolver.hasRole(sess.getPerunPrincipal(), Role.RPC)
-						&& !AuthzResolver.isAuthorized(sess, Role.SELF, app.getUser())
-						&& !AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)) {
-					throw new PrivilegeException(sess, "getApplicationById");
-				}
-
-			} else {
-
-				// is admin of application or self based on current actor/extSource
-				if (!AuthzResolver.isAuthorized(sess, Role.VOADMIN, app.getVo())
-						&& !AuthzResolver.isAuthorized(sess, Role.VOOBSERVER, app.getVo())
-						&& !AuthzResolver.isAuthorized(sess, Role.GROUPADMIN, app.getGroup())
-						&& !AuthzResolver.hasRole(sess.getPerunPrincipal(), Role.RPC)
-						&& !AuthzResolver.isAuthorized(sess, Role.PERUNOBSERVER)
-						&& !(app.getCreatedBy().equals(sess.getPerunPrincipal().getActor()) &&
-						app.getExtSourceName().equals(sess.getPerunPrincipal().getExtSourceName()))) {
-					throw new PrivilegeException(sess, "getApplicationById");
-				}
-
-			}
-
 		}
 
 		return app;
@@ -2088,13 +1998,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	public List<Application> getApplicationsForUser(PerunSession sess) {
 
 		try {
-			PerunPrincipal pp = sess.getPerunPrincipal();
-			if (pp.getUser() != null) {
-				return jdbc.query(APP_SELECT + " where user_id=? or (a.created_by=? and extsourcename=?) order by a.id desc", APP_MAPPER, pp.getUserId(), pp.getActor(), pp.getExtSourceName());
-			} else {
-				// sort by ID which respect latest applications
-				return jdbc.query(APP_SELECT + " where a.created_by=? and extsourcename=? order by a.id desc", APP_MAPPER, pp.getActor(), pp.getExtSourceName());
-			}
+			List<Application> allApplications = jdbc.query(APP_SELECT + " order by a.id desc", APP_MAPPER);
+			return filterPrincipalApplications(sess, allApplications);
 		} catch (EmptyResultDataAccessException ex) {
 			return new ArrayList<>();
 		}
@@ -2467,14 +2372,11 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 		// get necessary params from session
 		User user = sess.getPerunPrincipal().getUser();
-		String actor = sess.getPerunPrincipal().getActor();
-		String extSourceName = sess.getPerunPrincipal().getExtSourceName();
 		int extSourceLoa = sess.getPerunPrincipal().getExtSourceLoa();
 
 		if (AppType.INITIAL.equals(appType)) {
-
 			if (user != null) {
-				// user is known
+				//user is known
 				try {
 					Member m = membersManager.getMemberByUser(registrarSession, vo, user);
 					if (group != null) {
@@ -2484,9 +2386,8 @@ public class RegistrarManagerImpl implements RegistrarManager {
 							// user is member of group - can't post more initial applications
 							throw new AlreadyRegisteredException("You are already member of group "+group.getName()+".");
 						} else {
-							// user isn't member of group
-							checkDuplicateRegistration("Initial application for Group: "+group.getName()+" already exists.",
-									AppType.INITIAL, vo.getId(), group.getId(), user.getId(), actor, extSourceName);
+							checkDupplicateGroupApplications(sess, vo, group, AppType.INITIAL);
+							// pass if have approved or rejected app
 						}
 					} else {
 						// user is member of vo, can't post more initial applications
@@ -2495,64 +2396,43 @@ public class RegistrarManagerImpl implements RegistrarManager {
 				} catch (MemberNotExistsException ex) {
 					// user is not member of vo
 					if (group != null) {
-						// not member of VO - check for unprocessed applications to Group
-						checkDuplicateRegistration("Initial application for Group: "+group.getName()+" already exists.",
-								AppType.INITIAL, vo.getId(), group.getId(), user.getId(), actor, extSourceName);
+						checkDupplicateGroupApplications(sess, vo, group, AppType.INITIAL);
+						//throw new InternalErrorException("You must be member of vo: "+vo.getName()+" to apply for membership in group: "+group.getName());
 					} else {
-						// not member of VO - check for unprocessed applications
-						checkDuplicateRegistration("Initial application for Vo: "+vo.getName()+" already exists.",
-								AppType.INITIAL, vo.getId(), 0, user.getId(), actor, extSourceName);
+						checkDupplicateVoApplications(sess, vo, AppType.INITIAL);
+						// pass not member and have only approved or rejected apps
 					}
 				}
 			} else {
-
 				// user is not known
 				if (group != null) {
-					// group application
-					checkDuplicateRegistration("Initial application for Group: "+group.getName()+" already exists.",
-							AppType.INITIAL, vo.getId(), group.getId(), 0, actor, extSourceName);
+					checkDupplicateGroupApplications(sess, vo, group, AppType.INITIAL);
+					//throw new InternalErrorException("You must be member of vo: "+vo.getName()+" to apply for membership in group: "+group.getName());
 				} else {
-					// vo application
-					checkDuplicateRegistration("Initial application for VO: "+vo.getName()+" already exists.",
-							AppType.INITIAL, vo.getId(), 0, 0, actor, extSourceName);
+					checkDupplicateVoApplications(sess, vo, AppType.INITIAL);
+					// pass not member and have only approved or rejected apps
 				}
-
 			}
-
 			// if false, throws exception with reason for GUI
 			membersManager.canBeMemberWithReason(sess, vo, user, String.valueOf(extSourceLoa));
-
 		}
 		// if extension, user != null !!
 		if (AppType.EXTENSION.equals(appType)) {
-
 			if (user == null) {
 				throw new RegistrarException("Trying to get extension application for non-existing user. Try to log-in with different identity.");
 			}
-
 			// check for submitted registrations
 			Member member = membersManager.getMemberByUser(sess, vo, user);
-
 			if (group != null) {
-
 				member = groupsManager.getGroupMemberById(registrarSession, group, member.getId());
-
-				checkDuplicateRegistration("Extension application for Group: "+group.getName()+" already exists.",
-						AppType.EXTENSION, vo.getId(), group.getId(), user.getId(), actor, extSourceName);
-
+				checkDupplicateGroupApplications(sess, vo, group, AppType.EXTENSION);
 				// if false, throws exception with reason for GUI
 				groupsManager.canExtendMembershipInGroupWithReason(sess, member, group);
-
 				// vo sponsored members can extend in a group
-
 			} else {
-
-				checkDuplicateRegistration("Extension application for Vo: "+vo.getName()+" already exists.",
-						AppType.EXTENSION, vo.getId(), 0, user.getId(), actor, extSourceName);
-
+				checkDupplicateVoApplications(sess, vo, AppType.EXTENSION);
 				// if false, throws exception with reason for GUI
 				membersManager.canExtendMembershipWithReason(sess, member);
-
 				// sponsored vo members cannot be extended in this way
 				if (member.isSponsored()) {
 					throw new CantBeSubmittedException("Sponsored member cannot apply for membership extension, it must be extended by the sponsor.");
@@ -2561,73 +2441,6 @@ public class RegistrarManagerImpl implements RegistrarManager {
 			}
 
 		}
-
-	}
-
-	/**
-	 * Perform DB query and throws DuplicateRegistrationAttemptException when user or actor/extSource have
-	 * unprocessed applications (in NEW or VERIFIED state) within the same VO/Group context.
-	 *
-	 * @param exceptionText Dynamic exception text.
-	 * @param appType Application type to check INITIAL / EXTENSION.
-	 * @param voId ID of VO.
-	 * @param groupId ID of Group. If no group context is expected, pass value <= 0.
-	 * @param userId ID of user. If no user context in expected, pass value <= 0.
-	 * @param actor Identity context
-	 * @param extSourceName Identity context
-	 * @throws DuplicateRegistrationAttemptException When user / identity have unprocesed applications
-	 * @throws RegistrarException When implementation fails
-	 * @throws PrivilegeException Shouldn't happen
-	 */
-	private void checkDuplicateRegistration(String exceptionText, AppType appType, int voId, int groupId, int userId, String actor, String extSourceName) throws DuplicateRegistrationAttemptException, RegistrarException, PrivilegeException {
-
-		String selectVo = "select id from application where apptype=? and state in (?,?) and vo_id=? and group_id is null and created_by=? and extSourceName=?";
-		String selectGroup = "select id from application where apptype=? and state in (?,?) and vo_id=? and group_id=? and created_by=? and extSourceName=?";
-		String selectVoWithUser = "select id from application where apptype=? and state in (?,?) and vo_id=? and group_id is null and (user_id=? or (created_by=? and extSourceName=?))";
-		String selectGroupWithUser = "select id from application where apptype=? and state in (?,?) and vo_id=? and group_id=? and (user_id=? or (created_by=? and extSourceName=?))";
-
-		List<Integer> regs = new ArrayList<>();
-		if (AppType.EXTENSION.equals(appType)) {
-			if (userId <= 0) throw new InternalErrorException("Can't check for duplicate registration attempt on extension application without providing userId.");
-			if (groupId > 0) {
-				regs = jdbc.query(selectGroupWithUser, new SingleColumnRowMapper<>(Integer.class),
-						appType.toString(), AppState.NEW.toString(), AppState.VERIFIED.toString(), voId, groupId, userId, actor, extSourceName);
-			} else {
-				regs = jdbc.query(selectVoWithUser, new SingleColumnRowMapper<>(Integer.class),
-						appType.toString(), AppState.NEW.toString(), AppState.VERIFIED.toString(), voId, userId, actor, extSourceName);
-			}
-		} else if (AppType.INITIAL.equals(appType)) {
-
-			if (userId > 0) {
-				// with user
-				if (groupId > 0) {
-					regs = jdbc.query(selectGroupWithUser, new SingleColumnRowMapper<>(Integer.class),
-							appType.toString(), AppState.NEW.toString(), AppState.VERIFIED.toString(), voId, groupId, userId, actor, extSourceName);
-				} else {
-					regs = jdbc.query(selectVoWithUser, new SingleColumnRowMapper<>(Integer.class),
-							appType.toString(), AppState.NEW.toString(), AppState.VERIFIED.toString(), voId, userId, actor, extSourceName);
-				}
-			} else {
-				// without known user
-				if (groupId > 0) {
-					regs = jdbc.query(selectGroup, new SingleColumnRowMapper<>(Integer.class),
-							appType.toString(), AppState.NEW.toString(), AppState.VERIFIED.toString(), voId, groupId, actor, extSourceName);
-				} else {
-					regs = jdbc.query(selectVo, new SingleColumnRowMapper<>(Integer.class),
-							appType.toString(), AppState.NEW.toString(), AppState.VERIFIED.toString(), voId, actor, extSourceName);
-				}
-			}
-
-		}
-
-		if (!regs.isEmpty()) {
-			// user have unprocessed application for group
-			throw new DuplicateRegistrationAttemptException(exceptionText,
-					getApplicationById(regs.get(0)),
-					getApplicationDataById(registrarSession, regs.get(0)));
-		}
-
-		// pass if have approved or rejected applications or has none submitted
 
 	}
 
@@ -2799,6 +2612,97 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 	}
 
+	@Override
+	public List<Application> filterPrincipalApplications(PerunSession sess, List<Application> applications) {
+		// get necessary params from session
+		PerunPrincipal principal = sess.getPerunPrincipal();
+		User user = principal.getUser();
+		String actor = principal.getActor();
+		String extSourceName = principal.getExtSourceName();
+		Map<String, String> additionalInformation = principal.getAdditionalInformations();
+
+		List<Application> filteredApplications = new ArrayList<>();
+
+		// filter principal's applications
+		for (Application application : applications) {
+			// check existing application by user
+			if (user != null && application.getUser() != null && user.getId() == application.getUser().getId()) {
+				filteredApplications.add(application);
+			} else {
+				//check existing application by additional identifiers
+				String shibIdentityProvider = additionalInformation.get(UsersManagerBl.ORIGIN_IDENTITY_PROVIDER_KEY);
+				if (shibIdentityProvider != null && extSourcesWithMultipleIdentifiers.contains(shibIdentityProvider)) {
+					String principalAdditionalIdentifiers = principal.getAdditionalInformations().get(UsersManagerBl.ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME);
+					if (principalAdditionalIdentifiers == null) {
+						//This should not happen
+						throw new InternalErrorException("Entry " + UsersManagerBl.ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME + " is not defined in the principal's additional information. Either it was not provided by external source used for sign-in or the mapping configuration is wrong.");
+					}
+					LinkedHashMap<String, String> additionalFedAttributes = BeansUtils.stringToMapOfAttributes(application.getFedInfo());
+					String applicationAdditionalIdentifiers = additionalFedAttributes.get(UsersManagerBl.ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME);
+					List<String> identifiersInIntersection = BeansUtils.additionalIdentifiersIntersection(principalAdditionalIdentifiers, applicationAdditionalIdentifiers);
+					if (!identifiersInIntersection.isEmpty()) {
+						filteredApplications.add(application);
+					}
+				}
+				//check existing application by extSourceName and extSource login
+				else if (extSourceName.equals(application.getExtSourceName()) && actor.equals(application.getCreatedBy())) {
+					filteredApplications.add(application);
+				}
+			}
+		}
+		return filteredApplications;
+	}
+
+	@Override
+	public List<Application> filterUserApplications(PerunSession sess, User user, List<Application> applications) {
+
+		List<UserExtSource> userExtSources = usersManager.getUserExtSources(registrarSession, user);
+
+		List<Application> resultApps = new ArrayList<>();
+
+		for (Application application : applications) {
+			//check based on user id
+			if (application.getUser() != null && application.getUser().getId() == user.getId()) {
+				resultApps.add(application);
+			//check based on user extSources
+			} else {
+				for (UserExtSource ues : userExtSources) {
+					if (ues.getExtSource().getName().equals(application.getExtSourceName()) &&
+					ues.getExtSource().getType().equals(application.getExtSourceType())) {
+						//login check
+						if (ues.getLogin().equals(application.getCreatedBy())) {
+							resultApps.add(application);
+							break;
+						}
+						//additional identifiers check
+						try {
+							Attribute attribute = attrManager.getAttribute(sess, ues, UsersManagerBl.ADDITIONAL_IDENTIFIERS_PERUN_ATTRIBUTE_NAME);
+							if (attribute.getValue() != null) {
+								List<String> userIdentifiers = attribute.valueAsList();
+								// Creates Arrays from principal and application identifiers and makes intersection between them.
+								LinkedHashMap<String, String> additionalFedAttributes = BeansUtils.stringToMapOfAttributes(application.getFedInfo());
+								String applicationAdditionalIdentifiers = additionalFedAttributes.get(UsersManagerBl.ADDITIONAL_IDENTIFIERS_ATTRIBUTE_NAME);
+								String[] applicationIdentifiersArray = {};
+								if (applicationAdditionalIdentifiers != null) {
+									applicationIdentifiersArray = applicationAdditionalIdentifiers.split(UsersManagerBl.MULTIVALUE_ATTRIBUTE_SEPARATOR_REGEX);
+								}
+								HashSet<String> principalIdentifiersSet = new HashSet<>(userIdentifiers);
+								principalIdentifiersSet.retainAll(Arrays.asList(applicationIdentifiersArray));
+								if (!principalIdentifiersSet.isEmpty()) {
+									resultApps.add(application);
+									break;
+								}
+							}
+						} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+							//We can ignore that
+						}
+					}
+				}
+			}
+		}
+		return resultApps;
+	}
+
 	/**
 	 * Retrieve form item data by its ID or NULL if not exists.
 	 *
@@ -2921,7 +2825,9 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 			try {
 				if (app.getUser() == null) {
-					User u = usersManager.getUserByExtSourceNameAndExtLogin(sess, app.getExtSourceName(), app.getCreatedBy());
+					LinkedHashMap<String, String> additionalAttributes = BeansUtils.stringToMapOfAttributes(app.getFedInfo());
+					PerunPrincipal applicationPrincipal = new PerunPrincipal(app.getCreatedBy(), app.getExtSourceName(), app.getExtSourceType(), app.getExtSourceLoa(), additionalAttributes);
+					User u = perun.getUsersManagerBl().getUserByExtSourceInformation(sess, applicationPrincipal);
 					if (u != null) {
 						membersManager.getMemberByUser(sess, app.getVo(), u);
 					} else {
@@ -3333,25 +3239,13 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	 */
 	private void autoApproveUsersGroupApplications(PerunSession sess, Vo vo, User user) throws PerunException {
 
-		List<UserExtSource> ues = usersManager.getUserExtSources(registrarSession, user);
+		// get group apps based on the vo
+		List<Application> apps = jdbc.query(
+			APP_SELECT + " where a.vo_id=? and a.group_id is not null and a.state=?",
+			APP_MAPPER, vo.getId(), AppState.VERIFIED.toString());
 
-		List<Application> applications = new ArrayList<>();
-
-		// get apps based on user
-
-		List<Application> apps = jdbc.query(APP_SELECT + " where a.vo_id=? and a.group_id is not null and a.state=?" +
-				" and a.user_id=?", APP_MAPPER, vo.getId(), AppState.VERIFIED.toString(), user.getId());
-
-		if (!apps.isEmpty()) applications.addAll(apps);
-
-		for (UserExtSource ue : ues) {
-
-			List<Application> apps2 = jdbc.query(APP_SELECT + " where a.vo_id=? and a.group_id is not null and a.state=?" +
-					" and a.created_by=? and a.extsourcename=? and a.extsourcetype=?", APP_MAPPER, vo.getId(), AppState.VERIFIED.toString(), ue.getLogin(), ue.getExtSource().getName(), ue.getExtSource().getType());
-
-			if (!apps2.isEmpty()) applications.addAll(apps2);
-
-		}
+		//filter only user's apps
+		List<Application> applications = filterUserApplications(sess, user, apps);
 
 		for (Application a : applications) {
 			// if new => skipp user will approve automatically by verifying email
@@ -3436,6 +3330,136 @@ public class RegistrarManagerImpl implements RegistrarManager {
 
 	}
 
+	/**
+	 * Method creates a candidate object from application according to the application id.
+	 *
+	 * @param appId id of the application
+	 * @return Candidate
+	 */
+	private Candidate createCandidateFromApplicationData(Integer appId) {
+		// put application data into Candidate
+		final Map<String, String> attributes = new HashMap<>();
+		jdbc.query("select dst_attr,value from application_data d, application_form_items i where d.item_id=i.id "
+				+ "and i.dst_attr is not null and d.value is not null and app_id=?",
+			(resultSet, i) -> {
+				attributes.put(resultSet.getString("dst_attr"), resultSet.getString("value"));
+				return null;
+			}, appId);
+
+		// DO NOT STORE LOGINS THROUGH CANDIDATE
+		// we do not set logins by candidate object to prevent accidental overwrite while joining identities in process
+		attributes.entrySet().removeIf(entry -> entry.getKey().contains("urn:perun:user:attribute-def:def:login-namespace:"));
+
+		Candidate candidate = new Candidate();
+		candidate.setAttributes(attributes);
+
+		log.debug("[REGISTRAR] Retrieved candidate from DB {}", candidate);
+
+		// first try to parse display_name if not null and not empty
+		if (attributes.containsKey(URN_USER_DISPLAY_NAME) && attributes.get(URN_USER_DISPLAY_NAME) != null &&
+			!attributes.get(URN_USER_DISPLAY_NAME).isEmpty()) {
+			// parse
+			Map<String, String> commonName = Utils.parseCommonName(attributes.get(URN_USER_DISPLAY_NAME));
+			if (commonName.get("titleBefore") != null
+				&& !commonName.get("titleBefore").isEmpty()) {
+				candidate.setTitleBefore(commonName.get("titleBefore"));
+			}
+			if (commonName.get("firstName") != null
+				&& !commonName.get("firstName").isEmpty()) {
+				candidate.setFirstName(commonName.get("firstName"));
+			}
+			// FIXME - ? there is no middleName in Utils.parseCommonName() implementation
+			if (commonName.get("middleName") != null
+				&& !commonName.get("middleName").isEmpty()) {
+				candidate.setMiddleName(commonName.get("middleName"));
+			}
+			if (commonName.get("lastName") != null
+				&& !commonName.get("lastName").isEmpty()) {
+				candidate.setLastName(commonName.get("lastName"));
+			}
+			if (commonName.get("titleAfter") != null
+				&& !commonName.get("titleAfter").isEmpty()) {
+				candidate.setTitleAfter(commonName.get("titleAfter"));
+			}
+		}
+
+		// if names are separated, used them after
+		for (String attrName : attributes.keySet()) {
+			// if value not null or empty - set to candidate
+			if (attributes.get(attrName) != null
+				&& !attributes.get(attrName).isEmpty()) {
+				if (URN_USER_TITLE_BEFORE.equals(attrName)) {
+					candidate.setTitleBefore(attributes.get(attrName));
+				} else if (URN_USER_TITLE_AFTER.equals(attrName)) {
+					candidate.setTitleAfter(attributes.get(attrName));
+				} else if (URN_USER_FIRST_NAME.equals(attrName)) {
+					candidate.setFirstName(attributes.get(attrName));
+				} else if (URN_USER_LAST_NAME.equals(attrName)) {
+					candidate.setLastName(attributes.get(attrName));
+				} else if (URN_USER_MIDDLE_NAME.equals(attrName)) {
+					candidate.setMiddleName(attributes.get(attrName));
+				}
+			}
+		}
+
+		return candidate;
+	}
+
+	/**
+	 * Check whether a principal in perun session has already created application in group
+	 *
+	 * @param sess perun session containing principal
+	 * @param vo for application
+	 * @param group for application
+	 * @param applicationType type of application
+	 * @throws DuplicateRegistrationAttemptException if the principal has already created application
+	 * @throws RegistrarException
+	 * @throws PrivilegeException
+	 */
+	private void checkDupplicateGroupApplications(PerunSession sess, Vo vo, Group group, AppType applicationType) throws DuplicateRegistrationAttemptException, RegistrarException, PrivilegeException {
+		// select neccessary information from already existing Group applications
+		List<Application> applications = new ArrayList<>(jdbc.query(
+			"select id, user_id, created_by, extSourceName, fed_info from application where apptype=? and vo_id=? and group_id=? and (state=? or state=?)",
+			IDENTITY_APP_MAPPER,
+			applicationType.toString(), vo.getId(), group.getId(), AppState.NEW.toString(), AppState.VERIFIED.toString()));
+		// not member of VO - check for unprocessed applications to Group
+		List<Application> filteredApplications = filterPrincipalApplications(sess, applications);
+		if (!filteredApplications.isEmpty()) {
+			// user have unprocessed application for group
+			throw new DuplicateRegistrationAttemptException(
+				"Application for Group: "+group.getName()+" already exists.",
+				getApplicationById(filteredApplications.get(0).getId()),
+				getApplicationDataById(registrarSession, filteredApplications.get(0).getId()));
+		}
+	}
+
+	/**
+	 * Check whether a principal in perun session has already created application in vo
+	 *
+	 * @param sess perun session containing principal
+	 * @param vo for application
+	 * @param applicationType type of application
+	 * @throws DuplicateRegistrationAttemptException if the principal has already created application
+	 * @throws RegistrarException
+	 * @throws PrivilegeException
+	 */
+	private void checkDupplicateVoApplications(PerunSession sess, Vo vo, AppType applicationType) throws DuplicateRegistrationAttemptException, RegistrarException, PrivilegeException {
+		// select neccessary information from already existing Vo applications
+		List<Application> applications = jdbc.query(
+			"select id, user_id, created_by, extSourceName, fed_info from application where apptype=? and vo_id=? and group_id is null and (state=? or state=?)",
+			IDENTITY_APP_MAPPER,
+			applicationType.toString(), vo.getId(), AppState.NEW.toString(), AppState.VERIFIED.toString());
+		// not member of VO - check for unprocessed applications
+		List<Application> filteredApplications = filterPrincipalApplications(sess, applications);
+		if (!filteredApplications.isEmpty()) {
+			// user have unprocessed application for VO - can't post more
+			throw new DuplicateRegistrationAttemptException(
+				"Application for VO: "+vo.getName()+" already exists.",
+				getApplicationById(filteredApplications.get(0).getId()),
+				getApplicationDataById(registrarSession, filteredApplications.get(0).getId()));
+		}
+	}
+
 	// ------------------ MAPPERS AND SELECTS -------------------------------------
 
 	// FIXME - we are retrieving GROUP name using only "short_name" so it's not same as getGroupById()
@@ -3453,6 +3477,16 @@ public class RegistrarManagerImpl implements RegistrarManager {
 	private static final String FORM_ITEM_SELECT = "select id,ordnum,shortname,required,type,fed_attr,src_attr,dst_attr,regex from application_form_items";
 
 	private static final String FORM_ITEM_TEXTS_SELECT = "select locale,label,options,help,error_message from application_form_item_texts";
+
+	private static final RowMapper<Application> IDENTITY_APP_MAPPER = (resultSet, i) -> {
+		Application app = new Application();
+		app.setId(resultSet.getInt("id"));
+		app.setUser(new User(resultSet.getInt("user_id"),"","","","",""));
+		app.setCreatedBy(resultSet.getString("created_by"));
+		app.setExtSourceName(resultSet.getString("extsourcename"));
+		app.setFedInfo(resultSet.getString("fed_info"));
+		return app;
+	};
 
 	static final RowMapper<Application> APP_MAPPER = (resultSet, i) -> {
 

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/Api.java
@@ -18,6 +18,7 @@ import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PerunRuntimeException;
 import cz.metacentrum.perun.core.bl.PerunBl;
+import cz.metacentrum.perun.core.bl.UsersManagerBl;
 import cz.metacentrum.perun.core.blImpl.AttributesManagerBlImpl;
 import cz.metacentrum.perun.core.impl.AttributesManagerImpl;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
@@ -234,7 +235,7 @@ public class Api extends HttpServlet {
 
 			// Store IdP used by user to session, since for IdentityConsolidator and Registrar we need to know,
 			// if user logged in through proxy or not - we provide different links etc.
-			additionalInformations.put(PerunBl.ORIGIN_IDENTITY_PROVIDER_KEY, shibIdentityProvider);
+			additionalInformations.put(UsersManagerBl.ORIGIN_IDENTITY_PROVIDER_KEY, shibIdentityProvider);
 
 			if (isNotEmpty(remoteUser)) {
 				extLogin = remoteUser;


### PR DESCRIPTION
- Managers in registrar module did not work with additional identifiers
  yet. Therefore, the functionality was added.
- Method approveApplicationInternal() was using method createMember()
  which could not find user when additional identifiers were used.
  So this part tries to find user first. If it succeeds, createMember() is
  called with user parameter. Otherwise is used createMember() with
  candidate parameter as it was before.
- To prevent duplicities, method getUserByExtSourceInformation was
  created in UsersManagerBl.
- New method stringToMapOfAttributes was created in BeansUtils, which
  converts String representation of map attribute back to Map attribute.