### PR TITLE
removed limit on column ext_sources_attributes.attr_value

### DIFF
--- a/perun-base/src/test/resources/test-schema.sql
+++ b/perun-base/src/test/resources/test-schema.sql
@@ -2,7 +2,7 @@ set database sql syntax PGS true;
 -- fix unique index on authz, since PGS compatibility doesn't allow coalesce call in index and treats nulls in columns as different values.
 SET DATABASE SQL UNIQUE NULLS FALSE;
 
--- database version 3.1.58 (don't forget to update insert statement at the end of file)
+-- database version 3.1.59 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1049,7 +1049,7 @@ create table ext_sources (
 create table ext_sources_attributes (
 	ext_sources_id integer not null,   --identifier of ext. source (ext_sources.id)
 	attr_name varchar(128) not null,   --name of attribute at ext. source
-	attr_value varchar(4000),          --value of attribute
+	attr_value longvarchar,          --value of attribute
 	created_at timestamp default current_date not null,
 	created_by varchar(1300) default user not null,
 	modified_at timestamp default current_date not null,
@@ -1752,7 +1752,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.58');
+insert into configurations values ('DATABASE VERSION','3.1.59');
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');
 insert into membership_types (id, membership_type, description) values (2, 'INDIRECT', 'Member is added indirectly through UNION relation');
 insert into action_types (id, action_type, description) values (nextval('action_types_seq'), 'read', 'Can read value.');

--- a/perun-core/src/main/resources/hsqldbChangelog.txt
+++ b/perun-core/src/main/resources/hsqldbChangelog.txt
@@ -8,6 +8,10 @@
 
 -- this update is not supported on hsql since its used only as in-memory db
 
+3.1.59
+ALTER TABLE ext_sources_attributes ALTER COLUMN attr_value TYPE longvarchar;
+update configurations set value='3.1.59' where property='DATABASE VERSION';
+
 3.1.58
 alter table pwdreset add column mail text;
 update configurations set value='3.1.58' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -7,7 +7,7 @@
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
 3.1.59
-ALTER TABLE EXT_SOURCES_ATTRIBUTES ADD (tmpcolumn  CLOB);
+ALTER TABLE EXT_SOURCES_ATTRIBUTES ADD (tmpcolumn CLOB);
 UPDATE EXT_SOURCES_ATTRIBUTES SET tmpcolumn=attr_value;
 ALTER TABLE EXT_SOURCES_ATTRIBUTES DROP COLUMN attr_value;
 ALTER TABLE EXT_SOURCES_ATTRIBUTES RENAME COLUMN tmpcolumn TO attr_value;

--- a/perun-core/src/main/resources/oracleChangelog.txt
+++ b/perun-core/src/main/resources/oracleChangelog.txt
@@ -6,6 +6,13 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.59
+ALTER TABLE EXT_SOURCES_ATTRIBUTES ADD (tmpcolumn  CLOB);
+UPDATE EXT_SOURCES_ATTRIBUTES SET tmpcolumn=attr_value;
+ALTER TABLE EXT_SOURCES_ATTRIBUTES DROP COLUMN attr_value;
+ALTER TABLE EXT_SOURCES_ATTRIBUTES RENAME COLUMN tmpcolumn TO attr_value;
+update configurations set value='3.1.59' where property='DATABASE VERSION';
+
 3.1.58
 alter table pwdreset add mail nvarchar2(4000);
 update configurations set value='3.1.58' where property='DATABASE VERSION';

--- a/perun-core/src/main/resources/postgresChangelog.txt
+++ b/perun-core/src/main/resources/postgresChangelog.txt
@@ -6,6 +6,10 @@
 -- Directly under version number should be version commands. They will be executed in the order they are written here.
 -- Comments are prefixed with -- and can be written only between version blocks, that means not in the lines with commands. They have to be at the start of the line.
 
+3.1.59
+ALTER TABLE ext_sources_attributes ALTER COLUMN attr_value TYPE varchar;
+update configurations set value='3.1.59' where property='DATABASE VERSION';
+
 3.1.58
 alter table pwdreset add column mail text;
 update configurations set value='3.1.58' where property='DATABASE VERSION';

--- a/perun-db/oracle.sql
+++ b/perun-db/oracle.sql
@@ -1,4 +1,4 @@
--- database version 3.1.58 (don't forget to update insert statement at the end of file)
+-- database version 3.1.59 (don't forget to update insert statement at the end of file)
 
 create user perunv3 identified by password;
 grant create session to perunv3;
@@ -1055,7 +1055,7 @@ create table ext_sources (
 create table ext_sources_attributes (
 	ext_sources_id integer not null,   --identifier of ext. source (ext_sources.id)
 	attr_name nvarchar2(128) not null,   --name of attribute at ext. source
-	attr_value nvarchar2(4000),          --value of attribute
+	attr_value clob,          --value of attribute
 	created_at date default sysdate not null,
 	created_by nvarchar2(1300) default user not null,
 	modified_at date default sysdate not null,
@@ -1754,7 +1754,7 @@ CREATE INDEX ufauv_idx ON user_facility_attr_u_values (user_id, facility_id, att
 CREATE INDEX vauv_idx ON vo_attr_u_values (vo_id, attr_id) ;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.58');
+insert into configurations values ('DATABASE VERSION','3.1.59');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');

--- a/perun-db/postgres.sql
+++ b/perun-db/postgres.sql
@@ -1,4 +1,4 @@
--- database version 3.1.58 (don't forget to update insert statement at the end of file)
+-- database version 3.1.59 (don't forget to update insert statement at the end of file)
 
 -- VOS - virtual organizations
 create table vos (
@@ -1046,7 +1046,7 @@ create table ext_sources (
 create table ext_sources_attributes (
 	ext_sources_id integer not null,   --identifier of ext. source (ext_sources.id)
 	attr_name varchar(128) not null,   --name of attribute at ext. source
-	attr_value varchar(4000),          --value of attribute
+	attr_value varchar,          --value of attribute
 	created_at timestamp default statement_timestamp() not null,
 	created_by varchar(1300) default user not null,
 	modified_at timestamp default statement_timestamp() not null,
@@ -1851,7 +1851,7 @@ grant all on user_ext_source_attr_u_values to perun;
 grant all on members_sponsored to perun;
 
 -- set initial Perun DB version
-insert into configurations values ('DATABASE VERSION','3.1.58');
+insert into configurations values ('DATABASE VERSION','3.1.59');
 
 -- insert membership types
 insert into membership_types (id, membership_type, description) values (1, 'DIRECT', 'Member is directly added into group');


### PR DESCRIPTION
The value of ext_sources_attributes.attr_value may hold very large SQL texts, the original limit of 4000 bytes was too small. The changes:
- in PostgreSQL used VARCHAR without limit (the documentation says the limit is about 1GB)
- in Oracle used CLOB (the documentation says limit is 4GB)
- in HSQLDB used LONGVARCHAR (the documentation says limit is 16MB)