### PR TITLE
CORE: Fixed condition in getAllowedFacilities(user)

### DIFF
--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -17,7 +17,6 @@ import cz.metacentrum.perun.core.api.SecurityTeam;
 import cz.metacentrum.perun.core.api.Service;
 import cz.metacentrum.perun.core.api.User;
 import cz.metacentrum.perun.core.api.Vo;
-import cz.metacentrum.perun.core.api.exceptions.AlreadyAdminException;
 import cz.metacentrum.perun.core.api.exceptions.BanAlreadyExistsException;
 import cz.metacentrum.perun.core.api.exceptions.BanNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityAlreadyRemovedException;
@@ -25,19 +24,16 @@ import cz.metacentrum.perun.core.api.exceptions.FacilityContactNotExistsExceptio
 import cz.metacentrum.perun.core.api.exceptions.FacilityExistsException;
 import cz.metacentrum.perun.core.api.exceptions.FacilityNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.GroupAlreadyRemovedFromResourceException;
-import cz.metacentrum.perun.core.api.exceptions.GroupNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.HostAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.HostExistsException;
 import cz.metacentrum.perun.core.api.exceptions.HostNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.OwnerAlreadyRemovedException;
-import cz.metacentrum.perun.core.api.exceptions.PrivilegeException;
 import cz.metacentrum.perun.core.api.exceptions.RelationExistsException;
 import cz.metacentrum.perun.core.api.exceptions.ResourceAlreadyRemovedException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamAlreadyAssignedException;
 import cz.metacentrum.perun.core.api.exceptions.SecurityTeamNotAssignedException;
-import cz.metacentrum.perun.core.api.exceptions.UserNotAdminException;
 import cz.metacentrum.perun.core.api.exceptions.UserNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeAssignmentException;
 import cz.metacentrum.perun.core.api.exceptions.WrongAttributeValueException;
@@ -414,20 +410,18 @@ public interface FacilitiesManagerBl {
 	 *
 	 * @param sess
 	 * @param user
-	 * @return
-	 * @throws InternalErrorException
+	 * @return List of allowed facilities of the user.
 	 */
-	List<Facility> getAllowedFacilities(PerunSession sess, User user) throws InternalErrorException;
+	List<Facility> getAllowedFacilities(PerunSession sess, User user);
 
 	/**
 	 * Get facilities where member is allowed.
 	 *
 	 * @param sess
 	 * @param member
-	 * @return
-	 * @throws InternalErrorException
+	 * @return List of allowed facilities of the member.
 	 */
-	List<Facility> getAllowedFacilities(PerunSession sess, Member member) throws InternalErrorException;
+	List<Facility> getAllowedFacilities(PerunSession sess, Member member);
 
 	/**
 	 * Get facilities where the services is defined.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBl.java
@@ -410,15 +410,24 @@ public interface FacilitiesManagerBl {
 	List<Facility> getAssignedFacilities(PerunSession sess, User user) throws InternalErrorException;
 
 	/**
-	 * Get facilities where the user have access.
+	 * Get facilities where the user is allowed.
 	 *
 	 * @param sess
 	 * @param user
 	 * @return
-	 *
 	 * @throws InternalErrorException
 	 */
 	List<Facility> getAllowedFacilities(PerunSession sess, User user) throws InternalErrorException;
+
+	/**
+	 * Get facilities where member is allowed.
+	 *
+	 * @param sess
+	 * @param member
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	List<Facility> getAllowedFacilities(PerunSession sess, Member member) throws InternalErrorException;
 
 	/**
 	 * Get facilities where the services is defined.

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -466,12 +466,12 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 	}
 
 	@Override
-	public List<Facility> getAllowedFacilities(PerunSession sess, User user) throws InternalErrorException {
+	public List<Facility> getAllowedFacilities(PerunSession sess, User user) {
 		return getFacilitiesManagerImpl().getAllowedFacilities(sess, user);
 	}
 
 	@Override
-	public List<Facility> getAllowedFacilities(PerunSession sess, Member member) throws InternalErrorException {
+	public List<Facility> getAllowedFacilities(PerunSession sess, Member member) {
 		return getFacilitiesManagerImpl().getAllowedFacilities(sess, member);
 	}
 

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/blImpl/FacilitiesManagerBlImpl.java
@@ -467,16 +467,12 @@ public class FacilitiesManagerBlImpl implements FacilitiesManagerBl {
 
 	@Override
 	public List<Facility> getAllowedFacilities(PerunSession sess, User user) throws InternalErrorException {
-		List<Member> members = perunBl.getMembersManagerBl().getMembersByUser(sess, user);
+		return getFacilitiesManagerImpl().getAllowedFacilities(sess, user);
+	}
 
-		Set<Facility> assignedFacilities = new HashSet<>();
-		for(Member member : members) {
-			if(!getPerunBl().getMembersManagerBl().haveStatus(sess, member, Status.INVALID)) {
-				assignedFacilities.addAll(this.getAssignedFacilities(sess, member));
-			}
-		}
-
-		return new ArrayList<>(assignedFacilities);
+	@Override
+	public List<Facility> getAllowedFacilities(PerunSession sess, Member member) throws InternalErrorException {
+		return getFacilitiesManagerImpl().getAllowedFacilities(sess, member);
 	}
 
 	@Override

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -450,6 +450,44 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	}
 
 	@Override
+	public List<Facility> getAllowedFacilities(PerunSession sess, User user) throws InternalErrorException {
+		try  {
+			return jdbc.query("select distinct " + facilityMappingSelectQuery + " from groups_resources" +
+							" join groups on groups_resources.group_id=groups.id" +
+							" join groups_members on groups.id=groups_members.group_id" +
+							" join members on groups_members.member_id=members.id " +
+							" join resources on groups_resources.resource_id=resources.id " +
+							" join facilities on resources.facility_id=facilities.id " +
+							" where members.user_id=? and members.status!=? and members.status!=?",
+					FACILITY_MAPPER, user.getId(),
+					String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
+	public List<Facility> getAllowedFacilities(PerunSession sess, Member member) throws InternalErrorException {
+		try  {
+			return jdbc.query("select distinct " + facilityMappingSelectQuery + " from groups_resources" +
+							" join groups on groups_resources.group_id=groups.id" +
+							" join groups_members on groups.id=groups_members.group_id" +
+							" join members on groups_members.member_id=members.id " +
+							" join resources on groups_resources.resource_id=resources.id " +
+							" join facilities on resources.facility_id=facilities.id " +
+							" where members.id=? and members.status!=? and members.status!=?",
+					FACILITY_MAPPER, member.getId(),
+					String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
+		} catch (EmptyResultDataAccessException e) {
+			return new ArrayList<>();
+		} catch (RuntimeException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+
+	@Override
 	public List<Resource> getAssignedResources(PerunSession sess, Facility facility) throws InternalErrorException {
 		try {
 			return jdbc.query("select " + ResourcesManagerImpl.resourceMappingSelectQuery + " from resources where facility_id=?",

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/FacilitiesManagerImpl.java
@@ -450,7 +450,7 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 	}
 
 	@Override
-	public List<Facility> getAllowedFacilities(PerunSession sess, User user) throws InternalErrorException {
+	public List<Facility> getAllowedFacilities(PerunSession sess, User user) {
 		try  {
 			return jdbc.query("select distinct " + facilityMappingSelectQuery + " from groups_resources" +
 							" join groups on groups_resources.group_id=groups.id" +
@@ -461,15 +461,13 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 							" where members.user_id=? and members.status!=? and members.status!=?",
 					FACILITY_MAPPER, user.getId(),
 					String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<>();
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}
 	}
 
 	@Override
-	public List<Facility> getAllowedFacilities(PerunSession sess, Member member) throws InternalErrorException {
+	public List<Facility> getAllowedFacilities(PerunSession sess, Member member) {
 		try  {
 			return jdbc.query("select distinct " + facilityMappingSelectQuery + " from groups_resources" +
 							" join groups on groups_resources.group_id=groups.id" +
@@ -480,8 +478,6 @@ public class FacilitiesManagerImpl implements FacilitiesManagerImplApi {
 							" where members.id=? and members.status!=? and members.status!=?",
 					FACILITY_MAPPER, member.getId(),
 					String.valueOf(Status.INVALID.getCode()), String.valueOf(Status.DISABLED.getCode()));
-		} catch (EmptyResultDataAccessException e) {
-			return new ArrayList<>();
 		} catch (RuntimeException e) {
 			throw new InternalErrorException(e);
 		}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -179,6 +179,28 @@ public interface FacilitiesManagerImplApi {
 	List<Member> getAllowedMembers(PerunSession sess, Facility facility) throws InternalErrorException;
 
 	/**
+	 * Return all allowed facilities of the user.
+	 * It means all facilities, where is assigned through some resource and member is allowed on such resource.
+	 *
+	 * @param sess
+	 * @param user
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	List<Facility> getAllowedFacilities(PerunSession sess, User user) throws InternalErrorException;
+
+	/**
+	 * Return all allowed facilities of the member.
+	 * It means all facilities, where is assigned through some resource and member is allowed.
+	 *
+	 * @param sess
+	 * @param member
+	 * @return
+	 * @throws InternalErrorException
+	 */
+	List<Facility> getAllowedFacilities(PerunSession sess, Member member) throws InternalErrorException;
+
+	/**
 	 * Returns all resources assigned to the facility.
 	 *
 	 * @param perunSession

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/implApi/FacilitiesManagerImplApi.java
@@ -184,10 +184,9 @@ public interface FacilitiesManagerImplApi {
 	 *
 	 * @param sess
 	 * @param user
-	 * @return
-	 * @throws InternalErrorException
+	 * @return List of allowed facilities of the user.
 	 */
-	List<Facility> getAllowedFacilities(PerunSession sess, User user) throws InternalErrorException;
+	List<Facility> getAllowedFacilities(PerunSession sess, User user);
 
 	/**
 	 * Return all allowed facilities of the member.
@@ -195,10 +194,9 @@ public interface FacilitiesManagerImplApi {
 	 *
 	 * @param sess
 	 * @param member
-	 * @return
-	 * @throws InternalErrorException
+	 * @return List of allowed facilities of the member.
 	 */
-	List<Facility> getAllowedFacilities(PerunSession sess, Member member) throws InternalErrorException;
+	List<Facility> getAllowedFacilities(PerunSession sess, Member member);
 
 	/**
 	 * Returns all resources assigned to the facility.

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBlImplTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/bl/FacilitiesManagerBlImplTest.java
@@ -1,0 +1,221 @@
+package cz.metacentrum.perun.core.bl;
+
+import cz.metacentrum.perun.core.api.Candidate;
+import cz.metacentrum.perun.core.api.ExtSource;
+import cz.metacentrum.perun.core.api.ExtSourcesManager;
+import cz.metacentrum.perun.core.api.Facility;
+import cz.metacentrum.perun.core.api.Group;
+import cz.metacentrum.perun.core.api.Member;
+import cz.metacentrum.perun.core.api.PerunClient;
+import cz.metacentrum.perun.core.api.PerunPrincipal;
+import cz.metacentrum.perun.core.api.PerunSession;
+import cz.metacentrum.perun.core.api.Resource;
+import cz.metacentrum.perun.core.api.Status;
+import cz.metacentrum.perun.core.api.User;
+import cz.metacentrum.perun.core.api.UserExtSource;
+import cz.metacentrum.perun.core.api.Vo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Pavel Zlamal <zlamal@cesnet.cz>
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+		@ContextConfiguration(locations = { "classpath:perun-base.xml", "classpath:perun-core.xml" })
+})
+@Transactional(transactionManager = "springTransactionManager")
+public class FacilitiesManagerBlImplTest {
+
+	@Autowired
+	private PerunBl perun;
+
+	private PerunSession sess;
+	private User user;
+	private Vo vo;
+	private Member member;
+	private Group group;
+	private Resource resource;
+	private Facility facility;
+
+	private Vo vo2;
+	private Member member2;
+	private Group group2;
+	private Resource resource2;
+
+	private Resource resource3;
+	private Facility facility2;
+
+	private static final String EXT_SOURCE_NAME = "FacilitiesManagerBlExtSource";
+	private ExtSource extSource = new ExtSource(0, EXT_SOURCE_NAME, ExtSourcesManager.EXTSOURCE_INTERNAL);
+	private Candidate candidate;
+	private UserExtSource ues;
+
+
+	@Before
+	public void setUp() throws Exception {
+
+		candidate = new Candidate();
+		candidate.setFirstName("some");
+		candidate.setId(0);
+		candidate.setMiddleName("");
+		candidate.setLastName("testingUser");
+		candidate.setTitleBefore("");
+		candidate.setTitleAfter("");
+		ues = new UserExtSource(extSource, "extLogin");
+		candidate.setUserExtSource(ues);
+		candidate.setAttributes(new HashMap<>());
+
+		sess = perun.getPerunSession(
+				new PerunPrincipal("perunTests", ExtSourcesManager.EXTSOURCE_NAME_INTERNAL, ExtSourcesManager.EXTSOURCE_INTERNAL),
+				new PerunClient());
+
+
+		vo = new Vo(0, "FacilitiesManagerBlImplTestVo", "FacMgrBlImplTestVo");
+		vo = perun.getVosManagerBl().createVo(sess, vo);
+
+		member = perun.getMembersManagerBl().createMemberSync(sess, vo, candidate);
+
+		group = new Group("testGroup", "testGroup");
+		group = perun.getGroupsManagerBl().createGroup(sess, vo, group);
+
+		perun.getGroupsManagerBl().addMember(sess, group, member);
+
+		facility = new Facility(0, "testFac");
+		facility = perun.getFacilitiesManagerBl().createFacility(sess, facility);
+
+		resource = new Resource(0, "testRes", null, facility.getId(), vo.getId());
+		resource = perun.getResourcesManagerBl().createResource(sess, resource, vo ,facility);
+
+		perun.getResourcesManagerBl().assignGroupToResource(sess, group, resource);
+
+		// second branch
+
+		vo2 = new Vo(0, "FacilitiesManagerBlImplTestVo2", "FacMgrBlImplTestVo2");
+		vo2 = perun.getVosManagerBl().createVo(sess, vo2);
+
+		member2 = perun.getMembersManagerBl().createMemberSync(sess, vo2, candidate);
+
+		group2 = new Group("testGroup", "testGroup");
+		group2 = perun.getGroupsManagerBl().createGroup(sess, vo2, group2);
+
+		perun.getGroupsManagerBl().addMember(sess, group2, member2);
+
+		resource2 = new Resource(0, "testRes2", null, facility.getId(), vo2.getId());
+		resource2 = perun.getResourcesManagerBl().createResource(sess, resource2, vo2 ,facility);
+
+		// third branch
+
+		facility2 = new Facility(0, "testFac2");
+		facility2 = perun.getFacilitiesManagerBl().createFacility(sess, facility2);
+
+		resource3 = new Resource(0, "testRes3", null, facility2.getId(), vo2.getId());
+		resource3 = perun.getResourcesManagerBl().createResource(sess, resource3, vo2 ,facility2);
+
+		perun.getResourcesManagerBl().assignGroupToResources(sess, group2, Arrays.asList(resource2, resource3));
+
+	}
+
+	@Test
+	public void getAllowedFacilitiesTest() throws Exception {
+		System.out.println("FacilitiesManagerBlImpl.getAllowedFacilitiesTest");
+
+		user = perun.getUsersManagerBl().getUserByMember(sess, member);
+
+		List<Facility> allowedFacilitiesOld = getFacilitiesOldStyle();
+		List<Facility> allowedFacilitiesNew = perun.getFacilitiesManagerBl().getAllowedFacilities(sess, user);
+
+		Assert.assertTrue(allowedFacilitiesOld.containsAll(allowedFacilitiesNew));
+		Assert.assertTrue(allowedFacilitiesNew.size() == 2);
+
+		// disable 1st member => should make no change, since 2nd member is on both facilities
+		perun.getMembersManagerBl().setStatus(sess, member, Status.DISABLED);
+
+		allowedFacilitiesOld = getFacilitiesOldStyle();
+		allowedFacilitiesNew = perun.getFacilitiesManagerBl().getAllowedFacilities(sess, user);
+
+		Assert.assertTrue(allowedFacilitiesOld.containsAll(allowedFacilitiesNew));
+		Assert.assertTrue(allowedFacilitiesNew.size() == 2);
+
+		// disable 2nd member => user shouldn't be allowed anywhere
+		perun.getMembersManagerBl().setStatus(sess, member2, Status.DISABLED);
+
+		allowedFacilitiesOld = getFacilitiesOldStyle();
+		allowedFacilitiesNew = perun.getFacilitiesManagerBl().getAllowedFacilities(sess, user);
+		Assert.assertTrue(allowedFacilitiesNew.isEmpty() && allowedFacilitiesOld.isEmpty());
+
+		// enable 1st member => should be only on first facility
+		perun.getMembersManagerBl().setStatus(sess, member, Status.VALID);
+		allowedFacilitiesOld = getFacilitiesOldStyle();
+		allowedFacilitiesNew = perun.getFacilitiesManagerBl().getAllowedFacilities(sess, user);
+
+		Assert.assertTrue(allowedFacilitiesOld.size() == 1);
+		Assert.assertTrue(allowedFacilitiesNew.size() == 1);
+		Assert.assertTrue(allowedFacilitiesNew.contains(facility));
+		Assert.assertTrue(!allowedFacilitiesNew.contains(facility2));
+
+	}
+
+	@Test
+	public void getAllowedFacilitiesForMemberTest() throws Exception {
+		System.out.println("FacilitiesManagerBlImpl.getAllowedFacilitiesForMemberTest");
+
+		List<Facility> allowedFacilities = perun.getFacilitiesManagerBl().getAllowedFacilities(sess, member);
+		Assert.assertTrue(allowedFacilities.contains(facility));
+		Assert.assertTrue(allowedFacilities.size() == 1);
+		Assert.assertTrue(!allowedFacilities.contains(facility2));
+
+		// second member is on both facilities
+		List<Facility> allowedFacilities2 = perun.getFacilitiesManagerBl().getAllowedFacilities(sess, member2);
+		Assert.assertTrue(allowedFacilities2.contains(facility));
+		Assert.assertTrue(allowedFacilities2.contains(facility2));
+		Assert.assertTrue(allowedFacilities2.size() == 2);
+
+		// If member is not valid, we shouldn have any allowed facilities from it
+		perun.getMembersManagerBl().setStatus(sess, member, Status.DISABLED);
+
+		allowedFacilities = perun.getFacilitiesManagerBl().getAllowedFacilities(sess, member);
+		Assert.assertTrue(allowedFacilities.isEmpty());
+
+		// If member2 is not valid, we shouldn have any allowed facilities from it
+		perun.getMembersManagerBl().setStatus(sess, member2, Status.DISABLED);
+
+		allowedFacilities = perun.getFacilitiesManagerBl().getAllowedFacilities(sess, member2);
+		Assert.assertTrue(allowedFacilities.isEmpty());
+
+	}
+
+	/**
+	 * Returns allowed facilities using old implementation by iteration
+	 * @return
+	 */
+	private List<Facility> getFacilitiesOldStyle() {
+
+		Set<Facility> assignedFacilities = new HashSet<>();
+		for(Member member : perun.getMembersManagerBl().getMembersByUser(sess, user)) {
+			if(!perun.getMembersManagerBl().haveStatus(sess, member, Status.INVALID) &&
+					!perun.getMembersManagerBl().haveStatus(sess, member, Status.DISABLED)) {
+				assignedFacilities.addAll(perun.getFacilitiesManagerBl().getAssignedFacilities(sess, member));
+			}
+		}
+		return new ArrayList<>(assignedFacilities);
+
+	}
+
+
+
+}


### PR DESCRIPTION
- This method previously returned also facilities, where user
  was not allowed (was in disabled state) since it checked
  only invalid status of processed users members.
  It also iterated over those members.
- New implementation performs direct DB query to get all
  facilities, where user is assigned with allowed members.

- Added getAllowedFacilities(member), which can be later used
  (eg. when getting all dependant user-facility attrs for
  member attribute on input).
  We generally perform too many selects on resolving allowed
  state from entities and perform their intersection later.