### PR TITLE
Rework findMembers logic

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/MembersManager.java
@@ -641,13 +641,14 @@ public interface MembersManager {
 	 * @param vo
 	 * @param attrsNames
 	 * @param searchString
+	 * @param onlySponsored return only sponsored members
 	 * @return list of founded richMembers with specific attributes from Vo for searchString
 	 * @throws InternalErrorException
 	 * @throws PrivilegeException
 	 * @throws VoNotExistsException
 	 * @throws ParentGroupNotExistsException
 	 */
-	List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, String searchString) throws InternalErrorException, PrivilegeException, VoNotExistsException;
+	List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, String searchString, boolean onlySponsored) throws InternalErrorException, PrivilegeException, VoNotExistsException;
 
 	/**
 	 * Return list of richMembers for specific vo by the searchString with attrs specific for list of attrsNames

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/MembersManagerBl.java
@@ -699,10 +699,11 @@ public interface MembersManagerBl {
 	 * @param vo
 	 * @param attrsNames
 	 * @param searchString
+	 * @param onlySponsored return only sponsored members
 	 * @return list of founded richMembers with specific attributes from Vo for searchString
 	 * @throws InternalErrorException
 	 */
-	List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, String searchString) throws InternalErrorException;
+	List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, String searchString, boolean onlySponsored) throws InternalErrorException;
 
 	/**
 	 * Return list of richMembers by the searchString with attributes specific for list of attrsNames.
@@ -1066,19 +1067,21 @@ public interface MembersManagerBl {
 	 * @param sess
 	 * @param searchString
 	 * @param vo
+	 * @param onlySponsored return only sponsored members
 	 * @return list of rich members
 	 * @throws InternalErrorException
 	 */
-	List<RichMember> findRichMembersInVo(PerunSession sess, Vo vo, String searchString) throws InternalErrorException;
+	List<RichMember> findRichMembersInVo(PerunSession sess, Vo vo, String searchString, boolean onlySponsored) throws InternalErrorException;
 
 	/**
 	 * Return list of rich members by theirs name or login or email
 	 * @param sess
 	 * @param searchString
+	 * @param onlySponsored return only sponsored members
 	 * @return list of rich members
 	 * @throws InternalErrorException
 	 */
-	List<RichMember> findRichMembers(PerunSession sess, String searchString) throws InternalErrorException;
+	List<RichMember> findRichMembers(PerunSession sess, String searchString, boolean onlySponsored) throws InternalErrorException;
 
 	/**
 	 * Return list of rich members with certain attributes by theirs name or login or email defined VO.
@@ -1086,10 +1089,11 @@ public interface MembersManagerBl {
 	 * @param vo vo
 	 * @param searchString search string
 	 * @param attrsNames list of attribute names that should be found
+	 * @param onlySponsored return only sponsored members
 	 * @return list of rich members with certain attributes
 	 * @throws InternalErrorException
 	 */
-	List<RichMember> findRichMembersWithAttributesInVo(PerunSession sess, Vo vo, String searchString, List<String> attrsNames) throws InternalErrorException;
+	List<RichMember> findRichMembersWithAttributesInVo(PerunSession sess, Vo vo, String searchString, List<String> attrsNames, boolean onlySponsored) throws InternalErrorException;
 
 	/**
 	 * Return list of rich members with attributes by theirs name or login or email under defined VO.
@@ -1566,4 +1570,18 @@ public interface MembersManagerBl {
 	 */
 	MemberGroupStatus getUnifiedMemberGroupStatus(PerunSession sess, User user, Facility facility) throws InternalErrorException;
 
+	/**
+	 * Return list of members VO by specific string.
+	 * Looking for searchString in member mail, user preferredMail, logins, name and IDs (user and member).
+	 * If parameter onlySponsored is true, it will return only sponsored members by searchString.
+	 * If vo is null, looking for any members in whole Perun. If vo is not null, looking only in specific VO.<
+	 *
+	 * @param sess
+	 * @param vo for which searching will be filtered, if null there is no filter for vo
+	 * @param searchString it will be looking for this search string in the specific parameters in DB
+	 * @param onlySponsored it will return only sponsored members in vo
+	 * @return all members from specific VO by specific string
+	 * @throws InternalErrorException
+	 */
+	List<Member> findMembers(PerunSession sess, Vo vo, String searchString, boolean onlySponsored);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/MembersManagerEntry.java
@@ -650,7 +650,7 @@ public class MembersManagerEntry implements MembersManager {
 	}
 
 	@Override
-	public List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, String searchString) throws InternalErrorException, PrivilegeException, VoNotExistsException {
+	public List<RichMember> findCompleteRichMembers(PerunSession sess, Vo vo, List<String> attrsNames, String searchString, boolean onlySponsored) throws InternalErrorException, PrivilegeException, VoNotExistsException {
 		Utils.checkPerunSession(sess);
 
 		perunBl.getVosManagerBl().checkVoExists(sess, vo);
@@ -663,7 +663,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findCompleteRichMembers");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, vo, attrsNames, searchString), null, true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findCompleteRichMembers(sess, vo, attrsNames, searchString, onlySponsored), null, true);
 	}
 
 	@Override
@@ -1046,7 +1046,7 @@ public class MembersManagerEntry implements MembersManager {
 			throw new PrivilegeException(sess, "findRichMembersInVo");
 		}
 
-		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersInVo(sess, vo, searchString), null, true);
+		return getPerunBl().getMembersManagerBl().filterOnlyAllowedAttributes(sess, getMembersManagerBl().findRichMembersInVo(sess, vo, searchString, false), null, true);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/MembersManagerImplApi.java
@@ -340,4 +340,17 @@ public interface MembersManagerImplApi {
 	 */
 	MemberGroupStatus getUnifiedMemberGroupStatus(PerunSession sess, User user, Facility facility) throws InternalErrorException;
 
+	/**
+	 * Return list of members by specific string.
+	 * Looking for searchString in member mail, user preferredMail, logins, name and IDs (user and member).
+	 * If parameter onlySponsored is true, it will return only sponsored members by searchString.
+	 * If vo is null, looking for any members in whole Perun. If vo is not null, looking only in specific VO.
+	 *
+	 * @param sess
+	 * @param vo for which searching will be filtered, if null there is no filter for vo
+	 * @param searchString it will be looking for this search string in the specific parameters in DB
+	 * @param onlySponsored it will return only sponsored members in vo
+	 * @return all members from specific VO by specific string
+	 */
+	List<Member> findMembers(PerunSession sess, Vo vo, String searchString, boolean onlySponsored);
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/MembersManagerMethod.java
@@ -1023,6 +1023,17 @@ public enum MembersManagerMethod implements ManagerMethod {
  	 * @return List<RichMember> List of founded richMembers with specific attributes from Vo for searchString
  	 */
 	/*#
+	 * Return list of richMembers for specific vo by the searchString with attrs specific for list of attrsNames.
+	 * If attrsNames is empty or null return all attributes for specific richMembers.
+	 * By parameter onlySponsored we can return only sponsored members for specific vo.
+	 *
+	 * @param vo int Vo <code>id</code>
+	 * @param attrsNames List<String> Attribute names
+	 * @param searchString String String to search by
+	 * @param onlySponsored Boolean true, if only sponsored members should be returned, false otherwise
+	 * @return List<RichMember> List of founded richMembers with specific attributes from Vo for searchString
+	 */
+	/*#
  	 * Return list of richMembers for specific group by the searchString with attributes specific for list of attrsNames
  	 * and who have only status which is contain in list of statuses.
  	 * If attrsNames is empty or null return all attributes for specific richMembers.
@@ -1074,10 +1085,13 @@ public enum MembersManagerMethod implements ManagerMethod {
 							parms.readList("allowedStatuses", String.class),
 							parms.readString("searchString"));
 				} else {
+					boolean onlySponsored = false;
+					if(parms.contains("onlySponsored")) onlySponsored = parms.readBoolean("onlySponsored");
 					return ac.getMembersManager().findCompleteRichMembers(ac.getSession(),
 							ac.getVoById(parms.readInt("vo")),
 							parms.readList("attrsNames", String.class),
-							parms.readString("searchString"));
+							parms.readString("searchString"),
+							onlySponsored);
 				}
 			} else {
 				if(parms.contains("allowedStatuses")) {


### PR DESCRIPTION
 - logic about looking for members was done by looking for users and
 then filtering, now it is one separate sql query with the same meaning
 - we can specify vo (to filter only vo members) or not
 - we can specify if only sponsored users should be returned
 - all methods in MembersManager now using this logic
 - using filtering of sponsored accounts was added to one of existing
 methods and rpc was changed by that too
 - some basic tests were added