### PR TITLE
CORE: Fix allowed resource recognition, assignGroup optimization

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -5361,21 +5361,15 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public boolean isTrulyRequiredAttribute(PerunSession sess, Facility facility, User user, AttributeDefinition attributeDefinition) throws InternalErrorException, WrongAttributeAssignmentException {
 		this.checkNamespace(sess, attributeDefinition, NS_USER_FACILITY_ATTR);
-		List<Facility> allowedFacilities = getPerunBl().getFacilitiesManagerBl().getAllowedFacilities(sess, user);
-		if (!allowedFacilities.contains(facility)) {
-			return false;
-		} else {
-			if (!getAttributesManagerImpl().isAttributeRequiredByFacility(sess, facility, attributeDefinition))
-				return false;
-			List<Resource> resources = getPerunBl().getFacilitiesManagerBl().getAssignedResources(sess, facility);
-			resources.retainAll(getPerunBl().getUsersManagerBl().getAllowedResources(sess, user));
-			for (Resource resource : resources) {
-				if (getAttributesManagerImpl().isAttributeRequiredByResource(sess, resource, attributeDefinition))
-					return true;
-			}
+		if (!getAttributesManagerImpl().isAttributeRequiredByFacility(sess, facility, attributeDefinition)) {
 			return false;
 		}
-
+		List<Resource> resources = getPerunBl().getUsersManagerBl().getAllowedResources(sess, facility, user);
+		for (Resource resource : resources) {
+			if (getAttributesManagerImpl().isAttributeRequiredByResource(sess, resource, attributeDefinition))
+				return true;
+		}
+		return false;
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/AttributesManagerImpl.java
@@ -5097,7 +5097,8 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 */
 	GroupResourceVirtualAttributesModuleImplApi getResourceGroupVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
-		if (attributeModule == null) return null;
+		if (attributeModule == null)
+			throw new ModuleNotExistsException("Virtual attribute module for " + attribute + " doesn't exists.");
 
 		if (attributeModule instanceof GroupResourceVirtualAttributesModuleImplApi) {
 			return (GroupResourceVirtualAttributesModuleImplApi) attributeModule;
@@ -5114,7 +5115,8 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 */
 	MemberResourceVirtualAttributesModuleImplApi getResourceMemberVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
-		if (attributeModule == null) return null;
+		if (attributeModule == null)
+			throw new ModuleNotExistsException("Virtual attribute module for " + attribute + " doesn't exists.");
 
 		if (attributeModule instanceof MemberResourceVirtualAttributesModuleImplApi) {
 			return (MemberResourceVirtualAttributesModuleImplApi) attributeModule;
@@ -5131,7 +5133,8 @@ public class AttributesManagerImpl implements AttributesManagerImplApi {
 	 */
 	MemberGroupVirtualAttributesModuleImplApi getMemberGroupVirtualAttributeModule(PerunSession sess, AttributeDefinition attribute) throws InternalErrorException {
 		Object attributeModule = getAttributesModule(sess, attribute);
-		if (attributeModule == null) return null;
+		if (attributeModule == null)
+			throw new ModuleNotExistsException("Virtual attribute module for " + attribute + " doesn't exists.");
 
 		if (attributeModule instanceof MemberGroupVirtualAttributesModuleImplApi) {
 			return (MemberGroupVirtualAttributesModuleImplApi) attributeModule;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ResourcesManagerImpl.java
@@ -354,8 +354,8 @@ public class ResourcesManagerImpl implements ResourcesManagerImplApi {
 					" left outer join groups_resources on groups_resources.resource_id=resources.id" +
 					" left outer join groups_members on groups_members.group_id=groups_resources.group_id" +
 					" left outer join members on members.id=groups_members.member_id" +
-					" where facilities.id=? and members.user_id=? and members.status!=?",
-					RESOURCE_MAPPER, facility.getId(), user.getId(), String.valueOf(Status.INVALID.getCode()));
+					" where facilities.id=? and members.user_id=? and members.status!=? and members.status!=?",
+					RESOURCE_MAPPER, facility.getId(), user.getId(), String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
 		} catch (EmptyResultDataAccessException e) {
 			return new ArrayList<>();
 		}	catch (RuntimeException e) {


### PR DESCRIPTION
- Set group and group_resource required attributes together.
- We now set required attributes only to the valid, expired
  and suspended group members (same as assign service does).
- Optimized isTrulyRequired(user,facility), now we resolve
  allowed resources and check required attributes on them.
  For true it previously double checked allowed facilities,
  assigned and allowed resources.
- Fixed getAllowedResources(facility,user) which previously returned
  also resources, where member was disabled.
- Fixed getAllowedResources(member) which previously returned
  also resources, where member was disabled.