### PR TITLE
Core - assignService skip isTrulyRequired checks

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/AttributesManagerBl.java
@@ -1441,6 +1441,33 @@ public interface AttributesManagerBl {
 	void setRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException;
 
 	/**
+	 * Get and set required attribute for member, resource, user, facility and specific service.
+	 *
+	 * Procedure:
+	 * 1] Get all member, member-resource, user, user-facility required attributes for member, resource and specific service.
+	 * 2] Fill attributes and store those which were really filled. (value changed)
+	 * 3] Set filled attributes.
+	 * 4] Refresh value in all virtual attributes.
+	 * 5] Check all attributes and their dependencies.
+	 *
+	 * @param sess
+	 * @param service
+	 * @param facility
+	 * @param resource
+	 * @param user
+	 * @param member
+	 * @param forceAttributesChecks if true, all required attributes for given resource and user will be semantically
+	 *                              checked, no matter if the user has truly access to the given resource
+	 * @throws InternalErrorException
+	 * @throws WrongAttributeAssignmentException
+	 * @throws WrongReferenceAttributeValueException
+	 * @throws AttributeNotExistsException
+	 * @throws WrongAttributeValueException
+	 * @throws MemberResourceMismatchException
+	 */
+	void setRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, User user, Member member, boolean forceAttributesChecks) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException;
+
+	/**
 	 * Take list of required attributes and set those which are empty and can be filled, then check them all.
 	 *
 	 * Important: this method DO NOT set non-empty attributes in list, just refresh their values and check them

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/AttributesManagerBlImpl.java
@@ -1780,10 +1780,14 @@ public class AttributesManagerBlImpl implements AttributesManagerBl {
 
 	@Override
 	public void setRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, User user, Member member) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException {
+		setRequiredAttributes(sess, service, facility, resource, user, member, false);
+	}
+	@Override
+	public void setRequiredAttributes(PerunSession sess, Service service, Facility facility, Resource resource, User user, Member member, boolean forceAttributesChecks) throws InternalErrorException, WrongAttributeAssignmentException, WrongReferenceAttributeValueException, AttributeNotExistsException, WrongAttributeValueException, MemberResourceMismatchException {
 		//get all attributes (for member, resource, facility, user and service) with values
 		List<Attribute> attributes = this.getRequiredAttributes(sess, service, facility, resource, user, member);
 
-		this.setRequiredAttributes(sess, facility, resource, user, member, attributes);
+		this.setRequiredAttributes(sess, facility, resource, user, member, attributes, forceAttributesChecks);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/ResourcesManagerBlImpl.java
@@ -538,7 +538,7 @@ public class ResourcesManagerBlImpl implements ResourcesManagerBl {
 			for(Member member : members) {
 				User user = getPerunBl().getUsersManagerBl().getUserByMember(sess, member);
 				// use complex method for getting and setting member-resource, member, user-facility and user-facility required attributes for the service
-				getPerunBl().getAttributesManagerBl().setRequiredAttributes(sess, service, facility, resource, user, member);
+				getPerunBl().getAttributesManagerBl().setRequiredAttributes(sess, service, facility, resource, user, member, true);
 			}
 		} catch(WrongAttributeAssignmentException | GroupResourceMismatchException | MemberResourceMismatchException | AttributeNotExistsException ex) {
 			throw new ConsistencyErrorException(ex);


### PR DESCRIPTION
* In the assignService, it is possible to skip isTrulyRequired
attributes checks, since all members passed to it are allowed and only
required attributes are set.