### PR TITLE
CORE: Fixed SQL to get (group)members by expiration

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -80,12 +80,12 @@ public class SearcherImpl implements SearcherImplApi {
 
 		try {
 
-			AttributeDefinition def = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, "urn:perun:member:attribute-def:def:membershipExpiration");
+			String query = "select distinct " + MembersManagerImpl.memberMappingSelectQuery + " from member_attr_values val" +
+					" join members on val.member_id=members.id" +
+					" and val.attr_id=(select id from attr_names where attr_name='urn:perun:member:attribute-def:def:membershipExpiration')" +
+					" and TO_DATE(val.attr_value, 'YYYY-MM-DD')"+operator+compareDate;
 
-			String query = "select distinct " + MembersManagerImpl.memberMappingSelectQuery + " from members left join member_attr_values val on " +
-					"val.member_id=members.id and val.attr_id=? where TO_DATE(val.attr_value, 'YYYY-MM-DD')"+operator+compareDate;
-
-			return jdbcTemplate.query(query, MembersManagerImpl.MEMBER_MAPPER, def.getId());
+			return jdbcTemplate.query(query, MembersManagerImpl.MEMBER_MAPPER);
 
 		} catch (Exception e) {
 			throw new InternalErrorException(e);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/SearcherImpl.java
@@ -287,12 +287,16 @@ public class SearcherImpl implements SearcherImplApi {
 		}
 
 		try {
-			AttributeDefinition def = ((PerunBl) sess.getPerun()).getAttributesManagerBl().getAttributeDefinition(sess, AttributesManager.NS_MEMBER_GROUP_ATTR_DEF + ":groupMembershipExpiration");
 
-			String query = "select distinct " + MembersManagerImpl.groupsMembersMappingSelectQuery + " from members left join groups_members on members.id=groups_members.member_id and groups_members.group_id=? left join member_group_attr_values val on " +
-					"val.member_id=members.id and val.attr_id=? where val.group_id=? and TO_DATE(val.attr_value, 'YYYY-MM-DD')"+operator+compareDate;
+			String query = "select distinct " + MembersManagerImpl.groupsMembersMappingSelectQuery + " from member_group_attr_values val" +
+					" join groups_members on val.member_id=groups_members.member_id" +
+					" and val.group_id=groups_members.group_id" +
+					" and val.group_id=?" +
+					" and val.attr_id=(select id from attr_names where attr_name='urn:perun:member_group:attribute-def:def:groupMembershipExpiration')" +
+					" and TO_DATE(val.attr_value, 'YYYY-MM-DD')" + operator + compareDate +
+					" join members on members.id=val.member_id";
 
-			return jdbcTemplate.query(query, MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, group.getId(), def.getId(), group.getId());
+			return jdbcTemplate.query(query, MembersManagerImpl.MEMBERS_WITH_GROUP_STATUSES_SET_EXTRACTOR, group.getId());
 
 		} catch (Exception e) {
 			throw new InternalErrorException(e);


### PR DESCRIPTION
- Order of tables we join in a select has changed. We always start with most specific
  (attribute value) and then join (group_)members. Otherwise we get unnecessary
  duplicates or data outside expected scope (group).
- We determine proper attribute ID from within the select. There is no need to get it
  by core logic before actually performing select on members by expiration.