### PR TITLE
ExtSourceSql with pooling connections

### DIFF
--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -141,8 +141,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>jdom</groupId>
-			<artifactId>jdom</artifactId>
+			<groupId>org.dom4j</groupId>
+			<artifactId>dom4j</artifactId>
 		</dependency>
 
 		<dependency>

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/ExtSourcesManagerBl.java
@@ -20,6 +20,7 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationExc
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
 
+import javax.sql.DataSource;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +34,11 @@ public interface ExtSourcesManagerBl {
 	 * Initialize manager.
 	 */
 	void initialize(PerunSession sess);
+
+	/**
+	 * Destroy manager. Clean resources.
+	 */
+	void destroy();
 
 	/**
 	 * Creates an external source.
@@ -127,7 +133,7 @@ public interface ExtSourcesManagerBl {
 	 *
 	 * @throws InternalErrorException
 	 */
-	void addExtSource(PerunSession perunSession, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException;
+	void addExtSourceToVo(PerunSession perunSession, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException;
 
 	/**
 	 * Associate external source definition with the GROUP.
@@ -139,7 +145,7 @@ public interface ExtSourcesManagerBl {
 	 * @throws InternalErrorException
 	 * @throws ExtSourceAlreadyAssignedException
 	 */
-	void addExtSource(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException;
+	void addExtSourceToGroup(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException;
 
 	/**
 	 * Remove association of the external source from the VO.
@@ -152,7 +158,7 @@ public interface ExtSourcesManagerBl {
 	 * @throws ExtSourceNotAssignedException
 	 * @throws ExtSourceAlreadyRemovedException if there are 0 rows affected by delete from DB
 	 */
-	void removeExtSource(PerunSession perunSession, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException;
+	void removeExtSourceFromVo(PerunSession perunSession, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException;
 
 	/**
 	 * Remove association of the external source from the GROUP.
@@ -165,7 +171,7 @@ public interface ExtSourcesManagerBl {
 	 * @throws ExtSourceAlreadyRemovedException when 0 rows affected by removing from DB
 	 * @throws ExtSourceNotAssignedException
 	 */
-	void removeExtSource(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException;
+	void removeExtSourceFromGroup(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException;
 
 	/**
 	 * Checks whether the ExtSource exists, if not, then the ExtSource is created.
@@ -280,4 +286,11 @@ public interface ExtSourcesManagerBl {
 	 */
 	List<CandidateGroup> generateCandidateGroups(PerunSession perunSession, List<Map<String,String>> groupSubjectsData, ExtSource source) throws InternalErrorException;
 
+	/**
+	 * Returns a database connection pool.
+	 *
+	 * @param poolName named defined in perun-extSources.xml
+	 * @return database connection pool
+	 */
+	DataSource getDataSource(String poolName);
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -329,7 +329,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		List<ExtSource> assignedSources = getPerunBl().getExtSourcesManagerBl().getGroupExtSources(sess, group);
 		for(ExtSource source: assignedSources) {
 			try {
-				getPerunBl().getExtSourcesManagerBl().removeExtSource(sess, group, source);
+				getPerunBl().getExtSourcesManagerBl().removeExtSourceFromGroup(sess, group, source);
 			} catch (ExtSourceNotAssignedException | ExtSourceAlreadyRemovedException ex) {
 				//Just log this, because if method can't remove it, it is probably not assigned now
 				log.warn("Try to remove not existing extSource {} from group {} when deleting group.", source, group);
@@ -3570,7 +3570,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		//for each group set attributes for members synchronization, synchronize them and save the result
 		for (Group group: groupsForMemberSynchronization) {
 			try {
-				getPerunBl().getExtSourcesManagerBl().addExtSource(sess, group, source);
+				getPerunBl().getExtSourcesManagerBl().addExtSourceToGroup(sess, group, source);
 			} catch (ExtSourceAlreadyAssignedException e) {
 				log.info("ExtSource already assigned to group: {}", group);
 			}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/PerunBlImpl.java
@@ -570,6 +570,14 @@ public class PerunBlImpl implements PerunBl {
 		}
 	}
 
+	/**
+	 * Called when Perun is shutting down to clean up opened resources.
+	 */
+	public void destroy() {
+		log.debug("destroying");
+		this.extSourcesManagerBl.destroy();
+	}
+
 	@Override
 	public String toString() {
 		return getClass().getSimpleName() + ":[" +

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -151,7 +151,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 			List<ExtSource> ess = getPerunBl().getExtSourcesManagerBl().getVoExtSources(sess, vo);
 			log.debug("Deleting {} external sources binded to the vo {}", ess.size(), vo);
 			for (ExtSource es : ess) {
-				getPerunBl().getExtSourcesManagerBl().removeExtSource(sess, vo, es);
+				getPerunBl().getExtSourcesManagerBl().removeExtSourceFromVo(sess, vo, es);
 			}
 
 			// Delete members group

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntry.java
@@ -153,7 +153,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		if (!AuthzResolver.authorizedInternal(sess, "addExtSource_Vo_ExtSource_policy", Arrays.asList(vo, source)))
 			throw new PrivilegeException(sess, "addExtSource");
 
-		getExtSourcesManagerBl().addExtSource(sess, vo, source);
+		getExtSourcesManagerBl().addExtSourceToVo(sess, vo, source);
 	}
 
 	@Override
@@ -168,7 +168,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		if (!AuthzResolver.authorizedInternal(sess, "addExtSource_Group_ExtSource_policy", Arrays.asList(group, source)))
 			throw new PrivilegeException(sess, "addExtSource");
 
-		getExtSourcesManagerBl().addExtSource(sess, group, source);
+		getExtSourcesManagerBl().addExtSourceToGroup(sess, group, source);
 	}
 
 	@Override
@@ -194,7 +194,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		if (!AuthzResolver.authorizedInternal(sess, "removeExtSource_Vo_ExtSource_policy", Arrays.asList(vo, source)))
 			throw new PrivilegeException(sess, "removeExtSource");
 
-		getExtSourcesManagerBl().removeExtSource(sess, vo, source);
+		getExtSourcesManagerBl().removeExtSourceFromVo(sess, vo, source);
 	}
 
 	@Override
@@ -208,7 +208,7 @@ public class ExtSourcesManagerEntry implements ExtSourcesManager {
 		if (!AuthzResolver.authorizedInternal(sess, "removeExtSource_Group_ExtSource_policy", Arrays.asList(group, source)))
 			throw new PrivilegeException(sess, "removeExtSource");
 
-		getExtSourcesManagerBl().removeExtSource(sess, group, source);
+		getExtSourcesManagerBl().removeExtSourceFromGroup(sess, group, source);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceCSV.java
@@ -3,12 +3,10 @@ package cz.metacentrum.perun.core.impl;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,20 +27,12 @@ import java.util.Objects;
  * @author Sona Mastrakova
  * @author Pavel Zlámal
  */
-public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
+public class ExtSourceCSV extends ExtSourceImpl implements ExtSourceApi {
 
     private final static Logger log = LoggerFactory.getLogger(ExtSourceCSV.class);
 
     private String file = null;
     private String query = null;
-
-    private static PerunBlImpl perunBl;
-
-    // Filled by Spring (perun-core.xml)
-    public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-        perunBl = perun;
-        return perun;
-    }
 
     @Override
     public List<Map<String, String>> findSubjectsLogins(String searchString) throws ExtSourceUnsupportedOperationException {
@@ -312,15 +302,4 @@ public class ExtSourceCSV extends ExtSource implements ExtSourceApi {
         return attributeMapping;
 
     }
-
-    /**
-     * Get attributes of the external source (defined in perun-extSources.xml).
-     *
-     * @return map with attributes about the external source
-     * @throws InternalErrorException When implementation fails
-     */
-    protected Map<String,String> getAttributes() throws InternalErrorException {
-        return perunBl.getExtSourcesManagerBl().getAttributes(this);
-    }
-
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceGoogle.java
@@ -10,12 +10,10 @@ import com.google.api.services.admin.directory.Directory;
 import com.google.api.services.admin.directory.DirectoryScopes;
 import com.google.api.services.admin.directory.model.Member;
 import com.google.api.services.admin.directory.model.Members;
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +32,7 @@ import java.util.Map;
  * @author Sona Mastrakova
  * @date 05.08.2015
  */
-public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
+public class ExtSourceGoogle extends ExtSourceImpl implements ExtSourceApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceGoogle.class);
 
@@ -42,8 +40,6 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 	private Directory service = null;
 	private String domainName = null;
 	private String groupName = null;
-
-	private static PerunBlImpl perunBl;
 
 	/**
 	 * Application name.
@@ -610,15 +606,5 @@ public class ExtSourceGoogle extends ExtSource implements ExtSourceApi {
 				.setApplicationName(APPLICATION_NAME).build();
 
 		return serviceLocal;
-	}
-
-	protected Map<String,String> getAttributes() throws InternalErrorException {
-		return perunBl.getExtSourcesManagerBl().getAttributes(this);
-	}
-
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceISMU.java
@@ -3,11 +3,9 @@
  */
 package cz.metacentrum.perun.core.impl;
 
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
@@ -27,17 +25,9 @@ import java.util.Map;
 /**
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceISMU extends ExtSourceImpl implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceISMU.class);
-
-	private static PerunBlImpl perunBl;
-
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
-	}
 
 	@Override
 	public List<Map<String,String>> findSubjectsLogins(String searchString) throws ExtSourceUnsupportedOperationException {
@@ -166,9 +156,5 @@ public class ExtSourceISMU extends ExtSource implements ExtSourceSimpleApi {
 	@Override
 	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
-	}
-
-	protected Map<String,String> getAttributes() throws InternalErrorException {
-		return perunBl.getExtSourcesManagerBl().getAttributes(this);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceIdp.java
@@ -17,7 +17,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceIdp extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceIdp extends ExtSourceImpl implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceIdp.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceImpl.java
@@ -1,0 +1,28 @@
+package cz.metacentrum.perun.core.impl;
+
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+
+import java.util.Map;
+
+/**
+ * Common ancestor of ExtSource implementations.
+ */
+public abstract class ExtSourceImpl extends ExtSource {
+
+	protected PerunBl perunBl;
+
+	void setPerunBl(PerunBl perunBl) {
+		this.perunBl = perunBl;
+	}
+
+	private Map<String,String> extSourceAttributes;
+
+	protected Map<String,String> getAttributes() throws InternalErrorException {
+		if (extSourceAttributes == null) {
+			extSourceAttributes = perunBl.getExtSourcesManagerBl().getAttributes(this);
+		}
+		return extSourceAttributes;
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceInternal.java
@@ -17,7 +17,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceInternal extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceInternal extends ExtSourceImpl implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceInternal.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceKerberos.java
@@ -17,7 +17,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceKerberos extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceKerberos extends ExtSourceImpl implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceKerberos.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceLdap.java
@@ -1,11 +1,9 @@
 package cz.metacentrum.perun.core.impl;
 
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +31,7 @@ import java.util.regex.Pattern;
  * @author Michal Prochazka michalp@ics.muni.cz
  * @author Pavel Zlámal <zlamal@cesnet.cz>
  */
-public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
+public class ExtSourceLdap extends ExtSourceImpl implements ExtSourceApi {
 
 	protected Map<String, String> mapping;
 
@@ -47,14 +45,6 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 			initContext();
 		}
 		return dirContext;
-	}
-
-	private static PerunBlImpl perunBl;
-
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
 	}
 
 	@Override
@@ -416,9 +406,4 @@ public class ExtSourceLdap extends ExtSource implements ExtSourceApi {
 		// We can call original implementation, since LDAP always return whole entry and not just login
 		return findSubjectsLogins(searchString, maxResults);
 	}
-
-	protected Map<String,String> getAttributes() throws InternalErrorException {
-		return perunBl.getExtSourcesManagerBl().getAttributes(this);
-	}
-
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcePerun.java
@@ -2,7 +2,6 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.Attribute;
 import cz.metacentrum.perun.core.api.BeansUtils;
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.RichMember;
 import cz.metacentrum.perun.core.api.RichUser;
@@ -12,7 +11,6 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.PerunException;
 import cz.metacentrum.perun.core.api.exceptions.RpcException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import cz.metacentrum.perun.rpc.deserializer.Deserializer;
 import cz.metacentrum.perun.rpc.deserializer.JsonDeserializer;
@@ -47,7 +45,7 @@ import java.util.regex.Pattern;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
+public class ExtSourcePerun extends ExtSourceImpl implements ExtSourceApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourcePerun.class);
 
@@ -60,15 +58,6 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 
 	private String extSourceNameForLogin = null;
 	public static final Pattern attributePattern = Pattern.compile("[{](.+)[}]");
-
-	private static PerunBlImpl perunBl;
-
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
-	}
-
 
 	@Override
 	public List<Map<String,String>> findSubjectsLogins(String searchString) throws ExtSourceUnsupportedOperationException {
@@ -370,9 +359,5 @@ public class ExtSourcePerun extends ExtSource implements ExtSourceApi {
 	@Override
 	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws ExtSourceUnsupportedOperationException {
 		throw new ExtSourceUnsupportedOperationException();
-	}
-
-	protected Map<String,String> getAttributes() throws InternalErrorException {
-		return perunBl.getExtSourcesManagerBl().getAttributes(this);
 	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceREMS.java
@@ -11,7 +11,6 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,14 +29,6 @@ import java.util.Set;
 public class ExtSourceREMS extends ExtSourceSqlComplex implements ExtSourceApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceREMS.class);
-
-	private static PerunBlImpl perunBl;
-
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
-	}
 
 	@Override
 	public List<Map<String, String>> findSubjects(String searchString) throws InternalErrorException, ExtSourceUnsupportedOperationException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceSql.java
@@ -1,70 +1,58 @@
 package cz.metacentrum.perun.core.impl;
 
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
 import cz.metacentrum.perun.core.blImpl.GroupsManagerBlImpl;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceSimpleApi;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StreamUtils;
 
-import java.io.ByteArrayOutputStream;
+import javax.sql.DataSource;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
 
 /**
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceSql extends ExtSourceImpl implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceSql.class);
-	private static final Map<String, String> attributeNameMapping = new HashMap<>();
-	private Connection con;
-	private boolean isOracle = false;
-	private boolean isSQLite = false;
+	private static final Map<String, String> ATTRIBUTE_NAME_MAPPING = new HashMap<>();
+	public static final String DBPOOL = "dbpool";
+	public static final String USER = "user";
+	public static final String URL = "url";
 
-	private static PerunBlImpl perunBl;
-
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
-	}
+	private DataSource dataSource;
 
 	static {
-		attributeNameMapping.put("m", "urn:perun:member");
-		attributeNameMapping.put("u", "urn:perun:user");
-		attributeNameMapping.put("f", "urn:perun:facility");
-		attributeNameMapping.put("r", "urn:perun:resource");
-		attributeNameMapping.put("g", "urn:perun:group");
-		attributeNameMapping.put("v", "urn:perun:vo");
-		attributeNameMapping.put("h", "urn:perun:host");
-		attributeNameMapping.put("mr", "urn:perun:member_resource");
-		attributeNameMapping.put("uf", "urn:perun:user_facility");
-		attributeNameMapping.put("gr", "urn:perun:group_resource");
-		attributeNameMapping.put("o", ":attribute-def:opt:");
-		attributeNameMapping.put("d", ":attribute-def:def:");
+		ATTRIBUTE_NAME_MAPPING.put("m", "urn:perun:member");
+		ATTRIBUTE_NAME_MAPPING.put("u", "urn:perun:user");
+		ATTRIBUTE_NAME_MAPPING.put("f", "urn:perun:facility");
+		ATTRIBUTE_NAME_MAPPING.put("r", "urn:perun:resource");
+		ATTRIBUTE_NAME_MAPPING.put("g", "urn:perun:group");
+		ATTRIBUTE_NAME_MAPPING.put("v", "urn:perun:vo");
+		ATTRIBUTE_NAME_MAPPING.put("h", "urn:perun:host");
+		ATTRIBUTE_NAME_MAPPING.put("mr", "urn:perun:member_resource");
+		ATTRIBUTE_NAME_MAPPING.put("uf", "urn:perun:user_facility");
+		ATTRIBUTE_NAME_MAPPING.put("gr", "urn:perun:group_resource");
+		ATTRIBUTE_NAME_MAPPING.put("o", ":attribute-def:opt:");
+		ATTRIBUTE_NAME_MAPPING.put("d", ":attribute-def:def:");
 	}
 
-
-	public ExtSourceSql() {
-	}
 
 	@Override
 	public List<Map<String,String>> findSubjectsLogins(String searchString) throws InternalErrorException {
@@ -77,7 +65,6 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 		if (query == null) {
 			throw new InternalErrorException("query attribute is required");
 		}
-
 		return this.querySource(query, searchString, maxResults);
 	}
 
@@ -101,317 +88,184 @@ public class ExtSourceSql extends ExtSource implements ExtSourceSimpleApi {
 	}
 
 	@Override
-	public List<Map<String, String>> getGroupSubjects(Map<String, String> attributes) throws InternalErrorException {
+	public List<Map<String, String>> getGroupSubjects(Map<String, String> groupAttributes) throws InternalErrorException {
 		// Get the sql query for the group subjects
-		String sqlQueryForGroup = attributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
-
+		String sqlQueryForGroup = groupAttributes.get(GroupsManager.GROUPMEMBERSQUERY_ATTRNAME);
 		return this.querySource(sqlQueryForGroup, null, 0);
 	}
 
 	@Override
 	public List<Map<String,String>> getUsersSubjects() throws InternalErrorException, ExtSourceUnsupportedOperationException{
 		String query = getAttributes().get("usersQuery");
-
 		if (query == null) {
 			throw new InternalErrorException("usersQuery attribute is required");
 		}
-
 		return this.querySource(query, null, 0);
 	}
 
+	/**
+	 * Helper structure for holding data about database column mappings.
+	 */
+	private static class ColumnMapping {
+		int columnIndex;
+		String attributeName;
+		boolean blob;
+
+		public ColumnMapping(int columnIndex, String attributeName, boolean blob) {
+			this.columnIndex = columnIndex;
+			this.attributeName = attributeName;
+			this.blob = blob;
+		}
+	}
+
+	// database columns for base attributes
+	private static final String[] BASE_COLUMNS = new String[]{"login", "firstName", "lastName", "middleName", "titleBefore", "titleAfter"};
+
+	// column name should be matched case-insensitively
+	private static String matchingBaseColumnName(String s) {
+		for (String baseName : BASE_COLUMNS) {
+			if (baseName.equalsIgnoreCase(s)) {
+				return baseName;
+			}
+		}
+		return null;
+	}
+
 	protected List<Map<String,String>> querySource(String query, String searchString, int maxResults) throws InternalErrorException {
-		log.debug("Searching for '{}' in external source 'url:{}'", searchString, getAttributes().get("url"));
-
-		this.checkAndSetPrerequisites();
-
-		try (PreparedStatement st = getPreparedStatement(query, searchString, maxResults)) {
-			try (ResultSet rs = st.executeQuery()) {
-				List<Map<String, String>> subjects = new ArrayList<>();
-
+		log.debug("Searching for '{}' in external source '{}'", searchString, getName());
+		try (Connection con = getDataSource().getConnection()) {
+			try (PreparedStatement st = con.prepareStatement(query)) {
+				// Substitute the ? in the query by the searchString
+				if (StringUtils.isNotBlank(searchString)) {
+					for (int i = st.getParameterMetaData().getParameterCount(); i > 0; i--) {
+						st.setString(i, searchString);
+					}
+				}
+				// Limit results
+				if (maxResults > 0) {
+					st.setMaxRows(maxResults);
+				}
+				// make the SQL query
 				log.trace("Query {}", query);
-
-				while (rs.next()) {
-					Map<String, String> map = new HashMap<>();
-
-					try {
-						map.put("firstName", rs.getString("firstName"));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put("firstName", null);
-					}
-					try {
-						map.put("lastName", rs.getString("lastName"));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put("lastName", null);
-					}
-					try {
-						map.put("middleName", rs.getString("middleName"));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put("middleName", null);
-					}
-					try {
-						map.put("titleBefore", rs.getString("titleBefore"));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put("titleBefore", null);
-					}
-					try {
-						map.put("titleAfter", rs.getString("titleAfter"));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put("titleAfter", null);
-					}
-					try {
-						map.put("login", rs.getString("login"));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put("login", null);
-					}
-
-					for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
-						String columnName = rs.getMetaData().getColumnLabel(i);
-						log.trace("Iterating through attribute {}", columnName);
-						// Now go through all other attributes. If the column name(=attribute name) contains ":", then it represents an attribute
-						if (columnName.contains(":")) {
+				try (ResultSet rs = st.executeQuery()) {
+					// pre-process column metadata into columnMappings
+					ResultSetMetaData metaData = rs.getMetaData();
+					List<ColumnMapping> columnMappings = new ArrayList<>(metaData.getColumnCount());
+					for (int i = 1; i <= metaData.getColumnCount(); i++) {
+						String columnName = metaData.getColumnLabel(i);
+						String baseName = matchingBaseColumnName(columnName);
+						if (baseName != null) {
+							columnMappings.add(new ColumnMapping(i, baseName, false));
+						} else if (columnName.contains(":")) {
 							// Decode the attribute name (column name has limited size, so we need to code the attribute names)
 							// Coded attribute name: x:y:z
 							// x - m: member, u: user, f: facility, r: resource, mr: member-resource, uf: user-facility, h: host, v: vo, g: group, gr: group-resource
 							// y - d: def, o: opt
 							String[] attributeRaw = columnName.split(":", 3);
-							String attributeName = null;
-							if (!attributeNameMapping.containsKey(attributeRaw[0])) {
-								log.warn("Unknown attribute type '{}' for user {} {}, attributeRaw {}", attributeRaw[0], map.get("firstName"), map.get("lastName"), attributeRaw);
-							} else if (!attributeNameMapping.containsKey(attributeRaw[1])) {
-								log.warn("Unknown attribute type '{}' for user {} {}, attributeRaw {}", attributeRaw[1], map.get("firstName"), map.get("lastName"), attributeRaw);
+							if (!ATTRIBUTE_NAME_MAPPING.containsKey(attributeRaw[0])) {
+								log.warn("Unknown attribute type '{}', column {}", attributeRaw[0], columnName);
+							} else if (!ATTRIBUTE_NAME_MAPPING.containsKey(attributeRaw[1])) {
+								log.warn("Unknown attribute type '{}', column {}", attributeRaw[1], columnName);
 							} else {
-								attributeName = attributeNameMapping.get(attributeRaw[0]) + attributeNameMapping.get(attributeRaw[1]) + attributeRaw[2];
-								if (!Objects.equals(rs.getMetaData().getColumnTypeName(i), "BLOB")) {
-									// trace only string data
-									log.trace("Adding attribute {} with value {}", attributeName, rs.getString(i));
-								} else {
-									log.trace("Adding attribute {} with BLOB value", attributeName);
-								}
-							}
-
-							String attributeValue = null;
-							if (Objects.equals(rs.getMetaData().getColumnTypeName(i), "BLOB")) {
-								// source column is binary
-								try {
-									InputStream inputStream = rs.getBinaryStream(i);
-									if (inputStream != null) {
-										ByteArrayOutputStream result = new ByteArrayOutputStream();
-										byte[] buffer = new byte[1024];
-										int length;
-										while ((length = inputStream.read(buffer)) != -1) {
-											result.write(buffer, 0, length);
-										}
-										byte[] bytes = Base64.encodeBase64(result.toByteArray());
-										attributeValue = new String(bytes, StandardCharsets.UTF_8);
-									}
-								} catch (IOException ex) {
-									log.error("Unable to read BLOB for column {}", columnName);
-									throw new InternalErrorException("Unable to read BLOB data for column: " + columnName, ex);
-								}
-							} else {
-								// let driver to convert type to string
-								attributeValue = rs.getString(i);
-							}
-							if (rs.wasNull()) {
-								map.put(attributeName, null);
-							} else {
-								map.put(attributeName, attributeValue);
+								String attributeName = ATTRIBUTE_NAME_MAPPING.get(attributeRaw[0]) + ATTRIBUTE_NAME_MAPPING.get(attributeRaw[1]) + attributeRaw[2];
+								boolean blob = "BLOB".equals(metaData.getColumnTypeName(i));
+								columnMappings.add(new ColumnMapping(i, attributeName, blob));
 							}
 						} else if (columnName.toLowerCase().startsWith(ExtSourcesManagerImpl.USEREXTSOURCEMAPPING)) {
 							// additionalUserExtSources, we must do lower case because some DBs changes lower to upper
-							map.put(columnName.toLowerCase(), rs.getString(i));
-							log.trace("Adding attribute {} with value {}", columnName, rs.getString(i));
+							columnMappings.add(new ColumnMapping(i, columnName.toLowerCase(), false));
 						}
 					}
-					subjects.add(map);
+					// process each row
+					List<Map<String, String>> subjects = new ArrayList<>();
+					while (rs.next()) {
+						Map<String, String> map = new HashMap<>();
+						for (ColumnMapping columnMapping : columnMappings) {
+							if (columnMapping.blob) {
+								try (InputStream in = rs.getBinaryStream(columnMapping.columnIndex)) {
+									map.put(columnMapping.attributeName, Base64.encodeBase64String(StreamUtils.copyToByteArray(in)));
+								} catch (IOException ex) {
+									throw new InternalErrorException("Unable to read BLOB data for column: " + columnMapping.attributeName, ex);
+								}
+							} else {
+								map.put(columnMapping.attributeName, rs.getString(columnMapping.columnIndex));
+							}
+						}
+						subjects.add(map);
+					}
+					log.debug("Returning {} subjects from external source {} for searchString {}", subjects.size(), this, searchString);
+					return subjects;
 				}
-
-				log.debug("Returning {} subjects from external source {} for searchString {}", subjects.size(), this, searchString);
-				return subjects;
+			} catch (SQLException e) {
+				log.error("SQL exception during searching for subject '{}'", query);
+				throw new InternalErrorException(e);
 			}
 		} catch (SQLException e) {
-			log.error("SQL exception during searching for subject '{}'", query);
-			throw new InternalErrorException(e);
-		}
-	}
-
-	protected void createConnection() throws InternalErrorException {
-		try {
-
-			String connectionUrl = getAttributes().get("url");
-			String user = getAttributes().get("user");
-			String pass = getAttributes().get("password");
-			Properties connectionProperties = new Properties();
-
-			// set user/pass to properties if present
-			if (user != null && pass != null) {
-				connectionProperties.put("user", user);
-				connectionProperties.put("password", pass);
-			}
-
-			// set connection read_only for SQLite (doesn't follow JDBC standard)
-			if (connectionUrl.startsWith("jdbc:sqlite:")) {
-				isSQLite = true;
-				connectionProperties.put("open_mode","1");
-			}
-
-			// create connection
-			this.con = DriverManager.getConnection(connectionUrl, connectionProperties);
-
-			// Set connection to read-only mode for standard JDBC drivers
-			if (!isSQLite) {
-				this.con.setReadOnly(true);
-			}
-
-			if (this.con.getMetaData().getDriverName().toLowerCase().contains("oracle")) {
-				this.isOracle = true;
-				this.isSQLite = false;
-			}
-
-		} catch (SQLException e) {
-			log.error("SQL exception during creating the connection to URL", getAttributes().get("url"));
+			log.error("Cannot get connection from pool",e);
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
 	public void close() throws InternalErrorException {
-		if (this.con != null) {
-			try {
-				this.con.close();
-				this.con = null;
-			} catch (SQLException e) {
-				throw new InternalErrorException(e);
-			}
-		}
+		//no-op
 	}
 
 	@Override
-	public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
-		String sqlQueryForGroup = attributes.get(GroupsManager.GROUPSQUERY_ATTRNAME);
-
-		return this.groupQuery(sqlQueryForGroup, null, 0);
+	public List<Map<String, String>> getSubjectGroups(Map<String, String> groupAttributes) throws InternalErrorException, ExtSourceUnsupportedOperationException {
+		String sqlQueryForGroup = groupAttributes.get(GroupsManager.GROUPSQUERY_ATTRNAME);
+		return this.groupQuery(sqlQueryForGroup);
 	}
 
 	/**
 	 * Get subject groups from an external source
 	 *
 	 * @param query to select subject groups
-	 * @param searchString by which will be ? in query replaced
-	 * @param maxResults maximum subjects to get
 	 * @return list of subjects
-	 * @throws InternalErrorException
 	 */
-	protected List<Map<String,String>> groupQuery(String query, String searchString, int maxResults) throws InternalErrorException {
-
-		this.checkAndSetPrerequisites();
-
-		try (PreparedStatement st = getPreparedStatement(query, searchString, maxResults)) {
-			try (ResultSet rs = st.executeQuery()) {
-
-				List<Map<String, String>> subjects = new ArrayList<>();
-
-				log.trace("Query {}", query);
-
-				while (rs.next()) {
-					Map<String, String> map = new HashMap<>();
-
-					try {
-						map.put(GroupsManagerBlImpl.GROUP_NAME, rs.getString(GroupsManagerBlImpl.GROUP_NAME));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put(GroupsManagerBlImpl.GROUP_NAME, null);
+	protected List<Map<String,String>> groupQuery(String query) throws InternalErrorException {
+		try (Connection con = getDataSource().getConnection()) {
+			try (PreparedStatement st = con.prepareStatement(query)) {
+				try (ResultSet rs = st.executeQuery()) {
+					List<Map<String, String>> subjects = new ArrayList<>();
+					log.trace("Query {}", query);
+					while (rs.next()) {
+						Map<String, String> map = new HashMap<>();
+						try {
+							map.put(GroupsManagerBlImpl.GROUP_NAME, rs.getString(GroupsManagerBlImpl.GROUP_NAME));
+						} catch (SQLException ignored) {}
+						try {
+							map.put(GroupsManagerBlImpl.PARENT_GROUP_NAME, rs.getString(GroupsManagerBlImpl.PARENT_GROUP_NAME));
+						} catch (SQLException ignored) {}
+						try {
+							map.put(GroupsManagerBlImpl.GROUP_DESCRIPTION, rs.getString(GroupsManagerBlImpl.GROUP_DESCRIPTION));
+						} catch (SQLException ignored) {}
+						subjects.add(map);
 					}
-					try {
-						map.put(GroupsManagerBlImpl.PARENT_GROUP_NAME, rs.getString(GroupsManagerBlImpl.PARENT_GROUP_NAME));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put(GroupsManagerBlImpl.PARENT_GROUP_NAME, null);
-					}
-					try {
-						map.put(GroupsManagerBlImpl.GROUP_DESCRIPTION, rs.getString(GroupsManagerBlImpl.GROUP_DESCRIPTION));
-					} catch (SQLException e) {
-						// If the column doesn't exists, ignore it
-						map.put(GroupsManagerBlImpl.GROUP_DESCRIPTION, null);
-					}
-					subjects.add(map);
+					log.debug("Returning {} subjects from external source {}", subjects.size(), this);
+					return subjects;
 				}
-
-				log.debug("Returning {} subjects from external source {} for searchString {}", subjects.size(), this, searchString);
-				return subjects;
+			} catch (SQLException e) {
+				log.error("SQL exception during searching for subject '{}'", query);
+				throw new InternalErrorException(e);
 			}
 		} catch (SQLException e) {
-			log.error("SQL exception during searching for subject '{}'", query);
+			log.error("Cannot get connection from pool", e);
 			throw new InternalErrorException(e);
 		}
 	}
 
-	protected Map<String,String> getAttributes() throws InternalErrorException {
-		return perunBl.getExtSourcesManagerBl().getAttributes(this);
+	private DataSource getDataSource() {
+		if (dataSource == null) {
+			Map<String, String> attributes = this.getAttributes();
+			String dbpool = attributes.get(DBPOOL);
+			if (dbpool == null) {
+				dbpool = "db-" + attributes.get(USER) + "-" + attributes.get(URL);
+			}
+			this.dataSource = perunBl.getExtSourcesManagerBl().getDataSource(dbpool);
+			log.debug("ExtSource {} got dbpool {}", getName(), dbpool);
+		}
+		return dataSource;
 	}
 
-	/**
-	 * Check if needed prerequisites are set to be able to call query.
-	 *
-	 * @throws InternalErrorException if expected attributes are not set
-	 */
-	private void checkAndSetPrerequisites() throws InternalErrorException {
-		if (getAttributes().get("url") == null) {
-			throw new InternalErrorException("url attribute is required");
-		}
-
-		// Register driver if the attribute has been defined
-		if (getAttributes().get("driver") != null) {
-			try {
-				Class.forName(getAttributes().get("driver"));
-			} catch (ClassNotFoundException e) {
-				throw new InternalErrorException("Driver " + getAttributes().get("driver") + " cannot be registered", e);
-			}
-		}
-
-		try {
-			// Check if we have existing connection. In case of Oracle also checks the connection validity
-			if (this.con == null || (this.isOracle && !this.con.isValid(0))) {
-				this.createConnection();
-			}
-		} catch (SQLException ex) {
-			throw new InternalErrorException("Can't check if connection to database is still valid in SQL ExtSource.", ex);
-		}
-	}
-
-	/**
-	 * Prepares query statement from query.
-	 * - substitutes character '?' by searchString.
-	 * - set max results limit.
-	 *
-	 * @param query basic query
-	 * @param searchString search string
-	 * @param maxResults limit of max results where 0 is unlimited
-	 * @return
-	 * @throws SQLException
-	 */
-	private PreparedStatement getPreparedStatement(String query, String searchString, int maxResults) throws SQLException {
-		PreparedStatement st = this.con.prepareStatement(query);
-
-		// Substitute the ? in the query by the searchString
-		if (searchString != null && !searchString.isEmpty()) {
-			for (int i = st.getParameterMetaData().getParameterCount(); i > 0; i--) {
-				st.setString(i, searchString);
-			}
-		}
-
-		// Limit results
-		if (maxResults > 0) {
-			st.setMaxRows(maxResults);
-
-		}
-
-		return st;
-	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceTCS.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceTCS.java
@@ -2,7 +2,6 @@ package cz.metacentrum.perun.core.impl;
 
 import cz.metacentrum.perun.core.api.AttributeDefinition;
 import cz.metacentrum.perun.core.api.BeansUtils;
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.Pair;
@@ -14,7 +13,6 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationExc
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.InvalidCertificateException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.openssl.PEMParser;
@@ -44,20 +42,12 @@ import java.util.regex.Pattern;
  *
  * @author Michal Stava stavamichal@gmail.com
  */
-public class ExtSourceTCS extends ExtSource implements ExtSourceApi {
-
-	private static PerunBlImpl perunBl;
+public class ExtSourceTCS extends ExtSourceImpl implements ExtSourceApi {
 
 	private static final String attrLoginMUName = "urn:perun:user:attribute-def:def:login-namespace:mu";
 	private static final String attrUserCertificates = "urn:perun:user:attribute-def:def:userCertificates";
 	private final static Pattern loginPattern = Pattern.compile("^.*\\s([0-9]+)$");
 	private final static Pattern wrongLoginPattern = Pattern.compile("^.*\\s[0-9]+\\s[0-9]+$");
-
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
-	}
 
 	@Override
 	public List<Map<String,String>> findSubjectsLogins(String searchString) throws ExtSourceUnsupportedOperationException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceUnity.java
@@ -1,12 +1,10 @@
 package cz.metacentrum.perun.core.impl;
 
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -32,20 +30,13 @@ import static cz.metacentrum.perun.core.impl.Utils.parseCommonName;
  * @author Sona Mastrakova <sona.mastrakova@gmail.com>
  * @date 12.09.2016
  */
-public class ExtSourceUnity extends ExtSource implements ExtSourceApi {
+public class ExtSourceUnity extends ExtSourceImpl implements ExtSourceApi {
 
     private final static Logger log = LoggerFactory.getLogger(ExtSourceUnity.class);
     private String username;
     private String password;
     private String uriAll;
     private String uriEntity;
-    private static PerunBlImpl perunBl;
-
-    // filled by spring (perun-core.xml)
-    public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-        perunBl = perun;
-        return perun;
-    }
 
     @Override
     public List<Map<String, String>> findSubjectsLogins(String searchString) throws ExtSourceUnsupportedOperationException {
@@ -140,10 +131,6 @@ public class ExtSourceUnity extends ExtSource implements ExtSourceApi {
     @Override
     public List<Map<String, String>> getSubjectGroups(Map<String, String> attributes) throws ExtSourceUnsupportedOperationException {
         throw new ExtSourceUnsupportedOperationException();
-    }
-
-    protected Map<String, String> getAttributes() throws InternalErrorException {
-        return perunBl.getExtSourcesManagerBl().getAttributes(this);
     }
 
     private void prepareEnvironment() throws InternalErrorException {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceVOOT.java
@@ -1,11 +1,9 @@
 package cz.metacentrum.perun.core.impl;
 
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -31,7 +29,7 @@ import static cz.metacentrum.perun.core.impl.Utils.parseCommonName;
  * @author Sona Mastrakova <sona.mastrakova@gmail.com>
  * @date 12.07.2016
  */
-public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
+public class ExtSourceVOOT extends ExtSourceImpl implements ExtSourceApi {
 
     private final static Logger log = LoggerFactory.getLogger(ExtSourceVOOT.class);
 
@@ -40,13 +38,6 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
     private String query = null;
     private String username = null;
     private String password = null;
-    private static PerunBlImpl perunBl;
-
-    // filled by spring (perun-core.xml)
-    public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-        perunBl = perun;
-        return perun;
-    }
 
     @Override
     public List<Map<String, String>> findSubjectsLogins(String searchString) throws ExtSourceUnsupportedOperationException {
@@ -361,10 +352,6 @@ public class ExtSourceVOOT extends ExtSource implements ExtSourceApi {
         if (uriMembers == null || uriMembers.isEmpty()) {
             throw new InternalErrorException("uriMembers attribute is required");
         }
-    }
-
-    protected Map<String, String> getAttributes() throws InternalErrorException {
-        return perunBl.getExtSourcesManagerBl().getAttributes(this);
     }
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceX509.java
@@ -17,7 +17,7 @@ import java.util.Map;
  *
  * @author Michal Prochazka michalp@ics.muni.cz
  */
-public class ExtSourceX509 extends ExtSource implements ExtSourceSimpleApi {
+public class ExtSourceX509 extends ExtSourceImpl implements ExtSourceSimpleApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceX509.class);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourceXML.java
@@ -1,11 +1,9 @@
 package cz.metacentrum.perun.core.impl;
 
-import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.GroupsManager;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceUnsupportedOperationException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.SubjectNotExistsException;
-import cz.metacentrum.perun.core.blImpl.PerunBlImpl;
 import cz.metacentrum.perun.core.implApi.ExtSourceApi;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.slf4j.Logger;
@@ -41,7 +39,7 @@ import java.util.regex.Pattern;
 /**
  * @author Michal Stava stavamichal@gmail.com
  */
-public class ExtSourceXML extends ExtSource implements ExtSourceApi {
+public class ExtSourceXML extends ExtSourceImpl implements ExtSourceApi {
 
 	private final static Logger log = LoggerFactory.getLogger(ExtSourceXML.class);
 
@@ -49,14 +47,6 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 	private String loginQuery = null;
 	private String file = null;
 	private String uri = null;
-
-	private static PerunBlImpl perunBl;
-
-	// filled by spring (perun-core.xml)
-	public static PerunBlImpl setPerunBlImpl(PerunBlImpl perun) {
-		perunBl = perun;
-		return perun;
-	}
 
 	//URL connection
 	private HttpURLConnection con = null;
@@ -512,7 +502,4 @@ public class ExtSourceXML extends ExtSource implements ExtSourceApi {
 		this.con = con;
 	}
 
-	protected Map<String,String> getAttributes() throws InternalErrorException {
-		return perunBl.getExtSourcesManagerBl().getAttributes(this);
-	}
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/ExtSourcesManagerImpl.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.core.impl;
 
+import com.zaxxer.hikari.HikariDataSource;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSource;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
@@ -13,25 +14,24 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.implApi.ExtSourcesManagerImplApi;
+import org.apache.commons.lang3.StringUtils;
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+import org.dom4j.io.SAXReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcPerunTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import javax.sql.DataSource;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -45,23 +45,20 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	public final static String USEREXTSOURCEMAPPING = "additionalues_";
 
 	private ExtSourcesManagerImplApi self;
+	private PerunBl perunBl;
 
 	final static String extSourceMappingSelectQuery = "ext_sources.id as ext_sources_id, ext_sources.name as ext_sources_name, ext_sources.type as ext_sources_type, " +
 			"ext_sources.created_at as ext_sources_created_at, ext_sources.created_by as ext_sources_created_by, ext_sources.modified_by as ext_sources_modified_by, " +
 			"ext_sources.modified_at as ext_sources_modified_at, ext_sources.modified_by_uid as ext_sources_modified_by_uid, ext_sources.created_by_uid as ext_sources_created_by_uid";
 
-	private final static String extSourceMappingSelectQueryWithAttributes = "ext_sources.id as ext_sources_id, ext_sources.name as ext_sources_name, ext_sources.type as ext_sources_type, " +
-			"ext_sources.created_at as ext_sources_created_at, ext_sources.created_by as ext_sources_created_by, ext_sources.modified_by as ext_sources_modified_by, " +
-			"ext_sources.modified_at as ext_sources_modified_at, ext_sources.modified_by_uid as ext_sources_modified_by_uid, ext_sources.created_by_uid as ext_sources_created_by_uid, " +
-			"ext_sources_attributes.attr_name as attr_name, ext_sources_attributes.attr_value as attr_value";
-
 	// http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/jdbc.html
-	private static JdbcPerunTemplate jdbc;
+	private final JdbcPerunTemplate jdbc;
 
-	private static final RowMapper<ExtSource> EXTSOURCE_MAPPER = (rs, i) -> {
+	private final RowMapper<ExtSource> EXTSOURCE_MAPPER = (rs, i) -> {
 		try {
 			Class<?> extSourceClass = Class.forName(rs.getString("ext_sources_type"));
-			ExtSource es = (ExtSource) extSourceClass.newInstance();
+			ExtSourceImpl es = (ExtSourceImpl) extSourceClass.newInstance();
+			es.setPerunBl(perunBl);
 
 			es.setId(rs.getInt("ext_sources_id"));
 			es.setName(rs.getString("ext_sources_name"));
@@ -109,37 +106,17 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 					sess.getPerunPrincipal().getUserId());
 			extSource.setId(newId);
 
-			ExtSource es;
-
-			// Get the instance by the type of the extSource
-			try {
-				Class<?> extSourceClass = Class.forName(extSource.getType());
-				es = (ExtSource) extSourceClass.newInstance();
-			} catch (ClassNotFoundException e) {
-				throw new InternalErrorException(e);
-			} catch (InstantiationException | IllegalAccessException e) {
-				throw new InternalErrorException(e);
-			}
-
-			// Set the properties
-			es.setId(extSource.getId());
-			es.setName(extSource.getName());
-			es.setType(extSource.getType());
-
 			// Now store the attributes
 			if (attributes != null) {
 				for (String attr_name : attributes.keySet()) {
 					jdbc.update("insert into ext_sources_attributes (attr_name, attr_value, ext_sources_id,created_by, created_at, modified_by, modified_at, created_by_uid, modified_by_uid) " +
-									"values (?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)", attr_name, attributes.get(attr_name), extSource.getId(),
+									"values (?,?,?,?," + Compatibility.getSysdate() + ",?," + Compatibility.getSysdate() + ",?,?)", attr_name, attributes.get(attr_name), newId,
 							sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getActor(), sess.getPerunPrincipal().getUserId(), sess.getPerunPrincipal().getUserId());
 				}
 			}
 
-			// Assign newly created extSource
-			extSource = es;
-
-			return extSource;
-		} catch (RuntimeException e) {
+			return getExtSourceById(sess, newId);
+		} catch (RuntimeException | ExtSourceNotExistsException e) {
 			throw new InternalErrorException(e);
 		}
 	}
@@ -202,32 +179,10 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 		}
 	}
 
-	private static final ExtSourcesExtractor EXT_SOURCES_EXTRACTOR = new ExtSourcesExtractor();
-
-	private static class ExtSourcesExtractor implements ResultSetExtractor<List<ExtSource>> {
-
-		@Override
-		public List<ExtSource> extractData(ResultSet rs) throws SQLException, DataAccessException {
-			Map<Integer, ExtSource> map = new HashMap<>();
-			ExtSource myObject;
-			while (rs.next()) {
-				// fetch from map by ID
-				Integer id = rs.getInt("ext_sources_id");
-				myObject = map.get(id);
-				if (myObject == null) {
-					// if not preset, put in map
-					myObject = EXTSOURCE_MAPPER.mapRow(rs, rs.getRow());
-					map.put(id, myObject);
-				}
-			}
-			return new ArrayList<>(map.values());
-		}
-	}
-
 	@Override
 	public ExtSource getExtSourceById(PerunSession sess, int id) throws InternalErrorException, ExtSourceNotExistsException {
 		try {
-			return jdbc.queryForObject("select " + extSourceMappingSelectQueryWithAttributes + " from ext_sources left join ext_sources_attributes on ext_sources.id=ext_sources_attributes.ext_sources_id where id=?", EXT_SOURCES_EXTRACTOR, id);
+			return jdbc.queryForObject("select " + extSourceMappingSelectQuery + " from ext_sources where id=?", EXTSOURCE_MAPPER, id);
 		} catch (EmptyResultDataAccessException ex) {
 			throw new ExtSourceNotExistsException("ExtSource with ID=" + id + " not exists", ex);
 		} catch (RuntimeException ex) {
@@ -238,9 +193,7 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	@Override
 	public ExtSource getExtSourceByName(PerunSession sess, String name) throws InternalErrorException, ExtSourceNotExistsException {
 		try {
-			return jdbc.queryForObject("select " + extSourceMappingSelectQueryWithAttributes +
-					" from ext_sources left join ext_sources_attributes on ext_sources.id=ext_sources_attributes.ext_sources_id " +
-					"where name=?", EXT_SOURCES_EXTRACTOR, name);
+			return jdbc.queryForObject("select " + extSourceMappingSelectQuery + " from ext_sources where name=?", EXTSOURCE_MAPPER, name);
 		} catch (EmptyResultDataAccessException ex) {
 			throw new ExtSourceNotExistsException("ExtSource with name=" + name + " not exists", ex);
 		} catch (RuntimeException ex) {
@@ -250,26 +203,22 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	}
 
 	@Override
-	public List<ExtSource> getVoExtSources(PerunSession sess, Vo vo) throws InternalErrorException {
+	public List<Integer> getVoExtSourcesIds(PerunSession sess, Vo vo) throws InternalErrorException {
 		try {
-			return jdbc.query("SELECT " + extSourceMappingSelectQueryWithAttributes +
-					" FROM vo_ext_sources v INNER JOIN ext_sources ON v.ext_sources_id=ext_sources.id " +
-					"   LEFT JOIN ext_sources_attributes ON ext_sources.id=ext_sources_attributes.ext_sources_id " +
-					" WHERE v.vo_id=?", EXT_SOURCES_EXTRACTOR, vo.getId());
-
+			return jdbc.queryForList("SELECT ext_sources.id " +
+					" FROM vo_ext_sources v JOIN ext_sources ON v.ext_sources_id=ext_sources.id " +
+					" WHERE v.vo_id=?", Integer.class, vo.getId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public List<ExtSource> getGroupExtSources(PerunSession perunSession, Group group) throws InternalErrorException {
+	public List<Integer> getGroupExtSourcesIds(PerunSession perunSession, Group group) throws InternalErrorException {
 		try {
-			return jdbc.query("SELECT " + extSourceMappingSelectQueryWithAttributes +
-					" FROM group_ext_sources g_exts INNER JOIN ext_sources ON g_exts.ext_source_id=ext_sources.id " +
-					"   LEFT JOIN ext_sources_attributes ON ext_sources.id=ext_sources_attributes.ext_sources_id " +
-					" WHERE g_exts.group_id=?", EXT_SOURCES_EXTRACTOR, group.getId());
-
+			return jdbc.queryForList("SELECT ext_sources.id " +
+					" FROM group_ext_sources g_exts JOIN ext_sources ON g_exts.ext_source_id=ext_sources.id " +
+					" WHERE g_exts.group_id=?", Integer.class, group.getId());
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
@@ -278,16 +227,14 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	@Override
 	public List<ExtSource> getExtSources(PerunSession sess) throws InternalErrorException {
 		try {
-			return jdbc.query("SELECT " + extSourceMappingSelectQueryWithAttributes +
-					" FROM ext_sources LEFT JOIN ext_sources_attributes ON ext_sources.id=ext_sources_attributes.ext_sources_id ", EXT_SOURCES_EXTRACTOR);
-
+			return jdbc.query("SELECT " + extSourceMappingSelectQuery + " FROM ext_sources", EXTSOURCE_MAPPER);
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public void addExtSource(PerunSession sess, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException {
+	public void addExtSourceToVo(PerunSession sess, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException {
 		try {
 			if (0 < jdbc.queryForInt("select count('x') from vo_ext_sources where ext_sources_id=? and vo_id=?", source.getId(), vo.getId())) {
 				throw new ExtSourceAlreadyAssignedException(source);
@@ -303,7 +250,7 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	}
 
 	@Override
-	public void addExtSource(PerunSession sess, Group group, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException {
+	public void addExtSourceToGroup(PerunSession sess, Group group, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException {
 		try {
 			if (0 < jdbc.queryForInt("select count('x') from group_ext_sources where ext_source_id=? and group_id=?", source.getId(), group.getId())) {
 				throw new ExtSourceAlreadyAssignedException(source);
@@ -319,7 +266,7 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	}
 
 	@Override
-	public void removeExtSource(PerunSession sess, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException {
+	public void removeExtSourceFromVo(PerunSession sess, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException {
 		try {
 			if (jdbc.queryForInt("select count('x') from vo_ext_sources where ext_sources_id=? and vo_id=?", source.getId(), vo.getId()) == 0) {
 				// Source isn't assigned
@@ -334,7 +281,7 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	}
 
 	@Override
-	public void removeExtSource(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException {
+	public void removeExtSourceFromGroup(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException {
 		try {
 			if (jdbc.queryForInt("select count('x') from group_ext_sources where ext_source_id=? and group_id=?", source.getId(), group.getId()) == 0) {
 				// Source isn't assigned
@@ -362,7 +309,8 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	 * Routine which initialize the extSourcesManager.
 	 */
 	@Override
-	public void initialize(PerunSession sess) {
+	public void initialize(PerunSession sess, PerunBl perunBl) {
+		this.perunBl = perunBl;
 		if (sess.getPerun().isPerunReadOnly()) log.debug("Loading extSource manager init in readOnly version.");
 
 		//In read only just test if extSource Perun exists
@@ -397,92 +345,230 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	}
 
 	/**
+	 * Cleans up allocated resources.
+	 */
+	@Override
+	public void destroy() {
+		for (DataSource dataSource : dataSourceMap.values()) {
+			if (dataSource instanceof HikariDataSource) {
+				((HikariDataSource) dataSource).close();
+			}
+		}
+	}
+
+	/**
+	 * Map of db connection pools created for all ExtSourceSql in perun-extSources.xml
+	 */
+	private final Map<String, DataSource> dataSourceMap = new HashMap<>();
+
+	@Override
+	public DataSource getDataSource(String poolName) {
+			return dataSourceMap.get(poolName);
+	}
+
+
+
+	/**
 	 * Loads the extSources definitions from the XML configuration file.
 	 * All data from the extSouces XML file are synchronized with the DB.
+	 * <P>Example:</P>
+	 * <PRE>
+	 * &lt;extSources>
+	 *   &lt;dbpools>
+	 *     &lt;dbpool>
+	 *       &lt;name>MAIN&lt;/name>
+	 *       &lt;main&#47;>&lt;!-- indicates the main pool used by Perun -->
+	 *     &lt;/dbpool>
+	 *     &lt;dbpool>
+	 *       &lt;name>PEOPLEDB&lt;/name>&lt;!-- required -->
+	 *       &lt;url>jdbc:oracle:thin:@//oracle.example.com:1521/people&lt;/url>&lt;!-- required -->
+	 *       &lt;user>perun&lt;/user>&lt;!-- optional -->
+	 *       &lt;password>******&lt;/password>&lt;!-- optional -->
+	 *       &lt;driver>oracle.jdbc.OracleDriver&lt;/driver>&lt;!-- optional for postgresql, oracle, sqlite, mysql; required for others -->
+	 *       &lt;connectionTimeout>300000&lt;/connectionTimeout>&lt;!-- optional -->
+	 *       &lt;maxLifetime>600000&lt;/maxLifetime>&lt;!-- optional -->
+	 *       &lt;maximumPoolSize>10&lt;/maximumPoolSize>&lt;!-- optional -->
+	 *       &lt;minimumIdle>1&lt;/minimumIdle>&lt;!-- optional -->
+	 *       &lt;idleTimeout>300000&lt;/idleTimeout>&lt;!-- optional -->
+	 *       &lt;leakDetectionThreshold>30000&lt;/leakDetectionThreshold>&lt;!-- optional -->
+	 *     &lt;/dbpool>
+	 *   &lt;/dbpools>
+	 *   &lt;extSource>
+	 *     &lt;name>INET&lt;/name>
+	 *     &lt;type>cz.metacentrum.perun.core.impl.ExtSourceSql&lt;/type>
+	 *     &lt;description>&lt;/description>&lt;!-- ignored -->
+	 *     &lt;attributes>
+	 *       &lt;attribute name="dbpool">INETDB&lt;/attribute>
+	 *       &lt;attribute name="query">...&lt;/query>
+	 *       &lt;attribute name="loginQuery">...&lt;/query>
+	 *     &lt;/attributes>
+	 *   &lt;/extSource>
+	 * </PRE>
 	 */
 	@Override
 	public void loadExtSourcesDefinitions(PerunSession sess) {
+		File file = new File(ExtSourcesManager.CONFIGURATIONFILE);
+		if (!Files.isReadable(file.toPath())) {
+			log.warn("File " + file + " does not exist or is not readable");
+			return;
+		}
 		try {
 			// Load the XML file
-			BufferedInputStream is = new BufferedInputStream(new FileInputStream(ExtSourcesManager.CONFIGURATIONFILE));
-			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-			Document doc = dBuilder.parse(is);
-			doc.getDocumentElement().normalize();
-
-			// Check if the root element is "extSources"
-			if (!doc.getDocumentElement().getNodeName().equals("extSources")) {
+			log.debug("loading file {}", file);
+			Document document = new SAXReader().read(file);
+			Element extSources = document.getRootElement();
+			if (!extSources.getName().equals("extSources")) {
 				throw new InternalErrorException("perun-extSources.xml doesn't contain extSources as root element");
 			}
 
-			// Get all defined extSources
-			NodeList extSourcesNodes = doc.getElementsByTagName("extSource");
-			for (int extSourceSeq = 0; extSourceSeq < extSourcesNodes.getLength(); extSourceSeq++) {
-
-				// Get each extSource
-				Node extSourceNode = extSourcesNodes.item(extSourceSeq);
-				if (extSourceNode.getNodeType() == Node.ELEMENT_NODE) {
-
-					Element extSourceElement = (Element) extSourceNode;
-
-					// Get extSource name
-					String extSourceName = extSourceElement.getElementsByTagName("name").item(0).getChildNodes().item(0).getNodeValue();
-					if (extSourceName == null) {
-						throw new InternalErrorException("extSource doesn't have defined name");
-					}
-
-					// Get extSource type
-					String extSourceType = extSourceElement.getElementsByTagName("type").item(0).getChildNodes().item(0).getNodeValue();
-					if (extSourceType == null) {
-						throw new InternalErrorException("extSource " + extSourceName + " doesn't have defined type");
-					}
-
-					// Get all extSource attributes
-					NodeList attributeNodes = extSourceElement.getElementsByTagName("attribute");
-
-					Map<String, String> attributes = new HashMap<>();
-					for (int attributeSeq = 0; attributeSeq < attributeNodes.getLength(); attributeSeq++) {
-						Element elem = (Element) attributeNodes.item(attributeSeq);
-
-						if (elem.getNodeType() == Node.ELEMENT_NODE) {
-							String attrName = elem.getAttribute("name");
-							String attrValue = null;
-							if (elem.getChildNodes() != null && elem.getChildNodes().item(0) != null) {
-								attrValue = elem.getChildNodes().item(0).getNodeValue();
-							}
-
-							attributes.put(attrName, attrValue);
-						}
-					}
-
-					// Check if the extSource
-					try {
-						ExtSource extSource;
-						try {
-							extSource = this.getExtSourceByName(sess, extSourceName);
-							extSource.setName(extSourceName);
-							extSource.setType(extSourceType);
-
-							// ExtSource exists, so check values and potentionally update it
-							self.updateExtSource(sess, extSource, attributes);
-
-						} catch (ExtSourceNotExistsException e) {
-							// ExtSource doesn't exist, so create it
-							extSource = new ExtSource();
-							extSource.setName(extSourceName);
-							extSource.setType(extSourceType);
-							self.createExtSource(sess, extSource, attributes);
-						}
-					} catch (RuntimeException e) {
-						throw new InternalErrorException(e);
+			//shared database pools
+			Element dbpools = extSources.element("dbpools");
+			if (dbpools != null) {
+				for (Element dbpool : dbpools.elements("dbpool")) {
+					String poolName = dbpool.element("name").getText();
+					Element main = dbpool.element("main");
+					if (main != null) {
+						//use main pool
+						dataSourceMap.put(poolName, this.jdbc.getDataSource());
+						log.debug("creating ExtSourceSql dbpool {} referencing the main pool", poolName);
+					} else {
+						String url = dbpool.element("url").getText();
+						String driver = dbpool.element("driver") != null ? dbpool.element("driver").getText() : null;
+						String user = dbpool.element("user") != null ? dbpool.element("user").getText() : null;
+						String password = dbpool.element("password") != null ? dbpool.element("password").getText() : null;
+						HikariDataSource hds = createHikariPool(poolName, url, driver, user, password);
+						Integer maximumPoolSize = parsePoolIntProperty(dbpool, "maximumPoolSize");
+						if (maximumPoolSize != null) hds.setMaximumPoolSize(maximumPoolSize);
+						Integer minimumIdle = parsePoolIntProperty(dbpool, "minimumIdle");
+						if (minimumIdle != null) hds.setMinimumIdle(minimumIdle);
+						Integer connectionTimeout = parsePoolIntProperty(dbpool, "connectionTimeout");
+						if (connectionTimeout != null) hds.setConnectionTimeout(connectionTimeout);
+						Integer maxLifetime = parsePoolIntProperty(dbpool, "maxLifetime");
+						if (maxLifetime != null) hds.setMaxLifetime(maxLifetime);
+						Integer idleTimeout = parsePoolIntProperty(dbpool, "idleTimeout");
+						if (idleTimeout != null) hds.setIdleTimeout(idleTimeout);
+						Integer leakDetectionThreshold = parsePoolIntProperty(dbpool, "leakDetectionThreshold");
+						if (leakDetectionThreshold != null) hds.setLeakDetectionThreshold(leakDetectionThreshold);
+						log.debug("creating ExtSourceSql dbpool {} for user {} and db {}", poolName, user, url);
+						dataSourceMap.put(poolName, hds);
 					}
 				}
 			}
-		} catch (FileNotFoundException e) {
-			log.warn("No external source configuration file found.");
+
+			// Get each extSource
+			for (Element extSourceElement : extSources.elements("extSource")) {
+				// Get extSource name
+				String extSourceName = extSourceElement.element("name").getText();
+				if (StringUtils.isBlank(extSourceName)) {
+					throw new InternalErrorException("extSource doesn't have defined name");
+				}
+				// Get extSource type
+				String extSourceType = extSourceElement.element("type").getText();
+				if (StringUtils.isBlank(extSourceType)) {
+					throw new InternalErrorException("extSource doesn't have defined type");
+				}
+				// Get all extSource attributes
+				Map<String, String> attributes = new HashMap<>();
+				Element attrs = extSourceElement.element("attributes");
+				if (attrs != null) {
+					for (Element attribute : attrs.elements("attribute")) {
+						String attrName = attribute.attribute("name").getValue();
+						String attrValue = attribute.getText();
+						attributes.put(attrName, attrValue);
+					}
+				}
+				// Check if the extSource exists
+				ExtSource extSource;
+				try {
+					extSource = this.getExtSourceByName(sess, extSourceName);
+					extSource.setName(extSourceName);
+					extSource.setType(extSourceType);
+					// ExtSource exists, so check values and potentially update it
+					self.updateExtSource(sess, extSource, attributes);
+				} catch (ExtSourceNotExistsException e) {
+					// ExtSource doesn't exist, so create it
+					extSource = new ExtSource();
+					extSource.setName(extSourceName);
+					extSource.setType(extSourceType);
+					self.createExtSource(sess, extSource, attributes);
+				}
+				log.debug("ExtSource {} of type {} read from XML file", extSourceName, extSourceType);
+			}
+		} catch (DocumentException e) {
+			log.error("File " + file + " was not loaded", e);
 		} catch (Exception e) {
 			log.error("Cannot initialize ExtSourceManager.");
 			throw new InternalErrorException(e);
+		}
+
+		// check connection attributes for all ExtSourcesSql present in the database (may be more than in perun-extSources.xml)
+		for (ExtSource extSource : getExtSources(sess)) {
+			if (extSource instanceof ExtSourceSql) {
+				Map<String, String> attributes = getAttributes(extSource);
+				// pools in attributes
+				String dbpool = attributes.get(ExtSourceSql.DBPOOL);
+				String url = attributes.get(ExtSourceSql.URL);
+				if (dbpool != null) {
+					log.debug("ExtSource {} uses dbpool {}", extSource.getName(), dbpool);
+					if (dataSourceMap.get(dbpool) == null) {
+						log.error("ExtSource {} references non-existing pool {}", extSource.getName(), dbpool);
+					}
+				} else if (url != null) {
+					//for backward compatibility, create pools based on user and url
+					String user = attributes.get(ExtSourceSql.USER);
+					String password = attributes.get("password");
+					String driver = attributes.get("driver");
+					String poolKey = "db-" + user + "-" + url;
+					dataSourceMap.computeIfAbsent(poolKey, s -> {
+							log.debug("creating dbpool from legacy attributes for user \"{}\" and url \"{}\"", user, url);
+							return createHikariPool(poolKey, url, driver, user, password);
+						}
+					);
+					log.debug("ExtSource {} uses legacy dbpool {}", extSource.getName(), poolKey);
+				}
+			}
+		}
+	}
+
+	private static HikariDataSource createHikariPool(String name, String url, String driver, String user, String password) {
+		HikariDataSource hds = new HikariDataSource();
+		hds.setPoolName(name);
+		hds.setJdbcUrl(url);
+		if (StringUtils.isNotBlank(driver)) {
+			hds.setDriverClassName(driver);
+		} else if (url.startsWith("jdbc:oracle")) {
+			hds.setDriverClassName("oracle.jdbc.OracleDriver");
+		} else if (url.startsWith("jdbc:postgresql")) {
+			hds.setDriverClassName("org.postgresql.Driver");
+		} else if (url.startsWith("jdbc:sqlite")) {
+			hds.setDriverClassName("org.sqlite.JDBC");
+		} else if (url.startsWith("jdbc:mysql")) {
+			hds.setDriverClassName("com.mysql.jdbc.Driver");
+		} else {
+			log.error("Unknown JDBC driver for " + url + " pool " + name);
+		}
+		if (StringUtils.isNotBlank(user)) {
+			hds.setUsername(user);
+		}
+		if (StringUtils.isNotBlank(password)) {
+			hds.setPassword(password);
+		}
+		hds.setTransactionIsolation("TRANSACTION_READ_COMMITTED");
+		hds.setReadOnly(true);
+		if(url.startsWith("jdbc:sqlite")) {
+			hds.addDataSourceProperty("open_mode","1");
+		}
+		return hds;
+	}
+
+	private static Integer parsePoolIntProperty(Element dbpool, String propName) {
+		Element element = dbpool.element(propName);
+		if (element == null) return null;
+		try {
+			return Integer.parseInt(element.getText());
+		} catch (NumberFormatException e) {
+			log.error("<" + propName + "> of <dbpool name=\"" + dbpool.getName() + "\"> does not contain a number: " + element.getText());
+			return null;
 		}
 	}
 
@@ -512,7 +598,7 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 	/**
 	 * Result Set Extractor for Attributes map
 	 */
-	private class AttributesExtractor implements ResultSetExtractor<Map<String, String>> {
+	private static class AttributesExtractor implements ResultSetExtractor<Map<String, String>> {
 		@Override
 		public Map<String, String> extractData(ResultSet rs) throws SQLException {
 			Map<String, String> attributes = new HashMap<>();
@@ -537,7 +623,7 @@ public class ExtSourcesManagerImpl implements ExtSourcesManagerImplApi {
 		try {
 			return jdbc.query("select " + extSourceMappingSelectQuery + " from ext_sources, ext_sources_attributes where ext_sources.id=ext_sources_attributes.ext_sources_id and ext_sources_attributes.attr_name=? and ext_sources_attributes.attr_value=true", EXTSOURCE_MAPPER, ExtSourcesManager.EXTSOURCE_SYNCHRONIZATION_ENABLED_ATTRNAME);
 		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<ExtSource>();
+			return new ArrayList<>();
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourcesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/ExtSourcesManagerImplApi.java
@@ -10,7 +10,9 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.bl.PerunBl;
 
+import javax.sql.DataSource;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +25,12 @@ public interface ExtSourcesManagerImplApi {
 	/**
 	 * Initialize manager
 	 */
-	void initialize(PerunSession sess);
+	void initialize(PerunSession sess, PerunBl perunBl);
+
+	/**
+	 * Clean up allocated resources.
+	 */
+	void destroy();
 
 	/**
 	 * Creates an external source.
@@ -87,28 +94,28 @@ public interface ExtSourcesManagerImplApi {
 	ExtSource getExtSourceByName(PerunSession perunSession, String name) throws InternalErrorException, ExtSourceNotExistsException;
 
 	/**
-	 * Get list of external sources associated to the VO.
+	 * Get list of external sources ids associated to the VO.
 	 *
 	 * @param perunSession
 	 * @param vo
 	 *
-	 * @return list of VO
+	 * @return list of external sources ids associated with the VO
 	 *
 	 * @throws InternalErrorException
 	 */
-	List<ExtSource> getVoExtSources(PerunSession perunSession, Vo vo) throws InternalErrorException;
+	List<Integer> getVoExtSourcesIds(PerunSession perunSession, Vo vo) throws InternalErrorException;
 
 	/**
-	 * Get list of external sources associated with the GROUP.
+	 * Get list of external sources ids associated with the GROUP.
 	 *
 	 * @param perunSession
 	 * @param group
 	 *
-	 * @return list of external sources associated with the VO
+	 * @return list of external sources ids associated with the group
 	 *
 	 * @throws InternalErrorException
 	 */
-	List<ExtSource> getGroupExtSources(PerunSession perunSession, Group group) throws InternalErrorException;
+	List<Integer> getGroupExtSourcesIds(PerunSession perunSession, Group group) throws InternalErrorException;
 
 	/**
 	 * Get list of all external sources.
@@ -131,7 +138,7 @@ public interface ExtSourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 * @throws ExtSourceAlreadyAssignedException
 	 */
-	void addExtSource(PerunSession perunSession, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException;
+	void addExtSourceToVo(PerunSession perunSession, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException;
 
 	/**
 	 * Associate external source definition with the GROUP.
@@ -143,7 +150,7 @@ public interface ExtSourcesManagerImplApi {
 	 * @throws InternalErrorException
 	 * @throws ExtSourceAlreadyAssignedException
 	 */
-	void addExtSource(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException;
+	void addExtSourceToGroup(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceAlreadyAssignedException;
 
 	/**
 	 * Remove association of the external source from the VO.
@@ -156,7 +163,7 @@ public interface ExtSourcesManagerImplApi {
 	 * @throws ExtSourceNotAssignedException
 	 * @throws ExtSourceAlreadyRemovedException if there are 0 rows affected by remove in DB
 	 */
-	void removeExtSource(PerunSession perunSession, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException;
+	void removeExtSourceFromVo(PerunSession perunSession, Vo vo, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException;
 
 	/**
 	 * Remove association of the external source from the GROUP.
@@ -169,7 +176,7 @@ public interface ExtSourcesManagerImplApi {
 	 * @throws ExtSourceAlreadyRemovedException when 0 rows affected by removing from DB
 	 * @throws ExtSourceNotAssignedException
 	 */
-	void removeExtSource(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException;
+	void removeExtSourceFromGroup(PerunSession perunSession, Group group, ExtSource source) throws InternalErrorException, ExtSourceNotAssignedException, ExtSourceAlreadyRemovedException;
 
 	/**
 	 * Get all users' id associate with the provided ExtSource
@@ -205,6 +212,14 @@ public interface ExtSourcesManagerImplApi {
 	 * @throws ExtSourceNotExistsException
 	 */
 	void checkExtSourceExists(PerunSession perunSession, ExtSource extSource) throws InternalErrorException, ExtSourceNotExistsException;
+
+	/**
+	 * Returns a database connection pool.
+	 *
+	 * @param poolName named defined in perun-extSources.xml
+	 * @return database connection pool
+	 */
+	DataSource getDataSource(String poolName);
 
 	/**
 	 * Loads ext source definitions from the configuration file and updates entries stored in the DB.

--- a/perun-core/src/main/resources/perun-core.xml
+++ b/perun-core/src/main/resources/perun-core.xml
@@ -55,7 +55,8 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 		<!-- ExtSourcesManagerImpl -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl.createExtSource(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl.updateExtSource(..))"/>
-		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl.addExtSource(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl.addExtSourceToVo(..))"/>
+		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.ExtSourcesManagerImpl.addExtSourceToGroup(..))"/>
 		<!-- FacilitiesManagerImpl -->
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.FacilitiesManagerImpl.createFacility(..))"/>
 		<aop:advisor advice-ref="txAdviceNestedTransaction" pointcut="execution(* cz.metacentrum.perun.core.impl.FacilitiesManagerImpl.updateFacility(..))"/>
@@ -171,7 +172,7 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 	</bean>
 
 	<!-- Perun implementation -->
-	<bean id="perun" class="cz.metacentrum.perun.core.blImpl.PerunBlImpl" scope="singleton" init-method="initialize" depends-on="databaseManagerBl">
+	<bean id="perun" class="cz.metacentrum.perun.core.blImpl.PerunBlImpl" scope="singleton" init-method="initialize" destroy-method="destroy" depends-on="databaseManagerBl">
 		<constructor-arg name="auditer" ref="auditer"/>
 		<property name="vosManagerBl" ref="vosManagerBl"/>
 		<property name="usersManagerBl" ref="usersManagerBl"/>
@@ -410,43 +411,6 @@ http://www.springframework.org/schema/context http://www.springframework.org/sch
 	</bean>
 
 	<bean id="synchronizer" class="cz.metacentrum.perun.core.impl.Synchronizer" scope="singleton" depends-on="databaseManagerBl">
-		<constructor-arg ref="perun" />
-	</bean>
-
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceGoogle" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceVOOT" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceUnity" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-        </bean>
-        <bean class="cz.metacentrum.perun.core.impl.ExtSourceCSV" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceISMU" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceLdap" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourcePerun" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceSql" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceREMS" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceTCS" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceSqlComplex" factory-method="setPerunBlImpl">
-		<constructor-arg ref="perun" />
-	</bean>
-	<bean class="cz.metacentrum.perun.core.impl.ExtSourceXML" factory-method="setPerunBlImpl">
 		<constructor-arg ref="perun" />
 	</bean>
 

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/AbstractPerunIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/AbstractPerunIntegrationTest.java
@@ -72,6 +72,7 @@ public abstract class AbstractPerunIntegrationTest {
 		final PerunPrincipal pp = new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL);
 		sess = perun.getPerunSession(pp, new PerunClient());
 		CacheManager.setCacheDisabled(true);
+		perun.getExtSourcesManagerBl().loadExtSourcesDefinitions(sess);
 	}
 
 	@After

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBlImplTest.java
@@ -83,6 +83,7 @@ public class FacilitiesManagerBlImplTest {
 		sess = perun.getPerunSession(
 				new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL),
 				new PerunClient());
+		perun.getExtSourcesManagerBl().loadExtSourcesDefinitions(sess);
 
 
 		vo = new Vo(0, "FacilitiesManagerBlImplTestVo", "FacMgrBlImplTestVo");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/ExtSourcesManagerEntryIntegrationTest.java
@@ -154,7 +154,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	/**
-	 * Test method for {@link cz.metacentrum.perun.core.blImpl.ExtSourcesManagerBlImpl#addExtSource(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.Vo, cz.metacentrum.perun.core.api.ExtSource)}.
+	 * Test method for {@link cz.metacentrum.perun.core.blImpl.ExtSourcesManagerBlImpl#addExtSourceToVo(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.Vo, cz.metacentrum.perun.core.api.ExtSource)}.
 	 */
 	@Test
 	public void testAddExtSourceToVo() throws Exception {
@@ -207,7 +207,7 @@ public class ExtSourcesManagerEntryIntegrationTest extends AbstractPerunIntegrat
 	}
 
 	/**
-	 * Test method for {@link cz.metacentrum.perun.core.blImpl.ExtSourcesManagerBlImpl#removeExtSource(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.Vo, cz.metacentrum.perun.core.api.ExtSource)}.
+	 * Test method for {@link cz.metacentrum.perun.core.blImpl.ExtSourcesManagerBlImpl#removeExtSourceFromVo(cz.metacentrum.perun.core.api.PerunSession, cz.metacentrum.perun.core.api.Vo, cz.metacentrum.perun.core.api.ExtSource)}.
 	 */
 	@Test
 	public void testRemoveExtSourceFromVo() throws Exception {

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupStructureSynchronizationIntegrationTest.java
@@ -95,7 +95,7 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 		doReturn(essa).when(extSourceManagerBl).getExtSourceByName(any(PerunSession.class), any(String.class));
 		//noinspection ResultOfMethodCallIgnored
 		doReturn(EXT_SOURCE_NAME).when((ExtSourceLdap)essa).getName();
-		doNothing().when(extSourceManagerBl).addExtSource(any(PerunSession.class), any(Group.class), any(ExtSource.class));
+		doNothing().when(extSourceManagerBl).addExtSourceToGroup(any(PerunSession.class), any(Group.class), any(ExtSource.class));
 	}
 
 	@After
@@ -464,11 +464,11 @@ public class GroupStructureSynchronizationIntegrationTest extends AbstractPerunI
 
 		Group returnedGroup = groupsManagerBl.createGroup(sess, vo, baseGroup);
 
-		extSourceManagerBl.addExtSource(sess, vo, extSource);
+		extSourceManagerBl.addExtSourceToVo(sess, vo, extSource);
 		Attribute attr = attributesManagerBl.getAttribute(sess, baseGroup, GroupsManager.GROUPEXTSOURCE_ATTRNAME);
 		attr.setValue(extSource.getName());
 		attributesManagerBl.setAttribute(sess, baseGroup, attr);
-		extSourceManagerBl.addExtSource(sess, baseGroup, extSource);
+		extSourceManagerBl.addExtSourceToGroup(sess, baseGroup, extSource);
 
 		Attribute membersQuery = new Attribute(((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, GroupsManager.GROUPMEMBERSQUERY_ATTRNAME));
 		membersQuery.setValue("SELECT * from members where groupName='?';");

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/entry/GroupsManagerEntryIntegrationTest.java
@@ -1855,10 +1855,10 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		ExtSource newExtSource = new ExtSource("ExtSourcesManagerEntryIntegrationTest1", ExtSourcesManager.EXTSOURCE_INTERNAL);
 		newExtSource = perun.getExtSourcesManager().createExtSource(sess, newExtSource, null);
 
-		perun.getExtSourcesManagerBl().addExtSource(sess, vo, newExtSource);
+		perun.getExtSourcesManagerBl().addExtSourceToVo(sess, vo, newExtSource);
 
-		perun.getExtSourcesManagerBl().addExtSource(sess, group, newExtSource);
-		perun.getExtSourcesManagerBl().addExtSource(sess, group2, newExtSource);
+		perun.getExtSourcesManagerBl().addExtSourceToGroup(sess, group, newExtSource);
+		perun.getExtSourcesManagerBl().addExtSourceToGroup(sess, group2, newExtSource);
 
 		final List<Group> groups = groupsManagerBl.getGroupsWithAssignedExtSourceInVo(sess, newExtSource, vo);
 
@@ -2675,7 +2675,7 @@ public class GroupsManagerEntryIntegrationTest extends AbstractPerunIntegrationT
 		vo = setUpVo();
 		setUpGroup(vo);
 		ExtSource es = perun.getExtSourcesManagerBl().createExtSource(sess, extSource, null);
-		perun.getExtSourcesManagerBl().addExtSource(sess, vo, es);
+		perun.getExtSourcesManagerBl().addExtSourceToVo(sess, vo, es);
 		perun.getGroupsManager().createGroup(sess, vo, group2);
 
 		Attribute synchroAttr1 = new Attribute(perun.getAttributesManager().getAttributeDefinition(sess, GroupsManager.GROUPSYNCHROINTERVAL_ATTRNAME));

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 		<!-- versions of libraries not defined by the Spring Boot Starter Parent -->
 		<commons-cli.version>1.4</commons-cli.version>
 		<commons-text.version>1.6</commons-text.version>
+		<dom4j.version>2.1.3</dom4j.version>
 		<dumbster.version>1.6</dumbster.version>
 		<expiringmap.version>0.5.9</expiringmap.version>
 		<flying-saucer-pdf.version>9.1.18</flying-saucer-pdf.version>
@@ -75,7 +76,6 @@
 		<netty3.version>3.2.1.Final</netty3.version><!-- needed for HornetQ -->
 		<jboss-jms-api.version>1.1.0.GA</jboss-jms-api.version>
 		<jcip.version>1.0</jcip.version>
-		<jdom.version>1.0</jdom.version>
 		<json.version>20190722</json.version>
 		<oracle.version>19.6.0.0</oracle.version>
 		<reflections.version>0.9.11</reflections.version>
@@ -271,9 +271,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>jdom</groupId>
-				<artifactId>jdom</artifactId>
-				<version>${jdom.version}</version>
+				<groupId>org.dom4j</groupId>
+				<artifactId>dom4j</artifactId>
+				<version>${dom4j.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Changed implementation of **ExtSourceSql** and **ExtSourcesManagerImpl** to use database connections obtained from pooling DataSources instead of keeping a special connection open for each one.
- changed parsing of XML file perun-extSources.xml in ExtSourcesManagerImpl 
  - replaced parsing library DOM with DOM4J, it is much easier to use 
  - replaced project dependency on JDOM, which was not used, with dependency on DOM4J
  - parsing of perun-extSources.xml detects new tags **&lt;dbpool>** and creates a read-only Hikari pool for each one (special mark **&lt;main/>** is available for referencing the main pool instead of creating a new one)
  - extSources of type ExtSourceSql  now support a new attribute **dbpool** referencing a db pool
  - for backward compatibility, extSources of type ExtSourceSql with legacy attributes **url**, **driver**, **user** and **password** are detected and dbpools are created for them
- added method **destroy()** to PerunBlImpl, ExtSourcesManagerBl, ExtSourcesManagerBlImpl, ExtSourcesManagerImplApi and ExtSourcesManagerImpl which closes created DataSources on shutdown
- changed implementation of methods **querySource()** and **groupQuery()** to be faster by pre-processing result set metadata outside of the reading loop and reading only available columns, thus avoiding throwing-and-catching exceptions just to detect missing columns on each row
- rewrote  **ExtSourcesManagerBlImpl** to cache instances of ExtSources in memory to avoid a lot of database queries
- replaced injection of PerunBl instance into static variable in ExtSource* classes from perun-core.xml with all ExtSource descendants implementing a new class EtxSourceImpl that has a setter for PerunBl, and this is called right after creation of a new instance in EXTSOURCE_MAPPER
- replaced usages of EXT_SOURCES_EXTRACTOR with EXTSOURCE_MAPPER in ExtSourcesManagerImpl and changed SQL queries to spare useless extracting and immediate throwing away of attribute values when reading just ExtSources
- in AuthzResolverIntegrationTest added refreshing ExtSources before every test