### PR TITLE
CORE,RPC: Unified password manager modules logic

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/api/UsersManager.java
@@ -811,38 +811,6 @@ public interface UsersManager {
 	void changeNonAuthzPassword(PerunSession sess, String i, String m, String password, String lang)
 			throws InternalErrorException, UserNotExistsException, LoginNotExistsException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
 
-
-	/**
-	 * Creates the password in external system. User must not exists.
-	 *
-	 * @param sess
-	 * @param userLogin string representation of the userLogin
-	 * @param loginNamespace
-	 * @param password
-	 * @throws InternalErrorException
-	 * @throws PasswordCreationFailedException
-	 */
-	@Deprecated
-	void createPassword(PerunSession sess, String userLogin, String loginNamespace, String password)
-	throws InternalErrorException, PasswordCreationFailedException, PrivilegeException;
-
-	/**
-	 * Creates the password in external system. User must exists.
-	 *
-	 * @param sess
-	 * @param user
-	 * @param loginNamespace
-	 * @param password
-	 * @throws InternalErrorException
-	 * @throws PasswordCreationFailedException
-	 * @throws UserNotExistsException
-	 * @throws LoginNotExistsException
-	 * @throws PrivilegeException
-	 */
-	@Deprecated
-	void createPassword(PerunSession sess, User user, String loginNamespace, String password)
-	throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException;
-
 	/**
 	 * Reserves random password in external system. User must not exists.
 	 *

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/UsersManagerBl.java
@@ -42,6 +42,7 @@ import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentExceptio
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 
 import java.util.List;
 import java.util.Map;
@@ -924,35 +925,6 @@ public interface UsersManagerBl {
 			throws InternalErrorException, LoginNotExistsException, PasswordDoesntMatchException, PasswordChangeFailedException, PasswordOperationTimeoutException, PasswordStrengthFailedException;
 
 	/**
-	 * Creates the password in external system. User must not exists.
-	 *
-	 * @param sess
-	 * @param userLogin      string representation of the userLogin
-	 * @param loginNamespace
-	 * @param password
-	 * @throws InternalErrorException
-	 * @throws PasswordCreationFailedException
-	 */
-	@Deprecated
-	void createPassword(PerunSession sess, String userLogin, String loginNamespace, String password)
-			throws InternalErrorException, PasswordCreationFailedException;
-
-	/**
-	 * Creates the password in external system. User must exists.
-	 *
-	 * @param sess
-	 * @param user
-	 * @param loginNamespace
-	 * @param password
-	 * @throws InternalErrorException
-	 * @throws PasswordCreationFailedException
-	 * @throws LoginNotExistsException
-	 */
-	@Deprecated
-	void createPassword(PerunSession sess, User user, String loginNamespace, String password)
-			throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException;
-
-	/**
 	 * Reserves random password in external system. User must exists.
 	 *
 	 * @param sess
@@ -1347,6 +1319,17 @@ public interface UsersManagerBl {
 	 * @throws InternalErrorException
 	 */
 	List<User> getSponsors(PerunSession sess, Member sponsoredMember) throws InternalErrorException;
+
+	/**
+	 * Returns password manager module for specified login-namespace or falls back on generic password manager module.
+	 * Throws exception if no module implementation is found or it can't be instantiated.
+	 *
+	 * @param session session with authz
+	 * @param namespace specific namespace
+	 * @return Password manager module for namespace or 'generic' module.
+	 * @throws InternalErrorException When module instantiation fails or no module implementation is found by class loader.
+	 */
+	PasswordManagerModule getPasswordManagerModule(PerunSession session, String namespace) throws InternalErrorException;
 
 	/**
 	 * Removes all user's external sources.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -70,7 +70,6 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
-import cz.metacentrum.perun.core.api.exceptions.rt.EmptyPasswordRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.LoginNotExistsRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PasswordChangeFailedRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.PasswordCreationFailedRuntimeException;
@@ -92,12 +91,6 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -125,9 +118,6 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	private PerunBl perunBl;
 
 	private static final String A_USER_DEF_ALT_PASSWORD_NAMESPACE = AttributesManager.NS_USER_ATTR_DEF + ":altPasswords:";
-
-	private static final String PASSWORD_CREATE = "create";
-	private static final String PASSWORD_DELETE = "delete";
 
 	public final static String multivalueAttributeSeparatorRegExp = ";";
 	private final static String additionalIdentifiersAttributeName = "additionalIdentifiers";
@@ -1636,161 +1626,89 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 
 	@Override
 	public void createAlternativePassword(PerunSession sess, User user, String description, String loginNamespace, String password) throws InternalErrorException, PasswordCreationFailedException, LoginNotExistsException {
+
+		String passwordId = Long.toString(System.currentTimeMillis());
+		log.info("Creating alternative password for {} in login-namespace {} with description {} and passwordId {}.", user, loginNamespace, description, passwordId);
+
 		try {
-			manageAlternativePassword(sess, user, PASSWORD_CREATE, loginNamespace, null, description, password);
+			Attribute userAlternativePassword = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_ALT_PASSWORD_NAMESPACE + loginNamespace);
+			Map<String,String> altPassValue = new LinkedHashMap<>();
+			//Set not null value from altPassword attribute of this user
+			if (userAlternativePassword.getValue() != null) altPassValue = userAlternativePassword.valueAsMap();
+			//If password already exists, throw an exception
+			if (altPassValue.containsKey(description)) throw new ConsistencyErrorException("Password with this description already exists. Description: " + description);
+			//set new value to attribute
+			altPassValue.put(description, passwordId);
+			userAlternativePassword.setValue(altPassValue);
+			//set new attribute with value to perun
+			getPerunBl().getAttributesManagerBl().setAttribute(sess, user, userAlternativePassword);
+		} catch (WrongAttributeAssignmentException | WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
+			throw new InternalErrorException(ex);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		// actually create password in the backend
+		PasswordManagerModule module = getPasswordManagerModule(sess, loginNamespace);
+
+		try {
+			module.createAlternativePassword(sess, user, passwordId, password);
 		} catch(PasswordCreationFailedRuntimeException ex) {
 			throw new PasswordCreationFailedException(ex);
 		} catch(LoginNotExistsRuntimeException ex) {
 			throw new LoginNotExistsException(ex);
-		} catch(PasswordDeletionFailedException ex) {
-			//This probably never happend, if yes, its some error in code of manageAlternativePassword method
-			throw new InternalErrorException(ex);
+		} catch (Exception ex) {
+			// fallback for exception compatibility
+			throw new PasswordCreationFailedException("Alternative password creation failed for " + loginNamespace + ":" + passwordId + " of "+user+".", ex);
 		}
 	}
 
 	@Override
 	public void deleteAlternativePassword(PerunSession sess, User user, String loginNamespace, String passwordId) throws InternalErrorException, PasswordDeletionFailedException, LoginNotExistsException {
+		log.info("Deleting alternative password for {} in login-namespace {} with passwordId {}.", user, loginNamespace, passwordId);
+
 		try {
-			manageAlternativePassword(sess, user, PASSWORD_DELETE, loginNamespace, passwordId, null, null);
+			Attribute userAlternativePassword = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_ALT_PASSWORD_NAMESPACE + loginNamespace);
+			Map<String,String> altPassValue = new LinkedHashMap<>();
+			//Set not null value from altPassword attribute of this user
+			if (userAlternativePassword.getValue() != null) altPassValue = userAlternativePassword.valueAsMap();
+			//If password already exists, throw an exception
+			if (!altPassValue.containsValue(passwordId)) throw new PasswordDeletionFailedException("Password not found by ID.");
+			//remove key with this value from map
+			Set<String> keys = altPassValue.keySet();
+			String description = null;
+			for(String key: keys) {
+				String valueOfKey = altPassValue.get(key);
+				if(valueOfKey.equals(passwordId)) {
+					if(description != null) throw new ConsistencyErrorException("There is more than 1 password with same ID in value for user " + user);
+					description = key;
+				}
+			}
+			if(description == null) throw new InternalErrorException("Password not found by ID.");
+			altPassValue.remove(description);
+			//set new value for altPassword attribute for this user
+			userAlternativePassword.setValue(altPassValue);
+			getPerunBl().getAttributesManagerBl().setAttribute(sess, user, userAlternativePassword);
+		} catch (WrongAttributeAssignmentException | WrongReferenceAttributeValueException | WrongAttributeValueException ex) {
+			throw new InternalErrorException(ex);
+		} catch (AttributeNotExistsException ex) {
+			throw new ConsistencyErrorException(ex);
+		}
+
+		// actually delete password in the backend
+		PasswordManagerModule module = getPasswordManagerModule(sess, loginNamespace);
+
+		try {
+			module.deleteAlternativePassword(sess, user, passwordId);
 		} catch(PasswordDeletionFailedRuntimeException ex) {
 			throw new PasswordDeletionFailedException(ex);
 		} catch(LoginNotExistsRuntimeException ex) {
 			throw new LoginNotExistsException(ex);
+		} catch (Exception ex) {
+			// fallback for exception compatibility
+			throw new PasswordDeletionFailedException("Alternative password deletion failed for " + loginNamespace + ":" + passwordId + " of "+user+".", ex);
 		}
 	}
-
-	/**
-	 * Calls external program which do the job with the alternative passwords.
-	 *
-	 * Return codes of the external program
-	 * If password check fails then return 1
-	 * If there is no handler for loginNamespace return 2
-	 * If setting of the new password failed return 3
-	 *
-	 * @param sess
-	 * @param operation
-	 * @param loginNamespace
-	 * @param password
-	 * @throws InternalErrorException
-	 */
-	protected void manageAlternativePassword(PerunSession sess, User user, String operation, String loginNamespace, String passwordId, String description, String password) throws InternalErrorException, PasswordDeletionFailedException {
-		//if password id == null
-		if(passwordId == null) passwordId = Long.toString(System.currentTimeMillis());
-
-		//Prepare process builder
-		ProcessBuilder pb = new ProcessBuilder(BeansUtils.getCoreConfig().getAlternativePasswordManagerProgram(), operation, loginNamespace, Integer.toString(user.getId()), passwordId);
-
-		//Set password in Perun to attribute
-		if (operation.equals(PASSWORD_CREATE)) {
-			try {
-				Attribute userAlternativePassword = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_ALT_PASSWORD_NAMESPACE + loginNamespace);
-				Map<String,String> altPassValue = new LinkedHashMap<>();
-				//Set not null value from altPassword attribute of this user
-				if (userAlternativePassword.getValue() != null) altPassValue = (LinkedHashMap<String,String>) userAlternativePassword.getValue();
-				//If password already exists, throw an exception
-				if (altPassValue.containsKey(description)) throw new ConsistencyErrorException("Password with this description already exists. Description: " + description);
-				//set new value to attribute
-				altPassValue.put(description, passwordId);
-				userAlternativePassword.setValue(altPassValue);
-				//set new attribute with value to perun
-				getPerunBl().getAttributesManagerBl().setAttribute(sess, user, userAlternativePassword);
-			} catch (WrongAttributeAssignmentException | WrongAttributeValueException | WrongReferenceAttributeValueException ex) {
-				throw new InternalErrorException(ex);
-			} catch (AttributeNotExistsException ex) {
-				throw new ConsistencyErrorException(ex);
-			}
-		} else if (operation.equals(PASSWORD_DELETE)) {
-			try {
-				Attribute userAlternativePassword = getPerunBl().getAttributesManagerBl().getAttribute(sess, user, A_USER_DEF_ALT_PASSWORD_NAMESPACE + loginNamespace);
-				Map<String,String> altPassValue = new LinkedHashMap<>();
-				//Set not null value from altPassword attribute of this user
-				if (userAlternativePassword.getValue() != null) altPassValue = (LinkedHashMap<String,String>) userAlternativePassword.getValue();
-				//If password already exists, throw an exception
-				if (!altPassValue.containsValue(passwordId)) throw new PasswordDeletionFailedException("Password not found by ID.");
-				//remove key with this value from map
-				Set<String> keys = altPassValue.keySet();
-				description = null;
-				for(String key: keys) {
-					String valueOfKey = altPassValue.get(key);
-					if(valueOfKey.equals(passwordId)) {
-						if(description != null) throw new ConsistencyErrorException("There is more than 1 password with same ID in value for user " + user);
-						description = key;
-					}
-				}
-				if(description == null) throw new InternalErrorException("Password not found by ID.");
-				altPassValue.remove(description);
-				//set new value for altPassword attribute for this user
-				userAlternativePassword.setValue(altPassValue);
-				getPerunBl().getAttributesManagerBl().setAttribute(sess, user, userAlternativePassword);
-			} catch (WrongAttributeAssignmentException | WrongReferenceAttributeValueException | WrongAttributeValueException ex) {
-				throw new InternalErrorException(ex);
-			} catch (AttributeNotExistsException ex) {
-				throw new ConsistencyErrorException(ex);
-			}
-		} else {
-			throw new InternalErrorException("Not supported operation " + operation);
-		}
-
-		Process process;
-		try {
-			process = pb.start();
-		} catch (IOException e) {
-			throw new InternalErrorException(e);
-		}
-
-		InputStream es = process.getErrorStream();
-
-		//Set pasword in remote system
-		if (operation.equals(PASSWORD_CREATE)) {
-			OutputStream os = process.getOutputStream();
-			if (password == null || password.isEmpty()) {
-				throw new EmptyPasswordRuntimeException("Alternative password for " + loginNamespace + " cannot be empty.");
-			}
-			// Write password to the stdin of the program
-			PrintWriter pw = new PrintWriter(os, true);
-			pw.write(password);
-			pw.close();
-		}
-
-		// If non-zero exit code is returned, then try to read error output
-		try {
-			if (process.waitFor() != 0) {
-				if (process.exitValue() == 1) {
-					//throw new PasswordDoesntMatchRuntimeException("Old password doesn't match for " + loginNamespace + ":" + userLogin + ".");
-					throw new InternalErrorException("Alternative password manager returns unexpected return code: " + process.exitValue());
-				} else if (process.exitValue() == 3) {
-					//throw new PasswordChangeFailedRuntimeException("Password change failed for " + loginNamespace + ":" + userLogin + ".");
-					throw new InternalErrorException("Alternative password manager returns unexpected return code: " + process.exitValue());
-				} else if (process.exitValue() == 4) {
-					throw new PasswordCreationFailedRuntimeException("Alternative password creation failed for " + user + ". Namespace: " + loginNamespace + ", description: " + description + ".");
-				} else if (process.exitValue() == 5) {
-					throw new PasswordDeletionFailedRuntimeException("Password deletion failed for " + user + ". Namespace: " + loginNamespace + ", passwordId: " + passwordId + ".");
-				} else if (process.exitValue() == 6) {
-					throw new LoginNotExistsRuntimeException("User doesn't exists in underlying system for namespace " + loginNamespace + ", user: " + user + ".");
-				} else if (process.exitValue() == 7) {
-					throw new InternalErrorException("Problem with creating user entry in underlying system " + loginNamespace + ", user: " + user + ".");
-				} else {
-					// Some other error occured
-					BufferedReader inReader = new BufferedReader(new InputStreamReader(es));
-					StringBuilder errorMsg = new StringBuilder();
-					String line;
-					try {
-						while ((line = inReader.readLine()) != null) {
-							errorMsg.append(line);
-						}
-					} catch (IOException e) {
-						throw new InternalErrorException(e);
-					}
-
-					throw new InternalErrorException(errorMsg.toString());
-				}
-			}
-		} catch (InterruptedException e) {
-			throw new InternalErrorException(e);
-		}
-	}
-
-
 
 	@Override
 	public List<RichUser> convertUsersToRichUsersWithAttributesByNames(PerunSession sess, List<User> users, List<String> attrNames) throws InternalErrorException {
@@ -2101,9 +2019,9 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	}
 
 	@Override
-	public Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException {
-		PasswordManagerModule module = getPasswordManagerModule(session, namespace);
-		return module.generateAccount(session, parameters);
+	public Map<String,String> generateAccount(PerunSession sess, String loginNamespace, Map<String, String> parameters) throws InternalErrorException {
+		PasswordManagerModule module = getPasswordManagerModule(sess, loginNamespace);
+		return module.generateAccount(sess, parameters);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/entry/UsersManagerEntry.java
@@ -980,42 +980,6 @@ public class UsersManagerEntry implements UsersManager {
 	}
 
 	@Override
-	@Deprecated
-	public void createPassword(PerunSession sess, String userLogin, String loginNamespace, String password) throws InternalErrorException,
-			PrivilegeException, PasswordCreationFailedException {
-		Utils.checkPerunSession(sess);
-
-		// Authorization
-		if(!AuthzResolver.isAuthorized(sess, Role.REGISTRAR)) {
-			throw new PrivilegeException(sess, "createPassword");
-		}
-
-		// Check if the login is already occupied == reserved, if not throw an exception.
-		// We cannot set password for the users who have not reserved login in perun DB and in registrar DB as well.
-		if (!getPerunBl().getUsersManagerBl().isLoginAvailable(sess, loginNamespace, userLogin)) {
-			getUsersManagerBl().createPassword(sess, userLogin, loginNamespace, password);
-		} else {
-			throw new PasswordCreationFailedException("Login " + userLogin + " in namespace " + loginNamespace + " is not reserved.");
-		}
-	}
-
-	@Override
-	@Deprecated
-	public void createPassword(PerunSession sess, User user, String loginNamespace, String password) throws InternalErrorException,
-			PrivilegeException, PasswordCreationFailedException, UserNotExistsException, LoginNotExistsException {
-		Utils.checkPerunSession(sess);
-
-		// Authorization
-		if(!AuthzResolver.isAuthorized(sess, Role.SELF, user) && (!(AuthzResolver.isAuthorized(sess, Role.VOADMIN) && user.isServiceUser()))) {
-			throw new PrivilegeException(sess, "createPassword");
-		}
-
-		getPerunBl().getUsersManagerBl().checkUserExists(sess, user);
-
-		getUsersManagerBl().createPassword(sess, user, loginNamespace, password);
-	}
-
-	@Override
 	public void reserveRandomPassword(PerunSession sess, User user, String loginNamespace) throws InternalErrorException, PasswordCreationFailedException, PrivilegeException, UserNotExistsException, LoginNotExistsException, PasswordOperationTimeoutException, PasswordStrengthFailedException {
 		Utils.checkPerunSession(sess);
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/UsersManagerImpl.java
@@ -1312,17 +1312,6 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 	}
 
 	@Override
-	public Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException {
-
-		PasswordManagerModule module = getPasswordManagerModule(session, namespace);
-		if (module != null) {
-			return module.generateAccount(session, parameters);
-		}
-		return null;
-
-	}
-
-	@Override
 	public PasswordManagerModule getPasswordManagerModule(PerunSession session, String namespace) throws InternalErrorException {
 
 		if (namespace == null || namespace.isEmpty()) throw new InternalErrorException("Login-namespace to get password manager module must be specified.");
@@ -1332,7 +1321,9 @@ public class UsersManagerImpl implements UsersManagerImplApi {
 
 		try {
 			return (PasswordManagerModule) Class.forName("cz.metacentrum.perun.core.impl.modules.pwdmgr." + namespace + "PasswordManagerModule").newInstance();
-		} catch (Exception ex) {
+		} catch (ClassNotFoundException ex) {
+			return null;
+		} catch (InstantiationException | IllegalAccessException ex) {
 			throw new InternalErrorException("Unable to instantiate password manager module.", ex);
 		}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DummyPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DummyPasswordManagerModule.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,4 +57,15 @@ public class DummyPasswordManagerModule implements PasswordManagerModule {
 	public void deletePassword(PerunSession sess, String userLogin) {
 		log.debug("deletePassword(userLogin={})",userLogin);
 	}
+
+	@Override
+	public void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) {
+		log.debug("createAlternativePassword(user={},passwordId={})", user, passwordId);
+	}
+
+	@Override
+	public void deleteAlternativePassword(PerunSession sess, User user, String passwordId) {
+		log.debug("deleteAlternativePassword(user={},passwordId={})", user, passwordId);
+	}
+
 }

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DusambaPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/DusambaPasswordManagerModule.java
@@ -1,0 +1,171 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.rt.EmptyPasswordRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.LoginNotExistsRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PasswordCreationFailedRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PasswordDeletionFailedRuntimeException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+/**
+ * This module allows us to set alternative password for Samba share services.
+ * We do not have logins in du-samba namespace at all. It uses "einfra" namespace login instead.
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class DusambaPasswordManagerModule extends GenericPasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(DusambaPasswordManagerModule.class);
+
+	public DusambaPasswordManagerModule() {
+
+		// set proper namespace
+		this.actualLoginNamespace = "du-samba";
+
+		// if we are not faking password manager by using /bin/true value in the config,
+		// then append namespace to the script path to trigger correct password manager script.
+
+		if (!binTrue.equals(this.passwordManagerProgram)) {
+			passwordManagerProgram += ".du-samba";
+		}
+		if (!binTrue.equals(this.altPasswordManagerProgram)) {
+			altPasswordManagerProgram += ".du-samba";
+		}
+
+	}
+
+	@Override
+	public Map<String, String> generateAccount(PerunSession session, Map<String, String> parameters) throws InternalErrorException {
+		throw new InternalErrorException("Generating account in login namespace 'du-samba' is not supported.");
+	}
+
+	@Override
+	public void reservePassword(PerunSession session, String userLogin, String password) throws InternalErrorException {
+		throw new InternalErrorException("Reserving password in login namespace 'du-samba' is not supported.");
+	}
+
+	@Override
+	public void reserveRandomPassword(PerunSession session, String userLogin) throws InternalErrorException {
+		throw new InternalErrorException("Reserving random password in login namespace 'du-samba' is not supported.");
+	}
+
+	@Override
+	public void checkPassword(PerunSession sess, String userLogin, String password) {
+		throw new InternalErrorException("Checking password in login namespace 'du-samba' is not supported.");
+	}
+
+	@Override
+	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException {
+		throw new InternalErrorException("Changing password in login namespace 'du-samba' is not supported.");
+	}
+
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin) {
+		throw new InternalErrorException("Validating password in login namespace 'du-samba' is not supported.");
+	}
+
+	@Override
+	public void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException {
+		throw new InternalErrorException("Deleting password in login namespace 'du-samba' is not supported.");
+	}
+
+	@Override
+	public void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) {
+		if (StringUtils.isBlank(password)) {
+			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + passwordId + " cannot be empty.");
+		}
+		// TODO - enforce EINFRA password checks
+
+		ProcessBuilder pb = new ProcessBuilder(altPasswordManagerProgram);
+		// pass variables as ENV
+		Map<String,String> env = pb.environment();
+		// we do not store passwords under passwordId in the backend, but rather use 'einfra' login
+		env.put("PMGR_LOGIN", getEinfraLogin(sess, user));
+		env.put("PMGR_PASSWORD", password);
+
+		Process process;
+		try {
+			process = pb.start();
+		} catch (IOException e) {
+			throw new InternalErrorException(e);
+		}
+		handleAltPwdManagerExit(process, user, actualLoginNamespace, passwordId);
+
+	}
+
+	@Override
+	public void deleteAlternativePassword(PerunSession sess, User user, String passwordId) {
+		throw new InternalErrorException("Deleting alternative password in login namespace 'du-samba' is not supported.");
+	}
+
+	/**
+	 * Handle exit codes of samba-du password manager scripts
+	 *
+	 * @param process Running password manager script process.
+	 * @param user User for which operation was performed.
+	 * @param loginNamespace Namespace in which operation was performed.
+	 * @param passwordId ID of alt password entry for which it was performed.
+	 */
+	@Override
+	protected void handleAltPwdManagerExit(Process process, User user, String loginNamespace, String passwordId) {
+
+		InputStream es = process.getErrorStream();
+
+		// If non-zero exit code is returned, then try to read error output
+		try {
+			if (process.waitFor() != 0) {
+				if (process.exitValue() == 1) {
+					throw new PasswordCreationFailedRuntimeException("Alternative password creation failed for " + user + ". Namespace: " + loginNamespace + ", passwordId: " + passwordId + ".");
+				} else if (process.exitValue() == 2) {
+					throw new PasswordDeletionFailedRuntimeException("Alternative password deletion failed for " + user + ". Namespace: " + loginNamespace + ", passwordId: " + passwordId + ".");
+				} else {
+					handleGenericErrorCode(es);
+				}
+			}
+		} catch (InterruptedException e) {
+			throw new InternalErrorException(e);
+		}
+
+	}
+
+	/**
+	 * Retrieve "einfra" login of the user, since its necessary to set samba password at the backend.
+	 *
+	 * @param session session
+	 * @param user user to get login for
+	 * @return einfra login
+	 * @throws LoginNotExistsRuntimeException if user doesn't have "einfra" login
+	 */
+	private String getEinfraLogin(PerunSession session, User user) {
+
+		String login = null;
+		try {
+			Attribute attribute = ((PerunBl)session.getPerun()).getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF+":login-namespace:einfra");
+			if (attribute.getValue() == null) {
+				log.warn("{} doesn't have login in namespace 'einfra', so the Samba password can't be set.", user);
+				throw new LoginNotExistsRuntimeException(user+" doesn't have login in namespace 'einfra', so the Samba password can't be set.");
+			}
+			login = attribute.valueAsString();
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			// shouldn't happen
+			log.error("We couldn't retrieve 'einfra' login for the {} to create/delete alt password for samba-du.", user, e);
+			throw new InternalErrorException("We couldn't retrieve 'einfra' login for the "+user+" to create/delete alt password for samba-du.");
+		}
+		return login;
+
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -1,8 +1,21 @@
 package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 
+import cz.metacentrum.perun.core.api.Attribute;
+import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.AttributeNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
+import cz.metacentrum.perun.core.api.exceptions.rt.EmptyPasswordRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.LoginNotExistsRuntimeException;
+import cz.metacentrum.perun.core.bl.PerunBl;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * Password manager for EINFRA login-namespace. It performs custom checks
@@ -13,6 +26,8 @@ import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
  * @author Pavel Zlamal <zlamal@cesnet.cz>
  */
 public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
+
+	private final static Logger log = LoggerFactory.getLogger(EinfraPasswordManagerModule.class);
 
 	public EinfraPasswordManagerModule() {
 
@@ -53,8 +68,101 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 
 	@Override
 	public void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) {
+		if (StringUtils.isBlank(password)) {
+			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + passwordId + " cannot be empty.");
+		}
 		checkPasswordStrength(password);
-		super.createAlternativePassword(sess, user, passwordId, password);
+
+		ProcessBuilder pb = new ProcessBuilder(altPasswordManagerProgram, PASSWORD_CREATE);
+		// pass variables as ENV
+		Map<String,String> env = pb.environment();
+		env.put("PMGR_PASSWORD_ID", passwordId);
+		env.put("PMGR_PASSWORD", password);
+		if (StringUtils.isNotBlank(user.getDisplayName())) env.put("PMGR_CN", user.getDisplayName());
+		if (StringUtils.isNotBlank(user.getFirstName())) env.put("PMGR_GIVEN_NAME", user.getFirstName());
+		if (StringUtils.isNotBlank(user.getLastName())) env.put("PMGR_SN", user.getLastName());
+		String mail = getMail(sess, user);
+		if (StringUtils.isNotBlank(mail)) env.put("PMGR_MAIL", mail);
+		String login = getEinfraLogin(sess, user);
+		if (StringUtils.isNotBlank(login)) env.put("PMGR_LOGIN", login);
+
+		Process process;
+		try {
+			process = pb.start();
+		} catch (IOException e) {
+			throw new InternalErrorException(e);
+		}
+
+		handleAltPwdManagerExit(process, user, actualLoginNamespace, passwordId);
+
+	}
+
+	@Override
+	public void deleteAlternativePassword(PerunSession sess, User user, String passwordId) {
+
+		ProcessBuilder pb = new ProcessBuilder(altPasswordManagerProgram, PASSWORD_DELETE);
+		// pass variables as ENV
+		Map<String,String> env = pb.environment();
+		env.put("PMGR_PASSWORD_ID", passwordId);
+		String login = getEinfraLogin(sess, user);
+		if (StringUtils.isNotBlank(login)) env.put("PMGR_LOGIN", login);
+
+		Process process;
+		try {
+			process = pb.start();
+		} catch (IOException e) {
+			throw new InternalErrorException(e);
+		}
+
+		handleAltPwdManagerExit(process, user, actualLoginNamespace, passwordId);
+
+	}
+
+	/**
+	 * Retrieve "einfra" login of the user, since its necessary for alternative password backend
+	 *
+	 * @param session session
+	 * @param user user to get login for
+	 * @return einfra login
+	 * @throws LoginNotExistsRuntimeException if user doesn't have "einfra" login
+	 */
+	private String getEinfraLogin(PerunSession session, User user) {
+
+		String login = null;
+		try {
+			Attribute attribute = ((PerunBl)session.getPerun()).getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF+":login-namespace:einfra");
+			if (attribute.getValue() == null) {
+				log.warn("{} doesn't have login in namespace 'einfra', so the alternative password can't be set.", user);
+				throw new LoginNotExistsRuntimeException(user+" doesn't have login in namespace 'einfra', so the alternative password can't be set.");
+			}
+			login = attribute.valueAsString();
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			// shouldn't happen
+			log.error("We couldn't retrieve 'einfra' login for the {} to create/delete alternative password.", user, e);
+			throw new InternalErrorException("We couldn't retrieve 'einfra' login for the "+user+" to create/delete alternative password.");
+		}
+		return login;
+
+	}
+
+	/**
+	 * Retrieve users preferred mail
+	 *
+	 * @param session session
+	 * @param user user to get mail for
+	 * @return users preferred mail
+	 */
+	private String getMail(PerunSession session, User user) {
+
+		try {
+			Attribute attribute = ((PerunBl)session.getPerun()).getAttributesManagerBl().getAttribute(session, user, AttributesManager.NS_USER_ATTR_DEF+":preferredMail");
+			return attribute.valueAsString();
+		} catch (WrongAttributeAssignmentException | AttributeNotExistsException e) {
+			// shouldn't happen
+			log.error("We couldn't retrieve mail for the {} to create/delete alternative password.", user, e);
+			throw new InternalErrorException("We couldn't retrieve mail for the "+user+" to create/delete alternative password.");
+		}
+
 	}
 
 	private void checkLoginFormat(String userLogin) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -1,0 +1,69 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+
+/**
+ * Password manager for EINFRA login-namespace. It performs custom checks
+ * on password strength and login format.
+ *
+ * It calls generic pwd manager script logic with ".einfra"
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
+
+	public EinfraPasswordManagerModule() {
+
+		// set proper namespace
+		this.actualLoginNamespace = "einfra";
+
+		// if we are not faking password manager by using /bin/true value in the config,
+		// then append namespace to the script path to trigger correct password manager script.
+
+		if (!binTrue.equals(this.passwordManagerProgram)) {
+			passwordManagerProgram += ".einfra";
+		}
+		if (!binTrue.equals(this.altPasswordManagerProgram)) {
+			altPasswordManagerProgram += ".einfra";
+		}
+
+	}
+
+	@Override
+	public void reservePassword(PerunSession session, String userLogin, String password) throws InternalErrorException {
+		checkLoginFormat(userLogin);
+		checkPasswordStrength(password);
+		super.reservePassword(session, userLogin, password);
+	}
+
+	@Override
+	public void reserveRandomPassword(PerunSession session, String userLogin) throws InternalErrorException {
+		// FIXME - probably generate password here and perform standard reservation
+		checkLoginFormat(userLogin);
+		super.reserveRandomPassword(session, userLogin);
+	}
+
+	@Override
+	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException {
+		checkPasswordStrength(newPassword);
+		super.changePassword(sess,userLogin, newPassword);
+
+	}
+
+	@Override
+	public void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) {
+		checkPasswordStrength(password);
+		super.createAlternativePassword(sess, user, passwordId, password);
+	}
+
+	private void checkLoginFormat(String userLogin) {
+		// TODO
+	}
+
+	private void checkPasswordStrength(String password) {
+		// TODO
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/EinfraPasswordManagerModule.java
@@ -48,8 +48,7 @@ public class EinfraPasswordManagerModule extends GenericPasswordManagerModule {
 	@Override
 	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException {
 		checkPasswordStrength(newPassword);
-		super.changePassword(sess,userLogin, newPassword);
-
+		super.changePassword(sess, userLogin, newPassword);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
@@ -1,0 +1,175 @@
+package cz.metacentrum.perun.core.impl.modules.pwdmgr;
+
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.CoreConfig;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+import cz.metacentrum.perun.core.api.exceptions.rt.EmptyPasswordRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.LoginNotExistsRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PasswordChangeFailedRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PasswordCreationFailedRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PasswordDeletionFailedRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PasswordDoesntMatchRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PasswordOperationTimeoutRuntimeException;
+import cz.metacentrum.perun.core.api.exceptions.rt.PasswordStrengthFailedRuntimeException;
+import cz.metacentrum.perun.core.implApi.modules.pwdmgr.PasswordManagerModule;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.Map;
+
+/**
+ * Generic implementation of {@link PasswordManagerModule}. It runs generic password manger script
+ * defined as perun config in {@link CoreConfig#getPasswordManagerProgram()}
+ *
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+public class GenericPasswordManagerModule implements PasswordManagerModule {
+
+	protected static final String PASSWORD_VALIDATE = "validate";
+	protected static final String PASSWORD_CREATE = "create";
+	protected static final String PASSWORD_RESERVE = "reserve";
+	protected static final String PASSWORD_RESERVE_RANDOM = "reserve_random";
+	protected static final String PASSWORD_CHANGE = "change";
+	protected static final String PASSWORD_CHECK = "check";
+	protected static final String PASSWORD_DELETE = "delete";
+
+	private String actualLoginNamespace = "generic";
+
+	public String getActualLoginNamespace() {
+		return actualLoginNamespace;
+	}
+
+	public void setActualLoginNamespace(String actualLoginNamespace) {
+		this.actualLoginNamespace = actualLoginNamespace;
+	}
+
+	@Override
+	public Map<String, String> generateAccount(PerunSession session, Map<String, String> parameters) throws InternalErrorException {
+		// account generation is not supported
+		return null;
+	}
+
+	@Override
+	public void reservePassword(PerunSession session, String userLogin, String password) throws InternalErrorException {
+		if (StringUtils.isBlank(password)) {
+			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + userLogin + " cannot be empty.");
+		}
+		Process process = createProcess(PASSWORD_RESERVE, actualLoginNamespace, userLogin);
+		sendPassword(process, password);
+		handleExit(process, actualLoginNamespace, userLogin);
+	}
+
+	@Override
+	public void reserveRandomPassword(PerunSession session, String userLogin) throws InternalErrorException {
+		Process process = createProcess(PASSWORD_RESERVE_RANDOM, actualLoginNamespace, userLogin);
+		handleExit(process, actualLoginNamespace, userLogin);
+	}
+
+	@Override
+	public void checkPassword(PerunSession sess, String userLogin, String password) {
+		if (StringUtils.isBlank(password)) {
+			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + userLogin + " cannot be empty.");
+		}
+		Process process = createProcess(PASSWORD_CHECK, actualLoginNamespace, userLogin);
+		sendPassword(process, password);
+		handleExit(process, actualLoginNamespace, userLogin);
+	}
+
+	@Override
+	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException {
+		if (StringUtils.isBlank(newPassword)) {
+			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + userLogin + " cannot be empty.");
+		}
+		Process process = createProcess(PASSWORD_CHANGE, actualLoginNamespace, userLogin);
+		sendPassword(process, newPassword);
+		handleExit(process, actualLoginNamespace, userLogin);
+	}
+
+	@Override
+	public void validatePassword(PerunSession sess, String userLogin) {
+		Process process = createProcess(PASSWORD_VALIDATE, actualLoginNamespace, userLogin);
+		handleExit(process, actualLoginNamespace, userLogin);
+	}
+
+	@Override
+	public void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException {
+		Process process = createProcess(PASSWORD_DELETE, actualLoginNamespace, userLogin);
+		handleExit(process, actualLoginNamespace, userLogin);
+	}
+
+	private Process createProcess(String operation, String loginNamespace, String login) {
+
+		// Check validity of original password
+		ProcessBuilder pb = new ProcessBuilder(BeansUtils.getCoreConfig().getPasswordManagerProgram(), operation, loginNamespace, login);
+
+		Process process;
+		try {
+			process = pb.start();
+		} catch (IOException e) {
+			throw new InternalErrorException(e);
+		}
+
+		return process;
+
+	}
+
+	private void sendPassword(Process process, String password) {
+
+		OutputStream os = process.getOutputStream();
+		// Write password to the stdin of the program
+		PrintWriter pw = new PrintWriter(os, true);
+		pw.write(password);
+		pw.close();
+
+	}
+
+	private void handleExit(Process process, String loginNamespace, String userLogin) {
+
+		InputStream es = process.getErrorStream();
+
+		// If non-zero exit code is returned, then try to read error output
+		try {
+			if (process.waitFor() != 0) {
+				if (process.exitValue() == 1) {
+					throw new PasswordDoesntMatchRuntimeException("Old password doesn't match for " + loginNamespace + ":" + userLogin + ".");
+				} else if (process.exitValue() == 3) {
+					throw new PasswordChangeFailedRuntimeException("Password change failed for " + loginNamespace + ":" + userLogin + ".");
+				} else if (process.exitValue() == 4) {
+					throw new PasswordCreationFailedRuntimeException("Password creation failed for " + loginNamespace + ":" + userLogin + ".");
+				} else if (process.exitValue() == 5) {
+					throw new PasswordDeletionFailedRuntimeException("Password deletion failed for " + loginNamespace + ":" + userLogin + ".");
+				} else if (process.exitValue() == 6) {
+					throw new LoginNotExistsRuntimeException("User login doesn't exists in underlying system for " + loginNamespace + ":" + userLogin + ".");
+				} else if (process.exitValue() == 11) {
+					throw new PasswordStrengthFailedRuntimeException("Password to set doesn't match expected restrictions for " + loginNamespace + ":" + userLogin + ".");
+				} else if (process.exitValue() == 12) {
+					throw new PasswordOperationTimeoutRuntimeException("Operation with password exceeded expected limit for " + loginNamespace + ":" + userLogin + ".");
+				} else {
+					// Some other error occurred
+					BufferedReader inReader = new BufferedReader(new InputStreamReader(es));
+					StringBuilder errorMsg = new StringBuilder();
+					String line;
+					try {
+						while ((line = inReader.readLine()) != null) {
+							errorMsg.append(line);
+						}
+					} catch (IOException e) {
+						throw new InternalErrorException(e);
+					}
+
+					throw new InternalErrorException(errorMsg.toString());
+				}
+			}
+		} catch (InterruptedException e) {
+			throw new InternalErrorException(e);
+		}
+
+	}
+
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
@@ -41,7 +41,10 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 	protected static final String PASSWORD_CHECK = "check";
 	protected static final String PASSWORD_DELETE = "delete";
 
-	private String actualLoginNamespace = "generic";
+	protected static final String binTrue = "/bin/true";
+	protected String actualLoginNamespace = "generic";
+	protected String passwordManagerProgram = BeansUtils.getCoreConfig().getPasswordManagerProgram();
+	protected String altPasswordManagerProgram = BeansUtils.getCoreConfig().getAlternativePasswordManagerProgram();
 
 	public String getActualLoginNamespace() {
 		return actualLoginNamespace;
@@ -129,9 +132,9 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 	 * @param login Login to perform operation for
 	 * @return Started process
 	 */
-	private Process createPwdManagerProcess(String operation, String loginNamespace, String login) {
+	protected Process createPwdManagerProcess(String operation, String loginNamespace, String login) {
 
-		ProcessBuilder pb = new ProcessBuilder(BeansUtils.getCoreConfig().getPasswordManagerProgram(), operation, loginNamespace, login);
+		ProcessBuilder pb = new ProcessBuilder(passwordManagerProgram, operation, loginNamespace, login);
 
 		Process process;
 		try {
@@ -150,7 +153,7 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 	 * @param process process waiting for password on STDIN
 	 * @param password password to be set
 	 */
-	private void sendPassword(Process process, String password) {
+	protected void sendPassword(Process process, String password) {
 
 		OutputStream os = process.getOutputStream();
 		// Write password to the stdin of the program
@@ -167,7 +170,7 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 	 * @param loginNamespace Namespace in which operation was performed.
 	 * @param userLogin Login for which operation was performed.
 	 */
-	private void handleExit(Process process, String loginNamespace, String userLogin) {
+	protected void handleExit(Process process, String loginNamespace, String userLogin) {
 
 		InputStream es = process.getErrorStream();
 
@@ -198,9 +201,9 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 
 	}
 
-	private Process createAltPwdManagerProcess(String operation, String loginNamespace, User user, String passwordId) {
+	protected Process createAltPwdManagerProcess(String operation, String loginNamespace, User user, String passwordId) {
 
-		ProcessBuilder pb = new ProcessBuilder(BeansUtils.getCoreConfig().getAlternativePasswordManagerProgram(), operation, loginNamespace, Integer.toString(user.getId()), passwordId);
+		ProcessBuilder pb = new ProcessBuilder(altPasswordManagerProgram, operation, loginNamespace, Integer.toString(user.getId()), passwordId);
 
 		Process process;
 		try {
@@ -221,7 +224,7 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 	 * @param loginNamespace Namespace in which operation was performed.
 	 * @param passwordId ID of alt password entry for which it was performed.
 	 */
-	private void handleAltPwdManagerExit(Process process, User user, String loginNamespace, String passwordId) {
+	protected void handleAltPwdManagerExit(Process process, User user, String loginNamespace, String passwordId) {
 
 		InputStream es = process.getErrorStream();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.CoreConfig;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.rt.EmptyPasswordRuntimeException;
 import cz.metacentrum.perun.core.api.exceptions.rt.LoginNotExistsRuntimeException;
@@ -25,7 +26,8 @@ import java.util.Map;
 
 /**
  * Generic implementation of {@link PasswordManagerModule}. It runs generic password manger script
- * defined as perun config in {@link CoreConfig#getPasswordManagerProgram()}
+ * defined as perun config in {@link CoreConfig#getPasswordManagerProgram()} or
+ * {@link CoreConfig#getAlternativePasswordManagerProgram()}.
  *
  * @author Pavel Zlamal <zlamal@cesnet.cz>
  */
@@ -60,14 +62,14 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 		if (StringUtils.isBlank(password)) {
 			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + userLogin + " cannot be empty.");
 		}
-		Process process = createProcess(PASSWORD_RESERVE, actualLoginNamespace, userLogin);
+		Process process = createPwdManagerProcess(PASSWORD_RESERVE, actualLoginNamespace, userLogin);
 		sendPassword(process, password);
 		handleExit(process, actualLoginNamespace, userLogin);
 	}
 
 	@Override
 	public void reserveRandomPassword(PerunSession session, String userLogin) throws InternalErrorException {
-		Process process = createProcess(PASSWORD_RESERVE_RANDOM, actualLoginNamespace, userLogin);
+		Process process = createPwdManagerProcess(PASSWORD_RESERVE_RANDOM, actualLoginNamespace, userLogin);
 		handleExit(process, actualLoginNamespace, userLogin);
 	}
 
@@ -76,7 +78,7 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 		if (StringUtils.isBlank(password)) {
 			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + userLogin + " cannot be empty.");
 		}
-		Process process = createProcess(PASSWORD_CHECK, actualLoginNamespace, userLogin);
+		Process process = createPwdManagerProcess(PASSWORD_CHECK, actualLoginNamespace, userLogin);
 		sendPassword(process, password);
 		handleExit(process, actualLoginNamespace, userLogin);
 	}
@@ -86,26 +88,49 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 		if (StringUtils.isBlank(newPassword)) {
 			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + userLogin + " cannot be empty.");
 		}
-		Process process = createProcess(PASSWORD_CHANGE, actualLoginNamespace, userLogin);
+		Process process = createPwdManagerProcess(PASSWORD_CHANGE, actualLoginNamespace, userLogin);
 		sendPassword(process, newPassword);
 		handleExit(process, actualLoginNamespace, userLogin);
 	}
 
 	@Override
 	public void validatePassword(PerunSession sess, String userLogin) {
-		Process process = createProcess(PASSWORD_VALIDATE, actualLoginNamespace, userLogin);
+		Process process = createPwdManagerProcess(PASSWORD_VALIDATE, actualLoginNamespace, userLogin);
 		handleExit(process, actualLoginNamespace, userLogin);
 	}
 
 	@Override
 	public void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException {
-		Process process = createProcess(PASSWORD_DELETE, actualLoginNamespace, userLogin);
+		Process process = createPwdManagerProcess(PASSWORD_DELETE, actualLoginNamespace, userLogin);
 		handleExit(process, actualLoginNamespace, userLogin);
 	}
 
-	private Process createProcess(String operation, String loginNamespace, String login) {
+	@Override
+	public void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) {
+		if (StringUtils.isBlank(password)) {
+			throw new EmptyPasswordRuntimeException("Password for " + actualLoginNamespace + ":" + passwordId + " cannot be empty.");
+		}
+		Process process = createAltPwdManagerProcess(PASSWORD_CREATE, actualLoginNamespace, user, passwordId);
+		sendPassword(process, password);
+		handleAltPwdManagerExit(process, user, actualLoginNamespace, passwordId);
+	}
 
-		// Check validity of original password
+	@Override
+	public void deleteAlternativePassword(PerunSession sess, User user, String passwordId) {
+		Process process = createAltPwdManagerProcess(PASSWORD_DELETE, actualLoginNamespace, user, passwordId);
+		handleAltPwdManagerExit(process, user, actualLoginNamespace, passwordId);
+	}
+
+	/**
+	 * Run password manager script on path defined in perun config.
+	 *
+	 * @param operation Operation to perform (reserve, reserveRandom, validate, check, change, delete)
+	 * @param loginNamespace Namespace in which operation is performed.
+	 * @param login Login to perform operation for
+	 * @return Started process
+	 */
+	private Process createPwdManagerProcess(String operation, String loginNamespace, String login) {
+
 		ProcessBuilder pb = new ProcessBuilder(BeansUtils.getCoreConfig().getPasswordManagerProgram(), operation, loginNamespace, login);
 
 		Process process;
@@ -119,6 +144,12 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 
 	}
 
+	/**
+	 * Send password to the STDIN of running password manager script process.
+	 *
+	 * @param process process waiting for password on STDIN
+	 * @param password password to be set
+	 */
 	private void sendPassword(Process process, String password) {
 
 		OutputStream os = process.getOutputStream();
@@ -129,6 +160,13 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 
 	}
 
+	/**
+	 * Wait for password manager script to end and handle known return codes.
+	 *
+	 * @param process Running password manager script process.
+	 * @param loginNamespace Namespace in which operation was performed.
+	 * @param userLogin Login for which operation was performed.
+	 */
 	private void handleExit(Process process, String loginNamespace, String userLogin) {
 
 		InputStream es = process.getErrorStream();
@@ -151,24 +189,88 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 				} else if (process.exitValue() == 12) {
 					throw new PasswordOperationTimeoutRuntimeException("Operation with password exceeded expected limit for " + loginNamespace + ":" + userLogin + ".");
 				} else {
-					// Some other error occurred
-					BufferedReader inReader = new BufferedReader(new InputStreamReader(es));
-					StringBuilder errorMsg = new StringBuilder();
-					String line;
-					try {
-						while ((line = inReader.readLine()) != null) {
-							errorMsg.append(line);
-						}
-					} catch (IOException e) {
-						throw new InternalErrorException(e);
-					}
-
-					throw new InternalErrorException(errorMsg.toString());
+					handleGenericErrorCode(es);
 				}
 			}
 		} catch (InterruptedException e) {
 			throw new InternalErrorException(e);
 		}
+
+	}
+
+	private Process createAltPwdManagerProcess(String operation, String loginNamespace, User user, String passwordId) {
+
+		ProcessBuilder pb = new ProcessBuilder(BeansUtils.getCoreConfig().getAlternativePasswordManagerProgram(), operation, loginNamespace, Integer.toString(user.getId()), passwordId);
+
+		Process process;
+		try {
+			process = pb.start();
+		} catch (IOException e) {
+			throw new InternalErrorException(e);
+		}
+
+		return process;
+
+	}
+
+	/**
+	 * Wait for alternative password manager script to end and handle known return codes.
+	 *
+	 * @param process Running password manager script process.
+	 * @param user User for which operation was performed.
+	 * @param loginNamespace Namespace in which operation was performed.
+	 * @param passwordId ID of alt password entry for which it was performed.
+	 */
+	private void handleAltPwdManagerExit(Process process, User user, String loginNamespace, String passwordId) {
+
+		InputStream es = process.getErrorStream();
+
+		// If non-zero exit code is returned, then try to read error output
+		try {
+			if (process.waitFor() != 0) {
+				if (process.exitValue() == 1) {
+					//throw new PasswordDoesntMatchRuntimeException("Old password doesn't match for " + loginNamespace + ":" + userLogin + ".");
+					throw new InternalErrorException("Alternative password manager returns unexpected return code: " + process.exitValue());
+				} else if (process.exitValue() == 3) {
+					//throw new PasswordChangeFailedRuntimeException("Password change failed for " + loginNamespace + ":" + userLogin + ".");
+					throw new InternalErrorException("Alternative password manager returns unexpected return code: " + process.exitValue());
+				} else if (process.exitValue() == 4) {
+					throw new PasswordCreationFailedRuntimeException("Alternative password creation failed for " + user + ". Namespace: " + loginNamespace + ", passwordId: " + passwordId + ".");
+				} else if (process.exitValue() == 5) {
+					throw new PasswordDeletionFailedRuntimeException("Password deletion failed for " + user + ". Namespace: " + loginNamespace + ", passwordId: " + passwordId + ".");
+				} else if (process.exitValue() == 6) {
+					throw new LoginNotExistsRuntimeException("User doesn't exists in underlying system for namespace " + loginNamespace + ", user: " + user + ".");
+				} else if (process.exitValue() == 7) {
+					throw new InternalErrorException("Problem with creating user entry in underlying system " + loginNamespace + ", user: " + user + ".");
+				} else {
+					handleGenericErrorCode(es);
+				}
+			}
+		} catch (InterruptedException e) {
+			throw new InternalErrorException(e);
+		}
+
+	}
+
+	/**
+	 * Handle error stream from password manager script on unexpected return code.
+	 *
+	 * @param errorStream Password manager script error stream
+	 */
+	private void handleGenericErrorCode(InputStream errorStream) {
+
+		BufferedReader inReader = new BufferedReader(new InputStreamReader(errorStream));
+		StringBuilder errorMsg = new StringBuilder();
+		String line;
+		try {
+			while ((line = inReader.readLine()) != null) {
+				errorMsg.append(line);
+			}
+		} catch (IOException e) {
+			throw new InternalErrorException(e);
+		}
+
+		throw new InternalErrorException(errorMsg.toString());
 
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/GenericPasswordManagerModule.java
@@ -260,7 +260,7 @@ public class GenericPasswordManagerModule implements PasswordManagerModule {
 	 *
 	 * @param errorStream Password manager script error stream
 	 */
-	private void handleGenericErrorCode(InputStream errorStream) {
+	protected void handleGenericErrorCode(InputStream errorStream) {
 
 		BufferedReader inReader = new BufferedReader(new InputStreamReader(errorStream));
 		StringBuilder errorMsg = new StringBuilder();

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/MuPasswordManagerModule.java
@@ -3,6 +3,7 @@ package cz.metacentrum.perun.core.impl.modules.pwdmgr;
 import cz.metacentrum.perun.core.api.BeansUtils;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.UserExtSource;
 import cz.metacentrum.perun.core.api.exceptions.IllegalArgumentException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
@@ -103,6 +104,16 @@ public class MuPasswordManagerModule implements PasswordManagerModule {
 	@Override
 	public void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException {
 		throw new InternalErrorException("Deleting user/password in login namespace 'mu' is not supported.");
+	}
+
+	@Override
+	public void createAlternativePassword(PerunSession sess, User user, String passwordId, String password) {
+		throw new InternalErrorException("Creating alternative password in login namespace 'mu' is not supported.");
+	}
+
+	@Override
+	public void deleteAlternativePassword(PerunSession sess, User user, String passwordId) {
+		throw new InternalErrorException("Deleting alternative password in login namespace 'mu' is not supported.");
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SambaduPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SambaduPasswordManagerModule.java
@@ -26,60 +26,60 @@ import java.util.Map;
  *
  * @author Pavel Zlamal <zlamal@cesnet.cz>
  */
-public class DusambaPasswordManagerModule extends GenericPasswordManagerModule {
+public class SambaduPasswordManagerModule extends GenericPasswordManagerModule {
 
-	private final static Logger log = LoggerFactory.getLogger(DusambaPasswordManagerModule.class);
+	private final static Logger log = LoggerFactory.getLogger(SambaduPasswordManagerModule.class);
 
-	public DusambaPasswordManagerModule() {
+	public SambaduPasswordManagerModule() {
 
 		// set proper namespace
-		this.actualLoginNamespace = "du-samba";
+		this.actualLoginNamespace = "samba-du";
 
 		// if we are not faking password manager by using /bin/true value in the config,
 		// then append namespace to the script path to trigger correct password manager script.
 
 		if (!binTrue.equals(this.passwordManagerProgram)) {
-			passwordManagerProgram += ".du-samba";
+			passwordManagerProgram += ".samba-du";
 		}
 		if (!binTrue.equals(this.altPasswordManagerProgram)) {
-			altPasswordManagerProgram += ".du-samba";
+			altPasswordManagerProgram += ".samba-du";
 		}
 
 	}
 
 	@Override
 	public Map<String, String> generateAccount(PerunSession session, Map<String, String> parameters) throws InternalErrorException {
-		throw new InternalErrorException("Generating account in login namespace 'du-samba' is not supported.");
+		throw new InternalErrorException("Generating account in login namespace 'samba-du' is not supported.");
 	}
 
 	@Override
 	public void reservePassword(PerunSession session, String userLogin, String password) throws InternalErrorException {
-		throw new InternalErrorException("Reserving password in login namespace 'du-samba' is not supported.");
+		throw new InternalErrorException("Reserving password in login namespace 'samba-du' is not supported.");
 	}
 
 	@Override
 	public void reserveRandomPassword(PerunSession session, String userLogin) throws InternalErrorException {
-		throw new InternalErrorException("Reserving random password in login namespace 'du-samba' is not supported.");
+		throw new InternalErrorException("Reserving random password in login namespace 'samba-du' is not supported.");
 	}
 
 	@Override
 	public void checkPassword(PerunSession sess, String userLogin, String password) {
-		throw new InternalErrorException("Checking password in login namespace 'du-samba' is not supported.");
+		throw new InternalErrorException("Checking password in login namespace 'samba-du' is not supported.");
 	}
 
 	@Override
 	public void changePassword(PerunSession sess, String userLogin, String newPassword) throws InternalErrorException {
-		throw new InternalErrorException("Changing password in login namespace 'du-samba' is not supported.");
+		throw new InternalErrorException("Changing password in login namespace 'samba-du' is not supported.");
 	}
 
 	@Override
 	public void validatePassword(PerunSession sess, String userLogin) {
-		throw new InternalErrorException("Validating password in login namespace 'du-samba' is not supported.");
+		throw new InternalErrorException("Validating password in login namespace 'samba-du' is not supported.");
 	}
 
 	@Override
 	public void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException {
-		throw new InternalErrorException("Deleting password in login namespace 'du-samba' is not supported.");
+		throw new InternalErrorException("Deleting password in login namespace 'samba-du' is not supported.");
 	}
 
 	@Override
@@ -108,7 +108,7 @@ public class DusambaPasswordManagerModule extends GenericPasswordManagerModule {
 
 	@Override
 	public void deleteAlternativePassword(PerunSession sess, User user, String passwordId) {
-		throw new InternalErrorException("Deleting alternative password in login namespace 'du-samba' is not supported.");
+		throw new InternalErrorException("Deleting alternative password in login namespace 'samba-du' is not supported.");
 	}
 
 	/**

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SambaduPasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/pwdmgr/SambaduPasswordManagerModule.java
@@ -122,18 +122,10 @@ public class SambaduPasswordManagerModule extends GenericPasswordManagerModule {
 	@Override
 	protected void handleAltPwdManagerExit(Process process, User user, String loginNamespace, String passwordId) {
 
-		InputStream es = process.getErrorStream();
-
-		// If non-zero exit code is returned, then try to read error output
 		try {
 			if (process.waitFor() != 0) {
-				if (process.exitValue() == 1) {
-					throw new PasswordCreationFailedRuntimeException("Alternative password creation failed for " + user + ". Namespace: " + loginNamespace + ", passwordId: " + passwordId + ".");
-				} else if (process.exitValue() == 2) {
-					throw new PasswordDeletionFailedRuntimeException("Alternative password deletion failed for " + user + ". Namespace: " + loginNamespace + ", passwordId: " + passwordId + ".");
-				} else {
-					handleGenericErrorCode(es);
-				}
+				// on any exit code it means creation failed
+				throw new PasswordCreationFailedRuntimeException("Alternative password creation failed for " + user + ". Namespace: " + loginNamespace + ", passwordId: " + passwordId + ".");
 			}
 		} catch (InterruptedException e) {
 			throw new InternalErrorException(e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/UsersManagerImplApi.java
@@ -721,30 +721,13 @@ public interface UsersManagerImplApi {
 	int getUsersCount(PerunSession perunSession) throws InternalErrorException;
 
 	/**
-	 * Generate user account in a backend system associated with login-namespace in Perun.
+	 * Return instance of PasswordManagerModule for specified namespace or NULL if class for module is not found.
+	 * Throws exception if class can't be instantiated.
 	 *
-	 * This method consumes optional parameters map. Requirements are implementation-dependant
-	 * for each login-namespace.
-	 *
-	 * Returns map with
-	 * 1: key=login-namespace attribute urn, value=generated login
-	 * 2: rest of opt response attributes...
-	 *
-	 * @param session
-	 * @param namespace Namespace to generate account in
-	 * @param parameters Optional parameters
-	 * @return Map of data from backed response
-	 * @throws InternalErrorException
-	 */
-	Map<String,String> generateAccount(PerunSession session, String namespace, Map<String, String> parameters) throws InternalErrorException;
-
-	/**
-	 * Return instance of PasswordManagerModule for specified namespace or throw exception.
-	 *
-	 * @param session
+	 * @param session Session with authz
 	 * @param namespace Namespace to get PWDMGR module.
-	 * @return
-	 * @throws InternalErrorException
+	 * @return Instance of password manager module or NULL if not exists for passed namespace.
+	 * @throws InternalErrorException When module can't be instantiated.
 	 */
 	PasswordManagerModule getPasswordManagerModule(PerunSession session, String namespace) throws InternalErrorException;
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/modules/pwdmgr/PasswordManagerModule.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.core.implApi.modules.pwdmgr;
 
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 
 import java.util.Map;
@@ -25,6 +26,7 @@ public interface PasswordManagerModule {
 	String PASSWORD_KEY = "password";
 	//prefix for output, add namespace
 	String LOGIN_PREFIX = AttributesManager.NS_USER_ATTR_DEF + ":" + AttributesManager.LOGIN_NAMESPACE + ":";
+	String ALT_PASSWORD_PREFIX = AttributesManager.NS_USER_ATTR_DEF + ":altPasswords:";
 
 	Map<String,String> generateAccount(PerunSession session, Map<String, String> parameters) throws InternalErrorException;
 
@@ -39,5 +41,9 @@ public interface PasswordManagerModule {
 	void validatePassword(PerunSession sess, String userLogin);
 
 	void deletePassword(PerunSession sess, String userLogin) throws InternalErrorException;
+
+	void createAlternativePassword(PerunSession sess, User user, String passwordId, String password);
+
+	void deleteAlternativePassword(PerunSession sess, User user, String passwordId);
 
 }

--- a/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
+++ b/perun-rpc/src/main/java/cz/metacentrum/perun/rpc/methods/UsersManagerMethod.java
@@ -1003,29 +1003,6 @@ public enum UsersManagerMethod implements ManagerMethod {
 		}
 	},
 	/*#
-	 * Creates a password in external authz system.
-	 *
-	 * @param login String Login
-	 * @param namespace String Namespace
-	 * @param password String password
-	 */
-	@Deprecated
-	createPassword {
-		@Override
-		public Void call(ApiCaller ac, Deserializer parms) throws PerunException {
-			ac.stateChangingCheck();
-
-			if (parms.contains("user")) {
-				ac.getUsersManager().createPassword(ac.getSession(), ac.getUserById(parms.readInt("user")), parms.readString("namespace"), parms.readString("password"));
-			} else {
-				ac.getUsersManager().createPassword(ac.getSession(), parms.readString("login"), parms.readString("namespace"), parms.readString("password"));
-			}
-
-			return null;
-
-		}
-	},
-	/*#
 	 * Reserves a random password in external authz system. User shouldn't be able to log-in (account disabled, password unknown to him).
 	 * This is usefull when manager create account for others and later send them password reset request.
 	 *


### PR DESCRIPTION
- Added GenericPasswordManagerModule as default implementation
  for password manager logic replacing former implementation
  from inside of managePassword(), which was removed.
- Each outer API method to manage password now calls proper
  module / implementation.
- Method UsersManagerBl.getPasswordManagerModule() is now public
  and always returns module for namespace or generic implementation.
  If instantiation fails, then exception is thrown.
- Removed generateAccount() from UsersManagerImpl, it is now
  only in Bl, reusing bl method to get module.
- Removed long time deprecated createPassword() methods from all APIs.
- Removed unnecessary and incomplete javadoc from bl methods.

- Added createAlternativePassword() and deleteAlternativePassword()
  to PasswordManagerModule.
- Modified logic in UsersManagerBlImpl to use modules instead of
  shared manageAlternativePassword().
- Added generic implementation for alternative passwords inside
  GenericPasswordManagerModule.

- New Einfra/DusambaPasswordManagerModule and will pass necessary data as ENV
  variables for the new pwd manager script, avoiding STDIN.
- Both modules append their namespace after pwd manager script path, allowing custom
  implementation (unless its /bin/true). On deployment symlink or new script must be present.