### PR TITLE
Attribute modules configuration

### DIFF
--- a/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/rt/ModulePropertyNotFoundException.java
+++ b/perun-base/src/main/java/cz/metacentrum/perun/core/api/exceptions/rt/ModulePropertyNotFoundException.java
@@ -1,0 +1,27 @@
+package cz.metacentrum.perun.core.api.exceptions.rt;
+
+import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
+
+/**
+ * This exception is thrown when the loading of module configuration property
+ * is not found or it fails.
+ *
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ModulePropertyNotFoundException extends InternalErrorException {
+	public ModulePropertyNotFoundException(String message) {
+		super(message);
+	}
+
+	public ModulePropertyNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ModulePropertyNotFoundException(Throwable cause) {
+		super(cause);
+	}
+
+	public ModulePropertyNotFoundException(String module, String property) {
+		super("Failed to parse property: '" + property + "' for module: " + module);
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/ModulesConfigLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/ModulesConfigLoader.java
@@ -1,0 +1,108 @@
+package cz.metacentrum.perun.core.impl.modules;
+
+import cz.metacentrum.perun.core.api.exceptions.rt.ModulePropertyNotFoundException;
+
+import java.util.List;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public interface ModulesConfigLoader {
+
+	/**
+	 * For module with the given name, find a String configuration property with given name.
+	 *
+	 * @param moduleName name of a module
+	 * @param property name of a property
+	 * @return found String property for given module
+	 * @throws ModulePropertyNotFoundException when the specified property value is null or is not found
+	 *                                         or the specified module configuration is not found
+	 */
+	String loadString(String moduleName, String property) throws ModulePropertyNotFoundException;
+
+	/**
+	 * For module with the given name, find a String configuration property with given name.
+	 * If the module configuration does not contain the specified property, return the default value.
+	 *
+	 * @param moduleName name of a module
+	 * @param property name of a property
+	 * @param defaultValue default value
+	 * @return found String property for given module, or default value if not found
+	 * @throws ModulePropertyNotFoundException when the specified module configuration is not found
+	 */
+	String loadStringOrDefault(String moduleName, String property, String defaultValue)
+		throws ModulePropertyNotFoundException;
+
+	/**
+	 * For module with the given name, find an Integer configuration property with given name.
+	 *
+	 * @param moduleName name of a module
+	 * @param property name of a property
+	 * @return found Integer property for given module
+	 * @throws ModulePropertyNotFoundException when the specified property value is null or is not found
+	 *                                         or the specified module configuration is not found
+	 */
+	Integer loadInteger(String moduleName, String property) throws ModulePropertyNotFoundException;
+
+	/**
+	 * For module with the given name, find an Integer configuration property with given name.
+	 * If the module configuration does not contain the specified property, return the default value.
+	 *
+	 * @param moduleName name of a module
+	 * @param property name of a property
+	 * @param defaultValue default value
+	 * @return found Integer property for given module, or default value if not found
+	 * @throws ModulePropertyNotFoundException when the specified module configuration is not found
+	 */
+	Integer loadIntegerOrDefault(String moduleName, String property, Integer defaultValue)
+		throws ModulePropertyNotFoundException;
+
+	/**
+	 * For module with the given name, find a list of Strings configuration property with given name.
+	 *
+	 * @param moduleName name of a module
+	 * @param property name of a property
+	 * @return found list of Strings property for given module
+	 * @throws ModulePropertyNotFoundException when the specified property value is null or is not found
+	 *                                         or the specified module configuration is not found
+	 */
+	List<String> loadStringList(String moduleName, String property) throws ModulePropertyNotFoundException;
+
+	/**
+	 * For module with the given name, find a list of Strings configuration property with given name.
+	 * If the module configuration does not contain the specified property, return the default value.
+	 *
+	 * @param moduleName name of a module
+	 * @param property name of a property
+	 * @param defaultValue default value
+	 * @return found list of Strings property for given module, or default value if not found
+	 * @throws ModulePropertyNotFoundException when the specified module configuration is not found
+	 */
+	List<String> loadStringListOrDefault(String moduleName, String property, List<String> defaultValue)
+		throws ModulePropertyNotFoundException;
+
+	/**
+	 * For module with the given name, find a list of Integers configuration property with given name.
+	 *
+	 * @param moduleName name of a module
+	 * @param property name of a property
+	 * @return found list of Integers property for given module
+	 * @throws ModulePropertyNotFoundException when the specified property value is null or is not found
+	 *                                         or the specified module configuration is not found
+	 */
+	List<Integer> loadIntegerList(String moduleName, String property) throws ModulePropertyNotFoundException;
+
+	/**
+	 * For module with the given name, find a list of Integers configuration property with given name.
+	 * If the module configuration does not contain the specified property, return the default value.
+	 *
+	 * @param moduleName name of a module
+	 * @param property name of a property
+	 * @param defaultValue default value
+	 * @return found list of Integers property for given module, or default value if not found
+	 * @throws ModulePropertyNotFoundException when the specified property value is null or is not found
+	 *                                         or the specified module configuration is not found
+	 */
+	List<Integer> loadIntegerListOrDefault(String moduleName, String property, List<Integer> defaultValue)
+		throws ModulePropertyNotFoundException;
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/ModulesYamlConfigLoader.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/ModulesYamlConfigLoader.java
@@ -1,0 +1,164 @@
+package cz.metacentrum.perun.core.impl.modules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import cz.metacentrum.perun.core.api.exceptions.rt.ModulePropertyNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static cz.metacentrum.perun.core.impl.Utils.notNull;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+
+public class ModulesYamlConfigLoader implements ModulesConfigLoader {
+
+	private final static Logger log = LoggerFactory.getLogger(ModulesYamlConfigLoader.class);
+
+	private String modulesDirPath = "/etc/perun/modules/";
+
+	public ModulesYamlConfigLoader() { }
+
+	public ModulesYamlConfigLoader(String modulesDirPath) {
+		this.modulesDirPath = modulesDirPath;
+	}
+
+	@Override
+	public String loadString(String moduleName, String property) {
+		JsonNode propertyNode = loadPropertyNode(moduleName, property);
+		if (propertyNode == null || propertyNode.isNull()) {
+			throw new ModulePropertyNotFoundException(moduleName, property);
+		}
+		return propertyNode.asText();
+	}
+
+	@Override
+	public String loadStringOrDefault(String moduleName, String property, String defaultValue) {
+		JsonNode propertyNode = loadPropertyNode(moduleName, property);
+		if (propertyNode == null || propertyNode.isNull()) {
+			return defaultValue;
+		}
+		return propertyNode.asText();
+	}
+
+	@Override
+	public Integer loadInteger(String moduleName, String property) {
+		JsonNode propertyNode = loadPropertyNode(moduleName, property);
+		if (propertyNode == null || propertyNode.isNull()) {
+			throw new ModulePropertyNotFoundException(moduleName, property);
+		}
+		return propertyNode.asInt();
+	}
+
+	@Override
+	public Integer loadIntegerOrDefault(String moduleName, String property, Integer defaultValue) {
+		JsonNode propertyNode = loadPropertyNode(moduleName, property);
+		if (propertyNode == null || propertyNode.isNull()) {
+			return defaultValue;
+		}
+		return propertyNode.asInt();
+	}
+
+	@Override
+	public List<String> loadStringList(String moduleName, String property) {
+		JsonNode propertyNode = loadPropertyNode(moduleName, property);
+		if (propertyNode == null || propertyNode.isNull()) {
+			throw new ModulePropertyNotFoundException(moduleName, property);
+		}
+		List<String> values = new ArrayList<>();
+		propertyNode.iterator().forEachRemaining(node -> values.add(node.asText()));
+		return values;
+	}
+
+	@Override
+	public List<String> loadStringListOrDefault(String moduleName, String property, List<String> defaultValue) {
+		JsonNode propertyNode = loadPropertyNode(moduleName, property);
+		if (propertyNode == null || propertyNode.isNull()) {
+			return defaultValue;
+		}
+		List<String> values = new ArrayList<>();
+		propertyNode.iterator().forEachRemaining(node -> values.add(node.asText()));
+		return values;
+	}
+
+	@Override
+	public List<Integer> loadIntegerList(String moduleName, String property) {
+		JsonNode propertyNode = loadPropertyNode(moduleName, property);
+		if (propertyNode == null || propertyNode.isNull()) {
+			throw new ModulePropertyNotFoundException(moduleName, property);
+		}
+		List<Integer> values = new ArrayList<>();
+		propertyNode.iterator().forEachRemaining(node -> values.add(node.isNull() ? null : node.asInt()));
+		return values;
+	}
+
+	@Override
+	public List<Integer> loadIntegerListOrDefault(String moduleName, String property, List<Integer> defaultValue) {
+		JsonNode propertyNode = loadPropertyNode(moduleName, property);
+		if (propertyNode == null || propertyNode.isNull()) {
+			return defaultValue;
+		}
+		List<Integer> values = new ArrayList<>();
+		propertyNode.iterator().forEachRemaining(node -> values.add(node.isNull() ? null : node.asInt()));
+		return values;
+	}
+
+	/**
+	 * Loads a JsonNode corresponding to the given module and property name.
+	 * This method expects a {moduleName}.yaml file at the modulesDirPath.
+	 *
+	 * @param moduleName name of the module
+	 * @param propertyName property name
+	 * @return JsonNode corresponding to the desired property.
+	 */
+	private JsonNode loadPropertyNode(String moduleName, String propertyName) {
+		notNull(moduleName, "configFile");
+		notNull(propertyName, "propertyName");
+
+		String path = modulesDirPath + moduleName + ".yaml";
+
+		JsonNode root = loadModulesYamlFile(path);
+
+		return parsePropertyNode(root, propertyName);
+	}
+
+	/**
+	 * Parse a corresponding JsonNode from the given root node, with the specified property name.
+	 * The syntax supports a dot notation to identify children nodes. Eg: oidc.client.id.
+	 *
+	 * @param root root node
+	 * @param propertyName name of the desired property
+	 * @return JsonNode corresponding to the specified property name
+	 */
+	private static JsonNode parsePropertyNode(JsonNode root, String propertyName) {
+		JsonNode currentNode = root;
+		while (propertyName.contains(".")) {
+			String[] split = propertyName.split("\\.", 2);
+			currentNode = currentNode.get(split[0]);
+			propertyName = split[1];
+		}
+		return currentNode.get(propertyName);
+	}
+
+	/**
+	 * Loads a root JsonNode from the given path.
+	 *
+	 * @param path path
+	 * @return loaded root JsonNode
+	 */
+	private static JsonNode loadModulesYamlFile(String path) {
+		try {
+			YAMLMapper mapper = new YAMLMapper();
+			return mapper.readTree(new File(path));
+		} catch (IOException e) {
+			log.error("Failed to load a module's yaml property file at: {}", path);
+			throw new ModulePropertyNotFoundException("Failed to load a module's yaml property file.", e);
+		}
+	}
+}

--- a/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow.java
+++ b/perun-core/src/main/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow.java
@@ -10,6 +10,8 @@ import cz.metacentrum.perun.core.api.exceptions.ExtSourceNotExistsException;
 import cz.metacentrum.perun.core.api.exceptions.InternalErrorException;
 import cz.metacentrum.perun.core.api.exceptions.UserExtSourceExistsException;
 import cz.metacentrum.perun.core.impl.PerunSessionImpl;
+import cz.metacentrum.perun.core.impl.modules.ModulesConfigLoader;
+import cz.metacentrum.perun.core.impl.modules.ModulesYamlConfigLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,9 +23,20 @@ import org.slf4j.LoggerFactory;
 public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow extends urn_perun_user_attribute_def_def_login_namespace {
 
 	private final static Logger log = LoggerFactory.getLogger(urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow.class);
-	private final static String extSourceNameFenix = "https://proxy-fenix.pilot.eduteams.org/proxy";
-	private final static String domainNameFenix = "@fenix.pilot.eduteams.org";
 	private final static String attrNameFenix = "login-namespace:fenix-persistent-shadow";
+
+	private final static String CONFIG_EXT_SOURCE_NAME_FENIX = "extSourceNameFenix";
+	private final static String CONFIG_DOMAIN_NAME_FENIX = "domainNameFenix";
+
+	private ModulesConfigLoader loader = new ModulesYamlConfigLoader();
+	private String extSourceNameFenix = null;
+	private String domainNameFenix = null;
+
+	public urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow() { }
+
+	public urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow(ModulesConfigLoader loader) {
+		this.loader = loader;
+	}
 
 	/**
 	 * Filling implemented for login:namespace:fenix-persistent attribute
@@ -41,7 +54,8 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_s
 		Attribute filledAttribute = new Attribute(attribute);
 
 		if (attribute.getFriendlyName().equals(attrNameFenix)) {
-			filledAttribute.setValue(sha1HashCount(user, domainNameFenix).toString() + domainNameFenix);
+			String domain = "@" + getDomainNameFenix();
+			filledAttribute.setValue(sha1HashCount(user, domain).toString() + domain);
 			return filledAttribute;
 		} else {
 			// without value
@@ -66,7 +80,7 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_s
 			String userNamespace = attribute.getFriendlyNameParameter();
 
 			if(userNamespace.equals("fenix-persistent-shadow") && attribute.getValue() != null){
-				ExtSource extSource = session.getPerunBl().getExtSourcesManagerBl().getExtSourceByName(session, extSourceNameFenix);
+				ExtSource extSource = session.getPerunBl().getExtSourcesManagerBl().getExtSourceByName(session, getExtSourceNameFenix());
 				UserExtSource userExtSource = new UserExtSource(extSource, 0, attribute.getValue().toString());
 
 				session.getPerunBl().getUsersManagerBl().addUserExtSource(session, user, userExtSource);
@@ -89,4 +103,17 @@ public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_s
 		return attr;
 	}
 
+	public String getExtSourceNameFenix() {
+		if (extSourceNameFenix == null) {
+			extSourceNameFenix = loader.loadString(getClass().getSimpleName(), CONFIG_EXT_SOURCE_NAME_FENIX);
+		}
+		return extSourceNameFenix;
+	}
+
+	public String getDomainNameFenix() {
+		if (domainNameFenix == null) {
+			domainNameFenix = loader.loadString(getClass().getSimpleName(), CONFIG_DOMAIN_NAME_FENIX);
+		}
+		return domainNameFenix;
+	}
 }

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/ModulesYamlConfigLoaderTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/ModulesYamlConfigLoaderTest.java
@@ -1,0 +1,160 @@
+package cz.metacentrum.perun.core.impl.modules;
+
+import cz.metacentrum.perun.core.api.exceptions.rt.ModulePropertyNotFoundException;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class ModulesYamlConfigLoaderTest extends TestCase {
+
+	private static final String CONFIG_FILE = "test-module-config";
+	private static final String NULL_PROPERTY = "null";
+	private static final String NOT_EXISTING_PROPERTY = "not-existing";
+
+	private final ModulesYamlConfigLoader loader = new ModulesYamlConfigLoader("src/test/resources/");
+
+
+	public void testLoadStringProperty() {
+		String value = loader.loadString(CONFIG_FILE, "string");
+		assertThat(value).isEqualTo("John Doe");
+	}
+
+	public void testLoadNullStringThrowsError() {
+		assertThatExceptionOfType(ModulePropertyNotFoundException.class)
+			.isThrownBy(() -> loader.loadString(CONFIG_FILE, NULL_PROPERTY));
+	}
+
+	public void testLoadNotExistingStringThrowsException() {
+		assertThatExceptionOfType(ModulePropertyNotFoundException.class)
+			.isThrownBy(() -> loader.loadInteger(CONFIG_FILE, NULL_PROPERTY));
+	}
+
+	public void testLoadStringPropertyReturnsValueIfFound() {
+		String defaultValue = "DEFAULT";
+		String value = loader.loadStringOrDefault(CONFIG_FILE, "string", defaultValue);
+		assertThat(value).isEqualTo("John Doe");
+	}
+
+	public void testLoadStringPropertyReturnsDefaultIfNotFound() {
+		String defaultValue = "DEFAULT";
+		String value = loader.loadStringOrDefault(CONFIG_FILE, NOT_EXISTING_PROPERTY, defaultValue);
+		assertThat(value).isEqualTo(defaultValue);
+	}
+
+	public void testLoadStringPropertyReturnsDefaultIfNullValueFound() {
+		String defaultValue = "DEFAULT";
+		String value = loader.loadStringOrDefault(CONFIG_FILE, NULL_PROPERTY, defaultValue);
+		assertThat(value).isEqualTo(defaultValue);
+	}
+
+	public void testLoadIntegerProperty() {
+		Integer value = loader.loadInteger(CONFIG_FILE, "integer");
+		assertThat(value).isEqualTo(1);
+	}
+
+	public void testLoadNullIntegerThrowsError() {
+		assertThatExceptionOfType(ModulePropertyNotFoundException.class)
+			.isThrownBy(() -> loader.loadInteger(CONFIG_FILE, NULL_PROPERTY));
+	}
+
+	public void testLoadNotExistingIntegerThrowsException() {
+		assertThatExceptionOfType(ModulePropertyNotFoundException.class)
+			.isThrownBy(() -> loader.loadInteger(CONFIG_FILE, NOT_EXISTING_PROPERTY));
+	}
+
+	public void testLoadIntegerPropertyReturnsValueIfFound() {
+		Integer defaultValue = 42;
+		Integer value = loader.loadIntegerOrDefault(CONFIG_FILE, "integer", defaultValue);
+		assertThat(value).isEqualTo(1);
+	}
+
+	public void testLoadIntegerPropertyReturnsDefaultIfNotFound() {
+		Integer defaultValue = 42;
+		Integer value = loader.loadIntegerOrDefault(CONFIG_FILE, NOT_EXISTING_PROPERTY, defaultValue);
+		assertThat(value).isEqualTo(defaultValue);
+	}
+
+	public void testLoadIntegerPropertyReturnsDefaultIfNullValueFound() {
+		Integer defaultValue = 42;
+		Integer value = loader.loadIntegerOrDefault(CONFIG_FILE, NULL_PROPERTY, defaultValue);
+		assertThat(value).isEqualTo(defaultValue);
+	}
+
+	public void testLoadStringListProperty() {
+		List<String> values = loader.loadStringList(CONFIG_FILE, "stringList");
+		assertThat(values).containsExactly("one", "two");
+	}
+
+	public void testLoadNullStringListThrowsException() {
+		assertThatExceptionOfType(ModulePropertyNotFoundException.class)
+			.isThrownBy(() -> loader.loadStringList(CONFIG_FILE, NULL_PROPERTY));
+	}
+
+	public void testLoadNotExistingStringListThrowsException() {
+		assertThatExceptionOfType(ModulePropertyNotFoundException.class)
+			.isThrownBy(() -> loader.loadStringList(CONFIG_FILE, NOT_EXISTING_PROPERTY));
+	}
+
+	public void testLoadStringListPropertyReturnsValueIfFound() {
+		List<String> defaultValue = new ArrayList<>();
+		List<String> values = loader.loadStringListOrDefault(CONFIG_FILE, "stringList", defaultValue);
+		assertThat(values).containsExactly("one", "two");
+	}
+
+	public void testLoadStringListPropertyReturnsDefaultIfNotFound() {
+		List<String> defaultValue = new ArrayList<>();
+		List<String> values = loader.loadStringListOrDefault(CONFIG_FILE, NOT_EXISTING_PROPERTY, defaultValue);
+		assertThat(values).isEqualTo(defaultValue);
+	}
+
+	public void testLoadStringListPropertyReturnsDefaultIfNullValueFound() {
+		List<String> defaultValue = new ArrayList<>();
+		List<String> values = loader.loadStringListOrDefault(CONFIG_FILE, NULL_PROPERTY, defaultValue);
+		assertThat(values).isEqualTo(defaultValue);
+	}
+
+	public void testLoadIntegerListProperty() {
+		List<Integer> values = loader.loadIntegerList(CONFIG_FILE, "integerList");
+		assertThat(values).containsExactly(1, 2);
+	}
+
+	public void testLoadNullIntegerListThrowsException() {
+		assertThatExceptionOfType(ModulePropertyNotFoundException.class)
+			.isThrownBy(() -> loader.loadIntegerList(CONFIG_FILE, NULL_PROPERTY));
+	}
+
+	public void testLoadNotExistingIntegerListThrowsException() {
+		assertThatExceptionOfType(ModulePropertyNotFoundException.class)
+			.isThrownBy(() -> loader.loadIntegerList(CONFIG_FILE, NOT_EXISTING_PROPERTY));
+	}
+
+	public void testLoadIntegerListPropertyReturnsValueIfFound() {
+		List<Integer> defaultValues = new ArrayList<>();
+		List<Integer> values = loader.loadIntegerListOrDefault(CONFIG_FILE, "integerList", defaultValues);
+		assertThat(values).containsExactly(1, 2);
+	}
+
+	public void testLoadIntegerListPropertyReturnsDefaultIfNotFound() {
+		List<Integer> defaultValues = new ArrayList<>();
+		List<Integer> values = loader.loadIntegerListOrDefault(CONFIG_FILE, NOT_EXISTING_PROPERTY, defaultValues);
+		assertThat(values).isEqualTo(defaultValues);
+	}
+
+	public void testLoadIntegerListPropertyReturnsDefaultIfNullValueFound() {
+		List<Integer> defaultValues = new ArrayList<>();
+		List<Integer> values = loader.loadIntegerListOrDefault(CONFIG_FILE, NULL_PROPERTY, defaultValues);
+		assertThat(values).isEqualTo(defaultValues);
+	}
+
+	public void testParseInnerElement() {
+		List<Integer> values = loader.loadIntegerList(CONFIG_FILE, "innerIntegerList.list");
+		assertThat(values).containsExactly(1, 2, 3);
+	}
+}

--- a/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadowTest.java
+++ b/perun-core/src/test/java/cz/metacentrum/perun/core/impl/modules/attributes/urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadowTest.java
@@ -1,0 +1,87 @@
+package cz.metacentrum.perun.core.impl.modules.attributes;
+
+import cz.metacentrum.perun.core.api.BeansUtils;
+import cz.metacentrum.perun.core.api.CoreConfig;
+import cz.metacentrum.perun.core.impl.modules.ModulesConfigLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public class urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadowTest {
+
+	private final ModulesConfigLoader mockedModulesConfigLoader = Mockito.mock(ModulesConfigLoader.class);
+	private final CoreConfig mockedCoreConfig = Mockito.mock(CoreConfig.class, RETURNS_DEEP_STUBS);
+	private CoreConfig originConfig;
+
+	private urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow module;
+
+	@Before
+	public void setUp() {
+		originConfig = BeansUtils.getCoreConfig();
+		// this config has to be mocked, because it is used in the module's super class
+		BeansUtils.setConfig(mockedCoreConfig);
+		module = new urn_perun_user_attribute_def_def_login_namespace_fenix_persistent_shadow(mockedModulesConfigLoader);
+	}
+
+	@After
+	public void tearDown() {
+		BeansUtils.setConfig(originConfig);
+		Mockito.reset(mockedModulesConfigLoader);
+	}
+
+	@Test
+	public void testGetExtSourceNameFenix() {
+		String testValue = "ExtSourceName";
+		when(mockedModulesConfigLoader.loadString(any(), any()))
+			.thenReturn(testValue);
+
+		assertThat(module.getExtSourceNameFenix()).isEqualTo(testValue);
+	}
+
+	@Test
+	public void testGetDomainNameFenix() {
+		String testValue = "Domain name";
+		when(mockedModulesConfigLoader.loadString(any(), any()))
+			.thenReturn(testValue);
+
+		assertThat(module.getDomainNameFenix()).isEqualTo(testValue);
+	}
+
+	@Test
+	public void testExtSourceValueIsNotLoadedAgain() {
+		String testValue = "ExtSourceName";
+
+		when(mockedModulesConfigLoader.loadString(any(), any()))
+			.thenReturn(testValue);
+
+		module.getExtSourceNameFenix();
+		module.getExtSourceNameFenix();
+
+		verify(mockedModulesConfigLoader, times(1)).loadString(any(), eq("extSourceNameFenix"));
+	}
+
+	@Test
+	public void testdomainNameFenixIsNotLoadedAgain() {
+		String testValue = "Domain name";
+
+		when(mockedModulesConfigLoader.loadString(any(), any()))
+			.thenReturn(testValue);
+
+		module.getDomainNameFenix();
+		module.getDomainNameFenix();
+
+		verify(mockedModulesConfigLoader, times(1)).loadString(any(), eq("domainNameFenix"));
+	}
+}

--- a/perun-core/src/test/resources/test-module-config.yaml
+++ b/perun-core/src/test/resources/test-module-config.yaml
@@ -1,0 +1,14 @@
+integer: 1
+string: John Doe
+null:
+integerList:
+  - 1
+  - 2
+stringList:
+  - one
+  - two
+innerIntegerList:
+  list:
+    - 1
+    - 2
+    - 3


### PR DESCRIPTION
* Some attribute modules need to have a separate configuration file.
These configurations should be located inside the /etc/perun/modules/
folder.

* Created ModulesConfigLoader component that is used to load a module's
configurations.

* In the module of u:def:login_namespace_fenix_persistent_shadow
attribute added loading of extSourceNameFenix and domainNameFenix from
its configuration file. If the module is not used, the configuration
file does not need to exist.