### PR TITLE
CORE: Fixed getting group members by expiration on Oracle DB

### DIFF
--- a/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
+++ b/perun-registrar-lib/src/main/java/cz/metacentrum/perun/registrar/impl/ExpirationNotifScheduler.java
@@ -294,6 +294,9 @@ public class ExpirationNotifScheduler {
 		} catch(WrongAttributeAssignmentException e){
 			log.error("Synchronizer: checkMembersState, attribute name is from wrong namespace.", e);
 		}
+
+		log.debug("Processing checkMemberState() on (to be) expired members DONE!");
+
 	}
 
 	/**


### PR DESCRIPTION
- Oracle SQL query planner determine order of join/where
  conditions by itself. For some reason it prefers to
  convert all attr values to_date() instead of taking
  only values of specified attribute (by index on attr_id).
  This results in exception, since only one attribute has
  values, that can be converted to date.
- We now use Oracle specific hint (incorporated as SQL
  comment) to force its planner to use index search first,
  so that query succeeds. Note - we must reference renamed
  table (alias).
- Added debug and error log messages to expiration switching
  logic.