### PR TITLE
CORE: Code cleanup of idea warnings in BlImpl layer

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -54,7 +54,6 @@ import cz.metacentrum.perun.core.api.AttributeRights;
 import cz.metacentrum.perun.core.api.AttributesManager;
 import cz.metacentrum.perun.core.api.AuthzResolver;
 import cz.metacentrum.perun.core.api.BeansUtils;
-import cz.metacentrum.perun.core.api.CoreConfig;
 import cz.metacentrum.perun.core.api.ExtSourcesManager;
 import cz.metacentrum.perun.core.api.Facility;
 import cz.metacentrum.perun.core.api.Group;
@@ -111,7 +110,6 @@ import cz.metacentrum.perun.utils.graphs.serializers.GraphSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -175,8 +173,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, facility);
 		//filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 
 		//adds non-empty non-virtual attributes
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, facility));
@@ -195,8 +192,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, vo);
 		//filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 
 		//adds non-empty non-virtual attributes
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, vo));
@@ -208,8 +204,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, group);
 		//filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 
 		//adds non-empty non-virtual attributes
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, group));
@@ -221,8 +216,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//get virtual attributes
 		List<Attribute> attributes = getVirtualAttributes(sess, resource);
 		//filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 
 		//adds non-empty non-virtual attributes
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, resource));
@@ -248,8 +242,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		// get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, member, group);
 		// filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 		// adds non-empty non-virtual attributes
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, member, group));
 		return attributes;
@@ -267,8 +260,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		// get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, member, group);
 		// filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 		// adds non-empty non-virtual attributes
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, member, group));
 		if (workWithUserAttributes) {
@@ -313,9 +305,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		List<Attribute> attributes = getAttributesManagerImpl().getAttributes(sess, member, resource);
 		List<Attribute> virtualAttributes = getVirtualAttributes(sess, member, resource);
 		//remove virtual attributes with null value
-		Iterator<Attribute> virtualAttributesIterator = virtualAttributes.iterator();
-		while (virtualAttributesIterator.hasNext())
-			if (virtualAttributesIterator.next().getValue() == null) virtualAttributesIterator.remove();
+		virtualAttributes.removeIf(attribute -> attribute.getValue() == null);
 		// adds non-empty non-virtual attributes
 		attributes.addAll(virtualAttributes);
 
@@ -404,8 +394,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, member);
 		//filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 
 		//adds non-empty non-virtual attributes
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, member));
@@ -448,14 +437,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 	@Override
 	public List<Attribute> getAttributes(PerunSession sess, Member member, List<String> attrNames, boolean workWithUserAttributes) throws InternalErrorException {
 		List<Attribute> attributes = this.getAttributes(sess, member, attrNames);
-
-		if (!workWithUserAttributes) return attributes;
-		else {
+		if (workWithUserAttributes) {
 			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 			attributes.addAll(this.getAttributes(sess, user, attrNames));
-
-			return attributes;
 		}
+		return attributes;
 	}
 
 	@Override
@@ -604,8 +590,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, user);
 		//filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, user));
 		return attributes;
@@ -623,8 +608,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, host);
 		//filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 
 		//adds non-empty non-virtual attributes
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, host));
@@ -690,8 +674,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//get virtual attributes
 		List<Attribute> attributes = getAttributesManagerImpl().getVirtualAttributes(sess, ues);
 		//filter out virtual attributes with null value
-		Iterator<Attribute> attributeIterator = attributes.iterator();
-		while (attributeIterator.hasNext()) if (attributeIterator.next().getValue() == null) attributeIterator.remove();
+		attributes.removeIf(attribute -> attribute.getValue() == null);
 
 		attributes.addAll(getAttributesManagerImpl().getAttributes(sess, ues));
 		return attributes;
@@ -950,7 +933,7 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 						setAttributeWithoutCheck(sess, member, resource, attribute, false);
 					} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
 						setAttributeWithoutCheck(sess, facility, user, attribute);
-					} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) { ;
+					} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
 						setAttributeWithoutCheck(sess, user, attribute);
 					} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_ATTR)) {
 						setAttributeWithoutCheck(sess, member, attribute);
@@ -6396,19 +6379,19 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 			return;
 		}
 		if (attribute.getValue() instanceof String) {
-			if (((String) attribute.getValue()).matches("\\s*")) {
+			if (attribute.valueAsString().matches("\\s*")) {
 				attribute.setValue(null);
 			}
 		} else if (attribute.getValue() instanceof Boolean) {
-			if (attribute.getValue().equals(Boolean.FALSE)) {
+			if (!attribute.valueAsBoolean()) {
 				attribute.setValue(null);
 			}
 		} else if (attribute.getValue() instanceof ArrayList) {
-			if (((ArrayList) attribute.getValue()).isEmpty()) {
+			if (attribute.valueAsList().isEmpty()) {
 				attribute.setValue(null);
 			}
 		} else if (attribute.getValue() instanceof LinkedHashMap) {
-			if (((LinkedHashMap) attribute.getValue()).isEmpty()) {
+			if (attribute.valueAsMap().isEmpty()) {
 				attribute.setValue(null);
 			}
 		} else {
@@ -7485,26 +7468,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		Set<AttributeDefinition> allAttributesDef = new HashSet<>(this.getAttributesDefinition(sess));
 
 		initializeModuleDependencies(sess, allAttributesDef);
-		//DEBUG creating file with all dependencies of all attributes (180+- on devel)
-		/*String pathToFile = "./AllDependencies.log";
-			File f = new File(pathToFile);
-			try {
-			f.createNewFile();
-			PrintWriter writer;
-			writer = new PrintWriter(new FileWriter(f, true));
-			int i=1;
-			for(AttributeDefinition ad: allDependencies.keySet()) {
-			writer.println(i + ") " + ad.toString());
-			for(AttributeDefinition a: allDependencies.get(ad)) {
-			writer.println(" ---> " + a);
-			}
-			i++;
-			}
-			writer.close();
-			} catch (IOException ex) {
-			log.error("Error at saving AllDependencies file.");
-			}*/
-		//DEBUG end
 
 		log.debug("AttributesManagerBlImpl initialize ended.");
 	}
@@ -7536,8 +7499,6 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		//Fill dep and strongDep maps
 		for (AttributeDefinition ad : definitions) {
 			AttributesModuleImplApi module;
-			List<String> depList;
-			List<String> strongDepList = new ArrayList<>();
 			Set<AttributeDefinition> depSet = new HashSet<>();
 			Set<AttributeDefinition> strongDepSet = new HashSet<>();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ExtSourcesManagerBlImpl.java
@@ -259,11 +259,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 			candidate.setServiceUser(false);
 		} else {
 			String isServiceUser = subjectData.get("isServiceUser");
-			if(isServiceUser.equals("true")) {
-				candidate.setServiceUser(true);
-			} else {
-				candidate.setServiceUser(false);
-			}
+			candidate.setServiceUser(isServiceUser.equals("true"));
 		}
 
 		//Set sponsored user
@@ -271,11 +267,7 @@ public class ExtSourcesManagerBlImpl implements ExtSourcesManagerBl {
 			candidate.setSponsoredUser(false);
 		} else {
 			String isSponsoredUser = subjectData.get("isSponsoredUser");
-			if(isSponsoredUser.equals("true")) {
-				candidate.setSponsoredUser(true);
-			} else {
-				candidate.setSponsoredUser(false);
-			}
+			candidate.setSponsoredUser(isSponsoredUser.equals("true"));
 		}
 
 		// Filter attributes

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -73,13 +73,11 @@ import cz.metacentrum.perun.core.api.exceptions.WrongPatternException;
 import cz.metacentrum.perun.core.api.exceptions.WrongReferenceAttributeValueException;
 import cz.metacentrum.perun.core.bl.FacilitiesManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
-import cz.metacentrum.perun.core.bl.TasksManagerBl;
 import cz.metacentrum.perun.core.impl.Utils;
 import cz.metacentrum.perun.core.implApi.FacilitiesManagerImplApi;
 import cz.metacentrum.perun.taskslib.model.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -123,8 +121,7 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	@Override
 	public List<RichFacility> getRichFacilities(PerunSession perunSession) throws InternalErrorException {
 		List<Facility> facilities = getFacilities(perunSession);
-		List<RichFacility> richFacilities = this.getRichFacilities(perunSession, facilities);
-		return richFacilities;
+		return this.getRichFacilities(perunSession, facilities);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/GroupsManagerBlImpl.java
@@ -1292,24 +1292,21 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 	@Deprecated
 	public List<RichUser> getRichAdmins(PerunSession perunSession, Group group) throws InternalErrorException {
 		List<User> users = this.getAdmins(perunSession, group);
-		List<RichUser> richUsers = perunBl.getUsersManagerBl().getRichUsersFromListOfUsers(perunSession, users);
-		return richUsers;
+		return perunBl.getUsersManagerBl().getRichUsersFromListOfUsers(perunSession, users);
 	}
 
 	@Override
 	@Deprecated
 	public List<RichUser> getDirectRichAdmins(PerunSession perunSession, Group group) throws InternalErrorException {
 		List<User> users = this.getDirectAdmins(perunSession, group);
-		List<RichUser> richUsers = perunBl.getUsersManagerBl().getRichUsersFromListOfUsers(perunSession, users);
-		return richUsers;
+		return perunBl.getUsersManagerBl().getRichUsersFromListOfUsers(perunSession, users);
 	}
 
 	@Override
 	@Deprecated
 	public List<RichUser> getRichAdminsWithAttributes(PerunSession perunSession, Group group) throws InternalErrorException, UserNotExistsException {
 		List<User> users = this.getAdmins(perunSession, group);
-		List<RichUser> richUsers = perunBl.getUsersManagerBl().getRichUsersWithAttributesFromListOfUsers(perunSession, users);
-		return richUsers;
+		return perunBl.getUsersManagerBl().getRichUsersWithAttributesFromListOfUsers(perunSession, users);
 	}
 
 	@Override
@@ -3494,7 +3491,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			} catch (ExtSourceUnsupportedOperationException e) {
 				// ExtSource doesn't support that functionality, so silently skip it.
 			} catch (InternalErrorException e) {
-				log.info("Can't close membersSource connection. Cause: {}", e);
+				log.info("Can't close membersSource connection.", e);
 			}
 		}
 		if(source != null) {
@@ -3503,7 +3500,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 			} catch (ExtSourceUnsupportedOperationException e) {
 				// ExtSource doesn't support that functionality, so silently skip it.
 			} catch (InternalErrorException e) {
-				log.info("Can't close extSource connection. Cause: {}", e);
+				log.info("Can't close extSource connection.", e);
 			}
 		}
 	}
@@ -4550,7 +4547,7 @@ public class GroupsManagerBlImpl implements GroupsManagerBl {
 		if (membershipExpirationRulesAttribute == null) {
 			return;
 		}
-		LinkedHashMap<String, String> membershipExpirationRules = (LinkedHashMap<String, String>) membershipExpirationRulesAttribute.getValue();
+		LinkedHashMap<String, String> membershipExpirationRules = membershipExpirationRulesAttribute.valueAsMap();
 
 		LocalDate localDate = LocalDate.now();
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/MembersManagerBlImpl.java
@@ -774,8 +774,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	public List<RichMember> getRichMembersWithAttributes(PerunSession sess, Vo vo, List<AttributeDefinition> attrsDef) throws InternalErrorException {
 		List<Member> members = new ArrayList<>(perunBl.getMembersManagerBl().getMembers(sess, vo));
 		List<RichMember> richMembers = this.convertMembersToRichMembers(sess, members);
-		List<RichMember> richMembersWithAttributes = this.convertMembersToRichMembersWithAttributes(sess, richMembers, attrsDef);
-		return richMembersWithAttributes;
+		return this.convertMembersToRichMembersWithAttributes(sess, richMembers, attrsDef);
 	}
 
 	@Override
@@ -787,8 +786,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			AttributeDefinition attrDef = perunBl.getAttributesManagerBl().getAttributeDefinition(sess, atrrName);
 			attrsDef.add(attrDef);
 		}
-		List<RichMember> richMembersWithAttributes = this.convertMembersToRichMembersWithAttributes(sess, richMembers, attrsDef);
-		return richMembersWithAttributes;
+		return this.convertMembersToRichMembersWithAttributes(sess, richMembers, attrsDef);
 	}
 
 	@Override
@@ -913,16 +911,14 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			AttributeDefinition attrDef = perunBl.getAttributesManagerBl().getAttributeDefinition(sess, atrrName);
 			attrsDef.add(attrDef);
 		}
-		List<RichMember> richMembersWithAttributes = this.convertMembersToRichMembersWithAttributes(sess, group, richMembers, attrsDef);
-		return richMembersWithAttributes;
+		return this.convertMembersToRichMembersWithAttributes(sess, group, richMembers, attrsDef);
 	}
 
 	@Override
 	public List<RichMember> getRichMembersWithAttributes(PerunSession sess, Group group, List<AttributeDefinition> attrsDef) throws InternalErrorException {
 		List<Member> members = new ArrayList<>(perunBl.getGroupsManagerBl().getGroupMembers(sess, group));
 		List<RichMember> richMembers = this.convertMembersToRichMembers(sess, members);
-		List<RichMember> richMembersWithAttributes = this.convertMembersToRichMembersWithAttributes(sess, group, richMembers, attrsDef);
-		return richMembersWithAttributes;
+		return this.convertMembersToRichMembersWithAttributes(sess, group, richMembers, attrsDef);
 	}
 
 	@Override
@@ -934,8 +930,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	@Override
 	public List<RichMember> getRichMembers(PerunSession sess, Group group) throws InternalErrorException {
 		List<Member> members = new ArrayList<>(perunBl.getGroupsManagerBl().getGroupMembers(sess, group));
-		List<RichMember> richMembers = this.convertMembersToRichMembers(sess, members);
-		return richMembers;
+		return this.convertMembersToRichMembers(sess, members);
 	}
 
 	@Override
@@ -1402,10 +1397,8 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 
 	@Override
 	public boolean isMemberAllowed(PerunSession sess, Member member) throws InternalErrorException {
-		if(member == null) throw new InternalErrorException("Member can't be null.");
-		if(this.haveStatus(sess, member, Status.INVALID)) return false;
-		else if (this.haveStatus(sess, member, Status.DISABLED)) return false;
-		else return true;
+		if (member == null) throw new InternalErrorException("Member can't be null.");
+		return !this.haveStatus(sess, member, Status.INVALID) && !this.haveStatus(sess, member, Status.DISABLED);
 	}
 
 	@Override
@@ -1493,7 +1486,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 			try {
 				((PerunSessionImpl) sess).getPerunBl().getMembersManagerBl().validateMember(sess, member);
 			} catch(Exception ex) {
-				log.info("validateMemberAsync failed. Cause: {}", ex);
+				log.info("validateMemberAsync failed.", ex);
 				getPerunBl().getAuditer().log(sess, new MemberValidatedFailed(member, oldStatus));
 				log.info("Validation of {} failed. He stays in {} state.", member, oldStatus);
 			}
@@ -1659,7 +1652,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
     Attribute membershipExpirationRulesAttribute;
     try {
       membershipExpirationRulesAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, MembersManager.membershipExpirationRulesAttributeName);
-      membershipExpirationRules = (LinkedHashMap<String, String>) membershipExpirationRulesAttribute.getValue();
+      membershipExpirationRules = membershipExpirationRulesAttribute.valueAsMap();
       // If attribute was not filled, then silently exit with null
       if (membershipExpirationRules == null) return null;
     } catch (AttributeNotExistsException e) {
@@ -1774,8 +1767,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 	@Override
 	public Member getMemberByExtSourceNameAndExtLogin(PerunSession sess, Vo vo, String extSourceName, String extLogin) throws ExtSourceNotExistsException, UserExtSourceNotExistsException, MemberNotExistsException, UserNotExistsException, InternalErrorException {
 		User user = getPerunBl().getUsersManagerBl().getUserByExtSourceNameAndExtLogin(sess, extSourceName, extLogin);
-		Member member = getPerunBl().getMembersManagerBl().getMemberByUser(sess, vo, user);
-		return member;
+		return getPerunBl().getMembersManagerBl().getMemberByUser(sess, vo, user);
 	}
 
 	/* Check if the user can apply for VO membership
@@ -1932,7 +1924,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		Attribute membershipExpirationRulesAttribute;
 		try {
 			membershipExpirationRulesAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, MembersManager.membershipExpirationRulesAttributeName);
-			membershipExpirationRules = (LinkedHashMap<String, String>) membershipExpirationRulesAttribute.getValue();
+			membershipExpirationRules = membershipExpirationRulesAttribute.valueAsMap();
 			// If attribute was not filled, then silently exit
 			if (membershipExpirationRules == null) return true;
 		} catch (AttributeNotExistsException e) {
@@ -1996,7 +1988,7 @@ public class MembersManagerBlImpl implements MembersManagerBl {
 		try {
 			vo = getPerunBl().getVosManagerBl().getVoById(sess, member.getVoId());
 			membershipExpirationRulesAttribute = getPerunBl().getAttributesManagerBl().getAttribute(sess, vo, MembersManager.membershipExpirationRulesAttributeName);
-			membershipExpirationRules = (LinkedHashMap<String, String>) membershipExpirationRulesAttribute.getValue();
+			membershipExpirationRules = membershipExpirationRulesAttribute.valueAsMap();
 			// If attribute was not filled, then silently exit
 			if (membershipExpirationRules == null) return new Pair<>(true, null);
 		} catch (VoNotExistsException e) {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ModulesUtilsBlImpl.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -253,7 +252,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 	@Override
 	public void checkIfListOfGIDIsWithinRange(PerunSessionImpl sess, User user, Attribute attribute) throws InternalErrorException, WrongAttributeAssignmentException, AttributeNotExistsException, WrongAttributeValueException {
 		Utils.notNull(attribute, "attribute");
-		List<String> gidsToCheck = (List<String>)attribute.getValue();
+		List<String> gidsToCheck = attribute.valueAsList();
 		if (gidsToCheck != null){
 			String gidNamespace = attribute.getFriendlyNameParameter();
 			Attribute gidRangesAttribute = sess.getPerunBl().getAttributesManagerBl().getAttribute(sess, gidNamespace, A_E_namespace_GIDRanges);
@@ -295,7 +294,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		//return the minimum from all ranges
 		if(usedGids.getValue() == null) return allMinimums.get(0);
 		else {
-			Map<String,String> usedGidsValue = (Map<String, String>) usedGids.getValue();
+			Map<String,String> usedGidsValue = usedGids.valueAsMap();
 			Set<String> keys = usedGidsValue.keySet();
 
 			for(String key: keys) {
@@ -625,9 +624,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		if (email == null) return false;
 
 		Matcher emailMatcher = Utils.emailPattern.matcher(email);
-		if (emailMatcher.find()) return true;
-
-		return false;
+		return emailMatcher.find();
 	}
 
 	@Override
@@ -722,7 +719,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 
 		//Prepare result container and value of attribute
 		Map<String, Pair<BigDecimal, BigDecimal>> transferedQuotas = new HashMap<>();
-		Map<String, String> defaultQuotasMap = (Map<String, String>) quotasAttribute.getValue();
+		Map<String, String> defaultQuotasMap = quotasAttribute.valueAsMap();
 
 		//List to test if all paths are unique (/var/log and /var/log/ are the same so these two paths are not unique)
 		List<String> uniquePaths = new ArrayList<>();
@@ -856,7 +853,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 			}
 			//other cases are ok
 
-			transferedQuotas.put(canonicalPath, new Pair(softQuotaAfterTransfer, hardQuotaAfterTransfer));
+			transferedQuotas.put(canonicalPath, new Pair<>(softQuotaAfterTransfer, hardQuotaAfterTransfer));
 		}
 
 		return transferedQuotas;
@@ -952,7 +949,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 						hardQuota = quotasValue1.getRight().add(quotasValue2.getRight());
 					}
 					//create new pair of summed numbers
-					Pair<BigDecimal, BigDecimal> finalQuotasValue = new Pair(softQuota, hardQuota);
+					Pair<BigDecimal, BigDecimal> finalQuotasValue = new Pair<>(softQuota, hardQuota);
 					//add new summed pair to the result map
 					resultTransferredQuotas.put(pathKey, finalQuotasValue);
 				}
@@ -1090,7 +1087,7 @@ public class ModulesUtilsBlImpl implements ModulesUtilsBl {
 		//For null attribute throw an exception
 		if(gidRangesAttribute == null) throw new InternalErrorException("Can't get value from null attribute!");
 
-		Map<String, String> gidRanges = (LinkedHashMap) gidRangesAttribute.getValue();
+		Map<String, String> gidRanges = gidRangesAttribute.valueAsMap();
 
 		//Return empty map if there is empty input of gidRanges in method parameters
 		if(gidRanges == null || gidRanges.isEmpty()) return convertedRanges;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/RTMessagesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/RTMessagesManagerBlImpl.java
@@ -192,7 +192,7 @@ public class RTMessagesManagerBlImpl implements RTMessagesManagerBl {
 			}
 
 			//Return message if response is ok, or throw exception with bad response
-			int ticketNum = Integer.valueOf(ticketNumber);
+			int ticketNum = Integer.parseInt(ticketNumber);
 			if(ticketNum != 0) {
 				RTMessage rtmessage = new RTMessage(email, ticketNum);
 				log.debug("RT message was send successfully and the ticket has number: " + ticketNum);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -1,9 +1,5 @@
 package cz.metacentrum.perun.core.blImpl;
 
-import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminGroupAddedForResource;
-import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminGroupRemovedForResource;
-import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminUserAddedForResource;
-import cz.metacentrum.perun.audit.events.ResourceManagerEvents.AdminUserRemovedForResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.BanRemovedForResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.BanSetForResource;
 import cz.metacentrum.perun.audit.events.ResourceManagerEvents.BanUpdatedForResource;
@@ -59,7 +55,6 @@ import cz.metacentrum.perun.core.api.exceptions.ResourceTagNotAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceTagNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.ServiceNotAssignedException;
-import cz.metacentrum.perun.core.api.exceptions.ServiceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SearcherBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SearcherBlImpl.java
@@ -268,8 +268,8 @@ public class SearcherBlImpl implements SearcherBl {
 				}
 			} else if (entityAttribute.getValue() instanceof Integer) {
 				Integer attrValue = entityAttribute.valueAsInteger();
-				Integer valueInInteger = Integer.valueOf(value);
-				if (attrValue.intValue() != valueInInteger.intValue()) {
+				int valueInInteger = Integer.parseInt(value);
+				if (attrValue != valueInInteger) {
 					shouldBeAccepted = false;
 				}
 			} else {

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/SecurityTeamsManagerBlImpl.java
@@ -1,9 +1,5 @@
 package cz.metacentrum.perun.core.blImpl;
 
-import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.AdminAddedForSecurityTeam;
-import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.AdminGroupAddedForSecurityTeam;
-import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.AdminGroupRemovedFromSecurityTeam;
-import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.AdminRemovedFromSecurityTeam;
 import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.SecurityTeamCreated;
 import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.SecurityTeamDeleted;
 import cz.metacentrum.perun.audit.events.SecurityTeamsManagerEvents.SecurityTeamUpdated;
@@ -22,9 +18,7 @@ import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.ConsistencyErrorException;
 import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
-import cz.metacentrum.perun.core.api.exceptions.GroupNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamExistsException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotExistsException;
@@ -33,7 +27,6 @@ import cz.metacentrum.perun.core.api.exceptions.UserAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.SecurityTeamsManagerBl;
-import cz.metacentrum.perun.core.impl.AuthzResolverImpl;
 import cz.metacentrum.perun.core.implApi.SecurityTeamsManagerImplApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/UsersManagerBlImpl.java
@@ -385,8 +385,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 	public List<RichUser> getAllRichUsers(PerunSession sess, boolean includedSpecificUsers) throws InternalErrorException {
 		List<User> users = new ArrayList<>(this.getUsers(sess));
 		if(!includedSpecificUsers) users.removeAll(this.getSpecificUsers(sess));
-		List<RichUser> richUsers = this.convertUsersToRichUsers(sess, users);
-		return richUsers;
+		return this.convertUsersToRichUsers(sess, users);
 	}
 
 	@Override
@@ -394,22 +393,19 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 		List<User> users = new ArrayList<>(this.getUsers(sess));
 		if(!includedSpecificUsers) users.removeAll(this.getSpecificUsers(sess));
 		List<RichUser> richUsers = this.convertUsersToRichUsers(sess, users);
-		List<RichUser> richUsersWithAttributes = this.convertRichUsersToRichUsersWithAttributes(sess, richUsers);
-		return richUsersWithAttributes;
+		return this.convertRichUsersToRichUsersWithAttributes(sess, richUsers);
 	}
 
 
 	@Override
 	public List<RichUser> getRichUsersFromListOfUsers(PerunSession sess, List<User> users) throws InternalErrorException {
-		List<RichUser> richUsers = this.convertUsersToRichUsers(sess, users);
-		return richUsers;
+		return this.convertUsersToRichUsers(sess, users);
 	}
 
 	@Override
 	public List<RichUser> getRichUsersWithAttributesFromListOfUsers(PerunSession sess, List<User> users) throws InternalErrorException, UserNotExistsException {
 		List<RichUser> richUsers = this.convertUsersToRichUsers(sess, users);
-		List<RichUser> richUsersWithAttributes = this.convertRichUsersToRichUsersWithAttributes(sess, richUsers);
-		return richUsersWithAttributes;
+		return this.convertRichUsersToRichUsersWithAttributes(sess, richUsers);
 	}
 
 	@Override
@@ -552,7 +548,7 @@ public class UsersManagerBlImpl implements UsersManagerBl {
 				// OK - User hasn't assigned any password with this login
 			} catch (PasswordDeletionFailedException | PasswordOperationTimeoutException e) {
 				if (forceDelete) {
-					log.error("Error during deletion of the account at {} for user {} with login {}.", loginAttribute.getFriendlyNameParameter(), user, (String) loginAttribute.getValue());
+					log.error("Error during deletion of the account at {} for user {} with login {}.", loginAttribute.getFriendlyNameParameter(), user, loginAttribute.getValue());
 				} else {
 					throw new RelationExistsException("Error during deletion of the account at " + loginAttribute.getFriendlyNameParameter() +
 							" for user " + user + " with login " + loginAttribute.getValue() + ".");

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/VosManagerBlImpl.java
@@ -1,9 +1,5 @@
 package cz.metacentrum.perun.core.blImpl;
 
-import cz.metacentrum.perun.audit.events.VoManagerEvents.AdminAddedForVo;
-import cz.metacentrum.perun.audit.events.VoManagerEvents.AdminGroupAddedForVo;
-import cz.metacentrum.perun.audit.events.VoManagerEvents.AdminGroupRemovedForVo;
-import cz.metacentrum.perun.audit.events.VoManagerEvents.AdminRemovedForVo;
 import cz.metacentrum.perun.audit.events.VoManagerEvents.VoCreated;
 import cz.metacentrum.perun.audit.events.VoManagerEvents.VoDeleted;
 import cz.metacentrum.perun.audit.events.VoManagerEvents.VoUpdated;
@@ -15,7 +11,6 @@ import cz.metacentrum.perun.core.api.Host;
 import cz.metacentrum.perun.core.api.Member;
 import cz.metacentrum.perun.core.api.MemberCandidate;
 import cz.metacentrum.perun.core.api.Pair;
-import cz.metacentrum.perun.core.api.PerunBean;
 import cz.metacentrum.perun.core.api.PerunSession;
 import cz.metacentrum.perun.core.api.Resource;
 import cz.metacentrum.perun.core.api.RichUser;
@@ -40,7 +35,6 @@ import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoExistsException;
 import cz.metacentrum.perun.core.api.exceptions.VoNotExistsException;
-import cz.metacentrum.perun.core.bl.AuthzResolverBl;
 import cz.metacentrum.perun.core.bl.MembersManagerBl;
 import cz.metacentrum.perun.core.bl.PerunBl;
 import cz.metacentrum.perun.core.bl.UsersManagerBl;
@@ -296,7 +290,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 						} catch (ExtSourceUnsupportedOperationException e) {
 							// ExtSource doesn't support that functionality, so silently skip it.
 						} catch (InternalErrorException e) {
-							log.error("Can't close extSource connection. Cause: {}", e);
+							log.error("Can't close extSource connection.", e);
 						}
 					}
 
@@ -415,7 +409,7 @@ public class VosManagerBlImpl implements VosManagerBl {
 						} catch (ExtSourceUnsupportedOperationException e) {
 							// ExtSource doesn't support that functionality, so silently skip it.
 						} catch (InternalErrorException e) {
-							log.error("Can't close extSource connection. Cause: {}", e);
+							log.error("Can't close extSource connection.", e);
 						}
 					}
 


### PR DESCRIPTION
- Removed unused imports.
- Simplified some ifs.
- iterator.remove() replaced with collection.removeIf()
- Use attribute.valueAs...() to prevent cast warning.
- Removed {} placeholder in log messages taking only
  exception, since by API it is different from log
  messages taking array of objects.