### PR TITLE
GUI: Fixed displaying createdAt date in auditer log table

### DIFF
--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/auditMessagesManager/GetAuditMessagesByCount.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/json/auditMessagesManager/GetAuditMessagesByCount.java
@@ -141,7 +141,12 @@ public class GetAuditMessagesByCount implements JsonCallback, JsonCallbackTable<
 		// TIME COLUMN
 		TextColumn<AuditMessage> timeColumn = new TextColumn<AuditMessage>() {
 			public String getValue(AuditMessage msg) {
-				return msg.getCreatedAt().substring(0, msg.getCreatedAt().indexOf("."));
+				if (msg.getCreatedAt().contains(".")) {
+					return msg.getCreatedAt().substring(0, msg.getCreatedAt().indexOf("."));
+				} else {
+					// oracle timestamp doesn't have ending ".12345" in "2020-01-01 12:00:00.12345"
+					return msg.getCreatedAt();
+				}
 			}
 		};
 

--- a/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfApplicationDetailTabItem.java
+++ b/perun-web-gui/src/main/java/cz/metacentrum/perun/webgui/tabs/userstabs/SelfApplicationDetailTabItem.java
@@ -102,7 +102,7 @@ public class SelfApplicationDetailTabItem implements TabItem, TabItemWithUrl{
 			header += "group "+application.getGroup().getShortName()+" in VO "+application.getVo().getName();
 		}
 
-		String submitted = "</h2><p>Submitted on <strong>" + application.getCreatedAt().substring(0, application.getCreatedAt().indexOf("."));
+		String submitted = "</h2><p>Submitted on <strong>" + ((application.getCreatedAt().contains(".")) ? application.getCreatedAt().substring(0, application.getCreatedAt().indexOf(".")) : application.getCreatedAt());
 		submitted += "</strong> is in state <strong>"+application.getState().toUpperCase()+"</strong>";
 
 		vp.add(new HTML(header+submitted));


### PR DESCRIPTION
- Oracle timestamp doesn't contain ending ".12345" and
  hence we can't display date in table as substring ending with ".".