### PR TITLE
Core - optimization of setRequiredAttributes

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1380,6 +1380,32 @@ public interface AttributesManagerBl {
 	 * @param resource
 	 * @param user
 	 * @param facility
+	 * @param forceAttributesChecks if true, all required attributes for given resource and user will be semantically
+	 *                              checked, no matter if the user has truly access to the given resource
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws AttributeNotExistsException
+	 * @throws WrongAttributeValueException
+	 * @throws MemberResourceMismatchException
+	 */
+	void setRequiredAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, boolean forceAttributesChecks) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException;
+
+	/**
+	 * Get and set required attribute for member, resource, user and facility.
+	 *
+	 * Procedure:
+	 * 1] Get all member, member-resource, user, user-facility required attributes for member and resource.
+	 * 2] Fill attributes and store those which were really filled. (value changed)
+	 * 3] Set filled attributes.
+	 * 4] Refresh value in all virtual attributes.
+	 * 5] Check all attributes and their dependencies.
+	 *
+	 * @param sess
+	 * @param member
+	 * @param resource
+	 * @param user
+	 * @param facility
 	 * @throws InternalErrorException
 	 * @throws WrongAttributeAssignmentException
 	 * @throws WrongReferenceAttributeValueException
@@ -1440,6 +1466,35 @@ public interface AttributesManagerBl {
 	 * @throws MemberResourceMismatchException
 	 */
 	void setRequiredAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException;
+
+	/**
+	 * Take list of required attributes and set those which are empty and can be filled, then check them all.
+	 *
+	 * Important: this method DO NOT set non-empty attributes in list, just refresh their values and check them
+	 *
+	 * Procedure:
+	 * 1] Get all attrs from arrayList (they should be required attributes)
+	 * 2] Fill empty attributes and store those which were really filled. (value changed)
+	 * 3] Set filled attributes.
+	 * 4] Refresh value in all attributes (not only in virtual ones - because of possible change by changeAttributeHook in other filledAttributes)
+	 * 5] Check all attributes and their dependencies.
+	 *
+	 * @param sess
+	 * @param facility
+	 * @param resource
+	 * @param user
+	 * @param member
+	 * @param attributes
+	 * @param forceAttributesChecks if true, all required attributes for given resource and user will be semantically
+	 *                              checked, no matter if the user has truly access to the given resource
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws AttributeNotExistsException
+	 * @throws WrongAttributeValueException
+	 * @throws MemberResourceMismatchException
+	 */
+	void setRequiredAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes, boolean forceAttributesChecks) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Store the particular attribute associated with the facility. Core attributes can't be set this way.
@@ -2735,6 +2790,25 @@ public interface AttributesManagerBl {
 	 * @throws MemberResourceMismatchException if member and resource are not in the same VO
 	 */
 	void checkAttributesSemantics(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
+
+	/**
+	 * Check if value of attributes has valid semantics. Attributes can be from namespace: member,
+	 * user, member-resource and user-facility. This method does not validate, if all of these attributes are
+	 * truly required! This methods calls semantics checks on ALL of the given attributes.
+	 *
+	 * @param sess perun session
+	 * @param facility facility for which you want to check validity of attribute
+	 * @param resource resource for which you want to check validity of attribute
+	 * @param user user for which you want to check validity of attribute
+	 * @param member member for which you want to check validity of attribute
+	 * @param attributes list of attributes to check
+	 *
+	 * @throws InternalErrorException if an exception raise in concrete implementation, the exception is wrapped in InternalErrorException
+	 * @throws WrongAttributeAssignmentException if attribute does not belong to appropriate entity
+	 * @throws WrongReferenceAttributeValueException if the attribute value has wrong/illegal semantics
+	 * @throws MemberResourceMismatchException if member and resource are not in the same VO
+	 */
+	void forceCheckAttributesSemantics(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException;
 
 	/**
 	 * Check if value of attributes has valid semantics. Attributes can be from namespace: member, user, member-group, member-resource and user-facility.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1710,6 +1710,11 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	@Override
 	public void setRequiredAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException {
+		setRequiredAttributes(sess, facility, resource, user, member, attributes, false);
+	}
+
+	@Override
+	public void setRequiredAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes, boolean forceAttributesChecks) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException {
 		//fill attributes and get back only those which were really filled with new value
 		List<Attribute> filledAttributes = this.fillAttributes(sess, facility, resource, user, member, attributes, true);
 
@@ -1767,18 +1772,27 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 		}
 
 		//Check all attributes semantics
-		checkAttributesSemantics(sess, facility, resource, user, member, attributes);
+		if (forceAttributesChecks) {
+			forceCheckAttributesSemantics(sess, facility, resource, user, member, attributes);
+		} else {
+			checkAttributesSemantics(sess, facility, resource, user, member, attributes);
+		}
 
 		//Check all attributes dependencies
 		this.checkAttributesDependencies(sess, resource, member, user, facility, attributes);
 	}
 
 	@Override
-	public void setRequiredAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, WrongAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
+	public void setRequiredAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member, boolean forceAttributesChecks) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, WrongAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
 		//get all attributes (for member, resource, facility and user) with values
 		List<Attribute> attributes = this.getResourceRequiredAttributes(sess, resource, facility, resource, user, member);
 
-		this.setRequiredAttributes(sess, facility, resource, user, member, attributes);
+		setRequiredAttributes(sess, facility, resource, user, member, attributes, forceAttributesChecks);
+	}
+
+	@Override
+	public void setRequiredAttributes(PerunSession sess, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, WrongAttributeValueException, AttributeNotExistsException, MemberResourceMismatchException {
+		setRequiredAttributes(sess, facility, resource, user, member, false);
 	}
 
 	@Override
@@ -3616,6 +3630,24 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 				getAttributesManagerImpl().checkAttributeSemantics(sess, user, attribute);
 			} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_ATTR)) {
 				if (attribute.getValue() == null && !isTrulyRequiredAttribute(sess, member, attribute)) continue;
+				getAttributesManagerImpl().checkAttributeSemantics(sess, member, attribute);
+			} else {
+				throw new WrongAttributeAssignmentException(attribute);
+			}
+		}
+	}
+
+	@Override
+	public void forceCheckAttributesSemantics(PerunSession sess, Facility facility, Resource resource, User user, Member member, List<Attribute> attributes) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, MemberResourceMismatchException {
+		this.checkMemberIsFromTheSameVoLikeResource(sess, member, resource);
+		for (Attribute attribute : attributes) {
+			if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_RESOURCE_ATTR)) {
+				getAttributesManagerImpl().checkAttributeSemantics(sess, member, resource, attribute);
+			} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_FACILITY_ATTR)) {
+				getAttributesManagerImpl().checkAttributeSemantics(sess, facility, user, attribute);
+			} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_USER_ATTR)) {
+				getAttributesManagerImpl().checkAttributeSemantics(sess, user, attribute);
+			} else if (getAttributesManagerImpl().isFromNamespace(attribute, AttributesManager.NS_MEMBER_ATTR)) {
 				getAttributesManagerImpl().checkAttributeSemantics(sess, member, attribute);
 			} else {
 				throw new WrongAttributeAssignmentException(attribute);

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -392,7 +392,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 		for(Member member : members) {
 			User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 			try {
-				getPerunBl().getAttributesManagerBl().setRequiredAttributes(sess, facility, resource, user, member);
+				getPerunBl().getAttributesManagerBl().setRequiredAttributes(sess, facility, resource, user, member, true);
 			} catch(WrongAttributeAssignmentException | MemberResourceMismatchException | AttributeNotExistsException ex) {
 				throw new ConsistencyErrorException(ex);
 			}


### PR DESCRIPTION
* The old implementaion of setRequiredAttributes always checked, if the
given attributes are truly required. This method is called from
assignGroupToResource method and only allowed members are passed to it.
This method then gets all required attributes for these allowed members
and tries to set them.
* When running semantics verification, there were checks to verify, that
the given attributes are truly required. But since there were only
allowed members given and only required attributes were used, there was
no way that these checks would fail.
* I have created new versions of these methods that have a new
boolean flag. If this flag is true, than semantics checks are forced and
there is no further testing, if the attributes are reuqired.