### PR TITLE
Oracle driver 19.6 is public

### DIFF
--- a/perun-core/pom.xml
+++ b/perun-core/pom.xml
@@ -202,6 +202,15 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
+		<!-- Oracle -->
+		<dependency>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc8</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.database.nls</groupId>
+			<artifactId>orai18n</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.infinispan</groupId>
@@ -215,37 +224,10 @@
 
 	</dependencies>
 
-	<profiles>
-
-		<profile>
 			<!--
 			Run tests against Oracle DB with the following command:
-			  mvn -Dspring.profiles.active=production -Dperun.conf.custom=$HOME/perun_test -Doracle=True test
+			  mvn -Dspring.profiles.active=production -Dperun.conf.custom=$HOME/perun_test test
 			where $HOME/perun_test/ directory contains files jdbc.properties and perun.properties
 			-->
-			<id>oracle</id>
-			<activation>
-				<property>
-					<name>oracle</name>
-					<value>True</value>
-				</property>
-			</activation>
-			<dependencies>
-				<!-- Oracle jdbc driver -->
-				<dependency>
-					<groupId>com.oracle</groupId>
-					<artifactId>ojdbc8</artifactId>
-					<scope>test</scope>
-				</dependency>
-				<!-- Oracle internationalization -->
-				<dependency>
-					<groupId>com.oracle</groupId>
-					<artifactId>orai18n</artifactId>
-					<scope>test</scope>
-				</dependency>
-			</dependencies>
-		</profile>
-
-	</profiles>
 
 </project>

--- a/perun-ldapc/pom.xml
+++ b/perun-ldapc/pom.xml
@@ -100,31 +100,4 @@
 
 	</dependencies>
 
-	<profiles>
-
-		<profile>
-			<!-- adds Oracle JDBC drivers if run with "mvn -Doracle=True"-->
-			<id>oracle</id>
-			<activation>
-				<property>
-					<name>oracle</name>
-					<value>True</value>
-				</property>
-			</activation>
-			<dependencies>
-				<!-- Oracle jdbc driver -->
-				<dependency>
-					<groupId>com.oracle</groupId>
-					<artifactId>ojdbc8</artifactId>
-				</dependency>
-				<!-- Oracle internationalization -->
-				<dependency>
-					<groupId>com.oracle</groupId>
-					<artifactId>orai18n</artifactId>
-				</dependency>
-			</dependencies>
-		</profile>
-
-	</profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<jcip.version>1.0</jcip.version>
 		<jdom.version>1.0</jdom.version>
 		<json.version>20190722</json.version>
-		<oracle.version>12.2.0.1.0</oracle.version>
+		<oracle.version>19.6.0.0</oracle.version>
 		<reflections.version>0.9.11</reflections.version>
 	</properties>
 
@@ -243,13 +243,13 @@
 
 			<!-- Oracle jdbc driver -->
 			<dependency>
-				<groupId>com.oracle</groupId>
+				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>
 				<version>${oracle.version}</version>
 			</dependency>
 			<!-- Oracle internationalization -->
 			<dependency>
-				<groupId>com.oracle</groupId>
+				<groupId>com.oracle.database.nls</groupId>
 				<artifactId>orai18n</artifactId>
 				<version>${oracle.version}</version>
 			</dependency>


### PR DESCRIPTION
The Oracle JDBC driver version 19.3 is publicly available in Maven repo. It is compatible will Oracle DB versions 19.3, 18.3, 12.2., 12.1 and 11.2 according to https://www.oracle.com/database/technologies/faq-jdbc.html

We no longer need to handle Oracle drivers specially, they can be included in Perun just like drivers for PostgreSQL, SQLite, and MySQL. No more special Maven profiles and separate installation.