### PR TITLE
CORE: Do not recompile patterns on each check

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ModulesUtilsBl.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * @author Michal Stava <stavamichal@gmail.com>
@@ -331,7 +332,7 @@ public interface ModulesUtilsBl {
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeValueException
 	 */
-	void checkAttributeRegex(Attribute attribute, String defaultRegex) throws InternalErrorException, WrongAttributeValueException;
+	void checkAttributeRegex(Attribute attribute, Pattern defaultRegex) throws InternalErrorException, WrongAttributeValueException;
 
 	/**
 	 * Check if quotaToCheck is in limit of limitQuota.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -639,7 +639,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	}
 
 	@Override
-	public void checkAttributeRegex(Attribute attribute, String defaultRegex) throws InternalErrorException, WrongAttributeValueException {
+	public void checkAttributeRegex(Attribute attribute, Pattern defaultRegex) throws InternalErrorException, WrongAttributeValueException {
 		if (attribute == null || attribute.getValue() == null) throw new InternalErrorException("Attribute or it's value is null.");
 		String attributeValue = (String) attribute.getValue();
 		checkPerunNamespacesMap();
@@ -658,8 +658,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 			}
 		} else {
 			//Regex property not found in our attribute map, so use the default hardcoded regex
-			if (defaultRegex == null) return;
-			if (!attributeValue.matches(defaultRegex)) {
+			if (!defaultRegex.matcher(attributeValue).matches()) {
 				throw new WrongAttributeValueException(attribute, "Wrong format. Regex: \"" + defaultRegex +"\" expected for this attribute:");
 			}
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -72,6 +72,9 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	public static final Pattern letterPattern = Pattern.compile("[A-Z]");
 	public static final Pattern fqdnPattern = Pattern.compile("^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}\\.?$");
 
+	//previous regex ^/[-a-zA-Z0-9_/]*$"
+	public static final Pattern shellPattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
+
 	public final static List<String> reservedNamesForUnixGroups = Arrays.asList("root", "daemon", "tty", "bin", "sys", "sudo", "nogroup",
 	          "hadoop", "hdfs", "mapred", "yarn", "hsqldb", "derby", "jetty", "hbase", "zookeeper", "users", "oozie", "hive");
 	public final static List<String> unpermittedNamesForUserLogins = Arrays.asList("arraysvcs", "at", "backup", "bin", "daemon", "Debian-exim", "flexlm", "ftp", "games",
@@ -629,11 +632,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 
 	@Override
 	public void checkFormatOfShell(String shell, Attribute attribute) throws WrongAttributeValueException {
-		//previous regex ^/[-a-zA-Z0-9_/]*$"
-		Pattern pattern = Pattern.compile("^(/[-_a-zA-Z0-9]+)+$");
-
-		Matcher match = pattern.matcher(shell);
-
+		Matcher match = shellPattern.matcher(shell);
 		if (!match.matches()) {
 			throw new WrongAttributeValueException(attribute, "Bad shell attribute format " + shell);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_group_attribute_def_def_unixGroupName_namespace.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -31,11 +32,13 @@ public class urn_perun_group_attribute_def_def_unixGroupName_namespace extends G
 	private static final String A_G_unixGID_namespace = AttributesManager.NS_GROUP_ATTR_DEF + ":unixGID-namespace";
 	private static final String A_R_unixGID_namespace = AttributesManager.NS_RESOURCE_ATTR_DEF + ":unixGID-namespace";
 
+	protected static final Pattern defaultUnixGroupNamePattern = Pattern.compile("^[-_.a-zA-Z0-9]+$");
+
 	@Override
 	public void checkAttributeSyntax(PerunSessionImpl sess, Group group, Attribute attribute) throws WrongAttributeValueException, InternalErrorException {
 		if (attribute.getValue() == null) return;
 		//Check attribute regex
-		sess.getPerunBl().getModulesUtilsBl().checkAttributeRegex(attribute, "^[-._a-zA-Z0-9]+$");
+		sess.getPerunBl().getModulesUtilsBl().checkAttributeRegex(attribute, defaultUnixGroupNamePattern);
 
 		//Check reserved unix group names
 		sess.getPerunBl().getModulesUtilsBl().checkReservedUnixGroupNames(attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_resource_attribute_def_def_unixGroupName_namespace.java
@@ -17,6 +17,7 @@ import cz.metacentrum.perun.core.implApi.modules.attributes.ResourceAttributesMo
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -30,12 +31,14 @@ public class urn_perun_resource_attribute_def_def_unixGroupName_namespace extend
 	private static final String A_G_unixGID_namespace = AttributesManager.NS_GROUP_ATTR_DEF + ":unixGID-namespace";
 	private static final String A_G_unixGroupName_namespace = AttributesManager.NS_GROUP_ATTR_DEF + ":unixGroupName-namespace";
 
+	protected static final Pattern defaultUnixGroupNamePattern = Pattern.compile("^[-_.a-zA-Z0-9]+$");
+
 	@Override
 	public void checkAttributeSyntax(PerunSessionImpl sess, Resource resource, Attribute attribute) throws InternalErrorException, WrongAttributeValueException {
 		if(attribute.getValue() == null) return;
 
 		//Check attribute regex
-		sess.getPerunBl().getModulesUtilsBl().checkAttributeRegex(attribute, "^[-_.a-zA-Z0-9]+$");
+		sess.getPerunBl().getModulesUtilsBl().checkAttributeRegex(attribute, defaultUnixGroupNamePattern);
 
 		//Check reserved unix group names
 		sess.getPerunBl().getModulesUtilsBl().checkReservedUnixGroupNames(attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Class for checking login uniqueness in the namespace and filling login value in namespace
@@ -36,6 +37,8 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 
 	protected final static List<String> generatedNamespaces = BeansUtils.getCoreConfig().getGeneratedLoginNamespaces();
 
+	protected final static Pattern defaultLoginPattern = Pattern.compile("^[a-zA-Z0-9_][-A-z0-9_.@/]*$");
+
 	/**
 	 * Checks if the user's login is in the correct format and if it is permitted to use
 	 *
@@ -50,7 +53,7 @@ public class urn_perun_user_attribute_def_def_login_namespace extends UserAttrib
 		if (attribute.getValue() == null) return;
 
 		//Check attribute regex
-		sess.getPerunBl().getModulesUtilsBl().checkAttributeRegex(attribute, "^[a-zA-Z0-9_][-A-z0-9_.@/]*$");
+		sess.getPerunBl().getModulesUtilsBl().checkAttributeRegex(attribute, defaultLoginPattern);
 		//Check if user login is permitted or not permitted
 		sess.getPerunBl().getModulesUtilsBl().checkUnpermittedUserLogins(attribute);
 	}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fedcloud.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fedcloud.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Class for checking logins uniqueness and filling random unique ID.
@@ -25,6 +26,8 @@ import java.util.UUID;
 public class urn_perun_user_attribute_def_def_login_namespace_fedcloud extends urn_perun_user_attribute_def_def_login_namespace {
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace_fedcloud.class);
+
+	protected final static Pattern defaultFedcloudLoginPattern = Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
 
 	/**
 	 * Checks if the user's login has correct format and if it's not already reserved in that namespace.
@@ -40,7 +43,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_fedcloud extends u
 		if (attribute.valueAsString() == null) return;
 
 		//Check attribute regex
-		sess.getPerunBl().getModulesUtilsBl().checkAttributeRegex(attribute, "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+		sess.getPerunBl().getModulesUtilsBl().checkAttributeRegex(attribute, defaultFedcloudLoginPattern);
 	}
 
 	/**


### PR DESCRIPTION
- Pattern for the shell can be pre-compiled in static variable, there is
  no need to compile it on each check.
- ModulesUtilsBl.checkAttributeRegex() now takes compiled Pattern
  instead of String regex value. Like this we prevent same pattern
  re-compilation on each check of login or unix group names syntax.